### PR TITLE
iOS 15: fix tab bar background

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -59,6 +59,15 @@ extension WPStyleGuide {
     class func configureTabBarAppearance() {
         UITabBar.appearance().tintColor = .tabSelected
         UITabBar.appearance().unselectedItemTintColor = .tabUnselected
+
+        if #available(iOS 15.0, *) {
+            let appearance = UITabBarAppearance()
+            appearance.configureWithOpaqueBackground()
+            appearance.backgroundColor = .systemBackground
+
+            UITabBar.appearance().standardAppearance = appearance
+            UITabBar.appearance().scrollEdgeAppearance = appearance
+        }
     }
 
     /// Style the `LightNavigationController` UINavigationBar and BarButtonItems


### PR DESCRIPTION
Fixes #17172

All props to @momo-ozawa, I pretty much copy-pasted her solution from the original issue. Hope you don't mind, Momo!

### To test

1. Using Xcode 13, build the app
2. Go to My Sites
3. Go to Jetpack Settings
4. Make sure the tab bar color is normal
5. Test light and dark mode

## Regression Notes
1. Potential unintended areas of impact
I used a conditional for iOS 15, other versions should not be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested another iOS version.

3. What automated tests I added (or what prevented me from doing so)
Visual change due to newer iOS version.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
