### PR TITLE
Enable unified list feature flag for Comments and Notifications

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [internal] Converted Comment model properties to Swift. Should be no functional changes, but could cause regressions. [#16969]
 * [*] Posts: Ampersands are correctly decoded in publishing notices instead of showing as HTML entites. [#16972]
 * [***] Adjusted the image size of Theme Images for more optimal download speeds. [#16914]
+* [*] Comments and Notifications list are now displayed with a unified design. [#16985]
 
 17.9
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -60,7 +60,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .editorOnboardingHelpMenu:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .unifiedCommentsAndNotificationsList:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         }
     }
 


### PR DESCRIPTION
Closes #16738 

This enables the unified list feature flag for general public. Comments and Notifications should now be displayed with a unified design.

To test:

- Go to My Site > Comments. Verify that the Comments list are now displayed with the new designs.
- Go to Notifications. Verify that the Notifications list are now displayed with the new designs.

## Regression Notes
1. Potential unintended areas of impact
Old design is still displayed, or the new design is not displayed correctly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
