### PR TITLE
Comment Reply: add comment author's name to the Reply placeholder

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -104,7 +104,7 @@ extension Comment: PostContentProvider {
         return !title.isEmpty ? title.stringByDecodingXMLCharacters() : NSLocalizedString("(No Title)", comment: "Empty Post Title")
     }
 
-    public func authorForDisplay() -> String {
+    @objc public func authorForDisplay() -> String {
         let displayAuthor = authorName().stringByDecodingXMLCharacters().trim()
         return !displayAuthor.isEmpty ? displayAuthor : gravatarEmailForDisplay()
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -846,8 +846,7 @@ private extension CommentDetailViewController {
     func configureReplyView() {
         let replyView = ReplyTextView(width: view.frame.width)
 
-        // TODO: update placeholder per design
-        replyView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
+        replyView.placeholder = String(format: .replyCommentTitleFormat, comment.authorForDisplay())
         replyView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyView.delegate = self
         replyView.onReply = { [weak self] content in

--- a/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentViewController.m
@@ -114,9 +114,11 @@ typedef NS_ENUM(NSUInteger, CommentsDetailsRow) {
     }
     
     __typeof(self) __weak weakSelf = self;
-
+    
+    NSString *placeholderFormat = NSLocalizedString(@"Reply to %1$@", @"Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.");
+    
     ReplyTextView *replyTextView = [[ReplyTextView alloc] initWithWidth:CGRectGetWidth(self.view.frame)];
-    replyTextView.placeholder = NSLocalizedString(@"Write a reply…", @"Placeholder text for inline compose view");
+    replyTextView.placeholder = [NSString stringWithFormat:placeholderFormat, [self.comment authorForDisplay]];
     replyTextView.onReply = ^(NSString *content) {
         [weakSelf sendReplyWithNewContent:content];
     };

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -451,7 +451,7 @@ extension NotificationDetailsViewController {
         let previousReply = NotificationReplyStore.shared.loadReply(for: note.notificationId)
         let replyTextView = ReplyTextView(width: view.frame.width)
 
-        replyTextView.placeholder = NSLocalizedString("Write a reply…", comment: "Placeholder text for inline compose view")
+        replyTextView.placeholder = NSLocalizedString("Write a reply", comment: "Placeholder text for inline compose view")
         replyTextView.text = previousReply
         replyTextView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyTextView.delegate = self
@@ -518,7 +518,7 @@ extension NotificationDetailsViewController {
     }
 
     var shouldAttachReplyView: Bool {
-        // Attach the Reply component only if the noficiation has a comment, and it can be replied-to
+        // Attach the Reply component only if the notification has a comment, and it can be replied to.
         //
         guard let block: FormattableCommentContent = note.contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
             return false
@@ -772,6 +772,11 @@ private extension NotificationDetailsViewController {
         cell.site                   = userBlock.metaTitlesHome ?? userBlock.metaLinksHome?.host
         cell.attributedCommentText  = text.trimNewlines()
         cell.isApproved             = commentBlock.isCommentApproved
+
+        // Add comment author's name to Reply placeholder.
+        let placeholderFormat = NSLocalizedString("Reply to %1$@",
+                                                  comment: "Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.")
+        replyTextView.placeholder = String(format: placeholderFormat, cell.name ?? String())
 
         // Setup: Callbacks
         cell.onUserClick = { [weak self] in

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -714,9 +714,11 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 - (void)refreshReplyTextViewPlaceholder
 {
     if (self.tableView.indexPathForSelectedRow) {
-        self.replyTextView.placeholder = NSLocalizedString(@"Reply to comment…", @"Placeholder text for replying to a comment");
+        Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:self.indexPathForCommentRepliedTo];
+        NSString *placeholderFormat = NSLocalizedString(@"Reply to %1$@", @"Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.");
+        self.replyTextView.placeholder = [NSString stringWithFormat:placeholderFormat, [comment authorForDisplay]];
     } else {
-        self.replyTextView.placeholder = NSLocalizedString(@"Reply to post…", @"Placeholder text for replying to a post");
+        self.replyTextView.placeholder = NSLocalizedString(@"Reply to post", @"Placeholder text for replying to a post");
     }
 }
 


### PR DESCRIPTION
Ref: #17412 
Depends on: #17445

When replying to a comment, the comment author's name is added to the Reply placeholder text. 

Note: This is only for the minimized Reply view. The fullscreen Reply placeholder will be added in a follow-up PR.

To test:
- Go to these views.
  - Old comment details.
  - New comment details.
  - Reader > post > comments > Reply to _comment_.
  - Notifications > Comments > notification details.
- Verify the comment author's name is displayed in the Reply placeholder.

| Comment (old) | Comment (new) | Reader | Notification |
|--------|-------|-------|-------|
| ![old_comment_details](https://user-images.githubusercontent.com/1816888/141206299-ee2833e3-4a57-42d9-a7d0-fd8c82459631.png) | ![new_comment_details](https://user-images.githubusercontent.com/1816888/141206296-52e700b6-894f-40fe-8732-9033f869763e.png) | ![reader](https://user-images.githubusercontent.com/1816888/141206433-c95f88b1-ec11-4526-8ffa-a24bc58143cd.png) | ![notification](https://user-images.githubusercontent.com/1816888/141206290-c44b9291-cc32-4fc8-9c18-862379fb4cd6.png) |

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified the UI looked and functioned correctly.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
