### PR TITLE
Require authentication for login notification action

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 18.7
 -----
-
+* [***] Two-step Authentication notifications now require an unlocked device to approve or deny them.
 
 18.6
 -----

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -477,7 +477,12 @@ extension InteractiveNotificationsManager {
         }
 
         var requiresAuthentication: Bool {
-            return false
+            switch self {
+            case .approveLogin:
+                return true
+            default:
+                return false
+            }
         }
 
         var requiresForeground: Bool {

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -478,7 +478,7 @@ extension InteractiveNotificationsManager {
 
         var requiresAuthentication: Bool {
             switch self {
-            case .approveLogin:
+            case .approveLogin, .denyLogin:
                 return true
             default:
                 return false


### PR DESCRIPTION
Fixes: #17446

This PR enforces authentication before taking action on a login notification (e.g. Approve a 2FA login).

### To test:

**Prerequisites:**
- Disable unlocking with Face ID or Touch ID (Settings -> Face / Touch ID & Passcode -> iPhone Unlock), keep a device passcode enabled
- Set Notification Previews to always show (Settings -> Notifications -> Show Previews -> Always)
- Install WordPress for iOS, authenticate with the account protected by 2FA, and enable notifications from the app

1. In a web browser, login to your WordPress account with 2FA enabled
2. Wait for the "Sign in request..." push notification to be pushed to the mobile device
3. Long press the notification
4. Observe that to Approve or Deny the request a passcode must be provided

https://user-images.githubusercontent.com/2092798/141197077-cd2a2e89-62dd-43dc-8504-c5d7d016e771.mov


## Regression Notes
1. Potential unintended areas of impact
- Approving / Denying the request on a device with no passcode
- Other types of notifications from WPiOS

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested other types of notifications
- Tested different settings for how iOS shows previews (Settings -> Notifications -> Show Previews)

3. What automated tests I added (or what prevented me from doing so)
None. This would be a challenge due to the way notifications communicate with their host apps.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
