### PR TITLE
Add feature flag for new About screen flow

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -15,4 +15,5 @@ import Foundation
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
+    static let showsNewAboutScreen: Bool = true
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,6 +19,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newCommentDetail
     case domains
     case followConversationViaNotifications
+    case aboutScreen
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -62,6 +63,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return BuildConfiguration.current == .localDeveloper
         case .followConversationViaNotifications:
             return true
+        case .aboutScreen:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -122,6 +125,8 @@ extension FeatureFlag {
             return "Domain Purchases"
         case .followConversationViaNotifications:
             return "Follow Conversation via Notifications"
+        case .aboutScreen:
+            return "New Unified About Screen"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -469,7 +469,12 @@ private extension AppSettingsViewController {
             action: pushAbout()
         )
 
-        var rows: [ImmuTableRow] = [settingsRow, aboutRow]
+        var rows: [ImmuTableRow] = [settingsRow]
+
+        if !(AppConfiguration.showsNewAboutScreen && FeatureFlag.aboutScreen.enabled) {
+            rows.append(aboutRow)
+        }
+
         if AppConfiguration.allowsCustomAppIcons && UIApplication.shared.supportsAlternateIcons {
             // We don't show custom icons for Jetpack
             rows.insert(iconRow, at: 0)

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -158,7 +158,13 @@ class MeViewController: UITableViewController {
             // middle section
             .init(rows: {
                 var rows: [ImmuTableRow] = [helpAndSupportIndicator]
-                if isRecommendAppRowEnabled {
+                if AppConfiguration.showsNewAboutScreen && FeatureFlag.aboutScreen.enabled {
+                    rows.append(NavigationItemRow(title: RowTitles.about,
+                                                  icon: UIImage.gridicon(.mySites),
+                                                  accessoryType: .disclosureIndicator,
+                                                  action: pushAbout(),
+                                                  accessibilityIdentifier: "About"))
+                } else if isRecommendAppRowEnabled {
                     rows.append(NavigationItemRow(title: ShareAppContentPresenter.RowConstants.buttonTitle,
                                                   icon: ShareAppContentPresenter.RowConstants.buttonIconImage,
                                                   accessoryType: accessoryType,
@@ -239,6 +245,15 @@ class MeViewController: UITableViewController {
     func pushHelp() -> ImmuTableAction {
         return { [unowned self] row in
             let controller = SupportTableViewController()
+            self.navigationController?.pushViewController(controller,
+                                                          animated: true,
+                                                          rightBarButton: self.navigationItem.rightBarButtonItem)
+        }
+    }
+
+    private func pushAbout() -> ImmuTableAction {
+        return { [unowned self] _ in
+            let controller = AboutViewController()
             self.navigationController?.pushViewController(controller,
                                                           animated: true,
                                                           rightBarButton: self.navigationItem.rightBarButtonItem)
@@ -476,6 +491,7 @@ private extension MeViewController {
         static let support = NSLocalizedString("Help & Support", comment: "Link to Help section")
         static let logIn = NSLocalizedString("Log In", comment: "Label for logging in to WordPress.com account")
         static let logOut = NSLocalizedString("Log Out", comment: "Label for logging out from WordPress.com account")
+        static let about = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
     }
 
     enum HeaderTitles {

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -15,4 +15,5 @@ import Foundation
     @objc static let showsQuickActions: Bool = false
     @objc static let showsFollowedSitesSettings: Bool = false
     @objc static let showsWhatIsNew: Bool = false
+    static let showsNewAboutScreen: Bool = false
 }


### PR DESCRIPTION
Implements #17395. This PR adds a feature flag for the new about screen flow, limited to debug builds and only the WordPress app (not Jetpack).

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-11-01 at 14 50 55](https://user-images.githubusercontent.com/4780/139697007-9cacba45-2344-4fcb-9120-5aacac25959f.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-11-01 at 14 46 25](https://user-images.githubusercontent.com/4780/139696983-d1911e09-f1fc-4af3-94a9-f7a7e648af10.png) |
| ![Simulator Screen Shot - iPhone 12 Pro - 2021-11-01 at 14 50 52](https://user-images.githubusercontent.com/4780/139697182-04535777-b823-4989-8493-ebefb03cae79.png) | ![Simulator Screen Shot - iPhone 12 Pro - 2021-11-01 at 14 50 41](https://user-images.githubusercontent.com/4780/139697030-e832786a-1022-41f0-9a91-6cd9e3756a13.png) |

**To test**

- Build and run
- Check you see About WordPress on the Me screen, but don't see it at the bottom of App Settings
- Disable the feature flag and check that the opposite is true

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
