### PR TITLE
Adds tracking coverage to the My Sites No Sites view

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -209,6 +209,11 @@ import Foundation
     case domainsRegistrationFormViewed
     case domainsRegistrationFormSubmitted
     case domainsPurchaseWebviewViewed
+        
+    // My Site: No sites view displayed
+    case mySiteNoSitesViewDisplayed
+    case mySiteNoSitesViewActionTapped
+    case mySiteNoSitesViewHidden
 
     /// A String that represents the event
     var value: String {
@@ -574,6 +579,14 @@ import Foundation
             return "domains_registration_form_submitted"
         case .domainsPurchaseWebviewViewed:
             return "domains_purchase_webview_viewed"
+            
+        // My Site No Sites View
+        case .mySiteNoSitesViewDisplayed:
+            return "my_site_no_sites_view_displayed"
+        case .mySiteNoSitesViewActionTapped:
+            return "my_site_no_sites_view_action_tapped"
+        case .mySiteNoSitesViewHidden:
+            return "my_site_no_sites_view_hidden"
         }
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -209,7 +209,7 @@ import Foundation
     case domainsRegistrationFormViewed
     case domainsRegistrationFormSubmitted
     case domainsPurchaseWebviewViewed
-        
+
     // My Site: No sites view displayed
     case mySiteNoSitesViewDisplayed
     case mySiteNoSitesViewActionTapped
@@ -579,7 +579,7 @@ import Foundation
             return "domains_registration_form_submitted"
         case .domainsPurchaseWebviewViewed:
             return "domains_purchase_webview_viewed"
-            
+
         // My Site No Sites View
         case .mySiteNoSitesViewDisplayed:
             return "my_site_no_sites_view_displayed"

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -73,6 +73,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         FancyAlertViewController.presentCustomAppIconUpgradeAlertIfNecessary(from: self)
+        
+        trackNoSitesVisibleIfNeeded()
     }
 
     private func subscribeToPostSignupNotifications() {
@@ -173,6 +175,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - No Sites UI logic
 
     private func hideNoSites() {
+        // Only track if the no sites view is currently visible
+        if noResultsViewController.view.superview != nil {
+            WPAnalytics.track(.mySiteNoSitesViewHidden)
+        }
+        
         hideNoResults()
 
         cleanupNoResultsView()
@@ -195,6 +202,14 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         makeNoResultsScrollView()
         configureNoResultsView()
         addNoResultsViewAndConfigureConstraints()
+    }
+    
+    private func trackNoSitesVisibleIfNeeded() {
+        guard noResultsViewController.view.superview != nil else {
+            return
+        }
+        
+        WPAnalytics.track(.mySiteNoSitesViewDisplayed)
     }
 
     private func makeNoResultsScrollView() {
@@ -223,6 +238,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                                           image: "mysites-nosites")
         noResultsViewController.actionButtonHandler = { [weak self] in
             self?.presentInterfaceForAddingNewSite()
+            WPAnalytics.track(.mySiteNoSitesViewActionTapped)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -73,7 +73,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         FancyAlertViewController.presentCustomAppIconUpgradeAlertIfNecessary(from: self)
-        
+
         trackNoSitesVisibleIfNeeded()
     }
 
@@ -179,7 +179,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         if noResultsViewController.view.superview != nil {
             WPAnalytics.track(.mySiteNoSitesViewHidden)
         }
-        
+
         hideNoResults()
 
         cleanupNoResultsView()
@@ -203,12 +203,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         configureNoResultsView()
         addNoResultsViewAndConfigureConstraints()
     }
-    
+
     private func trackNoSitesVisibleIfNeeded() {
         guard noResultsViewController.view.superview != nil else {
             return
         }
-        
+
         WPAnalytics.track(.mySiteNoSitesViewDisplayed)
     }
 


### PR DESCRIPTION
## Description
This adds tracking coverage to the My Sites: No Sites view when:

1. The view is displayed: `my_site_no_sites_view_displayed`
2. The action button is tapped: `my_site_no_sites_view_action_tapped`
3. The view is hidden: `my_site_no_sites_hidden`

## To test:

1. Launch the app with an account that you have sites linked to
2. Verify the following events are not logged: `my_site_no_sites_view_displayed`, `my_site_no_sites_view_action_tapped`, `my_site_no_sites_hidden`
3. Logout of that account, and sign into an account that has no sites link it (or create a new account and skip the site creation process)
4. After logging in, verify you see `🔵 Tracked: my_site_no_sites_view_displayed <>` in the console
5. Tap the 'Add new site' button
6. Verify you see `🔵 Tracked: my_site_no_sites_view_action_tapped <>` in the console
7. Dismiss the site creation flow
8. Restart the app
9. Verify you see the following tracks in this order:
```
🔵 Tracked: application_opened <>
🔵 Tracked: my_site_tab_accessed <>
🔵 Tracked: my_site_no_sites_view_displayed <>
```
11. Tap the add site button again
7. Go through the site creation process 
8. After successfully creating your site verify you see `🔵 Tracked: my_site_no_sites_view_hidden <>` logged once
9. Delete the site using Site Settings
10. Verify `🔵 Tracked: my_site_no_sites_view_displayed <>` is logged in console

## Regression Notes
1. Potential unintended areas of impact
This only adds tracking and does not modify existing behavior. Therefore there should not be any unintended areas of impact. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
