### PR TITLE
Alphabetize non-standard post formats.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 18.2
 -----
-
+* [*] Set the post formats to have 'Standard' first and then alphabetized the remaining items. [#17074]
 
 18.1
 -----

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -242,16 +242,18 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     if ([self.postFormats count] == 0) {
         return @[];
     }
+
     NSMutableArray *sortedFormats = [NSMutableArray arrayWithCapacity:[self.postFormats count]];
- 
+
     if (self.postFormats[PostFormatStandard]) {
         [sortedFormats addObject:PostFormatStandard];
     }
-    [self.postFormats enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        if (![key isEqual:PostFormatStandard]) {
-            [sortedFormats addObject:key];
-        }
+
+    NSArray *sortedNonStandardFormats = [[self.postFormats keysSortedByValueUsingSelector:@selector(localizedCaseInsensitiveCompare:)] wp_filter:^BOOL(id obj) {
+        return ![obj isEqual:PostFormatStandard];
     }];
+
+    [sortedFormats addObjectsFromArray:sortedNonStandardFormats];
 
     return [NSArray arrayWithArray:sortedFormats];
 }

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -109,6 +109,12 @@ final class BlogBuilder {
         blog.options = options
         return self
     }
+
+    func with(postFormats: [String: String]) -> Self {
+        blog.postFormats = postFormats
+
+        return self
+    }
 }
 
 extension Blog {

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -210,6 +210,38 @@ class PostTests: XCTestCase {
         XCTAssertEqual(post.postFormat, secondaryPostFormat.key)
     }
 
+    func testPostFormatSorting() throws {
+        let postFormats = [
+            "b": "B",
+            "c": "C",
+            "q": "Q",
+            "z": "Z",
+            "standard": "Standard",
+            "a": "A",
+            "d": "D",
+        ]
+
+        let expectedPostFormats = [
+            ("standard", "Standard"),
+            ("a", "A"),
+            ("b", "B"),
+            ("c", "C"),
+            ("d", "D"),
+            ("q", "Q"),
+            ("z", "Z")
+        ]
+
+        let blog = BlogBuilder(context)
+            .with(postFormats: postFormats)
+            .build()
+
+        let sortedPostFormats = try XCTUnwrap(blog.sortedPostFormats as? [String])
+        let sortedPostFormatNames = try XCTUnwrap(blog.sortedPostFormatNames as? [String])
+
+        XCTAssertEqual(expectedPostFormats.map { $0.0 }, sortedPostFormats)
+        XCTAssertEqual(expectedPostFormats.map { $0.1 }, sortedPostFormatNames)
+    }
+
     func testThatHasCategoriesWorks() {
         let post = newTestPost()
 


### PR DESCRIPTION
Fixes #17072

## To test:

On a Simple site running the Twenty Twenty-One theme:

1. Create a new Post in WPiOS.
2. Tap the ellipses at the top right.
3. Choose Post Settings in the bottom sheet.
4. Tap Post Format.

## Regression Notes
1. Potential unintended areas of impact
Setting the post format doesn't match the post on the web.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested selecting a non-standard format and publishing a new post. I then verified that the format I selected matched what was set for the post on the web and WPiOS.

3. What automated tests I added (or what prevented me from doing so)
`PostTests:testPostFormatSorting`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
