### PR TITLE
Publishing decrements block type impressions

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -369,6 +369,10 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         gutenbergSettings.hasLaunchedGutenbergEditor = true
+
+        if post.isFirstTimePublish {
+            decrementBlockTypeImpressions()
+        }
     }
 
     override func viewLayoutMarginsDidChange() {
@@ -515,6 +519,12 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     func gutenbergDidRequestFeaturedImageId(_ mediaID: NSNumber) {
         gutenberg.featuredImageIdNativeUpdated(mediaId: Int32(truncating: mediaID))
+    }
+
+    func decrementBlockTypeImpressions(_ amount: Int = 1) -> Void {
+        gutenbergSettings.blockTypeImpressions = gutenbergSettings.blockTypeImpressions.mapValues {count -> Int in
+            return max(count - amount, 0)
+        }
     }
 
     // MARK: - Event handlers


### PR DESCRIPTION
To avoid new block badges remaining present longer than necessary, the block type impressions are decremented by 1 each time a post is published. When the block type impression count is no longer greater than 0, the new block badge is no longer displayed.

Relates to https://github.com/WordPress/gutenberg/issues/33528.

To test:

1. Remove previously installed WP apps and reinstall the installable build on this PR. 
1. Open the editor to create a new post. 
2. Add a title. 
3. Open the block inserter and note the new "sparkles" badge displayed on the Search, Audio, and Embed blocks.<sup>1</sup> 
4. Publish the post immediately. 
5. Repeat steps 2-4, then schedule the post for the future. 
6. Repeat steps 2-4, then publish the post immediately. 
7. Repeat step 2. 
8. Open the block inserter and note the new "sparkles" badge _no longer_ displayed on the Search, Audio, and Embed blocks.<sup>1</sup>  

[1]: ⚠️ The new block badge is only displayed for 50% of users based upon user ID, so one must log into an included account to test this feature. 

## Regression Notes
1. Potential unintended areas of impact
  Changes to the Gutenberg editor controller could disrupt writing and publishing flows. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manually verified the writing and publishing works as expected. 
3. What automated tests I added (or what prevented me from doing so)
  No automated tests were added for this experimental feature. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
