### PR TITLE
Make pre-publish sheet header opaque

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 18.5
 -----
 * [**] Block editor: Embed block: Include Jetpack embed variants. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
+* [*] Fixed a minor visual glitch on the pre-publishing nudge bottom sheet. [https://github.com/wordpress-mobile/WordPress-iOS/pull/17300]
 
 
 18.4

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing Nudge/PrepublishingHeaderView.swift
@@ -39,6 +39,7 @@ class PrepublishingHeaderView: UITableViewHeaderFooterView, NibLoadable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureBackgroundView()
         configureBackButton()
         configurePublishingToLabel()
         configureBlogTitleLabel()
@@ -50,6 +51,11 @@ class PrepublishingHeaderView: UITableViewHeaderFooterView, NibLoadable {
         super.prepareForReuse()
 
         self.delegate = nil
+    }
+
+    private func configureBackgroundView() {
+        backgroundView = UIView()
+        backgroundView?.backgroundColor = .basicBackground
     }
 
     private func configureBackButton() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/17143

The pre-publish header was transparent when it should have been opaque. This was noticeable if the user scrolled the sheet contents up under the (transparent) header.

Instead of simply setting the header's background color, this fix works by setting the header's background view and settings _its_ background color. This approach is described in https://stackoverflow.com/a/25588828/1305067 and is the only known way to set the background color of a `UITableViewHeaderFooterView` (which is what this table header is).

| <img src="https://user-images.githubusercontent.com/1898325/137015567-0d138010-c76c-4b8b-9b9a-2a440b4f13e6.gif" alt="" width="350"> |
| - |

### To test
Publish a post and verify that the pre-publishing nudge bottom sheet works and looks correct in light and dark mode. I also tested on an iPad, but that might not be necessary for reviewers to do.

## Regression Notes
1. Potential unintended areas of impact

This is a visual change to the pre-publishing bottom sheet so it has the potential to negatively impact this bottom sheet's visual looks & feel and/or its functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I relied on [`testTextPostPublish`](https://github.com/wordpress-mobile/WordPress-iOS/blob/7846795166e4d7699f65a3d55fb547c58285eec5/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift#L26-L39) and [`testBasicPostPublish`](https://github.com/wordpress-mobile/WordPress-iOS/blob/7846795166e4d7699f65a3d55fb547c58285eec5/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift#L41-L67), which include tapping the "Publish Now" button on the pre-publishing nudge bottom sheet. These tests ensure that the "Publish Now" button continues to work as expected.

3. What automated tests I added (or what prevented me from doing so)

This fixes a slight visual glitch only seen on overscroll of the bottom sheet content, so adding tests doesn't feel appropriate here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
