### PR TITLE
Comment Moderation Bar: update comment when Trash button tapped.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -509,6 +509,8 @@ extension CommentDetailViewController: CommentModerationBarDelegate {
             unapproveComment()
         case .approved:
             approveComment()
+        case .unapproved:
+            deleteComment()
         default:
             break
         }
@@ -541,11 +543,24 @@ private extension CommentDetailViewController {
         })
     }
 
+    func deleteComment() {
+        CommentAnalytics.trackCommentTrashed(comment: comment)
+
+        commentService.delete(comment, success: { [weak self] in
+            self?.displayNotice(title: ModerationMessages.trashSuccess)
+        }, failure: { [weak self] error in
+            self?.displayNotice(title: ModerationMessages.trashFail)
+            self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
+        })
+    }
+
     struct ModerationMessages {
         static let pendingSuccess = NSLocalizedString("Comment set to pending.", comment: "Message displayed when pending a comment succeeds.")
         static let pendingFail = NSLocalizedString("Error setting comment to pending.", comment: "Message displayed when pending a comment fails.")
         static let approveSuccess = NSLocalizedString("Comment approved.", comment: "Message displayed when approving a comment succeeds.")
         static let approveFail = NSLocalizedString("Error approving comment.", comment: "Message displayed when approving a comment fails.")
+        static let trashSuccess = NSLocalizedString("Comment moved to trash.", comment: "Message displayed when trashing a comment succeeds.")
+        static let trashFail = NSLocalizedString("Error moving comment to trash.", comment: "Message displayed when trashing a comment fails.")
     }
 
 }


### PR DESCRIPTION
Ref: #17200 
Depends on: #17280

When the `Trash` button is tapped on the moderation bar, the comment status is now updated.
- A success message appears when successful.
- When unsuccessful, a failure message appears and the button states are reset.

Note this will only work correctly if a comment is _not_ currently Spam or Trash. I'll fix that when the [Spam](https://github.com/wordpress-mobile/WordPress-iOS/pull/17279) action is merged and the Delete Permanently button is available.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment that is _not_ trash or spam.
- Select `Trash` on the moderation bar.
- Verify a success message is displayed.
- Go back to the comments list, and select the Trashed filter.
- Verify the comment appears in the list.

https://user-images.githubusercontent.com/1816888/136470627-ab46a230-44c1-41bb-ae79-fe6386a665be.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
