### PR TITLE
Remove unused code from some UI tests screen objects

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -8,13 +8,11 @@ private struct ElementStringIDs {
 public class LoginCheckMagicLinkScreen: BaseScreen {
     let passwordOption: XCUIElement
     let mailButton: XCUIElement
-    let mailAlert: XCUIElement
 
     init() {
         let app = XCUIApplication()
         passwordOption = app.buttons[ElementStringIDs.passwordOption]
         mailButton = app.buttons[ElementStringIDs.mailButton]
-        mailAlert = app.alerts.element(boundBy: 0)
 
         super.init(element: mailButton)
     }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -3,21 +3,18 @@ import XCTest
 // TODO: remove when unifiedAuth is permanent.
 
 private struct ElementStringIDs {
-    static let navBar = "WordPress.LoginEmailView"
     static let emailTextField = "Login Email Address"
     static let nextButton = "Login Email Next Button"
     static let siteAddressButton = "Self Hosted Login Button"
 }
 
 public class LoginEmailScreen: BaseScreen {
-    let navBar: XCUIElement
     let emailTextField: XCUIElement
     let nextButton: XCUIElement
     let siteAddressButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
         emailTextField = app.textFields[ElementStringIDs.emailTextField]
         nextButton = app.buttons[ElementStringIDs.nextButton]
         siteAddressButton = app.buttons[ElementStringIDs.siteAddressButton]

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,7 +1,6 @@
 import XCTest
 
 private struct ElementStringIDs {
-    static let navBar = "WordPressAuthenticator.LoginSiteAddressView"
     static let nextButton = "Site Address Next Button"
 
     // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
@@ -15,13 +14,11 @@ private struct ElementStringIDs {
 }
 
 public class LoginSiteAddressScreen: BaseScreen {
-    let navBar: XCUIElement
     let siteAddressTextField: XCUIElement
     let nextButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
         siteAddressTextField = app.textFields[ElementStringIDs.siteAddressTextField]
         nextButton = app.buttons[ElementStringIDs.nextButton]
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -2,8 +2,6 @@ import XCTest
 import XCUITestHelpers
 
 private struct ElementStringIDs {
-    static let navBar = "WordPressAuthenticator.LoginSelfHostedView"
-
     // TODO: clean up comments when unifiedSiteAddress is permanently enabled.
 
     // For original Site Address. These match accessibilityIdentifier in Login.storyboard.
@@ -19,14 +17,12 @@ private struct ElementStringIDs {
 }
 
 public class LoginUsernamePasswordScreen: BaseScreen {
-    let navBar: XCUIElement
     let usernameTextField: XCUIElement
     let passwordTextField: XCUIElement
     let nextButton: XCUIElement
 
     init() {
         let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
         usernameTextField = app.textFields[ElementStringIDs.usernameTextField]
         passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
         nextButton = app.buttons[ElementStringIDs.nextButton]

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -1,20 +1,17 @@
 import XCTest
 
 private struct ElementStringIDs {
-    static let navBar = "WordPress.PasswordView"
     static let passwordTextField = "Password"
     static let continueButton = "Continue Button"
     static let errorLabel = "Password Error"
 }
 
 public class PasswordScreen: BaseScreen {
-    let navBar: XCUIElement
     let passwordTextField: XCUIElement
     let continueButton: XCUIElement
 
     public init() {
         let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
         passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
         continueButton = app.buttons[ElementStringIDs.continueButton]
 

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -2,13 +2,11 @@ import XCTest
 
 public class NotificationsScreen: BaseScreen {
 
-    let tabBar: TabNavComponent
     let replyButton: XCUIElement
 
     init() {
         let navBar = XCUIApplication().tables["Notifications Table"]
         replyButton = XCUIApplication().buttons["reply-button"]
-        tabBar = TabNavComponent()
 
         super.init(element: navBar)
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -6,12 +6,10 @@ private struct ElementStringIDs {
 }
 
 public class ReaderScreen: BaseScreen {
-    let tabBar: TabNavComponent
     let discoverButton: XCUIElement
 
     init() {
         let readerTable = XCUIApplication().tables[ElementStringIDs.readerTable]
-        tabBar = TabNavComponent()
         discoverButton = XCUIApplication().buttons[ElementStringIDs.discoverButton]
 
         super.init(element: readerTable)


### PR DESCRIPTION
This PR only removes code 😄 If CI validates the UI tests, we're good to merge.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
