### PR TITLE
Onboarding Improvements: fine tune Epilogue screen UI

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
@@ -43,12 +43,12 @@ private extension LoginEpilogueChooseSiteTableViewCell {
         stackView.spacing = Constants.stackViewSpacing
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.addArrangedSubviews([titleLabel, subtitleLabel])
-        addSubview(stackView)
+        contentView.addSubview(stackView)
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.stackViewHorizontalMargin),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.stackViewHorizontalMargin),
-            stackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.stackViewTopMargin),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.stackViewBottomMargin)
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Constants.stackViewHorizontalMargin),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Constants.stackViewHorizontalMargin),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Constants.stackViewTopMargin),
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -Constants.stackViewBottomMargin)
         ])
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
@@ -28,12 +28,12 @@ private extension LoginEpilogueChooseSiteTableViewCell {
 
     func setupTitleLabel() {
         titleLabel.text = NSLocalizedString("Choose a site to open.", comment: "A text for title label on Login epilogue screen")
-        titleLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .medium)
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
     }
 
     func setupSubtitleLabel() {
         subtitleLabel.text = NSLocalizedString("You can switch sites at any time.", comment: "A text for subtitle label on Login epilogue screen")
-        subtitleLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
+        subtitleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         subtitleLabel.textColor = .secondaryLabel
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
@@ -53,7 +53,7 @@ private extension LoginEpilogueChooseSiteTableViewCell {
     }
 
     private enum Constants {
-        static let stackViewSpacing: CGFloat = 8.0
+        static let stackViewSpacing: CGFloat = 4.0
         static let stackViewHorizontalMargin: CGFloat = 20.0
         static let stackViewTopMargin: CGFloat = 16.0
         static let stackViewBottomMargin: CGFloat = 26.0


### PR DESCRIPTION
Part of #17385

Ref: pbArwn-32R-p2

## Description
This PR updates the Epilogue screen UI. It addresses the feedback outlined [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17426#pullrequestreview-797982292)

>Small UI detail while I'm here. I think maybe there should be less space between 'Choose your own site" and "you can switch sites any time". Also, maybe these text styles should be exactly the same as the title and url of the sites below. Currently they both look 1 size smaller than their counter parts in the title and url of the sites in the rows below. WDYT?

## Notes
- UI tests will be addressed in a different PR

## Merge directions
- Merge after #17426 

## How to test
1. Log out, then log in
2. ✅ Notice the UI updates Epilogue screen (smaller spacing between title / detail lables, font size of title / detail labels match the blog cells below)
3. ✅ Bonus: Use the view hierarchy tool to confirm that the font styles match that of the blog cells

Before | After
<img src="https://user-images.githubusercontent.com/6711616/140742995-05f33b18-8e18-41d6-abbe-8084a83b34a2.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/140742987-249f0cd4-f9c5-42b3-b1ee-78f6f5d6561b.png" width=200>


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
