### PR TITLE
Comments: Extract comment header cell configuration

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,6 +19,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case domains
     case followConversationViaNotifications
     case aboutScreen
+    case newCommentThread
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -63,6 +64,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .aboutScreen:
             return BuildConfiguration.current == .localDeveloper
+        case .newCommentThread:
+            return false
         }
     }
 
@@ -123,6 +126,8 @@ extension FeatureFlag {
             return "Follow Conversation via Notifications"
         case .aboutScreen:
             return "New Unified About Screen"
+        case .newCommentThread:
+            return "New Comment Thread"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -398,14 +398,12 @@ private extension CommentDetailViewController {
     func configureHeaderCell() {
         // if the comment is a reply, show the author of the parent comment.
         if let parentComment = self.parentComment {
-            headerCell.textLabel?.text = String(format: .replyCommentTitleFormat, parentComment.authorForDisplay())
-            headerCell.detailTextLabel?.text = parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines)
-            return
+            return headerCell.configure(for: .reply(parentComment.authorForDisplay()),
+                                        subtitle: parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines))
         }
 
         // otherwise, if this is a comment to a post, show the post title instead.
-        headerCell.textLabel?.text = .postCommentTitleText
-        headerCell.detailTextLabel?.text = comment.titleForDisplay()
+        headerCell.configure(for: .post, subtitle: comment.titleForDisplay())
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
@@ -631,12 +629,9 @@ private extension String {
     static let textCellIdentifier = "textCell"
 
     // MARK: Localization
-    static let postCommentTitleText = NSLocalizedString("Comment on", comment: "Provides hint that the current screen displays a comment on a post. "
-                                                            + "The title of the post will displayed below this string. "
-                                                            + "Example: Comment on \n My First Post")
-    static let replyCommentTitleFormat = NSLocalizedString("Reply to %1$@", comment: "Provides hint that the screen displays a reply to a comment."
-                                                           + "%1$@ is a placeholder for the comment author that's been replied to."
-                                                           + "Example: Reply to Pamela Nguyen")
+    static let replyPlaceholderFormat = NSLocalizedString("Reply to %1$@", comment: "Placeholder text for the reply text field."
+                                                          + "%1$@ is a placeholder for the comment author."
+                                                          + "Example: Reply to Pamela Nguyen")
     static let replyIndicatorLabelText = NSLocalizedString("You replied to this comment.", comment: "Informs that the user has replied to this comment.")
     static let webAddressLabelText = NSLocalizedString("Web address", comment: "Describes the web address section in the comment detail screen.")
     static let emailAddressLabelText = NSLocalizedString("Email address", comment: "Describes the email address section in the comment detail screen.")
@@ -859,7 +854,7 @@ private extension CommentDetailViewController {
     func configureReplyView() {
         let replyView = ReplyTextView(width: view.frame.width)
 
-        replyView.placeholder = String(format: .replyCommentTitleFormat, comment.authorForDisplay())
+        replyView.placeholder = String(format: .replyPlaceholderFormat, comment.authorForDisplay())
         replyView.accessibilityIdentifier = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
         replyView.delegate = self
         replyView.onReply = { [weak self] content in

--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -2,6 +2,24 @@ import UIKit
 
 class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 
+    enum Title {
+        /// Title for a top-level comment on a post.
+        case post
+
+        /// Title for a comment that's a reply to another comment.
+        /// Requires a String describing the replied author's name.
+        case reply(String)
+
+        var stringValue: String {
+            switch self {
+            case .post:
+                return .postCommentTitleText
+            case .reply(let author):
+                return String(format: .replyCommentTitleFormat, author)
+            }
+        }
+    }
+
     // MARK: Initialization
 
     required init() {
@@ -11,6 +29,18 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Configures the header cell.
+    /// - Parameters:
+    ///   - title: The title type for the header. See `Title`.
+    ///   - subtitle: A text snippet of the parent object.
+    ///   - showsDisclosureIndicator: When this is `false`, the cell is configured to look non-interactive.
+    func configure(for title: Title, subtitle: String, showsDisclosureIndicator: Bool = true) {
+        textLabel?.setText(title.stringValue)
+        detailTextLabel?.setText(subtitle)
+        accessoryType = showsDisclosureIndicator ? .disclosureIndicator : .none
+        selectionStyle = showsDisclosureIndicator ? .default : .none
     }
 
     // MARK: Helpers
@@ -29,4 +59,15 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
         detailTextLabel?.numberOfLines = 1
     }
 
+}
+
+// MARK: Localization
+
+private extension String {
+    static let postCommentTitleText = NSLocalizedString("Comment on", comment: "Provides hint that the current screen displays a comment on a post. "
+                                                            + "The title of the post will displayed below this string. "
+                                                            + "Example: Comment on \n My First Post")
+    static let replyCommentTitleFormat = NSLocalizedString("Reply to %1$@", comment: "Provides hint that the screen displays a reply to a comment."
+                                                           + "%1$@ is a placeholder for the comment author that's been replied to."
+                                                           + "Example: Reply to Pamela Nguyen")
 }


### PR DESCRIPTION
Refs #17475

This PR introduces a couple of small things:

- Added a feature flag for the new comment thread.
- Refactored `CommentDetailViewController` to move the header cell configuration logic to `CommentHeaderTableViewCell`, as this header cell will be reused for comment threads later on.
- Added capability on the header cell to hide the disclosure indicator. Here's how it looks when hidden:
  <img width="389" alt="Screen Shot 2021-11-16 at 18 00 51" src="https://user-images.githubusercontent.com/1299411/141973675-127dc930-44ad-4956-9ba6-a3aafb4afa7a.png">

## To Test

Since this is a minor refactor work, there should be no user-facing changes. 

- Navigate to My Sites > Comments, and select a post comment.
- 🔍 Verify that the comment header cell is displayed correctly:
  - Top text: `Comment on`
  - Bottom text: `<Title of the post>`
  - Disclosure indicator should be displayed.
  - When tapped, leads to the post.
- Go back to the comments list, and select a reply comment.
- 🔍 Verify that the comment header cell is displayed correctly:
  - Top text: `Reply to <replied author's name>`
  - Bottom text: `<Snippet of the comment>`
  - Disclosure indicator should be displayed.
  - When tapped, leads to the comment thread.

## Regression Notes
1. Potential unintended areas of impact
Should be none. If any, this should only affect the new comment details in My Sites.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure there's no impact.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
