### PR TITLE
Comment Moderation Bar: update comment when Pending button tapped.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -398,6 +398,8 @@ extension CommentDetailViewController: CommentModerationBarDelegate {
     func statusChangedTo(_ commentStatus: CommentStatusType) {
 
         switch commentStatus {
+        case .pending:
+            unapproveComment()
         case .approved:
             approveComment()
         default:
@@ -409,6 +411,17 @@ extension CommentDetailViewController: CommentModerationBarDelegate {
 // MARK: - Comment Moderation Actions
 
 private extension CommentDetailViewController {
+
+    func unapproveComment() {
+        CommentAnalytics.trackCommentUnApproved(comment: comment)
+
+        commentService.unapproveComment(comment, success: { [weak self] in
+            self?.displayNotice(title: ModerationMessages.pendingSuccess)
+        }, failure: { [weak self] error in
+            self?.displayNotice(title: ModerationMessages.pendingFail)
+            self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
+        })
+    }
 
     func approveComment() {
         CommentAnalytics.trackCommentApproved(comment: comment)
@@ -422,6 +435,8 @@ private extension CommentDetailViewController {
     }
 
     struct ModerationMessages {
+        static let pendingSuccess = NSLocalizedString("Comment set to pending.", comment: "Message displayed when pending a comment succeeds.")
+        static let pendingFail = NSLocalizedString("Error setting comment to pending.", comment: "Message displayed when pending a comment fails.")
         static let approveSuccess = NSLocalizedString("Comment approved.", comment: "Message displayed when approving a comment succeeds.")
         static let approveFail = NSLocalizedString("Error approving comment.", comment: "Message displayed when approving a comment fails.")
     }


### PR DESCRIPTION
Ref: #17200 

When the `Pending` button is tapped on the moderation bar, the comment status is now updated.
- A success message appears when successful.
- When unsuccessful, a failure message appears and the button states are reset.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment that is _not_ pending.
- Select `Pending` on the moderation bar.
- Verify a success message is displayed.
- Go back to the comments list, and select the Pending filter.
- Verify the comment appears in the list.

https://user-images.githubusercontent.com/1816888/136300486-97ebd6a5-7102-488c-9be2-d4603fe22400.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
