### PR TITLE
Comment Moderation Bar: move style settings to style guide extension

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+private typealias Style = WPStyleGuide.CommentDetail.ModerationBar
+
 class CommentModerationBar: UIView {
 
     // MARK: - Properties
@@ -65,22 +67,26 @@ private extension CommentModerationBar {
     func configureView() {
         configureBackground()
         configureDividers()
-        pendingButton.configureFor(.pending)
-        approvedButton.configureFor(.approved)
-        spamButton.configureFor(.spam)
-        trashButton.configureFor(.trash)
+        configureButtons()
         configureStackViewWidth()
     }
 
     func configureBackground() {
-        contentView.backgroundColor = .tertiaryFill
-        contentView.layer.cornerRadius = 15
+        contentView.backgroundColor = Style.barBackgroundColor
+        contentView.layer.cornerRadius = Style.cornerRadius
     }
 
     func configureDividers() {
         firstDivider.configureAsDivider()
         secondDivider.configureAsDivider()
         thirdDivider.configureAsDivider()
+    }
+
+    func configureButtons() {
+        pendingButton.configureFor(.pending)
+        approvedButton.configureFor(.approved)
+        spamButton.configureFor(.spam)
+        trashButton.configureFor(.trash)
     }
 
     @objc func configureStackViewWidth() {
@@ -133,7 +139,7 @@ private extension CommentModerationBar {
 
 // MARK: - Moderation Button Types
 
-private enum ModerationButtonType {
+enum ModerationButtonType {
     case pending
     case approved
     case spam
@@ -153,29 +159,11 @@ private enum ModerationButtonType {
     }
 
     var defaultIcon: UIImage? {
-        switch self {
-        case .pending:
-            return UIImage(systemName: "tray")?.imageWithTintColor(.textSubtle)
-        case .approved:
-            return UIImage(systemName: "checkmark.circle")?.imageWithTintColor(.textSubtle)
-        case .spam:
-            return UIImage(systemName: "exclamationmark.octagon")?.imageWithTintColor(.textSubtle)
-        case .trash:
-            return UIImage(systemName: "trash")?.imageWithTintColor(.textSubtle)
-        }
+        return Style.defaultImageFor(self)
     }
 
     var selectedIcon: UIImage? {
-        switch self {
-        case .pending:
-            return UIImage(systemName: "tray.fill")?.imageWithTintColor(.muriel(name: .yellow, .shade30))
-        case .approved:
-            return UIImage(systemName: "checkmark.circle.fill")?.imageWithTintColor(.muriel(name: .green, .shade40))
-        case .spam:
-            return UIImage(systemName: "exclamationmark.octagon.fill")?.imageWithTintColor(.muriel(name: .orange, .shade40))
-        case .trash:
-            return UIImage(systemName: "trash.fill")?.imageWithTintColor(.muriel(name: .red, .shade40))
-        }
+        return Style.selectedImageFor(self)
     }
 }
 
@@ -190,11 +178,11 @@ private extension UIButton {
 
     func configureState() {
         if isSelected {
-            backgroundColor = .white
-            layer.shadowColor = UIColor.black.cgColor
+            backgroundColor = Style.buttonSelectedBackgroundColor
+            layer.shadowColor = Style.buttonSelectedShadowColor
         } else {
-            backgroundColor = .clear
-            layer.shadowColor = UIColor.clear.cgColor
+            backgroundColor = Style.buttonDefaultBackgroundColor
+            layer.shadowColor = Style.buttonDefaultShadowColor
         }
     }
 
@@ -207,13 +195,13 @@ private extension UIButton {
     }
 
     func commonConfigure() {
-        setTitleColor(.textSubtle, for: UIControl.State())
-        setTitleColor(.black, for: .selected)
+        setTitleColor(Style.buttonDefaultTitleColor, for: UIControl.State())
+        setTitleColor(Style.buttonSelectedTitleColor, for: .selected)
 
-        layer.cornerRadius = 15
-        layer.shadowOffset = CGSize(width: 0, height: 2.0)
-        layer.shadowOpacity = 0.25
-        layer.shadowRadius = 2.0
+        layer.cornerRadius = Style.cornerRadius
+        layer.shadowOffset = Style.buttonShadowOffset
+        layer.shadowOpacity = Style.buttonShadowOpacity
+        layer.shadowRadius = Style.buttonShadowRadius
 
         verticallyAlignImageAndText()
         flipInsetsForRightToLeftLayoutDirection()
@@ -235,7 +223,7 @@ private extension UIView {
     }
 
     func hideDivider(_ hidden: Bool) {
-        backgroundColor = hidden ? .clear : .systemGray
+        backgroundColor = hidden ? Style.dividerHiddenColor : Style.dividerColor
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -61,14 +61,14 @@ extension WPStyleGuide {
 
         public struct ModerationBar {
             static let barBackgroundColor: UIColor = .systemGray6
-            static let cornerRadius = 15.0
+            static let cornerRadius: CGFloat = 15.0
 
             static let dividerColor: UIColor = .systemGray
             static let dividerHiddenColor: UIColor = .clear
 
             static let buttonShadowOffset = CGSize(width: 0, height: 2.0)
             static let buttonShadowOpacity: Float = 0.25
-            static let buttonShadowRadius = 2.0
+            static let buttonShadowRadius: CGFloat = 2.0
 
             static let buttonDefaultTitleColor = UIColor(light: .textSubtle, dark: .systemGray)
             static let buttonSelectedTitleColor = UIColor(light: .black, dark: .white)

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -58,5 +58,76 @@ extension WPStyleGuide {
                 .withRenderingMode(.alwaysTemplate)
                 .imageFlippedForRightToLeftLayoutDirection()
         }
+
+        public struct ModerationBar {
+            static let barBackgroundColor: UIColor = .systemGray6
+            static let cornerRadius = 15.0
+
+            static let dividerColor: UIColor = .systemGray
+            static let dividerHiddenColor: UIColor = .clear
+
+            static let buttonShadowOffset = CGSize(width: 0, height: 2.0)
+            static let buttonShadowOpacity: Float = 0.25
+            static let buttonShadowRadius = 2.0
+
+            static let buttonDefaultTitleColor = UIColor(light: .textSubtle, dark: .systemGray)
+            static let buttonSelectedTitleColor = UIColor(light: .black, dark: .white)
+            static let buttonDefaultBackgroundColor: UIColor = .clear
+            static let buttonDefaultShadowColor = UIColor.clear.cgColor
+            static let buttonSelectedBackgroundColor: UIColor = .tertiaryBackground
+            static let buttonSelectedShadowColor = UIColor.black.cgColor
+
+            static let pendingImageName = "tray"
+            static let approvedImageName = "checkmark.circle"
+            static let spamImageName = "exclamationmark.octagon"
+            static let trashImageName = "trash"
+
+            static let imageDefaultTintColor = buttonDefaultTitleColor
+            static let pendingSelectedColor: UIColor = .muriel(name: .yellow, .shade30)
+            static let approvedSelectedColor: UIColor = .muriel(name: .green, .shade40)
+            static let spamSelectedColor: UIColor = .muriel(name: .orange, .shade40)
+            static let trashSelectedColor: UIColor = .muriel(name: .red, .shade40)
+
+            static func defaultImageFor(_ buttonType: ModerationButtonType) -> UIImage? {
+                return UIImage(systemName: imageNameFor(buttonType))?
+                    .withTintColor(imageDefaultTintColor)
+                    .withRenderingMode(.alwaysOriginal)
+            }
+
+            static func selectedImageFor(_ buttonType: ModerationButtonType) -> UIImage? {
+                return UIImage(systemName: imageNameFor(buttonType, selected: true))?
+                    .imageWithTintColor(imageTintColorFor(buttonType))
+            }
+
+            static func imageNameFor(_ buttonType: ModerationButtonType, selected: Bool = false) -> String {
+                let imageName: String = {
+                    switch buttonType {
+                    case .pending:
+                        return pendingImageName
+                    case .approved:
+                        return approvedImageName
+                    case .spam:
+                        return spamImageName
+                    case .trash:
+                        return trashImageName
+                    }
+                }()
+
+                return selected ? (imageName + ".fill") : imageName
+            }
+
+            static func imageTintColorFor(_ buttonType: ModerationButtonType) -> UIColor {
+                switch buttonType {
+                case .pending:
+                    return pendingSelectedColor
+                case .approved:
+                    return approvedSelectedColor
+                case .spam:
+                    return spamSelectedColor
+                case .trash:
+                    return trashSelectedColor
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Ref: #17200

This change does two things:
- Moves style related settings to `WPStyleGuide+CommentDetail`.
- Updates colors for dark mode. 

To test:
- Enable the `newCommentDetail` feature.
- Run the app in light and dark modes.
- Verify all the colors and images match #17200 or in Zeplin.

Examples:
<kbd><img width="447" alt="light" src="https://user-images.githubusercontent.com/1816888/135345612-00a5b6e9-a869-4329-bfe1-53676ded8aff.png"></kbd>

<kbd><img width="449" alt="dark" src="https://user-images.githubusercontent.com/1816888/135345686-e1a8c164-87cb-458a-97f0-8a2fda307d8b.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
