### PR TITLE
Fix stat issues

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -234,11 +234,17 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
     /// Just a convenience method to know then this task is run, what run date to use as "current".
     ///
     private func currentRunPeriodEndDate() -> Date {
-        Calendar.current.nextDate(
+        let runDate = Calendar.current.nextDate(
             after: Date(),
             matching: runDateComponents,
             matchingPolicy: .nextTime,
             direction: .backward) ?? Date()
+
+        // The run date is when the task is scheduled to run, but the period end date is actually
+        // the previous day at 24:59:59.
+        let periodEndDate = Calendar.current.date(bySettingHour: 0, minute: 0, second: 0, of: runDate)!.addingTimeInterval(TimeInterval.init(-1))
+
+        return periodEndDate
     }
 
     func nextRunDate() -> Date? {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -245,8 +245,8 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
     func displayMediaWithID(_ mediaID: NSNumber) {
 
         guard let siteID = SiteStatsInformation.sharedInstance.siteID, let blog = Blog.lookup(withID: siteID, in: mainContext) else {
-                DDLogInfo("Unable to get blog when trying to show media from Stats.")
-                return
+            DDLogInfo("Unable to get blog when trying to show media from Stats.")
+            return
         }
 
         mediaService.getMediaWithID(mediaID, in: blog, success: { (media) in

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -34,7 +34,7 @@ class SiteStatsPeriodViewModel: Observable {
                     return
                 }
 
-                currentEntryIndex = mostRecentChartData.summaryData.lastIndex(where: { $0.periodStartDate < selectedDate })
+                currentEntryIndex = mostRecentChartData.summaryData.lastIndex(where: { $0.periodStartDate <= selectedDate })
                     ?? max(mostRecentChartData.summaryData.count - 1, 0)
             }
         }
@@ -342,7 +342,7 @@ private extension SiteStatsPeriodViewModel {
             barChartStyling.append(contentsOf: chart.barChartStyling)
 
             indexToHighlight = chartData.summaryData.lastIndex(where: {
-                $0.periodStartDate.normalizedDate() < selectedDate.normalizedDate()
+                $0.periodStartDate.normalizedDate() <= selectedDate.normalizedDate()
             })
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -126,9 +126,6 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
     }
 
     func animateGhostLayers(_ animate: Bool) {
-        forwardButton.isEnabled = !animate
-        backButton.isEnabled = !animate
-
         if animate {
             startGhostAnimation(style: GhostCellStyle.muriel)
             return

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -57,6 +57,8 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
         return -(expectedPeriodCount - 1)
     }
 
+    private var isRunningGhostAnimation: Bool = false
+
     // MARK: - View
 
     override func awakeFromNib() {
@@ -127,10 +129,14 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 
     func animateGhostLayers(_ animate: Bool) {
         if animate {
+            isRunningGhostAnimation = true
             startGhostAnimation(style: GhostCellStyle.muriel)
-            return
+        } else {
+            isRunningGhostAnimation = false
+            stopGhostAnimation()
         }
-        stopGhostAnimation()
+
+        updateButtonStates()
     }
 }
 
@@ -244,6 +250,12 @@ private extension SiteStatsTableHeaderView {
     }
 
     func updateButtonStates() {
+        guard !isRunningGhostAnimation else {
+            forwardButton.isEnabled = false
+            backButton.isEnabled = false
+            return
+        }
+
         guard let date = date, let period = period else {
             forwardButton.isEnabled = false
             backButton.isEnabled = false

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -90,7 +90,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         if traitCollection.verticalSizeClass == .regular, traitCollection.horizontalSizeClass == .compact {
-            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod, withDate: periodTableViewController.selectedDate)
+            updatePeriodView(oldSelectedPeriod: currentSelectedPeriod)
         }
     }
 }
@@ -172,7 +172,7 @@ private extension SiteStatsDashboardViewController {
         currentSelectedPeriod = getSelectedPeriodFromUserDefaults()
     }
 
-    func updatePeriodView(oldSelectedPeriod: StatsPeriodType, withDate periodDate: Date? = nil) {
+    func updatePeriodView(oldSelectedPeriod: StatsPeriodType) {
         let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
         let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
@@ -192,11 +192,9 @@ private extension SiteStatsDashboardViewController {
                                                        animated: false)
             }
 
-            if let newDate = periodDate {
-                periodTableViewController.selectedDate = newDate
-            }
+            if periodTableViewController.selectedDate == nil
+                || selectedPeriodChanged {
 
-            if periodTableViewController.selectedDate == nil {
                 periodTableViewController.selectedDate = StatsDataHelper.currentDateForSite()
             }
 


### PR DESCRIPTION
This PR fixes some stat issues that were introduced by Weekly Roundup in 18.2.

## To test:

### Test weekly roundup:

1. Go to Me > App Settings > Debug > Weekly Roundup.
2. Tap "Schedule Immediately"
3. When the notifications come up, tap on one, and make sure WordPress opens the stats screen for that site with the previous week selected.

### Test switching between periods in stats:

1. Open the stats section for a site that has stats enabled.
2. Switch to the "Years" period.
3. The last available year should be selected, tap the left and right arrow to force a refresh.
4. Switch to the "Days" period and make sure everything looks fine, with the current date being the one that's selected.

### Test tapping the forward and back arrows when disabled:

1. Open the stats section for a site that has stats enabled.
2. The last period should be selected and the forward arrow disabled.  Tap it and make sure nothing happens.
3. Tap on the first period or move to it using the back arrow.  The back arrow should become disabled.
4. Tap it and make sure nothing happens.

### Test tapping on the periods:

The period columns should work again and tapping on them should select the corret period.

## Regression Notes

1. Potential unintended areas of impact

This PR fixes many issues in stats, so test as much as you consider necessary in stats, aside from the tests proposed above.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Tested everything manually and found no other issues.

3. What automated tests I added (or what prevented me from doing so)

None as these are not unit testable.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
