### PR TITLE
Fix/16941 - Close account additional logic

### DIFF
--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -49,5 +49,6 @@
 - (void)addBlogs:(NSSet *)values;
 - (void)removeBlogs:(NSSet *)values;
 + (NSString *)tokenForUsername:(NSString *)username;
+- (BOOL)hasAtomicSite;
 
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -124,6 +124,15 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
     return [defaultAccount isEqual:self];
 }
 
+- (BOOL)hasAtomicSite {
+    for (Blog *blog in self.blogs) {
+        if ([blog isAtomic]) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
 #pragma mark - Static methods
 
 + (NSString *)tokenForUsername:(NSString *)username

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -125,7 +125,7 @@ private class AccountSettingsController: SettingsController {
 
         let closeAccount = DestructiveButtonRow(
             title: NSLocalizedString("Close Account", comment: "Close account action label"),
-            action: presenter.present(closeAccountAction),
+            action: closeAccountAction,
             accessibilityIdentifier: "closeAccountButtonRow")
 
         return ImmuTable(sections: [
@@ -239,9 +239,8 @@ private class AccountSettingsController: SettingsController {
         }
     }
 
-    private var closeAccountAction: (ImmuTableRow) -> UIAlertController {
+    private var closeAccountAction: (ImmuTableRow) -> Void {
         return { [weak self] _ in
-            return self?.closeAccountAlert ?? UIAlertController()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -244,6 +244,19 @@ private class AccountSettingsController: SettingsController {
         }
     }
 
+    private var hasAtomicSite: Bool {
+        let context = ContextManager.sharedInstance().mainContext
+        let service = AccountService(managedObjectContext: context)
+        guard let account = service.defaultWordPressComAccount() else {
+            return false
+        }
+
+        for blog in account.blogs where blog.isAtomic() {
+            return true
+        }
+        return false
+    }
+
     private var closeAccountAlert: UIAlertController? {
         guard let value = settings?.username else {
             return nil

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -33,6 +33,8 @@ private class AccountSettingsController: SettingsController {
     // MARK: - Initialization
 
     private let accountSettingsService: AccountSettingsService
+    private let accountService: AccountService
+
     var settings: AccountSettings? {
         didSet {
             NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: ImmuTableViewController.modelChangedNotification), object: nil)
@@ -45,8 +47,10 @@ private class AccountSettingsController: SettingsController {
     }
     private let alertHelper = DestructiveAlertHelper()
 
-    init(accountSettingsService: AccountSettingsService) {
+    init(accountSettingsService: AccountSettingsService,
+         accountService: AccountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)) {
         self.accountSettingsService = accountSettingsService
+        self.accountService = accountService
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadStatus), name: NSNotification.Name.AccountSettingsServiceRefreshStatusChanged, object: nil)
         notificationCenter.addObserver(self, selector: #selector(AccountSettingsController.loadSettings), name: NSNotification.Name.AccountSettingsChanged, object: nil)

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -254,14 +254,7 @@ private class AccountSettingsController: SettingsController {
     private var hasAtomicSite: Bool {
         let context = ContextManager.sharedInstance().mainContext
         let service = AccountService(managedObjectContext: context)
-        guard let account = service.defaultWordPressComAccount() else {
-            return false
-        }
-
-        for blog in account.blogs where blog.isAtomic() {
-            return true
-        }
-        return false
+        return service.defaultWordPressComAccount()?.hasAtomicSite() ?? false
     }
 
     private func showCloseAccountAlert() {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -203,12 +203,10 @@ private class AccountSettingsController: SettingsController {
     }
 
     func refreshAccountDetails(finished: @escaping () -> Void) {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = AccountService(managedObjectContext: context)
-        guard let account = service.defaultWordPressComAccount() else {
+        guard let account = accountService.defaultWordPressComAccount() else {
             return
         }
-        service.updateUserDetails(for: account, success: { () in
+        accountService.updateUserDetails(for: account, success: { () in
             finished()
         }, failure: { _ in
             finished()
@@ -256,9 +254,7 @@ private class AccountSettingsController: SettingsController {
     }
 
     private var hasAtomicSite: Bool {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = AccountService(managedObjectContext: context)
-        return service.defaultWordPressComAccount()?.hasAtomicSite() ?? false
+        return accountService.defaultWordPressComAccount()?.hasAtomicSite() ?? false
     }
 
     private func showCloseAccountAlert() {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -246,7 +246,7 @@ private class AccountSettingsController: SettingsController {
             case true:
                 self.showCloseAccountErrorAlert()
             case false :
-                self.closeAccountAlert?.presentFromRootViewController()
+                self.showCloseAccountAlert()
             }
         }
     }
@@ -264,9 +264,9 @@ private class AccountSettingsController: SettingsController {
         return false
     }
 
-    private var closeAccountAlert: UIAlertController? {
+    private func showCloseAccountAlert() {
         guard let value = settings?.username else {
-            return nil
+            return
         }
 
         let title = NSLocalizedString("Confirm Close Account", comment: "Close Account alert title")
@@ -275,7 +275,8 @@ private class AccountSettingsController: SettingsController {
         let destructiveActionTitle = NSLocalizedString("Permanently Close Account",
                                                        comment: "Close Account confirmation action title")
 
-        return alertHelper.makeAlertWithConfirmation(title: title, message: message, valueToConfirm: value, destructiveActionTitle: destructiveActionTitle, destructiveAction: closeAccount)
+        let alert = alertHelper.makeAlertWithConfirmation(title: title, message: message, valueToConfirm: value, destructiveActionTitle: destructiveActionTitle, destructiveAction: closeAccount)
+        alert.presentFromRootViewController()
     }
 
     private func closeAccount() {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -241,6 +241,13 @@ private class AccountSettingsController: SettingsController {
 
     private var closeAccountAction: (ImmuTableRow) -> Void {
         return { [weak self] _ in
+            guard let self = self else { return }
+            switch self.hasAtomicSite {
+            case true:
+                self.showCloseAccountErrorAlert()
+            case false :
+                self.closeAccountAlert?.presentFromRootViewController()
+            }
         }
     }
 


### PR DESCRIPTION
Complements [#17076](https://github.com/wordpress-mobile/WordPress-iOS/pull/17076)

This PR adds additional logic to the close account error flow.
It mimics the [logic found on Calypso front-end](https://github.com/Automattic/wp-calypso/blob/b550e845f46f9c93641f54193d73626cb5b669e9/client/me/account-close/main.jsx#L90), so now user cannot close the account even if it's added as an admin to the the atomic site.

## To test:
1. Make sure the current user is added to someone else's atomic site as an admin
2. Under **My Site** tab tap on profile button at the top right corner
3. Tap on **Account Settings**
4. Tap on **Close account**
5. Close account error alert is displayed

## Screenshot:
<img width="509" alt="Screen Shot 2021-08-31 at 15 33 21" src="https://user-images.githubusercontent.com/12729242/131513502-d3c33d17-2a9c-4169-a022-a8540cdefa0e.png">

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
