### PR TITLE
Comment Moderation Bar: retain button state on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -32,9 +32,10 @@ class CommentModerationBar: UIView {
 
     var commentStatus: CommentStatusType? {
         didSet {
-            if oldValue != commentStatus {
-                toggleButtonForStatus(oldValue)
+            guard oldValue != commentStatus else {
+                return
             }
+            toggleButtonForStatus(oldValue)
             toggleButtonForStatus(commentStatus)
         }
     }


### PR DESCRIPTION
Ref: #17200 

This fixes an issue that was causing the selected button to lose it's state on rotation.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments > Comment details.
- Rotate the device several times.
- Verify the selected button stays selected.


Before:

https://user-images.githubusercontent.com/1816888/136623295-bf35aa32-fb18-4c32-a068-aa651a934911.mp4

After:

https://user-images.githubusercontent.com/1816888/136623364-b3c0133a-5379-44e5-9a5e-255b531fcd0c.mp4



## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
