### PR TITLE
Comment Details: save changes from Comment Edit

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -47,7 +47,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .recommendAppToOthers:
             return true
         case .newCommentEdit:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .newCommentDetail:
             return false
         case .domains:

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -4,7 +4,7 @@ class CommentDetailViewController: UITableViewController {
 
     // MARK: Properties
 
-    private let comment: Comment
+    private var comment: Comment
 
     private var rows = [RowType]()
 
@@ -59,12 +59,38 @@ private extension CommentDetailViewController {
     }
 
     @objc func editButtonTapped() {
-        // NOTE: This depends on the new edit comment feature, which is still ongoing.
-        let navigationControllerToPresent = UINavigationController(rootViewController: EditCommentTableViewController(comment: comment))
+        let editCommentTableViewController = EditCommentTableViewController(comment: comment, completion: { [weak self] comment, commentChanged in
+            guard commentChanged else {
+                return
+            }
+
+            self?.comment = comment
+            self?.tableView.reloadData()
+            self?.updateComment()
+        })
+
+        let navigationControllerToPresent = UINavigationController(rootViewController: editCommentTableViewController)
         navigationControllerToPresent.modalPresentationStyle = .fullScreen
-        present(navigationControllerToPresent, animated: true) {
-            self.tableView.reloadData()
-        }
+        present(navigationControllerToPresent, animated: true)
+    }
+
+    func updateComment() {
+        // Regardless of success or failure track the user's intent to save a change.
+        CommentAnalytics.trackCommentEdited(comment: comment)
+
+        let context = ContextManager.sharedInstance().mainContext
+        let commentService = CommentService(managedObjectContext: context)
+
+        commentService.uploadComment(comment,
+                                     success: { [weak self] in
+                                        // The comment might have changed its approval status
+                                        self?.tableView.reloadData()
+                                     },
+                                     failure: { [weak self] error in
+                                        let message = NSLocalizedString("There has been an unexpected error while editing your comment",
+                                                                        comment: "Error displayed if a comment fails to get updated")
+                                        self?.displayNotice(title: message)
+                                     })
     }
 
 }


### PR DESCRIPTION
Ref: #17000
Depends on: #17096

This adds logic to the new Comment details view to save changes from the new Edit Comment view. Essentially, it's the same logic as in the [current](https://github.com/wordpress-mobile/WordPress-iOS/blob/1cb208ed1d6c7af22525b23e50f85a28d25df556/WordPress/Classes/ViewRelated/Comments/CommentViewController.m#L698) comment details. 

Also, since the new Edit Comment view is fully functional, it's enabled for development.

To test:

`newCommentDetail` feature enabled:
- Go to My Site > Comment > Comment details > Edit.
- Make changes and select `Done`.
- Go to Edit again (since the comment isn't displayed yet).
- Verify all the fields are the updated values.

`newCommentDetail` feature disabled:
- Go to My Site > Comment > Comment details > Edit.
- Verify the new Edit Comment view is displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
