### PR TITLE
Recommend App: Enable feature flag to public

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [**] Added a time selection feature to Blogging Reminders: users can now choose at what time they will receive the reminders [#17024, #17033]
 * [**] Block editor: Embed block: Add "Resize for smaller devices" setting. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3753]
 * [**] Account Settings: added the ability to close user account.
+* [*] Users can now share WordPress app with friends. Accessible from Me and About screen. [#16995]
 
 18.0
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,7 +43,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .unifiedCommentsAndNotificationsList:
             return true
         case .recommendAppToOthers:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return true
         case .newCommentEdit:
             return false
         }


### PR DESCRIPTION
Refs #16995

Enables the share button feature flag in Me and About screen for general public. Here's a 👀 :

Me screen | About screen
--|--
![me](https://user-images.githubusercontent.com/1299411/130436830-fb9fd3e2-752c-456d-96f7-70fa068c8607.png) | ![about](https://user-images.githubusercontent.com/1299411/130436837-df38c437-ed2c-4f62-97f7-cd5abaa1e436.png)

---
⚠️  Please note that this feature is only enabled in WordPress. This feature is disabled for Jetpack. ⚠️

https://github.com/wordpress-mobile/WordPress-iOS/blob/a56e6a6c561bbd9d66e639dcbc56ca2e1c33bb44/WordPress/Classes/ViewRelated/Me/App%20Settings/About/AboutViewController.swift#L280-L283

https://github.com/wordpress-mobile/WordPress-iOS/blob/a56e6a6c561bbd9d66e639dcbc56ca2e1c33bb44/WordPress/Classes/ViewRelated/Me/Me%20Main/MeViewController.swift#L413-L416 

---

To test:
- Go to Me screen. Verify that the share button is visible, accessible, and works as expected.
- Go to Me > App Settings > About screen. Verify that the share button is visible, accessible, and works as expected.
- Repeat the above 👆 with a self-hosted site. Verify that the share button works without a WordPress.com account.

## Regression Notes
1. Potential unintended areas of impact
Some parts in Me or About screen may not work correctly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested that the button is accessible and works as expected.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
