### PR TITLE
Comment Reply: show mention suggestions

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -948,7 +948,7 @@ extension CommentDetailViewController: SuggestionsTableViewDelegate {
 
     func suggestionsTableView(_ suggestionsTableView: SuggestionsTableView, didSelectSuggestion suggestion: String?, forSearchText text: String) {
         replyTextView?.replaceTextAtCaret(text as NSString?, withText: suggestion)
-        suggestionsTableView.showSuggestions(forWord: String())
+        suggestionsTableView.hideSuggestions()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -911,7 +911,6 @@ private extension CommentDetailViewController {
         ])
 
         suggestionsTableView = suggestionsView
-
     }
 
     var shouldShowSuggestions: Bool {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -895,9 +895,9 @@ private extension CommentDetailViewController {
     func configureSuggestionsView() {
         guard shouldShowSuggestions,
               let siteID = siteID,
-        let replyTextView = replyTextView else {
-            return
-        }
+              let replyTextView = replyTextView else {
+                  return
+              }
 
         let suggestionsView = SuggestionsTableView(siteID: siteID, suggestionType: .mention, delegate: self)
         suggestionsView.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
@@ -355,7 +355,11 @@ private extension FullScreenCommentReplyViewController {
 
     /// Determine if suggestions are enabled and visible for this site
     var shouldShowSuggestions: Bool {
-        guard let siteID = self.siteID, let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return false }
+        guard let siteID = siteID,
+              let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else {
+                  return false
+              }
+
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
     }
 


### PR DESCRIPTION
Ref: #17412 
Depends on: #17428

When @ is entered in the Reply field, the mention suggestions list is now shown.

Notes:
- The suggestions list is cut off in the fullscreen view. This is legacy, so I'll look at it separately.
- Replies are not created yet.
- UI updates are not done yet.

To test:
Sorry for the lack of screenshots, but there's just too much PII to block out. However, you can compare this with replying in the old comment details. It should look and function the same.

- Enable `newCommentDetail`.
- Go to My Site > Comments > comment details.
- Tap `Reply`.
- On a site that does not support @ mentions:
  - Hack tip: I couldn't find a site that didn't support @ mentions. So you can return `false` in `shouldShowSuggestions` in `CommentDetailViewController` to verify this scenario.
  - Enter @ in the reply field.
  - Verify nothing is displayed above the reply field.
- On a site that does support @ mentions:
  - Enter @ in the reply field.
  - Verify a list of users is displayed above the reply field.
  - Tap the up arrow to enter full screen.
  - Enter @ in the reply field.
  - Verify a list of users is displayed below the text.


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
