### PR TITLE
Blog url creation: Add check for optional strings.

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -221,6 +221,11 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (NSString *)urlWithPath:(NSString *)path
 {
+    if (!path || !self.xmlrpc) {
+        DDLogError(@"Blog: Error creating urlWithPath.");
+        return nil;
+    }
+
     NSError *error = nil;
     NSRegularExpression *xmlrpc = [NSRegularExpression regularExpressionWithPattern:@"xmlrpc.php$" options:NSRegularExpressionCaseInsensitive error:&error];
     return [xmlrpc stringByReplacingMatchesInString:self.xmlrpc options:0 range:NSMakeRange(0, [self.xmlrpc length]) withTemplate:path];


### PR DESCRIPTION
Fixes #17330 

This adds check for the two optional strings that are used to create a url string. This should prevent the crash on #17330.

To test:
I couldn't repro the crash, but per the Sentry logs it looks like it can occur when attempting to create a wp.com site or add a self-hosted site. Thus:
- Log in with an account that has no sites.
- Select `Add new site`.
- Select either `Create WordPress.com site` or `Add self-hosted site`.
- Verify the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested options for `Create WordPress.com site` and `Add self-hosted site`.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
