### PR TITLE
Add 16px padding to top of undo cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.swift
@@ -48,6 +48,10 @@ final class ReaderSavedPostUndoCell: UITableViewCell {
     }
 
     private func applyStyles() {
+        backgroundColor = .clear
+        contentView.backgroundColor = .listBackground
+        borderedView.backgroundColor = .listForeground
+
         borderedView.layer.borderColor = WPStyleGuide.readerCardCellBorderColor().cgColor
         borderedView.layer.borderWidth = .hairlineBorderWidth
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSavedPostUndoCell.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,66 +11,67 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="44" id="KGk-i7-Jjw" customClass="ReaderSavedPostUndoCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+            <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="60"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TBy-h6-gyK" userLabel="Bordered View">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                        <rect key="frame" x="0.0" y="16" width="320" height="44"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="44" id="OeB-Do-X3c"/>
-                        </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="0qS-wL-AiS">
-                        <rect key="frame" x="16" y="6" width="288" height="30"/>
+                        <rect key="frame" x="0.0" y="16" width="320" height="44"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="edF-mf-PsH">
-                                <rect key="frame" x="0.0" y="0.0" width="226" height="30"/>
+                                <rect key="frame" x="16" y="8" width="226" height="28"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Removed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qPM-It-aeV">
-                                        <rect key="frame" x="0.0" y="0.0" width="71.5" height="30"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="71.5" height="28"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="249" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lnR-4i-vdi">
-                                        <rect key="frame" x="77.5" y="0.0" width="148.5" height="30"/>
+                                        <rect key="frame" x="77.5" y="0.0" width="148.5" height="28"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
                             </stackView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
-                                <rect key="frame" x="242" y="0.0" width="46" height="30"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Jmj-W8-Yz3">
+                                <rect key="frame" x="258" y="8" width="46" height="28"/>
                                 <state key="normal" title="Button"/>
                                 <connections>
                                     <action selector="undo:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="ZyQ-ga-eiX"/>
                                 </connections>
                             </button>
                         </subviews>
+                        <edgeInsets key="layoutMargins" top="8" left="16" bottom="8" right="16"/>
                     </stackView>
                 </subviews>
+                <color key="backgroundColor" red="0.66667121650000005" green="0.66665846110000004" blue="0.66666716339999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                 <constraints>
-                    <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="FCo-M3-vdJ"/>
-                    <constraint firstAttribute="trailing" secondItem="TBy-h6-gyK" secondAttribute="trailing" id="HV5-h3-5B3"/>
-                    <constraint firstAttribute="bottom" secondItem="TBy-h6-gyK" secondAttribute="bottom" id="UDU-ic-hD6"/>
-                    <constraint firstAttribute="trailingMargin" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
-                    <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eGO-Jj-XbX"/>
-                    <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="pGx-RV-Mba"/>
-                    <constraint firstItem="0qS-wL-AiS" firstAttribute="centerY" secondItem="H2p-sc-9uM" secondAttribute="centerY" id="rhX-kB-f68"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="leading" secondItem="0qS-wL-AiS" secondAttribute="leading" id="3Om-KB-yeK"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="bottom" secondItem="0qS-wL-AiS" secondAttribute="bottom" id="Efm-bf-Ccw"/>
+                    <constraint firstItem="0qS-wL-AiS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="FCo-M3-vdJ"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="XDb-Vs-Md4"/>
+                    <constraint firstItem="TBy-h6-gyK" firstAttribute="top" secondItem="0qS-wL-AiS" secondAttribute="top" id="Yca-6A-zNY"/>
+                    <constraint firstAttribute="trailing" secondItem="0qS-wL-AiS" secondAttribute="trailing" id="dU4-cX-eF9"/>
+                    <constraint firstAttribute="bottom" secondItem="0qS-wL-AiS" secondAttribute="bottom" id="mLf-uf-Tyh"/>
+                    <constraint firstItem="0qS-wL-AiS" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="16" id="qJR-6z-cCt"/>
                 </constraints>
             </tableViewCellContentView>
-            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <viewLayoutGuide key="safeArea" id="fom-MN-bfE"/>
             <connections>
                 <outlet property="borderedView" destination="TBy-h6-gyK" id="yrB-iu-Zba"/>
                 <outlet property="removed" destination="qPM-It-aeV" id="UIu-47-UqL"/>
                 <outlet property="title" destination="lnR-4i-vdi" id="Eol-Q8-exV"/>
                 <outlet property="undoButton" destination="Jmj-W8-Yz3" id="rWp-Qa-Nyt"/>
             </connections>
+            <point key="canvasLocation" x="13" y="80"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
Fixes #16577

## Description 

This PR adds a **16 px padding** on the top of the **Undo cell**. This resolves an issue where the Undo cell looked like it was part of a different Post cell, due to the lack of padding.


Before | After 
-- | --
<img src="https://user-images.githubusercontent.com/6711616/129761038-d29c52fd-adcc-48a3-94d7-6205a8d5ae1a.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/129761058-6da59add-5347-4cd5-9b84-aa15b20bbdcb.png" width=300>

## To test
1. Go to the **Reader tab**
2. Save **3 posts**
3. Go to the **Saved tab**
4. Unsave the **second post** in the list
5. ✅ There should be a **16 px padding** on top of the **Undo cell**

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a, just visual changes

3. What automated tests I added (or what prevented me from doing so)
n/a, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
