### PR TITLE
Onboarding Improvements: Select site from Epilogue

### DIFF
--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -63,7 +63,7 @@ class WindowManager: NSObject {
             return
         }
 
-        WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
+        WPTabBarController.sharedInstance()?.showBlogDetails(for: blog)
     }
 
     /// Shows the initial UI for unauthenticated users.

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -26,9 +26,9 @@ class WindowManager: NSObject {
     /// Shows the initial UI for the App to be shown right after launch.  This method will present the sign-in flow if the user is not
     /// authenticated, or the actuall App UI if the user is already authenticated.
     ///
-    public func showUI() {
+    public func showUI(for blog: Blog? = nil) {
         if AccountHelper.isLoggedIn {
-            showAppUI()
+            showAppUI(for: blog)
         } else {
             showSignInUI()
         }
@@ -45,20 +45,25 @@ class WindowManager: NSObject {
         showSignInUI()
     }
 
-    func dismissFullscreenSignIn(completion: Completion? = nil) {
+    func dismissFullscreenSignIn(with blog: Blog? = nil, completion: Completion? = nil) {
         guard isShowingFullscreenSignIn == true && AccountHelper.isLoggedIn == true else {
             return
         }
 
-        showAppUI(completion: completion)
+        showAppUI(for: blog, completion: completion)
     }
 
     /// Shows the UI for authenticated users.
     ///
-    func showAppUI(completion: Completion? = nil) {
+    func showAppUI(for blog: Blog? = nil, completion: Completion? = nil) {
         isShowingFullscreenSignIn = false
-
         show(WPTabBarController.sharedInstance(), completion: completion)
+
+        guard let blog = blog else {
+            return
+        }
+
+        WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
     }
 
     /// Shows the initial UI for unauthenticated users.

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -45,12 +45,12 @@ class WindowManager: NSObject {
         showSignInUI()
     }
 
-    func dismissFullscreenSignIn(with blog: Blog? = nil, completion: Completion? = nil) {
+    func dismissFullscreenSignIn(blogToShow: Blog? = nil, completion: Completion? = nil) {
         guard isShowingFullscreenSignIn == true && AccountHelper.isLoggedIn == true else {
             return
         }
 
-        showAppUI(for: blog, completion: completion)
+        showAppUI(for: blogToShow, completion: completion)
     }
 
     /// Shows the UI for authenticated users.

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -188,8 +188,11 @@ extension LoginEpilogueTableViewController {
               tableView.cellForRow(at: indexPath) is LoginEpilogueBlogCell else {
             return
         }
-        
-        parent.onDismiss?()
+
+        let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
+        let blog = blogDataSource.blog(at: wrappedPath)
+
+        parent.onDismiss?(blog)
         navigationController?.dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -184,7 +184,13 @@ extension LoginEpilogueTableViewController {
     }
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // TODO: implement
+        guard let parent = parent as? LoginEpilogueViewController,
+              tableView.cellForRow(at: indexPath) is LoginEpilogueBlogCell else {
+            return
+        }
+        
+        parent.onDismiss?()
+        navigationController?.dismiss(animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -47,7 +47,7 @@ class LoginEpilogueViewController: UIViewController {
 
     /// Closure to be executed upon dismissal.
     ///
-    var onDismiss: (() -> Void)?
+    var onDismiss: ((Blog) -> Void)?
 
     /// Site that was just connected to our awesome app.
     ///

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -333,7 +333,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         epilogueViewController.onDismiss = { [weak self] blog in
             onDismiss()
 
-            self?.windowManager.dismissFullscreenSignIn(with: blog)
+            self?.windowManager.dismissFullscreenSignIn(blogToShow: blog)
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -330,10 +330,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         epilogueViewController.credentials = credentials
-        epilogueViewController.onDismiss = { [weak self] in
+        epilogueViewController.onDismiss = { [weak self] blog in
             onDismiss()
 
-            self?.windowManager.dismissFullscreenSignIn()
+            self?.windowManager.dismissFullscreenSignIn(with: blog)
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -1,5 +1,9 @@
 extension WPTabBarController {
 
+    func showBlogDetails(for blog: Blog) {
+        mySitesCoordinator.showBlogDetails(for: blog)
+    }
+
     @objc func showPageEditor(forBlog: Blog? = nil) {
         showPageEditor(blog: forBlog)
     }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -1,10 +1,10 @@
 import Foundation
 
 class JetpackWindowManager: WindowManager {
-    override func showUI() {
+    override func showUI(for blog: Blog?) {
         // If the user is logged in and has blogs sync'd to their account
         if AccountHelper.isLoggedIn && AccountHelper.hasBlogs {
-            showAppUI()
+            showAppUI(for: blog)
             return
         }
 


### PR DESCRIPTION
Part of #17385

## Description

This PR adds the capability to show the specific blog you selected in the Epilogue screen.

https://user-images.githubusercontent.com/6711616/139907043-e59d0d82-8063-4f44-b367-be93ef228282.mov

## How to test

### Test variation 1
1. Log in with user that has less than 4 sites
2. Select a site
3. ✅ My Site shows the selected site

### Test variation 2
1. Log in with user that has more than 4 sites
2. Select a site
3. ✅ My Site shows the selected site

## Regression Notes
1. Potential unintended areas of impact
Jetpack

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above steps on WP and JP

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
