### PR TITLE
Comment Details: delete comment when Delete Permanently button tapped.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -195,7 +195,10 @@ private extension CommentModerationBar {
     }
 
     @IBAction func trashTapped() {
-        guard !trashButton.isSelected else {
+        // The Delete Permanently functionality deletes a spam comment,
+        // so don't allow it to be Trashed from here.
+        guard commentStatus != .spam,
+              !trashButton.isSelected else {
             return
         }
 


### PR DESCRIPTION
Ref: #17087 , #17200
Depends on: #17279

Tapping the `Delete Permanently` button will now delete the comment.


To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a Spam or Trashed comment.
- Tap the `Delete Permanently` button.
- Verify:
  -  A success message is displayed.
  - The view is dismissed and you are returned to the comments list.
  - The comment doesn't appear in any comment filter.


https://user-images.githubusercontent.com/1816888/136843312-8439d6d2-6c1a-42c7-98e5-05a7c90f26e4.mp4

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
