### PR TITLE
Onboarding Improvements: Epilogue screen create new site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -28,9 +28,9 @@ final class QuickStartPromptViewController: UIViewController {
 
     // MARK: - Init
 
-    init(blog: Blog, quickStartSettings: QuickStartSettings? = nil) {
+    init(blog: Blog, quickStartSettings: QuickStartSettings = QuickStartSettings()) {
         self.blog = blog
-        self.quickStartSettings = quickStartSettings ?? QuickStartSettings()
+        self.quickStartSettings = quickStartSettings
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -22,9 +22,9 @@ final class QuickStartPromptViewController: UIViewController {
     private let blog: Blog
     private let quickStartSettings: QuickStartSettings
 
-    /// Closure to be executed upon dismissing the Login Epilogue.
+    /// Closure to be executed upon dismissal.
     ///
-    var onDismissEpilogue: (() -> Void)?
+    var onDismiss: ((Blog) -> Void)?
 
     // MARK: - Init
 
@@ -103,33 +103,13 @@ final class QuickStartPromptViewController: UIViewController {
     // MARK: - IBAction
 
     @IBAction private func showMeAroundButtonTapped(_ sender: Any) {
-        if let onDismissEpilogue = onDismissEpilogue {
-            onDismissEpilogue()
-
-            // Show the My Site screen for the specified blog
-            WordPressAppDelegate.shared?.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
-                // After a short delay, trigger the Quick Start tour
-                DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
-                    QuickStartTourGuide.shared.setup(for: self.blog)
-                }
-            })
-
-            return
-        }
-
+        onDismiss?(blog)
         dismiss(animated: true)
-        QuickStartTourGuide.shared.setup(for: blog)
     }
 
     @IBAction private func noThanksButtonTapped(_ sender: Any) {
         quickStartSettings.setPromptWasDismissed(true, for: blog)
-
-        if let onDismissEpilogue = onDismissEpilogue {
-            onDismissEpilogue()
-            WordPressAppDelegate.shared?.windowManager.dismissFullscreenSignIn(blogToShow: blog)
-            return
-        }
-
+        onDismiss?(blog)
         dismiss(animated: true)
     }
 }
@@ -143,7 +123,4 @@ extension QuickStartPromptViewController {
         static let noThanksButtonTitle = NSLocalizedString("No thanks", comment: "Button title. When tapped, the quick start checklist will not be shown, and the prompt will be dismissed.")
     }
 
-    private enum Constants {
-        static let quickStartDelay: DispatchTimeInterval = .milliseconds(500)
-    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -28,13 +28,7 @@ open class QuickStartTourGuide: NSObject {
         }
     }
 
-    func setup(for blog: Blog, withCompletedSteps steps: [QuickStartTour] = [], executeWithDelay: Bool = false) {
-
-        guard executeWithDelay else {
-            setup(for: blog, withCompletedSteps: steps)
-            return
-        }
-
+    func setupWithDelay(for blog: Blog, withCompletedSteps steps: [QuickStartTour] = []) {
         DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
             self.setup(for: blog, withCompletedSteps: steps)
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -28,6 +28,18 @@ open class QuickStartTourGuide: NSObject {
         }
     }
 
+    func setup(for blog: Blog, withCompletedSteps steps: [QuickStartTour] = [], executeWithDelay: Bool = false) {
+
+        guard executeWithDelay else {
+            setup(for: blog, withCompletedSteps: steps)
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
+            self.setup(for: blog, withCompletedSteps: steps)
+        }
+    }
+
     @objc func remove(from blog: Blog) {
         blog.removeAllTours()
     }
@@ -433,6 +445,7 @@ private extension QuickStartTourGuide {
     private struct Constants {
         static let maxSkippedTours = 3
         static let suggestionTimeout = 10.0
+        static let quickStartDelay: DispatchTimeInterval = .milliseconds(500)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -199,7 +199,10 @@ extension LoginEpilogueTableViewController {
 // MARK: - LoginEpilogueCreateNewSiteCellDelegate
 extension LoginEpilogueTableViewController: LoginEpilogueCreateNewSiteCellDelegate {
     func didTapCreateNewSite() {
-        // TODO: implement
+        guard let parent = parent as? LoginEpilogueViewController else {
+            return
+        }
+        parent.onCreateNewSite?()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -49,6 +49,10 @@ class LoginEpilogueViewController: UIViewController {
     ///
     var onBlogSelected: ((Blog) -> Void)?
 
+    /// Closure to be executed upon a new site creation.
+    ///
+    var onCreateNewSite: (() -> Void)?
+
     /// Site that was just connected to our awesome app.
     ///
     var credentials: AuthenticatorCredentials? {
@@ -216,6 +220,6 @@ private extension LoginEpilogueViewController {
     // MARK: - Actions
 
     @IBAction func createANewSite() {
-        // TODO: implement
+        onCreateNewSite?()
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -331,26 +331,22 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.credentials = credentials
 
-        let dismissAndShowBlog: ((Blog) -> Void) = { [weak self] blog in
-            onDismiss()
-            self?.windowManager.dismissFullscreenSignIn(blogToShow: blog)
-        }
-
-        epilogueViewController.onBlogSelected = { blog in
+        epilogueViewController.onBlogSelected = { [weak self] blog in
 
             guard !UserDefaults.standard.quickStartWasDismissed(for: blog) else {
-                dismissAndShowBlog(blog)
+                onDismiss()
+                self?.windowManager.dismissFullscreenSignIn(blogToShow: blog)
                 return
             }
 
             let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-            quickstartPrompt.onDismiss = dismissAndShowBlog
+            quickstartPrompt.onDismissEpilogue = onDismiss
             navigationController.pushViewController(quickstartPrompt, animated: true)
         }
 
         epilogueViewController.onCreateNewSite = {
 
-            let wizardLauncher = SiteCreationWizardLauncher(onDismissQuickStart: dismissAndShowBlog)
+            let wizardLauncher = SiteCreationWizardLauncher(onDismissEpilogue: onDismiss)
             guard let wizard = wizardLauncher.ui else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -351,7 +351,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 return
             }
 
-            // Otherwise, whow the My Site screen for the specified blog and after a short delay,
+            // Otherwise, show the My Site screen for the specified blog and after a short delay,
             // trigger the Quick Start tour
             self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
                 DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -354,7 +354,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             // Otherwise, show the My Site screen for the specified blog and after a short delay,
             // trigger the Quick Start tour
             self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
-                QuickStartTourGuide.shared.setup(for: blog, executeWithDelay: true)
+                QuickStartTourGuide.shared.setupWithDelay(for: blog)
             })
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -18,10 +18,10 @@ class WordPressAuthenticationManager: NSObject {
 
     init(windowManager: WindowManager,
          authenticationHandler: AuthenticationHandler? = nil,
-         quickStartSettings: QuickStartSettings? = nil) {
+         quickStartSettings: QuickStartSettings = QuickStartSettings()) {
         self.windowManager = windowManager
         self.authenticationHandler = authenticationHandler
-        self.quickStartSettings = quickStartSettings ?? QuickStartSettings()
+        self.quickStartSettings = quickStartSettings
     }
 
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -336,26 +336,38 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.credentials = credentials
 
-        epilogueViewController.onBlogSelected = { [weak self] blog in
+        let onDismissQuickStartPrompt: (Blog) -> Void = { [weak self] blog in
 
             guard let self = self else {
                 return
             }
 
+            onDismiss()
+
+            // If the quick start prompt has already been dismissed,
+            // then show the My Site screen for the specified blog
             guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
-                onDismiss()
                 self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
                 return
             }
 
+            // Otherwise, whow the My Site screen for the specified blog and after a short delay,
+            // trigger the Quick Start tour
+            self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
+                DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
+                    QuickStartTourGuide.shared.setup(for: blog)
+                }
+            })
+        }
+
+        epilogueViewController.onBlogSelected = { blog in
             let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-            quickstartPrompt.onDismissEpilogue = onDismiss
+            quickstartPrompt.onDismiss = onDismissQuickStartPrompt
             navigationController.pushViewController(quickstartPrompt, animated: true)
         }
 
         epilogueViewController.onCreateNewSite = {
-
-            let wizardLauncher = SiteCreationWizardLauncher(onDismissEpilogue: onDismiss)
+            let wizardLauncher = SiteCreationWizardLauncher(onDismiss: onDismissQuickStartPrompt)
             guard let wizard = wizardLauncher.ui else {
                 return
             }
@@ -560,5 +572,9 @@ private extension WordPressAuthenticationManager {
             RecentSitesService().touch(blog: blog)
             onCompletion()
         }
+    }
+
+    private enum Constants {
+        static let quickStartDelay: DispatchTimeInterval = .milliseconds(500)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -348,6 +348,16 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             navigationController.pushViewController(quickstartPrompt, animated: true)
         }
 
+        epilogueViewController.onCreateNewSite = {
+
+            let wizardLauncher = SiteCreationWizardLauncher()
+            guard let wizard = wizardLauncher.ui else {
+                return
+            }
+
+            navigationController.present(wizard, animated: true)
+        }
+
         navigationController.pushViewController(epilogueViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -350,7 +350,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.onCreateNewSite = {
 
-            let wizardLauncher = SiteCreationWizardLauncher()
+            let wizardLauncher = SiteCreationWizardLauncher(onDismissQuickStart: dismissAndShowBlog)
             guard let wizard = wizardLauncher.ui else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -354,9 +354,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             // Otherwise, show the My Site screen for the specified blog and after a short delay,
             // trigger the Quick Start tour
             self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
-                DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
-                    QuickStartTourGuide.shared.setup(for: blog)
-                }
+                QuickStartTourGuide.shared.setup(for: blog, executeWithDelay: true)
             })
         }
 
@@ -572,9 +570,5 @@ private extension WordPressAuthenticationManager {
             RecentSitesService().touch(blog: blog)
             onCompletion()
         }
-    }
-
-    private enum Constants {
-        static let quickStartDelay: DispatchTimeInterval = .milliseconds(500)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -25,9 +25,10 @@ final class SiteAssemblyStep: WizardStep {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismissEpilogue: (() -> Void)? = nil) {
+    ///   - onDismiss: the closure to be executed upon dismissal of the SiteAssemblyWizardContent
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismiss: ((Blog) -> Void)? = nil) {
         self.creator = creator
         self.service = service
-        self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismissEpilogue: onDismissEpilogue)
+        self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismiss: onDismiss)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -25,9 +25,9 @@ final class SiteAssemblyStep: WizardStep {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
-    init(creator: SiteCreator, service: SiteAssemblyService) {
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismissQuickStart: ((Blog) -> Void)? = nil) {
         self.creator = creator
         self.service = service
-        self.content = SiteAssemblyWizardContent(creator: creator, service: service)
+        self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismissQuickStart: onDismissQuickStart)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -25,9 +25,9 @@ final class SiteAssemblyStep: WizardStep {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismissQuickStart: ((Blog) -> Void)? = nil) {
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismissEpilogue: (() -> Void)? = nil) {
         self.creator = creator
         self.service = service
-        self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismissQuickStart: onDismissQuickStart)
+        self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismissEpilogue: onDismissEpilogue)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -32,8 +32,8 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// Locally tracks the network connection status via `NetworkStatusDelegate`
     private var isNetworkActive = ReachabilityUtils.isInternetReachable()
 
-    /// Closure to be executed upon dismissing the quick start prompt
-    private let onDismissQuickStart: ((Blog) -> Void)?
+    /// Closure to be executed upon dismissing the Login Epilogue
+    private let onDismissEpilogue: (() -> Void)?
 
     // MARK: SiteAssemblyWizardContent
 
@@ -42,10 +42,10 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismissQuickStart: ((Blog) -> Void)? = nil) {
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismissEpilogue: (() -> Void)? = nil) {
         self.siteCreator = creator
         self.service = service
-        self.onDismissQuickStart = onDismissQuickStart
+        self.onDismissEpilogue = onDismissEpilogue
         self.contentView = SiteAssemblyContentView(siteCreator: siteCreator)
 
         super.init(nibName: nil, bundle: nil)
@@ -224,9 +224,9 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             return
         }
 
-        if let onDismissQuickStart = onDismissQuickStart {
+        if let onDismissEpilogue = onDismissEpilogue {
             let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-            quickstartPrompt.onDismiss = onDismissQuickStart
+            quickstartPrompt.onDismissEpilogue = onDismissEpilogue
             navigationController?.pushViewController(quickstartPrompt, animated: true)
             return
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -235,11 +235,11 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             SiteCreationAnalyticsHelper.trackSiteCreationSuccessPreviewOkButtonTapped()
             WPTabBarController.sharedInstance()?.mySitesCoordinator.showBlogDetails(for: blog)
 
-            self?.showQuickStartAlert(for: blog)
+            self?.showQuickStartPrompt(for: blog)
         }
     }
 
-    private func showQuickStartAlert(for blog: Blog) {
+    private func showQuickStartPrompt(for blog: Blog) {
         guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
             return
         }
@@ -248,9 +248,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             return
         }
 
-        let fancyAlert = FancyAlertViewController.makeQuickStartAlertController(blog: blog)
-        fancyAlert.modalPresentationStyle = .custom
-        fancyAlert.transitioningDelegate = tabBar
-        tabBar.present(fancyAlert, animated: true)
+        let quickstartPrompt = QuickStartPromptViewController(blog: blog)
+        tabBar.present(quickstartPrompt, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -32,6 +32,9 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// Locally tracks the network connection status via `NetworkStatusDelegate`
     private var isNetworkActive = ReachabilityUtils.isInternetReachable()
 
+    /// UseDefaults helper for quick start settings
+    private let quickStartSettings: QuickStartSettings
+
     /// Closure to be executed upon dismissal
     private let onDismiss: ((Blog) -> Void)?
 
@@ -42,10 +45,15 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
+    ///   - quickStartSettings: the UserDefaults helper for quick start settings
     ///   - onDismiss: the closure to be executed upon dismissal
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismiss: ((Blog) -> Void)? = nil) {
+    init(creator: SiteCreator,
+         service: SiteAssemblyService,
+         quickStartSettings: QuickStartSettings? = nil,
+         onDismiss: ((Blog) -> Void)? = nil) {
         self.siteCreator = creator
         self.service = service
+        self.quickStartSettings = quickStartSettings ?? QuickStartSettings()
         self.onDismiss = onDismiss
         self.contentView = SiteAssemblyContentView(siteCreator: siteCreator)
 
@@ -241,7 +249,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
     }
 
     private func showQuickStartPrompt(for blog: Blog) {
-        guard !UserDefaults.standard.quickStartWasDismissedPermanently else {
+        guard !quickStartSettings.promptWasDismissed(for: blog) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -258,6 +258,9 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         }
 
         let quickstartPrompt = QuickStartPromptViewController(blog: blog)
+        quickstartPrompt.onDismiss = { blog in
+            QuickStartTourGuide.shared.setup(for: blog, executeWithDelay: true)
+        }
         tabBar.present(quickstartPrompt, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -32,8 +32,8 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// Locally tracks the network connection status via `NetworkStatusDelegate`
     private var isNetworkActive = ReachabilityUtils.isInternetReachable()
 
-    /// Closure to be executed upon dismissing the Login Epilogue
-    private let onDismissEpilogue: (() -> Void)?
+    /// Closure to be executed upon dismissal
+    private let onDismiss: ((Blog) -> Void)?
 
     // MARK: SiteAssemblyWizardContent
 
@@ -42,10 +42,11 @@ final class SiteAssemblyWizardContent: UIViewController {
     /// - Parameters:
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismissEpilogue: (() -> Void)? = nil) {
+    ///   - onDismiss: the closure to be executed upon dismissal
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismiss: ((Blog) -> Void)? = nil) {
         self.siteCreator = creator
         self.service = service
-        self.onDismissEpilogue = onDismissEpilogue
+        self.onDismiss = onDismiss
         self.contentView = SiteAssemblyContentView(siteCreator: siteCreator)
 
         super.init(nibName: nil, bundle: nil)
@@ -224,9 +225,9 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
             return
         }
 
-        if let onDismissEpilogue = onDismissEpilogue {
+        if let onDismiss = onDismiss {
             let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-            quickstartPrompt.onDismissEpilogue = onDismissEpilogue
+            quickstartPrompt.onDismiss = onDismiss
             navigationController?.pushViewController(quickstartPrompt, animated: true)
             return
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -259,7 +259,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
 
         let quickstartPrompt = QuickStartPromptViewController(blog: blog)
         quickstartPrompt.onDismiss = { blog in
-            QuickStartTourGuide.shared.setup(for: blog, executeWithDelay: true)
+            QuickStartTourGuide.shared.setupWithDelay(for: blog)
         }
         tabBar.present(quickstartPrompt, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -49,11 +49,11 @@ final class SiteAssemblyWizardContent: UIViewController {
     ///   - onDismiss: the closure to be executed upon dismissal
     init(creator: SiteCreator,
          service: SiteAssemblyService,
-         quickStartSettings: QuickStartSettings? = nil,
+         quickStartSettings: QuickStartSettings = QuickStartSettings(),
          onDismiss: ((Blog) -> Void)? = nil) {
         self.siteCreator = creator
         self.service = service
-        self.quickStartSettings = quickStartSettings ?? QuickStartSettings()
+        self.quickStartSettings = quickStartSettings
         self.onDismiss = onDismiss
         self.contentView = SiteAssemblyContentView(siteCreator: siteCreator)
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -20,7 +20,7 @@ final class SiteCreationWizardLauncher {
 
     private lazy var siteAssemblyStep: WizardStep = {
         let siteAssemblyService = EnhancedSiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService)
+        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismissQuickStart: onDismissQuickStart)
     }()
 
     private lazy var steps: [WizardStep] = {
@@ -45,4 +45,12 @@ final class SiteCreationWizardLauncher {
 
         return wizardContent
     }()
+
+    /// Closure to be executed upon dismissing the quick start prompt
+    ///
+    private let onDismissQuickStart: ((Blog) -> Void)?
+
+    init(onDismissQuickStart: ((Blog) -> Void)? = nil) {
+        self.onDismissQuickStart = onDismissQuickStart
+    }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -20,7 +20,7 @@ final class SiteCreationWizardLauncher {
 
     private lazy var siteAssemblyStep: WizardStep = {
         let siteAssemblyService = EnhancedSiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismissEpilogue: onDismissEpilogue)
+        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismiss: onDismiss)
     }()
 
     private lazy var steps: [WizardStep] = {
@@ -46,11 +46,11 @@ final class SiteCreationWizardLauncher {
         return wizardContent
     }()
 
-    /// Closure to be executed upon dismissing the Login Epilogue.
+    /// Closure to be executed upon dismissal of the SiteAssemblyWizardContent.
     ///
-    private let onDismissEpilogue: (() -> Void)?
+    private let onDismiss: ((Blog) -> Void)?
 
-    init(onDismissEpilogue: (() -> Void)? = nil) {
-        self.onDismissEpilogue = onDismissEpilogue
+    init(onDismiss: ((Blog) -> Void)? = nil) {
+        self.onDismiss = onDismiss
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -20,7 +20,7 @@ final class SiteCreationWizardLauncher {
 
     private lazy var siteAssemblyStep: WizardStep = {
         let siteAssemblyService = EnhancedSiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismissQuickStart: onDismissQuickStart)
+        return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismissEpilogue: onDismissEpilogue)
     }()
 
     private lazy var steps: [WizardStep] = {
@@ -46,11 +46,11 @@ final class SiteCreationWizardLauncher {
         return wizardContent
     }()
 
-    /// Closure to be executed upon dismissing the quick start prompt
+    /// Closure to be executed upon dismissing the Login Epilogue.
     ///
-    private let onDismissQuickStart: ((Blog) -> Void)?
+    private let onDismissEpilogue: (() -> Void)?
 
-    init(onDismissQuickStart: ((Blog) -> Void)? = nil) {
-        self.onDismissQuickStart = onDismissQuickStart
+    init(onDismissEpilogue: (() -> Void)? = nil) {
+        self.onDismissEpilogue = onDismissEpilogue
     }
 }


### PR DESCRIPTION
Part of #17385

## Description

This PR hooks up the **Create a new site** button on the Epilogue screen.

## Notes

- Please note that there is a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/17453) where the wrong cells get displayed in the Login Epilogue screen when an account has exactly 4 sites. This will be addressed in a separate PR. 
- There are some obsolete files we should be able to delete, once this PR gets approved. This will be addressed in a separate PR. 
- UI tests will be addressed in a different PR.

## Merge directions
- Merge after #17435

## How to test

### [NEW] Epilogue -> Create a new site -> Show me around

1. Log out, then log in
2. On the Epilogue screen, tap **Create a new site**
3. Choose a design and tap **Choose**
4. Choose a domain and tap **Create Site**
5. On the Site Created success screen, tap **Done**
6. ✅ The Quick Start prompt is displayed
7. On the Quick Start prompt, tap **Show me around**
8. ✅ The Quick Start checklist is displayed
9. On the Quick Start checklist, tap the **X button**
10. ✅ The checklist is dismissed, and the Quick Start menu items (i.e. Customize Your Site / Grow Your Audience) are showing in My Site

<details>
 <summary>Click here for iPhone video</summary>

https://user-images.githubusercontent.com/6711616/141370458-e3969557-3740-4b0c-8795-0c80ee785481.mp4

</details>

<details>
 <summary>Click here for iPad video</summary>

https://user-images.githubusercontent.com/6711616/141370494-f4362d81-1a6b-47ee-8596-19aad565e1ce.mp4

</details>

### [NEW] Epilogue > Create a new site > No thanks

1. Log out, then log in
2. On the Epilogue screen, tap **Create a new site**
3. Choose a design and tap **Choose**
4. Choose a domain and tap **Create Site**
5. On the Site Created success screen, tap **Done**
6. ✅ The Quick Start prompt is displayed
7. On the Quick Start prompt, tap **No thanks**
8. ✅ The prompt is dismissed, and the Quick Start menu items (i.e. Customize Your Site / Grow Your Audience) are NOT showing in My Site

<details>
 <summary>Click here for iPhone video</summary>

https://user-images.githubusercontent.com/6711616/141370526-06986785-b9a4-48d1-b2f1-2d60b9be319e.mp4

</details>

<details>
 <summary>Click here for iPad video</summary>

https://user-images.githubusercontent.com/6711616/141370556-a6845145-64e0-4e12-8d2c-e802d2221944.mp4

</details>


### [Regression] My Site > Create a new site > Show me around

1. Log in if not logged in
2. On My Site, tap the **chevron icon** by the site title header
3. On the Site Switcher screen, tap the **+ icon**
4. Tap **Create WordPress.com site** and go through the site creation flow
5. On the Site Created success screen, tap **Done**
6. ✅ The Quick Start prompt is displayed
7. On the Quick Start prompt, tap **Show me around**
8. ✅ The Quick Start checklist is displayed
9. On the Quick Start checklist, tap the **X button**
10. ✅ The checklist is dismissed, and the Quick Start menu items (i.e. Customize Your Site / Grow Your Audience) are showing in My Site

### [Regression] My Site > Create a new site > No thanks

1. Log in if not logged in
2. On My Site, tap the **chevron icon** by the site title header
3. On the Site Switcher screen, tap the **+ icon**
4. Tap **Create WordPress.com site** and go through the site creation flow
5. On the Site Created success screen, tap **Done**
6. ✅ The Quick Start prompt is displayed
7. On the Quick Start prompt, tap **No thanks**
8. ✅ The prompt is dismissed, and the Quick Start menu items (i.e. Customize Your Site / Grow Your Audience) are NOT showing in My Site

## Regression Notes
1. Potential unintended areas of impact
Site creation > Quick Start flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above steps manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
