### PR TITLE
Likes Summary: Use format specifiers for singular formats

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -98,11 +98,11 @@ private extension ReaderDetailLikesView {
         case (true, 0):
             summaryLabel.attributedText = highlightedText(SummaryLabelFormats.onlySelf)
         case (true, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
         case (true, _) where totalLikes > 1:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.pluralWithSelf, totalLikes))
         case (false, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular, totalLikes))
         default:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.plural, totalLikes))
         }
@@ -160,15 +160,17 @@ private extension ReaderDetailLikesView {
         static let onlySelf = NSLocalizedString("_You_ like this.",
                                                 comment: "Describes that the current user is the only one liking a post."
                                                     + " The underscores denote underline and is not displayed.")
-        static let singularWithSelf = NSLocalizedString("_You and 1 blogger_ like this.",
+        static let singularWithSelf = NSLocalizedString("_You and %1$d blogger_ like this.",
                                                         comment: "Describes that the current user and one other user like a post."
+                                                            + " %1$d is the number of likes, excluding the like by current user."
                                                             + " The underscores denote underline and is not displayed.")
         static let pluralWithSelf = NSLocalizedString("_You and %1$d bloggers_ like this.",
                                                       comment: "Plural format string for displaying the number of post likes, including the like from the current user."
                                                         + " %1$d is the number of likes, excluding the like by current user."
                                                         + " The underscores denote underline and is not displayed.")
-        static let singular = NSLocalizedString("_1 blogger_ likes this.",
-                                                comment: "Describes that only one user likes a post. The underscores denote underline and is not displayed.")
+        static let singular = NSLocalizedString("_%1$d blogger_ likes this.",
+                                                comment: "Describes that only one user likes a post. "
+                                                    + " %1$d is the number of likes. The underscores denote underline and is not displayed.")
         static let plural = NSLocalizedString("_%1$d bloggers_ like this.",
                                               comment: "Plural format string for displaying the number of post likes."
                                                 + " %1$d is the number of likes. The underscores denote underline and is not displayed.")


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/pull/16965#discussion_r682979305

Based on feedback from @AliSoftware, this PR reverts singular string formats used in `ReaderDetailLikesView` to use format specifiers instead of hardcoded values.

To test:

- Open a post where only you and one other person liked the post, and verify that the likes summary is displayed correctly.
- Open a post where only one person liked the post, and verify that the likes summary text is displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
Singular formats are not displayed correctly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested that they are displayed correctly.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
