### PR TITLE
Remove PR list generation at codefreeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -118,8 +118,6 @@ platform :ios do
       extracted_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt')
     )
     ios_update_release_notes(new_version: new_version)
-    get_prs_list(repository: GHHELPER_REPO, milestone: new_version.to_s,
-                 report_path: "#{File.expand_path('~')}/wpios_prs_list_#{old_version}_#{new_version}.txt")
     setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository: GHHELPER_REPO, milestone: new_version)
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -858,11 +858,6 @@ platform :ios do
 ########################################################################
 # Helper Lanes
 ########################################################################
-  desc "Get a list of pull request for a given `milestone`"
-  lane :get_pullrequests_list do | options |
-    get_prs_list(repository: GHHELPER_REPO, milestone:"#{options[:milestone]}", report_path:"#{File.expand_path('~')}/wpios_prs_list.txt")
-  end
-
   desc 'Verifies that Gutenberg is referenced by release version and not by commit'
   lane :gutenberg_dep_check do |_options|
     res = ''


### PR DESCRIPTION
This PR removes the step in Fastlane's `code_freeze` lane that generates a text file with a list of the PRs that made it to the new version. With the current process to generate the release notes and the new tooling we built to generate the draft of the release announcement, this file is not used anymore. 

~~I'm not removing the `get_pullrequests_list` lane that allows generating the same file on request.~~

## Regression Notes
1. Potential unintended areas of impact
- 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
