### PR TITLE
Reader Comments: Track when notification setting is toggled

### DIFF
--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -103,6 +103,9 @@ class FollowCommentsService: NSObject {
     @objc func toggleNotificationSettings(_ isNotificationsEnabled: Bool,
                                           success: @escaping () -> Void,
                                           failure: @escaping (Error?) -> Void) {
+        WPAnalytics.trackReader(.readerToggleCommentNotifications,
+                                properties: [WPAppAnalyticsKeyBlogID: self.siteID, AnalyticsKeys.enabled: isNotificationsEnabled])
+
         remote.updateNotificationSettingsForPost(with: postID, siteID: siteID, receiveNotifications: isNotificationsEnabled) { [weak self] in
             guard let self = self else {
                 failure(nil)
@@ -112,9 +115,6 @@ class FollowCommentsService: NSObject {
             self.post.receivesCommentNotifications = isNotificationsEnabled
             ContextManager.sharedInstance().saveContextAndWait(self.context)
             success()
-
-            WPAnalytics.trackReader(.readerToggleCommentNotifications,
-                                    properties: [WPAppAnalyticsKeyBlogID: self.siteID, AnalyticsKeys.enabled: isNotificationsEnabled])
 
         } failure: { error in
             DDLogError("Error updating notification settings for followed conversation: \(String(describing: error))")

--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -113,6 +113,9 @@ class FollowCommentsService: NSObject {
             ContextManager.sharedInstance().saveContextAndWait(self.context)
             success()
 
+            WPAnalytics.trackReader(.readerToggleCommentNotifications,
+                                    properties: [WPAppAnalyticsKeyBlogID: self.siteID, AnalyticsKeys.enabled: isNotificationsEnabled])
+
         } failure: { error in
             DDLogError("Error updating notification settings for followed conversation: \(String(describing: error))")
             failure(error)
@@ -122,5 +125,9 @@ class FollowCommentsService: NSObject {
     private enum FollowAction: String {
         case followed
         case unfollowed
+    }
+
+    private struct AnalyticsKeys {
+        static let enabled = "notifications_enabled"
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -78,6 +78,7 @@ import Foundation
     case readerBlogBlocked
     case readerChipsMoreToggled
     case readerToggleFollowConversation
+    case readerToggleCommentNotifications
     case readerPostReported
     case readerArticleDetailMoreTapped
     case readerSharedItem
@@ -325,6 +326,8 @@ import Foundation
             return "reader_chips_more_toggled"
         case .readerToggleFollowConversation:
             return "reader_toggle_follow_conversation"
+        case .readerToggleCommentNotifications:
+            return "reader_toggle_comment_notifications"
         case .readerPostReported:
             return "reader_post_reported"
         case .readerArticleDetailMoreTapped:


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/pull/17363#issuecomment-951362139
Depends on #17340

This adds a new event, `reader_toggle_comment_notifications`, which tracks whenever the comments notification setting is toggled. In addition, these properties are added:

- `blog_id`: The site ID of the blog that the user enabled the notifications on.
- `notifications_enabled`: `true` if the notifications is enabled, or `false` otherwise.

## To test:

Make sure the "Follow Conversation via Notifications" flag is enabled. You should see `🔵 Tracked: reader_toggle_comment_notifications` when:

- Tapping "Follow" > "Enable" notice action.
- Tapping the "Undo" notice action.
- Toggling the switch for the in-app notifications sheet.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
