### PR TITLE
When the user purchases a domain, set the new primary domain asynchronously

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -4,9 +4,8 @@ import UIKit
 /// Makes RegisterDomainSuggestionsViewController available to SwiftUI
 final class DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable {
 
-    let blog: Blog
-
-    weak var presentingController: RegisterDomainSuggestionsViewController?
+    private let blog: Blog
+    private weak var presentingController: RegisterDomainSuggestionsViewController?
 
     init(blog: Blog) {
         self.blog = blog


### PR DESCRIPTION
Depends on https://github.com/wordpress-mobile/WordPress-iOS/pull/17071

This is currently aimed at that PR because this was branched off it, and it helps show the specific diff introduced by this branch.  This PR will target `develop` once the dependency is merged..

## To test:

The following steps can be used to test the original issue in https://github.com/wordpress-mobile/WordPress-iOS/pull/17071 and the solution in this branch.

1. Go to `DomainsServiceRemote.swift:95`.
2. Prevent the service from being called and call the failure block with an error.

Steps:

1. Run the app
2. Purchase a domain (sandbox store recommended)
3. If you're in this branch, you should just get a notice telling you about the failure.  If you're in develop / https://github.com/wordpress-mobile/WordPress-iOS/pull/17071 you should be blocked from moving forward, even though the domain was purchased.

## Regression Notes

1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
