### PR TITLE
Comment Detail: Add regular text cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -87,12 +87,23 @@ private extension CommentDetailViewController {
         case text(title: String, detail: String, image: UIImage? = nil, action: (() -> Void)? = nil)
     }
 
+    struct Constants {
+        static let tableLeadingInset: CGFloat = 20.0
+    }
+
     func configureNavigationBar() {
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .edit, target: self, action: #selector(editButtonTapped))
     }
 
     func configureTable() {
-        tableView.tableFooterView = UIView(frame: .zero)
+        // get rid of the separator line for the last cell.
+        tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
+
+        // assign 20pt leading inset to the table view, as per the design.
+        // note that by default, the system assigns 16pt inset for .phone, and 20pt for .pad idioms.
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            tableView.directionalLayoutMargins.leading = Constants.tableLeadingInset
+        }
     }
 
     func configureRows() {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -49,9 +49,9 @@ class CommentDetailViewController: UITableViewController {
             configureHeaderCell()
             return headerCell
 
-        case .text(_, _, _, _):
+        case .text:
             let cell = tableView.dequeueReusableCell(withIdentifier: .textCellIdentifier) ?? .init(style: .subtitle, reuseIdentifier: .textCellIdentifier)
-            configureTextCell(cell, row: row)
+            configureTextCell(cell, with: row)
             return cell
 
         default:
@@ -124,7 +124,7 @@ private extension CommentDetailViewController {
         headerCell.detailTextLabel?.text = comment.titleForDisplay()
     }
 
-    func configureTextCell(_ cell: UITableViewCell, row: RowType) {
+    func configureTextCell(_ cell: UITableViewCell, with row: RowType) {
         guard case let .text(title, detail, image, _) = row else {
             return
         }


### PR DESCRIPTION
Refs #17087

Adds the regular text cells for comment detail view. Some notes:

- The cells are again, using plain `UITableViewCell` since the design matches the `.subtitle` cell style from iOS. 
- Configured table footer view to show a 1pt high plain `UIView`, to hide the separator for last cell.
- Configured the table's leading inset to 20pt as per the design.

Here's a peek:
![Simulator Screen Shot - iPhone 8 - 2021-09-01 at 16 04 34](https://user-images.githubusercontent.com/1299411/131644759-503d87e0-0fae-4db7-8676-96bf2cecbeec.png)


---

Question for @mattmiklic:

- How do we want to treat empty values on the cells? e.g. Web address on the screenshot 👆 . Should we put a placeholder text indicating that the value is empty, or should we just hide cells with empty values altogether?
- Specific for Web address field, if we want to use a placeholder text for empty values, should we hide the external icon on the right? Since empty values shouldn't lead the user anywhere when the cell is tapped.

---

## To test
- Ensure the `New comment detail` feature flag is switched on.
- Go to My Site > Comments, and tap on any comment.
- Verify that the new fields: web address, email address, and IP address is there.
- Verify that the web address can be tapped, and it shows the author's site in modal style.
- Verify that email and IP address doesn't do anything when tapped.
- Pick a comment where the author's URL is empty, and verify that tapping on the web address field does nothing.

## Regression Notes
1. Potential unintended areas of impact
n/a, feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a, feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a, feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
