### PR TITLE
Comment Moderation Bar: set button for comment's initial status

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -154,4 +154,21 @@ extension Comment: PostContentProvider {
             return "draft"
         }
     }
+
+    static func typeForStatus(_ status: String) -> CommentStatusType? {
+        switch status {
+        case "hold":
+            return .pending
+        case "approve":
+            return .approved
+        case "trash":
+            return .unapproved
+        case "spam":
+            return .spam
+        case "draft":
+            return .draft
+        default:
+            return nil
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -131,6 +131,10 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isAccessoryButtonEnabled = comment.isApproved()
         isModerationEnabled = comment.canModerate
 
+        if isModerationEnabled {
+            moderationBar.comment = comment
+        }
+
         // Configure comment content.
         self.onContentLoaded = onContentLoaded
         webView.isOpaque = false // gets rid of the white flash upon content load in dark mode.

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -6,6 +6,12 @@ class CommentModerationBar: UIView {
 
     // MARK: - Properties
 
+    var comment: Comment? {
+        didSet {
+            setButtonForStatus()
+        }
+    }
+
     @IBOutlet private weak var contentView: UIView!
 
     @IBOutlet private weak var pendingButton: UIButton!
@@ -110,6 +116,26 @@ private extension CommentModerationBar {
 
         buttonStackViewLeadingConstraint.constant = horizontalPadding
         buttonStackViewTrailingConstraint.constant = horizontalPadding
+    }
+
+    func setButtonForStatus() {
+        guard let comment = comment,
+              let commentStatusType = CommentStatusType.typeForStatus(comment.status) else {
+                  return
+              }
+
+        switch commentStatusType {
+        case .pending:
+            pendingTapped(pendingButton)
+        case .approved:
+            approvedTapped(approvedButton)
+        case .unapproved:
+            trashTapped(trashButton)
+        case .spam:
+            spamTapped(spamButton)
+        default:
+            break
+        }
     }
 
     // MARK: - Button Actions

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -126,13 +126,13 @@ private extension CommentModerationBar {
 
         switch commentStatusType {
         case .pending:
-            pendingTapped(pendingButton)
+            pendingTapped()
         case .approved:
-            approvedTapped(approvedButton)
+            approvedTapped()
         case .unapproved:
-            trashTapped(trashButton)
+            trashTapped()
         case .spam:
-            spamTapped(spamButton)
+            spamTapped()
         default:
             break
         }
@@ -140,26 +140,26 @@ private extension CommentModerationBar {
 
     // MARK: - Button Actions
 
-    @IBAction func pendingTapped(_ sender: UIButton) {
-        sender.toggleState()
-        firstDivider.hideDivider(sender.isSelected)
+    @IBAction func pendingTapped() {
+        pendingButton.toggleState()
+        firstDivider.hideDivider(pendingButton.isSelected)
     }
 
-    @IBAction func approvedTapped(_ sender: UIButton) {
-        sender.toggleState()
-        firstDivider.hideDivider(sender.isSelected)
-        secondDivider.hideDivider(sender.isSelected)
+    @IBAction func approvedTapped() {
+        approvedButton.toggleState()
+        firstDivider.hideDivider(approvedButton.isSelected)
+        secondDivider.hideDivider(approvedButton.isSelected)
     }
 
-    @IBAction func spamTapped(_ sender: UIButton) {
-        sender.toggleState()
-        secondDivider.hideDivider(sender.isSelected)
-        thirdDivider.hideDivider(sender.isSelected)
+    @IBAction func spamTapped() {
+        spamButton.toggleState()
+        secondDivider.hideDivider(spamButton.isSelected)
+        thirdDivider.hideDivider(spamButton.isSelected)
     }
 
-    @IBAction func trashTapped(_ sender: UIButton) {
-        sender.toggleState()
-        thirdDivider.hideDivider(sender.isSelected)
+    @IBAction func trashTapped() {
+        trashButton.toggleState()
+        thirdDivider.hideDivider(trashButton.isSelected)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.xib
@@ -93,7 +93,7 @@
                                         <imageReference key="image" image="tray" catalog="system" symbolScale="large"/>
                                     </state>
                                     <connections>
-                                        <action selector="pendingTapped:" destination="-1" eventType="touchUpInside" id="yN6-hc-bjS"/>
+                                        <action selector="pendingTapped" destination="-1" eventType="touchUpInside" id="abh-IY-oNX"/>
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LN1-7X-UXx">
@@ -106,7 +106,7 @@
                                         <imageReference key="image" image="checkmark.circle" catalog="system" symbolScale="large"/>
                                     </state>
                                     <connections>
-                                        <action selector="approvedTapped:" destination="-1" eventType="touchUpInside" id="PJo-FX-E5p"/>
+                                        <action selector="approvedTapped" destination="-1" eventType="touchUpInside" id="B2l-HC-xk7"/>
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="amj-pE-B3g">
@@ -119,7 +119,7 @@
                                         <imageReference key="image" image="exclamationmark.octagon" catalog="system" symbolScale="large"/>
                                     </state>
                                     <connections>
-                                        <action selector="spamTapped:" destination="-1" eventType="touchUpInside" id="B2t-fu-MCD"/>
+                                        <action selector="spamTapped" destination="-1" eventType="touchUpInside" id="kJJ-NH-Awv"/>
                                     </connections>
                                 </button>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wss-Fs-Ja4">
@@ -132,7 +132,7 @@
                                         <imageReference key="image" image="trash" catalog="system" symbolScale="large"/>
                                     </state>
                                     <connections>
-                                        <action selector="trashTapped:" destination="-1" eventType="touchUpInside" id="wpW-cn-khe"/>
+                                        <action selector="trashTapped" destination="-1" eventType="touchUpInside" id="6fP-BE-5rs"/>
                                     </connections>
                                 </button>
                             </subviews>


### PR DESCRIPTION
Ref: #17200
Depends on: #17242

When Comment details is shown, the moderation bar button is selected that corresponds with the Comment status.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment in each of these filters.
  - Pending
  - Approved
  - Spam
  - Trashed
- Verify the correct moderation bar button is selected.

Example:
| Filtered List | Moderation Button |
|--------|-------|
| <img width="472" alt="filter" src="https://user-images.githubusercontent.com/1816888/135363594-80665c37-a212-4cba-83ca-c873e03342e6.png"> | <img width="465" alt="button" src="https://user-images.githubusercontent.com/1816888/135363606-f96f1d9a-e841-455d-a8a2-b77b920701be.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
