### PR TITLE
Convert UI tests screens to be `ScreenObject` subclasses – Part 3 of many

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -77,7 +77,7 @@ class JetpackScreenshotGeneration: XCTestCase {
         }
 
         // Get Stats screenshot
-        let statsScreen = mySite.gotoStatsScreen()
+        let statsScreen = try mySite.goToStatsScreen()
         statsScreen
             .dismissCustomizeInsightsNotice()
             .switchTo(mode: .months)

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -35,7 +35,7 @@ class JetpackScreenshotGeneration: XCTestCase {
     func testGenerateScreenshots() throws {
 
         // Get My Site screenshot
-        let mySite = MySiteScreen()
+        let mySite = try MySiteScreen()
             .showSiteSwitcher()
             .switchToSite(withTitle: "yourjetpack.blog")
             .thenTakeScreenshot(1, named: "MySite")

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -13,4 +13,27 @@ extension ScreenObject {
     public func pop() {
         navBackButton.tap()
     }
+
+    public func openMagicLink() {
+        XCTContext.runActivity(named: "Open magic link in Safari") { activity in
+            let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+            safari.launch()
+
+            // Select the URL bar when Safari opens
+            let urlBar = safari.textFields["URL"]
+            if !urlBar.waitForExistence(timeout: 5) {
+                safari.buttons["URL"].tap()
+            }
+
+            // Follow the magic link
+            var magicLinkComponents = URLComponents(url: WireMock.URL(), resolvingAgainstBaseURL: false)!
+            magicLinkComponents.path = "/magic-link"
+            magicLinkComponents.queryItems = [URLQueryItem(name: "scheme", value: "wpdebug")]
+
+            urlBar.typeText("\(magicLinkComponents.url!.absoluteString)\n")
+
+            // Accept the prompt to open the deep link
+            safari.scrollViews.element(boundBy: 0).buttons.element(boundBy: 1).tap()
+        }
+    }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -23,9 +23,9 @@ public class LoginEpilogueScreen: BaseScreen {
         super.init(element: continueButton)
     }
 
-    public func continueWithSelectedSite() -> MySiteScreen {
+    public func continueWithSelectedSite() throws -> MySiteScreen {
         continueButton.tap()
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 
     // Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal (MySitesScreen)

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -1,3 +1,4 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
@@ -7,15 +8,21 @@ private struct ElementStringIDs {
     static let signupButton = "Prologue Signup Button"
 }
 
-public class WelcomeScreen: BaseScreen {
-    let logInButton: XCUIElement
-    let signupButton: XCUIElement
+public class WelcomeScreen: ScreenObject {
 
-    public init() {
-        logInButton = XCUIApplication().buttons[ElementStringIDs.loginButton]
-        signupButton = XCUIApplication().buttons[ElementStringIDs.signupButton]
+    private let logInButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Log In Button"]
+    }
 
-        super.init(element: logInButton)
+    private let signupButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Prologue Signup Button"]
+    }
+
+    var signupButton: XCUIElement { signupButtonGetter(app) }
+    var logInButton: XCUIElement { logInButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [logInButtonGetter, signupButtonGetter], app: app)
     }
 
     public func selectSignup() throws -> WelcomeScreenSignupComponent {
@@ -31,6 +38,6 @@ public class WelcomeScreen: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.loginButton].exists
+        (try? WelcomeScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -3,11 +3,6 @@ import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let loginButton = "Prologue Log In Button"
-    static let signupButton = "Prologue Signup Button"
-}
-
 public class WelcomeScreen: ScreenObject {
 
     private let logInButtonGetter: (XCUIApplication) -> XCUIElement = {

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -64,9 +64,9 @@ public class MeTabScreen: ScreenObject {
         return try PrologueScreen()
     }
 
-    public func dismiss() -> MySiteScreen {
+    public func dismiss() throws -> MySiteScreen {
         app.buttons["Done"].tap()
 
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -28,7 +28,7 @@ public class MeTabScreen: ScreenObject {
         return logOutButton.exists
     }
 
-    public func logout() -> WelcomeScreen {
+    public func logout() throws -> WelcomeScreen {
         app.cells["logOutFromWPcomButton"].tap()
 
         // Some localizations have very long "log out" text, which causes the UIAlertView
@@ -40,7 +40,7 @@ public class MeTabScreen: ScreenObject {
             logOutAlert.buttons.element(boundBy: 1).tap()
         }
 
-        return WelcomeScreen()
+        return try WelcomeScreen()
     }
 
     public func logoutToPrologue() throws -> PrologueScreen {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -105,9 +105,9 @@ public class MySiteScreen: BaseScreen {
         return MediaScreen()
     }
 
-    public func gotoStatsScreen() -> StatsScreen {
+    public func goToStatsScreen() throws -> StatsScreen {
         statsButton.tap()
-        return StatsScreen()
+        return try StatsScreen()
     }
 
     public func goToSettingsScreen() throws -> SiteSettingsScreen {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -40,9 +40,9 @@ public class MySiteScreen: BaseScreen {
         return blogTable.exists && blogTable.isHittable
     }
 
-    public init() {
+    public init() throws {
         let app = XCUIApplication()
-        tabBar = TabNavComponent()
+        tabBar = try TabNavComponent()
         removeSiteButton = app.cells[ElementStringIDs.removeSiteButton]
         removeSiteSheet = app.sheets.buttons.element(boundBy: 0)
         removeSiteAlert = app.alerts.buttons.element(boundBy: 1)
@@ -110,9 +110,9 @@ public class MySiteScreen: BaseScreen {
         return StatsScreen()
     }
 
-    public func gotoSettingsScreen() -> SiteSettingsScreen {
+    public func goToSettingsScreen() throws -> SiteSettingsScreen {
         siteSettingsButton.tap()
-        return SiteSettingsScreen()
+        return try SiteSettingsScreen()
     }
 
     func gotoCreateSheet() throws -> ActionSheetComponent {

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -30,14 +30,14 @@ public class MySitesScreen: BaseScreen {
         return LoginSiteAddressScreen()
     }
 
-    public func closeModal() -> MySiteScreen {
+    public func closeModal() throws -> MySiteScreen {
         cancelButton.tap()
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 
     @discardableResult
-    public func switchToSite(withTitle title: String) -> MySiteScreen {
+    public func switchToSite(withTitle title: String) throws -> MySiteScreen {
         XCUIApplication().cells[title].tap()
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
@@ -1,17 +1,13 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let mailButton = "Open Mail Button"
-}
+public class SignupCheckMagicLinkScreen: ScreenObject {
 
-public class SignupCheckMagicLinkScreen: BaseScreen {
-    let mailButton: XCUIElement
-
-    init() {
-        let app = XCUIApplication()
-        mailButton = app.buttons[ElementStringIDs.mailButton]
-
-        super.init(element: mailButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [{ $0.buttons["Open Mail Button"] }],
+            app: app
+        )
     }
 
     public func openMagicSignupLink() -> SignupEpilogueScreen {

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
@@ -5,6 +5,7 @@ public class SignupCheckMagicLinkScreen: ScreenObject {
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
+            // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.buttons["Open Mail Button"] }],
             app: app
         )

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
@@ -19,11 +19,11 @@ public class SignupEmailScreen: BaseScreen {
         super.init(element: emailTextField)
     }
 
-    public func proceedWith(email: String) -> SignupCheckMagicLinkScreen {
+    public func proceedWith(email: String) throws -> SignupCheckMagicLinkScreen {
         emailTextField.tap()
         emailTextField.typeText(email)
         nextButton.tap()
 
-        return SignupCheckMagicLinkScreen()
+        return try SignupCheckMagicLinkScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
@@ -1,22 +1,23 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let emailTextField = "Signup Email Address"
-    static let nextButton = "Signup Email Next Button"
-}
+public class SignupEmailScreen: ScreenObject {
 
-public class SignupEmailScreen: BaseScreen {
-    let emailTextField: XCUIElement
-    let nextButton: XCUIElement
+    private let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Signup Email Address"]
+    }
 
-    init() {
-        let app = XCUIApplication()
-        emailTextField = app.textFields[ElementStringIDs.emailTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
+    private let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Signup Email Next Button"]
+    }
 
-        super.init(element: emailTextField)
+    var emailTextField: XCUIElement { emailTextFieldGetter(app) }
+    var nextButton: XCUIElement { nextButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [emailTextFieldGetter, nextButtonGetter], app: app)
     }
 
     public func proceedWith(email: String) throws -> SignupCheckMagicLinkScreen {

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
@@ -49,9 +49,9 @@ public class SignupEpilogueScreen: BaseScreen {
         return self
     }
 
-    public func continueWithSignup() -> MySiteScreen {
+    public func continueWithSignup() throws -> MySiteScreen {
         continueButton.tap()
 
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -15,9 +15,9 @@ public class WelcomeScreenSignupComponent: ScreenObject {
         try super.init(expectedElementGetters: [emailSignupButtonGetter], app: app)
     }
 
-    public func selectEmailSignup() -> SignupEmailScreen {
+    public func selectEmailSignup() throws -> SignupEmailScreen {
         emailSignupButton.tap()
 
-        return SignupEmailScreen()
+        return try SignupEmailScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
@@ -1,22 +1,20 @@
+import ScreenObject
 import XCTest
 
-public class SiteSettingsScreen: BaseScreen {
+public class SiteSettingsScreen: ScreenObject {
 
     public enum Toggle {
         case on
         case off
     }
 
-    let settingsTable: XCUIElement
-    let blockEditorToggle: XCUIElement
-    let tabBar: TabNavComponent
+    private let blockEditorToggleGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["siteSettingsTable"].switches["useBlockEditorSwitch"]
+    }
+    var blockEditorToggle: XCUIElement { blockEditorToggleGetter(app) }
 
-    public init() throws {
-        settingsTable = XCUIApplication().tables["siteSettingsTable"]
-        blockEditorToggle = settingsTable.switches["useBlockEditorSwitch"]
-        tabBar = try TabNavComponent()
-
-        super.init(element: settingsTable)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [blockEditorToggleGetter], app: app)
     }
 
     @discardableResult
@@ -46,6 +44,6 @@ public class SiteSettingsScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().navigationBars["Settings"].exists
+        (try? SiteSettingsScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
@@ -11,10 +11,10 @@ public class SiteSettingsScreen: BaseScreen {
     let blockEditorToggle: XCUIElement
     let tabBar: TabNavComponent
 
-    public init() {
+    public init() throws {
         settingsTable = XCUIApplication().tables["siteSettingsTable"]
         blockEditorToggle = settingsTable.switches["useBlockEditorSwitch"]
-        tabBar = TabNavComponent()
+        tabBar = try TabNavComponent()
 
         super.init(element: settingsTable)
     }
@@ -34,11 +34,11 @@ public class SiteSettingsScreen: BaseScreen {
         return self
     }
 
-    public func goBackToMySite() -> MySiteScreen {
+    public func goBackToMySite() throws -> MySiteScreen {
         if XCUIDevice.isPhone {
             navBackButton.tap()
         }
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 
     private func isBlockEditorEnabled() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -1,27 +1,23 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let draftsButton = "drafts"
-}
-
-public class StatsScreen: BaseScreen {
+public class StatsScreen: ScreenObject {
 
     public enum Mode: String {
-        case months = "months"
-        case years = "years"
+        case months
+        case years
     }
 
-    struct ElementStringIDs {
-        static let dismissCustomizeInsightsButton = "dismiss-customize-insights-cell"
-    }
-
-    public init() {
-        super.init(element: XCUIApplication().otherElements.firstMatch)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [{ $0.otherElements.firstMatch }],
+            app: app
+        )
     }
 
     @discardableResult
     public func dismissCustomizeInsightsNotice() -> StatsScreen {
-        let button = XCUIApplication().buttons[ElementStringIDs.dismissCustomizeInsightsButton]
+        let button = app.buttons["dismiss-customize-insights-cell"]
 
         if button.exists {
             button.tap()
@@ -32,7 +28,7 @@ public class StatsScreen: BaseScreen {
 
     @discardableResult
     public func switchTo(mode: Mode) -> StatsScreen {
-        XCUIApplication().buttons[mode.rawValue].tap()
+        app.buttons[mode.rawValue].tap()
         return self
     }
 }

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -10,6 +10,7 @@ public class StatsScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
+            // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.otherElements.firstMatch }],
             app: app
         )

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -1,34 +1,54 @@
+import ScreenObject
 import XCTest
 
-public class TabNavComponent: BaseScreen {
+public class TabNavComponent: ScreenObject {
 
-    let mySitesTabButton: XCUIElement
-    let readerTabButton: XCUIElement
-    let notificationsTabButton: XCUIElement
-
-    public init() {
-        let tabBars = XCUIApplication().tabBars["Main Navigation"]
-        mySitesTabButton = tabBars.buttons["mySitesTabButton"]
-        readerTabButton = tabBars.buttons["readerTabButton"]
-        notificationsTabButton = tabBars.buttons["notificationsTabButton"]
-        super.init(element: mySitesTabButton)
+    private static let tabBarGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tabBars["Main Navigation"]
     }
 
-    public func gotoMeScreen() throws -> MeTabScreen {
-        gotoMySiteScreen()
+    private let mySitesTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        TabNavComponent.tabBarGetter($0).buttons["mySitesTabButton"]
+    }
+
+    private let readerTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        TabNavComponent.tabBarGetter($0).buttons["readerTabButton"]
+    }
+
+    private let notificationsTabButtonGetter: (XCUIApplication) -> XCUIElement = {
+        TabNavComponent.tabBarGetter($0).buttons["notificationsTabButton"]
+    }
+
+    var mySitesTabButton: XCUIElement { mySitesTabButtonGetter(app) }
+    var readerTabButton: XCUIElement { readerTabButtonGetter(app) }
+    var notificationsTabButton: XCUIElement { notificationsTabButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                mySitesTabButtonGetter,
+                readerTabButtonGetter,
+                notificationsTabButtonGetter
+            ],
+            app: app
+        )
+    }
+
+    public func goToMeScreen() throws -> MeTabScreen {
+        try goToMySiteScreen()
         let meButton = app.navigationBars.buttons["meBarButton"]
         meButton.tap()
         return try MeTabScreen()
     }
 
     @discardableResult
-    public func gotoMySiteScreen() -> MySiteScreen {
+    public func goToMySiteScreen() throws -> MySiteScreen {
         mySitesTabButton.tap()
-        return MySiteScreen()
+        return try MySiteScreen()
     }
 
     public func gotoAztecEditorScreen() throws -> AztecEditorScreen {
-        let mySiteScreen = gotoMySiteScreen()
+        let mySiteScreen = try goToMySiteScreen()
         let actionSheet = try mySiteScreen.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
@@ -36,7 +56,7 @@ public class TabNavComponent: BaseScreen {
     }
 
     public func gotoBlockEditorScreen() throws -> BlockEditorScreen {
-        let mySite = gotoMySiteScreen()
+        let mySite = try goToMySiteScreen()
         let actionSheet = try mySite.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
@@ -54,10 +74,11 @@ public class TabNavComponent: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons["mySitesTabButton"].exists
+        (try? TabNavComponent().isLoaded) ?? false
     }
 
     public static func isVisible() -> Bool {
-        return XCUIApplication().buttons["mySitesTabButton"].isHittable
+        guard let screen = try? TabNavComponent() else { return false }
+        return screen.mySitesTabButton.isHittable
     }
 }

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -1,3 +1,4 @@
+import ScreenObject
 import UIKit
 import UITestsFoundation
 import XCTest
@@ -85,7 +86,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         }
 
         // Get Stats screenshot
-        let statsScreen = mySite.gotoStatsScreen()
+        let statsScreen = try mySite.goToStatsScreen()
         statsScreen
             .dismissCustomizeInsightsNotice()
             .switchTo(mode: .months)
@@ -112,6 +113,19 @@ class WordPressScreenshotGeneration: XCTestCase {
 }
 
 extension BaseScreen {
+    @discardableResult
+    func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
+        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
+        let filename = "\(index)-\(mode)-\(title)"
+
+        snapshot(filename)
+
+        return self
+    }
+}
+
+extension ScreenObject {
+
     @discardableResult
     func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
         let mode = XCUIDevice.inDarkMode ? "dark" : "light"

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -34,7 +34,7 @@ class WordPressScreenshotGeneration: XCTestCase {
     func testGenerateScreenshots() throws {
 
         // Get post editor screenshot
-        let postList = MySiteScreen()
+        let postList = try MySiteScreen()
             .showSiteSwitcher()
             .switchToSite(withTitle: "fourpawsdoggrooming.wordpress.com")
             .gotoPostsScreen()
@@ -70,7 +70,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         }
 
         // Get My Site screenshot
-        let mySite = MySiteScreen()
+        let mySite = try MySiteScreen()
             .showSiteSwitcher()
             .switchToSite(withTitle: "tricountyrealestate.wordpress.com")
             .thenTakeScreenshot(4, named: "MySite")
@@ -93,7 +93,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         // Get Discover screenshot
         // Currently, the view includes the "You Might Like" section
-        TabNavComponent()
+        try TabNavComponent()
             .gotoReaderScreen()
             .openDiscover()
             .thenTakeScreenshot(2, named: "Discover")

--- a/WordPress/WordPressUITests/Flows/EditorFlow.swift
+++ b/WordPress/WordPressUITests/Flows/EditorFlow.swift
@@ -8,16 +8,16 @@ class EditorFlow {
         }
     }
 
-    static func gotoMySiteScreen() -> MySiteScreen {
-        return TabNavComponent().gotoMySiteScreen()
+    static func goToMySiteScreen() throws -> MySiteScreen {
+        return try TabNavComponent().goToMySiteScreen()
     }
 
-    static func toggleBlockEditor(to state: SiteSettingsScreen.Toggle) -> SiteSettingsScreen {
+    static func toggleBlockEditor(to state: SiteSettingsScreen.Toggle) throws -> SiteSettingsScreen {
         if !SiteSettingsScreen.isLoaded() {
-            _ = TabNavComponent()
-                .gotoMySiteScreen()
-                .gotoSettingsScreen()
+            _ = try TabNavComponent()
+                .goToMySiteScreen()
+                .goToSettingsScreen()
         }
-        return SiteSettingsScreen().toggleBlockEditor(to: state)
+        return try SiteSettingsScreen().toggleBlockEditor(to: state)
     }
 }

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -53,7 +53,7 @@ class LoginFlow {
         guard TabNavComponent.isLoaded() else {
             return try login(siteUrl: siteUrl, username: username, password: password).tabBar
         }
-        return TabNavComponent()
+        return try TabNavComponent()
     }
 
     // Login with WP site via Site Address.
@@ -61,18 +61,18 @@ class LoginFlow {
         guard TabNavComponent.isLoaded() else {
             return try login(siteUrl: siteUrl, email: email, password: password).tabBar
         }
-        return TabNavComponent()
+        return try TabNavComponent()
     }
 
     static func logoutIfNeeded() throws {
         try XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
             if TabNavComponent.isLoaded() {
                 Logger.log(message: "Logging out...", event: .i)
-                let meScreen = try TabNavComponent().gotoMeScreen()
+                let meScreen = try TabNavComponent().goToMeScreen()
                 if meScreen.isLoggedInToWpcom() {
                     _ = try meScreen.logoutToPrologue()
                 } else {
-                    meScreen.dismiss().removeSelfHostedSite()
+                    try meScreen.dismiss().removeSelfHostedSite()
                 }
                 return
             }

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -9,7 +9,7 @@ class EditorGutenbergTests: XCTestCase {
 
         _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = try EditorFlow
-            .gotoMySiteScreen()
+            .goToMySiteScreen()
             .tabBar.gotoBlockEditorScreen()
     }
 

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -44,7 +44,7 @@ class LoginTests: XCTestCase {
             .tabBar.goToMeScreen()
             .logout()
 
-        XCTAssert(welcomeScreen.isLoaded())
+        XCTAssert(welcomeScreen.isLoaded)
     }
 
     // Unified self hosted login/out

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -24,7 +24,7 @@ class LoginTests: XCTestCase {
             .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
-            .tabBar.gotoMeScreen()
+            .tabBar.goToMeScreen()
             .logoutToPrologue()
 
         XCTAssert(prologueScreen.isLoaded)
@@ -41,7 +41,7 @@ class LoginTests: XCTestCase {
             .openMagicLoginLink()
             .continueWithSelectedSite()
             .dismissNotificationAlertIfNeeded()
-            .tabBar.gotoMeScreen()
+            .tabBar.goToMeScreen()
             .logout()
 
         XCTAssert(welcomeScreen.isLoaded())
@@ -51,7 +51,7 @@ class LoginTests: XCTestCase {
     func testSelfHostedLoginLogout() throws {
         let prologueScreen = try PrologueScreen()
 
-        prologueScreen
+        try prologueScreen
             .selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
             .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
@@ -97,6 +97,6 @@ class LoginTests: XCTestCase {
             // So, we remove the self-hosted site before tearDown() starts.
             .removeSelfHostedSite()
 
-        XCTAssert(MySiteScreen().isLoaded())
+        XCTAssert(MySiteScreen.isLoaded())
     }
 }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -8,8 +8,8 @@ class MainNavigationTests: XCTestCase {
         setUpTestSuite()
 
         try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
-        mySiteScreen = TabNavComponent()
-         .gotoMySiteScreen()
+        mySiteScreen = try TabNavComponent()
+            .goToMySiteScreen()
     }
 
     override func tearDownWithError() throws {


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/17221 and https://github.com/wordpress-mobile/WordPress-iOS/pull/17348.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
