### PR TITLE
Empty stats: Show next nudge logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
@@ -11,7 +11,7 @@
 /**
  *	@brief	Controller to display Calypso sharing options
  */
-@interface SharingViewController : UITableViewController
+@interface SharingViewController : UITableViewController<UIAdaptivePresentationControllerDelegate>
 
 /**
  *	@brief	Convenience initializer

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -73,7 +73,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 -(void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
 {
-    
+    [self notifyDelegatePublicizeServicesChangedIfNeeded];
 }
 
 - (void)refreshPublicizers
@@ -86,9 +86,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)doneButtonTapped
 {
-    if ([self.publicizeServicesState hasAddedNewConnectionTo:[self allConnections]]) {
-        [self.delegate didChangePublicizeServices];
-    }
+    [self notifyDelegatePublicizeServicesChangedIfNeeded];
     [self dismissViewControllerAnimated:YES completion:nil];
 }
 
@@ -264,6 +262,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         }
     }
     return allConnections;
+}
+
+-(void)notifyDelegatePublicizeServicesChangedIfNeeded
+{
+    if ([self.publicizeServicesState hasAddedNewConnectionTo:[self allConnections]]) {
+        [self.delegate didChangePublicizeServices];
+    }
 }
 
 - (NSManagedObjectContext *)managedObjectContext

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -54,6 +54,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     [self syncServices];
     [self.publicizeServicesState addInitialConnections:[self allConnections]];
+
+    self.navigationController.presentationController.delegate = self;
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -67,6 +69,11 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     [super viewWillDisappear:animated];
     [ReachabilityUtils dismissNoInternetConnectionNotice];
+}
+
+-(void)presentationControllerDidDismiss:(UIPresentationController *)presentationController
+{
+    
 }
 
 - (void)refreshPublicizers

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -113,6 +113,13 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     // Local state for site current view count
     private var currentViewCount: Int?
 
+    private lazy var nudgeState: SiteStatsNudgeState? = {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID else {
+            return nil
+        }
+        return SiteStatsNudgeState(siteId: siteID)
+    }()
+
     private let insightsStore = StoreContainer.shared.statsInsights
 
     // Store Insights settings for all sites.
@@ -180,7 +187,8 @@ private extension SiteStatsInsightsTableViewController {
     func initViewModel() {
         viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow,
                                                insightsDelegate: self,
-                                               insightsStore: insightsStore)
+                                               insightsStore: insightsStore,
+                                               nudgeState: nudgeState)
         addViewModelListeners()
         viewModel?.fetchInsights()
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -361,10 +361,11 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Grow Audience Card Management
 
     func loadGrowAudienceCardSetting() {
-        guard shouldDisplayGrowAudienceCard else {
+        guard isSiteViewsCountLow, nudgeState?.nextNudge != nil else {
             dismissGrowAudienceCard()
             return
         }
+
         guard let key = userDefaultsHideGrowAudienceKey else { return }
         loadPermanentlyDismissableInsight(.growAudience, using: key)
     }
@@ -374,7 +375,7 @@ private extension SiteStatsInsightsTableViewController {
         permanentlyDismissInsight(.growAudience, using: key)
     }
 
-    var shouldDisplayGrowAudienceCard: Bool {
+    var isSiteViewsCountLow: Bool {
         let threshold = 30
         let count = insightsStore.getAllTimeStats()?.viewsCount ?? 0
         return count < threshold

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -361,7 +361,7 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Grow Audience Card Management
 
     func loadGrowAudienceCardSetting() {
-        guard isSiteViewsCountLow, nudgeState?.nextNudge != nil else {
+        guard isSiteViewsCountLow, nudgeState?.nudgeToDisplay != nil else {
             dismissGrowAudienceCard()
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -17,10 +17,10 @@ class SiteStatsInsightsViewModel: Observable {
     private var insightsToShow = [InsightType]()
 
     private let nudgeState: SiteStatsNudgeState?
-    private let nextNudge: GrowAudienceCell.HintType?
+    private let nudgeToDisplay: GrowAudienceCell.HintType?
     private var isNudgeCompleted: Bool {
         guard let nudgeState = nudgeState,
-              let nudge = nextNudge else {
+              let nudge = nudgeToDisplay else {
                   return false
               }
         return nudgeState.isNudgeCompleted(nudge)
@@ -40,7 +40,7 @@ class SiteStatsInsightsViewModel: Observable {
         self.insightsToShow = insightsToShow
         self.insightsStore = insightsStore
         self.nudgeState = nudgeState
-        self.nextNudge = nudgeState?.nextNudge
+        self.nudgeToDisplay = nudgeState?.nudgeToDisplay
 
         insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
             self?.emitChange()
@@ -81,7 +81,7 @@ class SiteStatsInsightsViewModel: Observable {
                                         type: .insights,
                                         status: insightsStore.allTimeStatus,
                                         block: {
-                                            let nudge = nextNudge ?? .social
+                                            let nudge = nudgeToDisplay ?? .social
                                             let viewsCount = insightsStore.getAllTimeStats()?.viewsCount
                                             return GrowAudienceRow(hintType: nudge,
                                                                    allTimeViewsCount: viewsCount ?? 0,
@@ -272,7 +272,7 @@ class SiteStatsInsightsViewModel: Observable {
     }
 
     func markEmptyStatsNudgeAsCompleted() {
-        guard let nudge = nextNudge else {
+        guard let nudge = nudgeToDisplay else {
             return
         }
         nudgeState?.markNudgeAsCompleted(nudge)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -34,18 +34,13 @@ class SiteStatsInsightsViewModel: Observable {
 
     init(insightsToShow: [InsightType],
          insightsDelegate: SiteStatsInsightsDelegate,
-         insightsStore: StatsInsightsStore) {
+         insightsStore: StatsInsightsStore,
+         nudgeState: SiteStatsNudgeState?) {
         self.siteStatsInsightsDelegate = insightsDelegate
         self.insightsToShow = insightsToShow
         self.insightsStore = insightsStore
-
-        if let siteID = SiteStatsInformation.sharedInstance.siteID {
-            self.nudgeState = SiteStatsNudgeState(siteId: siteID)
-            self.nextNudge = nudgeState?.nextNudge
-        } else {
-            self.nudgeState = nil
-            self.nextNudge = nil
-        }
+        self.nudgeState = nudgeState
+        self.nextNudge = nudgeState?.nextNudge
 
         insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
             self?.emitChange()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
@@ -1,27 +1,34 @@
 import Foundation
 
 final class SiteStatsNudgeState {
-    private let suggestionsOrder: [GrowAudienceCell.HintType] = [.social, .bloggingReminders]
+    private let nudges: [GrowAudienceCell.HintType] = [.social, .bloggingReminders]
     private let siteId: NSNumber
 
     init(siteId: NSNumber) {
         self.siteId = siteId
     }
+
+    // Returns the first uncompleted nudge
+    var nextNudge: GrowAudienceCell.HintType? {
+        for nudge in nudges where !isNudgeCompleted(nudge) {
+            return nudge
+        }
+        return nil
+    }
+
+    func markNudgeAsCompleted(_ nudge: GrowAudienceCell.HintType) {
+        UserDefaults.standard.set(true, forKey: userDefaultsKey(for: nudge))
+    }
+
+    func isNudgeCompleted(_ nudge: GrowAudienceCell.HintType) -> Bool {
+        UserDefaults.standard.bool(forKey: userDefaultsKey(for: nudge))
+    }
 }
 
 // MARK: - Private Methods
 private extension SiteStatsNudgeState {
-    // Post sharing enabled state key per site
-    var userDefaultsPostSharingEnabledKey: String {
-        let siteID = siteId.intValue
-        let key = "StatsInsightsPostSharingEnabled"
-        return key + "-\(siteID)"
-    }
-
-    // Blogging reminders enabled state key per site
-    var userDefaultsBloggingRemindersEnabledKey: String {
-        let siteID = siteId.intValue
-        let key = "StatsInsightsBloggingRemindersEnabled"
-        return key + "-\(siteID)"
+    // Nudge completed key per site
+    func userDefaultsKey(for nudge: GrowAudienceCell.HintType) -> String {
+        "StatsInsights-\(siteId.intValue)-\(nudge.rawValue)-nudge-completed"
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class SiteStatsNudgeState {
+    private let suggestionsOrder: [GrowAudienceCell.HintType] = [.social, .bloggingReminders]
+    private let siteId: NSNumber
+
+    init(siteId: NSNumber) {
+        self.siteId = siteId
+    }
+}
+
+// MARK: - Private Methods
+private extension SiteStatsNudgeState {
+    // Post sharing enabled state key per site
+    var userDefaultsPostSharingEnabledKey: String {
+        let siteID = siteId.intValue
+        let key = "StatsInsightsPostSharingEnabled"
+        return key + "-\(siteID)"
+    }
+
+    // Blogging reminders enabled state key per site
+    var userDefaultsBloggingRemindersEnabledKey: String {
+        let siteID = siteId.intValue
+        let key = "StatsInsightsBloggingRemindersEnabled"
+        return key + "-\(siteID)"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsNudgeState.swift
@@ -9,7 +9,7 @@ final class SiteStatsNudgeState {
     }
 
     // Returns the first uncompleted nudge
-    var nextNudge: GrowAudienceCell.HintType? {
+    var nudgeToDisplay: GrowAudienceCell.HintType? {
         for nudge in nudges where !isNudgeCompleted(nudge) {
             return nudge
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -164,7 +164,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
 extension GrowAudienceCell {
 
-    enum HintType {
+    enum HintType: String {
 
         case social
         case bloggingReminders

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -40,6 +40,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
     // MARK: - Styling
 
     private func applyStyles() {
+        selectionStyle = .none
         backgroundColor = .listForeground
         addBottomBorder(withColor: .divider)
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1455,6 +1455,8 @@
 		93CD939319099BE70049096E /* authtoken.json in Resources */ = {isa = PBXBuildFile; fileRef = 93CD939219099BE70049096E /* authtoken.json */; };
 		93CDC72126CD342900C8A3A8 /* DestructiveAlertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC72026CD342900C8A3A8 /* DestructiveAlertHelper.swift */; };
 		93CDC72226CD342900C8A3A8 /* DestructiveAlertHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CDC72026CD342900C8A3A8 /* DestructiveAlertHelper.swift */; };
+		93CFF5E12715D0C20057520B /* SiteStatsNudgeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CFF5E02715D0C20057520B /* SiteStatsNudgeState.swift */; };
+		93CFF5E22715D0C20057520B /* SiteStatsNudgeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CFF5E02715D0C20057520B /* SiteStatsNudgeState.swift */; };
 		93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */; };
 		93DEB88219E5BF7100F9546D /* TodayExtensionService.m in Sources */ = {isa = PBXBuildFile; fileRef = 93DEB88119E5BF7100F9546D /* TodayExtensionService.m */; };
 		93E3D3C819ACE8E300B1C509 /* SFHFKeychainUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 292CECFF1027259000BD407D /* SFHFKeychainUtils.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -6215,6 +6217,7 @@
 		93C8829B1EEB18D700227A59 /* rsd.xml */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = rsd.xml; sourceTree = "<group>"; };
 		93CD939219099BE70049096E /* authtoken.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = authtoken.json; sourceTree = "<group>"; };
 		93CDC72026CD342900C8A3A8 /* DestructiveAlertHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DestructiveAlertHelper.swift; sourceTree = "<group>"; };
+		93CFF5E02715D0C20057520B /* SiteStatsNudgeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsNudgeState.swift; sourceTree = "<group>"; };
 		93D86B931C63EC31003D8E3E /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		93D86B941C63EC31003D8E3E /* en-CA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-CA"; path = "en-CA.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		93DEB88019E5BF7100F9546D /* TodayExtensionService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TodayExtensionService.h; sourceTree = "<group>"; };
@@ -11720,6 +11723,7 @@
 				98880A4722B2E3FC00464538 /* Two Column Stats */,
 				988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */,
 				9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */,
+				93CFF5E02715D0C20057520B /* SiteStatsNudgeState.swift */,
 				98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */,
 				98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */,
 			);
@@ -17655,6 +17659,7 @@
 				7E4123C220F4097B00DF8486 /* FormattableContentFormatter.swift in Sources */,
 				7E21C765202BBF4400837CF5 /* SearchAdsAttribution.swift in Sources */,
 				5DF8D26119E82B1000A2CD95 /* ReaderCommentsViewController.m in Sources */,
+				93CFF5E12715D0C20057520B /* SiteStatsNudgeState.swift in Sources */,
 				1716AEFC25F2927600CF49EC /* MySiteViewController.swift in Sources */,
 				F18CB8962642E58700B90794 /* FixedSizeImageView.swift in Sources */,
 				7E3E7A6020E44E490075D159 /* FooterContentGroup.swift in Sources */,
@@ -19292,6 +19297,7 @@
 				FABB216D2602FC2C00C8785C /* StatsGhostTableViewRows.swift in Sources */,
 				FABB216E2602FC2C00C8785C /* ActivityContentRouter.swift in Sources */,
 				FABB216F2602FC2C00C8785C /* UIView+ContentLayout.swift in Sources */,
+				93CFF5E22715D0C20057520B /* SiteStatsNudgeState.swift in Sources */,
 				FABB21702602FC2C00C8785C /* PeopleCell.swift in Sources */,
 				FABB21712602FC2C00C8785C /* AbstractPost+Local.swift in Sources */,
 				FABB21722602FC2C00C8785C /* MeScenePresenter.swift in Sources */,


### PR DESCRIPTION
Part of [#17215](https://github.com/wordpress-mobile/WordPress-iOS/issues/17125)

This PR adds logic for showing the next available nudge. If all the nudges are complete then nothing is shown.

## To test
1. (If needed) Delete the app and reinstall it (to clear the cache), and log in
2. Select the site that has less than 30 views
3. Go to **My Site** > **Stats**
4. **Publizice nudge** should be presented
5. Tap on **Enable post sharing** and add new connection
6. Go back to **Stats** screen
7. Confirm **Sharing is set up!** message is displayed
8. Go back to **My Site**
9. Go back again to **My Site** > **Stats**
10. Confirm **Blogging reminders** nudge is displayed

## Screnshots

Publicize nudge | Blogging reminders nudge
--- | ---
<img width="502" alt="Screenshot 2021-10-12 at 21 39 15" src="https://user-images.githubusercontent.com/12729242/137018704-9d0e6169-f5ce-4e67-b3cc-ed00a8495d17.png"> | <img width="502" alt="Screenshot 2021-10-12 at 21 25 18" src="https://user-images.githubusercontent.com/12729242/137018735-db842d44-ce81-4f8b-b63d-622125438a76.png">

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
