### PR TITLE
Blogging Reminders - Fix ui issues

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -13,31 +13,55 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed description string of the current schedule for the specified blog.
     ///
-    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
+    func shortScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String? = nil) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return shortIntervalDescription(for: .none, time: time)
+                return shortScheduleDescription(for: .none, time: time)
             }
 
-            return Self.shortIntervalDescription(for: days.count, time: time)
+            return Self.shortScheduleDescription(for: days.count, time: time)
         }
     }
 
-    static func shortIntervalDescription(for days: Int, time: String) -> NSAttributedString {
+    static func shortScheduleDescription(for days: Int, time: String?) -> NSAttributedString {
+        guard let time = time else {
+            return shortScheduleDescription(for: days)
+        }
+        return shortScheduleDescriptionWithTime(for: days, time: time)
+    }
+
+    static func shortScheduleDescriptionWithTime(for days: Int, time: String) -> NSAttributedString {
         let text: String = {
             switch days {
             case 1:
-                return String(format: NSLocalizedString("<strong>Once</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."), time)
+                return String(format: TextContent.oneReminderShortDescriptionWithTime, time)
             case 2:
-                return String(format: NSLocalizedString("<strong>Twice</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."), time)
+                return String(format: TextContent.twoRemindersShortDescriptionWithTime, time)
             case 7:
-                return "<strong>" + String(format: NSLocalizedString("Every day at %@", comment: "Short title telling the user they will receive a blogging reminder every day of the week."), time) + "</strong>"
+                return "<strong>" + String(format: TextContent.everydayRemindersShortDescriptionWithTime, time) + "</strong>"
             default:
-                return String(format: NSLocalizedString("<strong>%d</strong> times a week at %@",
-                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days, time)
+                return String(format: TextContent.manyRemindersShortDescriptionWithTime, days, time)
+            }
+        }()
+
+        return Self.stringToAttributedString(text)
+    }
+
+    static func shortScheduleDescription(for days: Int) -> NSAttributedString {
+
+        let text: String = {
+            switch days {
+            case 1:
+                return TextContent.oneReminderShortDescription
+            case 2:
+                return TextContent.twoRemindersShortDescription
+            case 7:
+                return "<strong>" + TextContent.everydayRemindersShortDescription + "</strong>"
+            default:
+                return String(format: TextContent.manyRemindersShortDescription, days)
             }
         }()
 
@@ -69,11 +93,11 @@ struct BloggingRemindersScheduleFormatter {
             let text: String
 
             if days.count == 1 {
-                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "", "<strong>\(time)</strong>")
+                text = String(format: TextContent.oneReminderLongDescriptionWithTime, markedUpDays.first ?? "", "<strong>\(time)</strong>")
             } else {
                 let formatter = ListFormatter()
                 let formattedDays = formatter.string(from: markedUpDays) ?? ""
-                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
+                text = String(format: TextContent.manyRemindersLongDescriptionWithTime, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
             }
 
             return Self.stringToAttributedString(text)
@@ -113,10 +137,34 @@ struct BloggingRemindersScheduleFormatter {
         static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
 
         // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
+        static let oneReminderLongDescriptionWithTime = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
 
-        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@ at %@.",
+        static let manyRemindersLongDescriptionWithTime = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
+
+        static let oneReminderShortDescriptionWithTime = NSLocalizedString("<strong>Once</strong> a week at %@",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+
+        static let twoRemindersShortDescriptionWithTime = NSLocalizedString("<strong>Twice</strong> a week at %@",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+
+        static let manyRemindersShortDescriptionWithTime = NSLocalizedString("<strong>%d</strong> times a week at %@",
+                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+
+        static let everydayRemindersShortDescriptionWithTime = NSLocalizedString("Every day at %@",
+                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+
+        static let oneReminderShortDescription = NSLocalizedString("<strong>Once</strong> a week",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+
+        static let twoRemindersShortDescription = NSLocalizedString("<strong>Twice</strong> a week",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+
+        static let manyRemindersShortDescription = NSLocalizedString("<strong>%d</strong> times a week",
+                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+
+        static let everydayRemindersShortDescription = NSLocalizedString("Every day",
+                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
     }
 }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -13,44 +13,44 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed description string of the current schedule for the specified blog.
     ///
-    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
+    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return shortIntervalDescription(for: .none)
+                return shortIntervalDescription(for: .none, time: time)
             }
 
-            return Self.shortIntervalDescription(for: days.count)
+            return Self.shortIntervalDescription(for: days.count, time: time)
         }
     }
 
-    static func shortIntervalDescription(for days: Int) -> NSAttributedString {
+    static func shortIntervalDescription(for days: Int, time: String) -> NSAttributedString {
         let text: String = {
             switch days {
             case 1:
-                return NSLocalizedString("<strong>Once</strong> a week", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+                return String(format: NSLocalizedString("<strong>Once</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."), time)
             case 2:
-                return NSLocalizedString("<strong>Twice</strong> a week", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+                return String(format: NSLocalizedString("<strong>Twice</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."), time)
             case 7:
-                return "<strong>" + NSLocalizedString("Every day", comment: "Short title telling the user they will receive a blogging reminder every day of the week.") + "</strong>"
+                return "<strong>" + String(format: NSLocalizedString("Every day at %@", comment: "Short title telling the user they will receive a blogging reminder every day of the week."), time) + "</strong>"
             default:
-                return String(format: NSLocalizedString("<strong>%d</strong> times a week",
-                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days)
+                return String(format: NSLocalizedString("<strong>%d</strong> times a week at %@",
+                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days, time)
             }
         }()
 
         return Self.stringToAttributedString(text)
     }
 
-    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
+    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
         switch schedule {
         case .none:
             return NSAttributedString(string: TextContent.longNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return longScheduleDescription(for: .none)
+                return longScheduleDescription(for: .none, time: time)
             }
 
             // We want the days sorted by their localized index because under some locale configurations
@@ -69,11 +69,11 @@ struct BloggingRemindersScheduleFormatter {
             let text: String
 
             if days.count == 1 {
-                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "")
+                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "", "<strong>\(time)</strong>")
             } else {
                 let formatter = ListFormatter()
                 let formattedDays = formatter.string(from: markedUpDays) ?? ""
-                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays)
+                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
             }
 
             return Self.stringToAttributedString(text)
@@ -113,10 +113,10 @@ struct BloggingRemindersScheduleFormatter {
         static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
 
         // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@.",
+        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
 
-        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
+        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -202,7 +202,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let promptText = NSMutableAttributedString(attributedString: formatter.longScheduleDescription(for: schedule))
+        let promptText = NSMutableAttributedString(attributedString: formatter.longScheduleDescription(for: schedule, time: scheduler.scheduledTime(for: blog).toLocalTime()))
 
         promptText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: promptText.length))
         promptLabel.attributedText = promptText

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -381,6 +381,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             self?.scheduledTime = date
             self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
             self?.refreshNextButton()
+            self?.refreshFrequencyLabel(time: date.toLocalTime())
         }
         viewController.preferredWidth = self.view.frame.width
         navigationController?.pushViewController(viewController, animated: true)
@@ -446,7 +447,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     }
 
     /// Updates the label that contains the number of scheduled days as users change them
-    func refreshFrequencyLabel() {
+    func refreshFrequencyLabel(time: String? = nil) {
         guard weekdays.count > 0 else {
             frequencyLabel.isHidden = true
             timeSelectionStackView.isHidden = true
@@ -460,7 +461,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays))
+        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays), time: time ?? scheduler.scheduledTime(for: blog).toLocalTime())
         let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
         attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -80,7 +80,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
     private lazy var frequencyLabel: UILabel = {
         let label = UILabel()
-
+        label.translatesAutoresizingMaskIntoConstraints = false
         label.adjustsFontForContentSizeCategory = true
         label.adjustsFontSizeToFitWidth = true
         label.numberOfLines = 2
@@ -89,12 +89,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return label
     }()
 
-    // adds dividers for the time selection
-    private func makeDivider() -> UIView {
+    private lazy var frequencyView: UIView = {
         let view = UIView()
-        view.backgroundColor = UIColor.divider
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .basicBackground
+        view.addSubview(frequencyLabel)
         return view
-    }
+    }()
 
     private lazy var topDivider: UIView = {
         makeDivider()
@@ -116,58 +117,88 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         pushTimeSelectionViewController()
     }
 
+    private lazy var timeSelectionView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .basicBackground
+        view.addSubview(timeSelectionStackView)
+        return view
+    }()
 
     private lazy var timeSelectionStackView: UIStackView = {
         let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.addArrangedSubviews([topDivider, timeSelectionButton, bottomDivider])
         return stackView
+    }()
+
+    private lazy var trophy: UIView = {
+        let trophy = UIImageView(image: .gridicon(.trophy, size: Metrics.tipsTrophyImageSize))
+        trophy.translatesAutoresizingMaskIntoConstraints = false
+        trophy.tintColor = .secondaryLabel
+        return trophy
+    }()
+
+    private lazy var tipLabel: UILabel = {
+        let tipLabel = UILabel()
+        tipLabel.translatesAutoresizingMaskIntoConstraints = false
+        tipLabel.adjustsFontForContentSizeCategory = true
+        tipLabel.textColor = .secondaryLabel
+        tipLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
+        tipLabel.text = TextContent.tipPanelTitle
+        return tipLabel
+    }()
+
+    private lazy var tipDescriptionLabel: UILabel = {
+        let tipDescriptionLabel = UILabel()
+        tipDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        tipDescriptionLabel.adjustsFontForContentSizeCategory = true
+        tipDescriptionLabel.textColor = .secondaryLabel
+        tipDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
+        tipDescriptionLabel.text = TextContent.tipPanelDescription
+        tipDescriptionLabel.numberOfLines = 0
+        return tipDescriptionLabel
     }()
 
     private lazy var bottomTipPanel: UIView = {
         let view = UIView()
         view.backgroundColor = .quaternaryBackground
         view.layer.cornerRadius = Metrics.tipPanelCornerRadius
-
-        self.populateTipPanel(view)
+        view.addSubview(tipStackView)
 
         return view
     }()
 
-    private func populateTipPanel(_ panel: UIView) {
-        let innerStack = UIStackView()
-        innerStack.spacing = Metrics.tipPanelHorizontalStackSpacing
-        innerStack.translatesAutoresizingMaskIntoConstraints = false
-        innerStack.axis = .horizontal
-        innerStack.alignment = .top
-        panel.addSubview(innerStack)
-        panel.pinSubviewToAllEdges(innerStack, insets: Metrics.tipPanelMargins)
+    private lazy var tipStackView: UIStackView = {
+        let tipStackView = UIStackView(arrangedSubviews: [trophy, tipLabelsStackView])
+        tipStackView.spacing = Metrics.tipPanelHorizontalStackSpacing
+        tipStackView.translatesAutoresizingMaskIntoConstraints = false
+        tipStackView.axis = .horizontal
+        tipStackView.alignment = .top
+        return tipStackView
+    }()
 
-        let trophy = UIImageView(image: .gridicon(.trophy, size: Metrics.tipsTrophyImageSize))
-        trophy.tintColor = .secondaryLabel
+    private lazy var tipLabelsStackView: UIStackView = {
+        let tipLabelsStackView = UIStackView(arrangedSubviews: [tipLabel, tipDescriptionLabel])
+        tipLabelsStackView.translatesAutoresizingMaskIntoConstraints = false
+        tipLabelsStackView.axis = .vertical
+        tipLabelsStackView.alignment = .leading
+        tipLabelsStackView.addArrangedSubviews([tipLabel, tipDescriptionLabel])
+        return tipLabelsStackView
+    }()
 
-        let rightStack = UIStackView()
-        rightStack.spacing = Metrics.tipPanelVerticalStackSpacing
-        rightStack.axis = .vertical
-        rightStack.alignment = .leading
+    private lazy var timeSelectionToTipSpacer: UIView = {
+        makeSpacer()
+    }()
 
-        innerStack.addArrangedSubviews([trophy, rightStack])
+    private lazy var tipToConfirmationButtonSpacer: UIView = {
+        makeSpacer()
+    }()
 
-        let tipLabel = UILabel()
-        tipLabel.adjustsFontForContentSizeCategory = true
-        tipLabel.textColor = .secondaryLabel
-        tipLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
-        tipLabel.text = TextContent.tipPanelTitle
-
-        let tipDescriptionLabel = UILabel()
-        tipDescriptionLabel.adjustsFontForContentSizeCategory = true
-        tipDescriptionLabel.textColor = .secondaryLabel
-        tipDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
-        tipDescriptionLabel.text = TextContent.tipPanelDescription
-        tipDescriptionLabel.numberOfLines = 0
-
-        rightStack.addArrangedSubviews([tipLabel, tipDescriptionLabel])
-    }
+    private lazy var confirmationButtonBottomSpacer: UIView = {
+        makeSpacer()
+    }()
 
     private let dismissButton: UIButton = {
         let button = UIButton(type: .custom)
@@ -249,12 +280,15 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         populateCalendarDays()
         refreshNextButton()
         refreshFrequencyLabel()
+
+        showFullUI(shouldShowFullUI)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         tracker.screenShown(.dayPicker)
 
         super.viewDidAppear(animated)
+        calculatePreferredContentSize()
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -275,65 +309,225 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        bottomTipPanel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-        imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        bottomTipPanel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory || !shouldShowFullUI
+        imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory || !shouldShowFullUI
     }
 
-    private func calculatePreferredContentSize() {
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        showFullUI(shouldShowFullUI)
+        calculatePreferredContentSize()
+    }
+
+    // MARK: - Actions
+
+    @objc private func notifyMeButtonTapped() {
+        tracker.buttonPressed(button: .continue, screen: .dayPicker)
+
+        scheduleReminders()
+    }
+
+    /// Schedules the reminders and shows a VC that requests PN authorization, if necessary.
+    ///
+    /// - Parameters:
+    ///     - showPushPrompt: if `true` the PN authorization prompt VC will be shown.
+    ///         When `false`, the VC won't be shown.  This is useful because this method
+    ///         can also be called when the refrenced VC is already on-screen.
+    ///
+    private func scheduleReminders(showPushPrompt: Bool = true) {
+        let schedule: BloggingRemindersScheduler.Schedule
+
+        if weekdays.count > 0 {
+            schedule = .weekdays(weekdays)
+        } else {
+            schedule = .none
+        }
+
+        scheduler.schedule(schedule, for: blog, time: scheduledTime) { [weak self] result in
+            guard let self = self else {
+                return
+            }
+
+            switch result {
+            case .success:
+                self.tracker.scheduled(schedule, time: self.scheduledTime)
+
+                DispatchQueue.main.async { [weak self] in
+                    self?.pushCompletionViewController()
+                }
+            case .failure(let error):
+                switch error {
+                case BloggingRemindersScheduler.Error.needsPermissionForPushNotifications where showPushPrompt == true:
+                    DispatchQueue.main.async { [weak self] in
+                        self?.pushPushPromptViewController()
+                    }
+                default:
+                    // The scheduler should normally not fail unless it's because of having no push permissions.
+                    // As a simple solution for now, we'll just avoid taking any action if the scheduler did fail.
+                    DDLogError("Error scheduling blogging reminders: \(error)")
+                    break
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Navigation
+private extension BloggingRemindersFlowSettingsViewController {
+
+    func pushTimeSelectionViewController() {
+        let viewController = TimeSelectionViewController(scheduledTime: scheduler.scheduledTime(for: blog),
+                                                         tracker: tracker) { [weak self] date in
+            self?.scheduledTime = date
+            self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
+            self?.refreshNextButton()
+        }
+        viewController.preferredWidth = self.view.frame.width
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    func pushCompletionViewController() {
+        let viewController = BloggingRemindersFlowCompletionViewController(blog: blog, tracker: tracker, calendar: calendar)
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+
+    private func pushPushPromptViewController() {
+        let viewController = BloggingRemindersPushPromptViewController(tracker: tracker) { [weak self] in
+            self?.scheduleReminders(showPushPrompt: false)
+        }
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+// MARK: - Private Helpers
+private extension BloggingRemindersFlowSettingsViewController {
+
+    /// creates an instance of a UIView with a grey background, intended to be used as a divider
+    func makeDivider() -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = UIColor.divider
+        return view
+    }
+
+    /// instantiates a UIView with transparent background, intented to be used as a spacer in a UIStackView
+    func makeSpacer() -> UIView {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }
+
+    /// Determines if the calendar image and the tip should be displayed, depending on the screen vertical size
+    var shouldShowFullUI: Bool {
+        (WPDeviceIdentification.isiPhone() && UIScreen.main.bounds.height >= Metrics.minimumHeightForFullUI) ||
+            (WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait)
+    }
+
+    /// Hides/shows the optional UI Elements (dismiss button, calendar icon, tip)
+    /// - Parameter isVisible: true if we need to show the elements (Full UI), false otherwise
+    func showFullUI(_ isVisible: Bool) {
+        bottomTipPanel.isHidden = !isVisible
+        imageView.isHidden = !isVisible
+        dismissButton.isHidden = !isVisible
+    }
+
+    /// Updates the title of the cconfirmation button depending on the action (new schedule or updated schedule)
+    func refreshNextButton() {
+        if previousWeekdays.isEmpty {
+            button.setTitle(TextContent.nextButtonTitle, for: .normal)
+            button.isEnabled = !weekdays.isEmpty
+        } else if (weekdays == previousWeekdays) && (scheduledTime == scheduler.scheduledTime(for: blog)) {
+            button.setTitle(TextContent.nextButtonTitle, for: .normal)
+            button.isEnabled = true
+        } else {
+            button.setTitle(TextContent.updateButtonTitle, for: .normal)
+            button.isEnabled = true
+        }
+    }
+
+    /// Updates the label that contains the number of scheduled days as users change them
+    func refreshFrequencyLabel() {
+        guard weekdays.count > 0 else {
+            frequencyLabel.isHidden = true
+            timeSelectionStackView.isHidden = true
+            return
+        }
+
+        frequencyLabel.isHidden = false
+        timeSelectionStackView.isHidden = false
+
+        let defaultAttributes: [NSAttributedString.Key: AnyObject] = [
+            .foregroundColor: UIColor.text,
+        ]
+
+        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays))
+        let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
+        attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
+
+        frequencyLabel.attributedText = attributedText
+        frequencyLabel.sizeToFit()
+    }
+
+    func calculatePreferredContentSize() {
         let size = CGSize(width: view.bounds.width, height: UIView.layoutFittingCompressedSize.height)
         preferredContentSize = view.systemLayoutSizeFitting(size)
     }
 
-    // MARK: - View Configuration
-
-    private func configureStackView() {
+    func configureStackView() {
         view.addSubview(stackView)
-
-        // Used to expand the stackview vertically
-        let fillerView = UIView()
-        fillerView.translatesAutoresizingMaskIntoConstraints = false
-        fillerView.setContentHuggingPriority(.defaultLow, for: .vertical)
-        fillerView.heightAnchor.constraint(greaterThanOrEqualToConstant: 0.0).isActive = true
-
-        let bottomPadding = UIView()
 
         stackView.addArrangedSubviews([
             imageView,
             titleLabel,
             promptLabel,
             daysOuterStackView,
-            frequencyLabel,
-            timeSelectionStackView,
-            fillerView,
+            frequencyView,
+            timeSelectionView,
+            timeSelectionToTipSpacer,
             bottomTipPanel,
-            bottomPadding,
+            tipToConfirmationButtonSpacer,
             button,
-            UIView()
+            confirmationButtonBottomSpacer
         ])
 
         stackView.setCustomSpacing(Metrics.afterTitleLabelSpacing, after: titleLabel)
         stackView.setCustomSpacing(Metrics.afterPromptLabelSpacing, after: promptLabel)
     }
 
-    private func configureConstraints() {
+    func configureConstraints() {
+        frequencyView.pinSubviewToAllEdges(frequencyLabel)
+        timeSelectionView.pinSubviewToAllEdges(timeSelectionStackView)
+        bottomTipPanel.pinSubviewToAllEdges(tipStackView, insets: Metrics.tipPanelMargins)
+
+        imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        tipDescriptionLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        timeSelectionView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        button.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.edgeMargins.left),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
-            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: -Metrics.edgeMargins.bottom),
+            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: WPDeviceIdentification.isiPad() ? .zero : -Metrics.edgeMargins.bottom),
 
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor),
 
-            button.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.buttonHeight),
+            button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             button.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             bottomTipPanel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
             dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
             dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.right),
-            topDivider.heightAnchor.constraint(equalToConstant: Metrics.dividerHeight),
-            bottomDivider.heightAnchor.constraint(equalToConstant: Metrics.dividerHeight),
-            timeSelectionStackView.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
-            timeSelectionStackView.widthAnchor.constraint(equalTo: stackView.widthAnchor)
+            topDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
+            bottomDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
+            timeSelectionView.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
+            timeSelectionView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            frequencyView.heightAnchor.constraint(equalToConstant: Metrics.frequencyLabelHeight),
+            tipLabel.heightAnchor.constraint(equalTo: trophy.heightAnchor),
+            timeSelectionToTipSpacer.heightAnchor.constraint(equalTo: tipToConfirmationButtonSpacer.heightAnchor),
+            timeSelectionToTipSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor),
+            tipToConfirmationButtonSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor)
         ])
     }
 
@@ -381,7 +575,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return button
     }
 
-    private func populateCalendarDays() {
+    /// Adds the calendar days to the UI according to the device locale
+    func populateCalendarDays() {
         daysOuterStackView.addArrangedSubviews([daysTopInnerStackView, daysBottomInnerStackView])
 
         let topRow = 0 ..< Metrics.topRowDayCount
@@ -389,118 +584,6 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
         daysTopInnerStackView.addArrangedSubviews(topRow.compactMap({ createCalendarDayToggleButton(localizedWeekdayDayIndex: $0) }))
         daysBottomInnerStackView.addArrangedSubviews(bottomRow.compactMap({ createCalendarDayToggleButton(localizedWeekdayDayIndex: $0) }))
-    }
-
-    private func refreshNextButton() {
-        if previousWeekdays.isEmpty {
-            button.setTitle(TextContent.nextButtonTitle, for: .normal)
-            button.isEnabled = !weekdays.isEmpty
-        } else if (weekdays == previousWeekdays) && (scheduledTime == scheduler.scheduledTime(for: blog)) {
-            button.setTitle(TextContent.nextButtonTitle, for: .normal)
-            button.isEnabled = true
-        } else {
-            button.setTitle(TextContent.updateButtonTitle, for: .normal)
-            button.isEnabled = true
-        }
-    }
-
-    private func refreshFrequencyLabel() {
-        guard weekdays.count > 0 else {
-            frequencyLabel.isHidden = true
-            timeSelectionStackView.isHidden = true
-            return
-        }
-
-        frequencyLabel.isHidden = false
-        timeSelectionStackView.isHidden = false
-
-        let defaultAttributes: [NSAttributedString.Key: AnyObject] = [
-            .foregroundColor: UIColor.text,
-        ]
-
-        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays))
-        let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
-        attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
-
-        frequencyLabel.attributedText = attributedText
-        frequencyLabel.sizeToFit()
-    }
-
-    // MARK: - Actions
-
-    @objc private func notifyMeButtonTapped() {
-        tracker.buttonPressed(button: .continue, screen: .dayPicker)
-
-        scheduleReminders()
-    }
-
-    /// Schedules the reminders and shows a VC that requests PN authorization, if necessary.
-    ///
-    /// - Parameters:
-    ///     - showPushPrompt: if `true` the PN authorization prompt VC will be shown.
-    ///         When `false`, the VC won't be shown.  This is useful because this method
-    ///         can also be called when the refrenced VC is already on-screen.
-    ///
-    private func scheduleReminders(showPushPrompt: Bool = true) {
-        let schedule: BloggingRemindersScheduler.Schedule
-
-        if weekdays.count > 0 {
-            schedule = .weekdays(weekdays)
-        } else {
-            schedule = .none
-        }
-
-        scheduler.schedule(schedule, for: blog, time: scheduledTime) { [weak self] result in
-            guard let self = self else {
-                return
-            }
-
-            switch result {
-            case .success:
-                self.tracker.scheduled(schedule, time: self.scheduledTime)
-
-                DispatchQueue.main.async { [weak self] in
-                    self?.presentCompletionViewController()
-                }
-            case .failure(let error):
-                switch error {
-                case BloggingRemindersScheduler.Error.needsPermissionForPushNotifications where showPushPrompt == true:
-                    DispatchQueue.main.async { [weak self] in
-                        self?.presentPushPromptViewController()
-                    }
-                default:
-                    // The scheduler should normally not fail unless it's because of having no push permissions.
-                    // As a simple solution for now, we'll just avoid taking any action if the scheduler did fail.
-                    DDLogError("Error scheduling blogging reminders: \(error)")
-                    break
-                }
-            }
-        }
-    }
-
-    private func pushTimeSelectionViewController() {
-        let viewController = TimeSelectionViewController(scheduledTime: scheduler.scheduledTime(for: blog),
-                                                         tracker: tracker) { [weak self] date in
-            self?.scheduledTime = date
-            self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
-            self?.refreshNextButton()
-        }
-        viewController.preferredWidth = self.view.frame.width
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-
-    // MARK: - Completion Paths
-
-    private func presentCompletionViewController() {
-        let viewController = BloggingRemindersFlowCompletionViewController(blog: blog, tracker: tracker, calendar: calendar)
-        navigationController?.pushViewController(viewController, animated: true)
-    }
-
-    private func presentPushPromptViewController() {
-        let viewController = BloggingRemindersPushPromptViewController(tracker: tracker) { [weak self] in
-            self?.scheduleReminders(showPushPrompt: false)
-        }
-        navigationController?.pushViewController(viewController, animated: true)
     }
 }
 
@@ -524,6 +607,7 @@ extension BloggingRemindersFlowSettingsViewController: ChildDrawerPositionable {
     }
 }
 
+// MARK: - Constants
 private enum TextContent {
     static let settingsPrompt = NSLocalizedString("Select the days you want to blog on",
                                                   comment: "Prompt shown on the Blogging Reminders Settings screen.")
@@ -558,8 +642,11 @@ private enum Metrics {
     static let buttonHeight: CGFloat = 44.0
     static let tipPanelCornerRadius: CGFloat = 12.0
     static let tipsTrophyImageSize = CGSize(width: 20, height: 20)
+    static let tipDescriptionHeight: CGFloat = 34.0
+    static let frequencyLabelHeight: CGFloat = 30
 
     static let topRowDayCount = 4
 
-    static let dividerHeight: CGFloat = .hairlineBorderWidth
+    // the smallest logical iPhone height (iPhone 12 mini) to display the full UI, which includes calendar icon and tip.
+    static let minimumHeightForFullUI: CGFloat = 812
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -381,7 +381,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             self?.scheduledTime = date
             self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
             self?.refreshNextButton()
-            self?.refreshFrequencyLabel(time: date.toLocalTime())
+            self?.refreshFrequencyLabel()
         }
         viewController.preferredWidth = self.view.frame.width
         navigationController?.pushViewController(viewController, animated: true)
@@ -447,7 +447,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     }
 
     /// Updates the label that contains the number of scheduled days as users change them
-    func refreshFrequencyLabel(time: String? = nil) {
+    func refreshFrequencyLabel() {
         guard weekdays.count > 0 else {
             frequencyLabel.isHidden = true
             timeSelectionStackView.isHidden = true
@@ -461,7 +461,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays), time: time ?? scheduler.scheduledTime(for: blog).toLocalTime())
+        let frequencyDescription = scheduleFormatter.shortScheduleDescription(for: .weekdays(weekdays))
         let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
         attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -313,6 +313,8 @@ extension SiteSettingsViewController {
     private func configureCellForBloggingReminders(_ cell: SettingTableViewCell) {
         cell.editable = true
         cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
+        cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
+        cell.detailTextLabel?.minimumScaleFactor = 0.5
         cell.accessoryType = .none
         cell.textValue = schedule(for: blog)
     }
@@ -325,7 +327,7 @@ extension SiteSettingsViewController {
         }
 
         let formatter = BloggingRemindersScheduleFormatter()
-        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog)).string
+        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
     }
 
     // MARK: - Handling General Setting Cell Taps

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -327,7 +327,7 @@ extension SiteSettingsViewController {
         }
 
         let formatter = BloggingRemindersScheduleFormatter()
-        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
+        return formatter.shortScheduleDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
     }
 
     // MARK: - Handling General Setting Cell Taps


### PR DESCRIPTION
Fixes #NA

This PR fixes issues found [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17033#pullrequestreview-731138234)

This PR also introduces the simplified settings screen for older iPhones with lower resolution and for iPad landscape (see below). This simplified UI does not contain the calendar icon, the dismiss button (X) and the tip

Full UI | Simplified UI
-- | --
<img height="500"  src="https://user-images.githubusercontent.com/34376330/129982658-14b58b98-50e4-4970-842a-95da6f4cf557.png"> | <img height="500" src="https://user-images.githubusercontent.com/34376330/129982186-427764da-11df-4d6f-bdfc-12f4dc1ba734.png">


@osullivanchris please let me know your thoughts about iPad: we could also do simplified UI for both orientation if you think it's better, it's an easy fix.

**NOTE: this PR does not fix the transition animation on iPad, there will be a separate one for that issue**

To test:
- Build/run and go to My Site -> Site Settings and tap on "Blogging Reminders"
- If you had never set reminders for the current site, tap on "Get Started" on the intro screen. If you had, you can skip to the next step (you won't see the intro screen)
- On the day picker screen, try a variety of combinations between selecting/deselecting days, and going back and forth between the day picker and the time picker screen
- Make sure the UI looks good and the issues outlined [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17033#pullrequestreview-731138234) are not happening

## Regression Notes
1. Potential unintended areas of impact
This PR only changes UI elements in `BloggingRemindersFlowSettingsViewController`, any regression would be a UI issue in that same screen. No other part of the app is affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test on a variety of simulators and devices

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
