### PR TITLE
Blogging reminders in notification settings

### DIFF
--- a/WordPress/Classes/Models/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog+Capabilities.swift
@@ -64,4 +64,8 @@ extension Blog {
     private func isUserCapableOf(_ capability: String) -> Bool {
         return capabilities?[capability] as? Bool ?? false
     }
+
+    public func areBloggingRemindersAllowed() -> Bool {
+        return Feature.enabled(.bloggingReminders) && isUserCapableOf(.EditPosts)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -61,7 +61,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         switch source {
         case .publishFlow:
             return TextContent.postPublishingintroDescription
-        case .blogSettings:
+        case .blogSettings, .notificationSettings:
             return TextContent.siteSettingsIntroDescription
 
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
@@ -30,6 +30,7 @@ class BloggingRemindersTracker {
     enum FlowStartSource: String {
         case publishFlow = "publish_flow"
         case blogSettings = "blog_settings"
+        case notificationSettings = "notification_settings"
     }
 
     enum FlowDismissSource: String {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -194,7 +194,7 @@ extension SiteSettingsViewController {
             rows.append(.timezone)
         }
 
-        if Feature.enabled(.bloggingReminders) && blog.isUserCapableOf(.EditPosts) {
+        if blog.areBloggingRemindersAllowed() {
             rows.append(.bloggingReminders)
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -426,4 +426,3 @@ private struct SettingsSection {
         self.footerText     = footerText
     }
 }
-

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -23,7 +23,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     /// TableView Sections to be rendered
     ///
-    private var sections = [Section]()
+    private var sections = [SettingsSection]()
 
     /// Contains all of the updated Stream Settings
     ///
@@ -98,8 +98,8 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
     private func setupTableView() {
         // Register the cells
-        tableView.register(SwitchTableViewCell.self, forCellReuseIdentifier: Row.Kind.Setting.rawValue)
-        tableView.register(WPTableViewCell.self, forCellReuseIdentifier: Row.Kind.Text.rawValue)
+        tableView.register(SwitchTableViewCell.self, forCellReuseIdentifier: CellKind.Setting.rawValue)
+        tableView.register(WPTableViewCellValue1.self, forCellReuseIdentifier: CellKind.Text.rawValue)
 
         // Hide the separators, whenever the table is empty
         tableView.tableFooterView = UIView()
@@ -122,18 +122,18 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - Private Helpers
-    private func sectionsForSettings(_ settings: NotificationSettings, stream: NotificationSettings.Stream) -> [Section] {
+    private func sectionsForSettings(_ settings: NotificationSettings, stream: NotificationSettings.Stream) -> [SettingsSection] {
         // WordPress.com Channel requires a brief description per row.
         // For that reason, we'll render each row in its own section, with it's very own footer
         let singleSectionMode = settings.channel != .wordPressCom
 
         // Parse the Rows
-        var rows = [Row]()
+        var rows = [SettingsRow]()
 
         for key in settings.sortedPreferenceKeys(stream) {
             let description = settings.localizedDescription(key)
             let value       = stream.preferences?[key] ?? true
-            let row         = Row(kind: .Setting, description: description, key: key, value: value)
+            let row         = SwitchSettingsRow(kind: .Setting, description: description, key: key, value: value)
 
             rows.append(row)
         }
@@ -143,50 +143,57 @@ class NotificationSettingDetailsViewController: UITableViewController {
             // Switch on stream type to provide descriptive text in footer for more context
             switch stream.kind {
             case .Device:
-                return [Section(rows: rows, footerText: NSLocalizedString("Settings for push notifications that appear on your mobile device.", comment: "Descriptive text for the Push Notifications Settings"))]
+                if let blog = settings.blog {
+                    // This should only be added for the device push notifications settings view
+                    rows.append(TextSettingsRow(kind: .Text, description: NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting"), value: schedule(for: blog), onTap: { [weak self] in
+                        self?.presentBloggingRemindersFlow()
+                    }))
+                }
+
+                return [SettingsSection(rows: rows, footerText: NSLocalizedString("Settings for push notifications that appear on your mobile device.", comment: "Descriptive text for the Push Notifications Settings"))]
             case .Email:
-                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that are sent to the email tied to your account.", comment: "Descriptive text for the Email Notifications Settings"))]
+                return [SettingsSection(rows: rows, footerText: NSLocalizedString("Settings for notifications that are sent to the email tied to your account.", comment: "Descriptive text for the Email Notifications Settings"))]
             case .Timeline:
-                return [Section(rows: rows, footerText: NSLocalizedString("Settings for notifications that appear in the Notifications tab.", comment: "Descriptive text for the Notifications Tab Settings"))]
+                return [SettingsSection(rows: rows, footerText: NSLocalizedString("Settings for notifications that appear in the Notifications tab.", comment: "Descriptive text for the Notifications Tab Settings"))]
             }
         }
 
 
         // Multi Section Mode: We'll have one Section per Row
-        var sections = [Section]()
+        var sections = [SettingsSection]()
 
         for row in rows {
             let unwrappedKey    = row.key ?? String()
             let footerText      = settings.localizedDetails(unwrappedKey)
-            let section         = Section(rows: [row], footerText: footerText)
+            let section         = SettingsSection(rows: [row], footerText: footerText)
             sections.append(section)
         }
 
         return sections
     }
 
-    private func sectionsForDisabledDeviceStream() -> [Section] {
+    private func sectionsForDisabledDeviceStream() -> [SettingsSection] {
         let description     = NSLocalizedString("Go to iOS Settings", comment: "Opens WPiOS Settings.app Section")
-        let row             = Row(kind: .Text, description: description, key: nil, value: nil)
+        let row             = TextSettingsRow(kind: .Text, description: description, value: "")
 
         let footerText      = NSLocalizedString("Push Notifications have been turned off in iOS Settings App. " +
                                                 "Toggle \"Allow Notifications\" to turn them back on.",
                                                 comment: "Suggests to enable Push Notification Settings in Settings.app")
-        let section         = Section(rows: [row], footerText: footerText)
+        let section         = SettingsSection(rows: [row], footerText: footerText)
 
         return [section]
     }
 
-    private func sectionsForUnknownDeviceStream() -> [Section] {
+    private func sectionsForUnknownDeviceStream() -> [SettingsSection] {
         defer {
             WPAnalytics.track(.pushNotificationPrimerSeen, withProperties: [Analytics.locationKey: Analytics.alertKey])
         }
         let description     = NSLocalizedString("Allow push notifications", comment: "Shown to the user in settings when they haven't yet allowed or denied push notifications")
-        let row             = Row(kind: .Text, description: description, key: nil, value: nil)
+        let row             = TextSettingsRow(kind: .Text, description: description, value: "")
 
         let footerText      = NSLocalizedString("Allow WordPress to send you push notifications",
                                                 comment: "Suggests the user allow push notifications. Appears within app settings.")
-        let section         = Section(rows: [row], footerText: footerText)
+        let section         = SettingsSection(rows: [row], footerText: footerText)
 
         return [section]
     }
@@ -234,7 +241,13 @@ class NotificationSettingDetailsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectSelectedRowWithAnimation(true)
 
-        if isDeviceStreamDisabled() {
+        let section = sections[indexPath.section]
+
+        if let row = section.rows[indexPath.row] as? TextSettingsRow,
+           let onTap = row.onTap {
+            onTap()
+            return
+        } else if isDeviceStreamDisabled() {
             openApplicationSettings()
         } else if isDeviceStreamUnknown() {
             requestNotificationAuthorization()
@@ -243,12 +256,21 @@ class NotificationSettingDetailsViewController: UITableViewController {
 
 
     // MARK: - UITableView Helpers
-    private func configureTextCell(_ cell: WPTableViewCell, row: Row) {
-        cell.textLabel?.text    = row.description
+    private func configureTextCell(_ cell: WPTableViewCell, row: SettingsRow) {
+        guard let row = row as? TextSettingsRow else {
+            return
+        }
+
+        cell.textLabel?.text       = row.description
+        cell.detailTextLabel?.text = row.value
         WPStyleGuide.configureTableViewCell(cell)
     }
 
-    private func configureSwitchCell(_ cell: SwitchTableViewCell, row: Row) {
+    private func configureSwitchCell(_ cell: SwitchTableViewCell, row: SettingsRow) {
+        guard let row = row as? SwitchSettingsRow else {
+            return
+        }
+
         let settingKey          = row.key ?? String()
 
         cell.name               = row.description
@@ -328,35 +350,25 @@ class NotificationSettingDetailsViewController: UITableViewController {
         alertController.presentFromRootViewController()
     }
 
+    // MARK: - Blogging Reminders
 
-    // MARK: - Private Nested Class'ess
-    private class Section {
-        var rows: [Row]
-        var footerText: String?
+    func presentBloggingRemindersFlow() {
+        guard let blog = settings?.blog else {
+            return
+        }
 
-        init(rows: [Row], footerText: String? = nil) {
-            self.rows           = rows
-            self.footerText     = footerText
+        BloggingRemindersFlow.present(from: self, for: blog, source: .notificationSettings) { [weak self] in
+            self?.reloadTable()
         }
     }
 
-    private class Row {
-        let description: String
-        let kind: Kind
-        let key: String?
-        let value: Bool?
-
-        init(kind: Kind, description: String, key: String? = nil, value: Bool? = nil) {
-            self.description    = description
-            self.kind           = kind
-            self.key            = key
-            self.value          = value
+    private func schedule(for blog: Blog) -> String {
+        guard let scheduler = try? BloggingRemindersScheduler() else {
+            return NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
         }
 
-        enum Kind: String {
-            case Setting        = "SwitchCell"
-            case Text           = "TextCell"
-        }
+        let formatter = BloggingRemindersScheduleFormatter()
+        return formatter.shortScheduleDescription(for: scheduler.schedule(for: blog), time: scheduler.scheduledTime(for: blog).toLocalTime()).string
     }
 
     private struct Analytics {
@@ -364,3 +376,54 @@ class NotificationSettingDetailsViewController: UITableViewController {
         static let alertKey = "settings"
     }
 }
+
+private enum CellKind: String {
+    case Setting        = "SwitchCell"
+    case Text           = "TextCell"
+}
+
+private protocol SettingsRow {
+    var description: String { get }
+    var kind: CellKind { get }
+    var key: String? { get }
+}
+
+private struct SwitchSettingsRow: SettingsRow {
+    let description: String
+    let kind: CellKind
+    let key: String?
+    let value: Bool?
+
+    init(kind: CellKind, description: String, key: String? = nil, value: Bool? = nil) {
+        self.description    = description
+        self.kind           = kind
+        self.key            = key
+        self.value          = value
+    }
+}
+
+private struct TextSettingsRow: SettingsRow {
+    let description: String
+    let kind: CellKind
+    let key: String? = nil
+    let value: String
+    let onTap: (() -> Void)?
+
+    init(kind: CellKind, description: String, value: String, onTap: (() -> Void)? = nil) {
+        self.description    = description
+        self.kind           = kind
+        self.value          = value
+        self.onTap          = onTap
+    }
+}
+
+private struct SettingsSection {
+    var rows: [SettingsRow]
+    var footerText: String?
+
+    init(rows: [SettingsRow], footerText: String? = nil) {
+        self.rows           = rows
+        self.footerText     = footerText
+    }
+}
+


### PR DESCRIPTION
Fixes #17152.

This PR adds blogging reminders to the Push Notifications Settings section of the app. The screen was written with the intention of being driven entirely by a provided settings object, but I've added a special case to handle adding a Blogging Reminders row when necessary. There would likely be cleaner approaches to supporting multiple types of content in this screen, but as it's been so infrequently modified I figured that can be a future job if we ever need to add more things in here.

I also switched out some of the internal classes for structs and added a protocol to make it easier to support the different types.

| No reminders set | Reminders set | Doesn't show up in other settings |
|---|---|---|
| ![Simulator Screen Shot - iPhone 12 - 2021-09-30 at 17 02 30](https://user-images.githubusercontent.com/4780/135496255-cb616c42-e1f3-40f2-b77e-07ed9567575e.png) | ![Simulator Screen Shot - iPhone 12 - 2021-09-30 at 17 17 22](https://user-images.githubusercontent.com/4780/135496568-02326de9-9e55-4b45-8249-6ad4c7af78c8.png) | ![Simulator Screen Shot - iPhone 12 - 2021-09-30 at 16 44 19](https://user-images.githubusercontent.com/4780/135496297-8366dc0c-5600-4a5d-9691-35b8f4b418ea.png) |

### To test

#### Test 1

Site with no blogging reminders set up

- Go to Notifications > Notification Settings, and choose a site from the list at the top that **doesn't** already have blogging reminders set up. Then choose Push Notifications.
- You should see Blogging Reminders at the bottom of the list, with the value of None Set.
- Tap the row, and ensure you can set reminders. Also check that the row is updated after the reminders setting view is dismissed.
- Check in your console that the source for the flow start event is `notification_settings`:

```
2021-09-30 17:48:40:734 WordPress[58411:1720752] 🔵 Tracked: blogging_reminders_flow_start <blog_type: wpcom, source: notification_settings>
```

#### Test 2

Site with blogging reminders set up

- Go to Notifications > Notification Settings, and choose a site from the list at the top that **does** already have blogging reminders set up. Then choose Push Notifications.
- You should see Blogging Reminders at the bottom of the list, with a value showing your current reminder schedule.
- Tap the row, and ensure you can set reminders. Also check that the row is updated after the reminders setting view is dismissed.
- Check in your console that the source for the flow start event is `notification_settings`:

```
2021-09-30 17:48:40:734 WordPress[58411:1720752] 🔵 Tracked: blogging_reminders_flow_start <blog_type: wpcom, source: notification_settings>
```

#### Test 3

Other settings screens

- Go to Notifications > Notification Settings, and navigate into the subscreens of "Comments on other sites" and "Email from WordPress.com" (at the bottom of the list). You should not see Blogging Reminders show up there at all.

## Regression Notes
1. Potential unintended areas of impact

Other settings screens.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I conditionally added the row in one specific situation, and viewed the other settings screens to ensure the row wasn't visible.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
