### PR TITLE
Comment Detail: Fix cell separators not aligning correctly after rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -261,7 +261,7 @@ private extension CommentDetailViewController {
     }
 
     struct Constants {
-        static let tableLeadingInset: CGFloat = 20.0
+        static let tableHorizontalInset: CGFloat = 20.0
         static let tableBottomMargin: CGFloat = 40.0
         static let replyIndicatorVerticalSpacing: CGFloat = 14.0
 
@@ -270,8 +270,9 @@ private extension CommentDetailViewController {
 
     /// Convenience computed variable for an inset setting that hides a cell's separator by pushing it off the edge of the screen.
     /// This needs to be computed because the frame size changes on orientation change.
+    /// NOTE: There's no need to flip the insets for RTL language, since it will be automatically applied.
     var insetsForHiddenCellSeparator: UIEdgeInsets {
-        return .init(top: 0, left: tableView.frame.size.width, bottom: 0, right: 0).flippedForRightToLeftLayoutDirection()
+        return .init(top: 0, left: -tableView.separatorInset.left, bottom: 0, right: tableView.frame.size.width)
     }
 
     /// returns the height of the navigation bar + the status bar.
@@ -325,15 +326,17 @@ private extension CommentDetailViewController {
     func configureTable() {
         tableView.delegate = self
         tableView.dataSource = self
+        tableView.separatorInsetReference = .fromAutomaticInsets
 
         // get rid of the separator line for the last cell.
         tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: Constants.tableBottomMargin))
 
+
         // assign 20pt leading inset to the table view, as per the design.
-        // note that by default, the system assigns 16pt inset for .phone, and 20pt for .pad idioms.
-        if UIDevice.current.userInterfaceIdiom == .phone {
-            tableView.directionalLayoutMargins.leading = Constants.tableLeadingInset
-        }
+        tableView.directionalLayoutMargins = .init(top: tableView.directionalLayoutMargins.top,
+                                                   leading: Constants.tableHorizontalInset,
+                                                   bottom: tableView.directionalLayoutMargins.bottom,
+                                                   trailing: Constants.tableHorizontalInset)
 
         tableView.register(CommentContentTableViewCell.defaultNib, forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
     }
@@ -803,10 +806,12 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
             }
         }()
 
-        // hide cell separator if it's positioned before the delete button cell.
-        cell.separatorInset = shouldHideCellSeparator(for: indexPath) ? insetsForHiddenCellSeparator : tableView.separatorInset
-
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        // Hide cell separator if it's positioned before the delete button cell.
+        cell.separatorInset = self.shouldHideCellSeparator(for: indexPath) ? self.insetsForHiddenCellSeparator : .zero
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {


### PR DESCRIPTION
Refs #17087

As titled, this PR fixes the issue where sometimes the cell separator is still displaying the margins for the landscape orientation (around 67pt from the view edge) when the screen is already displayed in portrait (where it should be around 20pt). Here's a screenshot:

• | Before | After 
--|--|--
Content alignment, portrait.[^1] | ![before_noDelete_portrait](https://user-images.githubusercontent.com/1299411/141319291-9308f8b8-eba0-4982-8c61-73865f67f52f.png) | ![after_noDelete_portrait](https://user-images.githubusercontent.com/1299411/141319311-3edf48d9-6b10-476d-8b34-267ad71ae4b2.png)
Content alignment, landscape.[^2] | ![before_noDelete_landscape](https://user-images.githubusercontent.com/1299411/141319287-11a403e4-7e69-4991-bc8d-922c6d14fbc5.png) | ![after_noDelete_landscape](https://user-images.githubusercontent.com/1299411/141319301-154bfd1d-d5b8-478f-a229-8889eaad5bdf.png)
Content alignment (with Delete) button, portrait.[^3] | ![before_withDelete_portrait](https://user-images.githubusercontent.com/1299411/141319275-7ef05c69-52c7-4dba-a698-cd7e3e45befc.png) | ![after_withDelete_portrait](https://user-images.githubusercontent.com/1299411/141319307-9c46d090-a663-4329-9274-fb770e3a2bc1.png)
Content alignment (with Delete) button, landscape.[^4] | ![before_withDelete_landscape](https://user-images.githubusercontent.com/1299411/141320601-46b9510a-dc23-4c97-88e5-acbc433f23a5.png) | ![after_withDelete_landscape](https://user-images.githubusercontent.com/1299411/141319295-becd1519-bc2f-4460-96af-19740f311c56.png)

## To Test

- Enable `newCommentDetail` feature flag.
- Navigate to My Site > Comments, and select any approved comments.
- 🔎  Verify that the cells' contents are neatly aligned.[^1]
- Rotate the device/simulator to landscape.
- 🔎  Verify that the cell separators are aligned correctly.
- Rotate the device/simulator back to portrait.
- 🔎  Again, verify that the cell separators are aligned correctly.
- Go back to My Site > Comments, and select any spam or trashed comments. Repeat the verification steps above.
- 🔎 Also verify that while in portrait or landscape, the cells before the Delete button does not show a separator line.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is not released yet.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that it behaves correctly. 

3. What automated tests I added (or what prevented me from doing so)
4. n/a. Feature is not released yet.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: Notice in the before image the content cell's right side is not aligned with the others, making it look asymmetrical since the right side is closer to the trailing edge.
[^2]: Some of the cell separators overextended to the left side of the cells.
[^3]: Some cells have incorrect content insets / indentation level. This is due to the cell still using the margins in the landscape mode.
[^4]: Some of the cell separators overextended to the left side of the cells. 