### PR TITLE
Comment moderation snackbar: track when Next tapped

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -167,6 +167,7 @@ import Foundation
     case commentEdited
     case commentRepliedTo
     case commentFilterChanged
+    case commentSnackbarNext
 
     // InviteLinks
     case inviteLinksGetStatus
@@ -489,6 +490,8 @@ import Foundation
             return "comment_replied_to"
         case .commentFilterChanged:
             return "comment_filter_changed"
+        case .commentSnackbarNext:
+            return "comment_snackbar_next"
 
         // Invite Links
         case .inviteLinksGetStatus:

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -697,6 +697,7 @@ private extension CommentDetailViewController {
             return
         }
 
+        WPAnalytics.track(.commentSnackbarNext)
         delegate?.nextCommentSelected()
     }
 


### PR DESCRIPTION
Ref: #17290

This adds a `comment_snackbar_next` track when `Next` is tapped on the comment moderation confirmation snackbar.

To test:
- Enable the `newCommentDetail` feature.
- Go to My Site > Comments.
- Select a comment that is not last in a list.
- Moderate it and stay on the details view.
- Tap `Next` on the snackbar.
- Verify the logs show: `🔵 Tracked: comment_snackbar_next <>`

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
