### PR TITLE
Comment Detail:  Fix Delete button not shown or hidden after moderation status update

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -674,6 +674,7 @@ private extension CommentDetailViewController {
 
         commentService.unapproveComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.pendingSuccess)
+            self?.refreshData()
         }, failure: { [weak self] error in
             self?.displayNotice(title: ModerationMessages.pendingFail)
             self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
@@ -685,6 +686,7 @@ private extension CommentDetailViewController {
 
         commentService.approve(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.approveSuccess)
+            self?.refreshData()
         }, failure: { [weak self] error in
             self?.displayNotice(title: ModerationMessages.approveFail)
             self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
@@ -696,6 +698,7 @@ private extension CommentDetailViewController {
 
         commentService.spamComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.spamSuccess)
+            self?.refreshData()
         }, failure: { [weak self] error in
             self?.displayNotice(title: ModerationMessages.spamFail)
             self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
@@ -707,6 +710,7 @@ private extension CommentDetailViewController {
 
         commentService.trashComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.trashSuccess)
+            self?.refreshData()
         }, failure: { [weak self] error in
             self?.displayNotice(title: ModerationMessages.trashFail)
             self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)


### PR DESCRIPTION
Refs #17087

As titled. After successfully updating the moderation status, `refreshData` is called to make the Delete button appear/disappear where appropriate.

## To test

- Enable `newCommentDetail` feature flag.
- Go to My Site > Comments. 
- Select a pending or approved comment, and update its moderation status to Spam.
- 🔍  Verify that the Delete button is now shown, along with the notice.
- Update the moderation status again to pending or approved.
- 🔍  Verify that the Delete button is now hidden when the notice is shown.

---

⚠️ NOTE: Auto-merge is enabled! ⚠️ 

---

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
