### PR TITLE
Add subtitle support to `CheckmarkRow`

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -124,18 +124,27 @@ struct TextRow: ImmuTableRow {
 }
 
 struct CheckmarkRow: ImmuTableRow {
-    static let cell = ImmuTableCell.class(WPTableViewCellDefault.self)
+    static let cell = ImmuTableCell.class(WPTableViewCellSubtitle.self)
 
     let title: String
+    let subtitle: String?
     let checked: Bool
     let action: ImmuTableAction?
 
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
+        cell.detailTextLabel?.text = subtitle
         cell.selectionStyle = .none
         cell.accessoryType = (checked) ? .checkmark : .none
 
         WPStyleGuide.configureTableViewCell(cell)
+    }
+
+    init(title: String, subtitle: String? = nil, checked: Bool, action: ImmuTableAction?) {
+        self.title = title
+        self.subtitle = subtitle
+        self.checked = checked
+        self.action = action
     }
 
 }

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -132,6 +132,10 @@ struct CheckmarkRow: ImmuTableRow {
     let action: ImmuTableAction?
 
     func configureCell(_ cell: UITableViewCell) {
+        cell.isAccessibilityElement = true
+        cell.accessibilityLabel = title
+        cell.accessibilityHint = subtitle
+
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = subtitle
         cell.selectionStyle = .none


### PR DESCRIPTION
## Issue

Adds support for a UI element required by #16954.

This PR is intended to be merged by itself and should be safe to deploy (shouldn’t affect existing elements)

## Description

#16954 includes a design spec with the following element:
<img width="431" alt="Screen Shot 2021-08-04 at 2 19 01 PM" src="https://user-images.githubusercontent.com/784999/128233687-ac1a7078-2847-4e3c-83da-fa5080a6288f.png">

The existing `CheckmarkRow` only supports a single title label. This PR:

* Adds support for an optional `subtitle`
* Improves accessibility for the cell by setting an `accessibilityLabel` on it (and an `accessibilityHint` for cells with subtitles), since cells with checkmarks are by nature actionable elements

## Screenshot
![CheckmarkSubtitle](https://user-images.githubusercontent.com/784999/128234063-ae2bf854-4c5c-4b09-9055-dc48e89a1506.png)


## Regression Notes
1. Potential unintended areas of impact

Could affect existing cells that use `CheckmarkRow`

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- [x] Verified that the cell remains visually unchanged despite changing to a cell type that supports `detailTextLabel` 
- [x] Ensured the API remains unchanged (created memberwise initializer with default of `nil` for `subtitle`)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
