### PR TITLE
Track analytic event when editor help is shown

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -46,6 +46,7 @@ import Foundation
     case gutenbergUnsupportedBlockWebViewClosed
     case gutenbergSuggestionSessionFinished
     case gutenbergEditorSettingsFetched
+    case gutenbergEditorHelpShown
 
     // Notifications Permissions
     case pushNotificationsPrimerSeen
@@ -249,6 +250,8 @@ import Foundation
             return "suggestion_session_finished"
         case .gutenbergEditorSettingsFetched:
             return "editor_settings_fetched"
+        case .gutenbergEditorHelpShown:
+            return "editor_help_shown"
         // Notifications permissions
         case .pushNotificationsPrimerSeen:
             return "notifications_primer_seen"

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -481,6 +481,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     }
 
     func showEditorHelp() {
+        WPAnalytics.track(.gutenbergEditorHelpShown)
         gutenberg.showEditorHelp()
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -481,7 +481,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     }
 
     func showEditorHelp() {
-        WPAnalytics.track(.gutenbergEditorHelpShown)
+        WPAnalytics.track(.gutenbergEditorHelpShown, properties: [:], blog: post.blog)
         gutenberg.showEditorHelp()
     }
 


### PR DESCRIPTION
## Related PRs

* https://github.com/wordpress-mobile/WordPress-Android/pull/15219

## Description

Improve our ability to understand how users interact with the editor help content.

To test:

1. Launch the editor.
1. Tap the three-dot button in the top right corner of the editor.
1. Tap Help.
1. ℹ️ **Expected:** The `wpios_editor_help_shown` event arrives in Tracks.

## Regression Notes
1. Potential unintended areas of impact
  The new analytic event could disrupt opening the help content.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Verified the help content continues to display.
3. What automated tests I added (or what prevented me from doing so)
  The majority of the help content logic resides in the editor, so placing tests
within this repository makes less sense.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
