### PR TITLE
Likes lists: show specific error messages when fetching fails

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1385,18 +1385,14 @@ extension NotificationDetailsViewController: LikesListControllerDelegate {
         displayUserProfile(user, from: indexPath)
     }
 
-    func showErrorView() {
+    func showErrorView(title: String, subtitle: String?) {
         hideNoResults()
         configureAndDisplayNoResults(on: tableView,
-                                     title: NoResultsText.errorTitle,
-                                     subtitle: NoResultsText.errorSubtitle,
+                                     title: title,
+                                     subtitle: subtitle,
                                      image: "wp-illustration-notifications")
     }
 
-    private struct NoResultsText {
-        static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading notification likes.")
-        static let errorSubtitle = NSLocalizedString("There was an error loading likes", comment: "Text displayed when there is a failure loading notification likes.")
-    }
 }
 
 // MARK: - Private Properties

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesListController.swift
@@ -65,10 +65,6 @@ private extension ReaderDetailLikesListController {
                                               comment: "Plural format string for view title displaying the number of post likes. %1$d is the number of likes.")
     }
 
-    struct NoResultsText {
-        static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading notification likes.")
-        static let errorSubtitle = NSLocalizedString("There was an error loading likes", comment: "Text displayed when there is a failure loading notification likes.")
-    }
 }
 
 // MARK: - LikesListController Delegate
@@ -79,10 +75,10 @@ extension ReaderDetailLikesListController: LikesListControllerDelegate {
         displayUserProfile(user, from: indexPath)
     }
 
-    func showErrorView() {
+    func showErrorView(title: String, subtitle: String?) {
         configureAndDisplayNoResults(on: tableView,
-                                     title: NoResultsText.errorTitle,
-                                     subtitle: NoResultsText.errorSubtitle,
+                                     title: title,
+                                     subtitle: subtitle,
                                      image: "wp-illustration-reader-empty")
     }
 


### PR DESCRIPTION
Fixes #17009

This changes the Likes lists to show the API response error message when fetching likes fails so it's clear(er) to the user why it failed. 
- The error title is now `Error loading likes` (instead of `Oops`).
- The error subtitle is the API response error message.
- The error strings are now provided by `LikesListController`, instead of duplicated in `NotificationDetailsViewController` and `ReaderDetailLikesListController`.

To test:

Refer to https://github.com/wordpress-mobile/WordPress-iOS/issues/17009 for the specific error messages available for Comments and Posts likes. Since they're all displayed the same way in app, I don't think it's necessary to test _every_ case. Below are steps for two:
- `User cannot access this private blog`
- `Unknown comment`/`Unknown post`
---

`User cannot access this private blog`:

Notifications:
- In the app, find a Like notification (either Post or Comment) and verify you can view the likes list.
- Remove yourself as a member of that P2 with the Automattic Blogs tool.
- In the app, try to view the Likes list again. 
- Verify the error message is displayed.

Reader Post:
- In the app, find a Reader post with likes and verify you can view the likes list.
- Remove yourself as a member of that P2 with the Automattic Blogs tool.
- In the app, try to view the Likes list again. 
- Verify the error message is displayed.

| Notification | Reader Post |
|--------|-------|
| ![notif_likes](https://user-images.githubusercontent.com/1816888/129786877-7d327d99-9610-49f3-ae7e-0dbc4c1f7ab2.jpg) | ![reader_likes](https://user-images.githubusercontent.com/1816888/129786901-4ec65b5c-4c01-4212-a1a7-cce78900c8ac.jpg) |

---

`Unknown comment`/`Unknown post`:
- In the [`fetchLikes`](https://github.com/wordpress-mobile/WordPress-iOS/blob/2ee057815aa56eac808e6f318aa65f6bf8443b78/WordPress/Classes/ViewRelated/Likes/LikesListController.swift#L254) method, change `postID` and `commentID` to a bogus number.
```
postService.getLikesFor(postID: 999,
...
commentService.getLikesFor(commentID: 999,
```

- Attempt to view the Likes list for:
  - Comment like notification.
  - Post like notification.
  - Reader post.
- Verify the error message is displayed.

| Comment like | Post like | Reader Post likes |
|--------|-------|-------|
| ![notif_invalid_comment_id](https://user-images.githubusercontent.com/1816888/129787684-c6ab205e-39b2-487b-96cf-36806f5ae605.jpg) | ![notif_invalid_post_id](https://user-images.githubusercontent.com/1816888/129787720-56fd7c13-122b-4c1b-a4f0-b1cfc503f7ae.jpg) | ![reader_invalid_post_id](https://user-images.githubusercontent.com/1816888/129787758-512cd4fc-8888-43a7-8b88-21747721b77e.jpg) |
---

## Regression Notes
1. Potential unintended areas of impact
Shouldn't be any.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Likes lists in notifications and reader posts to ensure errors are displayed as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
