### PR TITLE
Comment edit: validate email address

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
@@ -1,17 +1,25 @@
 import Foundation
 
+
+protocol EditCommentSingleLineCellDelegate: AnyObject {
+    func fieldUpdated(_ type: TextFieldStyle, updatedText: String?, isValid: Bool)
+}
+
+// Used to determine TextField configuration options.
+enum TextFieldStyle {
+    case text
+    case url
+    case email
+}
+
+
 class EditCommentSingleLineCell: UITableViewCell, NibReusable {
 
     // MARK: - Properties
 
     @IBOutlet weak var textField: UITextField!
-
-    // Used to determine TextField configuration options.
-    enum TextFieldStyle {
-        case text
-        case url
-        case email
-    }
+    weak var delegate: EditCommentSingleLineCellDelegate?
+    private var textFieldStyle: TextFieldStyle = .text
 
     // MARK: - View
 
@@ -21,8 +29,9 @@ class EditCommentSingleLineCell: UITableViewCell, NibReusable {
     }
 
     func configure(text: String? = nil, style: TextFieldStyle = .text) {
-        applyTextFieldStyle(style)
         textField.text = text
+        textFieldStyle = style
+        applyTextFieldStyle()
     }
 
 }
@@ -36,6 +45,10 @@ extension EditCommentSingleLineCell: UITextFieldDelegate {
         return true
     }
 
+    @IBAction func textFieldChanged(_ sender: UITextField) {
+        validateText(sender.text)
+    }
+
 }
 
 // MARK: - Private Extension
@@ -47,8 +60,8 @@ private extension EditCommentSingleLineCell {
         textField.textColor = .text
     }
 
-    func applyTextFieldStyle(_ style: TextFieldStyle) {
-        switch style {
+    func applyTextFieldStyle() {
+        switch textFieldStyle {
         case .text:
             textField.autocorrectionType = .yes
             textField.keyboardType = .default
@@ -60,6 +73,22 @@ private extension EditCommentSingleLineCell {
             textField.autocorrectionType = .no
             textField.keyboardType = .emailAddress
         }
+    }
+
+    func validateText(_ text: String?) {
+        let isValid: Bool = {
+            switch textFieldStyle {
+            case .url:
+                // TODO: add URL validation
+                return true
+            case .email:
+                return text?.isValidEmail() ?? false
+            default:
+                return true
+            }
+        }()
+
+        delegate?.fieldUpdated(textFieldStyle, updatedText: text, isValid: isValid)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.xib
@@ -16,12 +16,13 @@
                 <rect key="frame" x="0.0" y="0.0" width="364" height="127"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="2wP-Ee-7cF">
+                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="2wP-Ee-7cF" userLabel="TextField">
                         <rect key="frame" x="16" y="11" width="332" height="105"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                         <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>
                         <connections>
-                            <outlet property="delegate" destination="LfA-no-L5x" id="ocs-Z3-8ze"/>
+                            <action selector="textFieldChanged:" destination="LfA-no-L5x" eventType="editingChanged" id="4Hk-W2-lj3"/>
+                            <outlet property="delegate" destination="LfA-no-L5x" id="J61-eD-vXs"/>
                         </connections>
                     </textField>
                 </subviews>
@@ -33,7 +34,7 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="textField" destination="2wP-Ee-7cF" id="jTB-O9-eh0"/>
+                <outlet property="textField" destination="2wP-Ee-7cF" id="SX1-jf-hu9"/>
             </connections>
             <point key="canvasLocation" x="-131.8840579710145" y="-23.772321428571427"/>
         </tableViewCell>


### PR DESCRIPTION
Ref: #17000

The Edit Comment controller is now informed on-the-fly when text changes in a single line field (Name, Web Address, Email Address). The updated text and validation status is provided. Right now, only email is actually validated. It uses the method used in Settings and Auth.

The edit view's `Done` nav bar button is initially disabled. It is enabled if:
- Changes have been made to any of the single line fields.
- If an email is provided, the email is valid.
- If the url is valid. Currently, this is always true. 

Note that `Done` still simply dismisses the view; changes are not saved yet.

And in case you're wondering, the Not Done Yet But Coming Soon ™️  list:
- `Web Address` validation.
- Handling changes made to the `Comment` field.
- Error messages for invalid email and url.

---
To test:
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
- Verify the `Done` nav bar button is disabled.
- Make changes to any of the single line fields.
- Verify the `Done` button is enabled.

| Initial View | Edited Field |
|--------|-------|
| ![initial_view](https://user-images.githubusercontent.com/1816888/131170906-10f2b3a6-608f-46de-857a-04712c10a2fc.png) | ![updated_field](https://user-images.githubusercontent.com/1816888/131170922-d6fe6f72-fafa-4815-a95f-3719b16578fd.png) |


---
- Modify the `Email Address`.
- Verify the `Done` button is enabled only when it looks like an email address.
- Note that email is not required. So when it is cleared, `Done` will be enabled.

| Valid | Invalid | None |
|--------|-------|-------|
| ![valid_email](https://user-images.githubusercontent.com/1816888/131171270-55a449a4-90de-45fc-acfe-cccaf301f03a.png) | ![invalid_email](https://user-images.githubusercontent.com/1816888/131171302-79556929-87bb-4d28-8644-ab404f08c27d.png) | ![no_email](https://user-images.githubusercontent.com/1816888/131171329-1e413b39-1672-45cc-85e4-c83a0bd54213.png) |

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
