### PR TITLE
Sync comments content only if needed

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -566,7 +566,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)refreshAndSyncIfNeeded
 {
-    if (self.blog) {
+    if (self.blog && self.contentIsEmpty) {
         [self.syncHelper syncContent];
     }
 }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/17202.

## Description

On each `viewWillAppear` method `syncContent` is called to reload all data, even if there is something already loaded.

The fix is adding a check and call `syncContent` only when it's needed (no loaded content).

## To test:

1. Run the app on an any device/simulator.
2. Select a site that has many comments, such that it has two or more pages when scrolling down the comments list.
3. Tap My Site > Comments.
4. Scroll down until the fetch request for more content is triggered.
5. Select any comment on page two.
6. Tap Back.
7. Check that the Comments list is still at same page and scroll position doesn't jump.

---
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
