### PR TITLE
Identify domain registration webview success.

### DIFF
--- a/WordPress/Classes/Utility/WebViewControllerFactory.swift
+++ b/WordPress/Classes/Utility/WebViewControllerFactory.swift
@@ -1,11 +1,12 @@
 import UIKit
+import WebKit
 
 class WebViewControllerFactory: NSObject {
     @available(*, unavailable)
     override init() {
     }
 
-    @objc static func controller(configuration: WebViewControllerConfiguration) -> UIViewController {
+    @objc static func controller(configuration: WebViewControllerConfiguration) -> WebKitViewController {
         let controller = WebKitViewController(configuration: configuration)
         return controller
     }
@@ -39,11 +40,11 @@ class WebViewControllerFactory: NSObject {
         return controller(configuration: configuration)
     }
 
-    static func controllerWithDefaultAccountAndSecureInteraction(url: URL) -> UIViewController {
+    static func controllerWithDefaultAccountAndSecureInteraction(url: URL) -> WebKitViewController {
         let configuration = WebViewControllerConfiguration(url: url)
         configuration.authenticateWithDefaultAccount()
         configuration.secureInteraction = true
+
         return controller(configuration: configuration)
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -167,10 +167,10 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
         },
                                                  failure: { error in })
     }
-    
+
     static private let checkoutURLPrefix = "https://wordpress.com/checkout"
     static private let checkoutSuccessURLPrefix = "https://wordpress.com/checkout/thank-you/"
-    
+
     /// Handles URL changes in the web view.  We only allow the user to stay within certain URLs.  Falling outside these URLs
     /// results in the web view being dismissed.  This method also handles the success condition for a successful domain registration
     /// through said web view.
@@ -186,7 +186,7 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
         domain: String,
         onCancel: () -> Void,
         onSuccess: () -> Void) {
-            
+
         let canOpenNewURL = newURL.absoluteString.starts(with: Self.checkoutURLPrefix)
 
         guard canOpenNewURL else {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -167,6 +167,40 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
         },
                                                  failure: { error in })
     }
+    
+    static private let checkoutURLPrefix = "https://wordpress.com/checkout"
+    static private let checkoutSuccessURLPrefix = "https://wordpress.com/checkout/thank-you/"
+    
+    /// Handles URL changes in the web view.  We only allow the user to stay within certain URLs.  Falling outside these URLs
+    /// results in the web view being dismissed.  This method also handles the success condition for a successful domain registration
+    /// through said web view.
+    ///
+    /// - Parameters:
+    ///     - newURL: the newly set URL for the web view.
+    ///     - domain: the domain the user is purchasing.
+    ///     - onCancel: the closure that will be executed if we detect the conditions for cancelling the registration were met.
+    ///     - onSuccess: the closure that will be executed if we detect a successful domain registration.
+    ///
+    private func handleWebViewURLChange(
+        _ newURL: URL,
+        domain: String,
+        onCancel: () -> Void,
+        onSuccess: () -> Void) {
+            
+        let canOpenNewURL = newURL.absoluteString.starts(with: Self.checkoutURLPrefix)
+
+        guard canOpenNewURL else {
+            onCancel()
+            return
+        }
+
+        let domainRegistrationSucceeded = newURL.absoluteString.starts(with: Self.checkoutSuccessURLPrefix)
+
+        if domainRegistrationSucceeded {
+            onSuccess()
+            return
+        }
+    }
 
     private func presentWebViewForCurrentSite(domain: String) {
         guard let siteUrl = URL(string: "\(site.homeURL)"), let host = siteUrl.host,
@@ -177,27 +211,24 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
         let webViewController = WebViewControllerFactory.controllerWithDefaultAccountAndSecureInteraction(url: url)
         let navController = LightNavigationController(rootViewController: webViewController)
 
+        // WORKAROUND: The reason why we have to use this mechanism to detect success and failure conditions
+        // for domain registration is because our checkout process (for some unknown reason) doesn't trigger
+        // call to WKWebViewDelegate methods.
+        //
+        // This was last checked by @diegoreymendez on 2021-09-22.
+        //
         webViewURLChangeObservation = webViewController.webView.observe(\.url, options: .new) { [weak self] _, change in
             guard let self = self,
                   let newURL = change.newValue as? URL else {
                 return
             }
 
-            let canOpenNewURL = newURL.absoluteString.starts(with: "https://wordpress.com/checkout")
-
-            guard canOpenNewURL else {
+            self.handleWebViewURLChange(newURL, domain: domain, onCancel: {
                 navController.dismiss(animated: true)
-                return
-            }
-
-            let domainRegistrationSucceeded = newURL.absoluteString.starts(with: "https://wordpress.com/checkout/thank-you/")
-
-            if domainRegistrationSucceeded {
+            }) {
                 self.dismiss(animated: true, completion: { [weak self] in
                     self?.domainPurchasedCallback(domain)
                 })
-
-                return
             }
         }
 


### PR DESCRIPTION
Fixes #17193

When purchasing a domain through the web view, we now recognize the success and failure conditions that should close the web view and complete the purchase flow.

## To test:

### Test indirect purchase cancellation:

Basically if the user removes the domain from the cart, we want to cancel the purchase and go one step back in the flow.

1. Go to Domains > Get your domain
2. Select a suggested domain and tap "Choose domain"
3. When the cart comes up tap "Remove from cart" for the domain.
4. Confirm the operation.

Make sure the web view closes and brings you back to the domain suggestion screen.

### Test a successful purchase:

1. Go to Domains > Get your domain
2. Select a suggested domain and tap "Choose domain"
3. Tap "Complete Checkout"

**Known Issues**
- When going back to the Domains Dashboard after the successful purchase, the Domains Dashboard will not update (at this time).

## Regression Notes

1. Potential unintended areas of impact

This is a new flow thats only active por developers.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
