### PR TITLE
Fix/15651 - Followed sites in Reader > Following > Filter

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -143,8 +143,7 @@ extension ReaderSiteTopic {
     private static func tableProvider(completion: @escaping (Result<[TableDataItem], Error>) -> Void) {
         let completionBlock: (Result<[ReaderSiteTopic], Error>) -> Void = { result in
             let itemResult = result.map { sites in
-                sites.filter {!$0.isExternal}
-                    .map { topic in
+                sites.map { topic in
                     return TableDataItem(topic: topic, configure: { cell in
                         cell.textLabel?.text = topic.title
                         cell.detailTextLabel?.text = topic.siteURL


### PR DESCRIPTION
Part of [#15651](https://github.com/wordpress-mobile/WordPress-iOS/issues/15651)

## Description

This PR fixes the Followed sites list in Reader > Following > Filter.

## Screenshots

Web version | Current behaviour | Desired Behaviour
--- | --- | ---
<img width="275" alt="Screenshot 2021-09-16 at 17 53 31" src="https://user-images.githubusercontent.com/12729242/133648760-7af7bae4-31d1-4438-830e-29cf0780fdc3.png"> | <img width="509" alt="Screenshot 2021-09-16 at 17 50 35" src="https://user-images.githubusercontent.com/12729242/133648797-0042471b-dd95-43d5-82b8-60c1540f456d.png"> | <img width="509" alt="Screenshot 2021-09-16 at 17 52 01" src="https://user-images.githubusercontent.com/12729242/133648842-138f0cc6-c302-4079-abd1-545967736ac1.png">

## To test:
1. Make sure you follow JP, WP and a non-JP, non-WP sites.
2. List of the followed sites in the web version and the App version in Reader > Following > Filter should match.

## Regression Notes
1. Potential unintended areas of impact
Not sure.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
