### PR TITLE
User Profile sheet: disable sheet resizing.

### DIFF
--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileSheetViewController.swift
@@ -67,6 +67,10 @@ extension UserProfileSheetViewController: DrawerPresentable {
         return tableView
     }
 
+    var allowsUserTransition: Bool {
+        false
+    }
+
 }
 
 // MARK: - UITableViewDataSource methods
@@ -171,6 +175,7 @@ private extension UserProfileSheetViewController {
     func configureTable() {
         tableView.backgroundColor = .basicBackground
         tableView.separatorStyle = .none
+        tableView.isScrollEnabled = false
     }
 
     func registerTableCells() {


### PR DESCRIPTION
Fixes #n/a
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/17379#pullrequestreview-791885593

This disables resizing of the user profile sheet.

To test:
- On an iPhone, go to either:
  - Notifications > Likes.
  - Reader > Post > Likes.
- Select a liker.
- Verify the sheet cannot be maximized.


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
