### PR TITLE
Remove unused feature flags

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -664,9 +664,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (BOOL)supportsLayoutGrid
 {
-    if (![Feature enabled:FeatureFlagLayoutGrid]) {
-        return false;
-    }
     return self.isHostedAtWPcom || self.isAtomic;
 }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,7 +7,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case readerCSS
     case homepageSettings
     case unifiedPrologueCarousel
-    case layoutGrid
     case todayWidget
     case milestoneNotifications
     case bloggingReminders
@@ -31,8 +30,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .homepageSettings:
             return true
         case .unifiedPrologueCarousel:
-            return true
-        case .layoutGrid:
             return true
         case .todayWidget:
             return true
@@ -82,8 +79,6 @@ extension FeatureFlag {
             return "Homepage Settings"
         case .unifiedPrologueCarousel:
             return "Unified Prologue Carousel"
-        case .layoutGrid:
-            return "Layout Grid"
         case .todayWidget:
             return "iOS 14 Today Widget"
         case .milestoneNotifications:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -7,7 +7,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case readerCSS
     case homepageSettings
     case unifiedPrologueCarousel
-    case stories
     case layoutGrid
     case todayWidget
     case milestoneNotifications
@@ -32,8 +31,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .homepageSettings:
             return true
         case .unifiedPrologueCarousel:
-            return true
-        case .stories:
             return true
         case .layoutGrid:
             return true
@@ -85,8 +82,6 @@ extension FeatureFlag {
             return "Homepage Settings"
         case .unifiedPrologueCarousel:
             return "Unified Prologue Carousel"
-        case .stories:
-            return "Stories"
         case .layoutGrid:
             return "Layout Grid"
         case .todayWidget:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -6,11 +6,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case debugMenu
     case readerCSS
     case homepageSettings
-    case gutenbergMentions
-    case gutenbergXposts
     case unifiedPrologueCarousel
     case stories
-    case contactInfo
     case layoutGrid
     case todayWidget
     case milestoneNotifications
@@ -34,15 +31,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .homepageSettings:
             return true
-        case .gutenbergMentions:
-            return true
-        case .gutenbergXposts:
-            return true
         case .unifiedPrologueCarousel:
             return true
         case .stories:
-            return true
-        case .contactInfo:
             return true
         case .layoutGrid:
             return true
@@ -92,16 +83,10 @@ extension FeatureFlag {
             return "Ignore Reader CSS Cache"
         case .homepageSettings:
             return "Homepage Settings"
-        case .gutenbergMentions:
-            return "Mentions in Gutenberg"
-        case .gutenbergXposts:
-            return "Xposts in Gutenberg"
         case .unifiedPrologueCarousel:
             return "Unified Prologue Carousel"
         case .stories:
             return "Stories"
-        case .contactInfo:
-            return "Contact Info"
         case .layoutGrid:
             return "Layout Grid"
         case .todayWidget:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FAB.swift
@@ -39,8 +39,7 @@ extension BlogDetailsViewController {
         return coordinator
     }
 
-    //TODO: Can be removed after stories launches
     private var shouldShowNewStory: Bool {
-        return Feature.enabled(.stories) && blog.supports(.stories) && !UIDevice.isPad()
+        return blog.supports(.stories) && !UIDevice.isPad()
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1134,7 +1134,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .unsupportedBlockEditor: isUnsupportedBlockEditorEnabled,
             .canEnableUnsupportedBlockEditor: post.blog.jetpack?.isConnected ?? false,
             .isAudioBlockMediaUploadEnabled: !isFreeWPCom,
-            .mediaFilesCollectionBlock: FeatureFlag.stories.enabled && post.blog.supports(.stories) && !UIDevice.isPad(),
+            .mediaFilesCollectionBlock: post.blog.supports(.stories) && !UIDevice.isPad(),
             // Only enable reusable block in WP.com sites until the issue
             // (https://github.com/wordpress-mobile/gutenberg-mobile/issues/3457) in self-hosted sites is fixed
             .reusableBlock: isWPComSite,

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1127,9 +1127,9 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
         let isFreeWPCom = post.blog.isHostedAtWPcom && !post.blog.hasPaidPlan
         let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic()
         return [
-            .mentions: FeatureFlag.gutenbergMentions.enabled && SuggestionService.shared.shouldShowSuggestions(for: post.blog),
-            .xposts: FeatureFlag.gutenbergXposts.enabled && SiteSuggestionService.shared.shouldShowSuggestions(for: post.blog),
-            .contactInfoBlock: post.blog.supports(.contactInfo) && FeatureFlag.contactInfo.enabled,
+            .mentions: SuggestionService.shared.shouldShowSuggestions(for: post.blog),
+            .xposts: SiteSuggestionService.shared.shouldShowSuggestions(for: post.blog),
+            .contactInfoBlock: post.blog.supports(.contactInfo),
             .layoutGridBlock: post.blog.supports(.layoutGrid),
             .unsupportedBlockEditor: isUnsupportedBlockEditorEnabled,
             .canEnableUnsupportedBlockEditor: post.blog.jetpack?.isConnected ?? false,

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -170,7 +170,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                     self?.createPost()
             }, source: Constants.source)
         ]
-        if Feature.enabled(.stories) && blog.supports(.stories) {
+        if blog.supports(.stories) {
             actions.insert(StoryAction(handler: { [weak self] in
                 guard let self = self else {
                     return

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -22,7 +22,7 @@ import WordPressFlux
     private let noticeAnimator = NoticeAnimator(duration: 0.5, springDampening: 0.7, springVelocity: 0.0)
 
     private func notice(for blog: Blog) -> Notice {
-        let showsStories = Feature.enabled(.stories) && blog.supports(.stories)
+        let showsStories = blog.supports(.stories)
         let title = showsStories ? NSLocalizedString("Create a post, page, or story", comment: "The tooltip title for the Floating Create Button") : NSLocalizedString("Creates new post, or page", comment: " Accessibility hint for create floating action button")
         let notice = Notice(title: title,
                             message: "",
@@ -182,7 +182,7 @@ import WordPressFlux
     }
 
     @objc func showCreateButton(for blog: Blog) {
-        let showsStories = Feature.enabled(.stories) && blog.supports(.stories)
+        let showsStories = blog.supports(.stories)
         button.accessibilityHint = showsStories ? NSLocalizedString("Creates new post, page, or story", comment: " Accessibility hint for create floating action button") : NSLocalizedString("Create a post or page", comment: " Accessibility hint for create floating action button")
         showCreateButton(notice: notice(for: blog))
     }


### PR DESCRIPTION
Removes feature flags that are no longer used and in-turn removes them from the app's Debug menu (tap Profile icon > App Settings > Debug – **only available on branch builds**):
- `gutenbergMentions`
- `gutenbergXposts`
- `contactInfo`
- `stories`
- `layoutGrid`

To test:

Smoke test each of the above features to make sure this PR didn't inadvertently break them.

## Regression Notes
1. Potential unintended areas of impact

If these feature flags are not removed properly, they can impact the features they were previously controlling.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Smoke test each feature to make sure it still works.

3. What automated tests I added (or what prevented me from doing so)

These feature flags affect blocks which all have tests in the Gutenberg Mobile repository; however, that doesn't help us verify that this PR didn't break those features because they are explicitly enabled in the demo app where tests are run (e.g. see [here](https://github.com/WordPress/gutenberg/blob/trunk/packages/react-native-editor/ios/GutenbergDemo/GutenbergViewController.swift#L304-L305)).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
