### PR TITLE
Fixes a scrolling issue in the plugins VC.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 18.1
 -----
+* [*] Fixed a bug that would make it impossible to scroll the plugins the first time the plugin section was opened.
 
 
 18.0

--- a/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift
@@ -134,24 +134,21 @@ class CollectionViewContainerCell: UITableViewCell {
             oldValue?.removeFromView()
 
             guard let noResultsView = noResultsView else {
-                    return
+                return
             }
 
-            let containerView = UIView(frame: collectionView.frame)
-            containerView.translatesAutoresizingMaskIntoConstraints = false
-
             noResultsView.view.backgroundColor = .clear
-            noResultsView.view.frame = containerView.frame
+            noResultsView.view.frame = collectionView.frame
             noResultsView.view.frame.origin.y = 0
+            noResultsView.view.translatesAutoresizingMaskIntoConstraints = false
 
-            containerView.addSubview(noResultsView.view)
-            addSubview(containerView)
+            addSubview(noResultsView.view)
 
             NSLayoutConstraint.activate([
-                containerView.topAnchor.constraint(equalTo: collectionView.topAnchor),
-                containerView.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor),
-                containerView.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor),
-                containerView.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor)
+                noResultsView.view.topAnchor.constraint(equalTo: collectionView.topAnchor),
+                noResultsView.view.bottomAnchor.constraint(equalTo: collectionView.bottomAnchor),
+                noResultsView.view.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor),
+                noResultsView.view.trailingAnchor.constraint(equalTo: collectionView.trailingAnchor)
                 ])
         }
     }


### PR DESCRIPTION
Fixes #https://github.com/wordpress-mobile/WordPress-iOS/issues/16087

This time for good.  The culprit was found.

It seems [we were adding an extra container view in a very hackish manner](https://github.com/wordpress-mobile/WordPress-iOS/blob/c57edd505c96e20f3f957e8d424a982437f141f2/WordPress/Classes/ViewRelated/Plugins/CollectionViewContainerRow.swift#L140-L148), but were not removing it ever, causing it to intercept all of the gestures that were intended for the collection view below.

## To test:

Test with an iPhone and an iPad.

1. Try loading the plugins view while offline, and make sure the no-results view looks good.
2. Go back online and tap "try again" a few times.  Make sure the plugins show up (it can take a few attempts until WPiOS realizes it's online).
3. Also try installing the App from scratch, as that was the plugins scrolling was broken on the first time the plugins section was opened.

## Regression Notes

1. Potential unintended areas of impact

There's a change the no-results logic could be broken, but I tested it as part of this PR.  Test the plugins section for a site with no connection and reconnect.  Make sure everything works.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested them.

3. What automated tests I added (or what prevented me from doing so)

None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
