### PR TITLE
Cherry pick #17434 in 18.5.1 – Remove domain synchronization

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -299,15 +299,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
         dispatch_group_leave(syncGroup);
     }];
 
-    dispatch_group_enter(syncGroup);
-    [self refreshDomainsFor:blog
-                    success:^{
-        dispatch_group_leave(syncGroup);
-    } failure:^(NSError *error) {
-        DDLogError(@"Failed to sync domains");
-        dispatch_group_leave(syncGroup);
-    }];
-
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler
     dispatch_group_notify(syncGroup, dispatch_get_main_queue(),^{


### PR DESCRIPTION
Cherry pick fa8c5f0 from #17434 into the hotfix release branch created for the occasion.

Notice that #17434 had already been approved by @frosty. 

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.