### PR TITLE
Fix page sharing issues

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -128,9 +128,15 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
                           }
                           if (remotePost) {
                               AbstractPost *post = [self findPostWithID:postID inBlog:blog];
+                              
                               if (!post) {
-                                  post = [self createPostForBlog:blog];
+                                  if ([remotePost.type isEqualToString:PostServiceTypePage]) {
+                                      post = [self createPageForBlog:blog];
+                                  } else {
+                                      post = [self createPostForBlog:blog];
+                                  }
                               }
+                              
                               [self updatePost:post withRemotePost:remotePost];
                               [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 


### PR DESCRIPTION
Fixes an issue with sharing pages to WordPress using the share extension.

Ref: p5T066-2G5-p2#comment-10093

## To test:

1. Start sharing something to WordPress through the Share Extension.
2. Select "Page" as the "Type".
3. Once you hit publish, make sure to quickly send the App you're sharing from to the background.
4. After a bit, open WordPress and make sure the content was shared as a Page.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
