### PR TITLE
Empty Stats: AB test the nudges order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,6 @@
 * [**] Block editor: Embed block: Detect when an embeddable URL is pasted into an empty paragraph. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4048]
 * [**] Block editor: Pullquote block - Added support for text and background color customization [https://github.com/WordPress/gutenberg/pull/34451]
 * [**] Block editor: Preformatted block - Added support for text and background color customization [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4071]
-* [**] Stats: added Publicize and Blogging Reminders nudges for sites with low traffic in order to increase it.
 * [**] Stats: added Publicize and Blogging Reminders nudges for sites with low traffic in order to increase it. [#17142, #17261, #17294, #17312, #17323]
 
 18.4

--- a/WordPress/Classes/ViewRelated/Stats/Insights/EmptyStatsAB.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/EmptyStatsAB.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+class EmptyStatsAB {
+    static let shared = EmptyStatsAB()
+
+    enum Variant {
+        case control
+        case treatment
+    }
+
+    private let accountService: AccountService
+
+    public var variant: Variant {
+        calculateVariant()
+    }
+
+    private init(accountService: AccountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)) {
+        self.accountService = accountService
+    }
+
+    private func calculateVariant() -> Variant {
+        let defaultAccount = accountService.defaultWordPressComAccount()
+        let token: String? = defaultAccount?.authToken
+
+        if let token = token {
+            return token.hashCode() % 2 == 0 ? .control : .treatment
+        } else {
+            return .control
+        }
+    }
+}
+
+private extension String {
+    var asciiArray: [UInt32] {
+        return unicodeScalars
+            .filter { $0.isASCII }
+            .map { $0.value }
+    }
+
+    func hashCode() -> Int32 {
+        var h: Int32 = 0
+        for i in self.asciiArray {
+            h = 31 &* h &+ Int32(i)
+        }
+        return h
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -652,9 +652,11 @@ extension SiteStatsInsightsTableViewController: NoResultsViewHost {
 private extension SiteStatsInsightsTableViewController {
 
     func trackNudgeEvent(_ event: WPAnalyticsEvent) {
+        let firstNudge: String = EmptyStatsAB.shared.variant == .control ? "social" : "bloggingReminder"
+
         if let blogId = SiteStatsInformation.sharedInstance.siteID,
            let blog = Blog.lookup(withID: blogId, in: mainContext) {
-            WPAnalytics.track(event, properties: [:], blog: blog)
+            WPAnalytics.track(event, properties: ["first_nudge": firstNudge], blog: blog)
         } else {
             WPAnalytics.track(event)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -652,7 +652,7 @@ extension SiteStatsInsightsTableViewController: NoResultsViewHost {
 private extension SiteStatsInsightsTableViewController {
 
     func trackNudgeEvent(_ event: WPAnalyticsEvent) {
-        let firstNudge: String = EmptyStatsAB.shared.variant == .control ? "social" : "bloggingReminder"
+        let firstNudge: String = EmptyStatsAB.shared.variant == .control ? "publicize" : "bloggingReminder"
 
         if let blogId = SiteStatsInformation.sharedInstance.siteID,
            let blog = Blog.lookup(withID: blogId, in: mainContext) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -4,11 +4,23 @@ import Foundation
 protocol SiteStatsPinnable { /* not implemented */ }
 
 final class SiteStatsPinnedItemStore {
-    private let items: [SiteStatsPinnable] = [
-        GrowAudienceCell.HintType.social,
-        GrowAudienceCell.HintType.bloggingReminders,
-        InsightType.customize
-    ]
+    private lazy var items: [SiteStatsPinnable] = {
+        if EmptyStatsAB.shared.variant == .control {
+            // Control has social first
+            return [
+                GrowAudienceCell.HintType.social,
+                GrowAudienceCell.HintType.bloggingReminders,
+                InsightType.customize
+            ]
+        } else {
+            // Treatment has blogging reminders first
+            return [
+                GrowAudienceCell.HintType.bloggingReminders,
+                GrowAudienceCell.HintType.social,
+                InsightType.customize
+            ]
+        }
+    }()
     private let lowSiteViewsCountTreshold = 30
     private let siteId: NSNumber
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1370,6 +1370,8 @@
 		8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
+		8B5483412719B1B1006E7386 /* EmptyStatsAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5483402719B1B1006E7386 /* EmptyStatsAB.swift */; };
+		8B5483422719B1B1006E7386 /* EmptyStatsAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B5483402719B1B1006E7386 /* EmptyStatsAB.swift */; };
 		8B55F9B82614D819007D618E /* UnifiedPrologueEditorContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F851414260D0A3300A4B938 /* UnifiedPrologueEditorContentView.swift */; };
 		8B55F9CA2614D8BC007D618E /* RoundRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8513DE260D091500A4B938 /* RoundRectangleView.swift */; };
 		8B55F9DC2614D902007D618E /* CircledIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F851427260D1EA300A4B938 /* CircledIcon.swift */; };
@@ -5988,6 +5990,7 @@
 		8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+mainWindow.swift"; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
+		8B5483402719B1B1006E7386 /* EmptyStatsAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStatsAB.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
@@ -11722,6 +11725,7 @@
 				988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */,
 				9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */,
 				93F7214E271831820021A09F /* SiteStatsPinnedItemStore.swift */,
+				8B5483402719B1B1006E7386 /* EmptyStatsAB.swift */,
 				934098C2271957A600B3E77E /* SiteStatsInsightsDelegate.swift */,
 				934098BF2719577D00B3E77E /* InsightType.swift */,
 				98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */,
@@ -17957,6 +17961,7 @@
 				937F3E321AD6FDA7006BA498 /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,
 				171096CB270F01EA001BCDD6 /* DomainSuggestionsTableViewController.swift in Sources */,
 				469CE07124BCFB04003BDC8B /* CollapsableHeaderCollectionViewCell.swift in Sources */,
+				8B5483412719B1B1006E7386 /* EmptyStatsAB.swift in Sources */,
 				7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */,
 				F53FF3AA23EA725C001AD596 /* SiteIconView.swift in Sources */,
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
@@ -19681,6 +19686,7 @@
 				FABB22DA2602FC2C00C8785C /* RoundedButton.swift in Sources */,
 				FABB22DB2602FC2C00C8785C /* AboutViewController.swift in Sources */,
 				FABB22DC2602FC2C00C8785C /* MenuLocation.m in Sources */,
+				8B5483422719B1B1006E7386 /* EmptyStatsAB.swift in Sources */,
 				FABB22DD2602FC2C00C8785C /* RevisionsTableViewCell.swift in Sources */,
 				E6D6A1312683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				E62CE58F26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,


### PR DESCRIPTION
Only merge after #17313

### To test

1. Do a fresh install
2. Go to Stats
3. Notice the order in which the first card appears to you
4. Check in the nudge events that a property called `first_nudge` is fired with the correct value

## Regression Notes
1. Potential unintended areas of impact
-

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
