### PR TITLE
Empty Stats: Add view count threshold for Grow Audience card display logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -184,6 +184,7 @@ private extension SiteStatsInsightsTableViewController {
         }
 
         insightsChangeReceipt = viewModel?.onChange { [weak self] in
+            self?.refreshGrowAudienceCardIfNecessary()
             self?.displayEmptyViewIfNecessary()
             self?.refreshTableView()
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -146,8 +146,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
-        loadInsightsFromUserDefaults()
         initViewModel()
+        loadInsightsFromUserDefaults()
+        updateView()
         tableView.estimatedRowHeight = 500
 
         displayEmptyViewIfNecessary()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -342,6 +342,10 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Grow Audience Card Management
 
     func loadGrowAudienceCardSetting() {
+        guard shouldDisplayGrowAudienceCard else {
+            dismissGrowAudienceCard()
+            return
+        }
         guard let key = userDefaultsHideGrowAudienceKey else { return }
         loadPermanentlyDismissableInsight(.growAudience, using: key)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -146,9 +146,8 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         WPStyleGuide.Stats.configureTable(tableView)
         refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
-        initViewModel()
         loadInsightsFromUserDefaults()
-        updateView()
+        initViewModel()
         tableView.estimatedRowHeight = 500
 
         displayEmptyViewIfNecessary()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -108,6 +108,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         return key + "-\(siteID)"
     }
 
+    // Local state for site current view count
+    private var currentViewCount: Int?
+
     // Store Insights settings for all sites.
     // Used when writing to/reading from User Defaults.
     // A single site's dictionary contains the InsightType values for that site.
@@ -360,6 +363,18 @@ private extension SiteStatsInsightsTableViewController {
         let insightsStore = StoreContainer.shared.statsInsights
         let count = insightsStore.getAllTimeStats()?.viewsCount ?? 0
         return count < threshold
+    }
+
+    func refreshGrowAudienceCardIfNecessary() {
+        let insightsStore = StoreContainer.shared.statsInsights
+        guard let count = insightsStore.getAllTimeStats()?.viewsCount,
+              count != self.currentViewCount else {
+                  return
+              }
+
+        self.currentViewCount = count
+        self.loadInsightsFromUserDefaults()
+        self.updateView()
     }
 
     // MARK: - Insights Management

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -351,6 +351,13 @@ private extension SiteStatsInsightsTableViewController {
         permanentlyDismissInsight(.growAudience, using: key)
     }
 
+    var shouldDisplayGrowAudienceCard: Bool {
+        let threshold = 30
+        let insightsStore = StoreContainer.shared.statsInsights
+        let count = insightsStore.getAllTimeStats()?.viewsCount ?? 0
+        return count < threshold
+    }
+
     // MARK: - Insights Management
 
     func showAddInsightView() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -111,6 +111,8 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     // Local state for site current view count
     private var currentViewCount: Int?
 
+    private let insightsStore = StoreContainer.shared.statsInsights
+
     // Store Insights settings for all sites.
     // Used when writing to/reading from User Defaults.
     // A single site's dictionary contains the InsightType values for that site.
@@ -173,7 +175,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
 private extension SiteStatsInsightsTableViewController {
 
     func initViewModel() {
-        viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow, insightsDelegate: self)
+        viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow,
+                                               insightsDelegate: self,
+                                               insightsStore: insightsStore)
         addViewModelListeners()
         viewModel?.fetchInsights()
     }
@@ -361,13 +365,11 @@ private extension SiteStatsInsightsTableViewController {
 
     var shouldDisplayGrowAudienceCard: Bool {
         let threshold = 30
-        let insightsStore = StoreContainer.shared.statsInsights
         let count = insightsStore.getAllTimeStats()?.viewsCount ?? 0
         return count < threshold
     }
 
     func refreshGrowAudienceCardIfNecessary() {
-        let insightsStore = StoreContainer.shared.statsInsights
         guard let count = insightsStore.getAllTimeStats()?.viewsCount,
               count != self.currentViewCount else {
                   return

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -11,7 +11,7 @@ class SiteStatsInsightsViewModel: Observable {
 
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
 
-    private let insightsStore = StoreContainer.shared.statsInsights
+    private let insightsStore: StatsInsightsStore
     private var insightsReceipt: Receipt?
     private var insightsChangeReceipt: Receipt?
     private var insightsToShow = [InsightType]()
@@ -23,11 +23,13 @@ class SiteStatsInsightsViewModel: Observable {
     // MARK: - Constructor
 
     init(insightsToShow: [InsightType],
-         insightsDelegate: SiteStatsInsightsDelegate) {
+         insightsDelegate: SiteStatsInsightsDelegate,
+         insightsStore: StatsInsightsStore) {
         self.siteStatsInsightsDelegate = insightsDelegate
         self.insightsToShow = insightsToShow
+        self.insightsStore = insightsStore
 
-        insightsChangeReceipt = insightsStore.onChange { [weak self] in
+        insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
             self?.emitChange()
         }
     }


### PR DESCRIPTION
Part of [#17215](https://github.com/wordpress-mobile/WordPress-iOS/issues/17215)

This PR adds a logic for displaying Grow Audience card if the view count is less than 30.

## To test
1. Delete the app and reinstall it (to delete the cache).
2. Log in
3. Go to **My Site** > **Stats**
4. Make sure the **Grow Audience** card is displayed only if the view count is less than 30
5. Go back, and go to stats again (for the same site)
6. Double check the displayed state of the card is the same as before.

### Note
Because of the data loading mechanism, by checking the newly fetched site, going back, and checking it again, we ensure the consistency between displaying sites from cache and the newly fetched ones.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
