### PR TITLE
Comment edit: fix jumpy text view

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
@@ -11,8 +11,6 @@ class EditCommentMultiLineCell: UITableViewCell, NibReusable {
 
     @IBOutlet weak var textView: UITextView!
     @IBOutlet weak var textViewMinHeightConstraint: NSLayoutConstraint!
-    @IBOutlet weak var textViewTopConstraint: NSLayoutConstraint!
-    private var textViewPadding: CGFloat = 0
     weak var delegate: EditCommentMultiLineCellDelegate?
 
     // MARK: - View
@@ -20,7 +18,6 @@ class EditCommentMultiLineCell: UITableViewCell, NibReusable {
     override func awakeFromNib() {
         super.awakeFromNib()
         configureCell()
-        textViewPadding = textViewTopConstraint.constant * 2
     }
 
     func configure(text: String? = nil) {

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.swift
@@ -52,13 +52,12 @@ private extension EditCommentMultiLineCell {
     }
 
     func adjustHeight() {
-        let originalCellHeight = frame.size.height
-        let textViewSize = textView.sizeThatFits(CGSize(width: textView.frame.size.width, height: CGFloat.greatestFiniteMagnitude))
-        let textViewHeight = ceilf(Float(max(textViewSize.height, textViewMinHeightConstraint.constant)))
-        let newCellHeight = CGFloat(textViewHeight) + textViewPadding
-        frame.size.height = newCellHeight
+        let originalHeight = textView.frame.size.height
+        textView.sizeToFit()
+        let textViewHeight = ceilf(Float(max(textView.frame.size.height, textViewMinHeightConstraint.constant)))
+        textView.frame.size.height = CGFloat(textViewHeight)
 
-        if newCellHeight != originalCellHeight {
+        if textViewHeight != Float(originalHeight) {
             delegate?.textViewHeightUpdated()
         }
     }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentMultiLineCell.xib
@@ -42,7 +42,6 @@
             <connections>
                 <outlet property="textView" destination="FkL-aB-20C" id="GOY-jR-qNE"/>
                 <outlet property="textViewMinHeightConstraint" destination="mme-Ba-30V" id="zh4-cE-ddl"/>
-                <outlet property="textViewTopConstraint" destination="mgJ-V6-WZA" id="b9P-BE-IiY"/>
             </connections>
             <point key="canvasLocation" x="-131.8840579710145" y="-16.071428571428569"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -266,9 +266,7 @@ extension EditCommentTableViewController: EditCommentSingleLineCellDelegate {
 extension EditCommentTableViewController: EditCommentMultiLineCellDelegate {
 
     func textViewHeightUpdated() {
-        tableView.beginUpdates()
-        tableView.scrollToRow(at: IndexPath(row: 0, section: TableSections.comment.rawValue), at: .bottom, animated: false)
-        tableView.endUpdates()
+        tableView.performBatchUpdates({})
     }
 
     func textUpdated(_ updatedText: String?) {


### PR DESCRIPTION
Ref: #17000 , https://github.com/wordpress-mobile/WordPress-iOS/pull/17077#pullrequestreview-736981753

When typing in the `Comment` text view, the text view no longer "jumps", losing it's scroll position. 

There are still some minor issues, which I'll fix later.
- Pasting doesn't scroll to the end of the text.
- When returning, the next row is sometimes behind the keyboard until text is entered.
- When the `Comment` cell is really long and you tap towards the bottom, when the keyboard appears sometimes the text isn't scrolled to where you tapped.

To test:
- Go to My Site > Comments > Comment details > Edit.
- Type text in the `Comment` field, including several returns so the `textView` grows.
  - If you're using a simulator, be sure the keyboard is showing.
- Verify the `textView` no longer jumps up, hiding your typing location behind the keyboard.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
