### PR TITLE
Comment Detail: Modify tap action and title when the comment is a reply

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -58,6 +58,10 @@ public class Comment: NSManagedObject {
         return !author_url.isEmpty
     }
 
+    func hasParentComment() -> Bool {
+        return parentID > 0
+    }
+
 }
 
 private extension Comment {

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -34,6 +34,8 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 
 - (NSSet *)findCommentsWithPostID:(NSNumber *)postID inBlog:(Blog *)blog;
 
+- (Comment *)findCommentWithID:(NSNumber *)commentID inBlog:(Blog *)blog;
+
 // Sync comments
 - (void)syncCommentsForBlog:(Blog *)blog
                     success:(void (^)(BOOL hasMore))success

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -60,7 +60,7 @@ class CommentDetailViewController: UITableViewController {
     }()
 
     private lazy var parentComment: Comment? = {
-        guard comment.hasParentComment,
+        guard comment.hasParentComment(),
               let blog = comment.blog,
               let parentComment = commentService.findComment(withID: NSNumber(value: comment.parentID), in: blog) else {
                   return nil
@@ -142,7 +142,7 @@ class CommentDetailViewController: UITableViewController {
 
         switch rows[indexPath.row] {
         case .header:
-            comment.hasParentComment ? navigateToParentComment() : navigateToPost()
+            comment.hasParentComment() ? navigateToParentComment() : navigateToPost()
 
         case .replyIndicator:
             // TODO: Navigate to the comment reply.
@@ -353,12 +353,6 @@ private extension CommentDetailViewController {
         openWebView(for: authorURL)
     }
 
-}
-
-private extension Comment {
-    var hasParentComment: Bool {
-        return parentID > 0
-    }
 }
 
 // MARK: - Strings

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -48,6 +48,20 @@ class CommentDetailViewController: UITableViewController {
         return cell
     }()
 
+    private lazy var commentService: CommentService = {
+        return .init()
+    }()
+
+    private lazy var parentComment: Comment? = {
+        guard comment.parentID > 0,
+              let blog = comment.blog,
+              let parentComment = commentService.findComment(withID: NSNumber(value: comment.parentID), in: blog) else {
+                  return nil
+              }
+
+        return parentComment
+    }()
+
     // MARK: Initialization
 
     @objc required init(comment: Comment) {
@@ -209,8 +223,14 @@ private extension CommentDetailViewController {
     // MARK: Cell configuration
 
     func configureHeaderCell() {
-        // TODO: detect if the comment is a reply.
+        // if the comment is a reply, show the author of the parent comment.
+        if let parentComment = self.parentComment {
+            headerCell.textLabel?.text = String(format: .replyCommentTitleFormat, parentComment.authorForDisplay())
+            headerCell.detailTextLabel?.text = parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines)
+            return
+        }
 
+        // otherwise, if this is a comment to a post, show the post title instead.
         headerCell.textLabel?.text = .postCommentTitleText
         headerCell.detailTextLabel?.text = comment.titleForDisplay()
     }
@@ -326,6 +346,9 @@ private extension String {
     static let postCommentTitleText = NSLocalizedString("Comment on", comment: "Provides hint that the current screen displays a comment on a post. "
                                                             + "The title of the post will displayed below this string. "
                                                             + "Example: Comment on \n My First Post")
+    static let replyCommentTitleFormat = NSLocalizedString("Reply to %1$@", comment: "Provides hint that the screen displays a reply to a comment."
+                                                           + "%1$@ is a placeholder for the comment author that's been replied to."
+                                                           + "Example: Reply to Pamela Nguyen")
     static let replyIndicatorLabelText = NSLocalizedString("You replied to this comment.", comment: "Informs that the user has replied to this comment.")
     static let webAddressLabelText = NSLocalizedString("Web address", comment: "Describes the web address section in the comment detail screen.")
     static let emailAddressLabelText = NSLocalizedString("Email address", comment: "Describes the email address section in the comment detail screen.")

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -269,7 +269,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     UIViewController *detailViewController;
 
     if ([Feature enabled:FeatureFlagNewCommentDetail]) {
-        detailViewController = [[CommentDetailViewController alloc] initWithComment:comment];
+        detailViewController = [[CommentDetailViewController alloc] initWithComment:comment managedObjectContext:[ContextManager sharedInstance].mainContext];
     } else {
         CommentViewController *vc   = [CommentViewController new];
         vc.comment                  = comment;


### PR DESCRIPTION
Refs #17087

This PR differentiates (1) the text displayed on the header row of the new Comment Detail and (2) the action performed when the header row is tapped, based on whether the comment is a reply to another comment (i.e. it has `parentID > 0`), or it's a comment to a post. 

## To test
Make sure the `New Comment Detail` feature flag is turned on.

### Scenario 1: Comment is a reply to another comment

- Go to My Site > Comments.
- Select a comment that's a reply to another comment.
- Verify that the header row shows `Reply to <parent comment's author>`.
- Verify that below the "Reply to..." text, the content snippet of the parent comment is displayed.
- Tap the header row and verify that the comment thread is displayed correctly, highlighting the parent comment.

Extra: Some content snippet contains `\n` characters at the start. Verify that the header row doesn't display blank lines due to the newline character at the start of the content snippet.

### Scenario 2: Comment is a direct comment to a post

- Go to My Site > Comments.
- Select a comment that's a direct comment to a post.
- Verify that the header row shows `Comment on`.
- Verify that below the "Comment on" text, the post title is displayed.
- Tap the header row and verify that the post is displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
