### PR TITLE
Convert UI tests screens to be `ScreenObject` subclasses – Part 2 of many

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -63,8 +63,8 @@ class JetpackScreenshotGeneration: XCTestCase {
         }
 
         // Get Backup screenshot
-        let jetpackBackup = mySite
-            .gotoJetpackBackup()
+        let jetpackBackup = try mySite
+            .goToJetpackBackup()
 
         let jetpackBackupOptions = try jetpackBackup
             .goToBackupOptions()

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -50,8 +50,8 @@ class JetpackScreenshotGeneration: XCTestCase {
         }
 
         // Get Scan screenshot
-        let jetpackScan = mySite
-            .gotoJetpackScan()
+        let jetpackScan = try mySite
+            .goToJetpackScan()
 
         sleep(scanWaitTime)
 

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -66,7 +66,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         let jetpackBackup = mySite
             .gotoJetpackBackup()
 
-        let jetpackBackupOptions = jetpackBackup
+        let jetpackBackupOptions = try jetpackBackup
             .goToBackupOptions()
             .thenTakeScreenshot(4, named: "JetpackBackup")
 

--- a/WordPress/UITestsFoundation/BaseScreen.swift
+++ b/WordPress/UITestsFoundation/BaseScreen.swift
@@ -90,13 +90,13 @@ extension BaseScreen {
     }
 
     @discardableResult
-    public func dismissNotificationAlertIfNeeded(_ action: FancyAlertComponent.Action = .cancel) -> Self {
+    public func dismissNotificationAlertIfNeeded(_ action: FancyAlertComponent.Action = .cancel) throws -> Self {
         if FancyAlertComponent.isLoaded() {
             switch action {
             case .accept:
-                FancyAlertComponent().acceptAlert()
+                try FancyAlertComponent().acceptAlert()
             case .cancel:
-                FancyAlertComponent().cancelAlert()
+                try FancyAlertComponent().cancelAlert()
             }
         }
         return self

--- a/WordPress/UITestsFoundation/FancyAlertComponent.swift
+++ b/WordPress/UITestsFoundation/FancyAlertComponent.swift
@@ -1,25 +1,30 @@
+import ScreenObject
 import XCTest
 import XCUITestHelpers
 
-public class FancyAlertComponent: BaseScreen {
-    let defaultAlertButton: XCUIElement
-    let cancelAlertButton: XCUIElement
+public class FancyAlertComponent: ScreenObject {
+
+    private let defaultAlertButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["fancy-alert-view-default-button"]
+    }
+
+    private let cancelAlertButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["fancy-alert-view-cancel-button"]
+    }
+
+    var defaultAlertButton: XCUIElement { defaultAlertButtonGetter(app) }
+    var cancelAlertButton: XCUIElement { cancelAlertButtonGetter(app) }
 
     public enum Action {
         case accept
         case cancel
     }
 
-    struct ElementIDs {
-        static let defaultButton = "fancy-alert-view-default-button"
-        static let cancelButton = "fancy-alert-view-cancel-button"
-    }
-
-    public init() {
-        defaultAlertButton = XCUIApplication().buttons[ElementIDs.defaultButton]
-        cancelAlertButton = XCUIApplication().buttons[ElementIDs.cancelButton]
-
-        super.init(element: defaultAlertButton)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [defaultAlertButtonGetter, cancelAlertButtonGetter],
+            app: app
+        )
     }
 
     public func acceptAlert() {
@@ -35,6 +40,6 @@ public class FancyAlertComponent: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementIDs.defaultButton].waitForExistence(timeout: 3)
+        (try? FancyAlertComponent().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -263,14 +263,14 @@ public class AztecEditorScreen: BaseScreen {
     func publish() throws -> EditorNoticeComponent {
         publishButton.tap()
 
-        confirmPublish()
+        try confirmPublish()
 
         return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
     }
 
-    private func confirmPublish() {
+    private func confirmPublish() throws {
         if FancyAlertComponent.isLoaded() {
-            FancyAlertComponent().acceptAlert()
+            try FancyAlertComponent().acceptAlert()
         } else {
             publishNowButton.tap()
         }

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -106,7 +106,7 @@ public class BlockEditorScreen: BaseScreen {
 
     public func publish() throws -> EditorNoticeComponent {
         publishButton.tap()
-        confirmPublish()
+        try confirmPublish()
 
         return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")
     }
@@ -138,9 +138,9 @@ public class BlockEditorScreen: BaseScreen {
             .selectImage(atIndex: 0)
     }
 
-    private func confirmPublish() {
+    private func confirmPublish() throws {
         if FancyAlertComponent.isLoaded() {
-            FancyAlertComponent().acceptAlert()
+            try FancyAlertComponent().acceptAlert()
         } else {
             publishNowButton.tap()
         }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
@@ -1,8 +1,12 @@
+import ScreenObject
 import XCTest
 
-public class JetpackBackupOptionsScreen: BaseScreen {
+public class JetpackBackupOptionsScreen: ScreenObject {
 
-    public init() {
-        super.init(element: XCUIApplication().otherElements.firstMatch)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [{ $0.otherElements.firstMatch }],
+            app: app
+        )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
@@ -5,7 +5,7 @@ public class JetpackBackupOptionsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [{ $0.otherElements.firstMatch }],
+            expectedElementGetters: [ { $0.otherElements.firstMatch } ],
             app: app
         )
     }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
@@ -1,21 +1,17 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let actionButton = "activity-cell-action-button"
-    static let backupTable = "jetpack-backup-table"
-}
+public class JetpackBackupScreen: ScreenObject {
 
-public class JetpackBackupScreen: BaseScreen {
-    let ellipsisButton: XCUIElement
-    let downloadBackupButton: XCUIElement
+    private let ellipsisButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["jetpack-backup-table"].cells.element(boundBy: 0).buttons["activity-cell-action-button"]
+    }
 
-    public init() {
-        let app = XCUIApplication()
-        let backupTable = app.tables[ElementStringIDs.backupTable]
-        let firstCell = backupTable.cells.element(boundBy: 0)
-        ellipsisButton = firstCell.buttons[ElementStringIDs.actionButton]
-        downloadBackupButton = app.sheets.buttons.element(boundBy: 1)
-        super.init(element: ellipsisButton)
+    var ellipsisButton: XCUIElement { ellipsisButtonGetter(app) }
+    var downloadBackupButton: XCUIElement { app.sheets.buttons.element(boundBy: 1) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [ellipsisButtonGetter], app: app)
     }
 
     public func goToBackupOptions() throws -> JetpackBackupOptionsScreen {

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
@@ -18,7 +18,7 @@ public class JetpackBackupScreen: BaseScreen {
         super.init(element: ellipsisButton)
     }
 
-    public func goToBackupOptions() -> JetpackBackupOptionsScreen {
+    public func goToBackupOptions() throws -> JetpackBackupOptionsScreen {
         ellipsisButton.tap()
 
         XCTAssert(downloadBackupButton.waitForExistence(timeout: 3))
@@ -28,6 +28,6 @@ public class JetpackBackupScreen: BaseScreen {
 
         downloadBackupButton.tap()
 
-        return JetpackBackupOptionsScreen()
+        return try JetpackBackupOptionsScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
@@ -5,7 +5,7 @@ public class JetpackScanScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [{ $0.otherElements.firstMatch }],
+            expectedElementGetters: [ { $0.otherElements.firstMatch } ],
             app: app
         )
     }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
@@ -1,8 +1,12 @@
+import ScreenObject
 import XCTest
 
-public class JetpackScanScreen: BaseScreen {
+public class JetpackScanScreen: ScreenObject {
 
-    public init() {
-        super.init(element: XCUIApplication().otherElements.firstMatch)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [{ $0.otherElements.firstMatch }],
+            app: app
+        )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -33,12 +33,12 @@ public class LoginSiteAddressScreen: BaseScreen {
         return LoginUsernamePasswordScreen()
     }
 
-    public func proceedWithWP(siteUrl: String) -> GetStartedScreen {
+    public func proceedWithWP(siteUrl: String) throws -> GetStartedScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
         nextButton.tap()
 
-        return GetStartedScreen()
+        return try GetStartedScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -25,11 +25,12 @@ public class GetStartedScreen: ScreenObject {
     var helpButton: XCUIElement { helpButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        // Notice we are not checking for the continue button, because that's visible but not
+        // enabled, and `ScreenObject` checks for enabled elements.
         try super.init(
             expectedElementGetters: [
                 navBarGetter,
                 emailTextFieldGetter,
-                continueButtonGetter,
                 helpButtonGetter
             ],
             app: app

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -44,10 +44,10 @@ public class GetStartedScreen: ScreenObject {
         return PasswordScreen()
     }
 
-    public func selectHelp() -> SupportScreen {
+    public func selectHelp() throws -> SupportScreen {
         helpButton.tap()
 
-        return SupportScreen()
+        return try SupportScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -1,26 +1,39 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let navBar = "WordPress.GetStartedView"
-    static let emailTextField = "Email address"
-    static let continueButton = "Get Started Email Continue Button"
-    static let helpButton = "authenticator-help-button"
-}
+public class GetStartedScreen: ScreenObject {
 
-public class GetStartedScreen: BaseScreen {
-    let navBar: XCUIElement
-    public let emailTextField: XCUIElement
-    let continueButton: XCUIElement
-    let helpButton: XCUIElement
+    private let navBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["WordPress.GetStartedView"]
+    }
 
-    public init() {
-        let app = XCUIApplication()
-        navBar = app.navigationBars[ElementStringIDs.navBar]
-        emailTextField = app.textFields[ElementStringIDs.emailTextField]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
-        helpButton = app.buttons[ElementStringIDs.helpButton]
+    private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Email address"]
+    }
 
-        super.init(element: emailTextField)
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Get Started Email Continue Button"]
+    }
+
+    private let helpButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["authenticator-help-button"]
+    }
+
+    var navBar: XCUIElement { navBarGetter(app) }
+    public var emailTextField: XCUIElement { emailTextFieldGetter(app) }
+    var continueButton: XCUIElement { continueButtonGetter(app) }
+    var helpButton: XCUIElement { helpButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                navBarGetter,
+                emailTextFieldGetter,
+                continueButtonGetter,
+                helpButtonGetter
+            ],
+            app: app
+        )
     }
 
     public func proceedWith(email: String) -> PasswordScreen {
@@ -38,12 +51,10 @@ public class GetStartedScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+        (try? GetStartedScreen().isLoaded) ?? false
     }
 
     public static func isEmailEntered() -> Bool {
-        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
-        return emailTextField.value != nil
+        (try? GetStartedScreen().emailTextField.value != nil) ?? false
     }
-
 }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -4,7 +4,7 @@ import XCTest
 public class GetStartedScreen: ScreenObject {
 
     private let navBarGetter: (XCUIApplication) -> XCUIElement = {
-        $0.navigationBars["WordPress.GetStartedView"]
+        $0.navigationBars["Get Started"]
     }
 
     private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -1,19 +1,24 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let continueButton = "Prologue Continue Button"
-    static let siteAddressButton = "Prologue Self Hosted Button"
-}
+public class PrologueScreen: ScreenObject {
 
-public class PrologueScreen: BaseScreen {
-    let continueButton: XCUIElement
-    let siteAddressButton: XCUIElement
+    private let continueButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Continue Button"]
+    }
 
-    public init() {
-        continueButton = XCUIApplication().buttons[ElementStringIDs.continueButton]
-        siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
+    private let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Self Hosted Button"]
+    }
 
-        super.init(element: continueButton)
+    var continueButton: XCUIElement { continueButtonGetter(app) }
+    var siteAddressButton: XCUIElement { siteAddressButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [continueButtonGetter, siteAddressButtonGetter],
+            app: app
+        )
     }
 
     public func selectContinue() -> GetStartedScreen {
@@ -28,7 +33,7 @@ public class PrologueScreen: BaseScreen {
         return LoginSiteAddressScreen()
     }
 
-    public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+    public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {
+        (try? PrologueScreen(app: app).isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -21,10 +21,10 @@ public class PrologueScreen: ScreenObject {
         )
     }
 
-    public func selectContinue() -> GetStartedScreen {
+    public func selectContinue() throws -> GetStartedScreen {
         continueButton.tap()
 
-        return GetStartedScreen()
+        return try GetStartedScreen()
     }
 
     public func selectSiteAddress() -> LoginSiteAddressScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -18,10 +18,10 @@ public class WelcomeScreen: BaseScreen {
         super.init(element: logInButton)
     }
 
-    public func selectSignup() -> WelcomeScreenSignupComponent {
+    public func selectSignup() throws -> WelcomeScreenSignupComponent {
         signupButton.tap()
 
-        return WelcomeScreenSignupComponent()
+        return try WelcomeScreenSignupComponent()
     }
 
     public func selectLogin() -> WelcomeScreenLoginComponent {

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -1,41 +1,28 @@
+import ScreenObject
 import XCTest
-
-private struct ElementStringIDs {
-    static let closeButton = "close-button"
-    static let helpCenter = "help-center-link-button"
-    static let contact = "contact-support-button"
-    static let myTickets = "my-tickets-button"
-    static let contactEmail = "set-contact-email-button"
-    static let activityLogs = "activity-logs-button"
-}
 
 /// This screen object is for the Support section. In the app, it's a modal we can get to from Me 
 /// > Help & Support, or, when logged out, from Prologue > tap either continue button > Help.
-public class SupportScreen: BaseScreen {
-    let closeButton: XCUIElement
-    let helpCenter: XCUIElement
-    let contact: XCUIElement
-    let myTickets: XCUIElement
-    let contactEmail: XCUIElement
-    let activityLogs: XCUIElement
+public class SupportScreen: ScreenObject {
 
-    public init() {
-        let app = XCUIApplication()
-        closeButton = app.buttons[ElementStringIDs.closeButton]
-        helpCenter = app.cells[ElementStringIDs.helpCenter]
-        contact = app.cells[ElementStringIDs.contact]
-        myTickets = app.cells[ElementStringIDs.myTickets]
-        contactEmail = app.cells[ElementStringIDs.contactEmail]
-        activityLogs = app.cells[ElementStringIDs.activityLogs]
+    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["close-button"]
+    }
 
-        super.init(element: activityLogs)
+    var closeButton: XCUIElement { closeButtonGetter(app) }
 
-        //Check that each item is loaded:
-        XCTAssert(helpCenter.exists)
-        XCTAssert(contact.exists)
-        XCTAssert(myTickets.exists)
-        XCTAssert(contactEmail.exists)
-        XCTAssert(activityLogs.exists)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                closeButtonGetter,
+                { $0.cells["help-center-link-button"] },
+                { $0.cells["contact-support-button"] },
+                { $0.cells["my-tickets-button"] },
+                { $0.cells["set-contact-email-button"] },
+                { $0.cells["activity-logs-button"] }
+            ],
+            app: app
+        )
     }
 
     public func dismiss() {
@@ -43,6 +30,6 @@ public class SupportScreen: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.activityLogs].exists
+        (try? SupportScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -15,11 +15,13 @@ public class SupportScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [
                 closeButtonGetter,
+                // swiftlint:disable opening_brace
                 { $0.cells["help-center-link-button"] },
                 { $0.cells["contact-support-button"] },
                 { $0.cells["my-tickets-button"] },
                 { $0.cells["set-contact-email-button"] },
                 { $0.cells["activity-logs-button"] }
+                // swiftlint:enable opening_brace
             ],
             app: app
         )

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -43,7 +43,7 @@ public class MeTabScreen: ScreenObject {
         return WelcomeScreen()
     }
 
-    public func logoutToPrologue() -> PrologueScreen {
+    public func logoutToPrologue() throws -> PrologueScreen {
         app.cells["logOutFromWPcomButton"].tap()
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
@@ -55,13 +55,13 @@ public class MeTabScreen: ScreenObject {
             logOutAlert.buttons.element(boundBy: 1).tap()
         }
 
-        return PrologueScreen()
+        return try PrologueScreen()
     }
 
-    func goToLoginFlow() -> PrologueScreen {
+    func goToLoginFlow() throws -> PrologueScreen {
         app.cells["Log In"].tap()
 
-        return PrologueScreen()
+        return try PrologueScreen()
     }
 
     public func dismiss() -> MySiteScreen {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -85,9 +85,9 @@ public class MySiteScreen: BaseScreen {
         return JetpackScanScreen()
     }
 
-    public func gotoJetpackBackup() -> JetpackBackupScreen {
+    public func goToJetpackBackup() throws -> JetpackBackupScreen {
         jetpackBackupButton.tap()
-        return JetpackBackupScreen()
+        return try JetpackBackupScreen()
     }
 
     public func gotoPostsScreen() -> PostsScreen {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -80,9 +80,9 @@ public class MySiteScreen: BaseScreen {
         return try ActivityLogScreen()
     }
 
-    public func gotoJetpackScan() -> JetpackScanScreen {
+    public func goToJetpackScan() throws -> JetpackScanScreen {
         jetpackScanButton.tap()
-        return JetpackScanScreen()
+        return try JetpackScanScreen()
     }
 
     public func goToJetpackBackup() throws -> JetpackBackupScreen {

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -36,7 +36,7 @@ public class PostsScreen: BaseScreen {
         return self
     }
 
-    public func selectPost(withSlug slug: String) -> EditorScreen {
+    public func selectPost(withSlug slug: String) throws -> EditorScreen {
 
         // Tap the current tab item to scroll the table to the top
         showOnly(currentlyFilteredPostStatus)
@@ -50,7 +50,7 @@ public class PostsScreen: BaseScreen {
         dismissAutosaveDialogIfNeeded()
 
         let editorScreen = EditorScreen()
-        editorScreen.dismissDialogsIfNeeded()
+        try editorScreen.dismissDialogsIfNeeded()
 
         return EditorScreen()
     }
@@ -85,9 +85,9 @@ public struct EditorScreen {
         return AztecEditorScreen(mode: .rich)
     }
 
-    func dismissDialogsIfNeeded() {
+    func dismissDialogsIfNeeded() throws {
         if self.isGutenbergEditor {
-            blockEditor.dismissNotificationAlertIfNeeded(.accept)
+            try blockEditor.dismissNotificationAlertIfNeeded(.accept)
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -1,18 +1,18 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let emailSignupButton = "Sign up with Email Button"
-}
+public class WelcomeScreenSignupComponent: ScreenObject {
 
-public class WelcomeScreenSignupComponent: BaseScreen {
-    let emailSignupButton: XCUIElement
+    private let emailSignupButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Sign up with Email Button"]
+    }
 
-    init() {
-        emailSignupButton = XCUIApplication().buttons[ElementStringIDs.emailSignupButton]
+    var emailSignupButton: XCUIElement { emailSignupButtonGetter(app) }
 
-        super.init(element: emailSignupButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [emailSignupButtonGetter], app: app)
     }
 
     public func selectEmailSignup() -> SignupEmailScreen {

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -31,7 +31,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         super.tearDown()
     }
 
-    func testGenerateScreenshots() {
+    func testGenerateScreenshots() throws {
 
         // Get post editor screenshot
         let postList = MySiteScreen()
@@ -40,7 +40,7 @@ class WordPressScreenshotGeneration: XCTestCase {
             .gotoPostsScreen()
             .showOnly(.drafts)
 
-        let postEditorScreenshot = postList.selectPost(withSlug: "our-services")
+        let postEditorScreenshot = try postList.selectPost(withSlug: "our-services")
         sleep(imagesWaitTime) // wait for post images to load
         if XCUIDevice.isPad {
             BlockEditorScreen()
@@ -55,7 +55,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         // Get a screenshot of the editor with keyboard (iPad only)
         if XCUIDevice.isPad {
-            let ipadScreenshot = MySiteScreen()
+            let ipadScreenshot = try MySiteScreen()
                 .showSiteSwitcher()
                 .switchToSite(withTitle: "weekendbakesblog.wordpress.com")
                 .gotoPostsScreen()
@@ -99,7 +99,7 @@ class WordPressScreenshotGeneration: XCTestCase {
             .thenTakeScreenshot(2, named: "Discover")
 
         // Get Notifications screenshot
-        let notificationList = TabNavComponent()
+        let notificationList = try TabNavComponent()
             .gotoNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
         if XCUIDevice.isPad {

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -78,11 +78,11 @@ class LoginFlow {
             }
         }
 
-        XCTContext.runActivity(named: "Return to app prologue screen if needed") { (activity) in
+        try XCTContext.runActivity(named: "Return to app prologue screen if needed") { (activity) in
             if !PrologueScreen.isLoaded() {
                 while PasswordScreen.isLoaded() || GetStartedScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
                     if GetStartedScreen.isLoaded() && GetStartedScreen.isEmailEntered() {
-                        GetStartedScreen().emailTextField.clearText()
+                        try GetStartedScreen().emailTextField.clearText()
                     }
                     navBackButton.tap()
                 }

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -7,7 +7,7 @@ class LoginFlow {
     static func login(email: String, password: String) throws -> MySiteScreen {
         try logoutIfNeeded()
 
-        return PrologueScreen().selectContinue()
+        return try PrologueScreen().selectContinue()
             .proceedWith(email: email)
             .proceedWith(password: password)
             .continueWithSelectedSite()
@@ -19,7 +19,7 @@ class LoginFlow {
     static func login(siteUrl: String, username: String, password: String) throws -> MySiteScreen {
         try logoutIfNeeded()
 
-        return PrologueScreen().selectSiteAddress()
+        return try PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
             .proceedWith(username: username, password: password)
             .continueWithSelectedSite()
@@ -40,7 +40,7 @@ class LoginFlow {
     static func login(siteUrl: String, email: String, password: String) throws -> MySiteScreen {
         try logoutIfNeeded()
 
-        return PrologueScreen().selectSiteAddress()
+        return try PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
             .proceedWith(email: email)
             .proceedWith(password: password)
@@ -70,7 +70,7 @@ class LoginFlow {
                 Logger.log(message: "Logging out...", event: .i)
                 let meScreen = try TabNavComponent().gotoMeScreen()
                 if meScreen.isLoggedInToWpcom() {
-                    _ = meScreen.logoutToPrologue()
+                    _ = try meScreen.logoutToPrologue()
                 } else {
                     meScreen.dismiss().removeSelfHostedSite()
                 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -27,7 +27,7 @@ class LoginTests: XCTestCase {
             .tabBar.gotoMeScreen()
             .logoutToPrologue()
 
-        XCTAssert(prologueScreen.isLoaded())
+        XCTAssert(prologueScreen.isLoaded)
     }
 
     /**
@@ -48,20 +48,23 @@ class LoginTests: XCTestCase {
     }
 
     // Unified self hosted login/out
-    func testSelfHostedLoginLogout() {
-        PrologueScreen().selectSiteAddress()
+    func testSelfHostedLoginLogout() throws {
+        let prologueScreen = try PrologueScreen()
+
+        prologueScreen
+            .selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .continueWithSelectedSite()
             .removeSelfHostedSite()
 
-        XCTAssert(PrologueScreen().isLoaded())
+        XCTAssert(prologueScreen.isLoaded)
     }
 
     // Unified WordPress.com email login failure due to incorrect password
-    func testWPcomInvalidPassword() {
-        _ = PrologueScreen().selectContinue()
+    func testWPcomInvalidPassword() throws {
+        _ = try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .tryProceed(password: "invalidPswd")
             .verifyLoginError()
@@ -69,8 +72,8 @@ class LoginTests: XCTestCase {
 
     // Self-Hosted after WordPress.com login.
     // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
-    func testAddSelfHostedSiteAfterWPcomLogin() {
-        PrologueScreen().selectContinue()
+    func testAddSelfHostedSiteAfterWPcomLogin() throws {
+        try PrologueScreen().selectContinue()
             .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
             .proceedWith(password: WPUITestCredentials.testWPcomPassword)
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -18,7 +18,7 @@ class MainNavigationTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testTabBarNavigation() {
+    func testTabBarNavigation() throws {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
         _ = mySiteScreen
@@ -26,7 +26,7 @@ class MainNavigationTests: XCTestCase {
 
         XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
 
-        _ = mySiteScreen
+        _ = try mySiteScreen
             .tabBar.gotoNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
 

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -16,8 +16,8 @@ class SignupTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    func testEmailSignup() {
-        let mySiteScreen = WelcomeScreen().selectSignup()
+    func testEmailSignup() throws {
+        let mySiteScreen = try WelcomeScreen().selectSignup()
             .selectEmailSignup()
             .proceedWith(email: WPUITestCredentials.signupEmail)
             .openMagicSignupLink()

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -20,7 +20,7 @@ class SupportScreenTests: XCTestCase {
     func testSupportScreenLoads() throws {
         let supportScreen = try PrologueScreen().selectContinue().selectHelp()
 
-        XCTAssert(supportScreen.isLoaded())
+        XCTAssert(supportScreen.isLoaded)
 
         //Dismiss because tearDown() can't handle modals currently
         supportScreen.dismiss()

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -17,8 +17,8 @@ class SupportScreenTests: XCTestCase {
 
     // Test Support Section Loads
     // From Prologue > continue, tap "help" and make sure Support Screen loads
-    func testSupportScreenLoads() {
-        let supportScreen = PrologueScreen().selectContinue().selectHelp()
+    func testSupportScreenLoads() throws {
+        let supportScreen = try PrologueScreen().selectContinue().selectHelp()
 
         XCTAssert(supportScreen.isLoaded())
 


### PR DESCRIPTION
Continues the work started in #17221. Refer to that PR for extra context on the structure of a `ScreenObject` subclass.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
