### PR TITLE
Fix UI tests not running since Xcode 13 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -304,7 +304,7 @@ workflows:
           requires: [ "Build Tests" ]
       # Always run UI tests on develop and release branches
       - UI Tests:
-          name: UI Tests (iPhone 11)
+          name: UI Tests (iPhone)
           <<: *iphone_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
@@ -315,7 +315,7 @@ workflows:
                 - /^release.*/
                 - /^gutenberg\/integrate_release_.*/
       - UI Tests:
-          name: UI Tests (iPad Air 4th generation)
+          name: UI Tests (iPad)
           <<: *ipad_test_device
           post-to-slack: true
           requires: [ "Build Tests" ]
@@ -338,11 +338,11 @@ workflows:
                 - /^release.*/
                 - /^gutenberg\/integrate_release_.*/
       - UI Tests:
-          name: UI Tests (iPhone 11)
+          name: UI Tests (iPhone)
           <<: *iphone_test_device
           requires: [ "Optional Tests" ]
       - UI Tests:
-          name: UI Tests (iPad Air 4th generation)
+          name: UI Tests (iPad)
           <<: *ipad_test_device
           requires: [ "Optional Tests" ]
   Installable Build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,7 +101,7 @@ jobs:
           command: bundle --path vendor/bundle
       - run:
           name: Run Unit Tests
-          command: bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3 device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
+          command: bundle exec fastlane test_without_building name:WordPressUnitTests device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
   UI Tests:
@@ -133,7 +133,7 @@ jobs:
           background: true
       - run:
           name: Run UI Tests
-          command: bundle exec fastlane test_without_building name:WordPressUITests try_count:3 device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
+          command: bundle exec fastlane test_without_building name:WordPressUITests device:'<< parameters.device >>' ios-version:'<< parameters.ios-version >>'
       - ios/save-xcodebuild-artifacts:
           result-bundle-path: build/results
       - when:

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -15,7 +15,8 @@
       "containerPath" : "container:WordPress.xcodeproj",
       "identifier" : "1D6058900D05DD3D006BFB54",
       "name" : "WordPress"
-    }
+    },
+    "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [
     {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -826,10 +826,10 @@ platform :ios do
   # It requires a prebuilt xctestrun file and simulator destination where the tests will be run.
   # -----------------------------------------------------------------------------------
   # Usage:
-  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>] [try_count:<Number of times to try tests>]
+  # bundle exec fastlane test_without_building [name:<Partial name of the .xctestrun file>]
   #
   # Example:
-  # bundle exec fastlane test_without_building name:UITests try_count:3
+  # bundle exec fastlane test_without_building name:UITests
   #####################################################################################
   desc 'Run tests without building'
   lane :test_without_building do |options|
@@ -844,25 +844,14 @@ platform :ios do
       UI.user_error!("Unable to find .xctestrun file at #{build_products_path}")
     end
 
-    # Because of what is likely a bug in `multi_scan`, we need to exclude
-    # certain tests from the execution.
-    #
-    # See more details at:
-    # - https://github.com/wordpress-mobile/WordPress-iOS/pull/17233#issuecomment-954897098
-    # - https://github.com/lyndsey-ferguson/fastlane-plugin-test_center/issues/358
-    all_tests = tests_from_xctestrun(xctestrun: test_plan_path)
-    only_testing = all_tests["WordPressTest"].reject { |t| t.include?("ContextManagerMock") || t.include?("TestContextManager") || t.include?("OCMLocation") || t.include?("HTTPStubsDescriptor") }
-
-    multi_scan(
+    run_tests(
       workspace: WORKSPACE_PATH,
       scheme: 'WordPress',
       device: options[:device],
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,
       test_without_building: true,
-      only_testing: only_testing,
       xctestrun: test_plan_path,
-      try_count: options[:try_count],
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
       result_bundle: true
     )


### PR DESCRIPTION
When we worked on [migrating to Xcode 13](https://github.com/wordpress-mobile/WordPress-iOS/pull/17233), we encountered weird looking failures running the tests via Fastlane. @leandroalonso did some [great investigation](https://github.com/wordpress-mobile/WordPress-iOS/pull/17233#issuecomment-954897098) and worked around them by introducing a filter for the tests to run (see the linked comments for more details).

What we didn't realize at the time was that those filters resulted in _every UI test being skipped_, as you can see by how fast the UI tests run and by the message they printed in the logs:

<img width="1130" alt="Screen Shot 2021-11-12 at 3 42 13 pm" src="https://user-images.githubusercontent.com/1218433/141410894-de22e7ab-ae69-4dc5-a2fd-f9d8ffb78c55.png">

_UI tests running in ~2 minutes when usually they run in ~20 minutes_


<img width="1183" alt="Screen Shot 2021-11-12 at 3 42 28 pm" src="https://user-images.githubusercontent.com/1218433/141410936-5efe4be1-c04f-4227-a8f7-50c6a89dbb3d.png">

_"then number of tests (0)"_

This PR address the issue by following up on [my observation](https://github.com/wordpress-mobile/WordPress-iOS/pull/17233#issuecomment-958648497) that the reason for the weird test failures was in `multi_scan` a third-party `xcodebuild test` overlay that we introduced in the past to have a form of test repetition in CI.

Xcode 13 introduced a Test Repetition Mode configuration for test plans and this PR uses it to remove `multi_scan` in favor of Fastlane's default `scan`.

To test this look at the CI behavior. As you can see in my [comment below](https://github.com/wordpress-mobile/WordPress-iOS/pull/17233#issuecomment-958648497), without even trying, we already had a chance to verify the retry on failure behavior 🙃 

![image](https://user-images.githubusercontent.com/1218433/141414393-21d50221-f049-4757-9041-4a37780a1ac4.png)
_You can see that the UI tests run in ~20 minutes each, as expected_