### PR TITLE
Edit Comment: show comment body in a dynamic text view

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+protocol EditCommentMultiLineCellDelegate: AnyObject {
+    func textViewHeightUpdated()
+}
+
+class EditCommentMultiLineCell: UITableViewCell, NibReusable {
+
+    // MARK: - Properties
+
+    @IBOutlet weak var textView: UITextView!
+    @IBOutlet weak var textViewMinHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var textViewTopConstraint: NSLayoutConstraint!
+    private var textViewPadding: CGFloat = 0
+    weak var delegate: EditCommentMultiLineCellDelegate?
+
+    // MARK: - View
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureCell()
+        textViewPadding = textViewTopConstraint.constant * 2
+    }
+
+    func configure(text: String? = nil) {
+        textView.text = text
+        adjustHeight()
+    }
+
+}
+
+// MARK: - UITextViewDelegate
+
+extension EditCommentMultiLineCell: UITextViewDelegate {
+
+    func textViewDidChange(_ textView: UITextView) {
+        adjustHeight()
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension EditCommentMultiLineCell {
+
+    func configureCell() {
+        textView.font = .preferredFont(forTextStyle: .body)
+        textView.textColor = .text
+        textView.backgroundColor = .clear
+    }
+
+    func adjustHeight() {
+        let originalCellHeight = frame.size.height
+        let textViewSize = textView.sizeThatFits(CGSize(width: textView.frame.size.width, height: CGFloat.greatestFiniteMagnitude))
+        let textViewHeight = ceilf(Float(max(textViewSize.height, textViewMinHeightConstraint.constant)))
+        let newCellHeight = CGFloat(textViewHeight) + textViewPadding
+        frame.size.height = newCellHeight
+
+        if newCellHeight != originalCellHeight {
+            delegate?.textViewHeightUpdated()
+        }
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.xib
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="LfA-no-L5x" customClass="EditCommentMultiLineCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="364" height="150"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LfA-no-L5x" id="20L-Xf-3Te">
+                <rect key="frame" x="0.0" y="0.0" width="364" height="150"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" contentInsetAdjustmentBehavior="never" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FkL-aB-20C">
+                        <rect key="frame" x="16" y="11" width="332" height="130"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="130" id="mme-Ba-30V"/>
+                        </constraints>
+                        <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. </string>
+                        <color key="textColor" systemColor="labelColor"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                        <connections>
+                            <outlet property="delegate" destination="LfA-no-L5x" id="Uer-HX-Iil"/>
+                        </connections>
+                    </textView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="FkL-aB-20C" secondAttribute="bottom" constant="11" id="42s-N9-VoW"/>
+                    <constraint firstItem="FkL-aB-20C" firstAttribute="leading" secondItem="20L-Xf-3Te" secondAttribute="leading" constant="16" id="5SV-Zt-oKA"/>
+                    <constraint firstItem="FkL-aB-20C" firstAttribute="top" secondItem="20L-Xf-3Te" secondAttribute="top" constant="11" id="mgJ-V6-WZA"/>
+                    <constraint firstAttribute="trailing" secondItem="FkL-aB-20C" secondAttribute="trailing" constant="16" id="z8Y-Et-ldW"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="textView" destination="FkL-aB-20C" id="GOY-jR-qNE"/>
+                <outlet property="textViewMinHeightConstraint" destination="mme-Ba-30V" id="zh4-cE-ddl"/>
+                <outlet property="textViewTopConstraint" destination="mgJ-V6-WZA" id="b9P-BE-IiY"/>
+            </connections>
+            <point key="canvasLocation" x="-131.8840579710145" y="-16.071428571428569"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="labelColor">
+            <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
@@ -9,7 +9,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="127" id="LfA-no-L5x" customClass="EditCommentSingleLineCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="LfA-no-L5x" customClass="EditCommentSingleLineCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="364" height="127"/>
             <autoresizingMask key="autoresizingMask"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LfA-no-L5x" id="20L-Xf-3Te">

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
@@ -16,7 +16,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="364" height="127"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="2wP-Ee-7cF">
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="2wP-Ee-7cF">
                         <rect key="frame" x="16" y="11" width="332" height="105"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -10,6 +10,11 @@ class EditCommentTableViewController: UITableViewController {
     private var authorWebAddress: String?
     private var authorEmailAddress: String?
 
+    // If the textView cell is recreated via dequeueReusableCell,
+    // the cursor location is lost when the cell is scrolled off screen.
+    // So save and use one instance of the cell.
+    private let commentContentCell = EditCommentMultiLineCell.loadFromNib()
+
     // MARK: - Init
 
     @objc convenience init(comment: Comment) {
@@ -18,6 +23,7 @@ class EditCommentTableViewController: UITableViewController {
         commentContent = comment.contentForEdit()
         authorWebAddress = comment.author_url
         authorEmailAddress = comment.author_email
+        configureCommentContentCell()
     }
 
     required convenience init() {
@@ -63,13 +69,7 @@ class EditCommentTableViewController: UITableViewController {
 
         // Comment content cell
         if tableSection == TableSections.comment {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: EditCommentMultiLineCell.defaultReuseID) as? EditCommentMultiLineCell else {
-                return UITableViewCell()
-            }
-
-            cell.configure(text: commentContent)
-            cell.delegate = self
-            return cell
+            return commentContentCell
         }
 
         // All other cells
@@ -118,6 +118,11 @@ private extension EditCommentTableViewController {
                            forCellReuseIdentifier: EditCommentMultiLineCell.defaultReuseID)
     }
 
+    func configureCommentContentCell() {
+        commentContentCell.configure(text: commentContent)
+        commentContentCell.delegate = self
+    }
+
     func setupNavBar() {
         title = NSLocalizedString("Edit Comment", comment: "View title when editing a comment.")
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancelButtonTapped))
@@ -159,7 +164,8 @@ private extension EditCommentTableViewController {
 
         var header: String {
             switch self {
-            case .name: return NSLocalizedString("Name", comment: "Header for a comment author's name, shown when editing a comment.").localizedUppercase
+            case .name:
+                return NSLocalizedString("Name", comment: "Header for a comment author's name, shown when editing a comment.").localizedUppercase
             case .webAddress:
                 return NSLocalizedString("Web Address", comment: "Header for a comment author's web address, shown when editing a comment.").localizedUppercase
             case .emailAddress:

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1661,6 +1661,10 @@
 		98E5D4922620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
 		98E5D4932620C2B40074A56A /* UserProfileSectionHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */; };
 		98EB126A20D2DC2500D2D5B5 /* NoResultsViewController+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */; };
+		98EC6B7926D019D40074DC70 /* EditCommentMultiLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EC6B7726D019D30074DC70 /* EditCommentMultiLineCell.swift */; };
+		98EC6B7A26D019D40074DC70 /* EditCommentMultiLineCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98EC6B7726D019D30074DC70 /* EditCommentMultiLineCell.swift */; };
+		98EC6B7B26D019D40074DC70 /* EditCommentMultiLineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98EC6B7826D019D40074DC70 /* EditCommentMultiLineCell.xib */; };
+		98EC6B7C26D019D40074DC70 /* EditCommentMultiLineCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98EC6B7826D019D40074DC70 /* EditCommentMultiLineCell.xib */; };
 		98ED5963265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */; };
 		98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */; };
 		98F0297C2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */; };
@@ -6308,6 +6312,8 @@
 		98E58A432361019300E5534B /* Pods_WordPressTodayWidget.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Pods_WordPressTodayWidget.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98E5D4912620C2B40074A56A /* UserProfileSectionHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserProfileSectionHeader.xib; sourceTree = "<group>"; };
 		98EB126920D2DC2500D2D5B5 /* NoResultsViewController+Model.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NoResultsViewController+Model.swift"; sourceTree = "<group>"; };
+		98EC6B7726D019D30074DC70 /* EditCommentMultiLineCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EditCommentMultiLineCell.swift; sourceTree = "<group>"; };
+		98EC6B7826D019D40074DC70 /* EditCommentMultiLineCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EditCommentMultiLineCell.xib; sourceTree = "<group>"; };
 		98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailLikesListController.swift; sourceTree = "<group>"; };
 		98F0297A2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginEpilogueConnectSiteCell.swift; sourceTree = "<group>"; };
 		98F0297B2405C9E500FFD862 /* LoginEpilogueConnectSiteCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LoginEpilogueConnectSiteCell.xib; sourceTree = "<group>"; };
@@ -12404,6 +12410,8 @@
 				9835F16D25E492EE002EFF23 /* CommentsList.storyboard */,
 				B5CEEB8D1B7920BE00E7B7B0 /* CommentsTableViewCell.swift */,
 				B5CEEB8F1B79244D00E7B7B0 /* CommentsTableViewCell.xib */,
+				98EC6B7726D019D30074DC70 /* EditCommentMultiLineCell.swift */,
+				98EC6B7826D019D40074DC70 /* EditCommentMultiLineCell.xib */,
 				9894080A26CEE0390035FB4C /* EditCommentSingleLineCell.swift */,
 				9894080B26CEE03A0035FB4C /* EditCommentSingleLineCell.xib */,
 				5D6C4AFD1B603CE9005E3C43 /* EditCommentViewController.xib */,
@@ -15183,6 +15191,7 @@
 				5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */,
 				B5C66B781ACF073900F68370 /* NoteBlockImageTableViewCell.xib in Resources */,
 				FEA088032696E81F00193358 /* ListTableHeaderView.xib in Resources */,
+				98EC6B7B26D019D40074DC70 /* EditCommentMultiLineCell.xib in Resources */,
 				B59F34A1207678480069992D /* SignupEpilogue.storyboard in Resources */,
 				B5683DB81B6C03810043447C /* NoteTableHeaderView.xib in Resources */,
 				98FCFC242231DF43006ECDD4 /* PostStatsTitleCell.xib in Resources */,
@@ -15765,6 +15774,7 @@
 				FABB20AD2602FC2C00C8785C /* StatsGhostSingleRowCell.xib in Resources */,
 				FABB20AE2602FC2C00C8785C /* ThemeBrowser.storyboard in Resources */,
 				FABB20AF2602FC2C00C8785C /* StatsGhostTabbedCell.xib in Resources */,
+				98EC6B7C26D019D40074DC70 /* EditCommentMultiLineCell.xib in Resources */,
 				FABB20B02602FC2C00C8785C /* CategorySectionTableViewCell.xib in Resources */,
 				FABB20B22602FC2C00C8785C /* ExpandableCell.xib in Resources */,
 				FABB20B42602FC2C00C8785C /* WidgetUrlCell.xib in Resources */,
@@ -17198,6 +17208,7 @@
 				E166FA1B1BB0656B00374B5B /* PeopleCellViewModel.swift in Sources */,
 				73CE3E0E21F7F9D3007C9C85 /* TableViewOffsetCoordinator.swift in Sources */,
 				436D56292117312700CEAA33 /* RegisterDomainDetailsViewController.swift in Sources */,
+				98EC6B7926D019D40074DC70 /* EditCommentMultiLineCell.swift in Sources */,
 				F5E29036243E4F5F00C19CA5 /* FilterProvider.swift in Sources */,
 				027AC51D227896540033E56E /* DomainCreditEligibilityChecker.swift in Sources */,
 				83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */,
@@ -20063,6 +20074,7 @@
 				FABB25072602FC2C00C8785C /* SiteAssemblyService.swift in Sources */,
 				FABB25082602FC2C00C8785C /* ManagedPerson.swift in Sources */,
 				FABB25092602FC2C00C8785C /* ChosenValueRow.swift in Sources */,
+				98EC6B7A26D019D40074DC70 /* EditCommentMultiLineCell.swift in Sources */,
 				FABB250A2602FC2C00C8785C /* ReplyTextView.swift in Sources */,
 				FABB250B2602FC2C00C8785C /* PublicizeConnectionStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB250C2602FC2C00C8785C /* MenuItemEditingFooterView.m in Sources */,


### PR DESCRIPTION
Ref: #17000
Discussion: pbArwn-2ks#comment-3755

This adds a new table cell to display the Comment body. 

- A new `EditCommentMultiLineCell` is used to display a `UITextView` to allow the content to be editable and the size dynamic.
- When initially displayed, it is sized per the text displayed.
- As the text is edited, the field height grows/shrinks accordingly. 
- The `UITextView` will not shrink below the minimum height of 130 pts, or about 5 lines.
- The order of the fields (table rows) has been updated so that `Comment` is last.
- The updated text is not saved yet.

As [noted](https://github.com/wordpress-mobile/WordPress-iOS/pull/17059#discussion_r693153835) with `EditCommentSingleLineCell`, if the new `EditCommentMultiLineCell` can be generic in the end, I'll make it so.

To test:

---
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
- Verify the body is displayed in the `Comment` field, and it is sized correctly.

| ![long_text](https://user-images.githubusercontent.com/1816888/130539312-6df9164f-c768-4f26-9bf5-dc46586a6894.png) | ![no_text](https://user-images.githubusercontent.com/1816888/130539328-341f1893-baf3-4e97-9738-14f0a397b496.png) |
|--------|-------|

---
- Type in the `Comment` field. 
- Verify the field grows accordingly.

| ![short_text](https://user-images.githubusercontent.com/1816888/130539511-fbd255ad-5ef7-49c3-9970-269fa870e85d.png) | ![grow](https://user-images.githubusercontent.com/1816888/130539528-0ac8c96b-4018-4cf7-89cd-4d6490b1a72c.png) |
|--------|-------|

---
- Remove text from the `Comment` field. 
- Verify the field shrinks accordingly.

| ![long_text](https://user-images.githubusercontent.com/1816888/130539596-6384bbcd-51f0-430e-9c34-8f68f25c0677.png) | ![shorten](https://user-images.githubusercontent.com/1816888/130539612-eed2827a-6967-4ea1-9844-3b8bd115101f.png) |
|--------|-------|

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
