### PR TITLE
Use bash cache artifact support

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -17,4 +17,4 @@ bundle exec fastlane build_for_testing
 
 echo "--- :arrow_up: Upload Build Products"
 tar -cf build-products.tar DerivedData/Build/Products/
-buildkite-agent artifact upload build-products.tar
+upload_artifact build-products.tar

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -7,7 +7,7 @@ IOS_VERSION=$3
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
 echo "--- 📦 Downloading Build Artifacts"
-buildkite-agent artifact download build-products.tar .
+download_artifact build-products.tar
 tar -xf build-products.tar
 
 echo "--- :wrench: Fixing VM"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo "--- 📦 Downloading Build Artifacts"
-buildkite-agent artifact download build-products.tar .
+download_artifact build-products.tar
 tar -xf build-products.tar
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#add/artifact-support
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#add/artifact-support
+    - automattic/bash-cache#v1.6.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"


### PR DESCRIPTION
Fixes slow artifact downloads by implementing our own layer for them.

**To test**
- Verify that the CI runs faster.

**Note:**
This PR will require cutting a new version of https://github.com/Automattic/bash-cache-buildkite-plugin after it's approved, but before it lands