### PR TITLE
Replay "Re-enable `EditorGutenberTests` (#17436) on top of `ScreenObject` updates

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -107,7 +107,14 @@ public class BlockEditorScreen: ScreenObject {
 
     public func publish() throws -> EditorNoticeComponent {
         let publishButton = app.buttons["Publish"]
-        publishButton.tap()
+        let publishNowButton = app.buttons["Publish Now"]
+        var tries = 0
+        // This loop to check for Publish Now Button is an attempt to confirm that the publishButton.tap() call took effect.
+        // The tests would fail sometimes in the pipeline with no apparent reason.
+        repeat {
+            publishButton.tap()
+            tries += 1
+        } while !publishNowButton.waitForIsHittable(timeout: 3) && tries <= 3
         try confirmPublish()
 
         return try EditorNoticeComponent(withNotice: "Post published", andAction: "View")

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -150,6 +150,17 @@ public class BlockEditorScreen: ScreenObject {
         } else {
             let publishNowButton = app.buttons["Publish Now"]
             publishNowButton.tap()
+            dismissBloggingRemindersAlertIfNeeded()
+        }
+    }
+
+    public func dismissBloggingRemindersAlertIfNeeded() {
+        let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
+
+        if bloggingRemindersAlertIsLoaded {
+            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+
+            dismissBloggingRemindersAlertButton.tap()
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -130,8 +130,10 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     private func addBlock(_ blockLabel: String) {
+        let blockButton = XCUIApplication().buttons[blockLabel]
         addBlockButton.tap()
-        XCUIApplication().buttons[blockLabel].tap()
+        guard blockButton.waitForIsHittable(timeout: 3) else { return }
+        blockButton.tap()
     }
 
     /*

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -158,9 +158,13 @@ public class BlockEditorScreen: ScreenObject {
         let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
 
         if bloggingRemindersAlertIsLoaded {
-            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+            if XCUIDevice.isPad {
+                app.swipeDown(velocity: .fast)
+            } else {
+                let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
 
-            dismissBloggingRemindersAlertButton.tap()
+                dismissBloggingRemindersAlertButton.tap()
+            }
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -130,9 +130,9 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     private func addBlock(_ blockLabel: String) {
-        let blockButton = XCUIApplication().buttons[blockLabel]
+        let blockButton = app.buttons[blockLabel]
         addBlockButton.tap()
-        guard blockButton.waitForIsHittable(timeout: 3) else { return }
+        XCTAssertTrue(blockButton.waitForIsHittable(timeout: 3))
         blockButton.tap()
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -155,16 +155,14 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     public func dismissBloggingRemindersAlertIfNeeded() {
-        let bloggingRemindersAlertIsLoaded = app.buttons["Set reminders"].waitForExistence(timeout: 3)
+        guard app.buttons["Set reminders"].waitForExistence(timeout: 3) else { return }
 
-        if bloggingRemindersAlertIsLoaded {
-            if XCUIDevice.isPad {
-                app.swipeDown(velocity: .fast)
-            } else {
-                let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
-
-                dismissBloggingRemindersAlertButton.tap()
-            }
+        if XCUIDevice.isPad {
+            app.swipeDown(velocity: .fast)
+        } else {
+            let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
+            dismissBloggingRemindersAlertButton.tap()
+        }
         }
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -163,7 +163,6 @@ public class BlockEditorScreen: ScreenObject {
             let dismissBloggingRemindersAlertButton = app.buttons.element(boundBy: 0)
             dismissBloggingRemindersAlertButton.tap()
         }
-        }
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -24,7 +24,6 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testTextPostPublish() throws {
-        try skipTillBloggingRemindersAreHandled()
 
         let title = getRandomPhrase()
         let content = getRandomContent()
@@ -39,7 +38,6 @@ class EditorGutenbergTests: XCTestCase {
     }
 
     func testBasicPostPublish() throws {
-        try skipTillBloggingRemindersAreHandled()
 
         let title = getRandomPhrase()
         let content = getRandomContent()
@@ -64,9 +62,5 @@ class EditorGutenbergTests: XCTestCase {
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()
-    }
-
-    func skipTillBloggingRemindersAreHandled(file: StaticString = #file, line: UInt = #line) throws {
-        try XCTSkipIf(true, "Skipping test because we haven't added support for Blogging Reminders. See https://github.com/wordpress-mobile/WordPress-iOS/issues/16797.", file: file, line: line)
     }
 }


### PR DESCRIPTION
See [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/17436#issuecomment-966698816).

~~**Update:** The green CI we're seeing is a _false positive_! See https://github.com/wordpress-mobile/WordPress-iOS/pull/17456.~~ The Xcode 13 UI tests CI fix has now been merged.