### PR TITLE
Comment Details: show Delete Permanently only for Trashed comments

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -51,9 +51,11 @@ public class Comment: NSManagedObject {
     }
 
     @objc func deleteWillBePermanent() -> Bool {
-        // If the Comment is currently Spam or Trash, the Trash action will permanently delete the Comment.
-        return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
+        if !FeatureFlag.newCommentDetail.enabled {
+            return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
+        }
 
+        return status.isEqual(to: Comment.descriptionFor(.unapproved))
     }
 
     func numberOfLikes() -> Int {

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -75,7 +75,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                success:(void (^)(void))success
                failure:(void (^)(NSError *error))failure;
 
-// Unapprove comment
+// Unapprove (Pending) comment
 - (void)unapproveComment:(Comment *)comment
                  success:(void (^)(void))success
                  failure:(void (^)(NSError *error))failure;
@@ -86,6 +86,11 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
             failure:(void (^)(NSError *error))failure;
 
 // Trash comment
+- (void)trashComment:(Comment *)comment
+             success:(void (^)(void))success
+             failure:(void (^)(NSError *error))failure;
+
+// Delete comment
 - (void)deleteComment:(Comment *)comment
               success:(void (^)(void))success
               failure:(void (^)(NSError *error))failure;

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -445,6 +445,17 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     
 }
 
+// Trash comment
+- (void)trashComment:(Comment *)comment
+                 success:(void (^)(void))success
+                 failure:(void (^)(NSError *error))failure
+{
+    [self moderateComment:comment
+               withStatus:CommentStatusTypeUnapproved
+                  success:success
+                  failure:failure];
+}
+
 // Delete comment
 - (void)deleteComment:(Comment *)comment
               success:(void (^)(void))success
@@ -779,7 +790,6 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                           failure:failure];
 }
 
-// Trash
 - (void)deleteCommentWithID:(NSNumber *)commentID
                      siteID:(NSNumber *)siteID
                     success:(void (^)(void))success

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -196,10 +196,7 @@ private extension CommentModerationBar {
     }
 
     @IBAction func trashTapped() {
-        // The Delete Permanently functionality deletes a spam comment,
-        // so don't allow it to be Trashed from here.
-        guard commentStatus != .spam,
-              !trashButton.isSelected else {
+        guard !trashButton.isSelected else {
             return
         }
 


### PR DESCRIPTION
Ref: #17087 , #17200, #17297

From [discussion](https://github.com/wordpress-mobile/WordPress-iOS/pull/17297#issuecomment-941698622) with @mattmiklic , this enables the `Delete Permanently` button only for Trashed comments. When trashing a Spam comment, the comment is now marked as Trash instead of deleted.


To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a Spam comment.
  - Verify `Delete Permanently` does not appear.
  - Verify selecting `Trash` moves the comment to the Trashed filter.
- Select a Trash comment.
  - Verify `Delete Permanently` does appear.
  - Verify tapping `Delete Permanently` deletes the comment.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
