### PR TITLE
Empty Stats, Publicize: add the option to enable the publicize module if not active

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -1,0 +1,37 @@
+import Foundation
+import UIKit
+
+/// Shows a NoResultsViewController on a given VC and handle enabling
+/// a Jetpack module
+@objc class JetpackModuleHelper: NSObject {
+    private weak var viewController: UIViewController?
+    private let moduleName: String
+    private var noResultsViewController: NoResultsViewController?
+
+    @objc init(viewController: UIViewController, moduleName: String) {
+        self.viewController = viewController
+        self.moduleName = moduleName
+    }
+
+    @objc func show() {
+        noResultsViewController = NoResultsViewController.controller()
+        noResultsViewController?.configure(
+            title: NSLocalizedString("Enable Publicize", comment: "Text shown when the site doesn't have the Publicize module enabled."),
+            attributedTitle: nil,
+            noConnectionTitle: nil,
+            buttonTitle: NSLocalizedString("Enable", comment: "Title of button to enable publicize."),
+            subtitle: NSLocalizedString("In order to share your published posts to your social media you need to enable the Publicize module.", comment: "Title of button to enable publicize."),
+            noConnectionSubtitle: nil,
+            attributedSubtitle: nil,
+            attributedSubtitleConfiguration: nil,
+            image: "mysites-nosites",
+            subtitleImage: nil,
+            accessoryView: nil
+        )
+
+        viewController?.addChild(noResultsViewController!)
+        viewController?.view.addSubview(withFadeAnimation: noResultsViewController!.view)
+        noResultsViewController?.view.frame = self.viewController?.view.bounds ?? .zero
+        noResultsViewController?.didMove(toParent: viewController!)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -1,6 +1,5 @@
 import Foundation
 import UIKit
-import Kanvas
 
 /// Shows a NoResultsViewController on a given VC and handle enabling
 /// a Jetpack module

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -41,12 +41,14 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
             accessoryView: nil
         )
 
-        noResultsViewController?.delegate = self
+        if let noResultsViewController = noResultsViewController, let viewController = viewController {
+            noResultsViewController.delegate = self
 
-        viewController?.addChild(noResultsViewController!)
-        viewController?.view.addSubview(withFadeAnimation: noResultsViewController!.view)
-        noResultsViewController?.didMove(toParent: viewController!)
-        noResultsViewController?.view.frame = self.viewController?.view.bounds ?? .zero
+            viewController.addChild(noResultsViewController)
+            viewController.view.addSubview(withFadeAnimation: noResultsViewController.view)
+            noResultsViewController.didMove(toParent: viewController)
+            noResultsViewController.view.frame = viewController.view.bounds
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -43,8 +43,8 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
 
         viewController?.addChild(noResultsViewController!)
         viewController?.view.addSubview(withFadeAnimation: noResultsViewController!.view)
-        noResultsViewController?.view.frame = self.viewController?.view.bounds ?? .zero
         noResultsViewController?.didMove(toParent: viewController!)
+        noResultsViewController?.view.frame = self.viewController?.view.bounds ?? .zero
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -18,6 +18,12 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
 
     private var noResultsViewController: NoResultsViewController?
 
+
+    /// Creates a Jetpack Module Wall that gives the user the option to enable a module
+    /// - Parameters:
+    ///   - viewController: a UIViewController that conforms to JetpackModuleHelperDelegate
+    ///   - moduleName: a `String` representing the name of the module
+    ///   - blog: a `Blog`
     @objc init(viewController: JetpackModuleHelperViewController, moduleName: String, blog: Blog) {
         self.viewController = viewController
         self.moduleName = moduleName
@@ -25,6 +31,11 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
         self.service = BlogJetpackSettingsService(managedObjectContext: blog.settings?.managedObjectContext ?? ContextManager.sharedInstance().mainContext)
     }
 
+
+    /// Show the No Results View Controller
+    /// - Parameters:
+    ///   - title: A `String` to display on the title of the NVC
+    ///   - subtitle: A `String` to display as the subtitle of the NVC
     @objc func show(title: String, subtitle: String) {
         noResultsViewController = NoResultsViewController.controller()
         noResultsViewController?.configure(

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -11,10 +11,12 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
 /// a Jetpack module
 @objc class JetpackModuleHelper: NSObject {
     private weak var viewController: JetpackModuleHelperViewController?
+
     private let moduleName: String
-    private var noResultsViewController: NoResultsViewController?
     private let blog: Blog
     private let service: BlogJetpackSettingsService
+
+    private var noResultsViewController: NoResultsViewController?
 
     @objc init(viewController: JetpackModuleHelperViewController, moduleName: String, blog: Blog) {
         self.viewController = viewController
@@ -23,14 +25,14 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
         self.service = BlogJetpackSettingsService(managedObjectContext: blog.settings?.managedObjectContext ?? ContextManager.sharedInstance().mainContext)
     }
 
-    @objc func show() {
+    @objc func show(title: String, subtitle: String) {
         noResultsViewController = NoResultsViewController.controller()
         noResultsViewController?.configure(
-            title: NSLocalizedString("Enable Publicize", comment: "Text shown when the site doesn't have the Publicize module enabled."),
+            title: title,
             attributedTitle: nil,
             noConnectionTitle: nil,
             buttonTitle: NSLocalizedString("Enable", comment: "Title of button to enable publicize."),
-            subtitle: NSLocalizedString("In order to share your published posts to your social media you need to enable the Publicize module.", comment: "Title of button to enable publicize."),
+            subtitle: subtitle,
             noConnectionSubtitle: nil,
             attributedSubtitle: nil,
             attributedSubtitleConfiguration: nil,

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -1,16 +1,22 @@
 import Foundation
 import UIKit
 
+public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate & UIViewController
+
+@objc public protocol JetpackModuleHelperDelegate: AnyObject {
+    func jetpackModuleEnabled()
+}
+
 /// Shows a NoResultsViewController on a given VC and handle enabling
 /// a Jetpack module
 @objc class JetpackModuleHelper: NSObject {
-    private weak var viewController: UIViewController?
+    private weak var viewController: JetpackModuleHelperViewController?
     private let moduleName: String
     private var noResultsViewController: NoResultsViewController?
     private let blog: Blog
     private let service: BlogJetpackSettingsService
 
-    @objc init(viewController: UIViewController, moduleName: String, blog: Blog) {
+    @objc init(viewController: JetpackModuleHelperViewController, moduleName: String, blog: Blog) {
         self.viewController = viewController
         self.moduleName = moduleName
         self.blog = blog
@@ -47,8 +53,9 @@ extension JetpackModuleHelper: NoResultsViewControllerDelegate {
         service.updateJetpackModuleActiveSettingForBlog(blog,
                                                         module: moduleName,
                                                         active: true,
-                                                        success: {
-
+                                                        success: { [weak self] in
+            self?.noResultsViewController?.removeFromView()
+            self?.viewController?.jetpackModuleEnabled()
         },
                                                         failure: { [weak self] _ in
             self?.viewController?.displayNotice(title: Constants.error)

--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -15,6 +15,7 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
     private let moduleName: String
     private let blog: Blog
     private let service: BlogJetpackSettingsService
+    private let blogService: BlogService
 
     private var noResultsViewController: NoResultsViewController?
 
@@ -29,6 +30,7 @@ public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate
         self.moduleName = moduleName
         self.blog = blog
         self.service = BlogJetpackSettingsService(managedObjectContext: blog.settings?.managedObjectContext ?? ContextManager.sharedInstance().mainContext)
+        self.blogService = BlogService(managedObjectContext: blog.settings?.managedObjectContext ?? ContextManager.sharedInstance().mainContext)
     }
 
 
@@ -69,8 +71,14 @@ extension JetpackModuleHelper: NoResultsViewControllerDelegate {
                                                         module: moduleName,
                                                         active: true,
                                                         success: { [weak self] in
-            self?.noResultsViewController?.removeFromView()
-            self?.viewController?.jetpackModuleEnabled()
+            guard let self = self else {
+                return
+            }
+
+            self.blogService.syncBlogAndAllMetadata(self.blog) {
+                self.noResultsViewController?.removeFromView()
+                self.viewController?.jetpackModuleEnabled()
+            }
         },
                                                         failure: { [weak self] _ in
             self?.viewController?.displayNotice(title: Constants.error)

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
@@ -6,12 +6,14 @@
 
 @end
 
+@protocol JetpackModuleHelperDelegate;
+
 @class Blog;
 
 /**
  *	@brief	Controller to display Calypso sharing options
  */
-@interface SharingViewController : UITableViewController<UIAdaptivePresentationControllerDelegate>
+@interface SharingViewController : UITableViewController<UIAdaptivePresentationControllerDelegate, JetpackModuleHelperDelegate>
 
 /**
  *	@brief	Convenience initializer

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -21,6 +21,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 @property (nonatomic, strong) NSArray *publicizeServices;
 @property (nonatomic, weak) id delegate;
 @property (nonatomic) PublicizeServicesState *publicizeServicesState;
+@property (nonatomic) JetpackModuleHelper *jetpackModuleHelper;
 
 @end
 
@@ -52,10 +53,18 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
-    [self syncServices];
     [self.publicizeServicesState addInitialConnections:[self allConnections]];
 
     self.navigationController.presentationController.delegate = self;
+
+    if ([self.blog supportsPublicize]) {
+        [self syncServices];
+    } else {
+        self.jetpackModuleHelper = [[JetpackModuleHelper alloc] initWithViewController:self moduleName:@"publicize" blog:self.blog];
+
+        [self.jetpackModuleHelper show];
+        self.tableView.dataSource = NULL;
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -237,6 +246,13 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     [self.navigationController pushViewController:controller animated:YES];
 }
 
+#pragma mark - JetpackModuleHelper
+
+- (void)jetpackModuleEnabled
+{
+    self.tableView.dataSource = self;
+    [self refreshPublicizers];
+}
 
 #pragma mark - Publicizer management
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -62,7 +62,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     } else {
         self.jetpackModuleHelper = [[JetpackModuleHelper alloc] initWithViewController:self moduleName:@"publicize" blog:self.blog];
 
-        [self.jetpackModuleHelper show];
+        [self.jetpackModuleHelper showWithTitle:NSLocalizedString(@"Enable Publicize", "Text shown when the site doesn't have the Publicize module enabled.") subtitle:NSLocalizedString(@"In order to share your published posts to your social media you need to enable the Publicize module.", "Title of button to enable publicize.")];
+
         self.tableView.dataSource = NULL;
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -252,7 +252,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)jetpackModuleEnabled
 {
     self.tableView.dataSource = self;
-    [self refreshPublicizers];
+    [self syncServices];
 }
 
 #pragma mark - Publicizer management

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -467,13 +467,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
-        var controller: UIViewController
-
-        if !blog.supportsPublicize() {
-            controller = SharingButtonsViewController(blog: blog)
-        } else {
-            controller = SharingViewController(blog: blog, delegate: self)
-        }
+        let controller: UIViewController = SharingViewController(blog: blog, delegate: self)
 
         let navigationController = UINavigationController(rootViewController: controller)
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1414,6 +1414,8 @@
 		8BB185D224B63D5F00A4CCE8 /* ReaderCardsStreamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB185D024B63D1600A4CCE8 /* ReaderCardsStreamViewController.swift */; };
 		8BB185D524B66FE600A4CCE8 /* ReaderCard+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB185D324B66FE500A4CCE8 /* ReaderCard+CoreDataProperties.swift */; };
 		8BB185D624B66FE600A4CCE8 /* ReaderCard+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BB185D424B66FE600A4CCE8 /* ReaderCard+CoreDataClass.swift */; };
+		8BBBCE702717651200B277AC /* JetpackModuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBBCE6F2717651200B277AC /* JetpackModuleHelper.swift */; };
+		8BBBCE712717651200B277AC /* JetpackModuleHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBBCE6F2717651200B277AC /* JetpackModuleHelper.swift */; };
 		8BBBEBB224B8F8C0005E358E /* ReaderCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBBEBB124B8F8C0005E358E /* ReaderCardTests.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
 		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
@@ -6021,6 +6023,7 @@
 		8BB185D024B63D1600A4CCE8 /* ReaderCardsStreamViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCardsStreamViewController.swift; sourceTree = "<group>"; };
 		8BB185D324B66FE500A4CCE8 /* ReaderCard+CoreDataProperties.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderCard+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		8BB185D424B66FE600A4CCE8 /* ReaderCard+CoreDataClass.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ReaderCard+CoreDataClass.swift"; sourceTree = "<group>"; };
+		8BBBCE6F2717651200B277AC /* JetpackModuleHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackModuleHelper.swift; sourceTree = "<group>"; };
 		8BBBEBB124B8F8C0005E358E /* ReaderCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCardTests.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
@@ -13920,6 +13923,7 @@
 				E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */,
 				E6431DE31C4E892900FD8D90 /* SharingViewController.h */,
 				E6431DE41C4E892900FD8D90 /* SharingViewController.m */,
+				8BBBCE6F2717651200B277AC /* JetpackModuleHelper.swift */,
 				E6431DDF1C4E892900FD8D90 /* SharingConnectionsViewController.h */,
 				E6431DE01C4E892900FD8D90 /* SharingConnectionsViewController.m */,
 				E63BBC941C5168BE00598BE8 /* SharingAuthorizationHelper.h */,
@@ -17021,6 +17025,7 @@
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,
 				B535209B1AF7BBB800B33BA8 /* PushAuthenticationManager.swift in Sources */,
 				AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */,
+				8BBBCE702717651200B277AC /* JetpackModuleHelper.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
 				40E728851FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift in Sources */,
 				46183D1F251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift in Sources */,
@@ -19637,6 +19642,7 @@
 				FABB22B32602FC2C00C8785C /* PrepublishingViewController.swift in Sources */,
 				FABB22B42602FC2C00C8785C /* PageListTableViewHandler.swift in Sources */,
 				FABB22B52602FC2C00C8785C /* SearchableItemConvertable.swift in Sources */,
+				8BBBCE712717651200B277AC /* JetpackModuleHelper.swift in Sources */,
 				FABB22B62602FC2C00C8785C /* WPAndDeviceMediaLibraryDataSource.m in Sources */,
 				FABB22B72602FC2C00C8785C /* SettingsListEditorViewController.swift in Sources */,
 				982DDF97263238A6002B3904 /* LikeUserPreferredBlog+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
Fixes #17309

### To test

1. Login with an account that has a Jetpack site without the `publicize` module enabled
2. For this Jetpack site, go to **Stats**
3. When the Publicize nudge appears tap on **Enable post sharing**
4. The screen should say that Publicize is not active, tap **Enable**
5. The regular Sharing screen should appear
6. Connect any social network to make sure it's working
7. Go back to **Stats**
8. Open the screen again, no message about the module should appear

Additional info:

* You can turn off the wi-fi to test the error
* You can activate/deactivate the Publicize module white testing. Just go to `yoursite/wp-admin/admin.php?page=jetpack_modules`

### Screenshots

| With the module deactivated | With the module active |
| --- | --- |
| ![Simulator Screen Shot - iPhone 13 - 2021-10-14 at 11 46 19](https://user-images.githubusercontent.com/7040243/137350716-401e2b33-ac9a-4e36-b3fa-ec03ed1c413c.png) | ![Simulator Screen Shot - iPhone 13 - 2021-10-14 at 12 27 05](https://user-images.githubusercontent.com/7040243/137350749-14f17f6f-7f04-4472-b3e9-0ad4b21a33a9.png) |

### Additional notes

I've added a new entity that works like a paywall but for Jetpack modules. We can even refactor Stats to use this one — I'll do that in another PR once that lands in `develop`.

The idea is that any VC can use it to block a feature until the module is enabled.

## Regression Notes
1. Potential unintended areas of impact
-

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
I'll add unit tests for the `JetpackModuleHelper` but want to make this PR available for review ASAP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
