### PR TITLE
Comment Detail: Add header cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -8,6 +8,10 @@ class CommentDetailViewController: UITableViewController {
 
     private var rows = [RowType]()
 
+    // MARK: Views
+
+    private var headerCell = CommentHeaderTableViewCell()
+
     // MARK: Initialization
 
     @objc required init(comment: Comment) {
@@ -25,6 +29,7 @@ class CommentDetailViewController: UITableViewController {
         super.viewDidLoad()
         configureNavigationBar()
         configureTable()
+        configureRows()
     }
 
     // MARK: Table view data source
@@ -35,6 +40,17 @@ class CommentDetailViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return rows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        switch rows[indexPath.row] {
+        case .header:
+            configureHeaderCell()
+            return headerCell
+
+        default:
+            return .init()
+        }
     }
 
 }
@@ -58,6 +74,21 @@ private extension CommentDetailViewController {
         tableView.tableFooterView = UIView(frame: .zero)
     }
 
+    func configureRows() {
+        rows = [.header]
+    }
+
+    // MARK: Cell configuration
+
+    func configureHeaderCell() {
+        // TODO: detect if the comment is a reply.
+
+        headerCell.textLabel?.text = .postCommentTitleText
+        headerCell.detailTextLabel?.text = comment.titleForDisplay()
+    }
+
+    // MARK: Button actions
+
     @objc func editButtonTapped() {
         // NOTE: This depends on the new edit comment feature, which is still ongoing.
         let navigationControllerToPresent = UINavigationController(rootViewController: EditCommentTableViewController(comment: comment))
@@ -67,4 +98,12 @@ private extension CommentDetailViewController {
         }
     }
 
+}
+
+// MARK: - Localization
+
+private extension String {
+    static let postCommentTitleText = NSLocalizedString("Comment on", comment: "Provides hint that the current screen displays a comment on a post. "
+                                                            + "The title of the post will displayed below this string. "
+                                                            + "Example: Comment on \n My First Post")
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -53,6 +53,18 @@ class CommentDetailViewController: UITableViewController {
         }
     }
 
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        switch rows[indexPath.row] {
+        case .header:
+            navigateToPost()
+
+        default:
+            break
+        }
+    }
+
 }
 
 // MARK: - Private Helpers
@@ -87,7 +99,32 @@ private extension CommentDetailViewController {
         headerCell.detailTextLabel?.text = comment.titleForDisplay()
     }
 
-    // MARK: Button actions
+    // MARK: Actions and navigations
+
+    func navigateToPost() {
+        guard let blog = comment.blog,
+              let siteID = blog.dotComID,
+              blog.supports(.wpComRESTAPI) else {
+            viewPostInWebView()
+            return
+        }
+
+        let readerViewController = ReaderDetailViewController.controllerWithPostID(NSNumber(value: comment.postID), siteID: siteID, isFeed: false)
+        navigationController?.pushFullscreenViewController(readerViewController, animated: true)
+    }
+
+    func viewPostInWebView() {
+        guard let post = comment.post,
+              let permalink = post.permaLink,
+              let url = URL(string: permalink) else {
+            return
+        }
+
+        let viewController = WebViewControllerFactory.controllerAuthenticatedWithDefaultAccount(url: url)
+        let navigationControllerToPresent = UINavigationController(rootViewController: viewController)
+
+        present(navigationControllerToPresent, animated: true, completion: nil)
+    }
 
     @objc func editButtonTapped() {
         // NOTE: This depends on the new edit comment feature, which is still ongoing.

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -4,8 +4,8 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 
     // MARK: Initialization
 
-    required init(reuseIdentifier: String = CommentHeaderTableViewCell.defaultReuseID) {
-        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
+    required init() {
+        super.init(style: .subtitle, reuseIdentifier: Self.defaultReuseID)
         configureStyle()
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+class CommentHeaderTableViewCell: UITableViewCell, Reusable {
+
+    // MARK: Initialization
+
+    required init() {
+        super.init(style: .subtitle, reuseIdentifier: Self.defaultReuseID)
+        configureStyle()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: Helpers
+
+    private func configureStyle() {
+        accessoryType = .disclosureIndicator
+
+        textLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+        textLabel?.textColor = .textSubtle
+        textLabel?.numberOfLines = 2
+
+        detailTextLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        detailTextLabel?.textColor = .text
+        detailTextLabel?.numberOfLines = 1
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -4,8 +4,8 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 
     // MARK: Initialization
 
-    required init() {
-        super.init(style: .subtitle, reuseIdentifier: Self.defaultReuseID)
+    required init(reuseIdentifier: String = CommentHeaderTableViewCell.defaultReuseID) {
+        super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
         configureStyle()
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4357,6 +4357,8 @@
 		FEA088012696E7F600193358 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
 		FEA088032696E81F00193358 /* ListTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEA088022696E81F00193358 /* ListTableHeaderView.xib */; };
 		FEA088052696F7AA00193358 /* WPStyleGuide+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */; };
+		FEA7948D26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
+		FEA7948E26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
 		FEC3B81726C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */; };
 		FEC3B81826C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */; };
 		FEC3B81926C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */; };
@@ -7529,6 +7531,7 @@
 		FEA088002696E7F600193358 /* ListTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableHeaderView.swift; sourceTree = "<group>"; };
 		FEA088022696E81F00193358 /* ListTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ListTableHeaderView.xib; sourceTree = "<group>"; };
 		FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+List.swift"; sourceTree = "<group>"; };
+		FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleButtonTableViewCell.swift; sourceTree = "<group>"; };
 		FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleButtonTableViewCell.xib; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
@@ -12427,6 +12430,7 @@
 		B56994481B7A82D400FF26FA /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				FEA7948B26DD134400CEC520 /* Detail */,
 				9835F16D25E492EE002EFF23 /* CommentsList.storyboard */,
 				B5CEEB8D1B7920BE00E7B7B0 /* CommentsTableViewCell.swift */,
 				B5CEEB8F1B79244D00E7B7B0 /* CommentsTableViewCell.xib */,
@@ -14447,6 +14451,14 @@
 				FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */,
 			);
 			path = List;
+			sourceTree = "<group>";
+		};
+		FEA7948B26DD134400CEC520 /* Detail */ = {
+			isa = PBXGroup;
+			children = (
+				FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */,
+			);
+			name = Detail;
 			sourceTree = "<group>";
 		};
 		FF2716901CAAC87B0006E2D4 /* WordPressUITests */ = {
@@ -17881,6 +17893,7 @@
 				400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,
 				F1C740BF26B18E42005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
+				FEA7948D26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */,
 				D80BC79C207464D200614A59 /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
 				46183CF4251BD658004F9AFD /* PageTemplateLayout+CoreDataClass.swift in Sources */,
 				982A4C3520227D6700B5518E /* NoResultsViewController.swift in Sources */,
@@ -19455,6 +19468,7 @@
 				FABB22AF2602FC2C00C8785C /* MenusService.m in Sources */,
 				FABB22B02602FC2C00C8785C /* QuickStartChecklistHeader.swift in Sources */,
 				FABB22B12602FC2C00C8785C /* ReaderDetailFeaturedImageView.swift in Sources */,
+				FEA7948E26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */,
 				FABB22B22602FC2C00C8785C /* StatsDataHelper.swift in Sources */,
 				FABB22B32602FC2C00C8785C /* PrepublishingViewController.swift in Sources */,
 				FABB22B42602FC2C00C8785C /* PageListTableViewHandler.swift in Sources */,


### PR DESCRIPTION
Refs #17087

This adds the header cell component for the new comment detail. Some notes:

- The header cell is pretty simple, since it's a `UITableViewCell` with `subtitle` style (with properly applied text styles for both text label and detail text label). However, since this cell will be reused again later in Comment Threads, I'll create a new class for now to encapsulate all the styling and the `.subtitle` cell style.
- There are two variants for the header cell content. For this PR, I'll only show the comment's post regardless if the comment is a reply or not.
  - If the current comment is a reply, I'll have to fetch the parent Comment object in order to get the both the replied author's name, and the content. This will be done in a separate PR. I've added a new entry in #17087.

Preview:

![Simulator Screen Shot - iPhone 8 - 2021-08-30 at 21 41 57](https://user-images.githubusercontent.com/1299411/131358983-4be93936-2537-493d-a658-3cdb698ab270.png)

To test:

- Ensure that the `New Comment Detail` feature flag is enabled.
- Go to My Site > Comments, and tap on any comment. Preferably not the reply ones.
- Verify that the header cell is displayed.
- Tap the header cell, and verify that the post is opened correctly.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
