### PR TITLE
Update My Site menu wording

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 18.3
 -----
 * [*] Fixed a bug on Reader that prevented Saved posts to be removed
+* [*] Updated the wording for the "Posts" and "Pages" entries in My Site screen [https://github.com/wordpress-mobile/WordPress-iOS/pull/17156]
 
 18.2
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -900,7 +900,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                             }];
     [rows addObject:mediaRow];
 
-    BlogDetailsRow *pagesRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Site Pages", @"Noun. Title. Links to the blog's Pages screen.")
+    BlogDetailsRow *pagesRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
                                              accessibilityIdentifier:@"Site Pages Row"
                                                     image:[UIImage gridiconOfType:GridiconTypePages]
                                                  callback:^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -884,7 +884,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
 
-    BlogDetailsRow *postsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blog Posts", @"Noun. Title. Links to the blog's Posts screen.")
+    BlogDetailsRow *postsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Posts", @"Noun. Title. Links to the blog's Posts screen.")
                                               accessibilityIdentifier:@"Blog Post Row"
                                                                 image:[[UIImage gridiconOfType:GridiconTypePosts] imageFlippedForRightToLeftLayoutDirection]
                                                              callback:^{

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -253,7 +253,7 @@ struct QuickStartReviewPagesTour: QuickStartTour {
 
     var waypoints: [WayPoint] = {
         let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let descriptionTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
+        let descriptionTarget = NSLocalizedString("Pages", comment: "The item to select during a guided tour.")
         return [(element: .pages, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.pages)))]
     }()
 
@@ -272,7 +272,7 @@ struct QuickStartEditHomepageTour: QuickStartTour {
 
     var waypoints: [WayPoint] = {
         let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let descriptionTarget = NSLocalizedString("Site Pages", comment: "The item to select during a guided tour.")
+        let descriptionTarget = NSLocalizedString("Pages", comment: "The item to select during a guided tour.")
         let descriptionHomepage = NSLocalizedString("Select %@ to edit your Homepage.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let homepageTarget = NSLocalizedString("Homepage", comment: "The item to select during a guided tour.")
         return [

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -134,7 +134,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         super.updateAndPerformFetchRequest()
 
-        title = NSLocalizedString("Site Pages", comment: "Title of the screen showing the list of pages for a blog.")
+        title = NSLocalizedString("Pages", comment: "Title of the screen showing the list of pages for a blog.")
 
         configureFilterBarTopConstraint()
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -153,7 +153,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Blog Posts", comment: "Title of the screen showing the list of posts for a blog.")
+        title = NSLocalizedString("Posts", comment: "Title of the screen showing the list of posts for a blog.")
 
         configureFilterBarTopConstraint()
         updateGhostableTableViewOptions()


### PR DESCRIPTION
Fixes #16418

## What this does

This PR is part of HACK week item p7cLQ7-1H5-p2#comment-3181.

 - Updates the "Blog Posts" to "Posts" in the "My Site" screen – as well as in the related screens pushed on tap of those items, for consistency
 - Updates the "Site Pages" to "Pages" in that same screen, for consistency – even if that wasn't part of the original issue and request; I took the liberty to update that too as I felt it made sense, but **we might want @eduardozulian's confirmation about this one** first (see p7cLQ7-1H5-p2#comment-3248)
 - Updates the Quick Tour copies accordingly

## Screenshots

<details><summary>🖼 "My Site" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="16418-MySite-Before" src="https://user-images.githubusercontent.com/216089/133341176-1a905eb3-2a89-43c0-b843-7751cfe77b5e.png" /></td>
<td><img alt="16418-MySite-After" src="https://user-images.githubusercontent.com/216089/133325863-2ad156cd-96b9-4e50-ae93-5eecd784cdfa.png" /></td>
</tr></table></details>

<details><summary>🖼 "Posts" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="16418-Posts-Before" src="https://user-images.githubusercontent.com/216089/133341697-4abf00ec-a746-4def-a054-e124c2b48d94.png" /></td>
<td><img alt="16418-Posts-After" src="https://user-images.githubusercontent.com/216089/133325954-8a234982-312d-4db2-9ff6-23fb142a2c95.png" /></td>
</tr></table></details>

<details><summary>🖼 "Pages" Screen</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="16418-Pages-Before" src="https://user-images.githubusercontent.com/216089/133341774-f9b29323-a3a1-4288-9efe-e26726f11103.png" /></td>
<td><img alt="16418-Pages-After" src="https://user-images.githubusercontent.com/216089/133326030-8ce6b1f3-d2ba-481b-b5a9-f39f5d853031.png" /></td>
</tr></table></details>

<details><summary>🖼 Quick Tour</summary>
<table><tr><th>Before</th><th>After</th></tr><tr>
<td><img alt="16418-QuickTour-Before" src="https://user-images.githubusercontent.com/216089/133341891-167dbdf6-8c99-4963-a7a7-e51f7471f5bf.png" /></td>
<td><img alt="16418-QuickTour-After" src="https://user-images.githubusercontent.com/216089/133326069-05aa84ef-b817-474d-8892-34f2c7d552c7.png" /></td>
</tr></table></details>

## To Test

1. Open the app
2. Tap on My Site
3. Check the titles in the menu are "Posts" and "Pages" (not "Blog Posts" nor "Site Pages")
4. Tap on "Posts" and check the title of the screen matches.
5. Go back to "My Sites", then Tap on "Pages" and check the title of the screen matches.
6. Restart the Quick Tour for your site (Me > App Settings > Debug > Enable Quick Start for site)
7. In the "Next Steps" section of "My Site" screen, tap "Customize Your Site" then "Review site pages"
8. Check the name of the section mentioned in the tooltip also matches the new name: "Select **Pages** to see your page list"

## Regression Notes

#### 1. Potential unintended areas of impact

This is not the only `NSLocalizedString` in the app using just "Posts" as the localization key anymore, which means that if for some locales, the translation of the term "Posts" should be different in the different contexts where this term is used, this might cause context to be lost in translation (since translation of the text "Posts" will be the same everywhere it's used in the app). This is not a new issue (there were already multiple places/screens/contexts where "Posts" string were used), but just wanted to pointing it out given this change.

#### 2. What I did to test those areas of impact (or what existing automated tests I relied on)

Couldn't do much for testing this, as this will highly depend on the translators feedback for any locale

####  3. What automated tests I added (or what prevented me from doing so)

I've run the UI tests and ensured that change in wording didn't break them.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.