### PR TITLE
Empty Stats: Reader Discover nudge spotlight view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -35,7 +35,6 @@ final class ReaderCellConfiguration {
                                delegate: ReaderPostCellDelegate?,
                                loggedInActionVisibility: ReaderActionsVisibility,
                                topicChipsDelegate: ReaderTopicsChipsDelegate? = nil,
-                               commentActionDelegate: ReaderCommentActionDelegate? = nil,
                                displayTopics: Bool = true) {
         // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
         guard !post.isDeleted else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCellConfiguration.swift
@@ -35,6 +35,7 @@ final class ReaderCellConfiguration {
                                delegate: ReaderPostCellDelegate?,
                                loggedInActionVisibility: ReaderActionsVisibility,
                                topicChipsDelegate: ReaderTopicsChipsDelegate? = nil,
+                               commentActionDelegate: ReaderCommentActionDelegate? = nil,
                                displayTopics: Bool = true) {
         // To help avoid potential crash: https://github.com/wordpress-mobile/WordPress-iOS/issues/6757
         guard !post.isDeleted else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -263,7 +263,7 @@ private extension ReaderPostCardCell {
         menuButton.setImage(highlightIcon, for: .highlighted)
     }
 
-    func setupSpotlightView() {
+    private func setupSpotlightView() {
         addSubview(spotlightView)
         bringSubviewToFront(spotlightView)
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -8,6 +8,10 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     func heightDidChange()
 }
 
+protocol ReaderCommentActionDelegate: AnyObject {
+    func didTapComment(_ cell: ReaderPostCardCell)
+}
+
 @objc public protocol ReaderPostCellDelegate: NSObjectProtocol {
     func readerCell(_ cell: ReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider)
     func readerCell(_ cell: ReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider)
@@ -96,6 +100,8 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     }
 
     weak var topicChipsDelegate: ReaderTopicsChipsDelegate?
+    weak var commentActionDelegate: ReaderCommentActionDelegate?
+
     var displayTopics: Bool = false
     var isP2Type: Bool = false
 
@@ -725,6 +731,7 @@ extension ReaderPostCardCell {
 
         switch tag {
         case .comment:
+            commentActionDelegate?.didTapComment(self)
             delegate?.readerCell(self, commentActionForProvider: contentProvider)
         case .like:
             delegate?.readerCell(self, likeActionForProvider: contentProvider)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -69,6 +69,21 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     // Ghost cells placeholders
     @IBOutlet private weak var ghostPlaceholderView: UIView!
 
+    // Spotlight view
+    private let spotlightView: UIView = {
+        let spotlightView = QuickStartSpotlightView()
+        spotlightView.translatesAutoresizingMaskIntoConstraints = false
+        spotlightView.isHidden = true
+        return spotlightView
+    }()
+
+    /// Whether or not to show the spotlight animation to illustrate tapping the icon.
+    var spotlightIsShown: Bool = false {
+        didSet {
+            spotlightView.isHidden = !spotlightIsShown || !shouldShowCommentActionButton
+        }
+    }
+
     @objc open weak var delegate: ReaderPostCellDelegate?
     private weak var contentProvider: ReaderPostContentProvider?
 
@@ -150,6 +165,7 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
         configureFeaturedImageView()
         setupSummaryLabel()
         setupAttributionView()
+        setupSpotlightView()
         adjustInsetsForTextDirection()
     }
 
@@ -213,6 +229,8 @@ private extension ReaderPostCardCell {
         static let authorAvatarPlaceholderImage: UIImage? = UIImage(named: "gravatar")
         static let rotate270Degrees: CGFloat = CGFloat.pi * 1.5
         static let rotate90Degrees: CGFloat = CGFloat.pi / 2
+        static let spotlightXOffset: CGFloat = 10
+        static let spotlightYOffset: CGFloat = 10
     }
 
     // MARK: - Configuration
@@ -242,6 +260,16 @@ private extension ReaderPostCardCell {
 
         menuButton.setImage(tintedIcon, for: .normal)
         menuButton.setImage(highlightIcon, for: .highlighted)
+    }
+
+    func setupSpotlightView() {
+        addSubview(spotlightView)
+        bringSubviewToFront(spotlightView)
+
+        NSLayoutConstraint.activate([
+            commentActionButton.centerXAnchor.constraint(equalTo: spotlightView.centerXAnchor),
+            commentActionButton.centerYAnchor.constraint(equalTo: spotlightView.centerYAnchor, constant: Constants.spotlightYOffset)
+        ])
     }
 
     func adjustInsetsForTextDirection() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -8,10 +8,6 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     func heightDidChange()
 }
 
-protocol ReaderCommentActionDelegate: AnyObject {
-    func didTapComment(_ cell: ReaderPostCardCell)
-}
-
 @objc public protocol ReaderPostCellDelegate: NSObjectProtocol {
     func readerCell(_ cell: ReaderPostCardCell, headerActionForProvider provider: ReaderPostContentProvider)
     func readerCell(_ cell: ReaderPostCardCell, commentActionForProvider provider: ReaderPostContentProvider)
@@ -100,7 +96,6 @@ protocol ReaderCommentActionDelegate: AnyObject {
     }
 
     weak var topicChipsDelegate: ReaderTopicsChipsDelegate?
-    weak var commentActionDelegate: ReaderCommentActionDelegate?
 
     var displayTopics: Bool = false
     var isP2Type: Bool = false
@@ -731,7 +726,6 @@ extension ReaderPostCardCell {
 
         switch tag {
         case .comment:
-            commentActionDelegate?.didTapComment(self)
             delegate?.readerCell(self, commentActionForProvider: contentProvider)
         case .like:
             delegate?.readerCell(self, likeActionForProvider: contentProvider)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -42,7 +42,7 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
            let indexPath = controller.tableView.indexPath(for: cell),
            let topic = controller.readerTopic,
            ReaderHelpers.topicIsDiscover(topic),
-           controller.isReaderDiscoverNudgeFlow {
+           controller.shouldShowCommentSpotlight {
             controller.reloadReaderDiscoverNudgeFlow(at: indexPath)
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -37,6 +37,15 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
         guard let post = provider as? ReaderPost, let origin = origin else {
             return
         }
+
+        if let controller = origin as? ReaderStreamViewController,
+           let indexPath = controller.tableView.indexPath(for: cell),
+           let topic = controller.readerTopic,
+           ReaderHelpers.topicIsDiscover(topic),
+           controller.isReaderDiscoverNudgeFlow {
+            controller.reloadReaderDiscoverNudgeFlow(at: indexPath)
+        }
+
         ReaderCommentAction().execute(post: post, origin: origin)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -369,8 +369,7 @@ import WordPressFlux
         }
 
         if isReaderDiscoverNudgeFlow {
-            isReaderDiscoverNudgeFlow = false
-            WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
+            resetReaderDiscoverNudgeFlow()
         }
 
         dismissNoNetworkAlert()
@@ -1249,7 +1248,6 @@ import WordPressFlux
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .visible(enabled: isLoggedIn),
                                                 topicChipsDelegate: self,
-                                                commentActionDelegate: self,
                                                 displayTopics: displayTopics)
 
     }
@@ -1552,6 +1550,16 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             post.rendered = true
             WPAppAnalytics.track(.trainTracksRender, withProperties: railcar)
         }
+    }
+
+    func reloadReaderDiscoverNudgeFlow(at indexPath: IndexPath) {
+        resetReaderDiscoverNudgeFlow()
+        tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
+    }
+
+    private func resetReaderDiscoverNudgeFlow() {
+        isReaderDiscoverNudgeFlow = false
+        WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -1969,19 +1977,5 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
     func didSelect(topic: String) {
         let topicStreamViewController = ReaderStreamViewController.controllerWithTagSlug(topic)
         navigationController?.pushViewController(topicStreamViewController, animated: true)
-    }
-}
-
-extension ReaderStreamViewController: ReaderCommentActionDelegate {
-    func didTapComment(_ cell: ReaderPostCardCell) {
-        guard let indexPath = tableView.indexPath(for: cell) else {
-            return
-        }
-
-        if isReaderDiscoverNudgeFlow {
-            isReaderDiscoverNudgeFlow = false
-            WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
-            tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
-        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -24,6 +24,8 @@ import WordPressFlux
     /// Called if the stream or tag fails to load
     var streamLoadFailureBlock: (() -> Void)? = nil
 
+    var isReaderDiscoverNudgeFlow: Bool = false
+
     var tableView: UITableView! {
         return tableViewController.tableView
     }
@@ -364,6 +366,10 @@ import WordPressFlux
 
         if contentType == .saved {
             postCellActions?.clearRemovedPosts()
+        }
+
+        if isReaderDiscoverNudgeFlow {
+            WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
         }
 
         dismissNoNetworkAlert()
@@ -1497,6 +1503,16 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
 
         let cell = tableConfiguration.postCardCell(tableView)
         configurePostCardCell(cell, post: post)
+
+        if let topic = readerTopic,
+           ReaderHelpers.topicIsDiscover(topic),
+           indexPath.row == 0,
+           isReaderDiscoverNudgeFlow {
+            cell.spotlightIsShown = true
+        } else {
+            cell.spotlightIsShown = false
+        }
+
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -24,7 +24,7 @@ import WordPressFlux
     /// Called if the stream or tag fails to load
     var streamLoadFailureBlock: (() -> Void)? = nil
 
-    var isReaderDiscoverNudgeFlow: Bool = false
+    var shouldShowCommentSpotlight: Bool = false
 
     var tableView: UITableView! {
         return tableViewController.tableView
@@ -368,7 +368,7 @@ import WordPressFlux
             postCellActions?.clearRemovedPosts()
         }
 
-        if isReaderDiscoverNudgeFlow {
+        if shouldShowCommentSpotlight {
             resetReaderDiscoverNudgeFlow()
         }
 
@@ -1507,7 +1507,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         if let topic = readerTopic,
            ReaderHelpers.topicIsDiscover(topic),
            indexPath.row == 0,
-           isReaderDiscoverNudgeFlow {
+           shouldShowCommentSpotlight {
             cell.spotlightIsShown = true
         } else {
             cell.spotlightIsShown = false
@@ -1558,7 +1558,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
     }
 
     private func resetReaderDiscoverNudgeFlow() {
-        isReaderDiscoverNudgeFlow = false
+        shouldShowCommentSpotlight = false
         WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -369,6 +369,7 @@ import WordPressFlux
         }
 
         if isReaderDiscoverNudgeFlow {
+            isReaderDiscoverNudgeFlow = false
             WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
         }
 
@@ -1248,6 +1249,7 @@ import WordPressFlux
                                                 delegate: postCellActions,
                                                 loggedInActionVisibility: .visible(enabled: isLoggedIn),
                                                 topicChipsDelegate: self,
+                                                commentActionDelegate: self,
                                                 displayTopics: displayTopics)
 
     }
@@ -1967,5 +1969,19 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
     func didSelect(topic: String) {
         let topicStreamViewController = ReaderStreamViewController.controllerWithTagSlug(topic)
         navigationController?.pushViewController(topicStreamViewController, animated: true)
+    }
+}
+
+extension ReaderStreamViewController: ReaderCommentActionDelegate {
+    func didTapComment(_ cell: ReaderPostCardCell) {
+        guard let indexPath = tableView.indexPath(for: cell) else {
+            return
+        }
+
+        if isReaderDiscoverNudgeFlow {
+            isReaderDiscoverNudgeFlow = false
+            WPTabBarController.sharedInstance().resetReaderDiscoverNudgeFlow()
+            tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.fade)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -43,6 +43,22 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     @IBOutlet weak var bottomSpaceHeightConstraint: NSLayoutConstraint!
 
+    // MARK: - Views
+
+    private let spotlightView: UIView = {
+        let spotlightView = QuickStartSpotlightView()
+        spotlightView.translatesAutoresizingMaskIntoConstraints = false
+        spotlightView.isHidden = true
+        return spotlightView
+    }()
+
+    /// Whether or not to show the spotlight animation to illustrate tapping the icon.
+    var spotlightIsShown: Bool = false {
+        didSet {
+            spotlightView.isHidden = !spotlightIsShown
+        }
+    }
+
     // MARK: - Data
     private lazy var dataSource: ReaderInterestsDataSource = {
         return ReaderInterestsDataSource(topics: topics)
@@ -99,6 +115,14 @@ class ReaderSelectInterestsViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+
+        view.addSubview(spotlightView)
+        view.bringSubviewToFront(spotlightView)
+
+        NSLayoutConstraint.activate([
+            collectionView.centerXAnchor.constraint(equalTo: spotlightView.centerXAnchor),
+            collectionView.centerYAnchor.constraint(equalTo: spotlightView.centerYAnchor)
+        ])
 
         WPAnalytics.trackReader(.selectInterestsShown)
     }
@@ -221,6 +245,8 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     @objc private func saveSelectedInterests() {
+        spotlightIsShown = false
+
         guard !dataSource.selectedInterests.isEmpty else {
             self.didSaveInterests?([])
             return

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -245,8 +245,6 @@ class ReaderSelectInterestsViewController: UIViewController {
     }
 
     @objc private func saveSelectedInterests() {
-        spotlightIsShown = false
-
         guard !dataSource.selectedInterests.isEmpty else {
             self.didSaveInterests?([])
             return
@@ -341,6 +339,11 @@ extension ReaderSelectInterestsViewController: UICollectionViewDataSource {
 // MARK: - UICollectionViewDelegate
 extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+
+        if spotlightIsShown {
+            spotlightIsShown = false
+        }
+
         dataSource.interest(for: indexPath.row).toggleSelected()
         updateNextButtonState()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -164,7 +164,7 @@ extension ReaderTabView {
         controller.add(childController)
         containerView.pinSubviewToAllEdges(childController.view)
 
-        if viewModel.isReaderDiscoverNudgeFlow {
+        if viewModel.shouldShowCommentSpotlight {
             let title = NSLocalizedString("Comment to start making connections.", comment: "Hint for users to grow their audience by commenting on other blogs.")
             childController.displayNotice(title: title)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabView.swift
@@ -163,6 +163,11 @@ extension ReaderTabView {
         }
         controller.add(childController)
         containerView.pinSubviewToAllEdges(childController.view)
+
+        if viewModel.isReaderDiscoverNudgeFlow {
+            let title = NSLocalizedString("Comment to start making connections.", comment: "Hint for users to grow their audience by commenting on other blogs.")
+            childController.displayNotice(title: title)
+        }
     }
 
     private func activateConstraints() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -103,10 +103,9 @@ class ReaderTabViewController: UIViewController {
     }
 
     func presentDiscoverTab() {
-        let discoverIndex = 1
         viewModel.isReaderDiscoverNudgeFlow = true
         viewModel.fetchReaderMenu()
-        viewModel.showTab(at: discoverIndex)
+        viewModel.showTab(at: ReaderTabConstants.discoverIndex)
     }
 }
 
@@ -170,5 +169,6 @@ extension ReaderTabViewController {
         static let storyBoardInitError = "Storyboard instantiation not supported"
         static let restorationIdentifier = "WPReaderTabControllerRestorationID"
         static let encodedIndexKey = "WPReaderTabControllerIndexRestorationKey"
+        static let discoverIndex = 1
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -103,7 +103,7 @@ class ReaderTabViewController: UIViewController {
     }
 
     func presentDiscoverTab() {
-        viewModel.isReaderDiscoverNudgeFlow = true
+        viewModel.shouldShowCommentSpotlight = true
         viewModel.fetchReaderMenu()
         viewModel.showTab(at: ReaderTabConstants.discoverIndex)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -104,6 +104,7 @@ class ReaderTabViewController: UIViewController {
 
     func presentDiscoverTab() {
         let discoverIndex = 1
+        viewModel.isReaderDiscoverNudgeFlow = true
         viewModel.fetchReaderMenu()
         viewModel.showTab(at: discoverIndex)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -34,7 +34,7 @@ import WordPressFlux
     }
 
     /// Spotlight
-    var isReaderDiscoverNudgeFlow: Bool = false
+    var shouldShowCommentSpotlight: Bool = false
 
     /// Settings
     private let settingsPresenter: ScenePresenter

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -33,6 +33,9 @@ import WordPressFlux
         return tabItems.count > 0
     }
 
+    /// Spotlight
+    var isReaderDiscoverNudgeFlow: Bool = false
+
     /// Settings
     private let settingsPresenter: ScenePresenter
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -41,7 +41,9 @@ extension WPTabBarController {
     private func makeReaderContentViewController(with content: ReaderContent) -> ReaderContentViewController {
 
         if content.topicType == .discover, let topic = content.topic {
-            return ReaderCardsStreamViewController.controller(topic: topic)
+            let controller = ReaderCardsStreamViewController.controller(topic: topic)
+            controller.isReaderDiscoverNudgeFlow = readerTabViewModel.isReaderDiscoverNudgeFlow
+            return controller
         } else if let topic = content.topic {
             return ReaderStreamViewController.controllerWithTopic(topic)
         } else {
@@ -81,6 +83,10 @@ extension WPTabBarController {
             return
         }
         readerNavigationController.pushViewController(controller, animated: true)
+    }
+
+    func resetReaderDiscoverNudgeFlow() {
+        readerTabViewModel.isReaderDiscoverNudgeFlow = false
     }
 
     /// methods to select one of the default Reader tabs

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -42,7 +42,7 @@ extension WPTabBarController {
 
         if content.topicType == .discover, let topic = content.topic {
             let controller = ReaderCardsStreamViewController.controller(topic: topic)
-            controller.isReaderDiscoverNudgeFlow = readerTabViewModel.isReaderDiscoverNudgeFlow
+            controller.shouldShowCommentSpotlight = readerTabViewModel.shouldShowCommentSpotlight
             return controller
         } else if let topic = content.topic {
             return ReaderStreamViewController.controllerWithTopic(topic)
@@ -86,7 +86,7 @@ extension WPTabBarController {
     }
 
     func resetReaderDiscoverNudgeFlow() {
-        readerTabViewModel.isReaderDiscoverNudgeFlow = false
+        readerTabViewModel.shouldShowCommentSpotlight = false
     }
 
     /// methods to select one of the default Reader tabs

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -506,6 +506,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         guard let vc = viewModel?.followTopicsViewController else {
             return
         }
+        vc.spotlightIsShown = true
         vc.readerDiscoverFlowDelegate = self
         vc.didSaveInterests = { [weak self] interests in
             guard let self = self else {


### PR DESCRIPTION
Part of #17126 

## Description
This PR adds the spotlight view (pulsing blue circle) to the Reader Discover nudge flow.

Follow Topics | Reader Discover
-- | --
<img src="https://user-images.githubusercontent.com/6711616/138744738-8d7efe5c-5a66-4d75-b9ff-9ceefe8b178c.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/138744731-0e4d5cf3-a466-46f6-bfcd-5aba81409b1c.png" width=200>

## How to test
1. Go to **My Site** > **Stats** for site with less than 30 views
2. Complete or dismiss the first two nudges (**Publicize** and **Blogging reminders**) in order to have the **Reader discover** nudge shown
3. Tap on **Discover blogs to follow**
4. **Follow topics** screen should be presented
5. ✅ Notice the spotlight view in the center of the screen
6. Select one or more topics and tap **Done**
7. **Reader** tab should be presented, with **Discover** tab selected
8. ✅ Notice the spotlight view on top of the comments button on the first post

## Regression Notes
1. Potential unintended areas of impact
Follow topics screen, Reader Discover screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the above steps

3. What automated tests I added (or what prevented me from doing so)
N/A, just visual changes

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
