### PR TITLE
Improve weekly roundup

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
@@ -118,23 +118,33 @@ class BackgroundTasksCoordinator {
     ///
     /// Ref: https://developer.apple.com/documentation/backgroundtasks/bgtaskscheduler
     ///
-    func scheduleTasks(completion: (Result<Void, Error>) -> Void) {
+    func scheduleTasks(completion: @escaping (Result<Void, Error>) -> Void) {
         var tasksAndErrors = [String: Error]()
 
-        scheduler.cancelAllTaskRequests()
+        scheduler.getPendingTaskRequests { [weak self] scheduledRequests in
+            guard let self = self else {
+                return
+            }
 
-        for task in registeredTasks {
-            schedule(task) { result in
-                if case .failure(let error) = result {
-                    tasksAndErrors[type(of: task).identifier] = error
+            let tasksToSchedule = self.registeredTasks.filter { task in
+                !scheduledRequests.contains { request in
+                    request.identifier == type(of: task).identifier
                 }
             }
-        }
 
-        if tasksAndErrors.isEmpty {
-            completion(.success(()))
-        } else {
-            completion(.failure(SchedulingError.schedulingFailed(tasksAndErrors: tasksAndErrors)))
+            for task in tasksToSchedule {
+                self.schedule(task) { result in
+                    if case .failure(let error) = result {
+                        tasksAndErrors[type(of: task).identifier] = error
+                    }
+                }
+            }
+
+            if tasksAndErrors.isEmpty {
+                completion(.success(()))
+            } else {
+                completion(.failure(SchedulingError.schedulingFailed(tasksAndErrors: tasksAndErrors)))
+            }
         }
     }
 
@@ -152,6 +162,19 @@ class BackgroundTasksCoordinator {
             try self.scheduler.submit(request)
         } catch {
             completion(.failure(SchedulingError.schedulingFailed(task: type(of: task).identifier, error: error)))
+        }
+    }
+
+    // MARK: - Querying Data
+
+    func getScheduledExecutionDate(taskIdentifier: String, completion: @escaping (Date?) -> Void) {
+        scheduler.getPendingTaskRequests { requests in
+            guard let weeklyRoundupRequest = requests.first(where: { $0.identifier == taskIdentifier }) else {
+                completion(nil)
+                return
+            }
+
+            return completion(weeklyRoundupRequest.earliestBeginDate)
         }
     }
 }

--- a/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
@@ -9,9 +9,9 @@ protocol BackgroundTask {
     ///
     func nextRunDate() -> Date?
 
-    /// This method allows the task to perform extra processing before scheduling the BG Task.
+    /// This method allows the task to perform extra processing after scheduling the BG Task.
     ///
-    func willSchedule(completion: @escaping (Result<Void, Error>) -> Void)
+    func didSchedule(completion: @escaping (Result<Void, Error>) -> Void)
 
     // MARK: - Execution
 
@@ -156,10 +156,9 @@ class BackgroundTasksCoordinator {
         let request = BGAppRefreshTaskRequest(identifier: type(of: task).identifier)
         request.earliestBeginDate = nextDate
 
-        task.willSchedule(completion: completion)
-
         do {
             try self.scheduler.submit(request)
+            task.didSchedule(completion: completion)
         } catch {
             completion(.failure(SchedulingError.schedulingFailed(task: type(of: task).identifier, error: error)))
         }

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -287,7 +287,8 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
            let lastValidDate = Calendar.current.nextDate(
             after: Date(),
             matching: runDateComponents,
-            matchingPolicy: .previousTimePreservingSmallerComponents),
+            matchingPolicy: .nextTime,
+            direction: .backward),
            lastValidDate > lastRunDate {
 
             return lastValidDate

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -248,13 +248,15 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
             matchingPolicy: .nextTime)
     }
 
-    func willSchedule(completion: @escaping (Result<Void, Error>) -> Void) {
+    func didSchedule(completion: @escaping (Result<Void, Error>) -> Void) {
         if Feature.enabled(.weeklyRoundupStaticNotification) {
             // We're scheduling a static notification in case the BG task won't run.
             // This will happen when the App has been explicitly killed by the user as of 2021/08/03,
             // as Apple doesn't let background tasks run in this scenario.
             notificationScheduler.scheduleStaticNotification(completion: completion)
         }
+
+        completion(.success(()))
     }
 
     func expirationHandler() {

--- a/WordPress/Classes/ViewRelated/Developer/WeeklyRoundupDebugScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/WeeklyRoundupDebugScreen.swift
@@ -182,9 +182,9 @@ struct WeeklyRoundupDebugScreen: View {
 
                     WordPressAppDelegate.shared?.backgroundTasksCoordinator.schedule(backgroundTask) { result in
                         switch result {
-                        case .success():
+                        case .success:
                             errorScheduling = false
-                        case .failure( _ ):
+                        case .failure:
                             errorScheduling = true
                         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -57,6 +57,8 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
         return -(expectedPeriodCount - 1)
     }
 
+    private var isRunningGhostAnimation: Bool = false
+
     // MARK: - View
 
     override func awakeFromNib() {
@@ -126,14 +128,15 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     }
 
     func animateGhostLayers(_ animate: Bool) {
-        forwardButton.isEnabled = !animate
-        backButton.isEnabled = !animate
-
         if animate {
+            isRunningGhostAnimation = true
             startGhostAnimation(style: GhostCellStyle.muriel)
-            return
+        } else {
+            isRunningGhostAnimation = false
+            stopGhostAnimation()
         }
-        stopGhostAnimation()
+
+        updateButtonStates()
     }
 }
 
@@ -247,6 +250,12 @@ private extension SiteStatsTableHeaderView {
     }
 
     func updateButtonStates() {
+        guard !isRunningGhostAnimation else {
+            forwardButton.isEnabled = false
+            backButton.isEnabled = false
+            return
+        }
+
         guard let date = date, let period = period else {
             forwardButton.isEnabled = false
             backButton.isEnabled = false


### PR DESCRIPTION
Fixes an issue with Weekly Roundup that could result in skipping the last roundup under certain circumstances.

This is actually a bit of an improvement since it makes Weekly Roundup work a bit better when the App is killed and re-launched.

This PR also introduces some additional info in the Weekly Roundup debug screen to make testing easier.  It now shows the next date when Weekly Roundup is scheduled to run, which can be checked at any time by going into:

Me > App Settings > Debug Menu > Weekly Roundup

## To test:

### Test killing App and re-opening:

1. Launch the App
2. Go to the debug menu, check that the scheduled date is next monday at 10:00 am
3. Kill the App and relaunch
4. Go to the debug menu, check that the scheduled date is next monday at 10:00 am

### Test skipping Weekly Roundup and running it within 2 days after a skipped Monday.

In order to test this, we need to use the debug menu to immediately run Weekly Roundup once.

This is necessary so that the feature stores the last execution date so that the following steps work properly.

1. Launch the app
2. Go to the debug menu, and tap "Schedule immediately".  Wait for the notifications to come up.
3. Kill the App
4. Go to your device's settings and move the date at least one week forward.  Make you can skip more weeks if needed, but make sure that the date you pick is within two days after a future Monday at 10:00 am.
5. Relaunch the App
6. Go to the debug menu and make sure that the run date is set to the previous Monday at 10:00 am.  This means the task should be run at any time starting now.

### Test skipping Weekly Roundup and running it beyond 2 days after a skipped Monday.

In order to test this, we need to use the debug menu to immediately run Weekly Roundup once.

This is necessary so that the feature stores the last execution date so that the following steps work properly.

1. Launch the app
2. Go to the debug menu, and tap "Schedule immediately".  Wait for the notifications to come up.
3. Kill the App
4. Go to your device's settings and move the date at least one week forward.  Make you can skip more weeks if needed, but make sure that the date you pick is at least two days after a future Monday at 10:00 am.
5. Relaunch the App
6. Go to the debug menu and make sure that the run date is set to the following Monday at 10:00 am.

## Regression Notes

1. Potential unintended areas of impact

The changes are limited to Weekly Roundup, which is a new feature in 18.2.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
