### PR TITLE
Convert some of the UI tests screen objects from `BaseScreen` to `ScreenObject` – Part 1 of many

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "df8ee4983e674b583b546bb0640ec83428be2465",
-          "version": "0.1.0"
+          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
+          "version": "0.2.0"
         }
       },
       {

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -1,3 +1,4 @@
+import ScreenObject
 import UIKit
 import UITestsFoundation
 import XCTest
@@ -85,6 +86,19 @@ class JetpackScreenshotGeneration: XCTestCase {
 }
 
 extension BaseScreen {
+    @discardableResult
+    func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
+        let filename = "\(index)-\(mode)-\(title)"
+
+        snapshot(filename)
+
+        return self
+    }
+}
+
+extension ScreenObject {
+
     @discardableResult
     func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -32,7 +32,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         super.tearDown()
     }
 
-    func testGenerateScreenshots() {
+    func testGenerateScreenshots() throws {
 
         // Get My Site screenshot
         let mySite = MySiteScreen()
@@ -41,8 +41,8 @@ class JetpackScreenshotGeneration: XCTestCase {
             .thenTakeScreenshot(1, named: "MySite")
 
         // Get Activity Log screenshot
-        let activityLog = mySite
-            .gotoActivityLog()
+        let activityLog = try mySite
+            .goToActivityLog()
             .thenTakeScreenshot(2, named: "ActivityLog")
 
         if !XCUIDevice.isPad {

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -1,6 +1,16 @@
 import UIKit
 import XCTest
+import ScreenObject
 
 // TODO: This should maybe go in an `XCUIApplication` extension? Also, should it be computed rather
 // than stored as a reference? 🤔
 public let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
+
+extension ScreenObject {
+
+    // TODO: This was implemented on the original `BaseScreen` and is here just as a copy-paste for the transition.
+    /// Pops the navigation stack, returning to the item above the current one.
+    public func pop() {
+        navBackButton.tap()
+    }
+}

--- a/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
@@ -1,19 +1,22 @@
+import ScreenObject
 import XCTest
+import XCUITestHelpers
 
-public class ActionSheetComponent: BaseScreen {
-    let blogPostButton: XCUIElement
-    let sitePageButton: XCUIElement
+public class ActionSheetComponent: ScreenObject {
 
-    struct ElementIDs {
-        static let blogPostButton = "blogPostButton"
-        static let sitePageButton = "sitePageButton"
+    private static let getBlogPostButton: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["blogPostButton"]
     }
 
-    public init() {
-        blogPostButton = XCUIApplication().buttons[ElementIDs.blogPostButton]
-        sitePageButton = XCUIApplication().buttons[ElementIDs.sitePageButton]
+    private static let getSitePageButton: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["sitePageButton"]
+    }
 
-        super.init(element: blogPostButton)
+    var blogPostButton: XCUIElement { Self.getBlogPostButton(app) }
+    var sitePageButton: XCUIElement { Self.getSitePageButton(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [Self.getBlogPostButton, Self.getSitePageButton])
     }
 
     public func goToBlogPost() {

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -1,8 +1,9 @@
+import ScreenObject
 import XCTest
 
-public class ActivityLogScreen: BaseScreen {
+public class ActivityLogScreen: ScreenObject {
 
-    public init() {
-        super.init(element: XCUIApplication().otherElements.firstMatch)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [ { $0.otherElements.firstMatch } ])
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -276,11 +276,11 @@ public class AztecEditorScreen: BaseScreen {
         }
     }
 
-    public func openPostSettings() -> EditorPostSettings {
+    public func openPostSettings() throws -> EditorPostSettings {
         moreButton.tap()
         postSettingsButton.tap()
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
     private func getHTMLContent() -> String {

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -260,12 +260,12 @@ public class AztecEditorScreen: BaseScreen {
         }
     }
 
-    func publish() -> EditorNoticeComponent {
+    func publish() throws -> EditorNoticeComponent {
         publishButton.tap()
 
         confirmPublish()
 
-        return EditorNoticeComponent(withNotice: "Post published", andAction: "View")
+        return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
     }
 
     private func confirmPublish() {

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -111,11 +111,11 @@ public class BlockEditorScreen: BaseScreen {
         return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
     }
 
-    public func openPostSettings() -> EditorPostSettings {
+    public func openPostSettings() throws -> EditorPostSettings {
         moreButton.tap()
         postSettingsButton.tap()
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
     private func addBlock(_ blockLabel: String) {

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -104,11 +104,11 @@ public class BlockEditorScreen: BaseScreen {
         }
     }
 
-    public func publish() -> EditorNoticeComponent {
+    public func publish() throws -> EditorNoticeComponent {
         publishButton.tap()
         confirmPublish()
 
-        return EditorNoticeComponent(withNotice: "Post published", andAction: "View")
+        return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
     }
 
     public func openPostSettings() -> EditorPostSettings {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
@@ -23,7 +23,7 @@ public class EditorNoticeComponent: ScreenObject {
         )
     }
 
-    public func viewPublishedPost(withTitle postTitle: String) -> EditorPublishEpilogueScreen {
+    public func viewPublishedPost(withTitle postTitle: String) throws -> EditorPublishEpilogueScreen {
         // The publish notice has a joined accessibility label equal to: title + message
         // (the postTitle). It does not seem possible to target the specific postTitle label
         // only because of this.
@@ -35,6 +35,6 @@ public class EditorNoticeComponent: ScreenObject {
 
         noticeActionGetter(app).tap()
 
-        return EditorPublishEpilogueScreen()
+        return try EditorPublishEpilogueScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
@@ -1,28 +1,39 @@
+import ScreenObject
 import XCTest
 
-public class EditorNoticeComponent: BaseScreen {
-    let noticeAction: XCUIElement
+public class EditorNoticeComponent: ScreenObject {
+
+    private let noticeTitleGetter: (XCUIApplication) -> XCUIElement
+    private let noticeActionGetter: (XCUIApplication) -> XCUIElement
 
     private let expectedNoticeTitle: String
 
-    init(withNotice noticeTitle: String, andAction buttonText: String) {
-        let notice = XCUIApplication().otherElements["notice_title_and_message"]
-
-        noticeAction = XCUIApplication().buttons[buttonText]
-
+    init(
+        withNotice noticeTitle: String,
+        andAction buttonText: String,
+        app: XCUIApplication = XCUIApplication()
+    ) throws {
+        noticeTitleGetter = { app in app.otherElements["notice_title_and_message"] }
+        noticeActionGetter = { app in app.buttons[buttonText] }
         expectedNoticeTitle = noticeTitle
 
-        super.init(element: notice)
+        try super.init(
+            expectedElementGetters: [ noticeTitleGetter, noticeActionGetter ],
+            app: app
+        )
     }
 
     public func viewPublishedPost(withTitle postTitle: String) -> EditorPublishEpilogueScreen {
         // The publish notice has a joined accessibility label equal to: title + message
         // (the postTitle). It does not seem possible to target the specific postTitle label
         // only because of this.
-        let expectedLabel = String(format: "%@. %@", expectedNoticeTitle, postTitle)
-        XCTAssertEqual(expectedElement.label, expectedLabel, "Post title not visible on published post notice")
+        XCTAssertEqual(
+            noticeTitleGetter(app).label,
+            String(format: "%@. %@", expectedNoticeTitle, postTitle),
+            "Post title not visible on published post notice"
+        )
 
-        noticeAction.tap()
+        noticeActionGetter(app).tap()
 
         return EditorPublishEpilogueScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -44,7 +44,8 @@ public class EditorPostSettings: ScreenObject {
 
     public func removeFeatureImage() throws -> EditorPostSettings {
         changeFeaturedImageButton.tap()
-        FeaturedImageScreen()
+
+        try FeaturedImageScreen()
             .tapRemoveFeaturedImageButton()
 
         return try EditorPostSettings()

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -1,22 +1,21 @@
+import ScreenObject
 import XCTest
 
-public class EditorPostSettings: BaseScreen {
-    let settingsTable: XCUIElement
-    let categoriesSection: XCUIElement
-    let tagsSection: XCUIElement
-    let featuredImageButton: XCUIElement
-    var changeFeaturedImageButton: XCUIElement {
-        return settingsTable.cells["CurrentFeaturedImage"]
-    }
+public class EditorPostSettings: ScreenObject {
 
-    init() {
-        let app = XCUIApplication()
-        settingsTable = app.tables["SettingsTable"]
-        categoriesSection = settingsTable.cells["Categories"]
-        tagsSection = settingsTable.cells["Tags"]
-        featuredImageButton = settingsTable.cells["SetFeaturedImage"]
+    // expectedElement comes from the superclass and gets the first expectedElementGetters result
+    var settingsTable: XCUIElement { expectedElement }
 
-        super.init(element: settingsTable)
+    var categoriesSection: XCUIElement { settingsTable.cells["Categories"] }
+    var tagsSection: XCUIElement { settingsTable.cells["Tags"] }
+    var featuredImageButton: XCUIElement { settingsTable.cells["SetFeaturedImage"] }
+    var changeFeaturedImageButton: XCUIElement { settingsTable.cells["CurrentFeaturedImage"] }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.tables["SettingsTable"] } ],
+            app: app
+        )
     }
 
     public func selectCategory(name: String) throws -> EditorPostSettings {
@@ -25,8 +24,8 @@ public class EditorPostSettings: BaseScreen {
             .goBackToSettings()
     }
 
-    public func addTag(name: String) -> EditorPostSettings {
-        return openTags()
+    public func addTag(name: String) throws -> EditorPostSettings {
+        return try openTags()
             .addTag(name: name)
             .goBackToSettings()
     }
@@ -43,24 +42,24 @@ public class EditorPostSettings: BaseScreen {
         return TagsComponent()
     }
 
-    public func removeFeatureImage() -> EditorPostSettings {
+    public func removeFeatureImage() throws -> EditorPostSettings {
         changeFeaturedImageButton.tap()
         FeaturedImageScreen()
             .tapRemoveFeaturedImageButton()
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
-    public func setFeaturedImage() -> EditorPostSettings {
+    public func setFeaturedImage() throws -> EditorPostSettings {
         featuredImageButton.tap()
         MediaPickerAlbumListScreen()
             .selectAlbum(atIndex: 0) // Select media library
             .selectImage(atIndex: 0) // Select latest uploaded image
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
-    public func verifyPostSettings(withCategory category: String? = nil, withTag tag: String? = nil, hasImage: Bool) -> EditorPostSettings {
+    public func verifyPostSettings(withCategory category: String? = nil, withTag tag: String? = nil, hasImage: Bool) throws -> EditorPostSettings {
         if let postCategory = category {
             XCTAssertTrue(categoriesSection.staticTexts[postCategory].exists, "Category \(postCategory) not set")
         }
@@ -74,15 +73,15 @@ public class EditorPostSettings: BaseScreen {
             XCTAssertTrue(imageCount == 0, "Featured image is set but should not be")
         }
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
-    // returns void since return screen depends on which editor you're in
+    /// - Note: Returns `Void` because the return screen depends on which editor the user is in.
     public func closePostSettings() {
         navBackButton.tap()
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().tables["SettingsTable"].exists
+        return (try? EditorPostSettings().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -19,8 +19,8 @@ public class EditorPostSettings: BaseScreen {
         super.init(element: settingsTable)
     }
 
-    public func selectCategory(name: String) -> EditorPostSettings {
-        return openCategories()
+    public func selectCategory(name: String) throws -> EditorPostSettings {
+        return try openCategories()
             .selectCategory(name: name)
             .goBackToSettings()
     }
@@ -31,10 +31,10 @@ public class EditorPostSettings: BaseScreen {
             .goBackToSettings()
     }
 
-    func openCategories() -> CategoriesComponent {
+    func openCategories() throws -> CategoriesComponent {
         categoriesSection.tap()
 
-        return CategoriesComponent()
+        return try CategoriesComponent()
     }
 
     func openTags() -> TagsComponent {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -36,10 +36,10 @@ public class EditorPostSettings: ScreenObject {
         return try CategoriesComponent()
     }
 
-    func openTags() -> TagsComponent {
+    func openTags() throws -> TagsComponent {
         tagsSection.tap()
 
-        return TagsComponent()
+        return try TagsComponent()
     }
 
     public func removeFeatureImage() throws -> EditorPostSettings {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
@@ -15,12 +15,13 @@ public class EditorPublishEpilogueScreen: ScreenObject {
     var viewButton: XCUIElement { getViewButton(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        // Defining this via a `let` rather than inline only to avoid a SwiftLint style violation
+        let publishedPostStatusGetter: (XCUIApplication) -> XCUIElement = {
+            $0.staticTexts["publishedPostStatusLabel"]
+        }
+
         try super.init(
-            expectedElementGetters: [
-                getDoneButton,
-                getViewButton,
-                { $0.staticTexts["publishedPostStatusLabel"] }
-            ],
+            expectedElementGetters: [ getDoneButton, getViewButton, publishedPostStatusGetter ],
             app: app
         )
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
@@ -1,26 +1,38 @@
+import ScreenObject
 import XCTest
 
-public class EditorPublishEpilogueScreen: BaseScreen {
-    let doneButton: XCUIElement
-    let viewButton: XCUIElement
+public class EditorPublishEpilogueScreen: ScreenObject {
 
-    public init() {
-        let app = XCUIApplication()
-        let published = app.staticTexts["publishedPostStatusLabel"]
-        doneButton = app.navigationBars.buttons["doneButton"]
-        viewButton = app.buttons["viewPostButton"]
-
-        super.init(element: published)
+    private let getDoneButton: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars.buttons["doneButton"]
     }
 
-    // returns void since return screen depends on what screen you started on
+    private let getViewButton: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["viewPostButton"]
+    }
+
+    var doneButton: XCUIElement { getDoneButton(app) }
+    var viewButton: XCUIElement { getViewButton(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                getDoneButton,
+                getViewButton,
+                { $0.staticTexts["publishedPostStatusLabel"] }
+            ],
+            app: app
+        )
+    }
+
+    /// - Note: Returns `Void` since the return screen depends on which screen we started from.
     public func done() {
         doneButton.tap()
     }
 
     public func verifyEpilogueDisplays(postTitle expectedPostTitle: String, siteAddress expectedSiteAddress: String) -> EditorPublishEpilogueScreen {
-        let actualPostTitle = XCUIApplication().staticTexts["postTitle"].label
-        let actualSiteAddress = XCUIApplication().staticTexts["siteUrl"].label
+        let actualPostTitle = app.staticTexts["postTitle"].label
+        let actualSiteAddress = app.staticTexts["siteUrl"].label
 
         XCTAssertEqual(expectedPostTitle, actualPostTitle, "Post title doesn't match expected title")
         XCTAssertEqual(expectedSiteAddress, actualSiteAddress, "Site address doesn't match expected address")

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -1,13 +1,10 @@
+import ScreenObject
 import XCTest
 
-public class CategoriesComponent: BaseScreen {
-    let categoriesList: XCUIElement
+public class CategoriesComponent: ScreenObject {
 
-    init() {
-        let app = XCUIApplication()
-        categoriesList = app.tables["CategoriesList"]
-
-        super.init(element: categoriesList)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [ { $0.tables["CategoriesList"] } ], app: app)
     }
 
     public func selectCategory(name: String) -> CategoriesComponent {
@@ -24,6 +21,6 @@ public class CategoriesComponent: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().tables["CategoriesList"].exists
+        (try? CategoriesComponent().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -14,10 +14,10 @@ public class CategoriesComponent: ScreenObject {
         return self
     }
 
-    func goBackToSettings() -> EditorPostSettings {
+    func goBackToSettings() throws -> EditorPostSettings {
         navBackButton.tap()
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -1,13 +1,13 @@
+import ScreenObject
 import XCTest
 
-public class TagsComponent: BaseScreen {
-    let tagsField: XCUIElement
+public class TagsComponent: ScreenObject {
 
-    init() {
-        let app = XCUIApplication()
-        tagsField = app.textViews["add-tags"]
+    // expectedElement comes from the superclass and gets the first expectedElementGetters result
+    var tagsField: XCUIElement { expectedElement }
 
-        super.init(element: tagsField)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [ { $0.textViews["add-tags"] } ], app: app)
     }
 
     func addTag(name: String) -> TagsComponent {
@@ -23,6 +23,6 @@ public class TagsComponent: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().textViews["add-tags"].exists
+        (try? TagsComponent().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -16,10 +16,10 @@ public class TagsComponent: BaseScreen {
         return self
     }
 
-    func goBackToSettings() -> EditorPostSettings {
+    func goBackToSettings() throws -> EditorPostSettings {
         navBackButton.tap()
 
-        return EditorPostSettings()
+        return try EditorPostSettings()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
@@ -1,13 +1,16 @@
+import ScreenObject
 import XCTest
 
-public class FeaturedImageScreen: BaseScreen {
+public class FeaturedImageScreen: ScreenObject {
 
-    let removeButton: XCUIElement
+    // expectedElement comes from the superclass and gets the first expectedElementGetters result
+    var removeButton: XCUIElement { expectedElement }
 
-    public init() {
-        let app = XCUIApplication()
-        removeButton = app.navigationBars.buttons["Remove Featured Image"]
-        super.init(element: removeButton )
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.navigationBars.buttons["Remove Featured Image"] } ],
+            app: app
+        )
     }
 
     public func tapRemoveFeaturedImageButton() {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -115,9 +115,9 @@ public class MySiteScreen: BaseScreen {
         return SiteSettingsScreen()
     }
 
-    func gotoCreateSheet() -> ActionSheetComponent {
+    func gotoCreateSheet() throws -> ActionSheetComponent {
         createButton.tap()
-        return ActionSheetComponent()
+        return try ActionSheetComponent()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -75,9 +75,9 @@ public class MySiteScreen: BaseScreen {
         }
     }
 
-    public func gotoActivityLog() -> ActivityLogScreen {
+    public func goToActivityLog() throws -> ActivityLogScreen {
         activityLogButton.tap()
-        return ActivityLogScreen()
+        return try ActivityLogScreen()
     }
 
     public func gotoJetpackScan() -> JetpackScanScreen {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -27,17 +27,17 @@ public class TabNavComponent: BaseScreen {
         return MySiteScreen()
     }
 
-    public func gotoAztecEditorScreen() -> AztecEditorScreen {
+    public func gotoAztecEditorScreen() throws -> AztecEditorScreen {
         let mySiteScreen = gotoMySiteScreen()
-        let actionSheet = mySiteScreen.gotoCreateSheet()
+        let actionSheet = try mySiteScreen.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
         return AztecEditorScreen(mode: .rich)
     }
 
-    public func gotoBlockEditorScreen() -> BlockEditorScreen {
+    public func gotoBlockEditorScreen() throws -> BlockEditorScreen {
         let mySite = gotoMySiteScreen()
-        let actionSheet = mySite.gotoCreateSheet()
+        let actionSheet = try mySite.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
         return BlockEditorScreen()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -25019,7 +25019,7 @@
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.0;
+				minimumVersion = 0.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -8,7 +8,7 @@ class EditorAztecTests: XCTestCase {
         setUpTestSuite()
 
         _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        editorScreen = EditorFlow
+        editorScreen = try EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()
             .tabBar.gotoAztecEditorScreen()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -45,7 +45,7 @@ class EditorGutenbergTests: XCTestCase {
         let content = getRandomContent()
         let category = getCategory()
         let tag = getTag()
-        editorScreen
+        try editorScreen
             .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -28,7 +28,7 @@ class EditorGutenbergTests: XCTestCase {
 
         let title = getRandomPhrase()
         let content = getRandomContent()
-        editorScreen
+        try editorScreen
             .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
@@ -60,7 +60,7 @@ class EditorGutenbergTests: XCTestCase {
             .setFeaturedImage()
             .verifyPostSettings(withCategory: category, withTag: tag, hasImage: true)
             .closePostSettings()
-        BlockEditorScreen().publish()
+        try BlockEditorScreen().publish()
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -8,7 +8,7 @@ class EditorGutenbergTests: XCTestCase {
         setUpTestSuite()
 
         _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        editorScreen = EditorFlow
+        editorScreen = try EditorFlow
             .gotoMySiteScreen()
             .tabBar.gotoBlockEditorScreen()
     }


### PR DESCRIPTION
This is the first PR of a series that will convert all `BaseScreen` subclasses into `ScreenObject` subclasses.

It might not be super clear by looking at the diff, so here's the structure of a simple `ScreenObject`:

```swift
import ScreenObject // ScreenObject comes from a Swift package, so we need to import it
import XCTest

public class FeaturedImageScreen: ScreenObject {

    // expectedElement comes from the superclass and gets the first expectedElementGetters result
    var removeButton: XCUIElement { expectedElement }

    // The subclass (this one, FeaturedImageScreen) wraps the superclass (ScreenObject)
	// init method so that we can call it with no parameters. All the defaults are set in
    // the context of this file and callers don't need to know about them.
    public init(app: XCUIApplication = XCUIApplication()) throws {
        try super.init(
			// In this simple screen, we only check for one element to verify wether the
            // screen is loaded.
            //
  			// This here is a closure and its type, as defined in the ScreenObject init
			// method signature is (XCUIApplication) -> XCUIElement. That means it
			// takes a XCUIApplication as input and returns an XCUIElement. The $0 is a
            // shorthand to represent the first (0 index) argument passed to the closure.
            //
            // Internally, ScreenObject uses the app instance we pass to in in the next line
            // to call this closure and get the expected element.
            expectedElementGetters: [ { $0.navigationBars.buttons["Remove Featured Image"] } ],
            app: app
        )
    }

	// ScreenObject subclasses in UITestFoundation can expose many methods to interact with
    // the screen they represent.
    public func tapRemoveFeaturedImageButton() {
        removeButton.tap()
        // app is the same value passed at init
        app.sheets.buttons.element(boundBy: 0).tap()
    }
}
```

Most screens use more than one element to verify if they're loaded correctly and for the test interactions. In those cases, we use a two step approach.

First, we define the getter closure as an instance `let`

```swift
let getDoneButton: (XCUIApplication) -> XCUIElement = {
    $0.navigationBars.buttons["doneButton"]
}
```

Then we pass the value in the `expectedElementGetters` array

```swift
init(app: XCUIApplication = XCUIApplication()) throws {
    try super.init(
        expectedElementGetters: [ getDoneButton, getViewButton, ... ],
        app: app
    )
}
```

Finally, we access the element themselves by calling the closure. We don't use `expectedElement` because that only returns the first element.

```swift
var doneButton: XCUIElement { getDoneButton(app) }
var viewButton: XCUIElement { getViewButton(app) }
```    

That's it. I wish I could have found a cleaner way to do this, or one that required less explanation and relied more on the type system. This is the best I could do so far. 😕

---

Notice that I run the UI tests and the all passed.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
