### PR TITLE
Empty Stats: refactor loading / dismissal logic for the customize card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -98,7 +98,6 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
 
     // Store 'customize' separately as it is not per site.
     private let userDefaultsHideCustomizeKey = "StatsInsightsHideCustomizeCard"
-    private var hideCustomizeCard = false
 
     // Store Insights settings for all sites.
     // Used when writing to/reading from User Defaults.
@@ -266,14 +265,9 @@ private extension SiteStatsInsightsTableViewController {
 
     func writeInsightsToUserDefaults() {
 
-        writeCustomizeCardSetting()
-
         guard let siteID = SiteStatsInformation.sharedInstance.siteID?.stringValue else {
             return
         }
-
-        // Remove 'customize' from array since it is not per site.
-        removeCustomizeCard()
 
         let insightTypesValues = InsightType.valuesForTypes(insightsToShow)
         let currentSiteInsights = [siteID: insightTypesValues]
@@ -283,13 +277,6 @@ private extension SiteStatsInsightsTableViewController {
         allSitesInsights.append(currentSiteInsights)
 
         UserDefaults.standard.set(allSitesInsights, forKey: userDefaultsInsightTypesKey)
-
-        // Add back 'customize'.
-        addCustomizeCard()
-    }
-
-    func writeCustomizeCardSetting() {
-        UserDefaults.standard.set(hideCustomizeCard, forKey: userDefaultsHideCustomizeKey)
     }
 
     /// Loads an insight that can be permanently dismissed. Adds or removes the insight from the list of insights to show.
@@ -327,17 +314,6 @@ private extension SiteStatsInsightsTableViewController {
 
     func dismissCustomizeCard() {
         permanentlyDismissInsight(.customize, using: userDefaultsHideCustomizeKey)
-    }
-
-    func removeCustomizeCard() {
-        insightsToShow = insightsToShow.filter { $0 != .customize }
-    }
-
-    func addCustomizeCard() {
-        if !hideCustomizeCard && !insightsToShow.contains(.customize) {
-            // Insert customize at the beginning of the array so it is displayed first.
-            insightsToShow.insert(.customize, at: 0)
-        }
     }
 
     // MARK: - Insights Management

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -396,7 +396,9 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func canMoveInsightUp(_ insight: InsightType) -> Bool {
-        let minIndex = hideCustomizeCard ? 0 : 1
+        let isShowingPinnedCard = insightsToShow.contains(.customize)
+
+        let minIndex = isShowingPinnedCard ? 1 : 0
 
         guard let currentIndex = indexOfInsight(insight),
             (currentIndex - 1) >= minIndex else {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -288,11 +288,6 @@ private extension SiteStatsInsightsTableViewController {
         addCustomizeCard()
     }
 
-    func loadCustomizeCardSetting() {
-        hideCustomizeCard = UserDefaults.standard.bool(forKey: userDefaultsHideCustomizeKey)
-        addCustomizeCard()
-    }
-
     func writeCustomizeCardSetting() {
         UserDefaults.standard.set(hideCustomizeCard, forKey: userDefaultsHideCustomizeKey)
     }
@@ -326,9 +321,12 @@ private extension SiteStatsInsightsTableViewController {
 
     // MARK: - Customize Card Management
 
+    func loadCustomizeCardSetting() {
+        loadPermanentlyDismissableInsight(.customize, using: userDefaultsHideCustomizeKey)
+    }
+
     func dismissCustomizeCard() {
-        hideCustomizeCard = true
-        removeCustomizeCard()
+        permanentlyDismissInsight(.customize, using: userDefaultsHideCustomizeKey)
     }
 
     func removeCustomizeCard() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -297,6 +297,33 @@ private extension SiteStatsInsightsTableViewController {
         UserDefaults.standard.set(hideCustomizeCard, forKey: userDefaultsHideCustomizeKey)
     }
 
+    /// Loads an insight that can be permanently dismissed. Adds or removes the insight from the list of insights to show.
+    ///
+    /// - Parameters:
+    ///   - insight: An insight that can be permanently dismissed for all sites
+    ///   - userDefaultsHideInsightKey: The UserDefaults key that indicates whether or not the insight should be hidden
+    func loadPermanentlyDismissableInsight(_ insight: InsightType, using userDefaultsHideInsightKey: String) {
+
+        let shouldAddInsight =
+            !UserDefaults.standard.bool(forKey: userDefaultsHideInsightKey) && !insightsToShow.contains(insight)
+
+        if shouldAddInsight {
+            insightsToShow.insert(insight, at: 0)
+        } else {
+            insightsToShow = insightsToShow.filter { $0 != insight }
+        }
+    }
+
+    /// Permanently dismisses an insight for all sites.
+    ///
+    /// - Parameters:
+    ///   - insight: An insight that can be permanently dismissed for all sites
+    ///   - userDefaultsHideInsightKey: The UserDefaults key that indicates whether or not the insight should be hidden
+    func permanentlyDismissInsight(_ insight: InsightType, using userDefaultsHideInsightKey: String) {
+        insightsToShow = insightsToShow.filter { $0 != insight }
+        UserDefaults.standard.set(true, forKey: userDefaultsHideInsightKey)
+    }
+
     // MARK: - Customize Card Management
 
     func dismissCustomizeCard() {


### PR DESCRIPTION
Part of #17123 

## Description

This PR refactors the loading / dismissal logic for the **Customize** card, in anticipation of the new **Grow Audience** card that will be added as part of the Empty Stats project. (See: https://github.com/wordpress-mobile/WordPress-iOS/pull/17142)

The Grow Audience card, like the Customize card, can be permanently dismissed. This refactor simplifies the loading / dismissal logic for cards that can be permanently dismissed.

## Notes

Hey there @ScoutHarris 👋 

Tagging you in the PR since you worked on Stats previously.

I noticed the Customize card was being removed then added back in the `writeInsightsToUserDefaults` method. I think this was being done because once a Customize card is dismissed, it subsequently needs to be hidden on _all_ sites.

In an effort to simplify this logic, I'm removing the Customize card in the new `loadPermanentlyDismissableInsight(: key:)` method. This ensures that if there's a site that was previously showing the Customize card, but the card was dismissed from a different site, the Customize card get removed from the list of insights to show.

## How to test

1. Delete WPiOS and do a fresh install
2. Log in to an account with multiple sites
3. Go to My Sites (Let's call the current site **Site A**)
4. Go to Stats
5. ✅ The Customize card should be displayed for Site A
6. Go back to My Sites and choose a different site (Let's call this site **Site B**)
7. Go to Stats
8. ✅ The Customize card should be displayed for Site B
9. Tap Dismiss on the Customize card
10. ✅ The Customize card should be dismissed for Site B
11. Go back to Site A > Stats
12.  ✅ The Customize card should be dismissed for Site A


## Regression Notes
1. Potential unintended areas of impact
Loading / dismissing the Customize card in the Stats screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the loading / dismissal flow

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
