### PR TITLE
Reader Comment: Add feature flag for following via notifications

### DIFF
--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -104,10 +104,15 @@ class FollowCommentsService: NSObject {
                                           success: @escaping () -> Void,
                                           failure: @escaping (Error?) -> Void) {
         remote.updateNotificationSettingsForPost(with: postID, siteID: siteID, receiveNotifications: isNotificationsEnabled) { [weak self] in
-            guard let self = self else { return }
+            guard let self = self else {
+                failure(nil)
+                return
+            }
+
             self.post.receivesCommentNotifications = isNotificationsEnabled
             ContextManager.sharedInstance().saveContextAndWait(self.context)
             success()
+
         } failure: { error in
             DDLogError("Error updating notification settings for followed conversation: \(String(describing: error))")
             failure(error)

--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -94,6 +94,26 @@ class FollowCommentsService: NSObject {
         }
     }
 
+    /// Toggles the notification setting for a specified post.
+    ///
+    /// - Parameters:
+    ///   - isNotificationsEnabled: Determines whether the user should receive notifications for new comments on the specified post.
+    ///   - success: Block called after the operation completes successfully.
+    ///   - failure: Block called when the operation fails.
+    @objc func toggleNotificationSettings(_ isNotificationsEnabled: Bool,
+                                          success: @escaping () -> Void,
+                                          failure: @escaping (Error?) -> Void) {
+        remote.updateNotificationSettingsForPost(with: postID, siteID: siteID, receiveNotifications: isNotificationsEnabled) { [weak self] in
+            guard let self = self else { return }
+            self.post.receivesCommentNotifications = isNotificationsEnabled
+            ContextManager.sharedInstance().saveContextAndWait(self.context)
+            success()
+        } failure: { error in
+            DDLogError("Error updating notification settings for followed conversation: \(String(describing: error))")
+            failure(error)
+        }
+    }
+
     private enum FollowAction: String {
         case followed
         case unfollowed

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -18,6 +18,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case weeklyRoundupStaticNotification
     case newCommentDetail
     case domains
+    case followConversationViaNotifications
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -59,6 +60,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .domains:
             return BuildConfiguration.current == .localDeveloper
+        case .followConversationViaNotifications:
+            return false
         }
     }
 
@@ -117,6 +120,8 @@ extension FeatureFlag {
             return "New Comment Detail"
         case .domains:
             return "Domain Purchases"
+        case .followConversationViaNotifications:
+            return "Follow Conversation via Notifications"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -536,8 +536,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     if (!_followBarButtonItem) {
         _followBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Follow", @"Button title. Follow the comments on a post.")
                                                                 style:UIBarButtonItemStylePlain
-                                                               target:self
-                                                               action:@selector(handleFollowConversationButtonTapped)];
+                                                               target:nil
+                                                               action:nil];
     }
 
     return _followBarButtonItem;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -59,6 +59,9 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 @property (nonatomic, strong) NSCache *cachedAttributedStrings;
 @property (nonatomic, strong) FollowCommentsService *followCommentsService;
 
+@property (nonatomic, strong) UIBarButtonItem *followBarButtonItem;
+@property (nonatomic, strong) UIBarButtonItem *subscriptionSettingsBarButtonItem;
+
 @end
 
 
@@ -273,6 +276,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     self.title = NSLocalizedString(@"Comments", @"Title of the reader's comments screen");
     self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+
+    [self refreshFollowButton];
 }
 
 - (void)configurePostHeader
@@ -521,6 +526,38 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     self.isLoggedIn = [AccountHelper isDotcomAvailable];
 }
 
+- (BOOL)followViaNotificationsEnabled
+{
+    return [Feature enabled:FeatureFlagFollowConversationViaNotifications];
+}
+
+- (UIBarButtonItem *)followBarButtonItem
+{
+    if (!_followBarButtonItem) {
+        _followBarButtonItem = [[UIBarButtonItem alloc] initWithTitle:NSLocalizedString(@"Follow", @"Button title. Follow the comments on a post.")
+                                                                style:UIBarButtonItemStylePlain
+                                                               target:self
+                                                               action:@selector(handleFollowConversationButtonTapped)];
+    }
+
+    return _followBarButtonItem;
+}
+
+- (UIBarButtonItem *)subscriptionSettingsBarButtonItem
+{
+    if (!_subscriptionSettingsBarButtonItem) {
+        _subscriptionSettingsBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage systemImageNamed:@"bell"]
+                                                                              style:UIBarButtonItemStylePlain
+                                                                             target:self
+                                                                             action:@selector(subscriptionSettingsTapped)];
+        _subscriptionSettingsBarButtonItem.accessibilityHint = NSLocalizedString(@"Open subscription settings for the post",
+                                                                                 @"VoiceOver hint. Informs the user that the button allows the user to access "
+                                                                                 + "post subscription settings.");
+    }
+
+    return _subscriptionSettingsBarButtonItem;
+}
+
 #pragma mark - Accessor methods
 
 - (void)setPost:(ReaderPost *)post
@@ -622,10 +659,22 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
             [self.postHeaderView setAvatarImage:image];
         }];
     }
-    
-    self.postHeaderView.showsFollowConversationButton = self.canFollowConversation;
+
+    // when the "follow via notifications" flag is enabled, the Follow button is moved into the navigation bar as a UIButtonBarItem.
+    self.postHeaderView.showsFollowConversationButton = self.canFollowConversation && ![self followViaNotificationsEnabled];
 }
 
+- (void)refreshFollowButton
+{
+    if (![self followViaNotificationsEnabled]) {
+        return;
+    }
+
+    self.navigationItem.rightBarButtonItem = self.post.isSubscribedComments ? self.subscriptionSettingsBarButtonItem : self.followBarButtonItem;
+}
+
+// NOTE: Remove this method once "follow via notifications" feature flag can be removed.
+// Subscription status is now available through ReaderPost's `isSubscribedComments` Boolean property.
 - (void)refreshSubscriptionStatusIfNeeded
 {
     if (!self.canFollowConversation) {
@@ -635,6 +684,13 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     __weak __typeof(self) weakSelf = self;
     [self.followCommentsService fetchSubscriptionStatusWithSuccess:^(BOOL isSubscribed) {
         weakSelf.postHeaderView.isSubscribedToPost = isSubscribed;
+
+        if ([self followViaNotificationsEnabled]) {
+            // update the ReaderPost button to keep it in-sync.
+            self.post.isSubscribedComments = isSubscribed;
+            [ContextManager.sharedInstance saveContext:self.post.managedObjectContext];
+        }
+
     } failure:^(NSError *error) {
         DDLogError(@"Error fetching subscription status for post: %@", error);
     }];
@@ -862,6 +918,11 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
                      failure:failureBlock];
     }
     self.indexPathForCommentRepliedTo = nil;
+}
+
+- (void)subscriptionSettingsTapped
+{
+    // TODO: Show bottom sheet.
 }
 
 


### PR DESCRIPTION
Refs `pctCYC-9x-p2`

Included in this PR:
- Added the feature flag for Follow Conversation via Notifications.
- Implemented logic in FollowCommentService for toggling the post subscription's notification settings.
- Added the new "Follow" button on the navigation bar. The new button is not functional yet, but it should correctly represent the subscription state (i.e. "Follow" button title when the user hasn't subscribed, or the bell icon otherwise).

## To Test

- To cut your testing time, scout for two posts where you have one post subscribed and the other unsubscribed.
- (with the feature flag disabled,) verify that the current "Follow conversation by email" buttons work as expected.
- When you have the posts ready, enable the "Follow Conversation via Notifications" feature flag.

#### Verifying the subscribed state
- Go to the Reader section, and select one of the subscribed posts. 
- Verify that the "Followed conversation by email" button in the post header is no longer there.
- Verify that the navigation bar shows a button on the right with a bell icon.

#### Verifying the unsubscribed state
- Go to the Reader section, and select one of the unsubscribed posts.
- Verify that the "Follow conversation by email" button in the post header is no longer there.
- Verify that the navigation bar shows a button with the title "Follow".

## Regression Notes
1. Potential unintended areas of impact
While the feature is still hidden behind a flag, the conditional implementation may affect the current Follow Conversation buttons.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the feature, ensured there are no side effects from the feature flag implementation.

3. What automated tests I added (or what prevented me from doing so)
Added tests for the FollowCommentService.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
