### PR TITLE
Comments: Enable the new comment details for My Site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Comment Reply: updated UI. [#17443, #17445]
 * [***] Two-step Authentication notifications now require an unlocked device to approve or deny them.
+* [***] Site Comments: Updated comment details with a fresh new look and capability to display rich contents. [#17466]
 
 18.6
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -55,7 +55,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             // This may be removed, but we're feature flagging it for now until we know for sure we won't need it.
             return false
         case .newCommentDetail:
-            return false
+            // NOTE: only applies to My Site > Comments.
+            return true
         case .domains:
             return BuildConfiguration.current == .localDeveloper
         case .followConversationViaNotifications:


### PR DESCRIPTION
Refs: #17087, `pbArwn-2ks-p2`

<img width="2175" alt="screen-shot-2021-08-20-at-2 37 25-pm" src="https://user-images.githubusercontent.com/1299411/141509773-69d746ee-3b7e-4cc4-bbe3-4fdd8349b67d.png">

This enables the new comment detail for the public. Please note that the new design is only enabled for comment details opened from My Site > Comments. The comment details from Notifications will still be using the previous design.

Aside from the new look, there are also some functional changes/additions:

- The top row should now show a sneak peek of the parent "object" – i.e. it shows the post title if the author commented on the post, or it shows the parent comment if the author replied to another comment. Previously, it always shows the post title.
- The comment detail should now display rich content properly.
- For approved comments, users can now tap on the share button (placed on the right side of the author's name) to share the comment link.
- When using accounts with moderation roles (Administrator or Editor), the comment detail should now display more detailed information about the author: Email address, IP address.
- To visit the author's URL, users can now tap on the Web address role, instead of previously tapping on the avatar image.

---

⚠️ NOTE: Before merging this, please ensure these are merged first: ⚠️ 
- #17460
- #17462
- #17463
- #17464
- #17469

---

## To Test

- Navigate to My Site > Comments.
- Select any comments.
- Observe that the comment details are displayed with a new look. ✨ 

## Regression Notes
1. Potential unintended areas of impact
Contents not displayed properly, functionality or behavior differs from the old design.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that the new design completely covers the capabilities of the old design.

3. What automated tests I added (or what prevented me from doing so)
All service-related logic is unit tested.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
