### PR TITLE
Empty Stats: Set up blogging reminders

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -744,7 +744,7 @@ SPEC CHECKSUMS:
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 43160fc29f428c84706fef4e284e28d50d9925e8
-  FBReactNativeSpec: ba5eb7d7b0d126dab503f227c4919213561b2c82
+  FBReactNativeSpec: 86afc815d056c20bb7f2c1c202f2660652a4e381
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86
   Gifu: 7bcb6427457d85e0b4dff5a84ec5947ac19a93ea

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -8,6 +8,7 @@ class BloggingRemindersFlow {
                         for blog: Blog,
                         source: BloggingRemindersTracker.FlowStartSource,
                         alwaysShow: Bool = true,
+                        delegate: BloggingRemindersFlowDelegate? = nil,
                         onDismiss: DismissClosure? = nil) {
 
         guard alwaysShow || !hasShownWeeklyRemindersFlow(for: blog) else {
@@ -19,7 +20,10 @@ class BloggingRemindersFlow {
         let tracker = BloggingRemindersTracker(blogType: blogType)
         tracker.flowStarted(source: source)
 
-        let flowStartViewController = makeStartViewController(for: blog, tracker: tracker, source: source)
+        let flowStartViewController = makeStartViewController(for: blog,
+                                                              tracker: tracker,
+                                                              source: source,
+                                                              delegate: delegate)
         let navigationController = BloggingRemindersNavigationController(
             rootViewController: flowStartViewController,
             onDismiss: {
@@ -38,14 +42,18 @@ class BloggingRemindersFlow {
     /// if the flow has never been seen, it starts with the intro. Otherwise it starts with the calendar settings
     private static func makeStartViewController(for blog: Blog,
                                                 tracker: BloggingRemindersTracker,
-                                                source: BloggingRemindersTracker.FlowStartSource) -> UIViewController {
+                                                source: BloggingRemindersTracker.FlowStartSource,
+                                                delegate: BloggingRemindersFlowDelegate? = nil) -> UIViewController {
 
         guard hasShownWeeklyRemindersFlow(for: blog) else {
-            return BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
+            return BloggingRemindersFlowIntroViewController(for: blog,
+                                                            tracker: tracker,
+                                                            source: source,
+                                                            delegate: delegate)
         }
 
-        return (try? BloggingRemindersFlowSettingsViewController(for: blog, tracker: tracker)) ??
-            BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source)
+        return (try? BloggingRemindersFlowSettingsViewController(for: blog, tracker: tracker, delegate: delegate)) ??
+            BloggingRemindersFlowIntroViewController(for: blog, tracker: tracker, source: source, delegate: delegate)
     }
 
     // MARK: - Weekly reminders flow presentation status

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 
-
 class BloggingRemindersFlowIntroViewController: UIViewController {
 
     // MARK: - Subviews
@@ -56,6 +55,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
     private let blog: Blog
     private let tracker: BloggingRemindersTracker
     private let source: BloggingRemindersTracker.FlowStartSource
+    private weak var delegate: BloggingRemindersFlowDelegate?
 
     private var introDescription: String {
         switch source {
@@ -68,10 +68,14 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         }
     }
 
-    init(for blog: Blog, tracker: BloggingRemindersTracker, source: BloggingRemindersTracker.FlowStartSource) {
+    init(for blog: Blog,
+         tracker: BloggingRemindersTracker,
+         source: BloggingRemindersTracker.FlowStartSource,
+         delegate: BloggingRemindersFlowDelegate? = nil) {
         self.blog = blog
         self.tracker = tracker
         self.source = source
+        self.delegate = delegate
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -156,7 +160,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         tracker.buttonPressed(button: .continue, screen: .main)
 
         do {
-            let flowSettingsViewController = try BloggingRemindersFlowSettingsViewController(for: blog, tracker: tracker)
+            let flowSettingsViewController = try BloggingRemindersFlowSettingsViewController(for: blog, tracker: tracker, delegate: delegate)
 
             navigationController?.pushViewController(flowSettingsViewController, animated: true)
         } catch {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -1,5 +1,8 @@
 import UIKit
 
+protocol BloggingRemindersFlowDelegate: AnyObject {
+    func didSetUpBloggingReminders()
+}
 
 class BloggingRemindersFlowSettingsViewController: UIViewController {
 
@@ -220,11 +223,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     private let blog: Blog
     private let tracker: BloggingRemindersTracker
     private var scheduledTime: Date
+    private weak var delegate: BloggingRemindersFlowDelegate?
 
     init(
         for blog: Blog,
         tracker: BloggingRemindersTracker,
-        calendar: Calendar? = nil) throws {
+        calendar: Calendar? = nil,
+        delegate: BloggingRemindersFlowDelegate? = nil) throws {
 
         self.blog = blog
         self.tracker = tracker
@@ -234,6 +239,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
             return calendar
         }()
+        self.delegate = delegate
 
         scheduler = try BloggingRemindersScheduler()
 
@@ -343,6 +349,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                 self.tracker.scheduled(schedule, time: self.scheduledTime)
 
                 DispatchQueue.main.async { [weak self] in
+                    self?.delegate?.didSetUpBloggingReminders()
                     self?.pushCompletionViewController()
                 }
             case .failure(let error):

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -610,7 +610,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
         BloggingRemindersFlow.present(from: self,
                                       for: blog,
-                                      source: .statsInsights)
+                                      source: .statsInsights,
+                                      delegate: self)
 
         applyTableUpdates()
     }
@@ -680,6 +681,15 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
 extension SiteStatsInsightsTableViewController: SharingViewControllerDelegate {
     func didChangePublicizeServices() {
+        viewModel?.markEmptyStatsNudgeAsCompleted()
+        refreshTableView()
+    }
+}
+
+// MARK: - BloggingRemindersFlowDelegate
+
+extension SiteStatsInsightsTableViewController: BloggingRemindersFlowDelegate {
+    func didSetUpBloggingReminders() {
         viewModel?.markEmptyStatsNudgeAsCompleted()
         refreshTableView()
     }


### PR DESCRIPTION
Fixes #17124

## Description

This PR marks the blogging reminders nudge as complete, if a user successfully sets up blogging reminders for their site.


https://user-images.githubusercontent.com/6711616/137166724-83808d60-773d-45b7-8151-86e1d11e7be6.mp4


## To test

First, go through the publicize nudge flow, then test the Happy flow and the Unhappy flow.
 

### Publicize nudge flow

1. Select the site that has less than 30 views
2. Go to **My Site** > **Stats**
3. Publizice nudge should be presented
4. Tap on **Enable post sharing** and add new connection
5. Go back to **Stats** screen
6. Confirm **Sharing is set up!** message is displayed

### Happy flow

1. Select the site that has less than 30 views
2. Go to **My Site** > **Stats**
3. Blogging reminders nudge should be presented
4. Tap on **Set up blogging reminders** and finish setting up reminders for your site
5. Go back to **Stats** screen
6. Confirm **You set up blogging reminders** message is displayed

### Unhappy flow

1. Repeat the steps **1, 2, 3**
2. Tap on **Set up blogging reminders** and don't actually set up the reminders... exit out of the modal
3. Go back to **Stats** screen
4. Confirm  **You set up blogging reminders** message is not displayed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
