### PR TITLE
Fixes a crash when accessing Plugins

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1731,7 +1731,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)showPlugins
 {
     [WPAppAnalytics track:WPAnalyticsStatOpenedPluginDirectory withBlog:self.blog];
-    PluginDirectoryViewController *controller = [[PluginDirectoryViewController alloc] initWithBlog:self.blog];
+    PluginDirectoryViewController *controller = [self makePluginDirectoryViewControllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];
 

--- a/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginDirectoryViewController.swift
@@ -23,15 +23,6 @@ class PluginDirectoryViewController: UITableViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    @objc convenience init?(blog: Blog) {
-        guard let site = JetpackSiteRef(blog: blog) else {
-            return nil
-        }
-
-        self.init(site: site)
-    }
-
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -231,5 +222,16 @@ extension PluginDirectoryViewController: PluginListPresenter {
 
         let listVC = PluginListViewController(site: site, query: query)
         navigationController?.pushViewController(listVC, animated: true)
+    }
+}
+
+extension BlogDetailsViewController {
+
+    @objc func makePluginDirectoryViewController(blog: Blog) -> PluginDirectoryViewController? {
+        guard let site = JetpackSiteRef(blog: blog) else {
+            return nil
+        }
+
+        return PluginDirectoryViewController(site: site)
     }
 }


### PR DESCRIPTION
Fixes #17170

To test:
- Build/run with Xcode 13 and go to My Site
- tap on Plugins and make sure no crashes due to "serious bugs" occur, and the Plugins page is displayed correctly


**NOTE:**
This stack overflow thread helped sort the bug out: https://stackoverflow.com/questions/69092599/xcode-13-beta-5-error-uiviewcontroller-is-missing-its-initial-trait-collection

## Regression Notes
1. Potential unintended areas of impact
None, this refactors a method but does not alter the logic

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test the feature and that the reported crash does not occur anymore

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
