### PR TITLE
Empty Stats: fix dismissing a completed nudge

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -255,10 +255,10 @@ private extension SiteStatsInsightsTableViewController {
     // MARK: - Grow Audience Card Management
 
     func dismissGrowAudienceCard() {
-        let viewsCount = insightsStore.getAllTimeStats()?.viewsCount ?? 0
-        guard let item = pinnedItemStore?.itemToDisplay(for: viewsCount) as? GrowAudienceCell.HintType else {
+        guard let item = pinnedItemStore?.currentItem as? GrowAudienceCell.HintType else {
             return
         }
+
         insightsToShow = insightsToShow.filter { $0 != .growAudience }
         pinnedItemStore?.markPinnedItemAsHidden(item)
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -23,6 +23,7 @@ final class SiteStatsPinnedItemStore {
     }()
     private let lowSiteViewsCountTreshold = 30
     private let siteId: NSNumber
+    private(set) var currentItem: SiteStatsPinnable?
 
     init(siteId: NSNumber) {
         self.siteId = siteId
@@ -30,10 +31,11 @@ final class SiteStatsPinnedItemStore {
 
     func itemToDisplay(for siteViewsCount: Int) -> SiteStatsPinnable? {
         if siteViewsCount < lowSiteViewsCountTreshold {
-            return nudgeToDisplay ?? customizeToDisplay
+            currentItem = nudgeToDisplay ?? customizeToDisplay
         } else {
-            return customizeToDisplay
+            currentItem = customizeToDisplay
         }
+        return currentItem
     }
 
     func markPinnedItemAsHidden(_ item: SiteStatsPinnable) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -21,7 +21,7 @@ final class SiteStatsPinnedItemStore {
             ]
         }
     }()
-    private let lowSiteViewsCountTreshold = 30
+    private let lowSiteViewsCountThreshold = 30
     private let siteId: NSNumber
     private(set) var currentItem: SiteStatsPinnable?
 
@@ -30,7 +30,7 @@ final class SiteStatsPinnedItemStore {
     }
 
     func itemToDisplay(for siteViewsCount: Int) -> SiteStatsPinnable? {
-        if siteViewsCount < lowSiteViewsCountTreshold {
+        if siteViewsCount < lowSiteViewsCountThreshold {
             currentItem = nudgeToDisplay ?? customizeToDisplay
         } else {
             currentItem = customizeToDisplay


### PR DESCRIPTION
Fixes #17335

## Description
This PR fixes an issue where if a user dismisses a completed nudge, the customize card was being shown instead of the next nudge.

## To test
0. Make sure to delete your app / and re-install it to clear the cache before testing
1. Select a site that has less than 30 views
2. Go to **My Site** > **Stats**
3. Publicize or Blogging Reminders nudge should be presented
4. Tap on **Enable post sharing** and add new connection... or tap on **Set up blogging reminders** and finish setting up reminders for your site
5. Go back to **Stats** screen
6. Confirm **Sharing is set up!** message... or the **You set up blogging reminders message** is displayed
7. Tap on **Dismiss**
8. Go back to **My Site** screen and then go to **Stats** screen again
9. ✅ The next nudge should be shown


## Regression Notes
1. Potential unintended areas of impact
Empty Stats nudges

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually following the steps above

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
