### PR TITLE
Comment Detail: Fix spacing for views in content cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -28,7 +28,14 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         }
     }
 
+    // MARK: Constants
+
+    private let customBottomSpacing: CGFloat = 10
+
     // MARK: Outlets
+
+    @IBOutlet private weak var containerStackView: UIStackView!
+    @IBOutlet private weak var containerStackBottomConstraint: NSLayoutConstraint!
 
     @IBOutlet private weak var avatarImageView: CircularImageView!
     @IBOutlet private weak var nameLabel: UILabel!
@@ -143,6 +150,13 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isCommentLikesEnabled = isReactionEnabled && (comment.blog?.supports(.commentLikes) ?? false)
         isAccessoryButtonEnabled = comment.isApproved()
         isModerationEnabled = comment.allowsModeration()
+
+        // When reaction bar is hidden, add some space between the webview and the moderation bar.
+        containerStackView.setCustomSpacing(isReactionEnabled ? 0 : customBottomSpacing, after: webView)
+
+        // When both reaction bar and moderation bar is hidden, the custom spacing for the webview won't be applied since it's at the bottom of the stack view.
+        // The reaction bar and the moderation bar have their own spacing, unlike the webview. Therefore, additional bottom spacing is needed.
+        containerStackBottomConstraint.constant = (isReactionEnabled || isModerationEnabled) ? 0 : customBottomSpacing
 
         if isModerationEnabled {
             moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -106,7 +106,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="60" y="0.0" width="82.5" height="0.0"/>
+                                        <rect key="frame" x="60" y="0.0" width="78.5" height="0.0"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="5" minY="10" maxX="35" maxY="15"/>
@@ -153,6 +153,8 @@
             <connections>
                 <outlet property="accessoryButton" destination="1G8-cc-t5d" id="kLS-Ag-hAG"/>
                 <outlet property="avatarImageView" destination="9QY-3I-cxv" id="lbp-Hv-zRm"/>
+                <outlet property="containerStackBottomConstraint" destination="jAu-U3-I4N" id="1Hk-Cp-fR5"/>
+                <outlet property="containerStackView" destination="hcN-S7-sLG" id="k9D-6a-BmR"/>
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="moderationBar" destination="T1Z-LV-01Y" id="YUL-ft-QkO"/>


### PR DESCRIPTION
Refs #17087

As titled, this fixes the spacing for the cell to make it look good in various scenarios. Here are some screenshots:

Description | Screenshot
--|--
All components are displayed. Full power mode! | ![full](https://user-images.githubusercontent.com/1299411/141453788-754c658f-888e-4139-a400-83a512d7be47.png)
No reaction bar | ![noReactionBar](https://user-images.githubusercontent.com/1299411/141453785-8bffd27c-8325-4d36-b15b-084c49bfcbb4.png)
No moderation bar | ![noModerationBar](https://user-images.githubusercontent.com/1299411/141453782-a2bebbbf-903f-4990-bac2-6774d5e1e912.png)
Read only | ![replyOnly](https://user-images.githubusercontent.com/1299411/141453774-9fe8af4e-d596-4c91-898f-cf841524719f.png)


---

⚠️ NOTE: Auto-merge is enabled. ⚠️ 

---

## To Test

Note: It's easiest for me to modify the values of `isReactionEnabled` and `isModerationEnabled` rather than having to switch sites or accounts, to be honest. 😅 

- Enable `newCommentDetail` feature flag.
- Go to My Site > Comments.
- Verify that the content cell is displayed properly when viewed:
  - With moderation capability and ENABLED reactions.
  - With moderation capability and DISABLED reactions. (I'm not sure if this is possible in a real use case, though...)
  - With NO moderation capability and ENABLED reactions.
  - With NO moderation capability and DISABLED reactions.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
