### PR TITLE
Removes JetpackSiteRef from the domain registration flows.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -21,23 +21,8 @@ extension BlogDetailsViewController {
     }
 
     @objc func showDomainCreditRedemption() {
-        guard let site = JetpackSiteRef(blog: blog) else {
-            DDLogError("Error: couldn't initialize `JetpackSiteRef` from blog with ID: \(blog.dotComID?.intValue ?? 0)")
-            let cancelActionTitle = NSLocalizedString(
-                "OK",
-                comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt."
-            )
-            let alertController = UIAlertController(
-                title: NSLocalizedString("Unable to register domain", comment: "Alert title when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
-                message: NSLocalizedString("Something went wrong, please try again.", comment: "Alert message when `JetpackSiteRef` cannot be initialized from a blog during domain credit redemption."),
-                preferredStyle: .alert
-            )
-            alertController.addCancelActionWithTitle(cancelActionTitle, handler: nil)
-            present(alertController, animated: true, completion: nil)
-            return
-        }
         let controller = RegisterDomainSuggestionsViewController
-            .instance(site: site, domainPurchasedCallback: { [weak self] domain in
+            .instance(site: blog, domainPurchasedCallback: { [weak self] domain in
                 WPAnalytics.track(.domainCreditRedemptionSuccess)
                 self?.presentDomainCreditRedemptionSuccess(domain: domain)
             })

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -48,7 +48,7 @@ class RegisterDomainDetailsViewModel {
     var registerDomainDetailsService: RegisterDomainDetailsServiceProxyProtocol = RegisterDomainDetailsServiceProxy()
 
     let domain: DomainSuggestion
-    let site: JetpackSiteRef
+    let siteID: Int
     let domainPurchasedCallback: ((String) -> Void)
 
     private(set) var addressSectionIndexHelper = CellIndex.AddressSectionIndexHelper()
@@ -68,8 +68,8 @@ class RegisterDomainDetailsViewModel {
         }
     }
 
-    init(site: JetpackSiteRef, domain: DomainSuggestion, domainPurchasedCallback: @escaping ((String) -> Void)) {
-        self.site = site
+    init(siteID: Int, domain: DomainSuggestion, domainPurchasedCallback: @escaping ((String) -> Void)) {
+        self.siteID = siteID
         self.domain = domain
         self.domainPurchasedCallback = domainPurchasedCallback
         manuallyTriggerValidation()
@@ -184,7 +184,7 @@ class RegisterDomainDetailsViewModel {
         let contactInformation = jsonRepresentation()
         let privacyEnabled = privacySectionSelectedItem() == CellIndex.PrivacyProtection.privately
         let registerDomainService = registerDomainDetailsService
-        let siteID = site.siteID
+        let siteID = siteID
         let onChange = onChange
 
         isLoading = true

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -24,7 +24,6 @@ final class DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
         let viewController = RegisterDomainSuggestionsViewController
-        /// TODO: - DOMAINS - Resolve the force unwrap here
             .instance(site: blog,
                       domainType: domainType,
                       includeSupportButton: false,

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -25,7 +25,7 @@ final class DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable
 
         let viewController = RegisterDomainSuggestionsViewController
         /// TODO: - DOMAINS - Resolve the force unwrap here
-            .instance(site: JetpackSiteRef(blog: blog)!,
+            .instance(site: blog,
                       domainType: domainType,
                       includeSupportButton: false,
                       domainPurchasedCallback: { domain in

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -163,7 +163,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
             vc.domainType = domainType
             vc.freeSiteAddress = site.freeSiteAddress
 
-            if site.hasBloggerPlan == true {
+            if site.hasBloggerPlan {
                 vc.domainSuggestionType = .allowlistedTopLevelDomains(["blog"])
             }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -301,7 +301,7 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
 
     private func presentWebViewForCurrentSite(domainSuggestion: DomainSuggestion) {
         guard let homeURL = site.homeURL,
-              let siteUrl = URL(string: "\(homeURL)"), let host = siteUrl.host,
+              let siteUrl = URL(string: homeURL as String), let host = siteUrl.host,
               let url = URL(string: Constants.checkoutWebAddress + host),
               let siteID = site.dotComID?.intValue else {
             return

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -534,7 +534,12 @@ class PluginViewModel: Observable {
     }
 
     private func presentDomainRegistration(for directoryEntry: PluginDirectoryEntry) {
-        let controller = RegisterDomainSuggestionsViewController.instance(site: site, domainPurchasedCallback: { [weak self] domain in
+        guard let blog = BlogService.blog(with: site) else {
+            DDLogError("Error obtaining the blog from the jetpack site ref.")
+            return
+        }
+
+        let controller = RegisterDomainSuggestionsViewController.instance(site: blog, domainPurchasedCallback: { [weak self] domain in
 
             guard let strongSelf = self,
                 let atHelper = AutomatedTransferHelper(site: strongSelf.site, plugin: directoryEntry) else {

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelLoadingStateTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelLoadingStateTests.swift
@@ -8,8 +8,10 @@ class RegisterDomainDetailsViewModelLoadingStateTests: XCTestCase {
         super.setUp()
 
         let domainSuggestion = try! DomainSuggestion(json: ["domain_name": "" as AnyObject])
-        let site = JetpackSiteRef.mock(siteID: 9001, username: "test")
-        viewModel = RegisterDomainDetailsViewModel(site: site, domain: domainSuggestion) { _ in return }
+        let siteID = 9001
+
+        viewModel = RegisterDomainDetailsViewModel(siteID: siteID, domain: domainSuggestion) { _ in return
+        }
     }
 
     func testLoadingStateWithContactInfoValidationFailure() {

--- a/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/RegisterDomainDetailsViewModelTests.swift
@@ -36,9 +36,9 @@ class RegisterDomainDetailsViewModelTests: XCTestCase {
         super.setUp()
 
         let domainSuggestion = try! DomainSuggestion(json: ["domain_name": "" as AnyObject])
-        let site = JetpackSiteRef.mock(siteID: 9001, username: "test")
+        let siteID = 9001
 
-        viewModel = RegisterDomainDetailsViewModel(site: site, domain: domainSuggestion) { _ in return }
+        viewModel = RegisterDomainDetailsViewModel(siteID: siteID, domain: domainSuggestion) { _ in return }
         viewModel.onChange = { [weak self] (change: Change) in
             self?.changeArray.append(change)
         }


### PR DESCRIPTION
Removes JetpackSiteRef from the domain registration flows.

This helps simplify the code a bit and actually make it better since `JetpackSiteRef` wasn't really needed.

## To test:

1. Test claiming the free domain that comes with a paid plan from the "Register domain cell"
2. Test claiming the free domain that comes with a paid plan from the Domain Dashboard
3. Test registering a domain with a free plan from the Domain Dashboard.

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
