### PR TITLE
Comment Moderation Bar: update comment when Approved button tapped.

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -859,7 +859,8 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                         if (success) {
                             success();
                         }
-                    } failure:^(NSError *error) {                        
+                    } failure:^(NSError *error) {
+                        DDLogError(@"Error moderating comment: %@", error);
                         [self.managedObjectContext performBlock:^{
                             // Note: The comment might have been deleted at this point
                             Comment *commentInContext = (Comment *)[self.managedObjectContext existingObjectWithID:commentID error:nil];

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -135,7 +135,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isModerationEnabled = comment.canModerate
 
         if isModerationEnabled {
-            moderationBar.comment = comment
+            moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)
         }
 
         // Configure comment content.

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -30,18 +30,12 @@ class CommentModerationBar: UIView {
 
     weak var delegate: CommentModerationBarDelegate?
 
-    var comment: Comment? {
+    var commentStatus: CommentStatusType? {
         didSet {
-            currentStatus = CommentStatusType.typeForStatus(comment?.status)
-        }
-    }
-
-    private var currentStatus: CommentStatusType? {
-        didSet {
-            if oldValue != currentStatus {
+            if oldValue != commentStatus {
                 toggleButtonForStatus(oldValue)
             }
-            toggleButtonForStatus(currentStatus)
+            toggleButtonForStatus(commentStatus)
         }
     }
 
@@ -209,9 +203,10 @@ private extension CommentModerationBar {
     }
 
     func updateStatusTo(_ status: CommentStatusType) {
-        // Don't change the comment.status. It is needed to fallback to if the update fails.
-        currentStatus = status
-        delegate?.statusChangedTo(status)
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            commentStatus = status
+            delegate?.statusChangedTo(status)
+        }
     }
 
 }


### PR DESCRIPTION
Ref: #17200 

When the `Approved` button is tapped on the moderation bar, the comment status is now updated.
- A success message appears when successful.
- When unsuccessful, a failure message appears and the button states are reset.
- A `No Connection` alert is displayed if there is no internet connection.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment that is _not_ approved.
- Select `Approved` on the moderation bar.
- Verify a success message is displayed.
- Go back to the comments list, and select the Approved filter.
- Verify the comment appears in the list.



https://user-images.githubusercontent.com/1816888/136121229-97929cc7-5c6d-473b-b26f-2cff767c5578.mp4


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
