### PR TITLE
Site Settings: Improve scroll performance

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -773,11 +773,11 @@ SPEC CHECKSUMS:
   React-jsinspector: dce15903df657a565e1f753e20b0864ceab7a181
   react-native-blur: 7f21bce1eeae924f28a4cefc7b23ce035c015ea5
   react-native-get-random-values: b441122f57ce07abacef889e87e77768fe5c9360
-  react-native-keyboard-aware-scroll-view: 1e8ddbe0138444283e6ca56e6a62ae835597fc84
+  react-native-keyboard-aware-scroll-view: 70e9aee078c494fba15d91b576bfbbd53639caca
   react-native-safe-area: e3de9e959c7baaae8db9bcb015d99ed1da25c9d5
-  react-native-safe-area-context: 713924ac0d8e1f324b45c73f2df7d5443292daa9
+  react-native-safe-area-context: ba2b2ec84d7a532d19c6b86f0deb2fd6d8a28362
   react-native-slider: 5ae4a65e7a80d5f0048cbb07944de6470b4a101b
-  react-native-video: a3ed30e1cbabaeac8f7e303ffd9985a353bc2268
+  react-native-video: 79b566a04ba3e90f2d21b2a7deb27b47b0123aa3
   React-perflogger: 1b191be4af85b046824841466b530926af106423
   React-RCTActionSheet: 6381fffb79f8574784be60e06b8a196ea31b694d
   React-RCTAnimation: 342a55b7d70b9f70dc3fa7cf9dcf0c2638c58cf4
@@ -790,7 +790,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 464cbf174f0c11d4853401fefe2627a3e648714d
   React-runtimeexecutor: 86375fe8e12dd6927345c677081b512d603d8adc
   ReactCommon: 05f421bbdca720b5706a988729512f0a482140eb
-  RNCMaskedView: 5db2009db2c2e72ec738e4f503f7cd4822c4235a
+  RNCMaskedView: e001674a509c52d3cfb7c5a0a2ca6f5d85d752d8
   RNGestureHandler: aaadb03e3637b3e7faf1f52d4872ffe32e613357
   RNReanimated: af718db8a69c9df3138aa6bb66ed48519fbf0afe
   RNScreens: 05c9398ab729aeaa010872cee9b0162876dffc31

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -773,11 +773,11 @@ SPEC CHECKSUMS:
   React-jsinspector: dce15903df657a565e1f753e20b0864ceab7a181
   react-native-blur: 7f21bce1eeae924f28a4cefc7b23ce035c015ea5
   react-native-get-random-values: b441122f57ce07abacef889e87e77768fe5c9360
-  react-native-keyboard-aware-scroll-view: 70e9aee078c494fba15d91b576bfbbd53639caca
+  react-native-keyboard-aware-scroll-view: 1e8ddbe0138444283e6ca56e6a62ae835597fc84
   react-native-safe-area: e3de9e959c7baaae8db9bcb015d99ed1da25c9d5
-  react-native-safe-area-context: ba2b2ec84d7a532d19c6b86f0deb2fd6d8a28362
+  react-native-safe-area-context: 713924ac0d8e1f324b45c73f2df7d5443292daa9
   react-native-slider: 5ae4a65e7a80d5f0048cbb07944de6470b4a101b
-  react-native-video: 79b566a04ba3e90f2d21b2a7deb27b47b0123aa3
+  react-native-video: a3ed30e1cbabaeac8f7e303ffd9985a353bc2268
   React-perflogger: 1b191be4af85b046824841466b530926af106423
   React-RCTActionSheet: 6381fffb79f8574784be60e06b8a196ea31b694d
   React-RCTAnimation: 342a55b7d70b9f70dc3fa7cf9dcf0c2638c58cf4
@@ -790,7 +790,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 464cbf174f0c11d4853401fefe2627a3e648714d
   React-runtimeexecutor: 86375fe8e12dd6927345c677081b512d603d8adc
   ReactCommon: 05f421bbdca720b5706a988729512f0a482140eb
-  RNCMaskedView: e001674a509c52d3cfb7c5a0a2ca6f5d85d752d8
+  RNCMaskedView: 5db2009db2c2e72ec738e4f503f7cd4822c4235a
   RNGestureHandler: aaadb03e3637b3e7faf1f52d4872ffe32e613357
   RNReanimated: af718db8a69c9df3138aa6bb66ed48519fbf0afe
   RNScreens: 05c9398ab729aeaa010872cee9b0162876dffc31

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -94,6 +94,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 @property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) NSString *username;
 @property (nonatomic, strong) NSString *password;
+
+@property (nonatomic, strong) NSArray<NSNumber *> *tableSections;
 @end
 
 @implementation SiteSettingsViewController
@@ -154,6 +156,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
 - (NSArray *)tableSections
 {
+    if (_tableSections) {
+        return _tableSections;
+    }
+
     NSMutableArray *sections = [NSMutableArray arrayWithObjects:@(SiteSettingsSectionGeneral), nil];
 
     if ([Feature enabled:FeatureFlagHomepageSettings] && [self.blog supports:BlogFeatureHomepageSettings]) {
@@ -187,6 +193,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         [sections addObject:@(SiteSettingsSectionAdvanced)];
     }
 
+    _tableSections = sections;
     return sections;
 }
 
@@ -984,6 +991,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     [service syncSettingsForBlog:self.blog success:^{
         [weakSelf.refreshControl endRefreshing];
         [weakSelf.tableView reloadData];
+        self.tableSections = nil; // force the tableSections to be repopulated.
     } failure:^(NSError *error) {
         [weakSelf.refreshControl endRefreshing];
     }];

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -990,8 +990,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
 
     [service syncSettingsForBlog:self.blog success:^{
         [weakSelf.refreshControl endRefreshing];
-        [weakSelf.tableView reloadData];
         self.tableSections = nil; // force the tableSections to be repopulated.
+        [weakSelf.tableView reloadData];
     } failure:^(NSError *error) {
         [weakSelf.refreshControl endRefreshing];
     }];


### PR DESCRIPTION
Refs `p5T066-2yQ-p2#comment-9613` (& the threads)

This fixes a frame drop issue while accessing and scrolling in the Site Settings page. Upon investigation, this is because the `tableSections` method always returns a new array object, populated with various conditionals and potential expensive operations. The `tableSections` method is called on these methods:

- `numberOfSectionsInTableView:`
- `tableView:cellForRowAtIndexPath:`
- `tableView:didSelectRowAtIndexPath:`
- `tableView:heightForRowAtIndexPath:`
- `tableView:numberOfRowsInSection:`
- `tableView:titleForHeaderInSection:`
- `tableView:viewForFooterInSection:`

The fix was to turn `tableSections` into an `NSArray<NSNumber *> *` instance variable. This makes the current `- (NSArray *)tableSections` method a setter override, and the method body is only invoked when the variable is nil.

Note that the page supports pull to refresh, which calls `refreshData`. To properly repopulate `tableSections`, the variable is reset to `nil` in order to properly repopulate the value.

--- 
cc: @mokagio if this is cutting too close to the submission, just let me know and I'll update this to target 18.1 instead. Thank you! 🙂 

## To test

### Scenario 1: The page should no longer be laggy.
- Select a site where you're an Administrator
- Open Site Settings.
- Verify that the page feels buttery smooth ✨ 

### Scenario 2: Data should be refreshed with new changes upon pull to refresh.
- Select a site where you're an Administrator.
- Open Site Settings.
- Open wordpress.com from the web, go to Settings, and change the Site Name and Site Tagline. Tap Save.
- Go back to the app, and perform a pull to refresh on the Site Settings page.
- Verify that the page is updated with the newest changes.

## Regression Notes
1. Potential unintended areas of impact
Table sections having stale values after pull to refresh.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually verified that the content is updated on pull to refresh.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
