### PR TITLE
Comment Detail: Show contents in a web view for self-hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -489,10 +489,13 @@ private extension CommentDetailViewController {
     // Shows the comment thread with the parent comment highlighted.
     func navigateToParentComment() {
         guard let parentComment = parentComment,
-              let siteID = siteID else {
-                  navigateToPost()
-                  return
-              }
+              let siteID = siteID,
+              let blog = comment.blog,
+              blog.supports(.wpComRESTAPI) else {
+            let parentCommentURL = URL(string: parentComment?.link ?? "")
+            openWebView(for: parentCommentURL)
+            return
+        }
 
         try? contentCoordinator.displayCommentsWithPostId(NSNumber(value: comment.postID),
                                                           siteID: siteID,


### PR DESCRIPTION
Refs #17087 

This fixes an issue where tapping the comment header on the new Comment Detail does nothing when the comment detail is displaying a comment that is a reply to another comment (e.g. a reply comment). The reason is mainly that because the `siteID` is never `nil`. Instead, it returns `0` for self-hosted non-Jetpack sites since the value is stored with an `Int32` type in the data model.

The fix adds a check for the comment's blog if it supports REST API, and instead of falling back to `navigateToPost()`, it should now show a web view displaying the parent comment.

## To Test

- Log in to a self-hosted site where you have a reply comment somewhere on the site.
- Enable the `newCommentDetail` feature flag.
- Go to My Site > Comments, and select any reply comment.
- Tap on the comment header.
- Verify that the web view should now be shown, displaying the content of the parent comment.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is still unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is still unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is still unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
