### PR TITLE
Comment Detail: Add functionality for the Like button

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -343,6 +343,11 @@ private extension CommentContentTableViewCell {
         }
 
         isLikeButtonAnimating = true
+
+        if isLiked {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+
         animateLikeButton {
             onAnimationComplete()
             self.isLikeButtonAnimating = false

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -354,7 +354,7 @@ private extension CommentContentTableViewCell {
         }
     }
 
-    /// Animates the Like button state change, as seen in `NoteBlockActionsTableViewCell`.
+    /// Animates the Like button state change.
     func animateLikeButton(completion: @escaping () -> Void) {
         guard let buttonImageView = likeButton.imageView,
               let overlayImage = Style.likedIconImage?.withTintColor(Style.likedTintColor) else {
@@ -366,9 +366,7 @@ private extension CommentContentTableViewCell {
         overlayImageView.frame = likeButton.convert(buttonImageView.bounds, from: buttonImageView)
         likeButton.addSubview(overlayImageView)
 
-        // isLiked has been updated.
         let animation = isLiked ? overlayImageView.fadeInWithRotationAnimation : overlayImageView.fadeOutWithRotationAnimation
-
         animation { _ in
             overlayImageView.removeFromSuperview()
             completion()

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -71,6 +71,14 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     /// Caches the HTML content, to be reused when the orientation changed.
     private var htmlContentCache: String? = nil
 
+    // MARK: Like Button State
+
+    private var isLiked: Bool = false
+
+    private var likeCount: Int = 0
+
+    private var isLikeButtonAnimating: Bool = false
+
     // MARK: Visibility Control
 
     /// Controls the visibility of the reaction bar view. Setting this to false disables Reply and Likes functionality.
@@ -205,6 +213,17 @@ private extension CommentContentTableViewCell {
         }
     }
 
+    var likeButtonTitle: String {
+        switch likeCount {
+        case .zero:
+            return .noLikes
+        case 1:
+            return String(format: .singularLikeFormat, likeCount)
+        default:
+            return String(format: .pluralLikesFormat, likeCount)
+        }
+    }
+
     // assign base styles for all the cell components.
     func configureViews() {
         selectionStyle = .none
@@ -297,21 +316,58 @@ private extension CommentContentTableViewCell {
         return htmlContent
     }
 
-    func likeButtonTitle(for numberOfLikes: Int) -> String {
-        switch numberOfLikes {
-        case .zero:
-            return .noLikes
-        case 1:
-            return String(format: .singularLikeFormat, numberOfLikes)
-        default:
-            return String(format: .pluralLikesFormat, numberOfLikes)
+    /// Updates the style and text of the Like button.
+    /// - Parameters:
+    ///   - liked: Represents the target state – true if the comment is liked, or should be false otherwise.
+    ///   - numberOfLikes: The number of likes to be displayed.
+    ///   - animated: Whether the Like button state change should be animated or not. Defaults to false.
+    ///   - completion: Completion block called once the animation is completed. Defaults to nil.
+    func updateLikeButton(liked: Bool, numberOfLikes: Int, animated: Bool = false, completion: (() -> Void)? = nil) {
+        guard !isLikeButtonAnimating else {
+            return
+        }
+
+        isLiked = liked
+        likeCount = numberOfLikes
+
+        let onAnimationComplete = {
+            self.likeButton.tintColor = liked ? Style.likedTintColor : Style.buttonTintColor
+            self.likeButton.setImage(liked ? Style.likedIconImage : Style.unlikedIconImage, for: .normal)
+            self.likeButton.setTitle(self.likeButtonTitle, for: .normal)
+            completion?()
+        }
+
+        guard animated else {
+            onAnimationComplete()
+            return
+        }
+
+        isLikeButtonAnimating = true
+        animateLikeButton {
+            onAnimationComplete()
+            self.isLikeButtonAnimating = false
         }
     }
 
-    func updateLikeButton(liked: Bool, numberOfLikes: Int) {
-        likeButton.tintColor = liked ? Style.likedTintColor : Style.buttonTintColor
-        likeButton.setImage(liked ? Style.likedIconImage : Style.unlikedIconImage, for: .normal)
-        likeButton.setTitle(likeButtonTitle(for: numberOfLikes), for: .normal)
+    /// Animates the Like button state change, as seen in `NoteBlockActionsTableViewCell`.
+    func animateLikeButton(completion: @escaping () -> Void) {
+        guard let buttonImageView = likeButton.imageView,
+              let overlayImage = Style.likedIconImage?.withTintColor(Style.likedTintColor) else {
+                  completion()
+                  return
+              }
+
+        let overlayImageView = UIImageView(image: overlayImage)
+        overlayImageView.frame = likeButton.convert(buttonImageView.bounds, from: buttonImageView)
+        likeButton.addSubview(overlayImageView)
+
+        // isLiked has been updated.
+        let animation = isLiked ? overlayImageView.fadeInWithRotationAnimation : overlayImageView.fadeOutWithRotationAnimation
+
+        animation { _ in
+            overlayImageView.removeFromSuperview()
+            completion()
+        }
     }
 
     @objc func accessoryButtonTapped() {
@@ -323,7 +379,11 @@ private extension CommentContentTableViewCell {
     }
 
     @objc func likeButtonTapped() {
-        likeButtonAction?()
+        ReachabilityUtils.onAvailableInternetConnectionDo {
+            updateLikeButton(liked: !isLiked, numberOfLikes: isLiked ? likeCount - 1 : likeCount + 1, animated: true) {
+                self.likeButtonAction?()
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -374,7 +374,6 @@ private extension CommentDetailViewController {
 
         if comment.isLiked {
             CommentAnalytics.trackCommentUnLiked(comment: comment)
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
         } else {
             CommentAnalytics.trackCommentLiked(comment: comment)
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -260,6 +260,10 @@ private extension CommentDetailViewController {
         cell.accessoryButtonAction = { senderView in
             self.shareCommentURL(senderView)
         }
+
+        cell.likeButtonAction = {
+            self.toggleCommentLike()
+        }
     }
 
     func configuredTextCell(for row: RowType) -> UITableViewCell {
@@ -360,6 +364,19 @@ private extension CommentDetailViewController {
                                                                         comment: "Error displayed if a comment fails to get updated")
                                         self?.displayNotice(title: message)
                                      })
+    }
+
+    func toggleCommentLike() {
+        if comment.isLiked {
+            CommentAnalytics.trackCommentUnLiked(comment: comment)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        } else {
+            CommentAnalytics.trackCommentLiked(comment: comment)
+        }
+
+        commentService.toggleLikeStatus(for: comment, siteID: comment.blog?.dotComID, success: {}, failure: { _ in
+            self.refreshData()
+        })
     }
 
     func visitAuthorURL() {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -367,6 +367,11 @@ private extension CommentDetailViewController {
     }
 
     func toggleCommentLike() {
+        guard let siteID = comment.blog?.dotComID else {
+            refreshData() // revert the like button state.
+            return
+        }
+
         if comment.isLiked {
             CommentAnalytics.trackCommentUnLiked(comment: comment)
             UINotificationFeedbackGenerator().notificationOccurred(.success)
@@ -374,8 +379,8 @@ private extension CommentDetailViewController {
             CommentAnalytics.trackCommentLiked(comment: comment)
         }
 
-        commentService.toggleLikeStatus(for: comment, siteID: comment.blog?.dotComID, success: {}, failure: { _ in
-            self.refreshData()
+        commentService.toggleLikeStatus(for: comment, siteID: siteID, success: {}, failure: { _ in
+            self.refreshData() // revert the like button state.
         })
     }
 


### PR DESCRIPTION
Refs #17108 
Depends on #17269. Please review this one first. 🙂 

As titled, this adds functionality for the Like button. I've also ported the Like button animation from the previous implementation.

## To test

Ensure that the `New Comment Detail` is enabled.

### Scenario 1: Normal flow

- Go to My Site > Comments.
- Select any comment (preferably comments for testing purposes 😬 ).
- Press the Like button.
- Verify that the animation shows correctly.
- Verify that the Like button is recorded on the backend correctly (verify the like state on the web).
- Verify that the event is tracked successfully.

Testing the unlike flow:
- Press the Like button again.
- Verify that the unlike animation is shown correctly.
- Verify that the unlike action is reflected correctly (verify the like state on the web).
- Verify that the event is tracked successfully.

### Scenario 2: Failed network request flow

- Set your network connection to a very slow mode (e.g. using a Network Link Conditioner).
- Select any comment.
- Tap on the Like button.
- Disable your connection while the network request is ongoing.
- Verify that after the like state is updated, it gets reverted back to the original state since the post request failed.

### Scenario 3: Disabled connection flow

- Turn off your connection / enable airplane mode.
- Select any comment.
- Press the Like button.
- Verify that the state is not changed.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
