### PR TITLE
Comment Reply fullscreen: display placeholder from minimized Reply

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.h
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.h
@@ -7,6 +7,7 @@ typedef void (^EditCommentCompletion)(BOOL hasNewContent, NSString *newContent);
 @property (nonatomic,           strong) NSString              *content;
 @property (nonatomic,           assign) BOOL                  interfaceEnabled;
 @property (readonly, nonatomic, weak) IBOutlet UITextView     *textView;
+@property (readonly, nonatomic, weak) IBOutlet UILabel        *placeholderLabel;
 @property (readonly, nonatomic, assign) CGRect keyboardFrame;
 
 + (instancetype)newEditViewController;

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.m
@@ -12,7 +12,8 @@
 #pragma mark ==========================================================================================
 
 @interface EditCommentViewController()
-@property (readwrite, nonatomic, weak) IBOutlet UITextView     *textView;
+@property (readwrite, nonatomic, weak) IBOutlet UITextView *textView;
+@property (readwrite, nonatomic, weak) IBOutlet UILabel *placeholderLabel;
 @property (nonatomic, strong) NSString *pristineText;
 @property (readwrite, nonatomic, assign) CGRect keyboardFrame;
 
@@ -70,6 +71,7 @@
     self.view.backgroundColor = [UIColor murielBasicBackground];
     self.textView.backgroundColor = [UIColor murielBasicBackground];
     self.textView.textColor = [UIColor murielText];
+    self.placeholderLabel.textColor = [UIColor murielTextPlaceholder];
     
     [self showCancelBarButton];
     [self showSaveBarButton];

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.xib
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentViewController.xib
@@ -10,6 +10,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="EditCommentViewController">
             <connections>
+                <outlet property="placeholderLabel" destination="JSO-Ox-i4X" id="1Bp-ly-7Hk"/>
                 <outlet property="textView" destination="4" id="5"/>
                 <outlet property="view" destination="1" id="3"/>
             </connections>
@@ -27,13 +28,25 @@
                         <outlet property="delegate" destination="-1" id="6"/>
                     </connections>
                 </textView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="JSO-Ox-i4X" userLabel="Placeholder Label">
+                    <rect key="frame" x="25" y="52" width="369" height="17"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <color key="textColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                    <size key="shadowOffset" width="-1" height="-1"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="hd0-DM-uqE"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="4" firstAttribute="bottom" secondItem="hd0-DM-uqE" secondAttribute="bottom" id="RoP-nH-YdT"/>
+                <constraint firstItem="hd0-DM-uqE" firstAttribute="trailing" secondItem="JSO-Ox-i4X" secondAttribute="trailing" constant="20" id="45P-3Y-0Nx"/>
+                <constraint firstItem="JSO-Ox-i4X" firstAttribute="leading" secondItem="hd0-DM-uqE" secondAttribute="leading" constant="25" id="JMN-iQ-CkE"/>
+                <constraint firstItem="hd0-DM-uqE" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="JSO-Ox-i4X" secondAttribute="bottom" id="NPH-li-HbF"/>
+                <constraint firstItem="hd0-DM-uqE" firstAttribute="bottom" secondItem="4" secondAttribute="bottom" id="OOw-O4-n5X"/>
+                <constraint firstItem="4" firstAttribute="top" secondItem="hd0-DM-uqE" secondAttribute="top" id="OVQ-ac-W8f"/>
                 <constraint firstItem="hd0-DM-uqE" firstAttribute="trailing" secondItem="4" secondAttribute="trailing" constant="20" id="SJl-lD-GAb"/>
-                <constraint firstItem="4" firstAttribute="top" secondItem="hd0-DM-uqE" secondAttribute="top" id="iHT-Cc-3MN"/>
+                <constraint firstItem="JSO-Ox-i4X" firstAttribute="top" secondItem="hd0-DM-uqE" secondAttribute="top" constant="8" id="Tmv-JE-Bnr"/>
                 <constraint firstItem="4" firstAttribute="leading" secondItem="hd0-DM-uqE" secondAttribute="leading" constant="20" id="jf7-Kx-yZn"/>
             </constraints>
             <point key="canvasLocation" x="-1414" y="-66"/>

--- a/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/FullScreenCommentReplyViewController.swift
@@ -31,16 +31,24 @@ public class FullScreenCommentReplyViewController: EditCommentViewController, Su
     // Static margin between the suggestions view and the text cursor position
     private let suggestionViewMargin: CGFloat = 5
 
+    public var placeholder = String()
+
     // MARK: - View Methods
     public override func viewDidLoad() {
         super.viewDidLoad()
+        placeholderLabel.text = placeholder
         setupNavigationItems()
         configureNavigationAppearance()
     }
 
+    public override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        refreshPlaceholder()
+        refreshReplyButton()
+    }
+
     public override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        refreshReplyButton()
         setupSuggestionsTableViewIfNeeded()
     }
 
@@ -73,6 +81,7 @@ public class FullScreenCommentReplyViewController: EditCommentViewController, Su
     public override func textViewDidEndEditing(_ textView: UITextView) { }
 
     public override func contentDidChange() {
+        refreshPlaceholder()
         refreshReplyButton()
     }
 
@@ -167,6 +176,10 @@ public class FullScreenCommentReplyViewController: EditCommentViewController, Su
     /// Changes the `refreshButton` enabled state
     private func refreshReplyButton() {
         replyButton.isEnabled = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    private func refreshPlaceholder() {
+        placeholderLabel.isHidden = !textView.text.isEmpty
     }
 
     /// Triggers the `onExitFullscreen` completion handler

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -191,6 +191,7 @@ import Gridicons
         let didHaveFirstResponder = textView.isFirstResponder
 
         editViewController.content = textView.text
+        editViewController.placeholder = placeholder
         editViewController.isModalInPresentation = true
         editViewController.onExitFullscreen = { (shouldSave, updatedContent) in
             self.text = updatedContent


### PR DESCRIPTION
Ref: #17412 
Depends on: #17447

This adds a placeholder label to the fullscreen Reply view, and populates it with the placeholder from the minimized Reply view.

To test:
- Go to any view where you can reply to a comment. (Comments, Reader post, Comment Notification)
- Tap the up arrow on the Reply view to enter fullscreen.
- Verify the placeholder matches the minimized Reply view placeholder.
- Enter text. Verify the placeholder is hidden.

| ![minimized](https://user-images.githubusercontent.com/1816888/141216532-05352691-e9a4-4fba-97a6-afdbf42b785c.png) | ![fullscreen](https://user-images.githubusercontent.com/1816888/141216530-0b88bdc1-8734-4303-912d-577f79c7b378.png) |
|--------|-------|


## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified the UI looked and functioned correctly.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
