### PR TITLE
Fix/16961 - Update existing events

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -20,11 +20,11 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    pod 'WordPressShared', '~> 1.16.0'
+    #pod 'WordPressShared', '~> 1.16.0'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
-    #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -22,9 +22,9 @@ workspace 'WordPress.xcworkspace'
 def wordpress_shared
     #pod 'WordPressShared', '~> 1.16.0'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
-    #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'fix/16961-update-reader-tracking-events'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
-    pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
+    #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end
 
 def aztec

--- a/Podfile
+++ b/Podfile
@@ -20,9 +20,9 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    #pod 'WordPressShared', '~> 1.16.0'
+    pod 'WordPressShared', '~> 1.16.0'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'fix/16961-update-reader-tracking-events'
+    #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
     #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -555,7 +555,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.42.0)
   - WordPressKit (~> 4.42.0)
   - WordPressMocks (~> 0.0.15)
-  - WordPressShared (from `../WordPress-iOS-Shared`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `fix/16961-update-reader-tracking-events`)
   - WordPressUI (~> 1.12.2-beta.1)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json`)
@@ -711,7 +711,8 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.62.0
   WordPressShared:
-    :path: "../WordPress-iOS-Shared"
+    :branch: fix/16961-update-reader-tracking-events
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json
 
@@ -727,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.62.0
+  WordPressShared:
+    :commit: 8f0bcc47c53f24328ba0e66ed6fe0ed2c686bc89
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -827,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 39dda0f5fb1a0abc77875bc071864f4f8b82aab3
+PODFILE CHECKSUM: e5974ae80d429b46530e494cd9eb50bc9139d94e
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -555,7 +555,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.42.0)
   - WordPressKit (~> 4.42.0)
   - WordPressMocks (~> 0.0.15)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `fix/16961-update-reader-tracking-events`)
+  - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2-beta.1)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json`)
@@ -606,6 +606,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressKit
     - WordPressMocks
+    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -710,9 +711,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.62.0
-  WordPressShared:
-    :branch: fix/16961-update-reader-tracking-events
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json
 
@@ -728,9 +726,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.62.0
-  WordPressShared:
-    :commit: 8f0bcc47c53f24328ba0e66ed6fe0ed2c686bc89
-    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -831,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: e5974ae80d429b46530e494cd9eb50bc9139d94e
+PODFILE CHECKSUM: 64119e05ada7945e9dcb2fcbd861a41d6eb4f293
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,15 +11,15 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - AppCenter (4.2.0):
-    - AppCenter/Analytics (= 4.2.0)
-    - AppCenter/Crashes (= 4.2.0)
-  - AppCenter/Analytics (4.2.0):
+  - AppCenter (4.3.0):
+    - AppCenter/Analytics (= 4.3.0)
+    - AppCenter/Crashes (= 4.3.0)
+  - AppCenter/Analytics (4.3.0):
     - AppCenter/Core
-  - AppCenter/Core (4.2.0)
-  - AppCenter/Crashes (4.2.0):
+  - AppCenter/Core (4.3.0)
+  - AppCenter/Crashes (4.3.0):
     - AppCenter/Core
-  - AppCenter/Distribute (4.2.0):
+  - AppCenter/Distribute (4.3.0):
     - AppCenter/Core
   - Automattic-Tracks-iOS (0.9.1):
     - CocoaLumberjack (~> 3)
@@ -61,7 +61,7 @@ PODS:
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.6.1)
+  - GTMSessionFetcher/Core (1.7.0)
   - Gutenberg (1.62.0):
     - React (= 0.64.0)
     - React-CoreModules (= 0.64.0)
@@ -565,7 +565,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressUI
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -608,6 +607,7 @@ SPEC REPOS:
     - WordPressKit
     - WordPressMocks
     - WordPressShared
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -734,7 +734,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
+  AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
   Automattic-Tracks-iOS: f5a6188ad8d00680748111466beabb0aea11f856
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e7305369025cbdb0172ecf9751e2075bd472004d
@@ -752,7 +752,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
+  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   Gutenberg: f36dd75a01a2d6a1cbed5f23fcf72f4bdf88c92a
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: 9eab00cc89669b38858d42d5f30c810876b31344
@@ -813,7 +813,7 @@ SPEC CHECKSUMS:
   WordPressKit: 0c8e1a1becfeffc882f06f55eb09cd485826c268
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
-  WordPressUI: 57cbe36d41fd95dc7597124c9010b9f872dc9951
+  WordPressUI: d3df8d4ba30d5d5e06adf2ba1349eb383aa699a1
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,15 +11,15 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - AppCenter (4.2.0):
-    - AppCenter/Analytics (= 4.2.0)
-    - AppCenter/Crashes (= 4.2.0)
-  - AppCenter/Analytics (4.2.0):
+  - AppCenter (4.3.0):
+    - AppCenter/Analytics (= 4.3.0)
+    - AppCenter/Crashes (= 4.3.0)
+  - AppCenter/Analytics (4.3.0):
     - AppCenter/Core
-  - AppCenter/Core (4.2.0)
-  - AppCenter/Crashes (4.2.0):
+  - AppCenter/Core (4.3.0)
+  - AppCenter/Crashes (4.3.0):
     - AppCenter/Core
-  - AppCenter/Distribute (4.2.0):
+  - AppCenter/Distribute (4.3.0):
     - AppCenter/Core
   - Automattic-Tracks-iOS (0.9.1):
     - CocoaLumberjack (~> 3)
@@ -61,7 +61,7 @@ PODS:
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.6.1)
+  - GTMSessionFetcher/Core (1.7.0)
   - Gutenberg (1.62.0):
     - React (= 0.64.0)
     - React-CoreModules (= 0.64.0)
@@ -555,7 +555,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 1.42.0)
   - WordPressKit (~> 4.42.0)
   - WordPressMocks (~> 0.0.15)
-  - WordPressShared (~> 1.16.0)
+  - WordPressShared (from `../WordPress-iOS-Shared`)
   - WordPressUI (~> 1.12.2-beta.1)
   - WPMediaPicker (~> 1.7.2)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json`)
@@ -565,7 +565,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressUI
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -607,7 +606,7 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
+    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -711,6 +710,8 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.62.0
+  WordPressShared:
+    :path: "../WordPress-iOS-Shared"
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.62.0/third-party-podspecs/Yoga.podspec.json
 
@@ -734,7 +735,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
+  AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
   Automattic-Tracks-iOS: f5a6188ad8d00680748111466beabb0aea11f856
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e7305369025cbdb0172ecf9751e2075bd472004d
@@ -752,7 +753,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
+  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
   Gutenberg: f36dd75a01a2d6a1cbed5f23fcf72f4bdf88c92a
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: 9eab00cc89669b38858d42d5f30c810876b31344
@@ -813,7 +814,7 @@ SPEC CHECKSUMS:
   WordPressKit: 0c8e1a1becfeffc882f06f55eb09cd485826c268
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
-  WordPressUI: 57cbe36d41fd95dc7597124c9010b9f872dc9951
+  WordPressUI: d3df8d4ba30d5d5e06adf2ba1349eb383aa699a1
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e
@@ -826,6 +827,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 64119e05ada7945e9dcb2fcbd861a41d6eb4f293
+PODFILE CHECKSUM: 39dda0f5fb1a0abc77875bc071864f4f8b82aab3
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -11,15 +11,15 @@ PODS:
     - AppAuth/ExternalUserAgent (= 1.4.0)
   - AppAuth/Core (1.4.0)
   - AppAuth/ExternalUserAgent (1.4.0)
-  - AppCenter (4.3.0):
-    - AppCenter/Analytics (= 4.3.0)
-    - AppCenter/Crashes (= 4.3.0)
-  - AppCenter/Analytics (4.3.0):
+  - AppCenter (4.2.0):
+    - AppCenter/Analytics (= 4.2.0)
+    - AppCenter/Crashes (= 4.2.0)
+  - AppCenter/Analytics (4.2.0):
     - AppCenter/Core
-  - AppCenter/Core (4.3.0)
-  - AppCenter/Crashes (4.3.0):
+  - AppCenter/Core (4.2.0)
+  - AppCenter/Crashes (4.2.0):
     - AppCenter/Core
-  - AppCenter/Distribute (4.3.0):
+  - AppCenter/Distribute (4.2.0):
     - AppCenter/Core
   - Automattic-Tracks-iOS (0.9.1):
     - CocoaLumberjack (~> 3)
@@ -61,7 +61,7 @@ PODS:
   - GTMAppAuth (1.2.2):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.7.0)
+  - GTMSessionFetcher/Core (1.6.1)
   - Gutenberg (1.62.0):
     - React (= 0.64.0)
     - React-CoreModules (= 0.64.0)
@@ -565,6 +565,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressUI
   trunk:
     - 1PasswordExtension
     - Alamofire
@@ -607,7 +608,6 @@ SPEC REPOS:
     - WordPressKit
     - WordPressMocks
     - WordPressShared
-    - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
     - ZendeskCommonUISDK
@@ -734,7 +734,7 @@ SPEC CHECKSUMS:
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
   AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 31bcec809a638d7bd2f86ea8a52bd45f6e81e7c7
-  AppCenter: 883369ab78427b0561c688158d689dfe1f993ea9
+  AppCenter: 87ef6eefd8ade4df59e88951288587429f3dd2a5
   Automattic-Tracks-iOS: f5a6188ad8d00680748111466beabb0aea11f856
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e7305369025cbdb0172ecf9751e2075bd472004d
@@ -752,7 +752,7 @@ SPEC CHECKSUMS:
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
   GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
+  GTMSessionFetcher: 36689134877faeb055b27dfa4ccc9ceaa42e029e
   Gutenberg: f36dd75a01a2d6a1cbed5f23fcf72f4bdf88c92a
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: 9eab00cc89669b38858d42d5f30c810876b31344
@@ -813,7 +813,7 @@ SPEC CHECKSUMS:
   WordPressKit: 0c8e1a1becfeffc882f06f55eb09cd485826c268
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 5477f179c7fe03b5d574f91adda66f67d131827e
-  WordPressUI: d3df8d4ba30d5d5e06adf2ba1349eb383aa699a1
+  WordPressUI: 57cbe36d41fd95dc7597124c9010b9f872dc9951
   WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -16,15 +16,15 @@ class NotificationActionsService: LocalCoreDataService {
             return
         }
 
-        siteService.followSite(withID: siteID, success: {
+        siteService.followSite(withID: siteID, site: nil) {
             DDLogInfo("Successfully followed site \(siteID)")
             self.invalidateCacheAndForceSyncNotification(with: block)
             completion?(true)
 
-        }, failure: { error in
+        } failure: { error in
             DDLogError("Error while trying to follow site: \(String(describing: error))")
             completion?(false)
-        })
+        }
     }
 
 
@@ -39,15 +39,15 @@ class NotificationActionsService: LocalCoreDataService {
             return
         }
 
-        siteService.unfollowSite(withID: siteID, success: {
+        siteService.unfollowSite(withID: siteID, site: nil) {
             DDLogInfo("Successfully unfollowed site \(siteID)")
             self.invalidateCacheAndForceSyncNotification(with: block)
             completion?(true)
 
-        }, failure: { error in
+        } failure: { error in
             DDLogError("Error while trying to unfollow site: \(String(describing: error))")
             completion?(false)
-        })
+        }
     }
 
 

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -102,6 +102,7 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
  Toggle the liked status of the specified post.
 
  @param post The reader post to like/unlike.
+ @param details Boolean value indicating if the action is initated from the article details screen.
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -106,6 +106,7 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)toggleLikedForPost:(ReaderPost *)post
+        fromArticleDetails:(BOOL) details
                    success:(void (^)(void))success
                    failure:(void (^)(NSError *error))failure;
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -321,9 +321,9 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
     ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if (following) {
-        [siteService followSiteWithID:[siteID integerValue] success:successBlock failure:failureBlock];
+        [siteService followSiteWithID:[siteID integerValue] site:NULL success:successBlock failure:failureBlock];
     } else {
-        [siteService unfollowSiteWithID:[siteID integerValue] success:successBlock failure:failureBlock];
+        [siteService unfollowSiteWithID:[siteID integerValue] site:NULL success:successBlock failure:failureBlock];
     }
 }
 
@@ -406,9 +406,9 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithManagedObjectContext:self.managedObjectContext];
     if (!post.isExternal) {
         if (follow) {
-            [siteService followSiteWithID:[post.siteID integerValue] success:successBlock failure:failureBlock];
+            [siteService followSiteWithID:[post.siteID integerValue] site:NULL success:successBlock failure:failureBlock];
         } else {
-            [siteService unfollowSiteWithID:[post.siteID integerValue] success:successBlock failure:failureBlock];
+            [siteService unfollowSiteWithID:[post.siteID integerValue] site:NULL success:successBlock failure:failureBlock];
         }
     } else if (post.blogURL) {
         if (follow) {

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -209,7 +209,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 #pragma mark - Update Methods
 
-- (void)toggleLikedForPost:(ReaderPost *)post success:(void (^)(void))success failure:(void (^)(NSError *error))failure
+- (void)toggleLikedForPost:(ReaderPost *)post fromArticleDetails:(BOOL)details success:(void (^)(void))success failure:(void (^)(NSError *))failure
 {
     [self.managedObjectContext performBlock:^{
 
@@ -251,14 +251,16 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
                 [properties setObject:readerPost.feedID forKey:WPAppAnalyticsKeyFeedID];
                 [properties setObject:[NSNumber numberWithBool:readerPost.isFollowing] forKey:WPAppAnalyticsKeyIsFollowing];
 
+                NSUInteger event;
                 if (like) {
-                    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleLiked properties:properties];
+                    event = (details) ? WPAnalyticsStatReaderArticleDetailLiked : WPAnalyticsStatReaderArticleLiked;
                     if (railcar) {
-                        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleLiked properties:railcar];
+                        [WPAnalytics trackReaderStat:event properties:railcar];
                     }
                 } else {
-                    [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleUnliked properties:properties];
+                    event = (details) ? WPAnalyticsStatReaderArticleDetailUnliked : WPAnalyticsStatReaderArticleUnliked;
                 }
+                [WPAnalytics trackReaderStat:event properties:properties];
             }
             if (success) {
                 success();

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -245,10 +245,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         NSNumber *siteID = readerPost.siteID;
         void (^successBlock)(void) = ^void() {
             if (postID && siteID) {
-                NSDictionary *properties = @{
-                                              WPAppAnalyticsKeyPostID: postID,
-                                              WPAppAnalyticsKeyBlogID: siteID
-                                              };
+                NSMutableDictionary *properties = [NSMutableDictionary new];
+                [properties setObject:postID forKey:WPAppAnalyticsKeyPostID];
+                [properties setObject:siteID forKey:WPAppAnalyticsKeyBlogID];
+                [properties setObject:readerPost.feedID forKey:WPAppAnalyticsKeyFeedID];
+                [properties setObject:[NSNumber numberWithBool:readerPost.isFollowing] forKey:WPAppAnalyticsKeyIsFollowing];
+
                 if (like) {
                     [WPAnalytics trackReaderStat:WPAnalyticsStatReaderArticleLiked properties:properties];
                     if (railcar) {

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -28,10 +28,12 @@ extern NSString * const ReaderSiteServiceErrorDomain;
  Follow a wpcom site by ID.
 
  @param siteID The ID of the site.
+ @param site Site that's being followed. Optional parameter.
  @param success block called on a successful follow.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)followSiteWithID:(NSUInteger)siteID
+                    site:(ReaderSiteTopic *)site
                  success:(void(^)(void))success
                  failure:(void(^)(NSError *error))failure;
 
@@ -39,10 +41,12 @@ extern NSString * const ReaderSiteServiceErrorDomain;
  Unfollow a wpcom site by ID
 
  @param siteID The ID of the site.
+ @param site Site that's being unfollowed. Optional parameter.
  @param success block called on a successful unfollow.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)unfollowSiteWithID:(NSUInteger)siteID
+                      site:(ReaderSiteTopic *)site
                    success:(void(^)(void))success
                    failure:(void(^)(NSError *error))failure;
 

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -35,7 +35,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     }];
 }
 
-- (void)followSiteWithID:(NSUInteger)siteID success:(void(^)(void))success failure:(void(^)(NSError *error))failure
+- (void)followSiteWithID:(NSUInteger)siteID site:(ReaderSiteTopic *)site success:(void(^)(void))success failure:(void(^)(NSError *error))failure
 {
     WordPressComRestApi *api = [self apiForRequest];
     if (!api) {
@@ -55,8 +55,11 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         }
         [service followSiteWithID:siteID success:^(){
             [self fetchTopicServiceWithID:siteID success:success failure:failure];
-            NSNumber *blogID = [NSNumber numberWithUnsignedInteger:siteID];
-            [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteFollowed properties:@{ @"blog_id": blogID }];
+            NSDictionary *properties = @{
+                @"blog_id": site.siteID,
+                @"feed_id": site.feedID
+            };
+            [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteFollowed properties:properties];
         } failure:failure];
 
     } failure:^(NSError *error) {
@@ -66,7 +69,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     }];
 }
 
-- (void)unfollowSiteWithID:(NSUInteger)siteID success:(void(^)(void))success failure:(void(^)(NSError *error))failure
+- (void)unfollowSiteWithID:(NSUInteger)siteID site:(ReaderSiteTopic *)site success:(void(^)(void))success failure:(void(^)(NSError *error))failure
 {
     WordPressComRestApi *api = [self apiForRequest];
     if (!api) {
@@ -82,8 +85,11 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         if (success) {
             success();
         }
-        NSNumber *blogID = [NSNumber numberWithUnsignedInteger:siteID];
-        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteUnfollowed properties:@{ @"blog_id": blogID }];
+        NSDictionary *properties = @{
+            @"blog_id": site.siteID,
+            @"feed_id": site.feedID
+        };
+        [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteUnfollowed properties:properties];
         
     } failure:failure];
 }
@@ -260,7 +266,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     ReaderSiteServiceRemote *service = [[ReaderSiteServiceRemote alloc] initWithWordPressComRestApi:api];
     [service findSiteIDForURL:siteURL success:^(NSUInteger siteID) {
         if (siteID) {
-            [self followSiteWithID:siteID success:success failure:failure];
+            [self followSiteWithID:siteID site:NULL success:success failure:failure];
         } else {
             [self followSiteAtURL:[siteURL absoluteString] success:success failure:failure];
         }

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -546,13 +546,13 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         }
     } else {
         if (newFollowValue) {
-            [siteService followSiteWithID:[topic.siteID integerValue] success:successBlock failure:failureBlock];
+            [siteService followSiteWithID:[topic.siteID integerValue] site:topic success:successBlock failure:failureBlock];
         } else {
             // Try to unfollow by ID as its the most reliable method.
             // Note that if the site has been deleted, attempting to unfollow by ID
             // results in an HTTP 403 on the v1.1 endpoint.  If this happens try
             // unfollowing via the less reliable URL method.
-            [siteService unfollowSiteWithID:[topic.siteID integerValue] success:successBlock failure:^(NSError *error) {
+            [siteService unfollowSiteWithID:[topic.siteID integerValue] site:topic success:successBlock failure:^(NSError *error) {
                 if (error.code == WordPressComRestApiErrorAuthorizationRequired) {
                     [siteService unfollowSiteAtURL:topic.siteURL success:successBlock failure:failureBlock];
                     return;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -68,6 +68,7 @@ import Foundation
     case readerBlogPreviewed
     case readerDiscoverPaginated
     case readerPostCardTapped
+    case readerArticleRendered
     case readerPullToRefresh
     case readerDiscoverTopicTapped
     case postCardMoreTapped
@@ -292,6 +293,8 @@ import Foundation
             return "reader_discover_paginated"
         case .readerPostCardTapped:
             return "reader_post_card_tapped"
+        case .readerArticleRendered:
+            return "reader_article_rendered"
         case .readerPullToRefresh:
             return "reader_pull_to_refresh"
         case .readerDiscoverTopicTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1490,7 +1490,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"reader_site_followed";
             break;
         case WPAnalyticsStatReaderSitePreviewed:
-            eventName = @"reader_blog_preview";
+            eventName = @"reader_blog_previewed";
             break;
         case WPAnalyticsStatReaderSiteUnfollowed:
             eventName = @"reader_site_unfollowed";
@@ -1506,7 +1506,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"reader_tag_loaded";
             break;
         case WPAnalyticsStatReaderTagPreviewed:
-            eventName = @"reader_tag_preview";
+            eventName = @"reader_tag_previewed";
             break;
         case WPAnalyticsStatReaderTagUnfollowed:
             eventName = @"reader_reader_tag_unfollowed";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1423,6 +1423,9 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatReaderArticleOpened:
             eventName = @"reader_article_opened";
             break;
+        case WPAnalyticsStatReaderArticleRendered:
+            eventName = @"reader_article_rendered";
+            break;
         case WPAnalyticsStatReaderArticleUnliked:
             eventName = @"reader_article_unliked";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1506,7 +1506,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
             eventName = @"reader_tag_loaded";
             break;
         case WPAnalyticsStatReaderTagPreviewed:
-            eventName = @"reader_tag_previewed";
+            eventName = @"reader_tag_preview";
             break;
         case WPAnalyticsStatReaderTagUnfollowed:
             eventName = @"reader_reader_tag_unfollowed";

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1423,9 +1423,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatReaderArticleOpened:
             eventName = @"reader_article_opened";
             break;
-        case WPAnalyticsStatReaderArticleRendered:
-            eventName = @"reader_article_rendered";
-            break;
         case WPAnalyticsStatReaderArticleUnliked:
             eventName = @"reader_article_unliked";
             break;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -12,6 +12,7 @@ extern NSString * const WPAppAnalyticsKeyPostID;
 extern NSString * const WPAppAnalyticsKeyFeedID;
 extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
+extern NSString * const WPAppAnalyticsKeyIsFollowing;
 extern NSString * const WPAppAnalyticsKeySessionCount;
 extern NSString * const WPAppAnalyticsKeyEditorSource;
 extern NSString * const WPAppAnalyticsKeyCommentID;

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -17,6 +17,7 @@ NSString * const WPAppAnalyticsKeyPostID                            = @"post_id"
 NSString * const WPAppAnalyticsKeyFeedID                            = @"feed_id";
 NSString * const WPAppAnalyticsKeyFeedItemID                        = @"feed_item_id";
 NSString * const WPAppAnalyticsKeyIsJetpack                         = @"is_jetpack";
+NSString * const WPAppAnalyticsKeyIsFollowing                       = @"follow";
 NSString * const WPAppAnalyticsKeySessionCount                      = @"session_count";
 NSString * const WPAppAnalyticsKeySubscriptionCount                 = @"subscription_count";
 NSString * const WPAppAnalyticsKeyEditorSource                      = @"editor_source";

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -400,7 +400,7 @@ class ReaderDetailCoordinator {
         guard let post = post else {
             return
         }
-        
+
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.primaryTagSlug as AnyObject?, forKey: "tag")
         WPAppAnalytics.track(.readerTagPreviewed, withProperties: properties)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -396,18 +396,11 @@ class ReaderDetailCoordinator {
     private func showTopic(_ topic: String) {
         let controller = ReaderStreamViewController.controllerWithTagSlug(topic)
         viewController?.navigationController?.pushViewController(controller, animated: true)
-    }
 
-    /// Show a list with posts containing this tag
-    ///
-    private func showTag() {
         guard let post = post else {
             return
         }
-
-        let controller = ReaderStreamViewController.controllerWithTagSlug(post.primaryTagSlug)
-        viewController?.navigationController?.pushViewController(controller, animated: true)
-
+        
         let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.primaryTagSlug as AnyObject?, forKey: "tag")
         WPAppAnalytics.track(.readerTagPreviewed, withProperties: properties)
     }
@@ -650,10 +643,6 @@ extension ReaderDetailCoordinator: ReaderDetailHeaderViewDelegate {
 
     func didTapMenuButton(_ sender: UIView) {
         showMenu(sender)
-    }
-
-    func didTapTagButton() {
-        showTag()
     }
 
     func didTapHeaderAvatar() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -760,6 +760,7 @@ extension ReaderDetailViewController: WKNavigationDelegate {
 
         isLoadingWebView = false
         hideLoading()
+        trackArticleRenderedReaderEvent()
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
@@ -771,6 +772,24 @@ extension ReaderDetailViewController: WKNavigationDelegate {
         } else {
             decisionHandler(.allow)
         }
+    }
+}
+
+// MARK: - Reader Events Tracking
+
+private extension ReaderDetailViewController {
+    func trackArticleRenderedReaderEvent() {
+        guard let blogID = post?.siteID,
+              let feedID = post?.feedID,
+              let isFollowing = post?.isFollowing else {
+                  return
+              }
+        let properties: [String: Any] = [
+            "blog_id": blogID,
+            "feed_id": feedID,
+            "follow": isFollowing
+        ]
+        WPAnalytics.trackReader(.readerArticleRendered, properties: properties)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -111,14 +111,13 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
 
         let service = ReaderPostService(managedObjectContext: post.managedObjectContext!)
-        service.toggleLiked(for: post, success: { [weak self] in
-            self?.trackArticleDetailsLikedOrUnliked()
-        }, failure: { [weak self] (error: Error?) in
-            self?.trackArticleDetailsLikedOrUnliked()
-            if let anError = error {
-                DDLogError("Error (un)liking post: \(anError.localizedDescription)")
+        service.toggleLiked(for: post, fromArticleDetails: true) {
+            DDLogInfo("Article (un)liked from details screen!")
+        } failure: { error in
+            if let error = error {
+                DDLogError("Error (un)liking post: \(error.localizedDescription)")
             }
-        })
+        }
     }
 
     // MARK: - Styles
@@ -357,23 +356,6 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         } else {
             return WPStyleGuide.likeCountForDisplay(count)
         }
-    }
-
-    // MARK: - Analytics
-
-    private func trackArticleDetailsLikedOrUnliked() {
-        guard let post = post else {
-            return
-        }
-
-        let stat: WPAnalyticsStat  = post.isLiked
-            ? .readerArticleDetailLiked
-            : .readerArticleDetailUnliked
-
-        var properties = [AnyHashable: Any]()
-        properties[WPAppAnalyticsKeyBlogID] = post.siteID
-        properties[WPAppAnalyticsKeyPostID] = post.postID
-        WPAnalytics.track(stat, withProperties: properties)
     }
 
     // MARK: - Voice Over

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHeaderAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHeaderAction.swift
@@ -2,8 +2,5 @@ final class ReaderHeaderAction {
     func execute(post: ReaderPost, origin: UIViewController) {
         let controller = ReaderStreamViewController.controllerWithSiteID(post.siteID, isFeed: post.isExternal)
         origin.navigationController?.pushViewController(controller, animated: true)
-
-        let properties = ReaderHelpers.statsPropertiesForPost(post, andValue: post.blogURL as AnyObject?, forKey: "url")
-        WPAppAnalytics.track(.readerSitePreviewed, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -224,6 +224,7 @@ struct ReaderPostMenuButtonTitles {
         properties[WPAppAnalyticsKeyBlogID] = post.siteID
         properties[WPAppAnalyticsKeyPostID] = post.postID
         properties[WPAppAnalyticsKeyIsJetpack] = post.isJetpack
+        properties[WPAppAnalyticsKeyIsFollowing] = post.isFollowing
         if let feedID = post.feedID, let feedItemID = post.feedItemID {
             properties[WPAppAnalyticsKeyFeedID] = feedID
             properties[WPAppAnalyticsKeyFeedItemID] = feedItemID

--- a/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderLikeAction.swift
@@ -9,7 +9,7 @@ final class ReaderLikeAction {
             UINotificationFeedbackGenerator().notificationOccurred(.success)
         }
         let service = ReaderPostService(managedObjectContext: context)
-        service.toggleLiked(for: post, success: {
+        service.toggleLiked(for: post, fromArticleDetails: false, success: {
             completion?()
         }, failure: { (error: Error?) in
             if let anError = error {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -4,7 +4,7 @@ import WordPressShared
 import Gridicons
 
 protocol ReaderTopicsChipsDelegate: AnyObject {
-    func didSelect(topic: String)
+    func didSelect(topic: String, from post: ReaderPost?)
     func heightDidChange()
 }
 
@@ -980,6 +980,6 @@ extension ReaderPostCardCell: ReaderTopicCollectionViewCoordinatorDelegate {
     }
 
     func coordinator(_ coordinator: ReaderTopicCollectionViewCoordinator, didSelectTopic topic: String) {
-        topicChipsDelegate?.didSelect(topic: topic)
+        topicChipsDelegate?.didSelect(topic: topic, from: contentProvider as? ReaderPost)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -76,14 +76,20 @@ extension ReaderSaveForLaterAction {
 }
 
 extension ReaderStreamViewController {
-    func trackSavedPostNavigation() {
+    func trackSavedPostNavigation(post: ReaderPost) {
+        let blogID = post.siteID ?? 0
+        let feedID = post.feedID ?? 0
+        var properties: [String: Any] = ["blog_id": blogID,
+                                         "feed_id": feedID,
+                                         "foolow": post.isFollowing]
+        
         if contentType == .saved {
-            WPAppAnalytics.track(.readerSavedPostOpened,
-                                 withProperties: [readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.savedStream.openPostValue])
+            properties[readerSaveForLaterSourceKey] = ReaderSaveForLaterOrigin.savedStream.openPostValue
         } else {
             // TODO: - READERNAV - See refactor note in ReaderSaveForLater+Analytics.viewAllPostsValue.
-            WPAppAnalytics.track(.readerSavedPostOpened,
-                                 withProperties: [readerSaveForLaterSourceKey: ReaderSaveForLaterOrigin.otherStream.openPostValue])
+            properties[readerSaveForLaterSourceKey] = ReaderSaveForLaterOrigin.otherStream.openPostValue
         }
+
+        WPAppAnalytics.track(.readerSavedPostOpened, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -81,7 +81,7 @@ extension ReaderStreamViewController {
         let feedID = post.feedID ?? 0
         var properties: [String: Any] = ["blog_id": blogID,
                                          "feed_id": feedID,
-                                         "foolow": post.isFollowing]
+                                         "follow": post.isFollowing]
 
         if contentType == .saved {
             properties[readerSaveForLaterSourceKey] = ReaderSaveForLaterOrigin.savedStream.openPostValue

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -82,7 +82,7 @@ extension ReaderStreamViewController {
         var properties: [String: Any] = ["blog_id": blogID,
                                          "feed_id": feedID,
                                          "foolow": post.isFollowing]
-        
+
         if contentType == .saved {
             properties[readerSaveForLaterSourceKey] = ReaderSaveForLaterOrigin.savedStream.openPostValue
         } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSaveForLater+Analytics.swift
@@ -54,7 +54,12 @@ extension ReaderSaveForLaterAction {
     func trackSaveAction(for post: ReaderPost, origin: ReaderSaveForLaterOrigin) {
         let willSave = (post.isSavedForLater == false)
 
-        let properties = [ readerSaveForLaterSourceKey: origin.saveActionValue ]
+        let siteID = post.siteID ?? 0
+        let feedID = post.feedID ?? 0
+        let properties: [String: Any] = [readerSaveForLaterSourceKey: origin.saveActionValue,
+                                         "blog_id": siteID,
+                                         "feed_id": feedID,
+                                         "follow": post.isFollowing]
 
         if willSave {
             WPAppAnalytics.track(.readerPostSaved, withProperties: properties)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShareAction.swift
@@ -6,7 +6,13 @@ final class ReaderShareAction {
             let sharingController = PostSharingController()
 
             sharingController.shareReaderPost(post, fromView: anchor, inViewController: vc)
-            WPAnalytics.trackReader(.itemSharedReader, properties: ["blogId": post.siteID as Any])
+
+            let siteID = post.siteID ?? 0
+            let feedID = post.feedID ?? 0
+            let properties: [String: Any] = ["blog_id": siteID,
+                                             "feed_id": feedID,
+                                             "follow": post.isFollowing]
+            WPAnalytics.trackReader(.itemSharedReader, properties: properties)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSitesCardCell.swift
@@ -63,6 +63,8 @@ extension ReaderSitesCardCell: ReaderRecommendedSitesCardCellDelegate {
         var properties = [String: Any]()
         properties[WPAppAnalyticsKeyFollowAction] = !topic.following
         properties[WPAppAnalyticsKeyBlogID] = topic.siteID
+        properties[WPAppAnalyticsKeyFeedID] = topic.feedID
+        properties[WPAppAnalyticsKeyIsFollowing] = topic.following
 
         WPAnalytics.trackReader(.readerSuggestedSiteToggleFollow, properties: properties)
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController+Sharing.swift
@@ -38,7 +38,9 @@ extension ReaderStreamViewController {
             return
         }
 
-        WPAppAnalytics.track(.readerSiteShared, withBlogID: sitePendingPost.siteID)
+        let dict: [String: Any] = ["feed_id": sitePendingPost.feedID,
+                                   "follow": sitePendingPost.following]
+        WPAppAnalytics.track(.readerSiteShared, withProperties: dict, withBlogID: sitePendingPost.siteID)
 
         let activities = WPActivityDefaults.defaultActivities() as! [UIActivity]
         let activityViewController = UIActivityViewController(activityItems: [sitePendingPost], applicationActivities: activities)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -736,11 +736,15 @@ import WordPressFlux
         }
 
         var dict: [String: Any] = [key: title, "source": statSource.rawValue]
-        
+
         if let post = post {
             dict["blog_id"] = String(Int(truncating: post.siteID))
             dict["feed_id"] = String(Int(truncating: post.feedID))
             dict["follow"] = post.isFollowing
+        } else if let topic = topic as? ReaderSiteTopic {
+            dict["blog_id"] = String(Int(truncating: topic.siteID))
+            dict["feed_id"] = String(Int(truncating: topic.feedID))
+            dict["follow"] = topic.following
         }
 
         print(dict)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1588,7 +1588,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         controller.coordinator?.readerTopic = readerTopic
 
         if post.isSavedForLater || contentType == .saved {
-            trackSavedPostNavigation()
+            trackSavedPostNavigation(post: apost)
         } else {
             WPAnalytics.trackReader(.readerPostCardTapped, properties: topicPropertyForStats(post: apost) ?? [:])
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -1961,8 +1961,14 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
         tableView.endUpdates()
     }
 
-    func didSelect(topic: String) {
+    func didSelect(topic: String, from post: ReaderPost?) {
         let topicStreamViewController = ReaderStreamViewController.controllerWithTagSlug(topic)
         navigationController?.pushViewController(topicStreamViewController, animated: true)
+
+        guard let post = post else {
+            return
+        }
+        let properties = topicPropertyForStats(post: post)
+        WPAppAnalytics.track(.readerTagPreviewed, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -747,7 +747,6 @@ import WordPressFlux
             dict["follow"] = topic.following
         }
 
-        print(dict)
         return dict
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -720,7 +720,7 @@ import WordPressFlux
 
 
     /// Returns the analytics property dictionary for the current topic.
-    private func topicPropertyForStats() -> [AnyHashable: Any]? {
+    private func topicPropertyForStats(post: ReaderPost? = nil) -> [AnyHashable: Any]? {
         guard let topic = readerTopic else {
             assertionFailure("A reader topic is required")
             return nil
@@ -735,7 +735,16 @@ import WordPressFlux
             key = "site"
         }
 
-        return [key: title, "source": statSource.rawValue]
+        var dict: [String: Any] = [key: title, "source": statSource.rawValue]
+        
+        if let post = post {
+            dict["blog_id"] = String(Int(truncating: post.siteID))
+            dict["feed_id"] = String(Int(truncating: post.feedID))
+            dict["follow"] = post.isFollowing
+        }
+
+        print(dict)
+        return dict
     }
 
     /// The fetch request can need a different predicate depending on how the content
@@ -1577,7 +1586,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         if post.isSavedForLater || contentType == .saved {
             trackSavedPostNavigation()
         } else {
-            WPAnalytics.trackReader(.readerPostCardTapped, properties: topicPropertyForStats() ?? [:])
+            WPAnalytics.trackReader(.readerPostCardTapped, properties: topicPropertyForStats(post: apost) ?? [:])
         }
 
         navigationController?.pushFullscreenViewController(controller, animated: true)

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -174,7 +174,7 @@ class ReaderDetailCoordinatorTests: XCTestCase {
         viewMock.navigationController = navigationControllerMock
         coordinator.post = post
 
-        coordinator.didTapTagButton()
+        coordinator.didSelectTopic(post.primaryTagSlug)
 
         expect(navigationControllerMock.didCallPushViewControllerWith).toEventually(beAKindOf(ReaderStreamViewController.self))
     }


### PR DESCRIPTION
Part of [#16961](https://github.com/wordpress-mobile/WordPress-iOS/issues/16961)

This PR updates Reader tracking events, so now they match proposal found in the spreadsheet shared on p9xfpQ-1eg-p2.

## Notes
- All reader tracking events (excluding `reader_reader_tag_followed` / `reader_reader_tag_unfollowed`) now contain: `blog_id`, `feed_id` and `follow` properties.
- `source` property will be added in a separate PR

## Review notes
- It is best to review this PR by going from commit to commit chronologically, since every commit addresses needed changes for a particular tracking event (including adding needed properties for a event, removing double event, fixing mistyped event, adding new event)

## To test
1. Trigger every event found in the events table found [here](https://github.com/wordpress-mobile/WordPress-Android/pull/14283) (with the generosity of @ParaskP7). Trigger can be found in the Trigger column.
2. Make sure tracking event log in the console includes: `blog_id`, `feed_id` and `follow` properties.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
