### PR TITLE
Comment Detail: Fix comment content cell not resizing after edit

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -114,11 +114,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         configureViews()
     }
 
-    override func prepareForReuse() {
-        onContentLoaded = nil
-        htmlContentCache = nil
-    }
-
     // MARK: Public Methods
 
     /// Configures the cell with a `Comment` object.
@@ -148,8 +143,14 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
             moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)
         }
 
+        // optimize: do not reload if the content doesn't change.
+        if let contentCache = commentContentCache, contentCache == comment.content {
+            return
+        }
+
         // Configure comment content.
         self.onContentLoaded = onContentLoaded
+        webViewHeightConstraint.constant = 1 // reset webview height to handle cases where the new content requires the webview to shrink.
         webView.isOpaque = false // gets rid of the white flash upon content load in dark mode.
         webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Self.resourceURL)
     }


### PR DESCRIPTION
Refs #17087 

As titled, this PR addresses an issue where the web view does not "shrink" properly when the content is edited to something that takes up less height than the previous content.

As an addition, I've also added an optimization method to minimize the number of HTML loads. In particular, since the comment content is cached, the configure method will now simply return early when the `Comment` object's `content` matches the cached content.

I've also noticed an issue where the content cell reloads twice after an edit, despite having the optimization method in place. Turns out, this is because the content is _slightly_ different. For example, let's assume we are editing a comment to: `An edited reply`. 

- Before the comment is successfully uploaded, the content is: `An edited reply`. The webview reload for this is expected, since it could need a height adjustment.
- After the comment is successfully uploaded, the content is: `<p>An edited reply</p>`. While it looks no different when rendered, it skips the optimization in the content cell.

Of course, there's I can try to sanitize it with regex, but I prefer [not to go down that road](https://stackoverflow.com/a/1732454) 😂 . Anyways, I'll note this down somewhere and see if there's a better solution to address this later on.

---

⚠️ NOTE: Auto-merge is enabled.

---

## To Test

- Enable the `newCommentDetail` feature flag.
- Go to My Site > Comments, and select a comment that's safe to edit.
- Edit the comment into something that has quite a long text. Here's one:
  ```
  Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
  ```
- 🔍 Verify that the content cell resizes properly.
- Rotate the interface to landscape. 
- 🔍 Verify that the content cell adjusts itself properly.
- Edit the comment back into something short, ideally a one-line text.
- 🔍 Verify that the content cell resizes properly.
- Rotate the interface back to portrait.
- 🔍 Verify that the content cell adjusts itself properly.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
