### PR TITLE
Empty stats: Publicize nudge dismissal logic

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -744,7 +744,7 @@ SPEC CHECKSUMS:
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 43160fc29f428c84706fef4e284e28d50d9925e8
-  FBReactNativeSpec: 86afc815d056c20bb7f2c1c202f2660652a4e381
+  FBReactNativeSpec: ba5eb7d7b0d126dab503f227c4919213561b2c82
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -744,7 +744,7 @@ SPEC CHECKSUMS:
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 43160fc29f428c84706fef4e284e28d50d9925e8
-  FBReactNativeSpec: ba5eb7d7b0d126dab503f227c4919213561b2c82
+  FBReactNativeSpec: 86afc815d056c20bb7f2c1c202f2660652a4e381
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1781,7 +1781,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         controller = [[SharingButtonsViewController alloc] initWithBlog:self.blog];
 
     } else {
-        controller = [[SharingViewController alloc] initWithBlog:self.blog];
+        controller = [[SharingViewController alloc] initWithBlog:self.blog delegate: nil];
     }
 
     [self trackEvent:WPAnalyticsStatOpenedSharingManagement fromSource:source];

--- a/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc class PublicizeServicesState: NSObject {
+@objc final class PublicizeServicesState: NSObject {
     private var connections = Set<PublicizeConnection>()
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
@@ -2,12 +2,15 @@ import Foundation
 
 @objc class PublicizeServicesState: NSObject {
     private var connections = Set<PublicizeConnection>()
+}
 
-    @objc func addInitialConnections(_ connections: [PublicizeConnection]) {
+// MARK: - Public Methods
+@objc extension PublicizeServicesState {
+    func addInitialConnections(_ connections: [PublicizeConnection]) {
         connections.forEach { self.connections.insert($0) }
     }
 
-    @objc func hasAddedNewConnectionTo(_ connections: [PublicizeConnection]) -> Bool {
+    func hasAddedNewConnectionTo(_ connections: [PublicizeConnection]) -> Bool {
         guard connections.count > 0 else {
             return false
         }

--- a/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+@objc class PublicizeServicesState: NSObject {
+    private var connections = Set<PublicizeConnection>() {
+        didSet {
+            print(connections, connections.count)
+        }
+    }
+
+    @objc func addConnections(_ connections: [PublicizeConnection]) {
+        connections.forEach { self.connections.insert($0) }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/PublicizeServicesState.swift
@@ -1,13 +1,25 @@
 import Foundation
 
 @objc class PublicizeServicesState: NSObject {
-    private var connections = Set<PublicizeConnection>() {
-        didSet {
-            print(connections, connections.count)
-        }
+    private var connections = Set<PublicizeConnection>()
+
+    @objc func addInitialConnections(_ connections: [PublicizeConnection]) {
+        connections.forEach { self.connections.insert($0) }
     }
 
-    @objc func addConnections(_ connections: [PublicizeConnection]) {
-        connections.forEach { self.connections.insert($0) }
+    @objc func hasAddedNewConnectionTo(_ connections: [PublicizeConnection]) -> Bool {
+        guard connections.count > 0 else {
+            return false
+        }
+
+        if connections.count > self.connections.count {
+            return true
+        }
+
+        for connection in connections where !self.connections.contains(connection) {
+            return true
+        }
+
+        return false
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
@@ -2,7 +2,7 @@
 
 @protocol SharingViewControllerDelegate
 
-- (void)someMethod;
+- (void)didChangePublicizeServices;
 
 @end
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
@@ -1,5 +1,11 @@
 #import <UIKit/UIKit.h>
 
+@protocol SharingViewControllerDelegate
+
+- (void)someMethod;
+
+@end
+
 @class Blog;
 
 /**
@@ -14,6 +20,6 @@
  *
  *  @return New instance of SharingViewController
  */
-- (instancetype)initWithBlog:(Blog *)blog;
+- (instancetype)initWithBlog:(Blog *)blog delegate:(id)delegate;
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -243,21 +243,19 @@ static NSString *const CellIdentifier = @"CellIdentifier";
             [connections addObject:pubConn];
         }
     }
-
-    NSArray *populated = [NSArray arrayWithArray:connections];
-    [self.publicizeServicesState addConnections:populated];
-    return populated;
+    return [NSArray arrayWithArray:connections];
 }
 
-- (BOOL)hasConnectedAccounts
+- (NSArray *)allConnections
 {
-    int count = 0;
+    NSMutableArray *allConnections = [NSMutableArray new];
     for (PublicizeService *service in self.publicizeServices) {
-        if ([self connectionsForService:service].count > 0) {
-            count += 1;
+        NSArray *connections = [self connectionsForService:service];
+        if (connections.count > 0) {
+            [allConnections addObjectsFromArray:connections];
         }
     }
-    return count > 0;
+    return allConnections;
 }
 
 - (NSManagedObjectContext *)managedObjectContext

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -19,18 +19,20 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 @property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, strong) NSArray *publicizeServices;
+@property (nonatomic, weak) id delegate;
 
 @end
 
 @implementation SharingViewController
 
-- (instancetype)initWithBlog:(Blog *)blog
+- (instancetype)initWithBlog:(Blog *)blog delegate:(id)delegate
 {
     NSParameterAssert([blog isKindOfClass:[Blog class]]);
     self = [self initWithStyle:UITableViewStyleGrouped];
     if (self) {
         _blog = blog;
         _publicizeServices = [NSMutableArray new];
+        _delegate = delegate;
     }
     return self;
 }
@@ -74,6 +76,9 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)doneButtonTapped
 {
+    if ([self hasConnectedAccounts]) {
+        [self.delegate someMethod];
+    }
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -237,6 +242,17 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         }
     }
     return [NSArray arrayWithArray:connections];
+}
+
+- (BOOL)hasConnectedAccounts
+{
+    int count = 0;
+    for (PublicizeService *service in self.publicizeServices) {
+        if ([self connectionsForService:service].count > 0) {
+            count += 1;
+        }
+    }
+    return count > 0;
 }
 
 - (NSManagedObjectContext *)managedObjectContext

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -20,6 +20,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 @property (nonatomic, strong, readonly) Blog *blog;
 @property (nonatomic, strong) NSArray *publicizeServices;
 @property (nonatomic, weak) id delegate;
+@property (nonatomic) PublicizeServicesState *publicizeServicesState;
 
 @end
 
@@ -33,6 +34,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         _blog = blog;
         _publicizeServices = [NSMutableArray new];
         _delegate = delegate;
+        _publicizeServicesState = [PublicizeServicesState new];
     }
     return self;
 }
@@ -241,7 +243,10 @@ static NSString *const CellIdentifier = @"CellIdentifier";
             [connections addObject:pubConn];
         }
     }
-    return [NSArray arrayWithArray:connections];
+
+    NSArray *populated = [NSArray arrayWithArray:connections];
+    [self.publicizeServicesState addConnections:populated];
+    return populated;
 }
 
 - (BOOL)hasConnectedAccounts

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -53,6 +53,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self syncServices];
+    [self.publicizeServicesState addInitialConnections:[self allConnections]];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -78,7 +79,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)doneButtonTapped
 {
-    if ([self hasConnectedAccounts]) {
+    if ([self.publicizeServicesState hasAddedNewConnectionTo:[self allConnections]]) {
         [self.delegate didChangePublicizeServices];
     }
     [self dismissViewControllerAnimated:YES completion:nil];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -77,7 +77,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)doneButtonTapped
 {
     if ([self hasConnectedAccounts]) {
-        [self.delegate someMethod];
+        [self.delegate didChangePublicizeServices];
     }
     [self dismissViewControllerAnimated:YES completion:nil];
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -224,7 +224,7 @@ private extension SiteStatsInsightsTableViewController {
 
     func refreshTableView() {
         guard let viewModel = viewModel else {
-                return
+            return
         }
 
         tableHandler.viewModel = viewModel.tableViewModel()
@@ -582,7 +582,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         if !blog.supportsPublicize() {
             controller = SharingButtonsViewController(blog: blog)
         } else {
-            controller = SharingViewController(blog: blog)
+            controller = SharingViewController(blog: blog, delegate: self)
         }
 
         let navigationController = UINavigationController(rootViewController: controller)
@@ -665,6 +665,16 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         present(alert, animated: true)
     }
 
+}
+
+// MARK: - SharingViewControllerDelegate
+
+extension SiteStatsInsightsTableViewController: SharingViewControllerDelegate {
+    func someMethod() {
+        print("it's working!")
+        viewModel?.markEmptyStatsNudgeAsCompleted()
+        refreshTableView()
+    }
 }
 
 // MARK: - No Results Handling

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -671,7 +671,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
 extension SiteStatsInsightsTableViewController: SharingViewControllerDelegate {
     func didChangePublicizeServices() {
-        print("it's working!")
         viewModel?.markEmptyStatsNudgeAsCompleted()
         refreshTableView()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -670,7 +670,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 // MARK: - SharingViewControllerDelegate
 
 extension SiteStatsInsightsTableViewController: SharingViewControllerDelegate {
-    func someMethod() {
+    func didChangePublicizeServices() {
         print("it's working!")
         viewModel?.markEmptyStatsNudgeAsCompleted()
         refreshTableView()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -15,6 +15,7 @@ class SiteStatsInsightsViewModel: Observable {
     private var insightsReceipt: Receipt?
     private var insightsChangeReceipt: Receipt?
     private var insightsToShow = [InsightType]()
+    private var isNudgeCompleted = false
 
     private var periodReceipt: Receipt?
 
@@ -71,6 +72,7 @@ class SiteStatsInsightsViewModel: Observable {
                                             let viewsCount = insightsStore.getAllTimeStats()?.viewsCount
                                             return GrowAudienceRow(hintType: .social,
                                                                    allTimeViewsCount: viewsCount ?? 0,
+                                                                   isNudgeCompleted: isNudgeCompleted,
                                                                    siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
                     return StatsGhostGrowAudienceImmutableRow()
@@ -256,6 +258,9 @@ class SiteStatsInsightsViewModel: Observable {
         insightsToShow = insights
     }
 
+    func markEmptyStatsNudgeAsCompleted() {
+        isNudgeCompleted = true
+    }
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -24,6 +24,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
     func configure(hintType: HintType,
                    allTimeViewsCount: Int,
+                   isNudgeCompleted: Bool,
                    insightsDelegate: SiteStatsInsightsDelegate?) {
         self.hintType = hintType
         self.insightsDelegate = insightsDelegate
@@ -33,7 +34,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         iconView.image = hintType.image
         dismissButton.setTitle(Strings.dismissButtonTitle, for: .normal)
 
-        updateView(isCompleted: false)
+        updateView(isCompleted: isNudgeCompleted)
     }
 
     // MARK: - Styling
@@ -87,7 +88,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
             return
         }
 
-        updateView(isCompleted: true)
+//        updateView(isCompleted: true)
 
         switch hintType {
         case .social:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -88,8 +88,6 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
             return
         }
 
-//        updateView(isCompleted: true)
-
         switch hintType {
         case .social:
             insightsDelegate?.growAudienceEnablePostSharingButtonTapped?()

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -99,6 +99,7 @@ struct GrowAudienceRow: ImmuTableRow {
 
     let hintType: GrowAudienceCell.HintType
     let allTimeViewsCount: Int
+    let isNudgeCompleted: Bool
     weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let action: ImmuTableAction? = nil
 
@@ -110,6 +111,7 @@ struct GrowAudienceRow: ImmuTableRow {
 
         cell.configure(hintType: hintType,
                        allTimeViewsCount: allTimeViewsCount,
+                       isNudgeCompleted: isNudgeCompleted,
                        insightsDelegate: siteStatsInsightsDelegate)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1419,6 +1419,8 @@
 		931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DE8A0401912D95B00B2FF59 /* ReaderPostServiceTest.m */; };
 		931D270019EDAE8600114F17 /* CoreDataMigrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */; };
 		931DF4D618D09A2F00540BDD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
+		931F312C2714302A0075433B /* PublicizeServicesState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931F312B2714302A0075433B /* PublicizeServicesState.swift */; };
+		931F312D2714302A0075433B /* PublicizeServicesState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 931F312B2714302A0075433B /* PublicizeServicesState.swift */; };
 		932225B11C7CE50300443B02 /* WordPressShareExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 932225A71C7CE50300443B02 /* WordPressShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		932645A41E7C206600134988 /* GutenbergSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932645A31E7C206600134988 /* GutenbergSettingsTests.swift */; };
 		933D1F471EA64108009FB462 /* TestingAppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 933D1F461EA64108009FB462 /* TestingAppDelegate.m */; };
@@ -6160,6 +6162,7 @@
 		931DF4DD18D09B1900540BDD /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		931DF4DE18D09B2600540BDD /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		931DF4DF18D09B3900540BDD /* id */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = id; path = id.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		931F312B2714302A0075433B /* PublicizeServicesState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublicizeServicesState.swift; sourceTree = "<group>"; };
 		932225A71C7CE50300443B02 /* WordPressShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		932645A31E7C206600134988 /* GutenbergSettingsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergSettingsTests.swift; sourceTree = "<group>"; };
 		93267A6019B896CD00997EB8 /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
@@ -13968,6 +13971,7 @@
 				E6431DE21C4E892900FD8D90 /* SharingDetailViewController.m */,
 				E64384821C628FCC0052ADB5 /* WPStyleGuide+Sharing.swift */,
 				E60BD230230A3DD400727E82 /* KeyringAccountHelper.swift */,
+				931F312B2714302A0075433B /* PublicizeServicesState.swift */,
 			);
 			name = Sharing;
 			sourceTree = "<group>";
@@ -17627,6 +17631,7 @@
 				E15644EF1CE0E53B00D96E64 /* PlanListViewModel.swift in Sources */,
 				983002A822FA05D600F03DBB /* AddInsightTableViewController.swift in Sources */,
 				98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */,
+				931F312C2714302A0075433B /* PublicizeServicesState.swift in Sources */,
 				8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */,
 				FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */,
 				93C1147F18EC5DD500DAC95C /* AccountService.m in Sources */,
@@ -20156,6 +20161,7 @@
 				FABB248D2602FC2C00C8785C /* PostCoordinator.swift in Sources */,
 				FABB248E2602FC2C00C8785C /* AztecAttachmentDelegate.swift in Sources */,
 				FABB248F2602FC2C00C8785C /* Memoize.swift in Sources */,
+				931F312D2714302A0075433B /* PublicizeServicesState.swift in Sources */,
 				FABB24902602FC2C00C8785C /* StatsPeriodAsyncOperation.swift in Sources */,
 				FABB24912602FC2C00C8785C /* NotificationsViewController.swift in Sources */,
 				FABB24922602FC2C00C8785C /* PingHubManager.swift in Sources */,


### PR DESCRIPTION
Part of [#17215](https://github.com/wordpress-mobile/WordPress-iOS/issues/17125)

This PR fixes Publicize nudge dismissal logic, so now publicize card is dismissed if the user has actually completed the step.

## To test

### Happy flow

1. Select the site that has less than 30 views
2. Go to **My Site** > **Stats**
3. Publizice nudge should be presented
4. Tap on **Enable post sharing** and add new connection
5. Go back to **Stats** screen
6. Confirm **Sharing is set up!** message is displayed

### Unhappy flow

1. Repeat the steps **1, 2, 3**
2. Tap on **Enable post sharing** and don't add a new connection, or remove the existing one
3. Go back to **Stats** screen
4. Confirm **Sharing is set up!** message is not displayed

## Screnshots

Sharing not set up | Sharing set up
--- | ---
<img width="502" alt="Screenshot 2021-10-12 at 10 04 22" src="https://user-images.githubusercontent.com/12729242/136916856-6ea624e4-d2d5-455f-8091-62654364a727.png"> | <img width="502" alt="Screenshot 2021-10-12 at 10 04 16" src="https://user-images.githubusercontent.com/12729242/136916871-cbc824c9-b321-402b-999c-5cb41f04950d.png">

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
