### PR TITLE
Link XCUITestHelpers Swift package to UITestsFoundation framework

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -9,6 +9,15 @@
           "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
           "version": "0.1.0"
         }
+      },
+      {
+        "package": "XCUITestHelpers",
+        "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
+        "state": {
+          "branch": null,
+          "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
+          "version": "0.1.0"
+        }
       }
     ]
   },

--- a/WordPress/UITestsFoundation/XCUIElement+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Utils.swift
@@ -3,23 +3,6 @@ import XCTest
 // TODO: This should go XCUITestHelpers if not there already
 public extension XCUIElement {
 
-    /**
-     Pastes text from clipboard to the field
-     Useful for scenarios where typing is problematic, e.g. secure text fields in Russian.
-     - Parameter text: the text to paste into the field
-     */
-    func pasteText(_ text: String) -> Void {
-        let previousPasteboardContents = UIPasteboard.general.string
-        UIPasteboard.general.string = text
-
-        press(forDuration: 1.2)
-        XCUIApplication().menuItems.firstMatch.tap()
-
-        if let string = previousPasteboardContents {
-            UIPasteboard.general.string = string
-        }
-    }
-
     @discardableResult
     // TODO: When moving to framework, find name that doesn't trigger grammar warning
     func waitForHittability(timeout: TimeInterval) -> Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -539,6 +539,7 @@
 		3FB34ADA25672AA5001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
 		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
+		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
 		3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -7632,6 +7633,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FA640662670CEFF0064401E /* XCTest.framework in Frameworks */,
+				3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14518,6 +14520,9 @@
 			dependencies = (
 			);
 			name = UITestsFoundation;
+			packageProductDependencies = (
+				3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */,
+			);
 			productName = UITestsFoundation;
 			productReference = 3FA640572670CCD40064401E /* UITestsFoundation.framework */;
 			productType = "com.apple.product-type.framework";
@@ -14976,6 +14981,7 @@
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
+				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -24736,6 +24742,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.1.0;
+			};
+		};
 		3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
@@ -24750,6 +24764,11 @@
 		24CE2EB0258D687A0000C297 /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = WordPressFlux;
+		};
+		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
+			productName = XCUITestHelpers;
 		};
 		3FF1442F266F3C2400138163 /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,5 +1,6 @@
 import UITestsFoundation
 import XCTest
+import XCUITestHelpers
 
 private struct ElementStringIDs {
     static let navBar = "WordPressAuthenticator.LoginSelfHostedView"
@@ -41,7 +42,7 @@ class LoginUsernamePasswordScreen: BaseScreen {
         // Workaround to enter password in languages where typing doesn't work
         // Pasting is not reliable enough to use all the time so we only use it where it's necessary
         if ["ru", "th"].contains(Locale.current.languageCode) {
-            passwordTextField.pasteText(password)
+            passwordTextField.paste(text: password)
         } else {
             passwordTextField.typeText(password)
         }


### PR DESCRIPTION
To make sure the linking works, I replace the custom "paste text" implementation usage with a call to the one exposed by the package.

To test, make sure the UI tests ~~and screenshots generation targets~~ (update: the Jetpack screenshots fail due to other reasons, [this other PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17013) fixes them) build locally. Also notice that the UI tests pass in CI 👌 .

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**