### PR TITLE
Shows the cost in the domain suggestions.

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.42.0'
+    pod 'WordPressKit', '~> 4.42.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '04de7356e4447b246cad0c4af88363766f7fd120'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.42.0'
+    # pod 'WordPressKit', '~> 4.42.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '04de7356e4447b246cad0c4af88363766f7fd120'
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.42.0):
+  - WordPressKit (4.42.1-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.1-beta.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `04de7356e4447b246cad0c4af88363766f7fd120`)
+  - WordPressKit (~> 4.42.0)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2)
@@ -605,6 +605,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WPMediaPicker
@@ -710,9 +711,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
-  WordPressKit:
-    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.64.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -728,9 +726,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
-  WordPressKit:
-    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -815,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 870c93297849072aadfc2223e284094e73023e82
   WordPress-Editor-iOS: 068b32d02870464ff3cb9e3172e74234e13ed88c
   WordPressAuthenticator: 828a4c2560e27443b5d7935a1b788aefe4f56792
-  WordPressKit: 0c8e1a1becfeffc882f06f55eb09cd485826c268
+  WordPressKit: 3662d191e44f5fd568dc8370fef5c7f037fc8874
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 3660920b90d44ca8cf6b4c9984aade433cdad50f
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
@@ -831,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 19c1867e71577a01f79096fda4874a0801a589ec
+PODFILE CHECKSUM: d280ea1ed3491c36a0362a8950dd227acbf57e36
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.4)
   - WordPressAuthenticator (~> 1.42.1-beta.2)
-  - WordPressKit (~> 4.42.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `04de7356e4447b246cad0c4af88363766f7fd120`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.0)
   - WordPressUI (~> 1.12.2)
@@ -605,7 +605,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WPMediaPicker
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.64.0-alpha2/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.64.0-alpha2
+  WordPressKit:
+    :commit: 04de7356e4447b246cad0c4af88363766f7fd120
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: d280ea1ed3491c36a0362a8950dd227acbf57e36
+PODFILE CHECKSUM: 19c1867e71577a01f79096fda4874a0801a589ec
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -15,6 +15,7 @@ class DomainSuggestionsTableViewController: UITableViewController {
 
     // MARK: - Properties
 
+    var blog: Blog?
     var siteName: String?
     var delegate: DomainSuggestionsTableViewControllerDelegate?
     var domainSuggestionType: DomainsServiceRemote.DomainSuggestionType = .noWordpressDotCom
@@ -302,6 +303,10 @@ extension DomainSuggestionsTableViewController {
         WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
     }
 
+    private static var freeForFirstYearFont: UIFont {
+        WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+    }
+
     // MARK: - Suggestion Cell
 
     private func suggestionCell(_ suggestion: DomainSuggestion) -> UITableViewCell {
@@ -337,13 +342,43 @@ extension DomainSuggestionsTableViewController {
 
     private func attributedCostInformation(for suggestion: DomainSuggestion) -> NSAttributedString {
         let attributedString = NSMutableAttributedString()
-        let suggestionCost = NSAttributedString(string: suggestion.costString, attributes: [.font: Self.suggestionCostFont])
-        let perYearPostfix = NSAttributedString(string: " / year", attributes: [.font: Self.perYearPostfixFont])
 
-        attributedString.append(suggestionCost)
-        attributedString.append(perYearPostfix)
+        let hasDomainCredit = blog?.hasDomainCredit ?? false
+
+        if hasDomainCredit {
+            let freeForFirstYear = NSAttributedString(string: "Free for the first year ", attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
+
+            attributedString.append(freeForFirstYear)
+        }
+
+        attributedString.append(attributedSuggestionCost(for: suggestion, hasDomainCredit: hasDomainCredit))
+        attributedString.append(attributedPerYearPostfix(hasDomainCredit: hasDomainCredit))
 
         return attributedString
+    }
+
+    private func attributedSuggestionCost(for suggestion: DomainSuggestion, hasDomainCredit: Bool) -> NSAttributedString {
+        NSAttributedString(
+            string: suggestion.costString,
+            attributes: suggestionCostAttributes(hasDomainCredit: hasDomainCredit))
+    }
+
+    private func attributedPerYearPostfix(hasDomainCredit: Bool) -> NSAttributedString {
+        NSAttributedString(
+            string: " / year",
+            attributes: perYearPostfixAttributes(hasDomainCredit: hasDomainCredit))
+    }
+
+    private func suggestionCostAttributes(hasDomainCredit: Bool) -> [NSAttributedString.Key: Any] {
+        [.font: Self.suggestionCostFont,
+         .foregroundColor: hasDomainCredit ? UIColor.secondaryLabel : UIColor.label,
+         .strikethroughStyle: hasDomainCredit ? 1 : 0]
+    }
+
+    private func perYearPostfixAttributes(hasDomainCredit: Bool) -> [NSAttributedString.Key: Any] {
+        [.font: Self.perYearPostfixFont,
+         .foregroundColor: hasDomainCredit ? UIColor.secondaryLabel : UIColor.label,
+         .strikethroughStyle: hasDomainCredit ? 1 : 0]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -13,6 +13,18 @@ protocol DomainSuggestionsTableViewControllerDelegate {
 ///
 class DomainSuggestionsTableViewController: UITableViewController {
 
+    // MARK: - Fonts
+
+    private let domainBaseFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+    private let domainTLDFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+    private let suggestionCostFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+    private let perYearPostfixFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
+    private let freeForFirstYearFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+
+    // MARK: - Cell Identifiers
+
+    private static let suggestionCellIdentifier = "org.wordpress.domainsuggestionstable.suggestioncell"
+
     // MARK: - Properties
 
     var blog: Blog?
@@ -327,32 +339,10 @@ extension DomainSuggestionsTableViewController {
         return cell
     }
 
-    // MARK: - Fonts
-
-    private static var domainBaseFont: UIFont {
-        WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
-    }
-
-    private static var domainTLDFont: UIFont {
-        WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
-    }
-
-    private static var suggestionCostFont: UIFont {
-        WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
-    }
-
-    private static var perYearPostfixFont: UIFont {
-        WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
-    }
-
-    private static var freeForFirstYearFont: UIFont {
-        WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
-    }
-
     // MARK: - Suggestion Cell
 
     private func suggestionCell(_ suggestion: DomainSuggestion) -> UITableViewCell {
-        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "org.wordpress.domainsuggestionstable.suggestioncell")
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: Self.suggestionCellIdentifier)
 
         cell.textLabel?.attributedText = attributedDomain(suggestion.domainName)
         cell.textLabel?.textColor = parentDomainColor
@@ -364,9 +354,7 @@ extension DomainSuggestionsTableViewController {
     }
 
     private func attributedDomain(_ domain: String) -> NSAttributedString {
-        let attributedDomain = NSMutableAttributedString()
-
-        attributedDomain.append(NSAttributedString(string: domain, attributes: [.font: Self.domainBaseFont]))
+        let attributedDomain = NSMutableAttributedString(string: domain, attributes: [.font: domainBaseFont])
 
         guard let dotPosition = domain.firstIndex(of: ".") else {
             return attributedDomain
@@ -376,7 +364,7 @@ extension DomainSuggestionsTableViewController {
         let nsRange = NSRange(tldRange, in: domain)
 
         attributedDomain.addAttribute(.font,
-                                      value: Self.domainTLDFont,
+                                      value: domainTLDFont,
                                       range: nsRange)
 
         return attributedDomain
@@ -402,7 +390,7 @@ extension DomainSuggestionsTableViewController {
     private func attributedFreeForTheFirstYear() -> NSAttributedString {
         NSAttributedString(
             string: NSLocalizedString("Free for the first year ", comment: "Label shown for domains that will be free for the first year due to the user having a premium plan with available domain credit."),
-            attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
+            attributes: [.font: freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
     }
 
     private func attributedSuggestionCost(for suggestion: DomainSuggestion, hasDomainCredit: Bool) -> NSAttributedString {
@@ -418,13 +406,13 @@ extension DomainSuggestionsTableViewController {
     }
 
     private func suggestionCostAttributes(hasDomainCredit: Bool) -> [NSAttributedString.Key: Any] {
-        [.font: Self.suggestionCostFont,
+        [.font: suggestionCostFont,
          .foregroundColor: hasDomainCredit ? UIColor.secondaryLabel : UIColor.label,
          .strikethroughStyle: hasDomainCredit ? 1 : 0]
     }
 
     private func perYearPostfixAttributes(hasDomainCredit: Bool) -> [NSAttributedString.Key: Any] {
-        [.font: Self.perYearPostfixFont,
+        [.font: perYearPostfixFont,
          .foregroundColor: UIColor.secondaryLabel,
          .strikethroughStyle: hasDomainCredit ? 1 : 0]
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -346,17 +346,21 @@ extension DomainSuggestionsTableViewController {
         let hasDomainCredit = blog?.hasDomainCredit ?? false
 
         if hasDomainCredit {
-            let freeForFirstYear = NSAttributedString(
-                string: NSLocalizedString("Free for the first year ", comment: "Label shown for domains that will be free for the first year due to the user having a premium plan with available domain credit."),
-                attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
-
-            attributedString.append(freeForFirstYear)
+            attributedString.append(attributedFreeForTheFirstYear())
         }
 
         attributedString.append(attributedSuggestionCost(for: suggestion, hasDomainCredit: hasDomainCredit))
         attributedString.append(attributedPerYearPostfix(hasDomainCredit: hasDomainCredit))
 
         return attributedString
+    }
+
+    // MARK: - Attributed partial strings
+
+    private func attributedFreeForTheFirstYear() -> NSAttributedString {
+        NSAttributedString(
+            string: NSLocalizedString("Free for the first year ", comment: "Label shown for domains that will be free for the first year due to the user having a premium plan with available domain credit."),
+            attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
     }
 
     private func attributedSuggestionCost(for suggestion: DomainSuggestion, hasDomainCredit: Bool) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -346,7 +346,9 @@ extension DomainSuggestionsTableViewController {
         let hasDomainCredit = blog?.hasDomainCredit ?? false
 
         if hasDomainCredit {
-            let freeForFirstYear = NSAttributedString(string: "Free for the first year ", attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
+            let freeForFirstYear = NSAttributedString(
+                string: NSLocalizedString("Free for the first year ", comment: "Label shown for domains that will be free for the first year due to the user having a premium plan with available domain credit."),
+                attributes: [.font: Self.freeForFirstYearFont, .foregroundColor: UIColor.muriel(name: .green, .shade50)])
 
             attributedString.append(freeForFirstYear)
         }
@@ -365,7 +367,7 @@ extension DomainSuggestionsTableViewController {
 
     private func attributedPerYearPostfix(hasDomainCredit: Bool) -> NSAttributedString {
         NSAttributedString(
-            string: " / year",
+            string: NSLocalizedString(" / year", comment: "Per-year postfix shown after a domain's cost."),
             attributes: perYearPostfixAttributes(hasDomainCredit: hasDomainCredit))
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -377,7 +377,7 @@ extension DomainSuggestionsTableViewController {
 
     private func perYearPostfixAttributes(hasDomainCredit: Bool) -> [NSAttributedString.Key: Any] {
         [.font: Self.perYearPostfixFont,
-         .foregroundColor: hasDomainCredit ? UIColor.secondaryLabel : UIColor.label,
+         .foregroundColor: UIColor.secondaryLabel,
          .strikethroughStyle: hasDomainCredit ? 1 : 0]
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -159,6 +159,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
         if let vc = segue.destination as? DomainSuggestionsTableViewController {
             vc.delegate = self
             vc.siteName = siteName
+            vc.blog = BlogService.blog(with: site)
 
             if BlogService.blog(with: site)?.hasBloggerPlan == true {
                 vc.domainSuggestionType = .allowlistedTopLevelDomains(["blog"])


### PR DESCRIPTION
First step to implement #17192 

In this PR we:

- Show the basic cost per year for each suggested domain.
- Show when a domain will be free for the first year.

## Known limitations:

We don't yet show product discount information (coming soon).

## Associated PRs:

WPKit: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/451

## To test:

### Regular price:

1. Go to the Domains section for a site that has no domain credit.
2. Claim your domain / Add domain

The suggested domains should come up with their cost per year.

<img src="https://user-images.githubusercontent.com/1836005/136941999-5b878b13-308a-47b0-b2f8-c6a32e1063ed.png" width=300>


### Free for the first year:

1. Go to the Domains section for a site that has domain credit.
2. Claim your domain / Add domain

The suggested domains should show a green label reading "Free for the first year" followed by the regular cost striked-through.

<img src="https://user-images.githubusercontent.com/1836005/136942166-ca71678a-c149-467f-b12f-62140b3f4aab.png" width=300>

## Regression Notes

1. Potential unintended areas of impact

None, this is a new feature and we're not changing anything that could affect existing features.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
