### PR TITLE
Stats Insights: strip html from post title.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [**] Block editor: Block inserter indicates newly available block types [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4047]
 * [*] Reader post comments: fixed an issue that prevented all comments from displaying. [#17373]
 * [**] Stats: added Reader Discover nudge for sites with low traffic in order to increase it. [#17349, #17352, #17354, #17377]
+* [*] Stats Insights: HTML tags no longer display in post titles. [#17380]
 
 18.5
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -149,7 +149,7 @@ private extension LatestPostSummaryCell {
 
         let postAge = lastPostInsight?.publishedDate.relativeStringInPast() ?? ""
 
-        if let title = lastPostInsight?.title, !title.isEmpty {
+        if let title = lastPostInsight?.title.strippingHTML(), !title.isEmpty {
             postTitle = title
         }
 


### PR DESCRIPTION
Fixes #17023 

This strips HTML tags from the post title when displayed in the `Latest Post Summary` block.

To note, I poked around other post titles in Stats, and we do strip HTML elsewhere, so I did it here to match.

To test:
- Create a post with HTML in the title (like `<em>My awesome title</em>`).
  - You may want to do it in a browser. When created in the app, the HTML is treated as regular text. It is stripped correctly in Stats, it just looks weird elsewhere.
- Go to Stats > Insights > Latest Post Summary.
  - If it's not listed, you may need to add it via the `Add stats card` option at the bottom.
- Verify the HTML is not displayed in the post title.

| Before | After |
|--------|-------|
| <img width="472" alt="before" src="https://user-images.githubusercontent.com/1816888/139167639-6e908dd8-8979-433d-9d9f-fa93e863a89f.png"> | <img width="470" alt="after" src="https://user-images.githubusercontent.com/1816888/139167640-9d2a63d6-e22a-48e2-9b0a-ef5b7782971a.png"> 


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
