### PR TITLE
Empty Stats: Stay on insights tab if Grow Audience card is showing

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -70,13 +70,17 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     private func setTimePeriodForStatsURLIfPossible(_ url: URL) {
+        guard let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey else {
+            return
+        }
+
         let matcher = RouteMatcher(routes: UniversalLinkRouter.statsRoutes)
         let matches = matcher.routesMatching(url)
         if let match = matches.first,
            let action = match.action as? StatsRoute,
            let timePeriod = action.timePeriod {
             // Initializing a StatsPeriodType to ensure we have a valid period
-            UserDefaults.standard.set(timePeriod.rawValue, forKey: SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey)
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -5,6 +5,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
     static var defaultStoryboardName: String = "SiteStatsDashboard"
 
     // MARK: - Properties
+    var isGrowAudienceShowing: Bool {
+        return insightsToShow.contains(.growAudience)
+    }
 
     private var insightsChangeReceipt: Receipt?
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -52,7 +52,13 @@ fileprivate extension StatsPeriodType {
 
 class SiteStatsDashboardViewController: UIViewController {
 
-    static let lastSelectedStatsPeriodTypeKey = "LastSelectedStatsPeriodType"
+    static var lastSelectedStatsPeriodTypeKey: String? {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else {
+            return nil
+        }
+        return "LastSelectedStatsPeriodType-\(siteID)"
+    }
+
     static let lastSelectedStatsDateKey = "LastSelectedStatsDate"
 
     // MARK: - Properties
@@ -148,11 +154,23 @@ private extension SiteStatsDashboardViewController {
 private extension SiteStatsDashboardViewController {
 
     func saveSelectedPeriodToUserDefaults() {
-        UserDefaults.standard.set(currentSelectedPeriod.rawValue, forKey: Self.lastSelectedStatsPeriodTypeKey)
+
+        guard let key = Self.lastSelectedStatsPeriodTypeKey,
+              !insightsTableViewController.isGrowAudienceShowing else {
+            return
+        }
+
+        UserDefaults.standard.set(currentSelectedPeriod.rawValue, forKey: key)
     }
 
     func getSelectedPeriodFromUserDefaults() -> StatsPeriodType {
-        return StatsPeriodType(rawValue: UserDefaults.standard.integer(forKey: Self.lastSelectedStatsPeriodTypeKey)) ?? .insights
+
+        guard let key = Self.lastSelectedStatsPeriodTypeKey,
+              let periodType = StatsPeriodType(rawValue: UserDefaults.standard.integer(forKey: key)) else {
+            return .insights
+        }
+
+        return periodType
     }
 
     func getLastSelectedDateFromUserDefaults() -> Date? {

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -129,7 +129,11 @@ class MySitesCoordinator: NSObject {
             UserDefaults.standard.set(date, forKey: SiteStatsDashboardViewController.lastSelectedStatsDateKey)
         }
 
-        UserDefaults.standard.set(timePeriod.rawValue, forKey: SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey)
+        guard let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey else {
+            return
+        }
+
+        UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
 
         mySiteViewController.showDetailView(for: .stats)
     }


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/17122

Ref: pbArwn-2NH-p2#comment-3933

## Description

This PR updates the Stats selected period behavior. 
- Grow Audience card showing -> Insights tab will be shown
- Grow Audience card not showing -> whichever tab the user previously selected will be shown

## To test

### Site where grow audience card isn't showing
1. Go to My Site > Stats
2. Choose a different stats period, and take note of which period you selected
3. Go back to My Site
4. Go to Stats
5. ✅ The selected stats period should be the same one you selected in step 2

### Site where grow audience card is showing
1. Go to My Site > Stats
2. Choose a different stats period (something other than insights)
3. Go back to My Site
4. Go to Stats
5. ✅ The selected stats period should be insights

## Regression Notes
1. Potential unintended areas of impact
Stats selected period (aka tabs)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested both scenarios: showing grow audience card vs not showing grow audience card 

3. What automated tests I added (or what prevented me from doing so)
N/A

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.