### PR TITLE
Empty stats: nudge presentation logic fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
@@ -11,7 +11,7 @@ import Foundation
     @objc optional func showPostStats(postID: Int, postTitle: String?, postURL: URL?)
     @objc optional func customizeDismissButtonTapped()
     @objc optional func customizeTryButtonTapped()
-    @objc optional func growAudienceDismissButtonTapped()
+    @objc optional func growAudienceDismissButtonTapped(_ hintType: GrowAudienceCell.HintType)
     @objc optional func growAudienceEnablePostSharingButtonTapped()
     @objc optional func growAudienceBloggingRemindersButtonTapped()
     @objc optional func growAudienceReaderDiscoverButtonTapped()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -465,8 +465,8 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         showAddInsightView()
     }
 
-    func growAudienceDismissButtonTapped() {
-        dismissGrowAudienceCard()
+    func growAudienceDismissButtonTapped(_ hintType: GrowAudienceCell.HintType) {
+        dismissGrowAudienceCard(hintType)
         updateView()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -254,14 +254,17 @@ private extension SiteStatsInsightsTableViewController {
 
     // MARK: - Grow Audience Card Management
 
-    func dismissGrowAudienceCard() {
+    func dismissGrowAudienceCard(_ hintType: GrowAudienceCell.HintType) {
         guard let item = pinnedItemStore?.currentItem as? GrowAudienceCell.HintType else {
             return
         }
 
         insightsToShow = insightsToShow.filter { $0 != .growAudience }
-        pinnedItemStore?.markPinnedItemAsHidden(item)
 
+        guard item == hintType else {
+            return
+        }
+        pinnedItemStore?.markPinnedItemAsHidden(item)
         trackNudgeDismissed(for: item)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -217,7 +217,7 @@ private extension SiteStatsInsightsTableViewController {
         let viewsCount = insightsStore.getAllTimeStats()?.viewsCount
         switch pinnedItemStore?.itemToDisplay(for: viewsCount ?? 0) {
         case .none:
-            insightsToShow = insightsToShow.filter { $0 != .growAudience || $0 != .customize }
+            insightsToShow = insightsToShow.filter { $0 != .growAudience && $0 != .customize }
         case .some(let item):
             switch item {
             case let hintType as GrowAudienceCell.HintType where !insightsToShow.contains(.growAudience):

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -69,7 +69,7 @@ private extension SiteStatsPinnedItemStore {
         switch item {
         case is GrowAudienceCell.HintType:
             let item = item as! GrowAudienceCell.HintType
-            return "StatsInsights-\(siteId.intValue)-\(item.rawValue)-isHidden"
+            return "StatsInsights-\(siteId.intValue)-\(item.userDefaultsKey)-isHidden"
         case InsightType.customize:
             return "StatsInsightsHideCustomizeCard"
         default:

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -224,7 +224,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
 extension GrowAudienceCell {
 
-    enum HintType: String, SiteStatsPinnable {
+    @objc enum HintType: Int, SiteStatsPinnable {
 
         case social
         case bloggingReminders
@@ -305,6 +305,17 @@ extension GrowAudienceCell {
                 return UIImage(named: "grow-audience-illustration-blogging-reminders")
             case .readerDiscover:
                 return UIImage(named: "grow-audience-illustration-reader")
+            }
+        }
+
+        var userDefaultsKey: String {
+            switch self {
+            case .social:
+                return "social"
+            case .bloggingReminders:
+                return "bloggingReminders"
+            case .readerDiscover:
+                return "readerDiscover"
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -114,7 +114,10 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
     // MARK: - IBAction
 
     @IBAction private func dismissButtonTapped(_ sender: UIButton) {
-        insightsDelegate?.growAudienceDismissButtonTapped?()
+        guard let hintType = hintType else {
+            return
+        }
+        insightsDelegate?.growAudienceDismissButtonTapped?(hintType)
     }
 
     @IBAction private func actionButtonTapped(_ sender: UIButton) {


### PR DESCRIPTION
Fixes #17371
FIxes #17376

### Test first nudge shown again after all the nudges are dismissed

1. Do a fresh install of WPiOS
2. On My Site select a site with more than 30 views 
3. Dismiss the Customize Insights card, then go back to My Site
4. On My Site select a site with less than 30 views
5. Go to Stats
6. Dismiss the first empty stats nudge, then go back to My Site
7. Go to Stats
8. Dismiss the second empty stats nudge, then go back to My Site
9. Go to Stats
10. Complete the Reader Discover nudge flow, then go back to My Site
11. Go to Stats
12. No nudge cards should be shown

### Test dismissing the completed nudge card dismisses the next (not completed) nudge
1. Complete **Publicize** or **Blogging reminders** nudge on the **My site** > **Stats** screen
2. Completed nudge card is presented for that nudge (that has just been completed)
3. Tap **Dismiss** on that card
4. Go back to **My site** and back again to **Stats** screen
5. The next nudge should be presented

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
