### PR TITLE
Remove UI tests utility logic in favor of XCUITestHelpers

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,9 +14,9 @@
         "package": "XCUITestHelpers",
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
-          "branch": null,
-          "revision": "47d688b0b2a6356361a16836c4d23f12d6643a73",
-          "version": "0.1.0"
+          "branch": "add-helpers-from-woo",
+          "revision": "fefe695dd1e81eeaf5389f0ddbe7ab53a54cdee5",
+          "version": null
         }
       }
     ]

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -87,7 +87,7 @@ class JetpackScreenshotGeneration: XCTestCase {
 extension BaseScreen {
     @discardableResult
     func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
-        let mode = isDarkMode ? "dark" : "light"
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(index)-\(mode)-\(title)"
 
         snapshot(filename)

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -17,7 +17,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         let app = XCUIApplication()
         setupSnapshot(app)
 
-        if isIpad {
+        if XCUIDevice.isPad {
             XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
         } else {
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
@@ -44,7 +44,7 @@ class JetpackScreenshotGeneration: XCTestCase {
             .gotoActivityLog()
             .thenTakeScreenshot(2, named: "ActivityLog")
 
-        if !isIpad {
+        if !XCUIDevice.isPad {
             activityLog.pop()
         }
 
@@ -57,7 +57,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         jetpackScan
             .thenTakeScreenshot(3, named: "JetpackScan")
 
-        if !isIpad {
+        if !XCUIDevice.isPad {
             jetpackScan.pop()
         }
 
@@ -71,7 +71,7 @@ class JetpackScreenshotGeneration: XCTestCase {
 
         jetpackBackupOptions.pop()
 
-        if !isIpad {
+        if !XCUIDevice.isPad {
             jetpackBackup.pop()
         }
 

--- a/WordPress/UITestsFoundation/BaseScreen.swift
+++ b/WordPress/UITestsFoundation/BaseScreen.swift
@@ -37,13 +37,6 @@ open class BaseScreen {
     public func isLoaded() -> Bool {
         return expectedElement.exists
     }
-
-    public func tapStatusBarToScrollToTop() {
-        // A hack to work around there being no status bar – just tap the appropriate spot on the navigation bar
-        XCUIApplication().navigationBars.allElementsBoundByIndex.forEach {
-           $0.coordinate(withNormalizedOffset: CGVector(dx: 20, dy: -20)).tap()
-        }
-    }
 }
 
 // MARK: - Dump of files from the other targets

--- a/WordPress/UITestsFoundation/BaseScreen.swift
+++ b/WordPress/UITestsFoundation/BaseScreen.swift
@@ -75,8 +75,6 @@ extension BaseScreen {
     /// TODO: The implementation of this could use work:
     /// - What happens if the element is above the current scroll view position?
     /// - What happens if it's a really long scroll view?
-    //
-    // FIXME: This is already part of XCUITestHelpers
     public func scrollElementIntoView(element: XCUIElement, within scrollView: XCUIElement, threshold: Int = 1000) {
 
         var iteration = 0

--- a/WordPress/UITestsFoundation/FancyAlertComponent.swift
+++ b/WordPress/UITestsFoundation/FancyAlertComponent.swift
@@ -1,4 +1,5 @@
 import XCTest
+import XCUITestHelpers
 
 public class FancyAlertComponent: BaseScreen {
     let defaultAlertButton: XCUIElement
@@ -23,7 +24,7 @@ public class FancyAlertComponent: BaseScreen {
 
     public func acceptAlert() {
         XCTAssert(defaultAlertButton.waitForExistence(timeout: 3))
-        XCTAssert(defaultAlertButton.waitForHittability(timeout: 3))
+        XCTAssert(defaultAlertButton.waitForIsHittable(timeout: 3))
 
         XCTAssert(defaultAlertButton.isHittable)
         defaultAlertButton.tap()

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -1,15 +1,6 @@
 import UIKit
 import XCTest
 
-// TODO: This should go into a UIDevice extension (eg: `UIDevice.current.isPad`)
-public var isIpad: Bool {
-    return UIDevice.current.userInterfaceIdiom == .pad
-}
-// TODO: This should go into a UIDevice extension (eg: `UIDevice.current.isPhone`)
-public var isIPhone: Bool {
-    return UIDevice.current.userInterfaceIdiom == .phone
-}
-
 // TODO: This should maybe go in an `XCUIApplication` extension? Also, should it be computed rather
 // than stored as a reference? 🤔
 public let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)

--- a/WordPress/UITestsFoundation/XCUIElement+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Utils.swift
@@ -25,12 +25,4 @@ public extension XCUIElement {
 
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)
     }
-
-    /// Removes any current text in the field
-    func clearTextIfNeeded() -> Void {
-        let app = XCUIApplication()
-
-        self.press(forDuration: 1.2)
-        app.keys["delete"].tap()
-    }
 }

--- a/WordPress/UITestsFoundation/XCUIElement+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Utils.swift
@@ -3,17 +3,6 @@ import XCTest
 // TODO: This should go XCUITestHelpers if not there already
 public extension XCUIElement {
 
-    @discardableResult
-    // TODO: When moving to framework, find name that doesn't trigger grammar warning
-    func waitForHittability(timeout: TimeInterval) -> Bool {
-
-        let predicate = NSPredicate(format: "isHittable == true")
-        let elementPredicate = XCTNSPredicateExpectation(predicate: predicate, object: self)
-        let result = XCTWaiter.wait(for: [elementPredicate], timeout: timeout)
-
-        return result == .completed
-    }
-
     var isFullyVisibleOnScreen: Bool {
         guard self.exists && !self.frame.isEmpty && self.isHittable else { return false }
         return XCUIApplication().windows.element(boundBy: 0).frame.contains(self.frame)

--- a/WordPress/UITestsFoundation/XCUIElementQuery+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElementQuery+Utils.swift
@@ -3,13 +3,6 @@ import XCTest
 // TODO: This might be better suited in the XCUITestHelpers frameworks.
 public extension XCUIElementQuery {
 
-    var allElementsShareCommonXAxis: Bool {
-        let elementXPositions = allElementsBoundByIndex.map { $0.frame.minX }
-
-        // Use a set to remove duplicates – if all elements are the same, only one should remain
-        return Set(elementXPositions).count == 1
-    }
-
     var lastMatch: XCUIElement? {
         return self.allElementsBoundByIndex.last
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24794,8 +24794,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				branch = "add-helpers-from-woo";
+				kind = branch;
 			};
 		};
 		3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -114,7 +114,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 extension BaseScreen {
     @discardableResult
     func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
-        let mode = isDarkMode ? "dark" : "light"
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
         let filename = "\(index)-\(mode)-\(title)"
 
         snapshot(filename)

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -17,7 +17,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         let app = XCUIApplication()
         setupSnapshot(app)
 
-        if isIpad {
+        if XCUIDevice.isPad {
             XCUIDevice.shared.orientation = UIDeviceOrientation.landscapeLeft
         } else {
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
@@ -42,7 +42,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         let postEditorScreenshot = postList.selectPost(withSlug: "our-services")
         sleep(imagesWaitTime) // wait for post images to load
-        if isIpad {
+        if XCUIDevice.isPad {
             BlockEditorScreen()
                 .thenTakeScreenshot(1, named: "Editor")
         } else {
@@ -54,7 +54,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         postEditorScreenshot.close()
 
         // Get a screenshot of the editor with keyboard (iPad only)
-        if isIpad {
+        if XCUIDevice.isPad {
             let ipadScreenshot = MySiteScreen()
                 .showSiteSwitcher()
                 .switchToSite(withTitle: "weekendbakesblog.wordpress.com")
@@ -80,7 +80,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         sleep(imagesWaitTime) // wait for post images to load
         mySite.thenTakeScreenshot(6, named: "Media")
 
-        if !isIpad {
+        if !XCUIDevice.isPad {
             postList.pop()
         }
 
@@ -102,7 +102,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         let notificationList = TabNavComponent()
             .gotoNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
-        if isIpad {
+        if XCUIDevice.isPad {
             notificationList
                 .openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
                 .replyToNotification()

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -82,7 +82,7 @@ class LoginFlow {
             if !PrologueScreen.isLoaded() {
                 while PasswordScreen.isLoaded() || GetStartedScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
                     if GetStartedScreen.isLoaded() && GetStartedScreen.isEmailEntered() {
-                        GetStartedScreen().emailTextField.clearTextIfNeeded()
+                        GetStartedScreen().emailTextField.clearText()
                     }
                     navBackButton.tap()
                 }

--- a/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
+++ b/WordPress/WordPressUITests/Screens/ActionSheetComponent.swift
@@ -19,7 +19,7 @@ class ActionSheetComponent: BaseScreen {
 
     func gotoBlogPost() {
         XCTAssert(blogPostButton.waitForExistence(timeout: 3))
-        XCTAssert(blogPostButton.waitForHittability(timeout: 3))
+        XCTAssert(blogPostButton.waitForIsHittable(timeout: 3))
 
         XCTAssert(blogPostButton.isHittable)
         blogPostButton.tap()
@@ -27,7 +27,7 @@ class ActionSheetComponent: BaseScreen {
 
     func gotoSitePage() {
         XCTAssert(sitePageButton.waitForExistence(timeout: 3))
-        XCTAssert(sitePageButton.waitForHittability(timeout: 3))
+        XCTAssert(sitePageButton.waitForIsHittable(timeout: 3))
 
         XCTAssert(sitePageButton.isHittable)
         sitePageButton.tap()

--- a/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/AztecEditorScreen.swift
@@ -236,7 +236,7 @@ class AztecEditorScreen: BaseScreen {
         XCTContext.runActivity(named: "Close the Aztec editor") { (activity) in
             XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
                 if actionSheet.exists {
-                    if isIpad {
+                    if XCUIDevice.isPad {
                         app.otherElements["PopoverDismissRegion"].tap()
                     } else {
                         keepEditingButton.tap()
@@ -248,7 +248,7 @@ class AztecEditorScreen: BaseScreen {
 
             XCTContext.runActivity(named: "Discard any local changes") { (activity) in
 
-                let discardButton = isIpad ? postHasChangesSheet.buttons.lastMatch : postHasChangesSheet.buttons.element(boundBy: 1)
+                let discardButton = XCUIDevice.isPad ? postHasChangesSheet.buttons.lastMatch : postHasChangesSheet.buttons.element(boundBy: 1)
 
                 if postHasChangesSheet.exists && (discardButton?.exists ?? false) {
                     Logger.log(message: "Discarding unsaved changes", event: .v)

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -80,7 +80,7 @@ class BlockEditorScreen: BaseScreen {
         XCTContext.runActivity(named: "Close the block editor") { (activity) in
             XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
                 if actionSheet.exists {
-                    if isIpad {
+                    if XCUIDevice.isPad {
                         app.otherElements["PopoverDismissRegion"].tap()
                     } else {
                         keepEditingButton.tap()

--- a/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/WordPressUITests/Screens/Editor/BlockEditorScreen.swift
@@ -89,7 +89,7 @@ class BlockEditorScreen: BaseScreen {
             }
 
             // Wait for close button to be hittable (i.e. React "Loading from pre-bundled file" message is gone)
-            editorCloseButton.waitForHittability(timeout: 3)
+            editorCloseButton.waitForIsHittable(timeout: 3)
             editorCloseButton.tap()
 
             XCTContext.runActivity(named: "Discard any local changes") { (activity) in

--- a/WordPress/WordPressUITests/Screens/JetpackBackupScreen.swift
+++ b/WordPress/WordPressUITests/Screens/JetpackBackupScreen.swift
@@ -23,7 +23,7 @@ class JetpackBackupScreen: BaseScreen {
         ellipsisButton.tap()
 
         XCTAssert(downloadBackupButton.waitForExistence(timeout: 3))
-        XCTAssert(downloadBackupButton.waitForHittability(timeout: 3))
+        XCTAssert(downloadBackupButton.waitForIsHittable(timeout: 3))
 
         XCTAssert(downloadBackupButton.isHittable)
 

--- a/WordPress/WordPressUITests/Screens/MeTabScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MeTabScreen.swift
@@ -34,7 +34,7 @@ class MeTabScreen: ScreenObject {
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
         // to stack. We need to detect these cases in order to reliably tap the correct button
-        if logOutAlert.buttons.allElementsShareCommonXAxis {
+        if logOutAlert.buttons.allElementsShareCommonAxisX {
             logOutAlert.buttons.element(boundBy: 0).tap()
         }
         else {
@@ -49,7 +49,7 @@ class MeTabScreen: ScreenObject {
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
         // to stack. We need to detect these cases in order to reliably tap the correct button
-        if logOutAlert.buttons.allElementsShareCommonXAxis {
+        if logOutAlert.buttons.allElementsShareCommonAxisX {
             logOutAlert.buttons.element(boundBy: 0).tap()
         }
         else {

--- a/WordPress/WordPressUITests/Screens/MySiteScreen.swift
+++ b/WordPress/WordPressUITests/Screens/MySiteScreen.swift
@@ -69,7 +69,7 @@ class MySiteScreen: BaseScreen {
 
     func removeSelfHostedSite() {
         removeSiteButton.tap()
-        if isIpad {
+        if XCUIDevice.isPad {
             removeSiteAlert.tap()
         } else {
             removeSiteSheet.tap()
@@ -94,7 +94,7 @@ class MySiteScreen: BaseScreen {
     func gotoPostsScreen() -> PostsScreen {
 
         // A hack for iPad, because sometimes tapping "posts" doesn't load it the first time
-        if isIpad {
+        if XCUIDevice.isPad {
             mediaButton.tap()
         }
 

--- a/WordPress/WordPressUITests/Screens/SiteSettingsScreen.swift
+++ b/WordPress/WordPressUITests/Screens/SiteSettingsScreen.swift
@@ -34,7 +34,7 @@ class SiteSettingsScreen: BaseScreen {
     }
 
     func goBackToMySite() -> MySiteScreen {
-        if isIPhone {
+        if XCUIDevice.isPhone {
             navBackButton.tap()
         }
         return MySiteScreen()

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -7,7 +7,7 @@ extension XCUIElement {
      - Parameter text: the text to enter into the field
      */
     func clearAndEnterText(text: String) -> Void {
-        clearTextIfNeeded()
+        clearText()
         self.tap()
         self.typeText(text)
     }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -19,10 +19,6 @@ extension XCUIElement {
         self.tap()
         self.typeText(text)
     }
-
-    var stringValue: String? {
-        return self.value as? String
-    }
 }
 
 extension XCTestCase {

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -1,14 +1,6 @@
 import UITestsFoundation
 import XCTest
 
-var isDarkMode: Bool {
-    if #available(iOS 12.0, *) {
-        return UIViewController().traitCollection.userInterfaceStyle == .dark
-    } else {
-        return false
-    }
-}
-
 extension XCUIElement {
     /**
      Removes any current text in the field before typing in the new value

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -105,9 +105,4 @@ extension XCTestCase {
         guard element.exists && !element.frame.isEmpty && element.isHittable else { return false }
         return XCUIApplication().windows.element(boundBy: 0).frame.contains(element.frame)
     }
-
-    // A shortcut to scroll TableViews or CollectionViews to top
-    func tapStatusBarToScrollToTop() {
-        XCUIApplication().statusBars.firstMatch.tap()
-    }
 }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -40,18 +40,6 @@ extension XCTestCase {
         }
     }
 
-    public func waitForElementToNotExist(element: XCUIElement, timeout: TimeInterval? = nil) {
-        let notExistsPredicate = NSPredicate(format: "exists == false")
-        let expectation = XCTNSPredicateExpectation(predicate: notExistsPredicate,
-                                                    object: element)
-
-        let timeoutValue = timeout ?? 30
-        guard XCTWaiter().wait(for: [expectation], timeout: timeoutValue) == .completed else {
-            XCTFail("\(element) still exists after \(timeoutValue) seconds.")
-            return
-        }
-    }
-
     public func getRandomPhrase() -> String {
         var wordArray: [String] = []
         let phraseLength = Int.random(in: 3...6)

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -1,18 +1,6 @@
 import UITestsFoundation
 import XCTest
 
-extension XCUIElement {
-    /**
-     Removes any current text in the field before typing in the new value
-     - Parameter text: the text to enter into the field
-     */
-    func clearAndEnterText(text: String) -> Void {
-        clearText()
-        self.tap()
-        self.typeText(text)
-    }
-}
-
 extension XCTestCase {
 
     public func setUpTestSuite() {

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -100,9 +100,4 @@ extension XCTestCase {
         static let category = "iOS Test"
         static let tag = "tag \(Date().toString())"
     }
-
-    public func elementIsFullyVisibleOnScreen(element: XCUIElement) -> Bool {
-        guard element.exists && !element.frame.isEmpty && element.isHittable else { return false }
-        return XCUIApplication().windows.element(boundBy: 0).frame.contains(element.frame)
-    }
 }


### PR DESCRIPTION
Update the UI tests and screenshots automation to lean into XCUITestHelpers, removing a bunch of duplicated code. (The less code we have in the targets themselves the faster they'll compile)

If you want to test this manually, checkout this branch and run the UI tests. Notice that I run the tests in CI and they [passed](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/23769/workflows/dbc6353a-bbc8-4631-b38a-6c327a58b7c6).

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**