### PR TITLE
Remove dismiss button from Blogging Reminders flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -63,15 +63,6 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         return button
     }()
 
-    private let dismissButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(.gridicon(.cross), for: .normal)
-        button.tintColor = .secondaryLabel
-        button.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
-        return button
-    }()
-
     // MARK: - Initializers
 
     let blog: Blog
@@ -103,7 +94,6 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .basicBackground
-        view.addSubview(dismissButton)
 
         configureStackView()
         configureConstraints()
@@ -170,9 +160,6 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
 
             doneButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.doneButtonHeight),
             doneButton.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.right)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -51,15 +51,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         return button
     }()
 
-    private let dismissButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(.gridicon(.cross), for: .normal)
-        button.tintColor = .secondaryLabel
-        button.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
-        return button
-    }()
-
     // MARK: - Initializers
 
     private let blog: Blog
@@ -97,7 +88,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .basicBackground
-        view.addSubview(dismissButton)
 
         configureStackView()
         configureConstraints()
@@ -158,9 +148,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
             getStartedButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.getStartedButtonHeight),
             getStartedButton.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.right)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -200,15 +200,6 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         makeSpacer()
     }()
 
-    private let dismissButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setImage(.gridicon(.cross), for: .normal)
-        button.tintColor = .secondaryLabel
-        button.addTarget(self, action: #selector(dismissTapped), for: .touchUpInside)
-        return button
-    }()
-
     // MARK: - Properties
 
     private let calendar: Calendar
@@ -273,7 +264,6 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .basicBackground
-        view.addSubview(dismissButton)
 
         configureStackView()
         configureConstraints()
@@ -429,7 +419,6 @@ private extension BloggingRemindersFlowSettingsViewController {
     func showFullUI(_ isVisible: Bool) {
         bottomTipPanel.isHidden = !isVisible
         imageView.isHidden = !isVisible
-        dismissButton.isHidden = !isVisible
     }
 
     /// Updates the title of the cconfirmation button depending on the action (new schedule or updated schedule)
@@ -518,8 +507,6 @@ private extension BloggingRemindersFlowSettingsViewController {
             button.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             bottomTipPanel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
-            dismissButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
-            dismissButton.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.right),
             topDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             bottomDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             timeSelectionView.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),


### PR DESCRIPTION
This PR removes the dismiss button "x" from all the screens in Blogging Reminders
Fixes #NA

To test:
Test on iPhone and iPad
Make sure to have a site where you never previously used Blogging Reminders (or fresh install)

- Build/run and go to My Site -> Site Settings
- Tap Blogging Reminders
- Make sure the intro screen does not have the dismiss button ("x")
- Complete the flow and make sure the remaining screens also don't have the dismiss button

## Regression Notes
1. Potential unintended areas of impact
none

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
