### PR TITLE
Comments: sync when view appears

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 18.5
 -----
 * [**] Block editor: Embed block: Include Jetpack embed variants. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
-
+* [*] Site Comments: fixed an issue that caused the lists to not refresh. [#17303]
 
 18.4
 -----

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -566,7 +566,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)refreshAndSyncIfNeeded
 {
-    if (self.blog && self.contentIsEmpty) {
+    if (self.blog) {
         [self.syncHelper syncContent];
     }
 }


### PR DESCRIPTION
Unfixes: #17202
Ref: #17234

This undoes the referenced fix. That change resulted in:
- Comment lists not being updated after the status changed, making it appear comment moderation didn't work until the view was manually refreshed.
- Comment lists containing comments from a previous site.

This of course re-introduces the original bug, but IMO that is less bad than the bugs it created.

FWIW, I _think_ there is a way to refresh the lists using `[self.tableViewHandler refreshTableViewPreservingOffset]`. I'll add my notes to #17202 when I reopen it (after this is merged).

To test:
- Verify the `newCommentDetail` feature is _not_ enabled.
- Go to My Site > Comments.
- Verify the selected filter automatically updates.
- Select a comment, and change the status.
- After the details view is automatically dismissed, verify the list is automatically updated.


https://user-images.githubusercontent.com/1816888/137033540-3b7d2937-a90e-4581-84e2-6e63985dd6b6.mp4



## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
