### PR TITLE
Fixes the unit tests for Xcode 13.

### DIFF
--- a/WordPress/WordPressTest/MockContext.swift
+++ b/WordPress/WordPressTest/MockContext.swift
@@ -30,8 +30,8 @@ class MockContext: NSManagedObjectContext {
     var successExpectation: XCTestExpectation?
     var failureExpectation: XCTestExpectation?
 
-    override
-    open func execute(_ request: NSPersistentStoreRequest) throws -> NSPersistentStoreResult {
+#if compiler(>=5.5)
+    override open func execute(_ request: NSPersistentStoreRequest) throws -> NSPersistentStoreResult {
         fetchExpectation?.fulfill()
         guard success else {
             failureExpectation?.fulfill()
@@ -41,4 +41,20 @@ class MockContext: NSManagedObjectContext {
 
         return MockFetchResult(results: returnedObjects)
     }
+#else
+    override func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) throws -> [Any] {
+         override
+         open func execute(_ request: NSPersistentStoreRequest) throws -> NSPersistentStoreResult {
+             fetchExpectation?.fulfill()
+             guard success else {
+                 failureExpectation?.fulfill()
+                 throw fetchError!
+             }
+             successExpectation?.fulfill()
+             return returnedObjects!
+
+             return MockFetchResult(results: returnedObjects)
+         }
+    }
+#endif
 }

--- a/WordPress/WordPressTest/MockContext.swift
+++ b/WordPress/WordPressTest/MockContext.swift
@@ -43,18 +43,15 @@ class MockContext: NSManagedObjectContext {
     }
 #else
     override func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) throws -> [Any] {
-         override
-         open func execute(_ request: NSPersistentStoreRequest) throws -> NSPersistentStoreResult {
-             fetchExpectation?.fulfill()
-             guard success else {
-                 failureExpectation?.fulfill()
-                 throw fetchError!
-             }
-             successExpectation?.fulfill()
-             return returnedObjects!
-
-             return MockFetchResult(results: returnedObjects)
+         fetchExpectation?.fulfill()
+         guard success else {
+             failureExpectation?.fulfill()
+             throw fetchError!
          }
+         successExpectation?.fulfill()
+         return returnedObjects!
+
+         return returnedObjects ?? []
     }
 #endif
 }

--- a/WordPress/WordPressTest/MockContext.swift
+++ b/WordPress/WordPressTest/MockContext.swift
@@ -49,8 +49,6 @@ class MockContext: NSManagedObjectContext {
              throw fetchError!
          }
          successExpectation?.fulfill()
-         return returnedObjects!
-
          return returnedObjects ?? []
     }
 #endif

--- a/WordPress/WordPressTest/MockContext.swift
+++ b/WordPress/WordPressTest/MockContext.swift
@@ -3,10 +3,23 @@ import CoreData
 
 @testable import WordPress
 
+class MockFetchResult: NSAsynchronousFetchResult<NSFetchRequestResult> {
+    let results: [NSFetchRequestResult]?
+
+    init(results: [NSFetchRequestResult]?) {
+        self.results = results
+    }
+
+    override open var finalResult: [NSFetchRequestResult]? {
+        results
+    }
+}
+
 /// Mock context that uses the existing Test Core Data Stack and overrides fetch for testing purposes
 class MockContext: NSManagedObjectContext {
     // set it to any array of objects you want ot return
-    var returnedObjects: [Any]?
+    var returnedObjects: [NSFetchRequestResult]?
+
     // set it to any error you want to return so simulate fetch error
     var fetchError: Error?
     // set to false to simulate fetch error
@@ -17,13 +30,15 @@ class MockContext: NSManagedObjectContext {
     var successExpectation: XCTestExpectation?
     var failureExpectation: XCTestExpectation?
 
-    override func fetch(_ request: NSFetchRequest<NSFetchRequestResult>) throws -> [Any] {
+    override
+    open func execute(_ request: NSPersistentStoreRequest) throws -> NSPersistentStoreResult {
         fetchExpectation?.fulfill()
         guard success else {
             failureExpectation?.fulfill()
             throw fetchError!
         }
         successExpectation?.fulfill()
-        return returnedObjects!
+
+        return MockFetchResult(results: returnedObjects)
     }
 }


### PR DESCRIPTION
**IMPORTANT NOTE:** I tackled this issue because I had already updated to Xcode 13 a while ago and it was becoming a little bit annoying on my end to test for breaking changes in Xcode 12 vs 13.  I [wasn't aware there was an ongoing effort](https://github.com/wordpress-mobile/WordPress-iOS/pull/17233) to get this sorted, so apologies to @leandroalonso and @mokagio for duplicating part of the effort.

This PR does NOT address updating the CIs Xcode version (which is indeed handled by the PR you're working on).  So we could see this PR as a temporary band-aid before the other PR is ready, if we wanted it.

That said, I'd encourage us to consider merging this PR as it resolves the biggest issue right away (which is our ability to build the tests in Xcode 13, for those of us who're already using it).

## Description:

This PR fixes the compatibility issues brought forward by Xcode 13 making the unit tests compile and run successfully again (both in Xcode 12 and 13).

The approach is minimalistic to try and get this core issue resolved quickly.

## To test:

Run the unit tests in Xcode 13
Make sure the tests succeed since they're using Xcode 12

## Regression Notes

1. Potential unintended areas of impact

None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
