### PR TITLE
Shows the cost in the domain suggestions.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.42.0'
+    # pod 'WordPressKit', '~> 4.42.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '04de7356e4447b246cad0c4af88363766f7fd120'
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.1-beta.2)
-  - WordPressKit (~> 4.42.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `04de7356e4447b246cad0c4af88363766f7fd120`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2)
@@ -605,7 +605,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WPMediaPicker
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.64.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: d280ea1ed3491c36a0362a8950dd227acbf57e36
+PODFILE CHECKSUM: 19c1867e71577a01f79096fda4874a0801a589ec
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
First step to implement #17192 

This initial PR adds the basic cost per year for each suggested domain.

## Known limitations:

We don't yet show any discount information.

## Associated PRs:

WPKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/451

## To test:

1. Go to the Domains section for a site.
2. Claim your domain / Add domain
3. The suggested domains should come up with their cost per year.

## Regression Notes

1. Potential unintended areas of impact

None, this is a new feature and we're not changing anything that could affect existing features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
