### PR TITLE
Remove duplicate/replaced UI login tests

### DIFF
--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -46,18 +46,6 @@ class LoginTests: XCTestCase {
         XCTAssert(welcomeScreen.isLoaded())
     }
 
-    // Unified WordPress.com login
-    func testWPcomLogin() {
-        _ = PrologueScreen().selectContinue()
-            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
-            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
-            .continueWithSelectedSite()
-            .dismissNotificationAlertIfNeeded()
-
-        XCTAssert(MySiteScreen().isLoaded())
-    }
-
     // Unified self hosted login/out
     func testSelfHostedLoginLogout() {
         PrologueScreen().selectSiteAddress()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -16,7 +16,7 @@ class LoginTests: XCTestCase {
     }
 
     // Unified email login/out
-    func testWordPressLoginLogout() throws {
+    func testWPcomLoginLogout() throws {
         let prologueScreen = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -65,26 +65,10 @@ class LoginTests: XCTestCase {
     }
 
     // Unified WordPress.com login
-    // Replaces testWpcomUsernamePasswordLogin
     func testWPcomLogin() {
         _ = PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
-            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
-            .continueWithSelectedSite()
-            .dismissNotificationAlertIfNeeded()
-
-        XCTAssert(MySiteScreen().isLoaded())
-    }
-
-    // Old WordPress.com login/out
-    // TODO: remove when unifiedAuth is permanent.
-    func testWpcomUsernamePasswordLogin() {
-        _ = WelcomeScreen().selectLogin()
-            .selectEmailLogin()
-            .goToSiteAddressLogin()
-            .proceedWith(siteUrl: "WordPress.com")
-            .proceedWith(username: WPUITestCredentials.testWPcomSitePrimaryAddress, password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -93,7 +93,6 @@ class LoginTests: XCTestCase {
     }
 
     // Unified self hosted login/out
-    // Replaces testSelfHostedUsernamePasswordLoginLogout
     func testSelfHostedLoginLogout() {
         PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
@@ -103,20 +102,6 @@ class LoginTests: XCTestCase {
             .removeSelfHostedSite()
 
         XCTAssert(PrologueScreen().isLoaded())
-    }
-
-    // Old self hosted login/out
-    // TODO: remove when unifiedAuth is permanent.
-    func testSelfHostedUsernamePasswordLoginLogout() {
-        WelcomeScreen().selectLogin()
-            .goToSiteAddressLogin()
-            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-            .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .continueWithSelectedSite()
-            .removeSelfHostedSite()
-
-        XCTAssert(WelcomeScreen().isLoaded())
     }
 
     // Unified WordPress.com email login failure due to incorrect password

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -16,7 +16,6 @@ class LoginTests: XCTestCase {
     }
 
     // Unified email login/out
-    // Replaces testEmailPasswordLoginLogout
     func testWordPressLoginLogout() throws {
         let prologueScreen = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
@@ -28,23 +27,6 @@ class LoginTests: XCTestCase {
             .logoutToPrologue()
 
         XCTAssert(prologueScreen.isLoaded())
-    }
-
-    // Old email login/out
-    // TODO: remove when unifiedAuth is permanent.
-    func testEmailPasswordLoginLogout() throws {
-        let welcomeScreen = try WelcomeScreen().selectLogin()
-            .selectEmailLogin()
-            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .proceedWithPassword()
-            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
-            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
-            .continueWithSelectedSite()
-            .dismissNotificationAlertIfNeeded()
-            .tabBar.gotoMeScreen()
-            .logout()
-
-        XCTAssert(welcomeScreen.isLoaded())
     }
 
     /**

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -120,21 +120,9 @@ class LoginTests: XCTestCase {
     }
 
     // Unified WordPress.com email login failure due to incorrect password
-    // Replaces testUnsuccessfulLogin
     func testWPcomInvalidPassword() {
         _ = PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .tryProceed(password: "invalidPswd")
-            .verifyLoginError()
-    }
-
-    // Old email login fail
-    // TODO: remove when unifiedAuth is permanent.
-    func testUnsuccessfulLogin() {
-        _ = WelcomeScreen().selectLogin()
-            .selectEmailLogin()
-            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
-            .proceedWithPassword()
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
     }


### PR DESCRIPTION
This PR is part of updating our login tests to account for the Unified Login & Signup flows. Context & status: paaHJt-1Kx-p2
This PR removes old (pre-unified-login) tests which have now been updated or replaced.

The following tests have been removed, as they have been replaced by new tests:
`testEmailPasswordLoginLogout()` replaced by `func testWordPressLoginLogout()` 
`testWpcomUsernamePasswordLogin()` replaced by ` func testWpcomLogin()` 
`testSelfHostedUsernameLoginLogout()` replaced by  `func testSelfHostedLoginLogout()`
`testUnsuccessfulLogin()` replaced by  `func testWPcomInvalidPassword()`

In addition, `func testWordPressLoginLogout()` and ` func testWpcomLogin()`  were redundant now that unified login uses email exclusively. Previously, these were separate tests for email login and username login. Now, `func testWordPressLoginLogout() is named `func testWPcomLoginLogout()` and ` func testWpcomLogin()`  has been removed.

To test:
Run LoginTests. The 4 existing and enabled tests should succeed.