### PR TITLE
Onboarding Improvements: Add feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,6 +19,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newCommentDetail
     case domains
     case followConversationViaNotifications
+    case onboardingImprovements
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -62,6 +63,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current == .localDeveloper
         case .followConversationViaNotifications:
             return true
+        case .onboardingImprovements:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -122,6 +125,8 @@ extension FeatureFlag {
             return "Domain Purchases"
         case .followConversationViaNotifications:
             return "Follow Conversation via Notifications"
+        case .onboardingImprovements:
+            return "Onboarding Improvements"
         }
     }
 


### PR DESCRIPTION
Fixes #17384 

## Description
This PR adds a new feature flag for the Onboarding Improvements project.

## How to test
1. Go to Me > App Settings > Debug
2. ✅ Notice the `Onboarding Improvements` feature flag at the bottom

<img src="https://user-images.githubusercontent.com/6711616/139692306-450ef34c-e3c3-42e6-8095-5947fa165207.png" width=200>

## Notes
I will update https://github.com/wordpress-mobile/WordPress-iOS/pull/17389 to use the feature flags, once this PR is merged.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
