### PR TITLE
Notifications: Adjust filter bar container background color

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -596,7 +596,7 @@ private extension NotificationsViewController {
         filterTabBarBottomConstraint.constant = usesUnifiedList ? Constants.filterTabBarBottomSpace : 0
 
         // With the 10pt bottom padding addition, ensure that the extra padding has the same background color
-        // as the table header cell.
+        // as the table header cell. NOTE: Move this line to `setupFilterBar` once the feature flag is removed.
         filterTabBar.superview?.backgroundColor = usesUnifiedList ? .systemBackground : .filterBarBackground
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -594,6 +594,10 @@ private extension NotificationsViewController {
     /// See: https://git.io/JBQlU
     func updateFilterBarConstraints() {
         filterTabBarBottomConstraint.constant = usesUnifiedList ? Constants.filterTabBarBottomSpace : 0
+
+        // With the 10pt bottom padding addition, ensure that the extra padding has the same background color
+        // as the table header cell.
+        filterTabBar.superview?.backgroundColor = usesUnifiedList ? .systemBackground : .filterBarBackground
     }
 }
 


### PR DESCRIPTION
This fixes the background color from the filter tab bar that looks like it's "leaking" to the table view's first header view cell in dark mode. This is because the background of the filter tab bar's superview is set to `.filterBackground`, and in #16962 a 10pt constraint is added on the bottom of the filter bar container to improve the visual aspects.

To fix this, the filter tab bar's superview is set to `.systemBackground` while the unified list feature flag is enabled.

Before | After
--|--
![filter_before](https://user-images.githubusercontent.com/1299411/129569793-74fbec7c-e754-4036-8a78-e54021e4acae.png) | ![filter_after](https://user-images.githubusercontent.com/1299411/129569800-d13d9bee-1c2e-494d-b873-30683f86a839.png)

To test:
- Set the app appearance settings to dark.
- Go to Notifications tab.
- Verify that the filter tab bar is displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested in iPhone and iPad.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
