### PR TITLE
Comment Detail: Reply indicator cell UI

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -80,6 +80,8 @@ class CommentDetailViewController: UITableViewController {
 
 private extension CommentDetailViewController {
 
+    typealias Style = WPStyleGuide.CommentDetail
+
     enum RowType {
         case header
         case content
@@ -129,14 +131,14 @@ private extension CommentDetailViewController {
             return
         }
 
-        cell.tintColor = .primary
+        cell.tintColor = Style.tintColor
 
-        cell.textLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        cell.textLabel?.textColor = .textSubtle
+        cell.textLabel?.font = Style.secondaryTextFont
+        cell.textLabel?.textColor = Style.secondaryTextColor
         cell.textLabel?.text = title
 
-        cell.detailTextLabel?.font = WPStyleGuide.fontForTextStyle(.body)
-        cell.detailTextLabel?.textColor = .text
+        cell.detailTextLabel?.font = Style.textFont
+        cell.detailTextLabel?.textColor = Style.textColor
         cell.detailTextLabel?.numberOfLines = 0
         cell.detailTextLabel?.text = detail.isEmpty ? " " : detail // prevent the cell from collapsing due to empty label text.
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -15,6 +15,8 @@ class CommentDetailViewController: UITableViewController {
     private lazy var replyIndicatorCell: UITableViewCell = {
         let cell = UITableViewCell()
 
+        // display the replied icon using attributed string instead of using the default image view.
+        // this is because the default image view is displayed beyond the separator line (within the layout margin area).
         let iconAttachment = NSTextAttachment()
         iconAttachment.image = Style.ReplyIndicator.iconImage
 
@@ -32,7 +34,7 @@ class CommentDetailViewController: UITableViewController {
         cell.textLabel?.attributedText = attributedString
         cell.textLabel?.numberOfLines = 0
 
-        // setup constraints for textLabel to match the spacing specified in the designs.
+        // setup constraints for textLabel to match the spacing specified in the design.
         if let textLabel = cell.textLabel {
             textLabel.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
@@ -105,6 +107,10 @@ class CommentDetailViewController: UITableViewController {
         case .header:
             navigateToPost()
 
+        case .replyIndicator:
+            // TODO: Navigate to the comment reply.
+            break
+
         case .text(_, _, _, let action):
             action?()
 
@@ -151,7 +157,7 @@ private extension CommentDetailViewController {
     func configureRows() {
         rows = [
             .header,
-            .replyIndicator,
+            .replyIndicator, // TODO: Conditionally add this when user has replied to the comment.
             .text(title: .webAddressLabelText, detail: comment.authorUrlForDisplay(), image: Style.externalIconImage, action: visitAuthorURL),
             .text(title: .emailAddressLabelText, detail: comment.author_email),
             .text(title: .ipAddressLabelText, detail: comment.author_ip)

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -15,15 +15,17 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 
     // MARK: Helpers
 
+    private typealias Style = WPStyleGuide.CommentDetail.Header
+
     private func configureStyle() {
         accessoryType = .disclosureIndicator
 
-        textLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
-        textLabel?.textColor = .textSubtle
+        textLabel?.font = Style.font
+        textLabel?.textColor = Style.textColor
         textLabel?.numberOfLines = 2
 
-        detailTextLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        detailTextLabel?.textColor = .text
+        detailTextLabel?.font = Style.detailFont
+        detailTextLabel?.textColor = Style.detailTextColor
         detailTextLabel?.numberOfLines = 1
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -25,9 +25,8 @@ extension WPStyleGuide {
                 .foregroundColor: CommentDetail.secondaryTextColor
             ]
 
-            private static let symbolName = "arrowshape.turn.up.left.circle"
             private static let symbolConfiguration = UIImage.SymbolConfiguration(font: CommentDetail.secondaryTextFont, scale: .small)
-            static let iconImage: UIImage? = .init(systemName: symbolName, withConfiguration: symbolConfiguration)?
+            static let iconImage: UIImage? = .init(systemName: "arrowshape.turn.up.left.circle", withConfiguration: symbolConfiguration)?
                 .withRenderingMode(.alwaysTemplate)
                 .imageFlippedForRightToLeftLayoutDirection()
         }

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -1,0 +1,32 @@
+/// This class groups all of the styles used by the comment detail screen.
+///
+extension WPStyleGuide {
+    public struct CommentDetail {
+        static let tintColor: UIColor = .primary
+
+        static let textFont = WPStyleGuide.fontForTextStyle(.body)
+        static let textColor = UIColor.text
+
+        static let secondaryTextFont = WPStyleGuide.fontForTextStyle(.subheadline)
+        static let secondaryTextColor = UIColor.textSubtle
+
+        public struct Header {
+            static let font = WPStyleGuide.fontForTextStyle(.footnote)
+            static let textColor = CommentDetail.secondaryTextColor
+
+            static let detailFont = CommentDetail.secondaryTextFont
+            static let detailTextColor = CommentDetail.textColor
+        }
+
+        public struct ReplyIndicator {
+            static let tintColor = CommentDetail.secondaryTextColor
+
+            static let font = CommentDetail.secondaryTextFont
+            static let textColor = CommentDetail.secondaryTextColor
+
+            private static let symbolName = "arrowshape.turn.up.left.circle"
+            private static let symbolConfiguration = UIImage.SymbolConfiguration(font: font, scale: .small)
+            static let iconImage: UIImage? = .init(systemName: symbolName, withConfiguration: symbolConfiguration)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -3,6 +3,7 @@
 extension WPStyleGuide {
     public struct CommentDetail {
         static let tintColor: UIColor = .primary
+        static let externalIconImage: UIImage = .gridicon(.external).imageFlippedForRightToLeftLayoutDirection()
 
         static let textFont = WPStyleGuide.fontForTextStyle(.body)
         static let textColor = UIColor.text
@@ -19,14 +20,16 @@ extension WPStyleGuide {
         }
 
         public struct ReplyIndicator {
-            static let tintColor = CommentDetail.secondaryTextColor
-
-            static let font = CommentDetail.secondaryTextFont
-            static let textColor = CommentDetail.secondaryTextColor
+            static let textAttributes: [NSAttributedString.Key: Any] = [
+                .font: CommentDetail.secondaryTextFont,
+                .foregroundColor: CommentDetail.secondaryTextColor
+            ]
 
             private static let symbolName = "arrowshape.turn.up.left.circle"
-            private static let symbolConfiguration = UIImage.SymbolConfiguration(font: font, scale: .small)
-            static let iconImage: UIImage? = .init(systemName: symbolName, withConfiguration: symbolConfiguration)
+            private static let symbolConfiguration = UIImage.SymbolConfiguration(font: CommentDetail.secondaryTextFont, scale: .small)
+            static let iconImage: UIImage? = .init(systemName: symbolName, withConfiguration: symbolConfiguration)?
+                .withRenderingMode(.alwaysTemplate)
+                .imageFlippedForRightToLeftLayoutDirection()
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4359,6 +4359,8 @@
 		FEA088052696F7AA00193358 /* WPStyleGuide+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */; };
 		FEA7948D26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
 		FEA7948E26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
+		FEA7949026DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */; };
+		FEA7949126DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */; };
 		FEC3B81726C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */; };
 		FEC3B81826C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */; };
 		FEC3B81926C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */; };
@@ -7532,6 +7534,7 @@
 		FEA088022696E81F00193358 /* ListTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ListTableHeaderView.xib; sourceTree = "<group>"; };
 		FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+List.swift"; sourceTree = "<group>"; };
 		FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentHeaderTableViewCell.swift; sourceTree = "<group>"; };
+		FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+CommentDetail.swift"; sourceTree = "<group>"; };
 		FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleButtonTableViewCell.swift; sourceTree = "<group>"; };
 		FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleButtonTableViewCell.xib; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
@@ -12404,6 +12407,7 @@
 			isa = PBXGroup;
 			children = (
 				B56994441B7A7EF200FF26FA /* WPStyleGuide+Comments.swift */,
+				FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */,
 			);
 			name = Style;
 			sourceTree = "<group>";
@@ -16950,6 +16954,7 @@
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,
 				17C1D67C2670E3DC006C8970 /* SiteIconPickerView.swift in Sources */,
 				E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */,
+				FEA7949026DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */,
 				F5A34A9925DEF47D00C9654B /* WPMediaPicker+MediaPicker.swift in Sources */,
 				9A8ECE132254A3260043C8DA /* JetpackInstallError+Blocking.swift in Sources */,
 				43AF2F972107D3810069C012 /* QuickStartTourState.swift in Sources */,
@@ -20040,6 +20045,7 @@
 				FABB24C52602FC2C00C8785C /* SiteSuggestion+CoreDataProperties.swift in Sources */,
 				FABB24C62602FC2C00C8785C /* UntouchableWindow.swift in Sources */,
 				FABB24C72602FC2C00C8785C /* WPProgressTableViewCell.m in Sources */,
+				FEA7949126DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */,
 				FABB24C82602FC2C00C8785C /* StockPhotosPicker.swift in Sources */,
 				FABB24C92602FC2C00C8785C /* BlogDetailHeader.swift in Sources */,
 				FABB24CA2602FC2C00C8785C /* UnifiedPrologueViewController.swift in Sources */,


### PR DESCRIPTION
Refs #17087
Depends on #17105

Adds the reply indicator cell in Comment Detail. 

- The reply indicator cell is always shown. The logic will be implemented in a future PR since it depends on the Comment's `i_replied` parameter. In short, these will be implemented later:
  - Show the reply indicator cell based on the Comment's `i_replied` value.
  - When the cell is tapped, show the comment reply.
- Tidied up all the style constants to `WPStyleGuide+CommentDetail`. 
- Aside from the reply indicator cell UI, I also included some changes that add support for RTL. Mainly, using `imageFlippedForRightToLeftLayoutDirection()` for the icons (since they have some directional aspects to it).

LTR | RTL
--|--
![comment_detail_ltr](https://user-images.githubusercontent.com/1299411/131671426-631b3e07-ef85-43a5-ba05-7299a348dfdb.png) | ![comment_detail_RTL](https://user-images.githubusercontent.com/1299411/131671432-eab4fa76-b4f6-410f-bae0-b06877a4934a.png)

## To Test

- Enable the `New Comment Detail` feature flag.
- Go to My Site > Comments, and select any comment. 
- Verify that the reply indicator cell is visible and displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
