### PR TITLE
Remove `newCommentEdit` feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -13,7 +13,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case siteIconCreator
     case unifiedCommentsAndNotificationsList
     case recommendAppToOthers
-    case newCommentEdit
     case weeklyRoundup
     case weeklyRoundupStaticNotification
     case newCommentDetail
@@ -48,8 +47,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .unifiedCommentsAndNotificationsList:
             return true
         case .recommendAppToOthers:
-            return true
-        case .newCommentEdit:
             return true
         case .weeklyRoundup:
             return true
@@ -110,8 +107,6 @@ extension FeatureFlag {
             return "Unified List for Comments and Notifications"
         case .recommendAppToOthers:
             return "Recommend App to Others"
-        case .newCommentEdit:
-            return "New Comment Edit"
         case .weeklyRoundup:
             return "Weekly Roundup"
         case .weeklyRoundupStaticNotification:

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -650,39 +650,19 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
 
 - (void)editComment
 {
-    UINavigationController *navController;
+    EditCommentTableViewController *editViewController = [[EditCommentTableViewController alloc] initWithComment:self.comment];
+    __typeof(self) __weak weakSelf = self;
+    editViewController.completion = ^(Comment *comment, BOOL commentChanged) {
+        if (commentChanged) {
+            weakSelf.comment = comment;
+            [weakSelf updateComment];
+        }
+    };
     
-    if ([Feature enabled:FeatureFlagNewCommentEdit]) {
-        EditCommentTableViewController *editViewController = [[EditCommentTableViewController alloc] initWithComment:self.comment];
-        
-        __typeof(self) __weak weakSelf = self;
-        editViewController.completion = ^(Comment *comment, BOOL commentChanged) {
-            if (commentChanged) {
-                weakSelf.comment = comment;
-                [weakSelf updateComment];
-            }
-        };
-
-        navController = [[UINavigationController alloc] initWithRootViewController:editViewController];
-        navController.modalPresentationStyle = UIModalPresentationFullScreen;
-    } else {
-        EditCommentViewController *editViewController = [EditCommentViewController newEditViewController];
-        editViewController.content = [self.comment contentForEdit];
-        
-        __typeof(self) __weak weakSelf = self;
-        editViewController.onCompletion = ^(BOOL hasNewContent, NSString *newContent) {
-            [self dismissViewControllerAnimated:YES completion:^{
-                if (hasNewContent) {
-                    weakSelf.comment.content = newContent;
-                    [weakSelf updateComment];
-                }
-            }];
-        };
-        
-        navController = [[UINavigationController alloc] initWithRootViewController:editViewController];
-        navController.modalPresentationStyle = UIModalPresentationFormSheet;
-    }
-
+    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:editViewController];
+    navController.modalPresentationStyle = UIModalPresentationFullScreen;
+    
+    
     navController.modalTransitionStyle = UIModalTransitionStyleCoverVertical;
     navController.navigationBar.translucent = NO;
 


### PR DESCRIPTION
Ref: #17000

This removes the `newCommentEdit` feature flag.

Note: The old `EditCommentViewController` is not removed yet as it is still being used. Required changes are noted in the `Remove Unused Files` section on the `Comments Phases` post (pctCYC-6n) and will be addressed later.

To test:
- Verify `newCommentDetail` is _not_ enabled.
- Go to My Site > Comments > comment detail > Edit.
- Verify the new edit view is displayed, and editing a comment works as expected. 
- Rejoice.

## Regression Notes
1. Potential unintended areas of impact
Should be none. This feature has been live for a couple releases with no reported issues.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
