### PR TITLE
Remove Feature flag for HomePagePicker

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -12,7 +12,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case stories
     case contactInfo
     case layoutGrid
-    case siteCreationHomePagePicker
     case todayWidget
     case milestoneNotifications
     case bloggingReminders
@@ -46,8 +45,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .contactInfo:
             return true
         case .layoutGrid:
-            return true
-        case .siteCreationHomePagePicker:
             return true
         case .todayWidget:
             return true
@@ -107,8 +104,6 @@ extension FeatureFlag {
             return "Contact Info"
         case .layoutGrid:
             return "Layout Grid"
-        case .siteCreationHomePagePicker:
-            return "Site Creation: Home Page Picker"
         case .todayWidget:
             return "iOS 14 Today Widget"
         case .milestoneNotifications:

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressWizardContent.swift
@@ -201,29 +201,6 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
 
     private func fetchAddresses(_ searchTerm: String) {
         isShowingError = false
-        data = []
-
-        if FeatureFlag.siteCreationHomePagePicker.enabled {
-            fetchDotComAndDotBlogAddresses(searchTerm)
-            return
-        }
-        // If siteCreationHomePagePicker is disabled we'll continue down this path.
-        // If the segment ID isn't set we'll fall through and search for dotcom and blog domains
-        guard let segmentID = siteCreator.segment?.identifier else {
-            fetchDotComAndDotBlogAddresses(searchTerm)
-            return
-        }
-
-        updateIcon(isLoading: true)
-        service.addresses(for: searchTerm, segmentID: segmentID) { [weak self] results in
-            DispatchQueue.main.async {
-                self?.handleResult(results)
-            }
-        }
-    }
-
-    // Fetches Addresss suggestions for dotCom sites without requiring a segment.
-    private func fetchDotComAndDotBlogAddresses(_ searchTerm: String) {
         updateIcon(isLoading: true)
         service.addresses(for: searchTerm) { [weak self] results in
             DispatchQueue.main.async {

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -24,9 +24,8 @@ final class SiteCreationWizardLauncher {
     }()
 
     private lazy var steps: [WizardStep] = {
-        let initialStep = FeatureFlag.siteCreationHomePagePicker.enabled ? self.designStep : self.segmentsStep
         return [
-            initialStep,
+            self.designStep,
             self.addressStep,
             self.siteAssemblyStep
         ]
@@ -41,12 +40,8 @@ final class SiteCreationWizardLauncher {
             return nil
         }
 
-        if FeatureFlag.siteCreationHomePagePicker.enabled {
-            wizardContent.modalPresentationStyle = .pageSheet
-            wizardContent.isModalInPresentation = true
-        } else {
-            wizardContent.modalPresentationStyle = .fullScreen
-        }
+        wizardContent.modalPresentationStyle = .pageSheet
+        wizardContent.isModalInPresentation = true
 
         return wizardContent
     }()

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -36,21 +36,13 @@ final class SiteCreator {
     /// - Returns: an Encodable object
     ///
     func build() throws -> SiteCreationRequest {
-        guard FeatureFlag.siteCreationHomePagePicker.enabled || segment?.identifier != nil else {
-            throw SiteCreationRequestAssemblyError.invalidSegmentIdentifier
-        }
-
         let verticalIdentifier = vertical?.identifier.description
 
         guard let domainSuggestion = address else {
             throw SiteCreationRequestAssemblyError.invalidDomain
         }
         let siteName = domainSuggestion.isWordPress ? domainSuggestion.subdomain : domainSuggestion.domainName
-
-        var siteDesign: String? = nil
-        if FeatureFlag.siteCreationHomePagePicker.enabled {
-            siteDesign = design?.slug ?? "default"
-        }
+        let siteDesign = design?.slug ?? "default"
 
         let request = SiteCreationRequest(
             segmentIdentifier: segment?.identifier,

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -41,10 +41,7 @@ final class WizardNavigation: GutenbergLightNavigationController {
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        if FeatureFlag.siteCreationHomePagePicker.enabled {
-            return .default
-        }
-        return super.preferredStatusBarStyle
+        return .default
     }
 
     private func configureSteps() {


### PR DESCRIPTION
This cleans up the HomePagePicker Feature Flag. It seems like this area could use some additional clean up but I was hesitant to do any of that because we might still find uses for some of the services etc as we start the site creation revamp work. 

## To test:
A simple quick run of creating a site is all that's needed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
