### PR TITLE
Support custom UIToolbar appearances in iOS 15

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -108,6 +108,16 @@ extension WPStyleGuide {
                                                    for: .disabled)
 
     }
+
+    class func configureToolbarAppearance() {
+        if #available(iOS 15.0, *) {
+            let appearance = UIToolbarAppearance()
+            appearance.configureWithDefaultBackground()
+
+            UIToolbar.appearance().standardAppearance = appearance
+            UIToolbar.appearance().scrollEdgeAppearance = appearance
+        }
+    }
 }
 
 

--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -110,11 +110,12 @@ extension WPStyleGuide {
     }
 
     class func configureToolbarAppearance() {
-        if #available(iOS 15.0, *) {
-            let appearance = UIToolbarAppearance()
-            appearance.configureWithDefaultBackground()
+        let appearance = UIToolbarAppearance()
+        appearance.configureWithDefaultBackground()
 
-            UIToolbar.appearance().standardAppearance = appearance
+        UIToolbar.appearance().standardAppearance = appearance
+
+        if #available(iOS 15.0, *) {
             UIToolbar.appearance().scrollEdgeAppearance = appearance
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -824,6 +824,7 @@ extension WordPressAppDelegate {
         WPStyleGuide.configureTableViewAppearance()
         WPStyleGuide.configureDefaultTint()
         WPStyleGuide.configureLightNavigationBarAppearance()
+        WPStyleGuide.configureToolbarAppearance()
 
         UISegmentedControl.appearance().setTitleTextAttributes( [NSAttributedString.Key.font: WPStyleGuide.regularTextFont()], for: .normal)
         UISwitch.appearance().onTintColor = .primary

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -319,14 +319,15 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
             return
         }
 
+        let appearance = UIToolbarAppearance()
+        appearance.configureWithDefaultBackground()
+        appearance.backgroundColor = UIColor(light: .white, dark: .appBarBackground)
+        appearance.backgroundEffect = UIBlurEffect(style: .systemThinMaterial)
+
+        toolBar.standardAppearance = appearance
+
         if #available(iOS 15.0, *) {
-            let appearance = UIToolbarAppearance()
-            appearance.configureWithDefaultBackground()
-            appearance.backgroundColor = UIColor(light: .white, dark: .appBarBackground)
-            toolBar.standardAppearance = appearance
             toolBar.scrollEdgeAppearance = appearance
-        } else {
-            toolBar.barTintColor = UIColor(light: .white, dark: .appBarBackground)
         }
 
         fixBarButtonsColorForBoldText(on: toolBar)

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -318,7 +318,17 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         guard let toolBar = navigationController?.toolbar else {
             return
         }
-        toolBar.barTintColor = UIColor(light: .white, dark: .appBarBackground)
+
+        if #available(iOS 15.0, *) {
+            let appearance = UIToolbarAppearance()
+            appearance.configureWithDefaultBackground()
+            appearance.backgroundColor = UIColor(light: .white, dark: .appBarBackground)
+            toolBar.standardAppearance = appearance
+            toolBar.scrollEdgeAppearance = appearance
+        } else {
+            toolBar.barTintColor = UIColor(light: .white, dark: .appBarBackground)
+        }
+
         fixBarButtonsColorForBoldText(on: toolBar)
     }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -322,7 +322,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         let appearance = UIToolbarAppearance()
         appearance.configureWithDefaultBackground()
         appearance.backgroundColor = UIColor(light: .white, dark: .appBarBackground)
-        appearance.backgroundEffect = UIBlurEffect(style: .systemThinMaterial)
 
         toolBar.standardAppearance = appearance
 


### PR DESCRIPTION
Fixes #17454

This PR aims to resolve a [toolbar](https://developer.apple.com/design/human-interface-guidelines/ios/bars/toolbars/) styling issue on iOS 15 when the project is compiled with Xcode 13+.

### To test:

**On an iOS 15 device running the project compiled by Xcode 13:**
1. On a site with published posts, go to My Site
2. Tap Posts
3. Tap View
4. Observe that the toolbar at the bottom has an opaque background that's appropriate for light and dark mode

<div>
<img src="https://user-images.githubusercontent.com/2092798/141499843-344cb34a-0628-45de-a1bf-c955d941d9ad.png" width="250px" alt="Post preview in light mode" />

<img src="https://user-images.githubusercontent.com/2092798/141499863-af297b29-d915-41bb-b4c2-5d08fa197f7b.png" width="250px" alt="Post preview in dark mode" />
</div>

## Regression Notes
1. Potential unintended areas of impact
- iOS 13 and iOS 14 views with toolbars (e.g. viewing a Post or Page preview)
- Any other views that include toolbars in the app [[See Apple HIG](https://developer.apple.com/design/human-interface-guidelines/ios/bars/toolbars/) for examples of toolbars]

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Compared the toolbars on iOS 14 and 15 when viewing a published post
- Inspected other toolbars, such as the one shown when cropping an image inside a post

3. What automated tests I added (or what prevented me from doing so)
None, as this is a visual change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
