### PR TITLE
Fix empty state layout bug in comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -660,6 +660,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)adjustNoResultViewPlacement
 {
+    // calling this too early results in wrong tableView frame used for initial state
     if(self.noResultsViewController.view.window == nil) {
         return;
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -660,6 +660,10 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)adjustNoResultViewPlacement
 {
+    if(self.noResultsViewController.view.window == nil) {
+        return;
+    }
+
     // Adjust the NRV placement to accommodate for the filterTabBar.
     CGRect noResultsFrame = self.tableView.frame;
     noResultsFrame.origin.y -= self.filterTabBar.frame.size.height;


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/17201.

## Description

Method `adjustNoResultViewPlacement` gets called few times after viewDidLoad and on first call it takes wrong `UITableView` frame, with negative x,y origin values. This results in initial jumping out of viewport until another refresh in a second.

The fix is simple - adding a check that empty state view already added to hierarchy. This delays frame adjustment to moment when tableView frame is correct.
I've tried instead to use different frames/bounds/etc but it all results in various new animation/layout issues.

## To test:

1. Run the app on an iPad simulator.
2. Tap My Site > Comments.
3. Select Pending/Spam tab to have empty state displayed (if needed).
4. Switch to other section and back to comments.
5. Empty state should appear correctly in detail VC on right side.

iPhone layout checked - unaffected by this change.

## Screenshots

before|after
--|--
![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/134504825-a2e997ac-0795-4a5c-9c5e-1cffe2f5d930.png)|![Simulator Screen Shot](https://user-images.githubusercontent.com/3132438/134504833-651f24ec-e8c9-4b34-89ac-4347bdf9f333.png)

---
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
