### PR TITLE
Empty Stats: Event tracking for Reader discover nudge

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -98,6 +98,10 @@ import Foundation
     case statsBloggingRemindersNudgeTapped
     case statsBloggingRemindersNudgeDismissed
     case statsBloggingRemindersNudgeCompleted
+    case statsReaderDiscoverNudgeShown
+    case statsReaderDiscoverNudgeTapped
+    case statsReaderDiscoverNudgeDismissed
+    case statsReaderDiscoverNudgeCompleted
 
     // Stats - Customize card
     case statsCustomizeInsightsShown
@@ -363,6 +367,14 @@ import Foundation
             return "stats_blogging_reminders_nudge_dismissed"
         case .statsBloggingRemindersNudgeCompleted:
             return "stats_blogging_reminders_nudge_completed"
+        case .statsReaderDiscoverNudgeShown:
+            return "stats_reader_discover_nudge_shown"
+        case .statsReaderDiscoverNudgeTapped:
+            return "stats_reader_discover_nudge_tapped"
+        case .statsReaderDiscoverNudgeDismissed:
+            return "stats_reader_discover_nudge_dismissed"
+        case .statsReaderDiscoverNudgeCompleted:
+            return "stats_reader_discover_nudge_completed"
 
         // Stats - Customize card
         case .statsCustomizeInsightsShown:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -530,6 +530,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             let text = NSLocalizedString("Follow topics you're interested in and we'll find some blogs you might like.", comment: "Guide for users to follow topics.")
             self?.displayNotice(title: text)
         }
+
+        trackNudgeEvent(.statsReaderDiscoverNudgeTapped)
     }
 
     func showAddInsight() {
@@ -616,7 +618,7 @@ extension SiteStatsInsightsTableViewController: BloggingRemindersFlowDelegate {
 extension SiteStatsInsightsTableViewController: ReaderDiscoverFlowDelegate {
     func didCompleteReaderDiscoverFlow() {
         markCurrentNudgeAsCompleted()
-        // TODO: implement tracking event
+        trackNudgeEvent(.statsReaderDiscoverNudgeCompleted)
     }
 }
 
@@ -703,8 +705,7 @@ private extension SiteStatsInsightsTableViewController {
         case .bloggingReminders:
             trackNudgeEvent(.statsBloggingRemindersNudgeShown)
         case .readerDiscover:
-            // TODO: implement
-            break
+            trackNudgeEvent(.statsReaderDiscoverNudgeShown)
         }
     }
 
@@ -715,8 +716,7 @@ private extension SiteStatsInsightsTableViewController {
         case .bloggingReminders:
             trackNudgeEvent(.statsBloggingRemindersNudgeDismissed)
         case .readerDiscover:
-            // TODO: implement
-            break
+            trackNudgeEvent(.statsReaderDiscoverNudgeDismissed)
         }
     }
 }


### PR DESCRIPTION
Part of [#17307](https://github.com/wordpress-mobile/WordPress-iOS/issues/17307)

This PR adds tracking events for Reader discover nudge.

## Test
1. Fire the events from the table below
2. Make sure they fire only once
3. Validate the events: PCYsg-ktp-p2

## Events table

Event | Trigger
--- | ---
stats_reader_discover_nudge_shown | Fired every time user goes to **My Site > Stats** screen and Reader discover nudge is shown
stats_reader_discover_nudge_tapped | Tap **Discover blogs to follow** on Reader discover nudge card
stats_reader_discover_nudge_dismissed | Tap **Dismiss** on Reader discover nudge card
stats_reader_discover_nudge_completed | Fired when user taps **Done** on Follow topics screen, while having selected at least one topic to follow

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
