### PR TITLE
Update My Site after successful domain registration 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -46,7 +46,9 @@ extension BlogDetailsViewController {
 
     private func presentDomainCreditRedemptionSuccess(domain: String) {
         let controller = DomainCreditRedemptionSuccessViewController(domain: domain, delegate: self)
-        present(controller, animated: true, completion: nil)
+        present(controller, animated: true) { [weak self] in
+            self?.updateHeaderAndMetadata()
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -47,7 +47,7 @@ extension BlogDetailsViewController {
     private func presentDomainCreditRedemptionSuccess(domain: String) {
         let controller = DomainCreditRedemptionSuccessViewController(domain: domain, delegate: self)
         present(controller, animated: true) { [weak self] in
-            self?.updateHeaderAndMetadata()
+            self?.updateTableViewAndHeader()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -156,5 +156,5 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)toggleSpotlightForSiteTitle;
 - (void)toggleSpotlightOnHeaderView;
 - (void)uploadDroppedSiteIcon:(nonnull UIImage *)image onCompletion:(nullable void(^)(void))completion;
-
+- (void)updateHeaderAndMetadata;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -156,5 +156,5 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)toggleSpotlightForSiteTitle;
 - (void)toggleSpotlightOnHeaderView;
 - (void)uploadDroppedSiteIcon:(nonnull UIImage *)image onCompletion:(nullable void(^)(void))completion;
-- (void)updateHeaderAndMetadata;
+- (void)updateTableViewAndHeader;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1969,7 +1969,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 /// This method syncs the blog and its metadata, then reloads the table view and updates the header with the synced blog.
 /// Used to update My Site after a successful domain registration.
-- (void)updateHeaderAndMetadata
+- (void)updateTableViewAndHeader
 {
     __weak __typeof(self) weakSelf = self;
     [self.blogService syncBlogAndAllMetadata:self.blog

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1965,4 +1965,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return nil;
 }
 
+#pragma mark - Domain Registration
+
+/// This method syncs the blog and its metadata, then reloads the table view and updates the header with the synced blog.
+/// Used to update My Site after a successful domain registration.
+- (void)updateHeaderAndMetadata
+{
+    __weak __typeof(self) weakSelf = self;
+    [self.blogService syncBlogAndAllMetadata:self.blog
+                           completionHandler:^{
+                               [weakSelf configureTableViewData];
+                               [weakSelf reloadTableViewPreservingSelection];
+                               [weakSelf.headerView setBlog:weakSelf.blog];
+                           }];
+}
+
 @end


### PR DESCRIPTION
Fixes #NA

To test:
Pre requisites:
- Use the store sandbox to avoid messing up with real domains
- On the store sandbox, have at least one site with a paid plan and no connected domain
- Configure the app to use the store sandbox cookie (see #16939 for details)
Test:
- Build/run and, in My Site, select the site with a paid plan and no connected domain
- You should see the "Register Domain" cell (see below): tap on it
- Complete the domain registration process, after which you will see the domain registration success modal (see below)
- Tap continue, and make sure that you don't see the "Register Domain" cell anymore, and that the url below the site title matches the registered domain

Register Domain cell | domain registration success modal
-- | --
<img width="400" src="https://user-images.githubusercontent.com/34376330/128426353-86b59ff7-4609-4d3f-9ca8-da0b9fae664e.png"> | <img width="400" src="https://user-images.githubusercontent.com/34376330/128426446-d1884bc1-0584-4ab6-ab92-3db7c00eff03.png">



## Regression Notes
1. Potential unintended areas of impact
Low: this PR adds a method that syncs the blog in my site with what's in the backend and then updates my site. The only risk would be to mix up the site itself

2. What I did to test those areas of impact (or what existing automated tests I relied on)
smoke test my site on this and another build that does not contain these changes and make sure the blog data were consistent

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
