### PR TITLE
Comment Detail: Adjust comment content for RTL layout

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -220,10 +220,12 @@ private extension CommentContentTableViewCell {
         replyButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         replyButton?.setImage(Style.replyIconImage, for: .normal)
         replyButton?.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
+        replyButton?.flipInsetsForRightToLeftLayoutDirection()
 
         likeButton?.titleLabel?.font = Style.reactionButtonFont
         likeButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         likeButton?.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
+        likeButton?.flipInsetsForRightToLeftLayoutDirection()
         updateLikeButton(liked: false, numberOfLikes: 0)
     }
 

--- a/WordPress/Resources/HTML/richCommentTemplate.html
+++ b/WordPress/Resources/HTML/richCommentTemplate.html
@@ -1,4 +1,4 @@
-<html>
+<html dir="auto">
 <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, shrink-to-fit=NO" />
     <link rel="stylesheet" type="text/css" href="richCommentStyle.css">


### PR DESCRIPTION
Refs #17108

This PR adds some minor changes for RTL support on comment content:
- Content direction is determined by the content. Contents with LTR languages (e.g. English) will be displayed in LTR, and contents with RTL languages (e.g. Arabic) will be displayed in RTL regardless of current UI layout direction.
- Insets for the Reply and Like button is adjusted based on layout direction. Previously, the distance between the button's icon and text was too close in RTL.

## To test

Ensure that the `New Comment Detail` feature flag is enabled.

### Scenario 1: Device is in LTR language

- Set device language to English or any LTR language.
- Go to My Site > Comments.
- Select a comment that contains content in RTL language.
- Verify that only the content is displayed right-to-left.
- Go back, and select a comment that contains content in LTR language.
- Verify that the content is displayed left-to-right.

### Scenario 2: Device is in RTL language

- Set the device language to Arabic or any RTL language.
- Go to My Site > Comments.
- Select a comment that contains content in LTR language.
- Verify that only the content is displayed left-to-right.
- Go back, and select a comment that contains content in RTL language.
- Verify that the content is displayed right-to-left.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
