### PR TITLE
Empty Stats: Make card site specific

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -101,8 +101,12 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     // Store 'customize' separately as it is not per site.
     private let userDefaultsHideCustomizeKey = "StatsInsightsHideCustomizeCard"
 
-    // Store 'grow audience' separately as it is not per site.
-    private let userDefaultsHideGrowAudienceKey = "StatsInsightsHideGrowAudienceCard"
+    // Grow audience key per site
+    private var userDefaultsHideGrowAudienceKey: String? {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else { return nil }
+        let key = "StatsInsightsHideGrowAudienceCard"
+        return key + "-\(siteID)"
+    }
 
     // Store Insights settings for all sites.
     // Used when writing to/reading from User Defaults.
@@ -338,11 +342,13 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Grow Audience Card Management
 
     func loadGrowAudienceCardSetting() {
-        loadPermanentlyDismissableInsight(.growAudience, using: userDefaultsHideGrowAudienceKey)
+        guard let key = userDefaultsHideGrowAudienceKey else { return }
+        loadPermanentlyDismissableInsight(.growAudience, using: key)
     }
 
     func dismissGrowAudienceCard() {
-        permanentlyDismissInsight(.growAudience, using: userDefaultsHideGrowAudienceKey)
+        guard let key = userDefaultsHideGrowAudienceKey else { return }
+        permanentlyDismissInsight(.growAudience, using: key)
     }
 
     // MARK: - Insights Management


### PR DESCRIPTION
Part of [#17215](https://github.com/wordpress-mobile/WordPress-iOS/issues/17215)

This PR includes logic for making the UserDefaults key site specific, so grow audience card dismissal state is stored per site.

## To test:
1. Navigate to **My Site** > **Stats**.
2. Dismiss **Grow audience** card.
3. Go back and change site.
4. Confirm that **Grow audience** card is presented.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
