### PR TITLE
Removes the synchronization of domains due to some crashes.

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -299,15 +299,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
         dispatch_group_leave(syncGroup);
     }];
 
-    dispatch_group_enter(syncGroup);
-    [self refreshDomainsFor:blog
-                    success:^{
-        dispatch_group_leave(syncGroup);
-    } failure:^(NSError *error) {
-        DDLogError(@"Failed to sync domains");
-        dispatch_group_leave(syncGroup);
-    }];
-
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler
     dispatch_group_notify(syncGroup, dispatch_get_main_queue(),^{


### PR DESCRIPTION
Removes some code we added to refresh domains, since the domains section is not going to be shown and the project has been put on pause.

This should solve the crashes we've seen since 18.5 by simply removing the call that was triggering them.

The actual culprit needs to be found, IMHO, but this change should quickly resolve the crashing issue for our users.

## To test:

Not really much to test.  Just make sure the code builds.

## Regression Notes

1. Potential unintended areas of impact

None as we're removing a call that's not necessary at all for the App to work correctly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
