### PR TITLE
Fix large text support in homepage/page layouts

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Block editor: Embed block: Include Jetpack embed variants. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4008]
 * [*] Fixed a minor visual glitch on the pre-publishing nudge bottom sheet. [https://github.com/wordpress-mobile/WordPress-iOS/pull/17300]
+* [*] Improved support for larger text sizes when choosing a homepage layout or page layout. [#17325]
 * [*] Site Comments: fixed an issue that caused the lists to not refresh. [#17303]
 
 18.4

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -331,12 +331,14 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
         [defaultActionButton, secondaryActionButton].forEach { (button) in
             button?.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
+            button?.titleLabel?.adjustsFontSizeToFitWidth = true
             button?.layer.borderColor = seperator.cgColor
             button?.layer.borderWidth = 1
             button?.layer.cornerRadius = 8
         }
 
         primaryActionButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
+        primaryActionButton.titleLabel?.adjustsFontSizeToFitWidth = true
         primaryActionButton.backgroundColor = accentColor
         primaryActionButton.layer.cornerRadius = 8
     }


### PR DESCRIPTION
Previously, when the user had large text enabled in device accessibility settings, text in homepage and page layout selector screens were being clipped.
This change uses `adjustsFontSizeToFitWidth` to allow text to be shrunk if necessary to fit available with. I don't think setting `minimumFontSize` is necessary here since the buttons affected by this change have a fixed width.

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/17035

_**Note:** The issue's scope was only the homepage layout selection screens, but because of shared logic, this also fixes a similar issue in the page layout selection screens._

## To test

If possible, use a smaller iPhone such as a iPhone 13 Mini, iPhone 12 Mini, or iPhone SE (2nd generation) as their smaller screen size will better test how well larger text is supported.

<details>
<summary>How to turn on larger test</summary>

- Open Settings
- Tap Accessibility 
- Tap "Display & Text Size"
- Tap "Larger Text"
- Turn "Larger Accessibility Sizes" ON
- Move the slider to the largest text size
</details>

### Site creation flow

| | Before | After |
| - | - | - |
| "Preview" and "Choose" buttons | <img width="200" alt="Screen Shot 2021-10-14 at 15 32 06" src="https://user-images.githubusercontent.com/1898325/137375739-be53d3a2-d0df-45b8-926d-1a871a14e877.png"> | <img width="200" alt="Screen Shot 2021-10-14 at 15 18 53" src="https://user-images.githubusercontent.com/1898325/137373898-24a3d5e9-9386-4550-b96b-02ca976f46d0.png"> |


1. Turn ON larger text
2. On the "My Site" screen, tap the chevron button next to the site title to reveal the list of sites
3. Tap the plus button
4. Select "Create WordPress.com site"
5. On the "Choose a design" screen, tap any layout
6. Notice the "Preview" and "Choose" button titles are no longer clipped but instead are slightly shrunk to fit their button sizes
7. Turn OFF larger text and repeat steps 2 to 6

### Page creation flow

1. Turn ON larger text
2. On the "My Site" screen, tap the floating action button (FAB)
3. Select "Site page"
4. Notice the default "Create Blank Page" button title is no longer clipped
5. Tap any layout
6. Notice the "Preview" and "Create page" button titles are no longer clipped
7. Turn OFF larger text and repeat steps 2 to 6 

| | Before | After |
| - | - | - |
| "Create Blank Page" button | <img width="200" alt="Screen Shot 2021-10-14 at 15 32 17" src="https://user-images.githubusercontent.com/1898325/137375989-038f7c72-9d34-4f7c-b746-91f0aa741aa7.png"> | <img width="200" alt="Screen Shot 2021-10-14 at 15 19 07" src="https://user-images.githubusercontent.com/1898325/137376888-6b32348d-35f3-4ad8-9cf7-0c0fa873d5b7.png"> |
| "Preview" and "Create page" buttons | <img width="200" alt="Screen Shot 2021-10-14 at 15 32 20" src="https://user-images.githubusercontent.com/1898325/137376633-89c4716d-5821-4fc7-918d-0593b72babe0.png"> | <img width="200" alt="Screen Shot 2021-10-14 at 15 19 11" src="https://user-images.githubusercontent.com/1898325/137376978-3ea80e28-e40d-4f1e-a818-0205084d530b.png"> |


## Regression Notes
1. Potential unintended areas of impact

This change allows button titles to shrink to fit their size, so it could inadvertently affect users who use regular text sizes as well.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested the changes at a larger text size as well as a normal text size. I also tested on iPad 

3. What automated tests I added (or what prevented me from doing so)

This change would be hard to target with an automated test. Having automated tests for the site creation flow and the page layout selection flow would be useful, but I don't think we have them and that would be out-of-scope here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
