### PR TITLE
Edit Comment: save changes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.40.0'
+    # pod 'WordPressKit', '~> 4.40.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/17000-update_comment_add_fields'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.40.0):
+  - WordPressKit (4.41.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.0)
-  - WordPressKit (~> 4.40.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/17000-update_comment_add_fields`)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -604,7 +604,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.60.1
+  WordPressKit:
+    :branch: feature/17000-update_comment_add_fields
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.60.1/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.60.1
+  WordPressKit:
+    :commit: db13add83ec91449f0cd988ef9bf1b14c5cc11d1
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -810,7 +815,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 06278534519c741ecea346f504ad8d08082bfb0d
-  WordPressKit: 062e4f57ce871e2217b632a1f3cb0bbd54b5df6d
+  WordPressKit: e61bbcb1fc031e5e797f69e05de6a24a92b09b23
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 823aaa862a826182778096b02714ae56d48bb14d
+PODFILE CHECKSUM: 1d1098f9d2652bcad89a95f6882194df36f81b84
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.0)
-  - WordPressKit (~> 4.41.0-beta.2)
+  - WordPressKit (~> 4.41.0-beta)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 753fa1aa237100f219af7371f391d846a5a427d0
+PODFILE CHECKSUM: 53164a8f45e7fdc6fbbf33b59bafc4b6f6695d15
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.41.0-beta.1):
+  - WordPressKit (4.41.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.0)
-  - WordPressKit (~> 4.41.0-beta)
+  - WordPressKit (~> 4.41.0-beta.2)
   - WordPressMocks (~> 0.0.13)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.1)
@@ -810,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 06278534519c741ecea346f504ad8d08082bfb0d
-  WordPressKit: 60ed78fe19e0e345c80a33661e85a68e9b99f64d
+  WordPressKit: aaa0734bfbbec50609c37f11fcba07e99226ee68
   WordPressMocks: dfac50a938ac74dddf5f7cce5a9110126408dd19
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
   WordPressUI: 414bf3a7d007618f94a1c7969d6e849779877d5d
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 53164a8f45e7fdc6fbbf33b59bafc4b6f6695d15
+PODFILE CHECKSUM: 753fa1aa237100f219af7371f391d846a5a427d0
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -658,6 +658,15 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     
     if ([Feature enabled:FeatureFlagNewCommentEdit]) {
         EditCommentTableViewController *editViewController = [[EditCommentTableViewController alloc] initWithComment:self.comment];
+        
+        __typeof(self) __weak weakSelf = self;
+        editViewController.completion = ^(Comment *comment, BOOL commentChanged) {
+            if (commentChanged) {
+                weakSelf.comment = comment;
+                [weakSelf updateComment];
+            }
+        };
+
         navController = [[UINavigationController alloc] initWithRootViewController:editViewController];
         navController.modalPresentationStyle = UIModalPresentationFullScreen;
     } else {
@@ -668,7 +677,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
         editViewController.onCompletion = ^(BOOL hasNewContent, NSString *newContent) {
             [self dismissViewControllerAnimated:YES completion:^{
                 if (hasNewContent) {
-                    [weakSelf updateCommentForNewContent:newContent];
+                    weakSelf.comment.content = newContent;
+                    [weakSelf updateComment];
                 }
             }];
         };
@@ -685,10 +695,8 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     [CommentAnalytics trackCommentEditorOpenedWithComment:[self comment]];
 }
 
-- (void)updateCommentForNewContent:(NSString *)content
+- (void)updateComment
 {
-    // Set the new Content Data
-    self.comment.content = content;
     [self reloadData];
 
     // Regardless of success or failure track the user's intent to save a change.

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -19,7 +19,16 @@ class EditCommentTableViewController: UITableViewController {
     // So save and use one instance of the cell.
     private let commentContentCell = EditCommentMultiLineCell.loadFromNib()
 
+    // A closure executed when the view is dismissed.
+    // Returns the Comment object and a Bool indicating if the Comment has been changed.
+    @objc var completion: ((Comment, Bool) -> Void)?
+
     // MARK: - Init
+
+    convenience init(comment: Comment, completion: ((Comment, Bool) -> Void)? = nil) {
+        self.init(comment: comment)
+        self.completion = completion
+    }
 
     @objc required init(comment: Comment) {
         self.comment = comment
@@ -148,8 +157,7 @@ private extension EditCommentTableViewController {
     }
 
     @objc func doneButtonTapped(sender: UIBarButtonItem) {
-        // TODO: save changes
-        dismiss(animated: true)
+        finishWithUpdates()
     }
 
     // MARK: - Tap gesture handling
@@ -160,8 +168,18 @@ private extension EditCommentTableViewController {
 
     // MARK: - View dismissal handling
 
+    func finishWithUpdates() {
+        comment.author = updatedName ?? ""
+        comment.author_url = updatedWebAddress ?? ""
+        comment.author_email = updatedEmailAddress ?? ""
+        comment.content = updatedContent ?? ""
+        completion?(comment, true)
+        dismiss(animated: true)
+    }
+
+
     func finishWithoutUpdates() {
-        // TODO: notify caller
+        completion?(comment, false)
         dismiss(animated: true)
     }
 


### PR DESCRIPTION
Ref: #17000 
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/440

When `Done` is selected, the Comment changes are now saved.
- A `completion` closure is called when `Done` or `Cancel` is tapped. It returns the Comment object and a Bool indicating if the Comment has been changed.
- The WPKit PR has changes to include the author's name, email, and url when updating a Comment.

To test:

---
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
- Modify all the fields.
- Select `Done`.
  - Verify the author name and web address are updated in the comment header.
  - Verify the comment content is updated in the comment details.
- Select `Edit` again. 
  - Verify all the info is the updated version.
- Repeat for a self-hosted site.

| Initial | Edited | Updated |
|--------|-------|-------|
| ![before_details](https://user-images.githubusercontent.com/1816888/131393126-e02a08d8-85fc-46d6-893c-c9b0992c5f1f.png) | ![edited](https://user-images.githubusercontent.com/1816888/131393137-330f85c1-0534-4a42-80d3-362d6135c8ba.png) | ![after_details](https://user-images.githubusercontent.com/1816888/131393158-d19b16a7-a9de-49ab-b73b-4a6e759bc551.png) |

---
- Disable `newCommentEdit`.
- Edit a Comment.
- Verify it is updated as expected.

---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
