### PR TITLE
Extract automation to check translations in dedicated lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -269,6 +269,38 @@ platform :ios do
   end
 
   #####################################################################################
+  # check_all_translations
+  # -----------------------------------------------------------------------------------
+  # This lane checks the translation progress for all the projects in GlotPress.
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane check_all_translations
+  #
+  # Example:
+  # bundle exec fastlane check_all_translations
+  #####################################################################################
+  desc 'Check translation progress for all GlotPress projects'
+  lane :check_all_translations do
+    UI.message('Checking app strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
+      abort_on_violations: false
+    )
+
+    UI.message('Checking WordPress release notes strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
+      abort_on_violations: false
+    )
+
+    UI.message('Checking Jetpack release notes strings translation status...')
+    check_translation_progress(
+      glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
+      abort_on_violations: false
+    )
+  end
+
+  #####################################################################################
   # finalize_release
   # -----------------------------------------------------------------------------------
   # This lane finalize a release: updates store metadata, bump final version number,
@@ -286,24 +318,8 @@ platform :ios do
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
     ios_finalize_prechecks(options)
-    
-    UI.message('Checking app strings translation status...')
-    check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
-      abort_on_violations: false
-    )
 
-    UI.message("Checking WordPress release notes strings translation status...")
-    check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
-      abort_on_violations: false
-    )
-
-    UI.message("Checking Jetpack release notes strings translation status...")
-    check_translation_progress(
-      glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
-      abort_on_violations: false
-    )
+    check_all_translations
 
     download_localized_strings_and_metadata(options)
     # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -272,31 +272,41 @@ platform :ios do
   # check_all_translations
   # -----------------------------------------------------------------------------------
   # This lane checks the translation progress for all the projects in GlotPress.
+  #
+  # By default, it will print all values. You can make it ask whether to continue when
+  # if found translations that are below the threshold by passing `interactive: true`.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane check_all_translations
+  # bundle exec fastlane check_all_translations [interactive:<interactive>]
   #
   # Example:
   # bundle exec fastlane check_all_translations
+  # bundle exec fastlane check_all_translations interactive:true
   #####################################################################################
   desc 'Check translation progress for all GlotPress projects'
-  lane :check_all_translations do
+  lane :check_all_translations do |options|
+    abort_on_violations = false
+    skip_confirm = options.fetch(:interactive, false) == false
+
     UI.message('Checking app strings translation status...')
     check_translation_progress(
       glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/dev/',
-      abort_on_violations: false
+      abort_on_violations: abort_on_violations,
+      skip_confirm: skip_confirm
     )
 
     UI.message('Checking WordPress release notes strings translation status...')
     check_translation_progress(
       glotpress_url: 'https://translate.wordpress.org/projects/apps/ios/release-notes/',
-      abort_on_violations: false
+      abort_on_violations: abort_on_violations,
+      skip_confirm: skip_confirm
     )
 
     UI.message('Checking Jetpack release notes strings translation status...')
     check_translation_progress(
       glotpress_url: 'https://translate.wordpress.com/projects/jetpack/apps/ios/release-notes/',
-      abort_on_violations: false
+      abort_on_violations: abort_on_violations,
+      skip_confirm: skip_confirm
     )
   end
 
@@ -319,7 +329,7 @@ platform :ios do
 
     ios_finalize_prechecks(options)
 
-    check_all_translations
+    check_all_translations(interactive: true)
 
     download_localized_strings_and_metadata(options)
     # FIXME: (2021.06.17) This is disabled because we currently have a >256 chars string which GlotPress truncates when exporting  the `.strings` files,


### PR DESCRIPTION
This way, I can run it in isolation to check the progress without the release finalization pre-checks overhead.

To test:

1. Checkout this branch
2. Run `bundle exec fastlane check_all_translations` and verify it checks all translation in one go

![check_not_interactive](https://user-images.githubusercontent.com/1218433/128437577-0de080f9-91b0-4692-9a6e-590b094f32c5.gif)

1. Repeat adding the `interactive:true` parameter and verify it asks whether to continue after each check (assuming there are values below the threshold)

![check_interactive](https://user-images.githubusercontent.com/1218433/128437779-3c409ae1-aecf-44ff-964e-df719b755306.gif)


## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
