### PR TITLE
Add the blog_id to editor session event properties

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -50,7 +50,7 @@ struct PostEditorAnalyticsSession {
 
     mutating func `switch`(editor: Editor) {
         currentEditor = editor
-        WPAppAnalytics.track(.editorSessionSwitchEditor, withProperties: commonProperties)
+        WPAppAnalytics.track(.editorSessionSwitchEditor, withProperties: commonProperties, withBlogID: blogID)
     }
 
     mutating func forceOutcome(_ newOutcome: Outcome) {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -3,6 +3,7 @@ import Foundation
 struct PostEditorAnalyticsSession {
     private let sessionId = UUID().uuidString
     let postType: String
+    let blogID: NSNumber?
     let blogType: String
     let contentType: String
     var started = false
@@ -14,6 +15,7 @@ struct PostEditorAnalyticsSession {
     init(editor: Editor, post: AbstractPost) {
         currentEditor = editor
         postType = post.analyticsPostType ?? "unsupported"
+        blogID = post.blog.dotComID
         blogType = post.blog.analyticsType.rawValue
         contentType = ContentType(post: post).rawValue
     }
@@ -24,7 +26,7 @@ struct PostEditorAnalyticsSession {
 
         let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding)
 
-        WPAppAnalytics.track(.editorSessionStart, withProperties: properties)
+        WPAppAnalytics.track(.editorSessionStart, withProperties: properties, withBlogID: blogID)
         started = true
     }
 
@@ -70,7 +72,7 @@ struct PostEditorAnalyticsSession {
 
         properties[Property.canViewEditorOnboarding] = canViewEditorOnboarding
 
-        WPAppAnalytics.track(.editorSessionEnd, withProperties: properties)
+        WPAppAnalytics.track(.editorSessionEnd, withProperties: properties, withBlogID: blogID)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -26,7 +26,7 @@ struct PostEditorAnalyticsSession {
 
         let properties = startEventProperties(with: unsupportedBlocks, canViewEditorOnboarding: canViewEditorOnboarding)
 
-        WPAppAnalytics.track(.editorSessionStart, withProperties: properties, withBlogID: blogID)
+        WPAppAnalytics.track(.editorSessionStart, withProperties: properties)
         started = true
     }
 
@@ -50,7 +50,7 @@ struct PostEditorAnalyticsSession {
 
     mutating func `switch`(editor: Editor) {
         currentEditor = editor
-        WPAppAnalytics.track(.editorSessionSwitchEditor, withProperties: commonProperties, withBlogID: blogID)
+        WPAppAnalytics.track(.editorSessionSwitchEditor, withProperties: commonProperties)
     }
 
     mutating func forceOutcome(_ newOutcome: Outcome) {
@@ -72,12 +72,13 @@ struct PostEditorAnalyticsSession {
 
         properties[Property.canViewEditorOnboarding] = canViewEditorOnboarding
 
-        WPAppAnalytics.track(.editorSessionEnd, withProperties: properties, withBlogID: blogID)
+        WPAppAnalytics.track(.editorSessionEnd, withProperties: properties)
     }
 }
 
 private extension PostEditorAnalyticsSession {
     enum Property {
+        static let blogID = "blog_id"
         static let blogType = "blog_type"
         static let contentType = "content_type"
         static let editor = "editor"
@@ -96,6 +97,7 @@ private extension PostEditorAnalyticsSession {
             Property.editor: currentEditor.rawValue,
             Property.contentType: contentType,
             Property.postType: postType,
+            Property.blogID: blogID?.stringValue,
             Property.blogType: blogType,
             Property.sessionId: sessionId,
             Property.hasUnsupportedBlocks: hasUnsupportedBlocks ? "1" : "0",

--- a/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
+++ b/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
@@ -122,19 +122,56 @@ class PostEditorAnalyticsSessionTests: XCTestCase {
         let trackedUnsupportedBlocks: [String]? = tracked?.value(for: "unsupported_blocks")
         XCTAssertNil(trackedUnsupportedBlocks)
     }
+
+    func testTrackBlogIdOnStart() {
+        startSession(editor: .gutenberg, blogID: 123)
+
+        XCTAssertEqual(TestAnalyticsTracker.tracked.count, 1)
+
+        let tracked = TestAnalyticsTracker.tracked.first
+
+        XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionStart)
+        XCTAssertEqual(tracked?.value(for: "blog_id"), "123")
+    }
+
+    func testTrackBlogIdOnSwitch() {
+        var session = startSession(editor: .gutenberg, blogID: 456)
+        session.switch(editor: .gutenberg)
+
+        XCTAssertEqual(TestAnalyticsTracker.tracked.count, 2)
+
+        let tracked = TestAnalyticsTracker.tracked.last
+
+        XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionSwitchEditor)
+        XCTAssertEqual(tracked?.value(for: "blog_id"), "456")
+    }
+
+    func testTrackBlogIdOnEnd() {
+        let session = startSession(editor: .gutenberg, blogID: 789)
+        session.end(outcome: .publish)
+
+        XCTAssertEqual(TestAnalyticsTracker.tracked.count, 2)
+
+        let tracked = TestAnalyticsTracker.tracked.last
+
+        XCTAssertEqual(tracked?.stat, WPAnalyticsStat.editorSessionEnd)
+        XCTAssertEqual(tracked?.value(for: "blog_id"), "789")
+    }
 }
 
 extension PostEditorAnalyticsSessionTests {
-    func createPost(title: String? = nil, body: String? = nil) -> AbstractPost {
+    func createPost(title: String? = nil, body: String? = nil, blogID: NSNumber? = nil) -> AbstractPost {
         let post = AbstractPost(context: context)
         post.postTitle = title
         post.content = body
+        post.blog = Blog(context: context)
+        post.blog.dotComID = blogID
         return post
     }
 
     @discardableResult
-    func startSession(editor: PostEditorAnalyticsSession.Editor, postTitle: String? = nil, postContent: String? = nil, unsupportedBlocks: [String] = []) -> PostEditorAnalyticsSession {
-        let post = createPost(title: postTitle, body: postContent)
+    func startSession(editor: PostEditorAnalyticsSession.Editor, postTitle: String? = nil, postContent: String? = nil, unsupportedBlocks: [String] = [], blogID: NSNumber? = nil) -> PostEditorAnalyticsSession {
+        let post = createPost(title: postTitle, body: postContent, blogID: blogID)
         var session = PostEditorAnalyticsSession(editor: .gutenberg, post: post)
         session.start(unsupportedBlocks: unsupportedBlocks)
         return session


### PR DESCRIPTION
Add the `blog_id` property to editor session analytic events. Field Guide documentation requests that all Tracks events that occur in the context of a site include the `blog_id` property. Relates to 1641-gh-Automattic/tracks-events-validation-status. 

To test: Perform the following steps while (1) logged in to a WP.com account and (2) logged in with WP Admin credentials only.

1. Open the block editor.
1. Tap the three-dot menu in the top right.
1. Tap Switch to HTML Mode.
1. Tap the three-dot menu in the top right.
1. Tap Switch to Visual Mode.
1. Close the editor.
1. Verify the following Tracks events include the correct `blog_id`
   property.<sup>1</sup>
    * `wpios_editor_session_start`
    * `wpios_editor_session_switch_editor`
    * `wpios_editor_session_end`

[1]: The `blog_id` while logged in with WP Admin credentials only will be `0`.

## Regression Notes
1. Potential unintended areas of impact
  Unintended event property changes could occur.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manually reviewed other properties on the event.
3. What automated tests I added (or what prevented me from doing so)
  Added unit tests to verify inclusion of `blog_id` for editor session events. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.