### PR TITLE
Disable Support Screen UI Test

### DIFF
--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -26,7 +26,8 @@
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
-        "SignupTests\/testEmailSignup()"
+        "SignupTests\/testEmailSignup()",
+        "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {
         "containerPath" : "container:WordPress.xcodeproj",


### PR DESCRIPTION
This PR comes out of updating our login tests to account for the Unified Login & Signup flows. Context & status: paaHJt-1Kx-p2

This PR disables `testSupportScreenLoads()` in WordPressUITests.
Because CI doesn't use secrets, the Zendesk key isn't loaded, and thus the important asserted items do not, in fact, appear in CI. 

For more details about the test itself, see the following PRs:
https://github.com/wordpress-mobile/WordPress-iOS/pull/16976
https://github.com/wordpress-mobile/WordPress-iOS/pull/16937
https://github.com/wordpress-mobile/WordPress-iOS/pull/16837
https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/604
