### PR TITLE
iOS 15: fix the top padding on Table View's header

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -55,6 +55,13 @@ extension WPStyleGuide {
         buttonBarAppearance.tintColor = .appBarTint
     }
 
+    /// Style `UITableView` in the app
+    class func configureTableViewAppearance() {
+        if #available(iOS 15.0, *) {
+            UITableView.appearance().sectionHeaderTopPadding = 0
+        }
+    }
+
     /// Style the tab bar using Muriel colors
     class func configureTabBarAppearance() {
         UITabBar.appearance().tintColor = .tabSelected

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -821,6 +821,7 @@ extension WordPressAppDelegate {
 
         WPStyleGuide.configureTabBarAppearance()
         WPStyleGuide.configureNavigationAppearance()
+        WPStyleGuide.configureTableViewAppearance()
         WPStyleGuide.configureDefaultTint()
         WPStyleGuide.configureLightNavigationBarAppearance()
 


### PR DESCRIPTION
This PR fixes the additional top padding introduced in iOS 15.

| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 13 - 2021-09-27 at 14 52 29](https://user-images.githubusercontent.com/7040243/134959928-2e866f8f-a04c-428e-8384-dffdb6cf4fd1.png) | ![Simulator Screen Shot - iPhone 13 - 2021-09-27 at 14 50 58](https://user-images.githubusercontent.com/7040243/134959973-ab4169e0-c1e1-490c-916e-9b4f8e0c45b9.png) |

### To test

1. Build the app using Xcode 13 on a device or simulator with iOS 15
2. Go to notifications or Activity Log
3. Check that the table view header has no additional top padding

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
