### PR TITLE
Convert UI tests screens to be `ScreenObject` subclasses – Part 4 of many

### DIFF
--- a/WordPress/UITestsFoundation/BaseScreen.swift
+++ b/WordPress/UITestsFoundation/BaseScreen.swift
@@ -69,24 +69,8 @@ extension BaseScreen {
         }
     }
 
-    /// Scroll an element into view within another element.
-    /// scrollView can be a UIScrollView, or anything that subclasses it like UITableView
-    ///
-    /// TODO: The implementation of this could use work:
-    /// - What happens if the element is above the current scroll view position?
-    /// - What happens if it's a really long scroll view?
     public func scrollElementIntoView(element: XCUIElement, within scrollView: XCUIElement, threshold: Int = 1000) {
-
-        var iteration = 0
-
-        while !element.isFullyVisibleOnScreen && iteration < threshold {
-            scrollView.scroll(byDeltaX: 0, deltaY: 100)
-            iteration += 1
-        }
-
-        if !element.isFullyVisibleOnScreen {
-            XCTFail("Unable to scroll element into view")
-        }
+        element.scrollIntoView(within: scrollView, threshold: threshold)
     }
 
     @discardableResult

--- a/WordPress/UITestsFoundation/FancyAlertComponent.swift
+++ b/WordPress/UITestsFoundation/FancyAlertComponent.swift
@@ -35,7 +35,7 @@ public class FancyAlertComponent: ScreenObject {
         defaultAlertButton.tap()
     }
 
-    func cancelAlert() {
+    public func cancelAlert() {
         cancelAlertButton.tap()
     }
 

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -36,4 +36,20 @@ extension ScreenObject {
             safari.scrollViews.element(boundBy: 0).buttons.element(boundBy: 1).tap()
         }
     }
+
+    @discardableResult
+    public func dismissNotificationAlertIfNeeded(
+        _ action: FancyAlertComponent.Action = .cancel
+    ) throws -> Self {
+        guard FancyAlertComponent.isLoaded() else { return self }
+
+        switch action {
+        case .accept:
+            try FancyAlertComponent().acceptAlert()
+        case .cancel:
+            try FancyAlertComponent().cancelAlert()
+        }
+
+        return self
+    }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -209,7 +209,7 @@ public class AztecEditorScreen: BaseScreen {
      Select Image from Camera Roll by its ID. Starts with 0
      Simulator range: 0..4
      */
-    func addImageByOrder(id: Int) -> AztecEditorScreen {
+    func addImageByOrder(id: Int) throws -> AztecEditorScreen {
         tapToolbarButton(button: mediaButton)
 
         // Allow access to device media
@@ -221,7 +221,7 @@ public class AztecEditorScreen: BaseScreen {
         }
 
         // Inject the first picture
-        MediaPickerAlbumScreen().selectImage(atIndex: 0)
+        try MediaPickerAlbumScreen().selectImage(atIndex: 0)
         insertMediaButton.tap()
 
         // Wait for upload to finish

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -57,9 +57,9 @@ public class BlockEditorScreen: BaseScreen {
     /**
      Adds an image block with latest image from device.
      */
-    public func addImage() -> BlockEditorScreen {
+    public func addImage() throws -> BlockEditorScreen {
         addBlock("Image block")
-        addImageByOrder(id: 0)
+        try addImageByOrder(id: 0)
 
         return self
     }
@@ -126,14 +126,14 @@ public class BlockEditorScreen: BaseScreen {
     /*
      Select Image from Camera Roll by its ID. Starts with 0
      */
-    private func addImageByOrder(id: Int) {
+    private func addImageByOrder(id: Int) throws {
         imageDeviceButton.tap()
 
         // Allow access to device media
         app.tap() // trigger the media permissions alert handler
 
         // Inject the first picture
-        MediaPickerAlbumListScreen()
+        try MediaPickerAlbumListScreen()
             .selectAlbum(atIndex: 0)
             .selectImage(atIndex: 0)
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -53,7 +53,7 @@ public class EditorPostSettings: ScreenObject {
 
     public func setFeaturedImage() throws -> EditorPostSettings {
         featuredImageButton.tap()
-        MediaPickerAlbumListScreen()
+        try MediaPickerAlbumListScreen()
             .selectAlbum(atIndex: 0) // Select media library
             .selectImage(atIndex: 0) // Select latest uploaded image
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -1,25 +1,26 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let emailTextField = "Login Email Address"
-    static let nextButton = "Login Email Next Button"
-    static let siteAddressButton = "Self Hosted Login Button"
-}
+public class LoginEmailScreen: ScreenObject {
 
-public class LoginEmailScreen: BaseScreen {
-    let emailTextField: XCUIElement
-    let nextButton: XCUIElement
-    let siteAddressButton: XCUIElement
+    let emailTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Login Email Address"]
+    }
 
-    init() {
-        let app = XCUIApplication()
-        emailTextField = app.textFields[ElementStringIDs.emailTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
-        siteAddressButton = app.buttons[ElementStringIDs.siteAddressButton]
+    let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Login Email Next Button"]
+    }
 
-        super.init(element: emailTextField)
+    var emailTextField: XCUIElement { emailTextFieldGetter(app) }
+    var nextButton: XCUIElement { nextButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [emailTextFieldGetter, nextButtonGetter],
+            app: app
+        )
     }
 
     public func proceedWith(email: String) -> LinkOrPasswordScreen {
@@ -31,18 +32,16 @@ public class LoginEmailScreen: BaseScreen {
     }
 
     func goToSiteAddressLogin() -> LoginSiteAddressScreen {
-        siteAddressButton.tap()
+        app.buttons["Self Hosted Login Button"].tap()
 
         return LoginSiteAddressScreen()
     }
 
     static func isLoaded() -> Bool {
-        let expectedElement = XCUIApplication().textFields[ElementStringIDs.emailTextField]
-        return expectedElement.exists && expectedElement.isHittable
+        (try? LoginEmailScreen().isLoaded) ?? false
     }
 
     static func isEmailEntered() -> Bool {
-        let emailTextField = XCUIApplication().textFields[ElementStringIDs.emailTextField]
-        return emailTextField.value != nil
+        (try? LoginEmailScreen().emailTextField.value != nil) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -25,12 +25,12 @@ public class LoginSiteAddressScreen: BaseScreen {
         super.init(element: siteAddressTextField)
     }
 
-    public func proceedWith(siteUrl: String) -> LoginUsernamePasswordScreen {
+    public func proceedWith(siteUrl: String) throws -> LoginUsernamePasswordScreen {
         siteAddressTextField.tap()
         siteAddressTextField.typeText(siteUrl)
         nextButton.tap()
 
-        return LoginUsernamePasswordScreen()
+        return try LoginUsernamePasswordScreen()
     }
 
     public func proceedWithWP(siteUrl: String) throws -> GetStartedScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -1,3 +1,4 @@
+import ScreenObject
 import XCTest
 import XCUITestHelpers
 
@@ -16,18 +17,35 @@ private struct ElementStringIDs {
     static let nextButton = "Continue Button"
 }
 
-public class LoginUsernamePasswordScreen: BaseScreen {
-    let usernameTextField: XCUIElement
-    let passwordTextField: XCUIElement
-    let nextButton: XCUIElement
+public class LoginUsernamePasswordScreen: ScreenObject {
 
-    init() {
-        let app = XCUIApplication()
-        usernameTextField = app.textFields[ElementStringIDs.usernameTextField]
-        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
+    let usernameTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields[ElementStringIDs.usernameTextField]
+    }
 
-        super.init(element: passwordTextField)
+    let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields[ElementStringIDs.passwordTextField]
+    }
+
+    let nextButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons[ElementStringIDs.nextButton]
+    }
+
+    var usernameTextField: XCUIElement { usernameTextFieldGetter(app) }
+    var passwordTextField: XCUIElement { passwordTextFieldGetter(app) }
+    var nextButton: XCUIElement { nextButtonGetter(app) }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        // Notice that we don't use the "next button" getter because, at the time the screen loads,
+        // that element is disabled. `ScreenObject` uses `isEnabled == true` on the elements we
+        // pass at `init`.
+        try super.init(
+            expectedElementGetters: [
+                usernameTextFieldGetter,
+                passwordTextFieldGetter
+            ],
+            app: app
+        )
     }
 
     public func proceedWith(username: String, password: String) -> LoginEpilogueScreen {
@@ -47,6 +65,6 @@ public class LoginUsernamePasswordScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
+        (try? LoginUsernamePasswordScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -18,10 +18,10 @@ public class WelcomeScreenLoginComponent: BaseScreen {
         super.init(element: emailLoginButton)
     }
 
-    public func selectEmailLogin() -> LoginEmailScreen {
+    public func selectEmailLogin() throws -> LoginEmailScreen {
         emailLoginButton.tap()
 
-        return LoginEmailScreen()
+        return try LoginEmailScreen()
     }
 
     func goToSiteAddressLogin() -> LoginSiteAddressScreen {

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -14,12 +14,12 @@ public class MediaPickerAlbumListScreen: ScreenObject {
         )
     }
 
-    public func selectAlbum(atIndex index: Int) -> MediaPickerAlbumScreen {
+    public func selectAlbum(atIndex index: Int) throws -> MediaPickerAlbumScreen {
         let selectedAlbum = albumListGetter(app).cells.element(boundBy: index)
         XCTAssertTrue(selectedAlbum.waitForExistence(timeout: 5), "Selected album did not load")
         selectedAlbum.tap()
 
-        return MediaPickerAlbumScreen()
+        return try MediaPickerAlbumScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -1,17 +1,21 @@
+import ScreenObject
 import XCTest
 
-public class MediaPickerAlbumListScreen: BaseScreen {
-    let albumList: XCUIElement
+public class MediaPickerAlbumListScreen: ScreenObject {
 
-    public init() {
-        let app = XCUIApplication()
-        albumList = app.tables["AlbumTable"]
+    private let albumListGetter: (XCUIApplication) -> XCUIElement = {
+        $0.tables["AlbumTable"]
+    }
 
-        super.init(element: albumList)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetter: albumListGetter,
+            app: app
+        )
     }
 
     public func selectAlbum(atIndex index: Int) -> MediaPickerAlbumScreen {
-        let selectedAlbum = albumList.cells.element(boundBy: index)
+        let selectedAlbum = albumListGetter(app).cells.element(boundBy: index)
         XCTAssertTrue(selectedAlbum.waitForExistence(timeout: 5), "Selected album did not load")
         selectedAlbum.tap()
 
@@ -19,6 +23,6 @@ public class MediaPickerAlbumListScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().tables["AlbumTable"].exists
+        (try? MediaPickerAlbumListScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
@@ -1,34 +1,32 @@
+import ScreenObject
 import XCTest
 
-public class MediaPickerAlbumScreen: BaseScreen {
-    let mediaCollection: XCUIElement
-    let insertButton: XCUIElement
+public class MediaPickerAlbumScreen: ScreenObject {
+    let mediaCollectionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.collectionViews["MediaCollection"]
+    }
 
-    public init() {
-        let app = XCUIApplication()
-        mediaCollection = app.collectionViews["MediaCollection"]
-        insertButton = app.buttons["SelectedActionButton"]
-
-        super.init(element: mediaCollection)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [mediaCollectionGetter], app: app)
     }
 
     public func selectImage(atIndex index: Int) {
-        let selectedImage = mediaCollection.cells.element(boundBy: index)
+        let selectedImage = mediaCollectionGetter(app).cells.element(boundBy: index)
         XCTAssertTrue(selectedImage.waitForExistence(timeout: 5), "Selected image did not load")
         selectedImage.tap()
     }
 
     func insertSelectedImage() {
-        insertButton.tap()
+        app.buttons["SelectedActionButton"].tap()
     }
 
-    public static func isLoaded() -> Bool {
+    public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {
         // Check if the media picker is loaded as a component within the editor
         // and only return true if the media picker is a full screen
-        if XCUIApplication().navigationBars["Azctec Editor Navigation Bar"].exists {
+        if app.navigationBars["Azctec Editor Navigation Bar"].exists {
             return false
         }
 
-        return XCUIApplication().collectionViews["MediaCollection"].exists
+        return (try? MediaPickerAlbumScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -90,14 +90,14 @@ public class MySiteScreen: BaseScreen {
         return try JetpackBackupScreen()
     }
 
-    public func gotoPostsScreen() -> PostsScreen {
+    public func gotoPostsScreen() throws -> PostsScreen {
         // A hack for iPad, because sometimes tapping "posts" doesn't load it the first time
         if XCUIDevice.isPad {
             mediaButton.tap()
         }
 
         postsButton.tap()
-        return PostsScreen()
+        return try PostsScreen()
     }
 
     public func gotoMediaScreen() -> MediaScreen {

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -1,28 +1,28 @@
+import ScreenObject
 import XCTest
 
-public class NotificationsScreen: BaseScreen {
+public class NotificationsScreen: ScreenObject {
 
-    let replyButton: XCUIElement
-
-    init() {
-        let navBar = XCUIApplication().tables["Notifications Table"]
-        replyButton = XCUIApplication().buttons["reply-button"]
-
-        super.init(element: navBar)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.tables["Notifications Table"] } ],
+            app: app
+        )
     }
 
     public func openNotification(withText notificationText: String) -> NotificationsScreen {
-        XCUIApplication().staticTexts[notificationText].tap()
+        app.staticTexts[notificationText].tap()
         return self
     }
 
     @discardableResult
     public func replyToNotification() -> NotificationsScreen {
+        let replyButton = app.buttons["reply-button"]
         replyButton.tap()
         return self
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().tables["Notifications Table"].exists
+        (try? NotificationsScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -1,13 +1,7 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let draftsButton = "drafts"
-    static let publishedButton = "published"
-
-    static let autosaveVersionsAlert = "autosave-options-alert"
-}
-
-public class PostsScreen: BaseScreen {
+public class PostsScreen: ScreenObject {
 
     public enum PostStatus {
         case published
@@ -16,19 +10,18 @@ public class PostsScreen: BaseScreen {
 
     private var currentlyFilteredPostStatus: PostStatus = .published
 
-    init() {
-        super.init(element: XCUIApplication().tables["PostsTable"])
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [ { $0.tables["PostsTable"] } ], app: app)
         showOnly(.published)
     }
 
     @discardableResult
     public func showOnly(_ status: PostStatus) -> PostsScreen {
-
         switch status {
-            case .published:
-                XCUIApplication().buttons[ElementStringIDs.publishedButton].tap()
-            case .drafts:
-                XCUIApplication().buttons[ElementStringIDs.draftsButton].tap()
+        case .published:
+            app.buttons["published"].tap()
+        case .drafts:
+            app.buttons["drafts"].tap()
         }
 
         currentlyFilteredPostStatus = status
@@ -44,7 +37,7 @@ public class PostsScreen: BaseScreen {
         let cell = expectedElement.cells[slug]
         XCTAssert(cell.waitForExistence(timeout: 5))
 
-        scrollElementIntoView(element: cell, within: expectedElement)
+        cell.scrollIntoView(within: expectedElement)
         cell.tap()
 
         dismissAutosaveDialogIfNeeded()
@@ -58,7 +51,7 @@ public class PostsScreen: BaseScreen {
     /// If there are two versions of a local post, the app will ask which version we want to use when editing.
     /// We always want to use the local version (which is currently the first option)
     private func dismissAutosaveDialogIfNeeded() {
-        let autosaveDialog = XCUIApplication().alerts[ElementStringIDs.autosaveVersionsAlert]
+        let autosaveDialog = app.alerts["autosave-options-alert"]
         if autosaveDialog.exists {
             autosaveDialog.buttons.firstMatch.tap()
         }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -1,22 +1,27 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let readerTable = "Reader"
-    static let discoverButton = "Discover"
-}
+public class ReaderScreen: ScreenObject {
 
-public class ReaderScreen: BaseScreen {
-    let discoverButton: XCUIElement
+    private let discoverButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Discover"]
+    }
 
-    init() {
-        let readerTable = XCUIApplication().tables[ElementStringIDs.readerTable]
-        discoverButton = XCUIApplication().buttons[ElementStringIDs.discoverButton]
+    var discoverButton: XCUIElement { discoverButtonGetter(app) }
 
-        super.init(element: readerTable)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                // swiftlint:skip:next opening_brace
+                { $0.tables["Reader"] },
+                discoverButtonGetter
+            ],
+            app: app
+        )
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().tables[ElementStringIDs.readerTable].exists
+        (try? ReaderScreen().isLoaded) ?? false
     }
 
     public func openDiscover() -> ReaderScreen {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -63,9 +63,9 @@ public class TabNavComponent: ScreenObject {
         return BlockEditorScreen()
     }
 
-    public func gotoReaderScreen() -> ReaderScreen {
+    public func goToReaderScreen() throws -> ReaderScreen {
         readerTabButton.tap()
-        return ReaderScreen()
+        return try ReaderScreen()
     }
 
     public func gotoNotificationsScreen() -> NotificationsScreen {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -68,9 +68,9 @@ public class TabNavComponent: ScreenObject {
         return try ReaderScreen()
     }
 
-    public func gotoNotificationsScreen() -> NotificationsScreen {
+    public func goToNotificationsScreen() throws -> NotificationsScreen {
         notificationsTabButton.tap()
-        return NotificationsScreen()
+        return try NotificationsScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+extension XCUIElement {
+
+    /// Scroll an element into view within another element.
+    /// scrollView can be a UIScrollView, or anything that subclasses it like UITableView
+    ///
+    /// TODO: The implementation of this could use work:
+    /// - What happens if the element is above the current scroll view position?
+    /// - What happens if it's a really long scroll view?
+    public func scrollIntoView(within scrollView: XCUIElement, threshold: Int = 1000) {
+        var iteration = 0
+
+        while !isFullyVisibleOnScreen && iteration < threshold {
+            scrollView.scroll(byDeltaX: 0, deltaY: 100)
+            iteration += 1
+        }
+
+        if !isFullyVisibleOnScreen {
+            XCTFail("Unable to scroll element into view")
+        }
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -608,6 +608,7 @@
 		3FB1929626C79EC6000F5AA3 /* Date+TimeStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB1929426C79EC6000F5AA3 /* Date+TimeStrings.swift */; };
 		3FB34ACB25672A90001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
 		3FB34ADA25672AA5001A74A6 /* HomeWidgetTodayData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */; };
+		3FB5C2B327059AC8007D0ECE /* XCUIElement+Scroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */; };
 		3FBF21B7267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */; };
 		3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */ = {isa = PBXBuildFile; productRef = 3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */; };
@@ -5216,6 +5217,7 @@
 		3FB1928F26C6109F000F5AA3 /* TimeSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeSelectionView.swift; sourceTree = "<group>"; };
 		3FB1929426C79EC6000F5AA3 /* Date+TimeStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+TimeStrings.swift"; sourceTree = "<group>"; };
 		3FB34ACA25672A90001A74A6 /* HomeWidgetTodayData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetTodayData.swift; sourceTree = "<group>"; };
+		3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIElement+Scroll.swift"; sourceTree = "<group>"; };
 		3FBF21B6267AA17A0098335F /* BloggingRemindersAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingRemindersAnimator.swift; sourceTree = "<group>"; };
 		3FC7F89D2612341900FD8728 /* UnifiedPrologueStatsContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnifiedPrologueStatsContentView.swift; sourceTree = "<group>"; };
 		3FC8D19A244F43B500495820 /* ReaderTabItemsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItemsStore.swift; sourceTree = "<group>"; };
@@ -9465,6 +9467,7 @@
 				3FE39A4326F8391D006E2B3A /* Screens */,
 				3FA640592670CCD40064401E /* UITestsFoundation.h */,
 				3F762E9426784B540088CD45 /* WireMock.swift */,
+				3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */,
 				3F762E9A26784D2A0088CD45 /* XCUIElement+Utils.swift */,
 				3F762E9826784CC90088CD45 /* XCUIElementQuery+Utils.swift */,
 			);
@@ -18527,6 +18530,7 @@
 				3FA640642670CED80064401E /* BaseScreen.swift in Sources */,
 				3F2F856026FAF235000FCDA5 /* NotificationsScreen.swift in Sources */,
 				3F2F854026FAE9DC000FCDA5 /* BlockEditorScreen.swift in Sources */,
+				3FB5C2B327059AC8007D0ECE /* XCUIElement+Scroll.swift in Sources */,
 				3F2F854726FAED51000FCDA5 /* MediaPickerAlbumListScreen.swift in Sources */,
 				3FE39A3626F8370D006E2B3A /* MySitesScreen.swift in Sources */,
 				3F762E9926784CC90088CD45 /* XCUIElementQuery+Utils.swift in Sources */,

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -101,7 +101,7 @@ class WordPressScreenshotGeneration: XCTestCase {
 
         // Get Notifications screenshot
         let notificationList = try TabNavComponent()
-            .gotoNotificationsScreen()
+            .goToNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
         if XCUIDevice.isPad {
             notificationList

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -95,7 +95,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         // Get Discover screenshot
         // Currently, the view includes the "You Might Like" section
         try TabNavComponent()
-            .gotoReaderScreen()
+            .goToReaderScreen()
             .openDiscover()
             .thenTakeScreenshot(2, named: "Discover")
 

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -32,7 +32,7 @@ class MainNavigationTests: XCTestCase {
         }
 
         _ = try mySiteScreen
-            .tabBar.gotoNotificationsScreen()
+            .tabBar.goToNotificationsScreen()
             .dismissNotificationAlertIfNeeded()
 
         XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -21,8 +21,8 @@ class MainNavigationTests: XCTestCase {
     func testTabBarNavigation() throws {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-        _ = mySiteScreen
-            .tabBar.gotoReaderScreen()
+        _ = try mySiteScreen
+            .tabBar.goToReaderScreen()
 
         XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
 

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -26,6 +26,11 @@ class MainNavigationTests: XCTestCase {
 
         XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
 
+        // We may get a notifications fancy alert when loading the reader for the first time
+        if let alert = try? FancyAlertComponent() {
+            alert.cancelAlert()
+        }
+
         _ = try mySiteScreen
             .tabBar.gotoNotificationsScreen()
             .dismissNotificationAlertIfNeeded()


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/17221, https://github.com/wordpress-mobile/WordPress-iOS/pull/17348, and #17359.

I made this on top of #17359 for ease of review.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
