### PR TITLE
Added pull-to-refresh to My Site.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 18.2
 -----
 * [*] Set the post formats to have 'Standard' first and then alphabetized the remaining items. [#17074]
+* [*] Added pull-to-refresh to My Site.
 
 18.1
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -332,6 +332,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;
     [self.view addSubview:self.tableView];
     [self.view pinSubviewToAllEdges:self.tableView];
+    
+    UIRefreshControl *refreshControl = [UIRefreshControl new];
+    [refreshControl addTarget:self action:@selector(pulledToRefresh) forControlEvents:UIControlEventValueChanged];
+    self.tableView.refreshControl = refreshControl;
 
     self.tableView.accessibilityIdentifier = @"Blog Details Table";
 
@@ -1967,17 +1971,41 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 #pragma mark - Domain Registration
 
-/// This method syncs the blog and its metadata, then reloads the table view and updates the header with the synced blog.
-/// Used to update My Site after a successful domain registration.
 - (void)updateTableViewAndHeader
+{
+    [self updateTableViewAndHeader:^{}];
+}
+
+/// This method syncs the blog and its metadata, then reloads the table view and updates the header with the synced blog.
+///
+- (void)updateTableViewAndHeader:(void(^)(void))onComplete
 {
     __weak __typeof(self) weakSelf = self;
     [self.blogService syncBlogAndAllMetadata:self.blog
-                           completionHandler:^{
-                               [weakSelf configureTableViewData];
-                               [weakSelf reloadTableViewPreservingSelection];
-                               [weakSelf.headerView setBlog:weakSelf.blog];
-                           }];
+                           completionHandler:
+     ^{
+        [weakSelf configureTableViewData];
+        [weakSelf reloadTableViewPreservingSelection];
+        [weakSelf.headerView setBlog:weakSelf.blog];
+        onComplete();
+    }];
+}
+
+#pragma mark - Pull To Refresh
+
+- (void)pulledToRefresh {
+    __weak __typeof(self) weakSelf = self;
+    
+    [self updateTableViewAndHeader: ^{
+        // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
+        // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
+        // down to refresh the site.
+        dispatch_async(dispatch_get_main_queue(), ^(void){
+            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            
+            [strongSelf.tableView.refreshControl endRefreshing];
+        });
+    }];
 }
 
 @end


### PR DESCRIPTION
Adds pull-to-refresh to My Site.

![mySitePullDownToRefresh](https://user-images.githubusercontent.com/1836005/131009345-56cd7b39-265c-420e-b238-c93d74f60836.gif)

## To test:

1. Launch the app and select your testing site.
2. Go to the web browser, open the same site and edit the site title or icon.  You can also add a premium subscription to check that the "Register your free domain" cell is shown.
3. Save your changes.
4. Go back to WPiOS and pull down to refresh.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
