### PR TITLE
Re-enable EditorGutenbergTests temporarily skipped because of missing Blogging Reminders support

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -148,16 +148,14 @@ public class BlockEditorScreen: BaseScreen {
     }
 
     public func dismissBloggingRemindersAlertIfNeeded() {
-        let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
+        guard app.buttons["Set reminders"].waitForExistence(timeout: 3) else { return }
 
-        if bloggingRemindersAlertIsLoaded {
-            if XCUIDevice.isPad {
-                app.swipeDown(velocity: .fast)
-            } else {
-                let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
-
-                dismissBloggingRemindersAlertButton.tap()
-            }
+        if XCUIDevice.isPad {
+            app.swipeDown(velocity: .fast)
+        } else {
+            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+            dismissBloggingRemindersAlertButton.tap()
+        }
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -156,7 +156,6 @@ public class BlockEditorScreen: BaseScreen {
             let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
             dismissBloggingRemindersAlertButton.tap()
         }
-        }
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -151,9 +151,13 @@ public class BlockEditorScreen: BaseScreen {
         let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
 
         if bloggingRemindersAlertIsLoaded {
-            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+            if XCUIDevice.isPad {
+                app.swipeDown(velocity: .fast)
+            } else {
+                let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
 
-            dismissBloggingRemindersAlertButton.tap()
+                dismissBloggingRemindersAlertButton.tap()
+            }
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -105,6 +105,8 @@ public class BlockEditorScreen: BaseScreen {
     }
 
     public func publish() throws -> EditorNoticeComponent {
+        // This check for Publish Now Button is an attempt to confirm that the publishButton.tap() call took effect.
+        // The tests would fail sometimes in the pipeline with no apparent reason.
         var tries = 0
         repeat {
             publishButton.tap()

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -143,6 +143,17 @@ public class BlockEditorScreen: BaseScreen {
             try FancyAlertComponent().acceptAlert()
         } else {
             publishNowButton.tap()
+            dismissBloggingRemindersAlertIfNeeded()
+        }
+    }
+
+    public func dismissBloggingRemindersAlertIfNeeded() {
+        let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
+
+        if bloggingRemindersAlertIsLoaded {
+            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+
+            dismissBloggingRemindersAlertButton.tap()
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -105,7 +105,11 @@ public class BlockEditorScreen: BaseScreen {
     }
 
     public func publish() throws -> EditorNoticeComponent {
-        publishButton.tap()
+        var tries = 0
+        repeat {
+            publishButton.tap()
+            tries += 1
+        } while !publishNowButton.waitForIsHittable(timeout: 3) && tries <= 3
         try confirmPublish()
 
         return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -24,7 +24,6 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testTextPostPublish() throws {
-        try skipTillBloggingRemindersAreHandled()
 
         let title = getRandomPhrase()
         let content = getRandomContent()
@@ -39,7 +38,6 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testBasicPostPublish() throws {
-        try skipTillBloggingRemindersAreHandled()
 
         let title = getRandomPhrase()
         let content = getRandomContent()
@@ -64,9 +62,5 @@ class EditorGutenbergTests: XCTestCase {
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()
-    }
-
-    func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)
     }
 }


### PR DESCRIPTION
Editor Gutenberg UI tests [were skipped by this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/16798) as they were failing since the introduction of the new blogging reminders feature [as described in this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/16797).

This PR adds support for the blogging reminders alert dismissal and re-enables the skipped tests.

Commits
[Re-enables Gutenberg UI tests by adding support for blogging reminders alert dismissal](https://github.com/wordpress-mobile/WordPress-iOS/pull/17436/commits/d4c602c36db5959ae41b19eb0aefbbc98e230433)
[Adds support for blogging reminders dismissal on iPads](https://github.com/wordpress-mobile/WordPress-iOS/pull/17436/commits/ac2e7c27055c2122635256ec19d95b359e7b6719)

## To test
EditorGutenbergTests tests must pass on CI.

Testing "WordPressUITests" scheme locally must pass.

## Regression Notes
1. Potential unintended areas of impact
None. The changes would only impact  EditorGutenbergTests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N/A**
- [x] I have considered adding accessibility improvements for my changes. **N/A**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N/A**
