### PR TITLE
Comment Detail: Add functionality to the share button

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -10,7 +10,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: - Public Properties
 
-    var accessoryButtonAction: (() -> Void)? = nil
+    /// A closure that's called when the accessory button is tapped.
+    /// The button's view is sent as the closure's parameter for reference.
+    var accessoryButtonAction: ((UIView) -> Void)? = nil
 
     var replyButtonAction: (() -> Void)? = nil
 
@@ -313,7 +315,7 @@ private extension CommentContentTableViewCell {
     }
 
     @objc func accessoryButtonTapped() {
-        accessoryButtonAction?()
+        accessoryButtonAction?(accessoryButton)
     }
 
     @objc func replyButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -256,6 +256,10 @@ private extension CommentDetailViewController {
             // TODO: Explore reusing URL handling logic from ReaderDetailCoordinator.
             self.openWebView(for: url)
         }
+
+        cell.accessoryButtonAction = { senderView in
+            self.shareCommentURL(senderView)
+        }
     }
 
     func configuredTextCell(for row: RowType) -> UITableViewCell {
@@ -364,6 +368,16 @@ private extension CommentDetailViewController {
         }
 
         openWebView(for: authorURL)
+    }
+
+    func shareCommentURL(_ senderView: UIView) {
+        guard let commentURL = comment.commentURL() else {
+            return
+        }
+
+        let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = senderView
+        present(activityViewController, animated: true, completion: nil)
     }
 
 }


### PR DESCRIPTION
Refs #17108 

Adds functionality to the share button when tapped; which should present a share sheet for the comment URL.

## To test

- Make sure that the `New Comment Detail` is enabled.
- Also, make sure that you're on a site where you have moderation capabilities (Admin or Editor).
- Go to My Site > Comments.
- Select any comment.
- Tap on the share button (on the top right side of the comment content cell).
- Verify that the share sheet appears, and the comment URL is correct.

Extra: Repeat the flow on an iPad, and verify that the share sheet pops up based on the share button.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
