### PR TITLE
Edit Comment: add red border to email field if email is invalid.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
@@ -41,7 +41,7 @@ class EditCommentSingleLineCell: UITableViewCell, NibReusable {
             return
         }
 
-        contentView.layer.borderColor = UIColor.red.cgColor
+        contentView.layer.borderColor = UIColor.error.cgColor
         contentView.layer.borderWidth = 1.0
         contentView.layer.cornerRadius = 10
     }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentSingleLineCell.swift
@@ -2,7 +2,7 @@ import Foundation
 
 
 protocol EditCommentSingleLineCellDelegate: AnyObject {
-    func fieldUpdated(_ type: TextFieldStyle, updatedText: String?, isValid: Bool)
+    func textUpdatedForCell(_ cell: EditCommentSingleLineCell)
 }
 
 // Used to determine TextField configuration options.
@@ -19,7 +19,8 @@ class EditCommentSingleLineCell: UITableViewCell, NibReusable {
 
     @IBOutlet weak var textField: UITextField!
     weak var delegate: EditCommentSingleLineCellDelegate?
-    private var textFieldStyle: TextFieldStyle = .text
+    private(set) var textFieldStyle: TextFieldStyle = .text
+    private(set) var isValid: Bool = true
 
     // MARK: - View
 
@@ -32,6 +33,17 @@ class EditCommentSingleLineCell: UITableViewCell, NibReusable {
         textField.text = text
         textFieldStyle = style
         applyTextFieldStyle()
+    }
+
+    func showInvalidState(_ show: Bool = true) {
+        guard show else {
+            contentView.layer.borderColor = UIColor.clear.cgColor
+            return
+        }
+
+        contentView.layer.borderColor = UIColor.red.cgColor
+        contentView.layer.borderWidth = 1.0
+        contentView.layer.cornerRadius = 10
     }
 
 }
@@ -76,7 +88,7 @@ private extension EditCommentSingleLineCell {
     }
 
     func validateText(_ text: String?) {
-        let isValid: Bool = {
+        isValid = {
             switch textFieldStyle {
             case .email:
                 return text?.isValidEmail() ?? false
@@ -85,7 +97,7 @@ private extension EditCommentSingleLineCell {
             }
         }()
 
-        delegate?.fieldUpdated(textFieldStyle, updatedText: text, isValid: isValid)
+        delegate?.textUpdatedForCell(self)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -221,20 +221,23 @@ private extension EditCommentTableViewController {
 
 extension EditCommentTableViewController: EditCommentSingleLineCellDelegate {
 
-    func fieldUpdated(_ type: TextFieldStyle, updatedText: String?, isValid: Bool) {
-        switch type {
+    func textUpdatedForCell(_ cell: EditCommentSingleLineCell) {
+        let updatedText = cell.textField.text?.trim()
+
+        switch cell.textFieldStyle {
         case .text:
-            updatedName = updatedText?.trim()
+            updatedName = updatedText
         case .url:
-            updatedWebAddress = updatedText?.trim()
+            updatedWebAddress = updatedText
         case .email:
-            updatedEmailAddress = updatedText?.trim()
+            updatedEmailAddress = updatedText
             isEmailValid = {
                 if updatedEmailAddress == nil || updatedEmailAddress?.isEmpty == true {
                     return true
                 }
-                return isValid
+                return cell.isValid
             }()
+            cell.showInvalidState(!isEmailValid)
         }
 
         updateDoneButton()


### PR DESCRIPTION
Ref: #17000

This shows/hides a red border on the email field depending on the entered email's validity.

To test:
- Enable the `newCommentEdit` feature.
- Go to My Site > Comments > Comment details > Edit.
- Change the email address.
- Verify the red border appears when the email is invalid, and does not when the email in valid. Note that email is not required, so if it is cleared it is valid.


https://user-images.githubusercontent.com/1816888/131565437-8337cb83-cdb1-4566-b4f5-e1628a5d0887.mp4



## Regression Notes
1. Potential unintended areas of impact
N/A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
