### PR TITLE
iOS 15: Fix user profile sheet being shown fullscreen

### DIFF
--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -45,7 +45,6 @@ class UserProfileSheetViewController: UITableViewController {
         size.height += bottomPadding
 
         preferredContentSize = size
-        presentedVC?.presentedView?.layoutIfNeeded()
     }
 }
 
@@ -171,6 +170,7 @@ private extension UserProfileSheetViewController {
     func configureTable() {
         tableView.backgroundColor = .basicBackground
         tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
     }
 
     func registerTableCells() {


### PR DESCRIPTION
Fixes #17378

This fixes the issue where, on iOS15 iPhone, the user profile sheet was presented fullscreen instead of collapsed.

NOTE: Making this change in `develop` didn't fix the problem. This needs other iOS15 fixes in the `issue\xcode_13` branch. Thus, this PR targets that branch.

To test:
On an iOS15 iPhone:
- Go to either:
  - Notifications > Likes.
  - Reader > Post > Likes.
- Select a liker.
- Verify the sheet is collapsed initially.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/139156417-018c56b3-9a26-4045-a23b-30642e499795.png) | ![after](https://user-images.githubusercontent.com/1816888/139156427-382b9ea5-c825-4c19-bee1-ffad4ec9fbaa.png) |

## Regression Notes
1. Potential unintended areas of impact
Prior iOS versions could render incorrectly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on iOS13 and iOS14 to verify no change there.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
