### PR TITLE
Edit Comment: show comment data from selected comment

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -657,7 +657,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     UINavigationController *navController;
     
     if ([Feature enabled:FeatureFlagNewCommentEdit]) {
-        EditCommentTableViewController *editViewController = [[EditCommentTableViewController alloc] init];
+        EditCommentTableViewController *editViewController = [[EditCommentTableViewController alloc] initWithComment:self.comment];
         navController = [[UINavigationController alloc] initWithRootViewController:editViewController];
         navController.modalPresentationStyle = UIModalPresentationFullScreen;
     } else {

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+class EditCommentSingleLineCell: UITableViewCell, NibReusable {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var textField: UITextField!
+
+    // Used to determine TextField configuration options.
+    enum TextFieldStyle {
+        case text
+        case url
+        case email
+    }
+
+    // MARK: - View
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureCell()
+    }
+
+    func configure(text: String? = nil, style: TextFieldStyle = .text) {
+        applyTextFieldStyle(style)
+        textField.text = text
+    }
+
+}
+
+// MARK: - UITextFieldDelegate
+
+extension EditCommentSingleLineCell: UITextFieldDelegate {
+
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        textField.resignFirstResponder()
+        return true
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension EditCommentSingleLineCell {
+
+    func configureCell() {
+        textField.font = .preferredFont(forTextStyle: .body)
+        textField.textColor = .text
+    }
+
+    func applyTextFieldStyle(_ style: TextFieldStyle) {
+        switch style {
+        case .text:
+            textField.autocorrectionType = .yes
+            textField.keyboardType = .default
+            textField.returnKeyType = .default
+        case .url:
+            textField.autocorrectionType = .no
+            textField.keyboardType = .URL
+        case .email:
+            textField.autocorrectionType = .no
+            textField.keyboardType = .emailAddress
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="127" id="LfA-no-L5x" customClass="EditCommentSingleLineCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="364" height="127"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LfA-no-L5x" id="20L-Xf-3Te">
+                <rect key="frame" x="0.0" y="0.0" width="364" height="127"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="2wP-Ee-7cF">
+                        <rect key="frame" x="16" y="11" width="332" height="105"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>
+                        <connections>
+                            <outlet property="delegate" destination="LfA-no-L5x" id="ocs-Z3-8ze"/>
+                        </connections>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="2wP-Ee-7cF" secondAttribute="bottom" constant="11" id="90b-bJ-IoF"/>
+                    <constraint firstItem="2wP-Ee-7cF" firstAttribute="leading" secondItem="20L-Xf-3Te" secondAttribute="leading" constant="16" id="LfS-0x-Dwu"/>
+                    <constraint firstItem="2wP-Ee-7cF" firstAttribute="top" secondItem="20L-Xf-3Te" secondAttribute="top" constant="11" id="YXg-DW-6qd"/>
+                    <constraint firstAttribute="trailing" secondItem="2wP-Ee-7cF" secondAttribute="trailing" constant="16" id="trM-a6-0C0"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="textField" destination="2wP-Ee-7cF" id="jTB-O9-eh0"/>
+            </connections>
+            <point key="canvasLocation" x="-131.8840579710145" y="-23.772321428571427"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -5,6 +5,11 @@ class EditCommentTableViewController: UITableViewController {
 
     // MARK: - Properties
 
+    private var authorName: String?
+    private var commentContent: String?
+    private var authorWebAddress: String?
+    private var authorEmailAddress: String?
+
     private let sectionHeaders =
         [NSLocalizedString("Name", comment: "Header for a comment author's name, shown when editing a comment.").localizedUppercase,
          NSLocalizedString("Comment", comment: "Header for a comment's content, shown when editing a comment.").localizedUppercase,
@@ -12,6 +17,14 @@ class EditCommentTableViewController: UITableViewController {
          NSLocalizedString("Email Address", comment: "Header for a comment author's email address, shown when editing a comment.").localizedUppercase]
 
     // MARK: - Init
+
+    @objc convenience init(comment: Comment) {
+        self.init()
+        authorName = comment.author
+        commentContent = comment.contentForEdit()
+        authorWebAddress = comment.author_url
+        authorEmailAddress = comment.author_email
+    }
 
     required convenience init() {
         self.init(style: .insetGrouped)
@@ -29,6 +42,7 @@ class EditCommentTableViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupTableView()
         setupNavBar()
     }
 
@@ -47,8 +61,26 @@ class EditCommentTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: return custom cell
-        return UITableViewCell()
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: EditCommentSingleLineCell.defaultReuseID) as? EditCommentSingleLineCell else {
+            return UITableViewCell()
+        }
+
+        switch indexPath.section {
+        case 0:
+            cell.configure(text: authorName)
+        case 1:
+            // TODO: use multiline textView
+            cell.configure(text: commentContent)
+        case 2:
+            cell.configure(text: authorWebAddress, style: .url)
+        case 3:
+            cell.configure(text: authorEmailAddress, style: .email)
+        default:
+            DDLogError("Edit Comment: unsupported table section.")
+            break
+        }
+
+        return cell
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
@@ -66,6 +98,11 @@ class EditCommentTableViewController: UITableViewController {
 private extension EditCommentTableViewController {
 
     // MARK: - View Config
+
+    func setupTableView() {
+        tableView.register(EditCommentSingleLineCell.defaultNib,
+                           forCellReuseIdentifier: EditCommentSingleLineCell.defaultReuseID)
+    }
 
     func setupNavBar() {
         title = NSLocalizedString("Edit Comment", comment: "View title when editing a comment.")

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1223,30 +1223,20 @@ private extension NotificationDetailsViewController {
     }
 
     func displayCommentEditorWithBlock(_ block: FormattableCommentContent) {
-
-        var navController: UINavigationController
-
-        if FeatureFlag.newCommentEdit.enabled {
-            let editViewController = EditCommentTableViewController()
-            navController = UINavigationController(rootViewController: editViewController)
-            navController.modalPresentationStyle = .fullScreen
-        } else {
-            let editViewController = EditCommentViewController.newEdit()
-            editViewController?.content = block.text
-            editViewController?.onCompletion = { (hasNewContent, newContent) in
-                self.dismiss(animated: true, completion: {
-                    guard hasNewContent else {
-                        return
-                    }
-                    let newContent = newContent ?? ""
-                    self.updateComment(with: block, content: newContent)
-                })
-            }
-
-            navController = UINavigationController(rootViewController: editViewController!)
-            navController.modalPresentationStyle = .formSheet
+        let editViewController = EditCommentViewController.newEdit()
+        editViewController?.content = block.text
+        editViewController?.onCompletion = { (hasNewContent, newContent) in
+            self.dismiss(animated: true, completion: {
+                guard hasNewContent else {
+                    return
+                }
+                let newContent = newContent ?? ""
+                self.updateComment(with: block, content: newContent)
+            })
         }
 
+        let navController = UINavigationController(rootViewController: editViewController!)
+        navController.modalPresentationStyle = .formSheet
         navController.modalTransitionStyle = .coverVertical
         navController.navigationBar.isTranslucent = false
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1586,6 +1586,10 @@
 		98906508237CC1DF00218CD2 /* WidgetTwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989064FE237CC1DE00218CD2 /* WidgetTwoColumnCell.xib */; };
 		98906509237CC1DF00218CD2 /* WidgetTwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989064FE237CC1DE00218CD2 /* WidgetTwoColumnCell.xib */; };
 		98921EF721372E12004949AA /* MediaCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98921EF621372E12004949AA /* MediaCoordinator.swift */; };
+		9894080C26CEE03A0035FB4C /* EditCommentSingleLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9894080A26CEE0390035FB4C /* EditCommentSingleLineCell.swift */; };
+		9894080D26CEE03A0035FB4C /* EditCommentSingleLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9894080A26CEE0390035FB4C /* EditCommentSingleLineCell.swift */; };
+		9894080E26CEE03A0035FB4C /* EditCommentSingleLineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9894080B26CEE03A0035FB4C /* EditCommentSingleLineCell.xib */; };
+		9894080F26CEE03B0035FB4C /* EditCommentSingleLineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9894080B26CEE03A0035FB4C /* EditCommentSingleLineCell.xib */; };
 		9895401126C1F39300EDEB5A /* EditCommentTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9895401026C1F39300EDEB5A /* EditCommentTableViewController.swift */; };
 		9895401226C1F39300EDEB5A /* EditCommentTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9895401026C1F39300EDEB5A /* EditCommentTableViewController.swift */; };
 		9895B6E021ED49160053D370 /* TopTotalsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9895B6DF21ED49160053D370 /* TopTotalsCell.xib */; };
@@ -6250,6 +6254,8 @@
 		989064FD237CC1DE00218CD2 /* WidgetTwoColumnCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetTwoColumnCell.swift; sourceTree = "<group>"; };
 		989064FE237CC1DE00218CD2 /* WidgetTwoColumnCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WidgetTwoColumnCell.xib; sourceTree = "<group>"; };
 		98921EF621372E12004949AA /* MediaCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaCoordinator.swift; sourceTree = "<group>"; };
+		9894080A26CEE0390035FB4C /* EditCommentSingleLineCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditCommentSingleLineCell.swift; sourceTree = "<group>"; };
+		9894080B26CEE03A0035FB4C /* EditCommentSingleLineCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EditCommentSingleLineCell.xib; sourceTree = "<group>"; };
 		9895401026C1F39300EDEB5A /* EditCommentTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCommentTableViewController.swift; sourceTree = "<group>"; };
 		9895B6DF21ED49160053D370 /* TopTotalsCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = TopTotalsCell.xib; sourceTree = "<group>"; };
 		989643EA23A0437B0070720A /* WidgetDifferenceCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDifferenceCell.swift; sourceTree = "<group>"; };
@@ -12420,6 +12426,8 @@
 				9835F16D25E492EE002EFF23 /* CommentsList.storyboard */,
 				B5CEEB8D1B7920BE00E7B7B0 /* CommentsTableViewCell.swift */,
 				B5CEEB8F1B79244D00E7B7B0 /* CommentsTableViewCell.xib */,
+				9894080A26CEE0390035FB4C /* EditCommentSingleLineCell.swift */,
+				9894080B26CEE03A0035FB4C /* EditCommentSingleLineCell.xib */,
 				5D6C4AFD1B603CE9005E3C43 /* EditCommentViewController.xib */,
 				FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */,
 			);
@@ -15347,6 +15355,7 @@
 				596C03601B84F24000899EEB /* ThemeBrowser.storyboard in Resources */,
 				17222DA4261DDDF90047B163 /* spectrum-icon-app-83.5x83.5@2x.png in Resources */,
 				9A9E3FB2230EB74300909BC4 /* StatsGhostTabbedCell.xib in Resources */,
+				9894080E26CEE03A0035FB4C /* EditCommentSingleLineCell.xib in Resources */,
 				469CE06E24BCED75003BDC8B /* CategorySectionTableViewCell.xib in Resources */,
 				4034FDEE2007D4F700153B87 /* ExpandableCell.xib in Resources */,
 				1761F18026209AEE000815EF /* jetpack-green-icon-app-76x76.png in Resources */,
@@ -15643,6 +15652,7 @@
 				FABB1FF72602FC2C00C8785C /* Revisions.storyboard in Resources */,
 				FABB1FF82602FC2C00C8785C /* ActivityDetailViewController.storyboard in Resources */,
 				FABB1FF92602FC2C00C8785C /* ReaderDetailHeaderView.xib in Resources */,
+				9894080F26CEE03B0035FB4C /* EditCommentSingleLineCell.xib in Resources */,
 				FABB1FFA2602FC2C00C8785C /* ReaderTagsFooter.xib in Resources */,
 				FABB1FFB2602FC2C00C8785C /* PostingActivityLegend.xib in Resources */,
 				FABB1FFC2602FC2C00C8785C /* PostingActivityViewController.storyboard in Resources */,
@@ -17808,6 +17818,7 @@
 				8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */,
 				329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */,
 				436D56242117312700CEAA33 /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
+				9894080C26CEE03A0035FB4C /* EditCommentSingleLineCell.swift in Sources */,
 				C81CCD65243AECA200A83E27 /* TenorGIF.swift in Sources */,
 				596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */,
 				4353BFA9219E0E820009CED3 /* RevisionOperationViewController.swift in Sources */,
@@ -19986,6 +19997,7 @@
 				FABB24B52602FC2C00C8785C /* RestoreStatusView.swift in Sources */,
 				FABB24B62602FC2C00C8785C /* CustomizeInsightsCell.swift in Sources */,
 				FABB24B72602FC2C00C8785C /* SVProgressHUD+Dismiss.m in Sources */,
+				9894080D26CEE03A0035FB4C /* EditCommentSingleLineCell.swift in Sources */,
 				FABB24B82602FC2C00C8785C /* DynamicHeightCollectionView.swift in Sources */,
 				FABB24B92602FC2C00C8785C /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
 				FABB24BA2602FC2C00C8785C /* TenorGIF.swift in Sources */,


### PR DESCRIPTION
Ref: #17000

This displays the comment data from the selected comment in the new Edit Comment view.
- A new `EditCommentSingleLineCell` is used to display a `UITextField` in the cells to allow the data to be editable.
- For now, the `Comment` field uses this new cell. That will be changed to a multi-line field in a future PR.
- The fields are editable, but changes are not saved yet.
- The keyboard displayed is specific to each field:
  - `Name` and `Comment` = `default`
  - `Web Address` = `URL`
  - `Email Address` = `emailAddress`

Also, since getting comment information for Notifications will require an API change, I've removed showing the new Edit Comment view from comment notifications.

To test:
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
  - Verify the comment and author information is displayed.
- Go to  Notifications > Comments > notification details > Edit.
  - Verify the new Edit Comment view is not displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
