### PR TITLE
Merge editorialized release notes for 18.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: git@github.com:wordpress-mobile/release-toolkit
+  revision: 964e732e2996730beb04953a6a0299437ed99c5e
+  branch: trunk
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (1.4.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -91,7 +110,7 @@ GEM
     ethon (0.14.0)
       ffi (>= 1.15.0)
     excon (0.82.0)
-    faraday (1.7.0)
+    faraday (1.7.1)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -163,19 +182,6 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
-    fastlane-plugin-wpmreleasetoolkit (1.4.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (~> 12.3)
-      rake-compiler (~> 1.0)
     ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -245,13 +251,13 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
-    nokogiri (1.12.3)
+    nokogiri (1.12.4)
       mini_portile2 (~> 2.6.1)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
-    oj (3.13.1)
+    oj (3.13.4)
     optimist (3.0.1)
     options (2.3.2)
     os (1.1.1)
@@ -337,7 +343,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit (~> 1.4)
+  fastlane-plugin-wpmreleasetoolkit!
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: git@github.com:wordpress-mobile/release-toolkit
-  revision: 964e732e2996730beb04953a6a0299437ed99c5e
-  branch: trunk
+  revision: 603e6f6a7ea9de03ffd7b8c1934efdc04eb98e2f
+  branch: develop
   specs:
     fastlane-plugin-wpmreleasetoolkit (1.4.0)
       activesupport (~> 5)
@@ -14,7 +14,7 @@ GIT
       octokit (~> 4.18)
       parallel (~> 1.14)
       progress_bar (~> 1.3)
-      rake (~> 12.3)
+      rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
 
 GEM
@@ -268,7 +268,7 @@ GEM
       options (~> 2.3.0)
     public_suffix (4.0.6)
     racc (1.5.2)
-    rake (12.3.3)
+    rake (13.0.6)
     rake-compiler (1.1.1)
       rake
     rchardet (1.8.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: git@github.com:wordpress-mobile/release-toolkit
-  revision: 603e6f6a7ea9de03ffd7b8c1934efdc04eb98e2f
-  branch: develop
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (1.4.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -182,6 +163,19 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
+    fastlane-plugin-wpmreleasetoolkit (1.4.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (~> 12.3)
+      rake-compiler (~> 1.0)
     ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -268,7 +262,7 @@ GEM
       options (~> 2.3.0)
     public_suffix (4.0.6)
     racc (1.5.2)
-    rake (13.0.6)
+    rake (12.3.3)
     rake-compiler (1.1.1)
       rake
     rchardet (1.8.0)
@@ -343,7 +337,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 1.4)
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -15,7 +15,8 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Make your WordPress site faster and safer."
+msgid "Make your WordPress site faster and safer.
+"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.
@@ -38,15 +39,16 @@ msgctxt "app_store_keywords"
 msgid "social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal"
 msgstr ""
 
-msgctxt "v18.1-whats-new"
+msgctxt "v18.2-whats-new"
 msgid ""
-"Do you use the Embed block? For media that you embed on your site, you’ll now see an option to “Resize for smaller devices.” Toggle on to resize your content to fit your screen; toggle off to disable.\n"
+"- Stay informed! You can now receive a weekly summary of the activity on your most popular sites.\n"
 "\n"
-"Enjoying the Blogging Reminders tool? We’ve added a new feature that lets you choose a specific time to receive a notification.\n"
+"- You have even more control of your site comments — when you edit them you can now also adjust the author’s name, email address, and web address.\n"
+"We have made a couple of handy tweaks to the Block editor. The Embed block now gives you a sneak preview when you add something from YouTube or Twitter (more providers to come). Also, when you go to insert a block and nothing is found, there is now a no results view.\n"
 "\n"
-"Need to close your account? (We hope you never leave us!) But if needed, you now have the ability to do so in your Account Settings.\n"
+"- If you go to Post Settings > Post Format, you will find the “Standard” option still at the top, but the other options are now neatly alphabetized below. (Options will vary with themes!)\n"
 "\n"
-"Geotagging posts is no longer supported on the web, so we’ve removed the Location option under Post Settings.\n"
+"- And one more quick one: Refreshing your site is now super easy — just pull to refresh from the My Site screen!\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of the first screenshot in the App Store.

--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -15,8 +15,7 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Make your WordPress site faster and safer.
-"
+msgid "Make your WordPress site faster and safer."
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,7 +1,8 @@
-Do you use the Embed block? For media that you embed on your site, you’ll now see an option to “Resize for smaller devices.” Toggle on to resize your content to fit your screen; toggle off to disable.
+- Stay informed! You can now receive a weekly summary of the activity on your most popular sites.
 
-Enjoying the Blogging Reminders tool? We’ve added a new feature that lets you choose a specific time to receive a notification.
+- You have even more control of your site comments — when you edit them you can now also adjust the author’s name, email address, and web address.
+We have made a couple of handy tweaks to the Block editor. The Embed block now gives you a sneak preview when you add something from YouTube or Twitter (more providers to come). Also, when you go to insert a block and nothing is found, there is now a no results view.
 
-Need to close your account? (We hope you never leave us!) But if needed, you now have the ability to do so in your Account Settings.
+- If you go to Post Settings > Post Format, you will find the “Standard” option still at the top, but the other options are now neatly alphabetized below. (Options will vary with themes!)
 
-Geotagging posts is no longer supported on the web, so we’ve removed the Location option under Post Settings.
+- And one more quick one: Refreshing your site is now super easy — just pull to refresh from the My Site screen!

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -15,8 +15,7 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Build a website or blog
-"
+msgid "Build a website or blog"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -15,7 +15,8 @@ msgstr ""
 
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
-msgid "Build a website or blog"
+msgid "Build a website or blog
+"
 msgstr ""
 
 #. translators: Multi-paragraph text used to display in the Apple App Store.
@@ -40,17 +41,16 @@ msgctxt "app_store_keywords"
 msgid "social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal"
 msgstr ""
 
-msgctxt "v18.1-whats-new"
+msgctxt "v18.2-whats-new"
 msgid ""
-"Do you use the Embed block? For media that you embed on your site, you’ll now see an option to “Resize for smaller devices.” Toggle on to resize your content to fit your screen; toggle off to disable.\n"
+"- Stay informed! You can now receive a weekly summary of the activity on your most popular sites.\n"
 "\n"
-"Enjoying the Blogging Reminders tool? We’ve added a new feature that lets you choose a specific time to receive a notification.\n"
+"- You have even more control of your site comments — when you edit them you can now also adjust the author’s name, email address, and web address.\n"
+"We have made a couple of handy tweaks to the Block editor. The Embed block now gives you a sneak preview when you add something from YouTube or Twitter (more providers to come). Also, when you go to insert a block and nothing is found, there is now a no results view.\n"
 "\n"
-"Need to close your account? (We hope you never leave us!) But if needed, you now have the ability to do so in your Account Settings.\n"
+"- If you go to Post Settings > Post Format, you will find the “Standard” option still at the top, but the other options are now neatly alphabetized below. (Options will vary with themes!)\n"
 "\n"
-"Geotagging posts is no longer supported on the web, so we’ve removed the Location option under Post Settings.\n"
-"\n"
-"We also made other improvements, including a fix to a cropping issue in the Reader, as well as the ability to recommend the app to your friends on your Me and About screens.\n"
+"- And one more quick one: Refreshing your site is now super easy — just pull to refresh from the My Site screen!\n"
 msgstr ""
 
 #. translators: This is a standard chunk of text used to tell a user what's new with a release when nothing major has changed.

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,9 +1,8 @@
-* [internal] Fixed an issue where source and platform tags were not added to a Zendesk ticket if the account has no blogs. [#17084]
-* [*] Set the post formats to have 'Standard' first and then alphabetized the remaining items. [#17074]
-* [*] Added pull-to-refresh to My Site. [#17089]
-* [***] Weekly Roundup: users will receive a weekly notification that presents a summary of the activity on their most used sites [#17066, #17116]
-* [*] Added pull-to-refresh to My Site.
-* [**] Site Comments: when editing a Comment, the author's name, email address, and web address can now be changed. [#17111]
-* [**] Block editor: Enable embed preview for a list of providers (for now only YouTube and Twitter) [https://github.com/WordPress/gutenberg/pull/34446]
-* [***] Block editor: Add Inserter Block Search [https://github.com/WordPress/gutenberg/pull/33237]
+- Stay informed! You can now receive a weekly summary of the activity on your most popular sites.
 
+- You have even more control of your site comments — when you edit them you can now also adjust the author’s name, email address, and web address.
+We have made a couple of handy tweaks to the Block editor. The Embed block now gives you a sneak preview when you add something from YouTube or Twitter (more providers to come). Also, when you go to insert a block and nothing is found, there is now a no results view.
+
+- If you go to Post Settings > Post Format, you will find the “Standard” option still at the top, but the other options are now neatly alphabetized below. (Options will vary with themes!)
+
+- And one more quick one: Refreshing your site is now super easy — just pull to refresh from the My Site screen!

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'trunk'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'develop'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.4'
+gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'trunk'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,7 +6,7 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'develop'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 1.4'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
Please forgive the long commit history. I was curious to try my `msgid` fix, which is merged in the release toolkit `develop` but hasn't been release yet, in another codebase but pointed to `trunk` instead of `develop` and, because `update_appstore_strings` pushes, I didn't have a chance to rebase the mistake away. FWIW, 69e4335 and confirm 7b3ecb5 one more time that the fix is legit.