### PR TITLE
Remove translations reviewers build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,6 @@ orbs:
   slack: circleci/slack@3.4.2
 
 parameters:
-  translation_review_build:
-    type: boolean
-    default: false
-  translation_review_lang_id:
-    type: string
-    default: all-lang
   beta_build:
     type: boolean
     default: false
@@ -239,43 +233,6 @@ jobs:
           webhook: '${SLACK_BUILD_WEBHOOK}'
           failure_message: '${SLACK_FAILURE_MESSAGE}'
           success_message: '${SLACK_SUCCESS_MESSAGE}'
-  translation-review-build:
-    executor:
-      name: ios/default
-      <<: *xcode_version
-    environment:
-      HOMEBREW_NO_AUTO_UPDATE: 1
-    steps:
-      - fix-image
-      - git/shallow-checkout
-      - ios/install-dependencies:
-            bundle-install: true
-            pod-install: true
-            cache-prefix: cache-prefix-{{ checksum ".circleci/cache-version" }}
-      - run:
-          name: Copy Secrets
-          command: bundle exec fastlane run configure_apply
-      - run:
-          name: Install other tools
-          command: |
-            brew update # Update homebrew to temporarily fix a bintray issue
-            brew install imagemagick
-            brew install ghostscript
-            curl -sL https://sentry.io/get-cli/ | bash
-      - run:
-          name: Build
-          command: |
-            orig_version=`cat config/Version.internal.xcconfig | grep VERSION_SHORT | cut -d'=' -f2`
-            sed -i '' "$(awk '/^VERSION_SHORT/{ print NR; exit }' "config/Version.internal.xcconfig")s/=.*/="${orig_version}"-`date +"%Y%d%m"`-"${CIRCLE_BUILD_NUM}"/" "config/Version.internal.xcconfig"
-
-            VERSION_NAME="all-lang-build-${CIRCLE_BUILD_NUM}"
-            echo "export VERSION_NAME=$VERSION_NAME" >> $BASH_ENV
-
-            bundle exec fastlane build_for_translation_review version_name:$VERSION_NAME
-          no_output_timeout: 60m
-      - store_artifacts:
-          path: Artifacts
-          destination: Artifacts
   Jetpack Installable Build:
     executor:
       name: ios/default
@@ -337,7 +294,6 @@ workflows:
   wordpress_ios:
     when:
       and:
-        - not: << pipeline.parameters.translation_review_build >>
         - not: << pipeline.parameters.beta_build >>
         - not: << pipeline.parameters.release_build >>
     jobs:
@@ -392,7 +348,6 @@ workflows:
   Installable Build:
     when:
       and:
-        - not: << pipeline.parameters.translation_review_build >>
         - not: << pipeline.parameters.beta_build >>
         - not: << pipeline.parameters.release_build >>
     jobs:
@@ -422,10 +377,6 @@ workflows:
       or: [ << pipeline.parameters.beta_build >>, << pipeline.parameters.release_build >> ]
     jobs:
       - Release Build
-  Translation Review Build:
-    when: << pipeline.parameters.translation_review_build >>
-    jobs:
-      - translation-review-build
   Jetpack Nightly:
     triggers:
        - schedule:

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -679,60 +679,6 @@ platform :ios do
     end
   end
 
-  #####################################################################################
-  # build_for_translation_review
-  # -----------------------------------------------------------------------------------
-  # This lane builds the app with pending translations for reviewers
-  # -----------------------------------------------------------------------------------
-  # Usage:
-  # bundle exec fastlane build_for_translation_review version_name:1234
-  #
-  # Example:
-  # bundle exec fastlane build_for_translation_review version_name:1234
-  #####################################################################################
-  desc 'Builds and uploads for translation review'
-  lane :build_for_translation_review do |options|
-    ios_build_preflight unless options[:skip_prechecks]
-
-    puts "Building version: #{options[:version_name]}"
-
-    update_translations_script_path = File.join(PROJECT_ROOT_FOLDER, 'Scripts', 'update-translations.rb')
-    sh(update_translations_script_path, 'review', 'current')
-    sh(update_translations_script_path, 'review', 'waiting')
-    sh(update_translations_script_path, 'review', 'fuzzy')
-
-    ios_merge_translators_strings(strings_folder: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources'))
-
-    extract_framework_translations_script_path = File.join(PROJECT_ROOT_FOLDER, 'Scripts', 'extract-framework-translations.swift')
-    sh(extract_framework_translations_script_path)
-
-    gym(
-      clean: true,
-      workspace: WORKSPACE_PATH,
-      scheme: 'WordPress',
-      configuration: 'Debug',
-      derived_data_path: DERIVED_DATA_PATH,
-      skip_package_ipa: true,
-      skip_archive: true,
-      destination: 'generic/platform=iOS Simulator'
-    )
-
-    FileUtils.mkdir_p(File.join(PROJECT_ROOT_FOLDER, 'Artifacts'))
-
-    build_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products', 'Debug-iphonesimulator', 'WordPress.app')
-    output_path = File.join(PROJECT_ROOT_FOLDER, 'Artifacts', "WordPress-#{options[:version_name]}.zip")
-
-    # Appetize.io expects the `.app` bundle to be wrapped in a `.zip` file
-    zip(path: build_path, output_path: output_path)
-
-    # Upload the app to Appetize.io
-    appetize(
-      path: output_path,
-      api_token: ENV['APPET_TOKEN'],
-      public_key: 'u33365457th0bw8wga7x856a8r'
-    )
-  end
-
   desc 'Build for Testing'
   lane :build_for_testing do |options|
     run_tests(


### PR DESCRIPTION
Translations Reviewers build was a HackWeek effort by i18n and Platform9 teams to try to create a tool to support the reviewers during their work. The project hasn't seen a lot of users and, so, recently, we decided not to renew one of the services it relied on.

This PR removes the related job from the CircleCI config in order to keep the file clean and avoid working on migrating unused jobs :-)

To test:
- Check that CI is green.
- 
## Regression Notes
1. Potential unintended areas of impact
None that I can think of.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
 - 

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
