### PR TITLE
Display editor help button for all users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [**] Embed block: Add the top 5 specific embed blocks to the Block inserter list. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3995]
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
+* [**] Block editor: Support articles available within the block editor help menu [#17265]
 
 18.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * [**] Embed block: Add the top 5 specific embed blocks to the Block inserter list. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3995]
 * [*] Embed block: Fix URL update when edited after setting a bad URL of a provider. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4002]
 * [**] Users can now contact support from inside the block editor screen. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3975]
-* [**] Block editor: Support articles available within the block editor help menu [#17265]
+* [**] Block editor: Help menu with guides about how to work with blocks [#17265]
 
 18.3
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -68,11 +68,9 @@ extension GutenbergViewController {
             ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
-        if canViewEditorOnboarding() {
-            alert.addDefaultActionWithTitle(MoreSheetAlert.editorHelpTitle) { [weak self] _ in
-                self?.showEditorHelp()
-                ActionDispatcher.dispatch(NoticeAction.unlock)
-            }
+        alert.addDefaultActionWithTitle(MoreSheetAlert.editorHelpTitle) { [weak self] _ in
+            self?.showEditorHelp()
+            ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
         if #available(iOS 14.0, *),


### PR DESCRIPTION
## Description

We decided to enable the help section for all users, which includes a list of support articles and the ability to open a support ticket from #17175. 

## Testing

For the installable build:
1. Remove any previous WPiOS app installations and install the build from this PR. 
1. Launch the block editor. 
2. Tap the three-dot menu in the top-right corner of the editor. 
3. Tap "Help & Support." 
4. ℹ️ **Expected:** The list of support articles are displayed alongside the "contact support" button. 

For a local development build: 
1. Remove any previous WPiOS app installations and build to device from this branch. 
1. Apply the following patch for the branch locally disabling automatic cohort inclusion for development builds. 
    ```diff
    diff --git a/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift b/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
    index f9733bf7ba..b4c2a325a6 100644
    --- a/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
    +++ b/WordPress/Classes/Utility/Editor/GutenbergOnboardingRollout.swift
    @@ -1,10 +1,10 @@
    /// This structs helps encapsulate logic related to Gutenberg editor onboarding rollout phases.
    ///
    struct GutenbergOnboardingRollout {
    -    private let phasePercentage = 50
    +    private let phasePercentage = 0
    
        func isRolloutIdInPhaseRolloutPercentage(_ uniqueRolloutId: Int) -> Bool {
    -        return convertRolloutIdToRank(uniqueRolloutId: String(uniqueRolloutId)) >= (100 - phasePercentage) || BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
    +        return convertRolloutIdToRank(uniqueRolloutId: String(uniqueRolloutId)) >= (100 - phasePercentage)
        }
    
        func convertRolloutIdToRank(uniqueRolloutId: String) -> Int {

    ```
1. Launch the block editor. 
2. Open the block inserter. 
3. ℹ️ **Expected:** There are no ["new" block sparkle badges](https://github.com/WordPress/gutenberg/pull/33119) on any block button.<sup>1</sup>  
2. Tap the three-dot menu in the top-right corner of the editor. 
3. Tap "Help & Support." 
4. ℹ️ **Expected:** The list of support articles are displayed alongside the "contact support" button. 

[1]: The "new" block badges will not be present due to patch applied. 

## Regression Notes
1. Potential unintended areas of impact
    The single line removal hopefully minimizes the possibility that any other items in the menu are effected. 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Navigated to each of the items in the menu. 
3. What automated tests I added (or what prevented me from doing so)
    Out of scope for this minimal PR to unblock shipping #17175. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.