### PR TITLE
Fix build failures in screenshot targets after adding ScreenObject

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -5,7 +5,7 @@ import XCTest
 class JetpackScreenshotGeneration: XCTestCase {
     let scanWaitTime: UInt32 = 5
 
-    override func setUp() {
+    override func setUpWithError() throws {
         super.setUp()
 
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -23,7 +23,7 @@ class JetpackScreenshotGeneration: XCTestCase {
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
         }
 
-        LoginFlow.login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
     }
 
     override func tearDown() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -546,6 +546,7 @@
 		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
+		3FC2C33F26C4E75F00C6D98F /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33E26C4E75F00C6D98F /* ScreenObject */; };
 		3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -7777,6 +7778,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FA640672670D1290064401E /* UITestsFoundation.framework in Frameworks */,
+				3FC2C33F26C4E75F00C6D98F /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14780,6 +14782,9 @@
 				FAF64C3A2637E02700E8A1DF /* PBXTargetDependency */,
 			);
 			name = JetpackScreenshotGeneration;
+			packageProductDependencies = (
+				3FC2C33E26C4E75F00C6D98F /* ScreenObject */,
+			);
 			productName = WordPressScreenshotGeneration;
 			productReference = FAF64BA22637DEEC00E8A1DF /* JetpackScreenshotGeneration.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -24795,6 +24800,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
+		};
+		3FC2C33E26C4E75F00C6D98F /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
 		};
 		3FF1442F266F3C2400138163 /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -525,6 +525,7 @@
 		3F8EEC7025B4849A00EC9DAE /* SiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EEC6F25B4849A00EC9DAE /* SiteListProvider.swift */; };
 		3F946C592684DD8E00B946F6 /* BloggingRemindersActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F946C582684DD8E00B946F6 /* BloggingRemindersActions.swift */; };
 		3F946C5A2684DD8E00B946F6 /* BloggingRemindersActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F946C582684DD8E00B946F6 /* BloggingRemindersActions.swift */; };
+		3F95FF4026C4F385007731D3 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C34226C4E8B700C6D98F /* ScreenObject */; };
 		3F9E724125A8E69900AAAB1A /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 3F9E724325A8E69900AAAB1A /* Localizable.strings */; };
 		3FA53E9C256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
 		3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA53E9B256571D800F4D9A2 /* HomeWidgetCache.swift */; };
@@ -546,8 +547,6 @@
 		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
-		3FC2C33F26C4E75F00C6D98F /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33E26C4E75F00C6D98F /* ScreenObject */; };
-		3FC2C34126C4E86500C6D98F /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C34026C4E86500C6D98F /* ScreenObject */; };
 		3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -7645,6 +7644,7 @@
 			files = (
 				3FA640662670CEFF0064401E /* XCTest.framework in Frameworks */,
 				3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */,
+				3F95FF4026C4F385007731D3 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7681,7 +7681,6 @@
 				3FA640622670CE260064401E /* UITestsFoundation.framework in Frameworks */,
 				2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
 				976E325EAC3B33524407BFC0 /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
-				3FC2C34126C4E86500C6D98F /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7780,7 +7779,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FA640672670D1290064401E /* UITestsFoundation.framework in Frameworks */,
-				3FC2C33F26C4E75F00C6D98F /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14546,6 +14544,7 @@
 			name = UITestsFoundation;
 			packageProductDependencies = (
 				3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */,
+				3FC2C34226C4E8B700C6D98F /* ScreenObject */,
 			);
 			productName = UITestsFoundation;
 			productReference = 3FA640572670CCD40064401E /* UITestsFoundation.framework */;
@@ -14624,7 +14623,6 @@
 			);
 			name = WordPressScreenshotGeneration;
 			packageProductDependencies = (
-				3FC2C34026C4E86500C6D98F /* ScreenObject */,
 			);
 			productName = WordPressScreenshotGeneration;
 			productReference = 8511CFB61C607A7000B7CEED /* WordPressScreenshotGeneration.xctest */;
@@ -14788,7 +14786,6 @@
 			);
 			name = JetpackScreenshotGeneration;
 			packageProductDependencies = (
-				3FC2C33E26C4E75F00C6D98F /* ScreenObject */,
 			);
 			productName = WordPressScreenshotGeneration;
 			productReference = FAF64BA22637DEEC00E8A1DF /* JetpackScreenshotGeneration.xctest */;
@@ -24811,7 +24808,7 @@
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
 		};
-		3FC2C34026C4E86500C6D98F /* ScreenObject */ = {
+		3FC2C34226C4E8B700C6D98F /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -566,7 +566,6 @@
 		3FE3D1FF26A6F56700F3CD10 /* Comment+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02F95E269DC14A00752A44 /* Comment+Interface.swift */; };
 		3FE77C8325B0CA89007DE9E5 /* LocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE77C8225B0CA89007DE9E5 /* LocalizableStrings.swift */; };
 		3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC241425D73E8B007AFE63 /* ConfettiView.swift */; };
-		3FF14430266F3C2400138163 /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FF1442F266F3C2400138163 /* ScreenObject */; };
 		3FF1A853242D5FCB00373F5D /* WPTabBarController+ReaderTabNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FF1A852242D5FCB00373F5D /* WPTabBarController+ReaderTabNavigation.swift */; };
 		400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AA222590E100EB0906 /* AllTimeStatsRecordValueTests.swift */; };
 		400199AD22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400199AC22259FF300EB0906 /* AnnualAndMostPopularTimeStatsRecordValueTests.swift */; };
@@ -7788,7 +7787,6 @@
 			files = (
 				3FA640612670CE210064401E /* UITestsFoundation.framework in Frameworks */,
 				4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */,
-				3FF14430266F3C2400138163 /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14808,7 +14806,6 @@
 			);
 			name = WordPressUITests;
 			packageProductDependencies = (
-				3FF1442F266F3C2400138163 /* ScreenObject */,
 			);
 			productName = WordPressUITests;
 			productReference = FF27168F1CAAC87A0006E2D4 /* WordPressUITests.xctest */;
@@ -24803,17 +24800,7 @@
 			package = 3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
 		};
-		3FC2C33E26C4E75F00C6D98F /* ScreenObject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = ScreenObject;
-		};
 		3FC2C34226C4E8B700C6D98F /* ScreenObject */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
-			productName = ScreenObject;
-		};
-		3FF1442F266F3C2400138163 /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -547,6 +547,7 @@
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
 		3FC2C33F26C4E75F00C6D98F /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33E26C4E75F00C6D98F /* ScreenObject */; };
+		3FC2C34126C4E86500C6D98F /* ScreenObject in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C34026C4E86500C6D98F /* ScreenObject */; };
 		3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */; };
 		3FC8D19B244F43B500495820 /* ReaderTabItemsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */; };
 		3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -7680,6 +7681,7 @@
 				3FA640622670CE260064401E /* UITestsFoundation.framework in Frameworks */,
 				2611CC62A62F9E6BC25350FE /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
 				976E325EAC3B33524407BFC0 /* Pods_WordPressScreenshotGeneration.framework in Frameworks */,
+				3FC2C34126C4E86500C6D98F /* ScreenObject in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -14621,6 +14623,9 @@
 				8511CFBC1C607A7000B7CEED /* PBXTargetDependency */,
 			);
 			name = WordPressScreenshotGeneration;
+			packageProductDependencies = (
+				3FC2C34026C4E86500C6D98F /* ScreenObject */,
+			);
 			productName = WordPressScreenshotGeneration;
 			productReference = 8511CFB61C607A7000B7CEED /* WordPressScreenshotGeneration.xctest */;
 			productType = "com.apple.product-type.bundle.ui-testing";
@@ -24802,6 +24807,11 @@
 			productName = XCUITestHelpers;
 		};
 		3FC2C33E26C4E75F00C6D98F /* ScreenObject */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
+			productName = ScreenObject;
+		};
+		3FC2C34026C4E86500C6D98F /* ScreenObject */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -21,7 +21,7 @@
             </BuildableReference>
          </BuildActionEntry>
          <BuildActionEntry
-            buildForTesting = "NO"
+            buildForTesting = "YES"
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -28,20 +28,6 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "E16AB92914D978240047A2E5"
-               BuildableName = "WordPressTest.xctest"
-               BlueprintName = "WordPressTest"
-               ReferencedContainer = "container:WordPress.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "8511CFB51C607A7000B7CEED"
                BuildableName = "WordPressScreenshotGeneration.xctest"
                BlueprintName = "WordPressScreenshotGeneration"

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressUITests.xcscheme
@@ -28,20 +28,6 @@
             buildForAnalyzing = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "FFF96F8119EBE7FB00DFC821"
-               BuildableName = "UITests.xctest"
-               BlueprintName = "UITests"
-               ReferencedContainer = "container:WordPress.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "NO"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
                BlueprintIdentifier = "E16AB92914D978240047A2E5"
                BuildableName = "WordPressTest.xctest"
                BlueprintName = "WordPressTest"

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -5,7 +5,7 @@ import XCTest
 class WordPressScreenshotGeneration: XCTestCase {
     let imagesWaitTime: UInt32 = 10
 
-    override func setUp() {
+    override func setUpWithError() throws {
         super.setUp()
 
         // Put setup code here. This method is called before the invocation of each test method in the class.
@@ -23,7 +23,7 @@ class WordPressScreenshotGeneration: XCTestCase {
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
         }
 
-        LoginFlow.login(siteUrl: "WordPress.com", username: ScreenshotCredentials.username, password: ScreenshotCredentials.password)
+        try LoginFlow.login(siteUrl: "WordPress.com", username: ScreenshotCredentials.username, password: ScreenshotCredentials.password)
     }
 
     override func tearDown() {


### PR DESCRIPTION
Sorry about missing them 🤦‍♂️ 😳 

To test, try building any of the two screenshots targets in `develop` and notice they'll fail. On this branch, they'll pass. Also notice CI is green, [including the UI tests](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/23619/workflows/ab888b8e-c2e9-4d5c-b000-ffdf412df287).

~~To avoid making this mistake again, I instructed the UI tests scheme to also build the screenshots targets. This should give us faster feedback on the need to update files from those targets in the future.~~ **Update** I had to remove this because, after the changes in how the code signing secrets are generated (#16806) building the Jetpack screenshots together with the WordPress ones resulted in two calls to the `Secrets.swift` generation and the build failed because multiple phases generated that same file.

Ideally, as we move more logic in the shared UI tests frameworks, this kind of errors will become less likely to occur because most things will be centralized.

## Regression Notes

1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
