### PR TITLE
Comment Moderation Bar: set button states when one is selected

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -159,7 +159,7 @@ extension Comment: PostContentProvider {
         }
     }
 
-    static func typeForStatus(_ status: String) -> CommentStatusType? {
+    static func typeForStatus(_ status: String?) -> CommentStatusType? {
         switch status {
         case "hold":
             return .pending

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -41,7 +41,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var likeButton: UIButton!
 
     // This is public so its delegate can be set directly.
-    @IBOutlet weak var moderationBar: CommentModerationBar!
+    @IBOutlet private(set) weak var moderationBar: CommentModerationBar!
 
     // MARK: Private Properties
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -40,7 +40,8 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var replyButton: UIButton!
     @IBOutlet private weak var likeButton: UIButton!
 
-    @IBOutlet private weak var moderationBar: CommentModerationBar!
+    // This is public so its delegate can be set directly.
+    @IBOutlet weak var moderationBar: CommentModerationBar!
 
     // MARK: Private Properties
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -130,6 +130,7 @@ class CommentDetailViewController: UITableViewController {
             }
 
             configureContentCell(cell, comment: comment)
+            cell.moderationBar.delegate = self
             return cell
 
         case .replyIndicator:
@@ -385,4 +386,19 @@ private extension String {
     static let webAddressLabelText = NSLocalizedString("Web address", comment: "Describes the web address section in the comment detail screen.")
     static let emailAddressLabelText = NSLocalizedString("Email address", comment: "Describes the email address section in the comment detail screen.")
     static let ipAddressLabelText = NSLocalizedString("IP address", comment: "Describes the IP address section in the comment detail screen.")
+}
+
+
+// MARK: - CommentModerationBarDelegate
+
+extension CommentDetailViewController: CommentModerationBarDelegate {
+    func statusChangedTo(_ commentStatus: CommentStatusType) {
+
+        // TODO: update Comment
+
+        switch commentStatus {
+        default:
+            break
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -281,7 +281,7 @@ private extension UIButton {
         layer.shadowOffset = Style.buttonShadowOffset
         layer.shadowOpacity = Style.buttonShadowOpacity
         layer.shadowRadius = Style.buttonShadowRadius
-        
+
         isExclusiveTouch = true
 
         verticallyAlignImageAndText()

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -281,6 +281,8 @@ private extension UIButton {
         layer.shadowOffset = Style.buttonShadowOffset
         layer.shadowOpacity = Style.buttonShadowOpacity
         layer.shadowRadius = Style.buttonShadowRadius
+        
+        isExclusiveTouch = true
 
         verticallyAlignImageAndText()
         flipInsetsForRightToLeftLayoutDirection()

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -1,5 +1,9 @@
 import UIKit
 
+protocol CommentModerationBarDelegate: AnyObject {
+    func statusChangedTo(_ commentStatus: CommentStatusType)
+}
+
 private typealias Style = WPStyleGuide.CommentDetail.ModerationBar
 
 class CommentModerationBar: UIView {
@@ -30,6 +34,7 @@ class CommentModerationBar: UIView {
     private let iPadPaddingMultiplier: CGFloat = 0.33
     private let iPhonePaddingMultiplier: CGFloat = 0.15
 
+    weak var delegate: CommentModerationBarDelegate?
     // MARK: - Init
 
     required init?(coder aDecoder: NSCoder) {


### PR DESCRIPTION
Ref: #17200

When a button on the moderation bar is selected:
- The previously selected button is reset.
- Only one button can be selected at a time.
- Re-selecting the active button does nothing.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment in each of the filters  `Pending`, `Approved`, `Spam`, `Trashed`.
  - Verify the correct moderation bar button is selected.
- Tap other buttons.
  - Verify the tapped buttons are selected, and the other buttons are not.
  - Verify tapping a selected button does nothing.

https://user-images.githubusercontent.com/1816888/135928290-a5d48992-e7e2-47ec-85cc-a91d548fdd3f.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
