### PR TITLE
Unified About: Add device motion and haptics

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,5 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
+BUNDLE_RETRY: "3"
+BUNDLE_JOBS: "3"
 BUNDLE_WITHOUT: "screenshots"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,5 +1,3 @@
 ---
 BUNDLE_PATH: "vendor/bundle"
-BUNDLE_RETRY: "3"
-BUNDLE_JOBS: "3"
 BUNDLE_WITHOUT: "screenshots"

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -254,6 +254,17 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
 
+    // Note that this method only appears to be called for iPhone devices, not iPad.
+    // This allows individual view controllers to cancel rotation if they need to.
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        if let vc = window?.topmostPresentedViewController,
+           vc is OrientationLimited {
+            return vc.supportedInterfaceOrientations
+        }
+
+        return application.supportedInterfaceOrientations(for: window)
+    }
+
     // MARK: - Setup
 
     func runStartupSequence(with launchOptions: [UIApplication.LaunchOptionsKey: Any] = [:]) {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
@@ -261,11 +261,15 @@ private class AppLogosScene: SKScene {
     }
 
     private func gravityVector(with acceleration: CMAcceleration) -> CGVector {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            // iPhone locks the interface orientation, so we can just use the acceleration as-is
+            return CGVector(dx: acceleration.x, dy: acceleration.y)
+        }
+        
+        // iPad rotates the interface so we need to change the gravity acceleration to match
         switch UIDevice.current.orientation {
         case .portraitUpsideDown:
-            // iPad always rotates the screen so needs the axes flipped, but iPhone keeps the orientation locked
-            return UIDevice.current.userInterfaceIdiom == .pad ?
-                CGVector(dx: -acceleration.x, dy: -acceleration.y) : CGVector(dx: acceleration.x, dy: acceleration.y)
+            return CGVector(dx: -acceleration.x, dy: -acceleration.y)
         case .landscapeLeft:
             return CGVector(dx: -acceleration.y, dy: acceleration.x)
         case .landscapeRight:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SpriteKit
+import CoreMotion
 
 /// A table view cell that contains a SpriteKit game scene which shows logos
 /// of the various apps from Automattic.
@@ -82,6 +83,8 @@ private class AppLogosScene: SKScene {
     // Stores a reference to each of the balls in the scene
     private var balls: [SKNode] = []
 
+    private let motionManager = CMMotionManager()
+
     private var traitCollection: UITraitCollection?
 
 
@@ -89,7 +92,8 @@ private class AppLogosScene: SKScene {
 
     override func didMove(to view: SKView) {
         super.didMove(to: view)
-
+        
+        motionManager.startAccelerometerUpdates()
         generateScene()
     }
 
@@ -227,5 +231,11 @@ private class AppLogosScene: SKScene {
     enum Constants {
         static let appLogoPrefix = "ua-logo-"
         static let physicsRestitution: CGFloat = 0.5
+    }
+
+    override func update(_ currentTime: TimeInterval) {
+        if let accelerometerData = motionManager.accelerometerData {
+            physicsWorld.gravity = CGVector(dx: accelerometerData.acceleration.x * 9.8, dy: accelerometerData.acceleration.y * 9.8)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
@@ -265,7 +265,7 @@ private class AppLogosScene: SKScene {
             // iPhone locks the interface orientation, so we can just use the acceleration as-is
             return CGVector(dx: acceleration.x, dy: acceleration.y)
         }
-        
+
         // iPad rotates the interface so we need to change the gravity acceleration to match
         switch UIDevice.current.orientation {
         case .portraitUpsideDown:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -162,6 +162,14 @@ class UnifiedAboutViewController: UIViewController {
         tableView.reloadData()
     }
 
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            self.tableView.scrollToRow(at: IndexPath(row: 1, section: 2), at: .middle, animated: true)
+        }
+    }
+
     // MARK: - Constants
 
     enum Metrics {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -68,7 +68,7 @@ struct AboutItem {
     }
 }
 
-class UnifiedAboutViewController: UIViewController {
+class UnifiedAboutViewController: UIViewController, OrientationLimited {
     static let sections: [[AboutItem]] = [
         [
             AboutItem(title: "Rate Us"),
@@ -86,6 +86,8 @@ class UnifiedAboutViewController: UIViewController {
             AboutItem(title: "Work With Us", subtitle: "Join From Anywhere", cellStyle: .subtitle)
         ]
     ]
+
+    private static let appLogosIndexPath = IndexPath(row: 1, section: 2)
 
     let headerView: UIView = {
         // These customizations are temporarily here, but if this VC is moved into a framework we'll need to move them
@@ -138,6 +140,10 @@ class UnifiedAboutViewController: UIViewController {
         return footerView
     }()
 
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+
     // MARK: - View lifecycle
 
     override func viewDidLoad() {
@@ -165,8 +171,8 @@ class UnifiedAboutViewController: UIViewController {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-            self.tableView.scrollToRow(at: IndexPath(row: 1, section: 2), at: .middle, animated: true)
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.appLogosScrollDelay) {
+            self.tableView.scrollToRow(at: UnifiedAboutViewController.appLogosIndexPath, at: .middle, animated: true)
         }
     }
 
@@ -175,6 +181,10 @@ class UnifiedAboutViewController: UIViewController {
     enum Metrics {
         static let footerHeight: CGFloat = 58.0
         static let footerVerticalOffset: CGFloat = 20.0
+    }
+
+    enum Constants {
+        static let appLogosScrollDelay: TimeInterval = 0.25
     }
 
     enum Images {

--- a/WordPress/Classes/ViewRelated/System/OrientationLimited.swift
+++ b/WordPress/Classes/ViewRelated/System/OrientationLimited.swift
@@ -1,0 +1,6 @@
+import UIKit
+
+// On rotation, WordPressAppDelegate will check if a VC is OrientationLimited.
+// If so, it will use the VC's value for supportedInterfaceOrientations when
+// returning a value from application(_:supportedInterfaceOrientationsFor:)
+protocol OrientationLimited: UIViewController {}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		1730D4A31E97E3E400326B7C /* MediaItemTableViewCells.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1730D4A21E97E3E400326B7C /* MediaItemTableViewCells.swift */; };
 		173BCE791CEB780800AE8817 /* Domain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173BCE781CEB780800AE8817 /* Domain.swift */; };
 		173D82E7238EE2A7008432DA /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */; };
+		173DF288274294DB007C64B5 /* OrientationLimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF287274294DB007C64B5 /* OrientationLimited.swift */; };
+		173DF289274294DB007C64B5 /* OrientationLimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF287274294DB007C64B5 /* OrientationLimited.swift */; };
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
 		1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1749965E2271BF08007021BD /* WordPressAppDelegate.swift */; };
 		174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C116E2624603400346EC6 /* MBarRouteTests.swift */; };
@@ -4807,6 +4809,7 @@
 		1730D4A21E97E3E400326B7C /* MediaItemTableViewCells.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaItemTableViewCells.swift; sourceTree = "<group>"; };
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
 		173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
+		173DF287274294DB007C64B5 /* OrientationLimited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLimited.swift; sourceTree = "<group>"; };
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1749965E2271BF08007021BD /* WordPressAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAppDelegate.swift; sourceTree = "<group>"; };
 		174C116E2624603400346EC6 /* MBarRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBarRouteTests.swift; sourceTree = "<group>"; };
@@ -11232,6 +11235,7 @@
 				3F30E50823FB362700225013 /* WPTabBarController+MeNavigation.swift */,
 				43DDFE8B21715ADD008BE72F /* WPTabBarController+QuickStart.swift */,
 				57BAD50B225CCE1A006139EC /* WPTabBarController+Swift.swift */,
+				173DF287274294DB007C64B5 /* OrientationLimited.swift */,
 			);
 			path = System;
 			sourceTree = "<group>";
@@ -17934,6 +17938,7 @@
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
 				98BAA7C326F925F70073A2F9 /* InlineEditableSingleLineCell.swift in Sources */,
 				57276E71239BDFD200515BE2 /* NotificationCenter+ObserveMultiple.swift in Sources */,
+				173DF288274294DB007C64B5 /* OrientationLimited.swift in Sources */,
 				D817799020ABF26800330998 /* ReaderCellConfiguration.swift in Sources */,
 				FF1B11E5238FDFE70038B93E /* GutenbergGalleryUploadProcessor.swift in Sources */,
 				F5E1BA9B253A0A5E0091E9A6 /* StoriesIntroViewController.swift in Sources */,
@@ -19807,6 +19812,7 @@
 				3FE3D1FE26A6F4AC00F3CD10 /* ListTableHeaderView.swift in Sources */,
 				FABB23052602FC2C00C8785C /* WPAnalyticsEvent.swift in Sources */,
 				FABB23062602FC2C00C8785C /* Coordinate.m in Sources */,
+				173DF289274294DB007C64B5 /* OrientationLimited.swift in Sources */,
 				F1D8C6EC26BABE3E002E3323 /* WeeklyRoundupDebugScreen.swift in Sources */,
 				FABB23072602FC2C00C8785C /* SiteCreationRotatingMessageView.swift in Sources */,
 				FABB23082602FC2C00C8785C /* SignupUsernameViewController.swift in Sources */,


### PR DESCRIPTION
Refs #17405. This PR re-introduces device motion to the about screen and also adds haptic feedback on iPhones (thanks for the suggestion @annchichi!)

https://user-images.githubusercontent.com/4780/141813384-e01f090b-4d2d-4e6f-a6ea-053566aaa93d.mov

(the above video doesn't seem to be working for me in Firefox but is fine in Safari)

I finally found a way to lock the orientation of this screen on iPhone! I don't feel like it's too much of a hack, and it's limited to only this screen so it shouldn't affect anything else. As such, I've re-added device motion support to the app bubbles. Now as you rotate your device they should track the motion of the device. You'll also feel some haptic feedback on iPhone devices as they collide.

On iPad the orientation isn't locked, so the screen will auto-rotate. However, as the device is larger this doesn't feel as bad as it did on iPhones (you only had to tilt them a little before the screen would flip).

**Known Issues**

On iPhone, if you're viewing the Me screen in landscape and tap to view the About screen, it initially displays in landscape and the balls won't move in the correct direction of gravity. Once you rotate to portrait everything will be correct. I would hope that this is a quite unlikely to happen and it'll likely resolve itself as the user rotates their device anyway.

**To test:**

* Build and run on physical devices. Test both iPhone and iPad.
* Navigate to the About screen and try tilting and rotating the device. Check that the balls move in the direction you expect.
* Double check that a few other screens continue to rotate as you'd expect – I think essentially most screens should rotate except for the login flow.

## Regression Notes

1. Potential unintended areas of impact

* Rotation in other areas of the app, but I think my changes are just limited to this one specific screen due to the extra protocol I added.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I did a smoke test of rotating various areas of the app and everything seems to work as it should.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
