### PR TITLE
Comment Detail: Fix content cell elements not resizing in AX size

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -244,16 +244,22 @@ private extension CommentContentTableViewCell {
 
         replyButton?.tintColor = Style.buttonTintColor
         replyButton?.titleLabel?.font = Style.reactionButtonFont
+        replyButton?.titleLabel?.adjustsFontSizeToFitWidth = true
+        replyButton?.titleLabel?.adjustsFontForContentSizeCategory = true
         replyButton?.setTitle(.reply, for: .normal)
         replyButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         replyButton?.setImage(Style.replyIconImage, for: .normal)
         replyButton?.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
         replyButton?.flipInsetsForRightToLeftLayoutDirection()
+        replyButton?.adjustsImageSizeForAccessibilityContentSizeCategory = true
 
         likeButton?.titleLabel?.font = Style.reactionButtonFont
+        likeButton?.titleLabel?.adjustsFontSizeToFitWidth = true
+        likeButton?.titleLabel?.adjustsFontForContentSizeCategory = true
         likeButton?.setTitleColor(Style.reactionButtonTextColor, for: .normal)
         likeButton?.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
         likeButton?.flipInsetsForRightToLeftLayoutDirection()
+        likeButton?.adjustsImageSizeForAccessibilityContentSizeCategory = true
         updateLikeButton(liked: false, numberOfLikes: 0)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -40,7 +40,7 @@
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
                                                 <rect key="frame" x="0.0" y="16.5" width="208" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
@@ -106,7 +106,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="60" y="0.0" width="82.5" height="0.0"/>
+                                        <rect key="frame" x="60" y="0.0" width="78.5" height="0.0"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="5" minY="10" maxX="35" maxY="15"/>

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -68,7 +68,7 @@
                                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="CzL-pe-Tnr" secondAttribute="bottom" constant="15" id="FLO-bi-cgb"/>
                                     <constraint firstItem="CzL-pe-Tnr" firstAttribute="top" secondItem="9QY-3I-cxv" secondAttribute="top" id="Fs5-LK-eAC"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="CzL-pe-Tnr" secondAttribute="trailing" id="R3L-jf-zLP"/>
-                                    <constraint firstAttribute="bottom" secondItem="9QY-3I-cxv" secondAttribute="bottom" priority="750" constant="15" id="S4y-cM-fX9"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9QY-3I-cxv" secondAttribute="bottom" priority="750" constant="15" id="S4y-cM-fX9"/>
                                     <constraint firstItem="9QY-3I-cxv" firstAttribute="top" secondItem="f2E-yC-BJS" secondAttribute="top" constant="20" id="VRu-Tu-EzK"/>
                                     <constraint firstItem="1G8-cc-t5d" firstAttribute="centerY" secondItem="9QY-3I-cxv" secondAttribute="centerY" id="iiu-dq-fba"/>
                                     <constraint firstItem="1G8-cc-t5d" firstAttribute="leading" secondItem="CzL-pe-Tnr" secondAttribute="trailing" id="kMf-Ux-GI7"/>


### PR DESCRIPTION
Refs #17087

As titled, this PR now ensures that:

- The content cell header properly displays the text under increased font size.
- The Reply and Like buttons' sizes are adjusted along with the device's font size.

---

⚠️ Auto-merge is enabled. ⚠️ 

---

To note: I've tried to fix an issue with VoiceOver but to no avail. The screen reader somehow jumps to the top of the screen again after reading the contents of the web view. It looks like WKWebView is buggy (just my luck), and after loading the HTML content, somehow the accessibility parent of the web view got reassigned. I believe this is what caused the screen reader to "jump".

<img width="565" alt="Screen Shot 2021-11-12 at 23 48 14" src="https://user-images.githubusercontent.com/1299411/141503728-e041bb12-f00b-4b67-b6b6-28fc5d05b3fa.png">

The highlighted element is the table view container. As you can see, there are five elements. The first one is the comment header, the second one is the content cell, and so on. Next is the hierarchy for the content cell:

<img width="566" alt="Screen Shot 2021-11-12 at 23 49 01" src="https://user-images.githubusercontent.com/1299411/141504175-844c7ee8-dc57-412e-b92a-723e1f3022b0.png">

Above is the content cell element unwrapped. You can see all the accessible elements there in the content cell[^1], and the one that I highlighted is a group for the web view. Next, I'll go deeper into the web view and this is what I got:

<img width="564" alt="Screen Shot 2021-11-12 at 23 49 21" src="https://user-images.githubusercontent.com/1299411/141504211-5b2c11d0-7532-46fd-bc54-03b65b80f42d.png">

"Hey there." is the comment content. As you can see, it's somehow nested right under `SimulatorKit.SimDisplayRenderableView`, which is almost at the very top of the hierarchy. This is why the screen reader won't continue after reading the contents of the web view. Sigh.

I have tried a lot of things to fix this and to the point of accessing the private `WKContentView` class of WKWebView to see if I could apply some hack or something, but nope. This gives me more reason to create a standalone, reproducible project and submit a radar. 😅 

## To test

- Increase device/simulator font size.
- Enable `newCommentDetail` feature flag.
- Go to My Site > Comments and select any comment.
- 🔍  Verify that the content cell is displayed correctly, adjusting the contents' sizes with the device's current font size.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: There's also a strange ordering issue here. Somehow the web view element is placed _after_ the Reply and Like button. 🤔 