### PR TITLE
Fix editor_session_start event custom property key

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -96,7 +96,7 @@ private extension PostEditorAnalyticsSession {
         static let template = "template"
         static let startupTime = "startup_time_ms"
         static let canViewEditorOnboarding = "can_view_editor_onboarding"
-        static let unstableGalleryWithImageBlocks = "unstableGalleryWithImageBlocks"
+        static let unstableGalleryWithImageBlocks = "unstable_gallery_with_image_blocks"
     }
 
     var commonProperties: [String: String] {


### PR DESCRIPTION
Prior to this change, `wpios_editor_session_start` events were not sent to Tracks, as they were marked as invalid with the following error. This relates to changes made in #16848 and #16832.

```
Custom properties dictionary keys must contain alpha characters and underscores only.
```

To test: 

1. Install `18.2` beta build. 
2. Launch post editor. 
3. ⚠️ Verify `wpios_editor_session_start` event _does not_ arrive to Tracks. 
4. Install build from this PR. 
5. Launch post editor. 
6. ✅ Verify `wpios_editor_session_start` event arrives to Tracks with expected properties. 

## Regression Notes
1. Potential unintended areas of impact
    Custom properties for the event are missing. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verified custom properties arrived with the event in Tracks. 
3. What automated tests I added (or what prevented me from doing so)
   None. We would need to either write an integration test to verify the session event property keys are "valid" with `Automattic-Tracks-iOS` or iterate over them manually asserting their validity. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
