### PR TITLE
Convert UI tests screens to be a ScreenObject subclasses – 5 of many

### DIFF
--- a/WordPress/UITestsFoundation/FancyAlertComponent.swift
+++ b/WordPress/UITestsFoundation/FancyAlertComponent.swift
@@ -23,7 +23,8 @@ public class FancyAlertComponent: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [defaultAlertButtonGetter, cancelAlertButtonGetter],
-            app: app
+            app: app,
+            waitTimeout: 3
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -1,35 +1,28 @@
+import ScreenObject
 import XCTest
 
-public class BlockEditorScreen: BaseScreen {
+public class BlockEditorScreen: ScreenObject {
 
-    // Navigation bar
-    let editorNavBar = XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"]
-    let editorCloseButton = XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"]
-    let publishButton = XCUIApplication().buttons["Publish"]
-    let publishNowButton = XCUIApplication().buttons["Publish Now"]
-    let moreButton = XCUIApplication().buttons["more_post_options"]
+    let editorCloseButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"]
+    }
 
-    // Editor area
-    // Title
-    let titleView = XCUIApplication().otherElements["Post title. Empty"].firstMatch // Uses a localized string
-    // Paragraph block
-    let paragraphView = XCUIApplication().otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
-    // Image block
-    let imagePlaceholder = XCUIApplication().buttons["Image block. Empty"] // Uses a localized string
+    var editorCloseButton: XCUIElement { editorCloseButtonGetter(app) }
 
-    // Toolbar
-    let addBlockButton = XCUIApplication().buttons["add-block-button"] // Uses a testID
+    let addBlockButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-block-button"] // Uses a testID
+    }
 
-    // Action sheets
-    let actionSheet = XCUIApplication().sheets.element(boundBy: 0)
-    let imageDeviceButton = XCUIApplication().sheets.buttons["Choose from device"] // Uses a localized string
-    let discardButton = XCUIApplication().buttons["Discard"] // Uses a localized string
-    let postSettingsButton = XCUIApplication().sheets.buttons["Post Settings"] // Uses a localized string
-    let keepEditingButton = XCUIApplication().sheets.buttons["Keep Editing"] // Uses a localized string
+    var addBlockButton: XCUIElement { addBlockButtonGetter(app) }
 
-    public init() {
-        // Check addBlockButton element to ensure block editor is fully loaded
-        super.init(element: addBlockButton)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        // The block editor has _many_ elements but most are loaded on-demand. To verify the screen
+        // is loaded, we rely only on the button to add a new block and on the navigation bar we
+        // expect to encase the screen.
+        try super.init(
+            expectedElementGetters: [ addBlockButtonGetter, editorCloseButtonGetter ],
+            app: app
+        )
     }
 
     /**
@@ -37,6 +30,8 @@ public class BlockEditorScreen: BaseScreen {
      - Parameter text: the test to enter into the title
      */
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
+        let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
+
         titleView.tap()
         titleView.typeText(text)
 
@@ -49,6 +44,8 @@ public class BlockEditorScreen: BaseScreen {
      */
     public func addParagraphBlock(withText text: String) -> BlockEditorScreen {
         addBlock("Paragraph block")
+
+        let paragraphView = app.otherElements["Paragraph Block. Row 1. Empty"].textViews.element(boundBy: 0)
         paragraphView.typeText(text)
 
         return self
@@ -78,10 +75,12 @@ public class BlockEditorScreen: BaseScreen {
     public func closeEditor() {
         XCTContext.runActivity(named: "Close the block editor") { (activity) in
             XCTContext.runActivity(named: "Close the More menu if needed") { (activity) in
+                let actionSheet = app.sheets.element(boundBy: 0)
                 if actionSheet.exists {
                     if XCUIDevice.isPad {
                         app.otherElements["PopoverDismissRegion"].tap()
                     } else {
+                        let keepEditingButton = app.sheets.buttons["Keep Editing"] // Uses a localized string
                         keepEditingButton.tap()
                     }
                 }
@@ -95,16 +94,19 @@ public class BlockEditorScreen: BaseScreen {
                 let notSavedState = app.staticTexts["You have unsaved changes."]
                 if notSavedState.exists {
                     Logger.log(message: "Discarding unsaved changes", event: .v)
+                    let discardButton = app.buttons["Discard"] // Uses a localized string
                     discardButton.tap()
                 }
             }
 
-            let editorClosed = waitFor(element: editorNavBar, predicate: "isEnabled == false")
-            XCTAssert(editorClosed, "Block editor should be closed but is still loaded.")
+            let editorNavBar = app.navigationBars["Gutenberg Editor Navigation Bar"]
+            let waitForEditorToClose = editorNavBar.waitFor(predicateString: "isEnabled == false")
+            XCTAssertEqual(waitForEditorToClose, .completed, "Block editor should be closed but is still loaded.")
         }
     }
 
     public func publish() throws -> EditorNoticeComponent {
+        let publishButton = app.buttons["Publish"]
         publishButton.tap()
         try confirmPublish()
 
@@ -112,7 +114,9 @@ public class BlockEditorScreen: BaseScreen {
     }
 
     public func openPostSettings() throws -> EditorPostSettings {
+        let moreButton = app.buttons["more_post_options"]
         moreButton.tap()
+        let postSettingsButton = app.sheets.buttons["Post Settings"] // Uses a localized string
         postSettingsButton.tap()
 
         return try EditorPostSettings()
@@ -127,6 +131,8 @@ public class BlockEditorScreen: BaseScreen {
      Select Image from Camera Roll by its ID. Starts with 0
      */
     private func addImageByOrder(id: Int) throws {
+        let imageDeviceButton = app.sheets.buttons["Choose from device"] // Uses a localized string
+
         imageDeviceButton.tap()
 
         // Allow access to device media
@@ -142,23 +148,43 @@ public class BlockEditorScreen: BaseScreen {
         if FancyAlertComponent.isLoaded() {
             try FancyAlertComponent().acceptAlert()
         } else {
+            let publishNowButton = app.buttons["Publish Now"]
             publishNowButton.tap()
         }
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().navigationBars["Gutenberg Editor Navigation Bar"].buttons["Close"].exists
+        (try? BlockEditorScreen().isLoaded) ?? false
     }
 
     @discardableResult
-    public func openBlockPicker() -> BlockEditorScreen {
+    public func openBlockPicker() throws -> BlockEditorScreen {
         addBlockButton.tap()
-        return BlockEditorScreen()
+        return try BlockEditorScreen()
     }
 
     @discardableResult
-    public func closeBlockPicker() -> BlockEditorScreen {
+    public func closeBlockPicker() throws -> BlockEditorScreen {
         editorCloseButton.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0)).tap()
-        return BlockEditorScreen()
+        return try BlockEditorScreen()
+    }
+}
+
+// TODO: Move this to XCUITestHelpers or ScreenObject
+extension XCUIElement {
+
+    func waitFor(
+        predicateString: String,
+        timeout: TimeInterval = 10
+    ) -> XCTWaiter.Result {
+        XCTWaiter.wait(
+            for: [
+                XCTNSPredicateExpectation(
+                    predicate: NSPredicate(format: predicateString),
+                    object: self
+                )
+            ],
+            timeout: timeout
+        )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -30,9 +30,9 @@ public class LoginEpilogueScreen: BaseScreen {
 
     // Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal (MySitesScreen)
     // remains active after the epilogue "done" button is tapped.
-    public func continueWithSelfHostedSiteAddedFromSitesList() -> MySitesScreen {
+    public func continueWithSelfHostedSiteAddedFromSitesList() throws -> MySitesScreen {
         continueButton.tap()
-        return MySitesScreen()
+        return try MySitesScreen()
     }
 
     func connectSite() {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -17,7 +17,8 @@ public class PrologueScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [continueButtonGetter, siteAddressButtonGetter],
-            app: app
+            app: app,
+            waitTimeout: 3
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MediaScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MediaScreen.swift
@@ -1,17 +1,16 @@
+import ScreenObject
 import XCTest
 
-public class MediaScreen: BaseScreen {
+public class MediaScreen: ScreenObject {
 
-    private struct ElementIDs {
-        static let mediaGridView = "MediaCollection"
-    }
-
-    public init() {
-        let mediaGrid = XCUIApplication().collectionViews[ElementIDs.mediaGridView]
-        super.init(element: mediaGrid)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [ { $0.collectionViews["MediaCollection"] } ],
+            app: app
+        )
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().tables[ElementIDs.mediaGridView].exists
+        (try? MediaScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -61,9 +61,9 @@ public class MySiteScreen: BaseScreen {
         super.init(element: navBar)
     }
 
-    public func showSiteSwitcher() -> MySitesScreen {
+    public func showSiteSwitcher() throws -> MySitesScreen {
         switchSiteButton.tap()
-        return MySitesScreen()
+        return try MySitesScreen()
     }
 
     public func removeSelfHostedSite() {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -107,9 +107,9 @@ public class MySiteScreen: ScreenObject {
         return try PostsScreen()
     }
 
-    public func gotoMediaScreen() -> MediaScreen {
+    public func goToMediaScreen() throws -> MediaScreen {
         mediaButton.tap()
-        return MediaScreen()
+        return try MediaScreen()
     }
 
     public func goToStatsScreen() throws -> StatsScreen {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -77,9 +77,15 @@ public class MySiteScreen: ScreenObject {
 
     public func removeSelfHostedSite() {
         app.cells[ElementStringIDs.removeSiteButton].tap()
-        // TODO: Wouldn't it be better to do this with an accessibility label?
-        let index = XCUIDevice.isPad ? 1 : 0
-        app.sheets.buttons.element(boundBy: index).tap()
+
+        let removeButton: XCUIElement
+        if XCUIDevice.isPad {
+            removeButton = app.alerts.buttons.element(boundBy: 1)
+        } else {
+            removeButton = app.sheets.buttons.element(boundBy: 0)
+        }
+
+        removeButton.tap()
     }
 
     public func goToActivityLog() throws -> ActivityLogScreen {

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -1,43 +1,43 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let blogsTable = "Blogs"
-    static let cancelButton = "cancel-button"
-    static let plusButton = "add-site-button"
-    static let addSelfHostedSiteButton = "Add self-hosted site"
-}
+/// The site switcher AKA blog list. Currently presented as a modal we can get to from My Site by
+/// tapping the down arrow next to the site title.
+public class MySitesScreen: ScreenObject {
+    let cancelButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["cancel-button"]
+    }
 
-/// The site switcher aka blog list. In the app, it's a modal we can get to from My Site by tapping the down arrow next to the site title.
-public class MySitesScreen: BaseScreen {
-    let blogsTable: XCUIElement
-    let cancelButton: XCUIElement
-    let plusButton: XCUIElement
-    let addSelfHostedSiteButton: XCUIElement
+    let plusButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["add-site-button"]
+    }
 
-    init() {
-        let app = XCUIApplication()
-        blogsTable = app.staticTexts[ElementStringIDs.blogsTable]
-        cancelButton = app.buttons[ElementStringIDs.cancelButton]
-        plusButton = app.buttons[ElementStringIDs.plusButton]
-        addSelfHostedSiteButton = app.buttons[ElementStringIDs.addSelfHostedSiteButton]
-
-        super.init(element: plusButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                // swiftlint:disable:next opening_brace
+                { $0.staticTexts["Blogs"] },
+                cancelButtonGetter,
+                plusButtonGetter
+            ],
+            app: app
+        )
     }
 
     public func addSelfHostedSite() -> LoginSiteAddressScreen {
-        plusButton.tap()
-        addSelfHostedSiteButton.tap()
+        plusButtonGetter(app).tap()
+        app.buttons["Add self-hosted site"].tap()
         return LoginSiteAddressScreen()
     }
 
     public func closeModal() throws -> MySiteScreen {
-        cancelButton.tap()
+        cancelButtonGetter(app).tap()
         return try MySiteScreen()
     }
 
     @discardableResult
     public func switchToSite(withTitle title: String) throws -> MySiteScreen {
-        XCUIApplication().cells[title].tap()
+        app.cells[title].tap()
         return try MySiteScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -16,7 +16,7 @@ public class MySitesScreen: ScreenObject {
         try super.init(
             expectedElementGetters: [
                 // swiftlint:disable:next opening_brace
-                { $0.staticTexts["Blogs"] },
+                { $0.staticTexts["My Sites"] },
                 cancelButtonGetter,
                 plusButtonGetter
             ],

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -60,18 +60,9 @@ public class PostsScreen: ScreenObject {
 
 public struct EditorScreen {
 
-    var isGutenbergEditor: Bool {
-        let blockEditorElement = "add-block-button"
-        return XCUIApplication().buttons[blockEditorElement].waitForExistence(timeout: 3)
-    }
-
     var isAztecEditor: Bool {
         let aztecEditorElement = "Azctec Editor Navigation Bar"
         return XCUIApplication().navigationBars[aztecEditorElement].exists
-    }
-
-    private var blockEditor: BlockEditorScreen {
-        return BlockEditorScreen()
     }
 
     private var aztecEditor: AztecEditorScreen {
@@ -79,14 +70,14 @@ public struct EditorScreen {
     }
 
     func dismissDialogsIfNeeded() throws {
-        if self.isGutenbergEditor {
-            try blockEditor.dismissNotificationAlertIfNeeded(.accept)
-        }
+        guard let blockEditor = try? BlockEditorScreen() else { return }
+
+        try blockEditor.dismissNotificationAlertIfNeeded(.accept)
     }
 
     public func close() {
-        if isGutenbergEditor {
-            self.blockEditor.closeEditor()
+        if let blockEditor = try? BlockEditorScreen() {
+            blockEditor.closeEditor()
         }
 
         if isAztecEditor {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -30,7 +30,8 @@ public class TabNavComponent: ScreenObject {
                 readerTabButtonGetter,
                 notificationsTabButtonGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 3
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -60,7 +60,7 @@ public class TabNavComponent: ScreenObject {
         let actionSheet = try mySite.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
-        return BlockEditorScreen()
+        return try BlockEditorScreen()
     }
 
     public func goToReaderScreen() throws -> ReaderScreen {

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -44,10 +44,10 @@ class WordPressScreenshotGeneration: XCTestCase {
         let postEditorScreenshot = try postList.selectPost(withSlug: "our-services")
         sleep(imagesWaitTime) // wait for post images to load
         if XCUIDevice.isPad {
-            BlockEditorScreen()
+            try BlockEditorScreen()
                 .thenTakeScreenshot(1, named: "Editor")
         } else {
-            BlockEditorScreen()
+            try BlockEditorScreen()
                 .openBlockPicker()
                 .thenTakeScreenshot(1, named: "Editor-With-BlockPicker")
                 .closeBlockPicker()
@@ -62,9 +62,9 @@ class WordPressScreenshotGeneration: XCTestCase {
                 .gotoPostsScreen()
                 .showOnly(.drafts)
                 .selectPost(withSlug: "easy-blueberry-muffins")
-            BlockEditorScreen().selectBlock(containingText: "Ingredients")
+            try BlockEditorScreen().selectBlock(containingText: "Ingredients")
             sleep(imagesWaitTime) // wait for post images to load
-            BlockEditorScreen().thenTakeScreenshot(7, named: "Editor-With-Keyboard")
+            try BlockEditorScreen().thenTakeScreenshot(7, named: "Editor-With-Keyboard")
             ipadScreenshot.close()
         } else {
             postList.pop()

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -77,7 +77,7 @@ class WordPressScreenshotGeneration: XCTestCase {
             .thenTakeScreenshot(4, named: "MySite")
 
         // Get Media screenshot
-        _ = mySite.gotoMediaScreen()
+        _ = try mySite.goToMediaScreen()
         sleep(imagesWaitTime) // wait for post images to load
         mySite.thenTakeScreenshot(6, named: "Media")
 

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -26,6 +26,6 @@ class SignupTests: XCTestCase {
             .continueWithSignup()
             .dismissNotificationAlertIfNeeded()
 
-        XCTAssert(mySiteScreen.isLoaded())
+        XCTAssert(mySiteScreen.isLoaded)
     }
 }


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/17221, https://github.com/wordpress-mobile/WordPress-iOS/pull/17348, #17359, and #17360

I made this on top of #17360 for ease of review.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
