### PR TITLE
Stats Insights: Fix reloading for empty insights

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -216,6 +216,11 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     @objc func refreshData() {
+        guard !insightsToShow.isEmpty else {
+            refreshControl?.endRefreshing()
+            return
+        }
+
         refreshControl?.beginRefreshing()
         clearExpandedRows()
         refreshInsights()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -173,6 +173,7 @@ private extension SiteStatsInsightsTableViewController {
         }
 
         insightsChangeReceipt = viewModel?.onChange { [weak self] in
+            self?.displayEmptyViewIfNecessary()
             self?.refreshTableView()
         }
     }


### PR DESCRIPTION
This PR fixes an issue where the Stats insights screen wasn't being properly reloaded if no insights have been added yet.

Fixes #16816


## To test

1. Open Jetpack Stats, first tab: `Insights`
2. Make sure you have no insights (delete all)
3. Go back and open `Insights` tab again. You should see the `No insights added yet` message
4. Swipe down to refresh 
5. ✅ The `No insights added yet` message should be displayed again 
 
https://user-images.githubusercontent.com/6711616/129594613-5993d5dd-8cb6-4530-91aa-070c1dfdd4c5.mp4

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
