### PR TITLE
Comments: conditionally purge trashed comments

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -50,6 +50,12 @@ public class Comment: NSManagedObject {
         return URL(string: link)
     }
 
+    @objc func deleteWillBePermanent() -> Bool {
+        // If the Comment is currently Spam or Trash, the Trash action will permanently delete the Comment.
+        return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
+
+    }
+
     func numberOfLikes() -> Int {
         return Int(likeCount)
     }

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -446,12 +446,19 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
         return;
     }
 
+    RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
+    id<CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
+    
+    // If the Comment is not permanently deleted, don't remove it from the local cache as it can still be displayed.
+    if (!comment.deleteWillBePermanent) {
+        [remote trashComment:remoteComment success:success failure:failure];
+        return;
+    }
+
     // For the best user experience we want to optimistically delete the comment.
     // However, if there is an error we need to restore it.
-    RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
     NSManagedObjectID *blogObjID = comment.blog.objectID;
     NSManagedObjectContext *context = self.managedObjectContext;
-    id<CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
 
     [context deleteObject:comment];
     [[ContextManager sharedInstance] saveContext:context withCompletionBlock:^{

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -543,11 +543,7 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     }
 
     __typeof(self) __weak weakSelf = self;
-
-    // If the Comment is currently Spam or Trash, the Trash action will permanently delete the Comment.
-    // Set the displayed messages accordingly.
-    BOOL willBePermanentlyDeleted = [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeSpam]] ||
-                                    [self.comment.status isEqualToString:[Comment descriptionFor:CommentStatusTypeUnapproved]];
+    BOOL willBePermanentlyDeleted = [self.comment deleteWillBePermanent];
     
     NSString *trashMessage = NSLocalizedString(@"Are you sure you want to mark this comment as Trash?",
                                                @"Message asking for confirmation before marking a comment as trash");


### PR DESCRIPTION
Ref: #17200 

This changes the `CommentService.deleteComment` method to remove the Comment from the local cache only if the Comment is permanently deleted.

There should be no visible changes to Comment deletion (but this change is needed for the Trash functionality on the new moderation bar).

To test:
The best/easiest way to confirm there are no regressions is to verify the fix implemented with #16991 .
- Verify the `newCommentDetail` feature is _not_ enabled.
- On a self-hosted site, install a plugin that will allow you to toggle XML-RPC. ([This](https://wordpress.org/plugins/disable-xml-rpc/) one works well.)
- Go to My Site > Comments.
- Select a non-Trashed comment.
- Disable XML-RPC.
- Select `Trash`.
  - Verify the confirmation alert does not say "permanently delete".
  - After the Comment view is dismissed, verify the comment still appears in whatever list you were on.
- Enable XML-RPC.
- Go to the `Trashed` filter and select a comment.
- Disable XML-RPC.
- Select `Trash`.
  - Verify the confirmation alert does say "permanently delete".
  - After the Comment view is dismissed, verify the comment still appears in the `Trashed` list.


## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified trashing comments behaved as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
