### PR TITLE
Temporarily remove aggregate target for credentials codegen in Jetpack

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4491,13 +4491,6 @@
 			remoteGlobalIDString = 096A92F526E29FFF00448C68;
 			remoteInfo = GenerateCredentials;
 		};
-		096A92FE26E2A0C000448C68 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 096A92F526E29FFF00448C68;
-			remoteInfo = GenerateCredentials;
-		};
 		3F526C5A2538CF2B0069706C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
@@ -14959,6 +14952,7 @@
 			buildConfigurationList = FABB264D2602FC2C00C8785C /* Build configuration list for PBXNativeTarget "Jetpack" */;
 			buildPhases = (
 				FABB1FA72602FC2C00C8785C /* [CP] Check Pods Manifest.lock */,
+				3F32E4AE270EAF5100A33D51 /* Generate Credentials */,
 				FABB1FA92602FC2C00C8785C /* App Icons: Add Version For Internal Releases */,
 				FABB1FAA2602FC2C00C8785C /* Resources */,
 				FABB20C12602FC2C00C8785C /* Copy Alternate Internal Icons (if needed) */,
@@ -14972,7 +14966,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				096A92FF26E2A0C000448C68 /* PBXTargetDependency */,
 				FABB1F902602FC2C00C8785C /* PBXTargetDependency */,
 			);
 			name = Jetpack;
@@ -16191,6 +16184,26 @@
 			shellPath = /bin/sh;
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WordPressThisWeekWidget/Pods-WordPressThisWeekWidget-resources.sh\"\n";
 			showEnvVarsInLog = 0;
+		};
+		3F32E4AE270EAF5100A33D51 /* Generate Credentials */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"$(SRCROOT)/../Scripts/BuildPhases/GenerateCredentials.xcfilelist",
+			);
+			inputPaths = (
+			);
+			name = "Generate Credentials";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(BUILD_DIR)/Secrets/Secrets.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "$SRCROOT/../Scripts/BuildPhases/GenerateCredentials.sh\n";
 		};
 		4CB8AA817C9BD74F3416B27C /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -20704,11 +20717,6 @@
 			isa = PBXTargetDependency;
 			target = 096A92F526E29FFF00448C68 /* GenerateCredentials */;
 			targetProxy = 096A92FC26E2A0AE00448C68 /* PBXContainerItemProxy */;
-		};
-		096A92FF26E2A0C000448C68 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 096A92F526E29FFF00448C68 /* GenerateCredentials */;
-			targetProxy = 096A92FE26E2A0C000448C68 /* PBXContainerItemProxy */;
 		};
 		3F526C5B2538CF2B0069706C /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;


### PR DESCRIPTION
We noticed that Google Login was broken — resulting in the app to crash – in Jetpack.

My diagnosis is that was because the codegen script receiving a `BUILD_SCHEME = WordPress` value, instead of `Jetpack`. The reason, I think, is that the aggregate target has it's own set of build settings and doesn't use the Jetpack ones, despite the build being set with the
aggregate target as a dependency for Jetpack.

To resolve this in the short term, I have rolled back to running the codegen script as a Build Phase Run Script as part of the Jetpack target, removing the dependency on the aggregate target.

There might be better ways to do this in the long run, but for the purpose of fixing this in the code freeze branch or to ship a hotfix, this was the fastest thing I could come up with.

To test: verify that the Jetpack app crashes when trying to Google login on `develop`. Switch to this branch and verify it succeeds.

@yaelirub @leandroalonso let me know whether you think this should be a hotfix or it's fine to put it in the current release. I defaulted to current release to avoid starting an unnecessary hotfix workflow, but we might want to do a hotfix (or maybe not? this issue has possibly been out for a while and we haven't heard of it from users yet).

## Regression Notes
1. Potential unintended areas of impact
N.A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
See above

3. What automated tests I added (or what prevented me from doing so)
None :/

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
