### PR TITLE
Comment Details: show Delete Permanently for Spam comments

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -51,11 +51,7 @@ public class Comment: NSManagedObject {
     }
 
     @objc func deleteWillBePermanent() -> Bool {
-        if !FeatureFlag.newCommentDetail.enabled {
-            return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
-        }
-
-        return status.isEqual(to: Comment.descriptionFor(.unapproved))
+        return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
     }
 
     func numberOfLikes() -> Int {


### PR DESCRIPTION
Ref: #17087 , #17200, #17297

From [further clarification](https://github.com/wordpress-mobile/WordPress-iOS/pull/17297#issuecomment-942715871) from @mattmiklic , this enables the `Delete Permanently` button for Spam comments, allowing Spam to be either deleted or Trashed. 🤞 I got it right this time!

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a Spam comment.
  - Verify `Delete Permanently` appears.
  - Verify tapping it deletes the comment.
- Select another Spam comment.  
  - Verify selecting `Trash` moves the comment to the Trashed filter.

---
⚠️ Auto merge is enabled. ⚠️ 
 
---
## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
