### PR TITLE
Add validation rules to organization field in domain registration detail

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.42.0'
+    pod 'WordPressKit', '~> 4.42.1-beta.1'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/domain-contact-messages'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/domain-contact-messages'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.42.0'
+    # pod 'WordPressKit', '~> 4.42.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/domain-contact-messages'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.1-beta.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/domain-contact-messages`)
+  - WordPressKit (~> 4.42.1-beta.1)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2)
@@ -565,6 +565,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -710,9 +711,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
-  WordPressKit:
-    :branch: feature/domain-contact-messages
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.64.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -728,9 +726,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
-  WordPressKit:
-    :commit: 533f34515bbbe73e0ec3af67356b42035387fab8
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -815,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 828a4c2560e27443b5d7935a1b788aefe4f56792
-  WordPressKit: d556ff91aa383bbf6b831ed3e5a7290a3d0cb731
+  WordPressKit: 47f85458d42e44c75f279f745df7ae712f5f4a0e
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 3660920b90d44ca8cf6b4c9984aade433cdad50f
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
@@ -831,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 44cc0ff1d28cda056f67a9d3bab53f2b4bc36b5c
+PODFILE CHECKSUM: fd0fb982f7e8a9f4d31ae1f5e03c00954fa8d681
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.42.0):
+  - WordPressKit (4.42.1-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.1-beta.2)
-  - WordPressKit (~> 4.42.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/domain-contact-messages`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2)
@@ -605,7 +605,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WPMediaPicker
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :branch: feature/domain-contact-messages
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.64.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :commit: 533f34515bbbe73e0ec3af67356b42035387fab8
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -810,7 +815,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 828a4c2560e27443b5d7935a1b788aefe4f56792
-  WordPressKit: 0c8e1a1becfeffc882f06f55eb09cd485826c268
+  WordPressKit: d556ff91aa383bbf6b831ed3e5a7290a3d0cb731
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 3660920b90d44ca8cf6b4c9984aade433cdad50f
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: d280ea1ed3491c36a0362a8950dd227acbf57e36
+PODFILE CHECKSUM: 44cc0ff1d28cda056f67a9d3bab53f2b4bc36b5c
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+LocalizedStrings.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+LocalizedStrings.swift
@@ -10,6 +10,10 @@ enum RegisterDomainDetails {
             "Please enter a valid Last Name",
             comment: "Register Domain - Domain contact information validation error message for an input field"
         )
+        static let validationErrorOrganization = NSLocalizedString(
+            "Please enter a valid Organization",
+            comment: "Register Domain - Domain contact information validation error message for an input field"
+        )
         static let validationErrorEmail = NSLocalizedString(
             "Please enter a valid Email",
             comment: "Register Domain - Domain contact information validation error message for an input field"

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel+RowList.swift
@@ -55,6 +55,8 @@ extension RegisterDomainDetailsViewModel {
                 errorMessage = Localized.validationErrorFirstName
             case Localized.ContactInformation.lastName:
                 errorMessage = Localized.validationErrorLastName
+            case Localized.ContactInformation.organization:
+                errorMessage = Localized.validationErrorOrganization
             case Localized.ContactInformation.email:
                 errorMessage = Localized.validationErrorEmail
             case Localized.ContactInformation.country:
@@ -114,6 +116,7 @@ extension RegisterDomainDetailsViewModel {
                 value: nil,
                 placeholder: Localized.ContactInformation.organizationPlaceholder,
                 editingStyle: .inline,
+                validationRules: [serverSideRule(with: Localized.ContactInformation.organization)],
                 valueSanitizer: transformToLatinASCII
                 )),
             .inlineEditable(.init(

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -486,7 +486,7 @@ extension RegisterDomainDetailsViewModel {
                     return
                 }
 
-                if response.success {
+                if response.success && !response.hasMessages {
                     strongSelf.clearValidationErrors()
                     strongSelf.onChange?(.remoteValidationFinished)
                     successCompletion()
@@ -580,8 +580,8 @@ extension ValidateDomainContactInformationResponse.Messages {
             return firstName?.first
         case .lastName:
             return lastName?.first
-        default:
-            return nil
+        case .organization:
+            return organization?.first
         }
     }
 


### PR DESCRIPTION
Fixes #17138. This PR adds validation rules to the organization field in the domain registration detail screen, to allow us to display relevant error messages like this:

<img src="https://user-images.githubusercontent.com/4780/136822217-dd68f82f-d0cd-400f-93af-93d69b2d5e16.png" width="350">

I presume this field was omitted previously because the organization field is optional. However, adding this support in still allows the field to be left blank. If it contains any content, it will be validated.

See also https://github.com/wordpress-mobile/WordPressKit-iOS/pull/450

**To test**

* Build and run, and attempt to add a domain to a site with a domain credit (using the native flow)
* On the registration details screen, enter an organization including invalid characters like punctuation
* When you attempt to confirm the registration, you should see a red error as in the screenshot above
* Test also that you can:
** Submit the form with no organization entered
** Submit the form with a valid organization entered

## Regression Notes

1. Potential unintended areas of impact

- I don't think any, as this data structure is only used by this screen as far as I can see.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
