### PR TITLE
Add time labels to Blogging Reminders

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -13,31 +13,55 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed description string of the current schedule for the specified blog.
     ///
-    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
+    func shortScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String? = nil) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return shortIntervalDescription(for: .none, time: time)
+                return shortScheduleDescription(for: .none, time: time)
             }
 
-            return Self.shortIntervalDescription(for: days.count, time: time)
+            return Self.shortScheduleDescription(for: days.count, time: time)
         }
     }
 
-    static func shortIntervalDescription(for days: Int, time: String) -> NSAttributedString {
+    static func shortScheduleDescription(for days: Int, time: String?) -> NSAttributedString {
+        guard let time = time else {
+            return shortScheduleDescription(for: days)
+        }
+        return shortScheduleDescriptionWithTime(for: days, time: time)
+    }
+
+    static func shortScheduleDescriptionWithTime(for days: Int, time: String) -> NSAttributedString {
         let text: String = {
             switch days {
             case 1:
-                return String(format: NSLocalizedString("<strong>Once</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."), time)
+                return String(format: TextContent.oneReminderShortDescriptionWithTime, time)
             case 2:
-                return String(format: NSLocalizedString("<strong>Twice</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."), time)
+                return String(format: TextContent.twoRemindersShortDescriptionWithTime, time)
             case 7:
-                return "<strong>" + String(format: NSLocalizedString("Every day at %@", comment: "Short title telling the user they will receive a blogging reminder every day of the week."), time) + "</strong>"
+                return "<strong>" + String(format: TextContent.everydayRemindersShortDescriptionWithTime, time) + "</strong>"
             default:
-                return String(format: NSLocalizedString("<strong>%d</strong> times a week at %@",
-                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days, time)
+                return String(format: TextContent.manyRemindersShortDescriptionWithTime, days, time)
+            }
+        }()
+
+        return Self.stringToAttributedString(text)
+    }
+
+    static func shortScheduleDescription(for days: Int) -> NSAttributedString {
+
+        let text: String = {
+            switch days {
+            case 1:
+                return TextContent.oneReminderShortDescription
+            case 2:
+                return TextContent.twoRemindersShortDescription
+            case 7:
+                return "<strong>" + TextContent.everydayRemindersShortDescription + "</strong>"
+            default:
+                return String(format: TextContent.manyRemindersShortDescription, days)
             }
         }()
 
@@ -69,11 +93,11 @@ struct BloggingRemindersScheduleFormatter {
             let text: String
 
             if days.count == 1 {
-                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "", "<strong>\(time)</strong>")
+                text = String(format: TextContent.oneReminderLongDescriptionWithTime, markedUpDays.first ?? "", "<strong>\(time)</strong>")
             } else {
                 let formatter = ListFormatter()
                 let formattedDays = formatter.string(from: markedUpDays) ?? ""
-                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
+                text = String(format: TextContent.manyRemindersLongDescriptionWithTime, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
             }
 
             return Self.stringToAttributedString(text)
@@ -113,10 +137,34 @@ struct BloggingRemindersScheduleFormatter {
         static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
 
         // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
+        static let oneReminderLongDescriptionWithTime = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
 
-        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@ at %@.",
+        static let manyRemindersLongDescriptionWithTime = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
+
+        static let oneReminderShortDescriptionWithTime = NSLocalizedString("<strong>Once</strong> a week at %@",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+
+        static let twoRemindersShortDescriptionWithTime = NSLocalizedString("<strong>Twice</strong> a week at %@",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+
+        static let manyRemindersShortDescriptionWithTime = NSLocalizedString("<strong>%d</strong> times a week at %@",
+                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+
+        static let everydayRemindersShortDescriptionWithTime = NSLocalizedString("Every day at %@",
+                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+
+        static let oneReminderShortDescription = NSLocalizedString("<strong>Once</strong> a week",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+
+        static let twoRemindersShortDescription = NSLocalizedString("<strong>Twice</strong> a week",
+                                                                            comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+
+        static let manyRemindersShortDescription = NSLocalizedString("<strong>%d</strong> times a week",
+                                                                             comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags.")
+
+        static let everydayRemindersShortDescription = NSLocalizedString("Every day",
+                                                                                 comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
     }
 }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -13,44 +13,44 @@ struct BloggingRemindersScheduleFormatter {
 
     /// Attributed description string of the current schedule for the specified blog.
     ///
-    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
+    func shortIntervalDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
         switch schedule {
         case .none:
             return Self.stringToAttributedString(TextContent.shortNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return shortIntervalDescription(for: .none)
+                return shortIntervalDescription(for: .none, time: time)
             }
 
-            return Self.shortIntervalDescription(for: days.count)
+            return Self.shortIntervalDescription(for: days.count, time: time)
         }
     }
 
-    static func shortIntervalDescription(for days: Int) -> NSAttributedString {
+    static func shortIntervalDescription(for days: Int, time: String) -> NSAttributedString {
         let text: String = {
             switch days {
             case 1:
-                return NSLocalizedString("<strong>Once</strong> a week", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags.")
+                return String(format: NSLocalizedString("<strong>Once</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags."), time)
             case 2:
-                return NSLocalizedString("<strong>Twice</strong> a week", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags.")
+                return String(format: NSLocalizedString("<strong>Twice</strong> a week at %@", comment: "Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags."), time)
             case 7:
-                return "<strong>" + NSLocalizedString("Every day", comment: "Short title telling the user they will receive a blogging reminder every day of the week.") + "</strong>"
+                return "<strong>" + String(format: NSLocalizedString("Every day at %@", comment: "Short title telling the user they will receive a blogging reminder every day of the week."), time) + "</strong>"
             default:
-                return String(format: NSLocalizedString("<strong>%d</strong> times a week",
-                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days)
+                return String(format: NSLocalizedString("<strong>%d</strong> times a week at %@",
+                                                        comment: "A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags."), days, time)
             }
         }()
 
         return Self.stringToAttributedString(text)
     }
 
-    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule) -> NSAttributedString {
+    func longScheduleDescription(for schedule: BloggingRemindersScheduler.Schedule, time: String) -> NSAttributedString {
         switch schedule {
         case .none:
             return NSAttributedString(string: TextContent.longNoRemindersDescription)
         case .weekdays(let days):
             guard days.count > 0 else {
-                return longScheduleDescription(for: .none)
+                return longScheduleDescription(for: .none, time: time)
             }
 
             // We want the days sorted by their localized index because under some locale configurations
@@ -69,11 +69,11 @@ struct BloggingRemindersScheduleFormatter {
             let text: String
 
             if days.count == 1 {
-                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "")
+                text = String(format: TextContent.longNoRemindersDescriptionSingular, markedUpDays.first ?? "", "<strong>\(time)</strong>")
             } else {
                 let formatter = ListFormatter()
                 let formattedDays = formatter.string(from: markedUpDays) ?? ""
-                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays)
+                text = String(format: TextContent.longNoRemindersDescriptionPlural, "<strong>\(days.count)</strong>", formattedDays, "<strong>\(time)</strong>")
             }
 
             return Self.stringToAttributedString(text)
@@ -113,10 +113,10 @@ struct BloggingRemindersScheduleFormatter {
         static let longNoRemindersDescription = NSLocalizedString("You have no reminders set.", comment: "Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders.")
 
         // Ideally we should use stringsdict to translate plurals, but GlotPress currently doesn't support this.
-        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@.",
+        static let longNoRemindersDescriptionSingular = NSLocalizedString("You'll get a reminder to blog <strong>once</strong> a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'.")
 
-        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@.",
+        static let longNoRemindersDescriptionPlural = NSLocalizedString("You'll get reminders to blog %@ times a week on %@ at %@.",
                                                               comment: "Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -202,7 +202,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let promptText = NSMutableAttributedString(attributedString: formatter.longScheduleDescription(for: schedule))
+        let promptText = NSMutableAttributedString(attributedString: formatter.longScheduleDescription(for: schedule, time: scheduler.scheduledTime(for: blog).toLocalTime()))
 
         promptText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: promptText.length))
         promptLabel.attributedText = promptText

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -381,6 +381,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             self?.scheduledTime = date
             self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
             self?.refreshNextButton()
+            self?.refreshFrequencyLabel(time: date.toLocalTime())
         }
         viewController.preferredWidth = self.view.frame.width
         navigationController?.pushViewController(viewController, animated: true)
@@ -446,7 +447,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     }
 
     /// Updates the label that contains the number of scheduled days as users change them
-    func refreshFrequencyLabel() {
+    func refreshFrequencyLabel(time: String? = nil) {
         guard weekdays.count > 0 else {
             frequencyLabel.isHidden = true
             timeSelectionStackView.isHidden = true
@@ -460,7 +461,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays))
+        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays), time: time ?? scheduler.scheduledTime(for: blog).toLocalTime())
         let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
         attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -381,7 +381,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             self?.scheduledTime = date
             self?.timeSelectionButton.setSelectedTime(date.toLocalTime())
             self?.refreshNextButton()
-            self?.refreshFrequencyLabel(time: date.toLocalTime())
+            self?.refreshFrequencyLabel()
         }
         viewController.preferredWidth = self.view.frame.width
         navigationController?.pushViewController(viewController, animated: true)
@@ -447,7 +447,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     }
 
     /// Updates the label that contains the number of scheduled days as users change them
-    func refreshFrequencyLabel(time: String? = nil) {
+    func refreshFrequencyLabel() {
         guard weekdays.count > 0 else {
             frequencyLabel.isHidden = true
             timeSelectionStackView.isHidden = true
@@ -461,7 +461,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             .foregroundColor: UIColor.text,
         ]
 
-        let frequencyDescription = scheduleFormatter.shortIntervalDescription(for: .weekdays(weekdays), time: time ?? scheduler.scheduledTime(for: blog).toLocalTime())
+        let frequencyDescription = scheduleFormatter.shortScheduleDescription(for: .weekdays(weekdays))
         let attributedText = NSMutableAttributedString(attributedString: frequencyDescription)
         attributedText.addAttributes(defaultAttributes, range: NSRange(location: 0, length: attributedText.length))
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -313,6 +313,8 @@ extension SiteSettingsViewController {
     private func configureCellForBloggingReminders(_ cell: SettingTableViewCell) {
         cell.editable = true
         cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
+        cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
+        cell.detailTextLabel?.minimumScaleFactor = 0.5
         cell.accessoryType = .none
         cell.textValue = schedule(for: blog)
     }
@@ -325,7 +327,7 @@ extension SiteSettingsViewController {
         }
 
         let formatter = BloggingRemindersScheduleFormatter()
-        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog)).string
+        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
     }
 
     // MARK: - Handling General Setting Cell Taps

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -327,7 +327,7 @@ extension SiteSettingsViewController {
         }
 
         let formatter = BloggingRemindersScheduleFormatter()
-        return formatter.shortIntervalDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
+        return formatter.shortScheduleDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
     }
 
     // MARK: - Handling General Setting Cell Taps


### PR DESCRIPTION
Fixes #NA

This PR adds the time in two parts of Blogging Reminders (see screenshots):
- Site settings cell
- Blogging Reminders epilogue screen

To test:

- Build/run and go to site settings
- Set some reminders if you haven't done so already (tap Blogging Reminders then choose some days, choose a time or leave the default, then tap "Notify Me" and then "Done" in the following screen. You can also just dismiss the epilogue screen)
- Make sure the "Blogging Reminders" cell displays frequency and time in the detail label
- Tap on Blogging Reminders select/change days and/or time, then tap "Notify Me" (or "Update" if you have changed an existing schedule) and make sure the epilogue screen shows the days and the time you selected, in the description

Site Settings | Day Picker
-- | --
<img width="375" src="https://user-images.githubusercontent.com/34376330/130013102-21d43355-c658-41b0-b658-a31a8463061b.png"> | <img width="375" src="https://user-images.githubusercontent.com/34376330/130013145-e6fa1c02-7d59-4892-af97-d8316141608b.png">


## Regression Notes
1. Potential unintended areas of impact
None, this PR only changes descriptions

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
