### PR TITLE
Empty Stats: Add a11y for Grow Audience card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -35,6 +35,39 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         dismissButton.setTitle(Strings.dismissButtonTitle, for: .normal)
 
         updateView(isCompleted: isNudgeCompleted)
+
+        prepareForVoiceOver(hintType: hintType,
+                            allTimeViewsCount: allTimeViewsCount,
+                            isNudgeCompleted: isNudgeCompleted)
+    }
+
+    // MARK: - A11y
+
+    func prepareForVoiceOver(hintType: HintType, allTimeViewsCount: Int, isNudgeCompleted: Bool) {
+
+        viewCountStackView.isAccessibilityElement = true
+        viewCountStackView.accessibilityTraits = .staticText
+        viewCountStackView.accessibilityLabel = Strings.getViewCountSummary(viewsCount: allTimeViewsCount)
+
+        tipLabel.isAccessibilityElement = true
+        tipLabel.accessibilityTraits = .staticText
+        tipLabel.accessibilityLabel = hintType.getTipTitle((isNudgeCompleted))
+
+        detailsLabel.isAccessibilityElement = true
+        detailsLabel.accessibilityTraits = .staticText
+        detailsLabel.accessibilityLabel = hintType.getDetailsTitle(isNudgeCompleted)
+
+        dismissButton.accessibilityLabel = Strings.dismissButtonTitle
+
+        actionButton.accessibilityLabel = hintType.getActionButtonTitle(isNudgeCompleted)
+
+        accessibilityElements = [
+            viewCountStackView,
+            tipLabel,
+            detailsLabel,
+            dismissButton,
+            actionButton
+        ].compactMap { $0 }
     }
 
     // MARK: - Styling
@@ -117,6 +150,11 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
         static func getViewsCountDescription(viewsCount: Int) -> String {
             return viewsCount == 1 ? viewsCountDescriptionSingular : viewsCountDescriptionPlural
+        }
+
+        static func getViewCountSummary(viewsCount: Int) -> String {
+            let description = getViewsCountDescription(viewsCount: viewsCount)
+            return "\(viewsCount) \(description)"
         }
 
         enum Social {


### PR DESCRIPTION
Fixes #17317 

## Description

This PR adds a11y to the Grow Audience card

## To test

### Tip💡 

- Test VoiceOver via the Accessibilty Inspector
- On Xcode, go to the menu bar and tap on Xcode > Open Developer Tool > Accessibility Inspector
- See video below for how to use Accessibility Inspector (Use the target button to select the accessibility element, the speech bubble button to hear VoiceOver, the arrows to cycle through the accessibility elements)

<img width="439" alt="Screen Shot 2021-10-14 at 16 23 04" src="https://user-images.githubusercontent.com/6711616/137348230-bc3ef892-1beb-48bb-a833-9cc098cf2bb0.png">

<details>
 <summary>Expand for video</summary>
 
https://user-images.githubusercontent.com/6711616/137349389-1fa3f48f-34b7-479b-a589-05773413b7b0.mov
 
</details>


### VoiceOver 🗣️ 

1. Select the site that has less than 30 views
2. Go to My Site > Stats
3. Publizice nudge should be presented
4. ✅ All elements on the nudge card should be compatible w VoiceOver
5. Connect a social network
6. Go back to My Site, then to Stats again
7. Blogging reminders nudge should be presented
8. ✅ All elements on the nudge card should be compatible w VoiceOver

## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
