### PR TITLE
Comment Detail: Handle content link clicks

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -16,6 +16,8 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     var likeButtonAction: (() -> Void)? = nil
 
+    var contentLinkTapAction: ((URL) -> Void)? = nil
+
     /// Encapsulate the accessory button image assignment through an enum, to apply a standardized image configuration.
     /// See `accessoryIconConfiguration` in `WPStyleGuide+CommentDetail`.
     var accessoryButtonType: AccessoryButtonType = .share {
@@ -167,13 +169,17 @@ extension CommentContentTableViewCell: WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        // TODO: Offload the decision making to the delegate.
-        // For now, all navigation requests will be rejected (except for loading local files).
         switch navigationAction.navigationType {
         case .other:
+            // allow local file requests.
             decisionHandler(.allow)
         default:
             decisionHandler(.cancel)
+            guard let destinationURL = navigationAction.request.url,
+                  let linkTapAction = contentLinkTapAction else {
+                      return
+                  }
+            linkTapAction(destinationURL)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -103,9 +103,8 @@ class CommentDetailViewController: UITableViewController {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
                 return .init()
             }
-            cell.configure(with: comment) { _ in
-                self.tableView.performBatchUpdates({})
-            }
+
+            configureContentCell(cell, comment: comment)
             return cell
 
         case .replyIndicator:
@@ -213,6 +212,18 @@ private extension CommentDetailViewController {
 
         headerCell.textLabel?.text = .postCommentTitleText
         headerCell.detailTextLabel?.text = comment.titleForDisplay()
+    }
+
+    func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
+        cell.configure(with: comment) { _ in
+            self.tableView.performBatchUpdates({})
+        }
+
+        cell.contentLinkTapAction = { url in
+            // open all tapped links in web view.
+            // TODO: Explore reusing URL handling logic from ReaderDetailCoordinator.
+            self.openWebView(for: url)
+        }
     }
 
     func configuredTextCell(for row: RowType) -> UITableViewCell {


### PR DESCRIPTION
Refs #17108

All links tapped in the new Comment Detail's content should now be displayed in a web view[^1]. 

[^1]: Maybe it's worth exploring whether the URL handling logic in the `ReaderDetailCoordinator` can be reused since it already contains some logic that filters the URL and shows the content natively when possible. The only blocker is that the `ReaderDetailCoordinator` is tightly coupled with `ReaderDetailViewController` (... of course! 😄 ) and the `init` method requires an object that conforms to `ReaderDetailView` protocol, which methods doesn't apply to the Comment Detail.

## To test

- Ensure that the `New Comment Detail` feature flag is enabled.
- Go to My Site > Comments.
- Select any comment that has one or more links in the content.
- Tap the link.
- Verify that the link contents are shown in a web view.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
