### PR TITLE
Comment Detail: Fix comment moderation checks for self-hosted sites

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -66,6 +66,16 @@ public class Comment: NSManagedObject {
         return parentID > 0
     }
 
+
+    /// Convenience method to check if the current user can actually moderate.
+    /// `canModerate` is only applicable when the site is dotcom-related (hosted or atomic). For self-hosted sites, default to true.
+    func allowsModeration() -> Bool {
+        guard let blog = blog,
+              (blog.isHostedAtWPcom || blog.isAtomic()) else {
+                  return true
+              }
+        return canModerate
+    }
 }
 
 private extension Comment {

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -142,7 +142,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isReactionEnabled = !comment.isReadOnly()
         isCommentLikesEnabled = isReactionEnabled && (comment.blog?.supports(.commentLikes) ?? false)
         isAccessoryButtonEnabled = comment.isApproved()
-        isModerationEnabled = comment.canModerate
+        isModerationEnabled = comment.allowsModeration()
 
         if isModerationEnabled {
             moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)


### PR DESCRIPTION
Refs #17087

As titled, this PR should now enable moderation actions in self-hosted sites. Additionally, I've also added a convenience method `allowModeration()` on Comment so it properly captures both WP.com and self-hosted scenarios.

(Note: There is also a similar method `isReadOnly()`, but it can't be used to check for moderation permissions because of the additional `!isApproved()` check.)

# To Test

- Enable `newCommentDetails` feature flag.
- In a self-hosted site:
  - Go to My Site > Comments. 
  - Select any pending/approved comment. Verify that moderation actions[^1] are shown.
  - Select any spam/trashed comment. Verify that the Delete button is also shown. 
- In a WP.com site with a moderating role:
  - Go to My Site > Comments. 
  - Select any pending/approved comment. Verify that moderation actions[^1] are shown.
  - Select any spam/trashed comment. Verify that the Delete button is also shown. 
- In a WP.com site with a non-moderating role:
  - Go to My Site > Comments. 
  - Select any pending/approved comment. Verify that moderation actions[^1] are NOT shown.
  - Select any spam/trashed comment. Verify that the Delete button is NOT shown. 
    
## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure the fix works.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: Edit button on the navigation bar, Moderation bar, and extra Comment Detail fields (email address and IP address) are shown.