### PR TITLE
Comment Moderation snackbar: add `>` after the Next button

### DIFF
--- a/WordPress/Classes/Extensions/UIViewController+Notice.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Notice.swift
@@ -1,13 +1,25 @@
 import Foundation
 import WordPressFlux
 
-@objc extension UIViewController {
+extension UIViewController {
     @objc func displayNotice(title: String, message: String? = nil) {
         displayActionableNotice(title: title, message: message)
     }
 
-    @objc func displayActionableNotice(title: String, message: String? = nil, actionTitle: String? = nil, actionHandler: ((Bool) -> Void)? = nil) {
-        let notice = Notice(title: title, message: message, actionTitle: actionTitle, actionHandler: actionHandler)
+    @objc func displayActionableNotice(title: String,
+                                       message: String? = nil,
+                                       actionTitle: String? = nil,
+                                       actionHandler: ((Bool) -> Void)? = nil) {
+        displayActionableNotice(title: title, message: message, style: NormalNoticeStyle(), actionTitle: actionTitle, actionHandler: actionHandler)
+    }
+
+    // NoticeStyle is Swift only, so this method is needed to set it.
+    func displayActionableNotice(title: String,
+                                 message: String? = nil,
+                                 style: NoticeStyle = NormalNoticeStyle(),
+                                 actionTitle: String? = nil,
+                                 actionHandler: ((Bool) -> Void)? = nil) {
+        let notice = Notice(title: title, message: message, style: style, actionTitle: actionTitle, actionHandler: actionHandler)
         ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -684,7 +684,10 @@ private extension CommentDetailViewController {
             return
         }
 
-        displayActionableNotice(title: title, actionTitle: ModerationMessages.next, actionHandler: { [weak self] _ in
+        displayActionableNotice(title: title,
+                                style: NormalNoticeStyle(showNextArrow: true),
+                                actionTitle: ModerationMessages.next,
+                                actionHandler: { [weak self] _ in
             self?.showNextComment()
         })
     }

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
@@ -32,6 +32,9 @@ public protocol NoticeStyle {
     var isDismissable: Bool { get }
     var animationStyle: NoticeAnimationStyle { get }
     var dismissGesture: NoticeDismissGesture? { get }
+
+    // Show an arrow (>) after the action button.
+    var showNextArrow: Bool { get }
 }
 
 extension NoticeStyle {
@@ -60,6 +63,7 @@ public struct NormalNoticeStyle: NoticeStyle {
     public let layoutMargins = UIEdgeInsets(top: 10.0, left: 16.0, bottom: 10.0, right: 16.0)
 
     public let isDismissable = true
+    public var showNextArrow = false
 
     public let animationStyle = NoticeAnimationStyle.moveIn
 
@@ -78,6 +82,7 @@ public struct QuickStartNoticeStyle: NoticeStyle {
     public let layoutMargins = UIEdgeInsets(top: 13.0, left: 16.0, bottom: 13.0, right: 16.0)
 
     public let isDismissable = false
+    public let showNextArrow = false
 
     public let animationStyle = NoticeAnimationStyle.moveIn
 
@@ -100,6 +105,7 @@ public struct ToolTipNoticeStyle: NoticeStyle {
     public let layoutMargins = UIEdgeInsets(top: 13.0, left: 16.0, bottom: 13.0, right: 16.0)
 
     public let isDismissable = false
+    public let showNextArrow = false
 
     public let animationStyle = NoticeAnimationStyle.fade
 

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -17,6 +17,10 @@ class NoticeView: UIView {
     private let actionButton = UIButton(type: .system)
     private let cancelButton = UIButton(type: .system)
 
+    private lazy var nextArrowImageView: UIImageView = {
+        configureNextArrow()
+    }()
+
     internal let notice: Notice
     internal var dualButtonsStackView: UIStackView?
 
@@ -55,6 +59,8 @@ class NoticeView: UIView {
 
         if notice.actionTitle != nil && notice.cancelTitle != nil {
             configureDualButtons()
+        } else if notice.actionTitle != nil && notice.style.showNextArrow {
+            configureActionButtonWithArrow()
         } else if notice.actionTitle != nil {
             configureActionButton()
         }
@@ -251,6 +257,60 @@ class NoticeView: UIView {
             self?.cancelButtonTapped()
         }
         cancelButton.setContentCompressionResistancePriority(.required, for: .vertical)
+    }
+
+    private func configureActionButtonWithArrow() {
+        guard let actionTitle = notice.actionTitle,
+              notice.style.showNextArrow else {
+                  actionBackgroundView.isHidden = true
+                  return
+              }
+
+        contentStackView.addArrangedSubview(actionBackgroundView)
+        actionBackgroundView.translatesAutoresizingMaskIntoConstraints = false
+        actionBackgroundView.layoutMargins = notice.style.layoutMargins
+        actionBackgroundView.backgroundColor = notice.style.backgroundColor
+
+        NSLayoutConstraint.activate([
+            actionBackgroundView.topAnchor.constraint(equalTo: backgroundView.contentView.topAnchor),
+            actionBackgroundView.bottomAnchor.constraint(equalTo: backgroundView.contentView.bottomAnchor)
+        ])
+
+        actionButton.setTitle(actionTitle, for: .normal)
+        actionButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        actionButton.setTitleColor(.invertedLink, for: .normal)
+        actionButton.addTarget(self, action: #selector(actionButtonTapped), for: .touchUpInside)
+
+        actionBackgroundView.addSubviews([actionButton, nextArrowImageView])
+
+        actionButton.translatesAutoresizingMaskIntoConstraints = false
+        nextArrowImageView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            actionButton.centerYAnchor.constraint(equalTo: actionBackgroundView.centerYAnchor),
+            actionButton.leadingAnchor.constraint(greaterThanOrEqualTo: actionBackgroundView.leadingAnchor)
+        ])
+
+        NSLayoutConstraint.activate([
+            nextArrowImageView.centerYAnchor.constraint(equalTo: actionButton.centerYAnchor),
+            nextArrowImageView.leadingAnchor.constraint(equalTo: actionButton.trailingAnchor, constant: 5),
+            nextArrowImageView.trailingAnchor.constraint(equalTo: actionBackgroundView.trailingAnchor, constant: -16)
+        ])
+    }
+
+    private func configureNextArrow() -> UIImageView {
+        guard let image = UIImage(named: "disclosure-chevron")?.withTintColor(.invertedLink).imageFlippedForRightToLeftLayoutDirection() else {
+            return UIImageView()
+        }
+
+        let arrowImageView = UIImageView(image: image)
+        arrowImageView.backgroundColor = notice.style.backgroundColor
+
+        NSLayoutConstraint.activate([
+            arrowImageView.heightAnchor.constraint(greaterThanOrEqualToConstant: 13.0)
+        ])
+
+        return arrowImageView
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {


### PR DESCRIPTION
Ref: #17290 
Depends on: #17351

This adds a `>` image after the `Next` button on the comment moderation confirmation snackbar.

NOTE: The tappable area is still just the size of the `Next` button (this is legacy), so it's kind of small. I'll see about making it bigger and including the arrow in a follow up.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment that is not last in a list.
- Moderate it and stay on the details view.
- Verify `>` appears after the `Next` button.

![next_action](https://user-images.githubusercontent.com/1816888/138534333-8d500900-b560-44ab-809a-62fbe8eda81b.png)

- Select the last comment in a list.
- Moderate it and stay on the details view.
- Verify `Next >` does not appear. 

![no_action](https://user-images.githubusercontent.com/1816888/138534340-3294eb5a-afdf-4dd3-a2eb-eea00a16a19c.png)

- Do some other action in the app that presents a snackbar with an action button. (The new `followConversationViaNotifications` is a good example.)
- Verify the `>` does not appear.
 
![other_action](https://user-images.githubusercontent.com/1816888/138534356-31dcd119-eb40-47c9-a4b8-47685f1bf417.png)



## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
