### PR TITLE
Comment Detail: Add UI for the delete button

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -136,7 +136,7 @@ class CommentDetailViewController: UITableViewController {
         super.viewWillTransition(to: size, with: coordinator)
 
         // when an orientation change is triggered, recalculate the content cell's height.
-        guard let contentRowIndex = rows.firstIndex(where: { $0 == .content }) else {
+        guard let contentRowIndex = rows.firstIndex(of: .content) else {
             return
         }
         tableView.reloadRows(at: [.init(row: contentRowIndex, section: .zero)], with: .fade)

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -55,13 +55,13 @@ class CommentDetailViewController: UITableViewController {
 
     private lazy var deleteButton: UIButton = {
         let button = UIButton()
+        let buttonColor = UIColor(light: .error, dark: .muriel(name: .red, .shade40))
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.tintColor = .error
         button.setTitle(.deleteButtonText, for: .normal)
-        button.setTitleColor(.error, for: .normal)
+        button.setTitleColor(buttonColor, for: .normal)
         button.setTitleColor(.white, for: .highlighted)
-        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: .error), for: .normal)
-        button.setBackgroundImage(.renderBackgroundImage(fill: .error, border: .error), for: .highlighted)
+        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: buttonColor), for: .normal)
+        button.setBackgroundImage(.renderBackgroundImage(fill: buttonColor, border: buttonColor), for: .highlighted)
 
         button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         button.titleLabel?.textAlignment = .center

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -53,6 +53,43 @@ class CommentDetailViewController: UITableViewController {
         return cell
     }()
 
+    private lazy var deleteButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.tintColor = .error
+        button.setTitle(.deleteButtonText, for: .normal)
+        button.setTitleColor(.error, for: .normal)
+        button.setTitleColor(.white, for: .highlighted)
+        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: .error), for: .normal)
+        button.setBackgroundImage(.renderBackgroundImage(fill: .error, border: .error), for: .highlighted)
+
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+
+        // add constraints for the title label for the button to contain the label properly in multi-line cases.
+        if let label = button.titleLabel {
+            button.pinSubviewToAllEdgeMargins(label)
+        }
+
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.deleteButtonTapped()
+        }
+
+        return button
+    }()
+
+    private lazy var deleteButtonCell: UITableViewCell = {
+        let cell = UITableViewCell()
+        cell.selectionStyle = .none
+        cell.accessibilityTraits = .button
+
+        cell.contentView.addSubview(deleteButton)
+        cell.contentView.pinSubviewToAllEdges(deleteButton, insets: Constants.deleteButtonInsets)
+
+        return cell
+    }()
+
     private lazy var commentService: CommentService = {
         return .init(managedObjectContext: managedObjectContext)
     }()
@@ -121,27 +158,37 @@ class CommentDetailViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let row = rows[indexPath.row]
-        switch row {
-        case .header:
-            configureHeaderCell()
-            return headerCell
+        let cell: UITableViewCell = {
+            switch row {
+            case .header:
+                configureHeaderCell()
+                return headerCell
 
-        case .content:
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
-                return .init()
+            case .content:
+                guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
+                    return .init()
+                }
+
+                configureContentCell(cell, comment: comment)
+                cell.moderationBar.delegate = self
+                moderationBar = cell.moderationBar
+                return cell
+
+            case .replyIndicator:
+                return replyIndicatorCell
+
+            case .text:
+                return configuredTextCell(for: row)
+
+            case .deleteComment:
+                return deleteButtonCell
             }
+        }()
 
-            configureContentCell(cell, comment: comment)
-            cell.moderationBar.delegate = self
-            moderationBar = cell.moderationBar
-            return cell
+        // hide cell separator if it's positioned before the delete button cell.
+        cell.separatorInset = shouldHideCellSeparator(for: indexPath) ? insetsForHiddenCellSeparator : tableView.separatorInset
 
-        case .replyIndicator:
-            return replyIndicatorCell
-
-        case .text:
-            return configuredTextCell(for: row)
-        }
+        return cell
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -176,11 +223,21 @@ private extension CommentDetailViewController {
         case content
         case replyIndicator
         case text(title: String, detail: String, image: UIImage? = nil)
+        case deleteComment
     }
 
     struct Constants {
         static let tableLeadingInset: CGFloat = 20.0
+        static let tableBottomMargin: CGFloat = 40.0
         static let replyIndicatorVerticalSpacing: CGFloat = 14.0
+
+        static let deleteButtonInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
+    }
+
+    /// Convenience computed variable for an inset setting that hides a cell's separator by pushing it off the edge of the screen.
+    /// This needs to be computed because the frame size changes on orientation change.
+    var insetsForHiddenCellSeparator: UIEdgeInsets {
+        return .init(top: 0, left: tableView.frame.size.width, bottom: 0, right: 0).flippedForRightToLeftLayoutDirection()
     }
 
     func configureNavigationBar() {
@@ -191,7 +248,7 @@ private extension CommentDetailViewController {
 
     func configureTable() {
         // get rid of the separator line for the last cell.
-        tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
+        tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: Constants.tableBottomMargin))
 
         // assign 20pt leading inset to the table view, as per the design.
         // note that by default, the system assigns 16pt inset for .phone, and 20pt for .pad idioms.
@@ -222,6 +279,11 @@ private extension CommentDetailViewController {
             }
 
             rows.append(.text(title: .ipAddressLabelText, detail: comment.author_ip))
+
+            if let statusType = CommentStatusType.typeForStatus(comment.status),
+               (statusType == .spam || statusType == .unapproved) {
+                rows.append(.deleteComment)
+            }
         }
 
         self.rows = rows
@@ -232,6 +294,16 @@ private extension CommentDetailViewController {
     func refreshData() {
         configureRows()
         tableView.reloadData()
+    }
+
+
+    /// Checks if the index path is positioned before the delete button cell.
+    func shouldHideCellSeparator(for indexPath: IndexPath) -> Bool {
+        guard let deleteCellIndex = rows.firstIndex(of: .deleteComment) else {
+            return false
+        }
+
+        return indexPath.row == deleteCellIndex - 1
     }
 
     // MARK: Cell configuration
@@ -353,6 +425,10 @@ private extension CommentDetailViewController {
         present(navigationControllerToPresent, animated: true)
     }
 
+    func deleteButtonTapped() {
+        // TODO: Implement delete functionality.
+    }
+
     func updateComment() {
         // Regardless of success or failure track the user's intent to save a change.
         CommentAnalytics.trackCommentEdited(comment: comment)
@@ -424,6 +500,7 @@ private extension String {
     static let webAddressLabelText = NSLocalizedString("Web address", comment: "Describes the web address section in the comment detail screen.")
     static let emailAddressLabelText = NSLocalizedString("Email address", comment: "Describes the email address section in the comment detail screen.")
     static let ipAddressLabelText = NSLocalizedString("IP address", comment: "Describes the IP address section in the comment detail screen.")
+    static let deleteButtonText = NSLocalizedString("Delete Permanently", comment: "Title for button on the comment details page that deletes the comment when tapped.")
 }
 
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -67,7 +67,7 @@ class CommentDetailViewController: UITableViewController {
         button.titleLabel?.textAlignment = .center
         button.titleLabel?.numberOfLines = 0
 
-        // add constraints for the title label for the button to contain the label properly in multi-line cases.
+        // add constraints to the title label, so the button can contain it properly in multi-line cases.
         if let label = button.titleLabel {
             button.pinSubviewToAllEdgeMargins(label)
         }


### PR DESCRIPTION
Refs #17087 

This adds the UI for the "Delete Permanently" button. The functionality hasn't been implemented yet, so clicking on it does nothing. A couple of notes:
- From the designs, note that there is no separator for the cell before the "Delete Permanently" button. To achieve this, I've alternatively explored `viewForFooterInSection`, or through `tableView.tableFooterView` and ended up registering it as a table view row.
  - For `viewForFooterInSection` in `.plain` table view style, the footer sticks to the bottom screen. To make sure that the footer stays at the bottom, I'd have to change the table style to `grouped`, but this introduces several bits like different cell background colors and additional padding around the top.
  - For `tableFooterView`, the container doesn't support auto layout (shocking), so I'd have to manually calculate the height of the footer view after the layout pass is completed (probably via `systemLayoutFittingSize`), and then resize the height of the `tableFooterView`.
  - Finally, if it's registered as a normal table view cell, I just need to hide the cell separator (via `separatorInset`) when the cell is placed right before the "Delete Permanently" button. I decided to go with this instead.
-   The current `tableFooterView` is used to hide the cell separator for the last row, but I've noticed that the "Delete Permanently" button is too close to the tab bar. Checking on the designs, I've noticed that there's 45pt of distance between the button and the tab bar, so I've added some height for the `tableFooterView` to implement the bottom padding.

Lastly, a tiny question for @mattmiklic: here's how the button is currently displayed and highlighted (both in Light and Dark mode). Does this look good for you? Thanks!
• | Light 🌝 | Dark 🌚 
--|--|--
Normal | ![light_normal](https://user-images.githubusercontent.com/1299411/136580880-c9432e8a-dd5b-4355-8bdb-2017675a9e75.png) | ![dark_normal](https://user-images.githubusercontent.com/1299411/136580884-24514d43-e2fd-4ece-9697-0c3a867ad920.png)
Highlighted | ![light_highlighted](https://user-images.githubusercontent.com/1299411/136580868-4c27c77f-e7c4-4338-9a95-1d377f13ef8b.png) | ![dark_highlighted](https://user-images.githubusercontent.com/1299411/136580883-1c43478f-2c04-48cb-9e02-bb96e569ecd9.png)

## To test

- Ensure that the `New Comment Detail` flag is enabled.
- Ensure that you have moderation rights for the selected site.
- Go to My Site > Comments.
- Select any comments in the Spam or Trashed filter.
- Verify that the Delete Permanently button is shown.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
