### PR TITLE
Make Plugins selectable and scrollable (again)

### DIFF
--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -67,7 +67,9 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
         cell.titleLabel.text = title
 
         cell.actionButton.setTitle(secondaryTitle, for: .normal)
-        cell.buttonTappedAction = { self.action?(self) }
+        cell.buttonTappedAction = {
+            self.action?(self)
+        }
 
         cell.noResultsView = noResultsView
 
@@ -80,6 +82,7 @@ struct CollectionViewContainerRow<CollectionViewCellType: UICollectionViewCell, 
 
         cell.collectionView.delegate = helper
         cell.collectionView.dataSource = helper
+        cell.collectionView.isUserInteractionEnabled = true
     }
 
 }


### PR DESCRIPTION

Fixes #16087 

To test:
Test on iPhone and iPad
- Build run and go to My Site -> Plugins
- make sure the plugins are scrollable and selectable
- make sure the action buttons (Manage and See All) work properly

## Regression Notes
1. Potential unintended areas of impact
- None, this just sets a property that should have been implicitly set on an object (`UICollectionView`)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
test on iPhone and iPad

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
