### PR TITLE
Comment edit: show confirmation alert when cancelling with changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol EditCommentMultiLineCellDelegate: AnyObject {
     func textViewHeightUpdated()
+    func textUpdated(_ updatedText: String?)
 }
 
 class EditCommentMultiLineCell: UITableViewCell, NibReusable {
@@ -34,6 +35,7 @@ class EditCommentMultiLineCell: UITableViewCell, NibReusable {
 extension EditCommentMultiLineCell: UITextViewDelegate {
 
     func textViewDidChange(_ textView: UITextView) {
+        delegate?.textUpdated(textView.text)
         adjustHeight()
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
@@ -78,9 +78,6 @@ private extension EditCommentSingleLineCell {
     func validateText(_ text: String?) {
         let isValid: Bool = {
             switch textFieldStyle {
-            case .url:
-                // TODO: add URL validation
-                return true
             case .email:
                 return text?.isValidEmail() ?? false
             default:

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -13,7 +13,6 @@ class EditCommentTableViewController: UITableViewController {
     private var updatedContent: String?
 
     private var isEmailValid = true
-    private var isUrlValid = true
 
     // If the textView cell is recreated via dequeueReusableCell,
     // the cursor location is lost when the cell is scrolled off screen.
@@ -199,6 +198,8 @@ extension EditCommentTableViewController: EditCommentSingleLineCellDelegate {
         switch type {
         case .text:
             updatedName = updatedText?.trim()
+        case .url:
+            updatedWebAddress = updatedText?.trim()
         case .email:
             updatedEmailAddress = updatedText?.trim()
             isEmailValid = {
@@ -207,9 +208,6 @@ extension EditCommentTableViewController: EditCommentSingleLineCellDelegate {
                 }
                 return isValid
             }()
-        case .url:
-            updatedWebAddress = updatedText?.trim()
-            isUrlValid = isValid
         }
 
         updateDoneButton()


### PR DESCRIPTION
Ref: #17000
Depends on: #17092

The Edit Comment controller is now informed on-the-fly when text changes in the `Comment` field. Now that Edit Comment knows about all text changes, a confirmation action sheet is displayed when tapping `Cancel` if there are changes to any of the comment fields.

To test:

---
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
- Make changes to the `Comment` field.
- Verify the `Done` button is enabled.

| Before | After |
|--------|-------|
| ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-27 at 15 36 02](https://user-images.githubusercontent.com/1816888/131191280-368f44cd-df58-432e-bbde-d26c0a4438e8.png) | ![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-27 at 15 36 13](https://user-images.githubusercontent.com/1816888/131191296-15d1b667-2b3b-4c99-b256-8690577cbc33.png) |

---
- Tap `Cancel` on the nav bar.
- Verify the action sheet is displayed.
  - Discard - dismisses the Edit Comment view, returning to Comment details.
  - Keep Editing - dismisses the action sheet, staying on Edit Comment.

![Simulator Screen Shot - iPhone 12 Pro Max - 2021-08-27 at 15 37 53](https://user-images.githubusercontent.com/1816888/131191395-b2387856-c6f3-42dc-89c4-b4c2415e82f6.png)

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
