### PR TITLE
Domain search design tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsTableViewController.swift
@@ -10,15 +10,7 @@ class RegisterDomainSuggestionsTableViewController: DomainSuggestionsTableViewCo
     override open var useFadedColorForParentDomains: Bool {
         return false
     }
-    override open var sectionTitle: String {
-        return ""
-    }
-    override open var sectionDescription: String {
-        return NSLocalizedString(
-            "Pick an available address",
-            comment: "Register domain - Suggested Domain description for the screen"
-        )
-    }
+
     override open var searchFieldPlaceholder: String {
         return NSLocalizedString(
             "Type to get more suggestions",

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -290,9 +290,9 @@ extension RegisterDomainSuggestionsViewController {
 
     enum TextContent {
 
-        static let title = NSLocalizedString("Register domain",
-                                             comment: "Register domain - Title for the Suggested domains screen")
-        static let primaryButtonTitle = NSLocalizedString("Choose domain",
+        static let title = NSLocalizedString("Search domains",
+                                             comment: "Search domain - Title for the Suggested domains screen")
+        static let primaryButtonTitle = NSLocalizedString("Select domain",
                                                           comment: "Register domain - Title for the Choose domain button of Suggested domains screen")
         static let supportButtonTitle = NSLocalizedString("Help", comment: "Help button")
     }

--- a/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/DomainSuggestionsTableViewController.swift
@@ -180,8 +180,9 @@ extension DomainSuggestionsTableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         switch section {
-        case Sections.titleAndDescription.rawValue,
-             Sections.searchField.rawValue:
+        case Sections.titleAndDescription.rawValue:
+            return !sectionTitle.isEmpty || !sectionDescription.isEmpty ? 1 : 0
+        case Sections.searchField.rawValue:
             return 1
         case Sections.suggestions.rawValue:
             if noSuggestions == true {
@@ -244,6 +245,22 @@ extension DomainSuggestionsTableViewController {
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
         if section == Sections.suggestions.rawValue {
             return 0.5
+        }
+        return 0
+    }
+
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        if section == Sections.searchField.rawValue {
+            let header = UIView()
+            header.backgroundColor = tableView.backgroundColor
+            return header
+        }
+        return nil
+    }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if section == Sections.searchField.rawValue {
+            return 10
         }
         return 0
     }


### PR DESCRIPTION
A couple of small design tweaks to bring domain search closer to our intended designs. I renamed the search screen and 'select domain' button, and removed the top prompt text.

| Before | After | Design |
|---|---|---|
| ![Simulator Screen Shot - iPhone 12 mini - 2021-10-06 at 17 46 49](https://user-images.githubusercontent.com/4780/136247999-ba85b135-8455-4cc3-a5d1-9149ae436934.png) | ![Simulator Screen Shot - iPhone 12 mini - 2021-10-06 at 17 30 22](https://user-images.githubusercontent.com/4780/136247057-b6dfe56c-cad7-4f10-b288-cd6abb7d9623.png) | ![](https://user-images.githubusercontent.com/4780/136247085-cc6a659c-ad4e-4620-bdef-acae3693c020.png) | 

Note that the padding above and below the search cell doesn't exactly match the designs right now, but this is defined in the search cell's xib in authenticator and I didn't want to potentially mess up any other screens. For now, I've made the top padding match the existing bottom padding.

**To test:**

- Build and run and navigate to Domain search. Check it looks as in the screenshots above.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
