### PR TITLE
Unified About: Add 'Share' navigation

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+typealias AboutScreenSection = [AboutItem]
+
+/// Users of UnifiedAboutViewController must provide a configuration conforming to this protocol.
+/// It provides a list of AboutItems, grouped into sections, which will be displayed in the about screen's table view.
+protocol AboutScreenConfiguration {
+    var sections: [AboutScreenSection] { get }
+}
+
+typealias AboutItemAction = ((AboutItemActionContext) -> Void)
+
+struct AboutItemActionContext {
+    /// The About Screen view controller itself.
+    let viewController: UIViewController
+
+    /// If the action was triggered by the user interacting with a specific view, it'll be available here.
+    let sourceView: UIView?
+}
+
+/// Defines a single row in the unified about screen.
+///
+struct AboutItem {
+    /// Title displayed in the main textLabel of the item's table row
+    let title: String
+
+    /// Subtitle displayed in the detailTextLabel of the item's table row
+    let subtitle: String?
+
+    /// Which cell style should be used to render the item's cell. See `AboutItemCellStyle` for options.
+    let cellStyle: AboutItemCellStyle
+
+    /// The accessory type that should be used for the item's table row
+    let accessoryType: UITableViewCell.AccessoryType
+
+    /// If `true`, the item's table row will hide its bottom separator
+    let hidesSeparator: Bool
+
+    /// An optional action that can be performed when the item's table row is tapped.
+    /// The action will be passed an `AboutItemActionContext` containing references to the view controller
+    /// and the source view that triggered the action.
+    let action: AboutItemAction?
+
+    init(title: String, subtitle: String? = nil, cellStyle: AboutItemCellStyle = .default, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, hidesSeparator: Bool = false, action: AboutItemAction? = nil) {
+        self.title = title
+        self.subtitle = subtitle
+        self.cellStyle = cellStyle
+        self.accessoryType = accessoryType
+        self.hidesSeparator = hidesSeparator
+        self.action = action
+    }
+
+    enum AboutItemCellStyle: String {
+        // Displays only a title
+        case `default`
+        // Displays a title on the leading side and a secondary value on the trailing side
+        case value1
+        // Displays a title with a smaller subtitle below
+        case subtitle
+        // Displays the custom app logos cell
+        case appLogos
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
+    let sharePresenter: ShareAppContentPresenter
+
+    lazy var sections: [[AboutItem]] = {
+        [
+            [
+                AboutItem(title: TextContent.rateUs, accessoryType: .none),
+                AboutItem(title: TextContent.share, accessoryType: .none, action: { [weak self] context in
+                    self?.sharePresenter.present(for: .wordpress, in: context.viewController, source: .about, sourceView: context.sourceView)
+                }),
+                AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, accessoryType: .none),
+            ],
+            [
+                AboutItem(title: TextContent.legalAndMore),
+            ],
+            [
+                AboutItem(title: TextContent.automatticFamily, hidesSeparator: true),
+                AboutItem(title: "", cellStyle: .appLogos)
+            ],
+            [
+                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle)
+            ]
+        ]
+    }()
+
+    init(sharePresenter: ShareAppContentPresenter) {
+        self.sharePresenter = sharePresenter
+    }
+
+    private enum TextContent {
+        static let rateUs             = NSLocalizedString("Rate Us", comment: "Title for button allowing users to rate the app in the App Store")
+        static let share              = NSLocalizedString("Share with Friends", comment: "Title for button allowing users to share information about the app with friends, such as via Messages")
+        static let twitter            = NSLocalizedString("Twitter", comment: "Title of button that displays the app's Twitter profile")
+        static let legalAndMore       = NSLocalizedString("Legal and More", comment: "Title of button which shows a list of legal documentation such as privacy policy and acknowledgements")
+        static let automatticFamily   = NSLocalizedString("Automattic Family", comment: "Title of button that displays information about the other apps available from Automattic")
+        static let workWithUs         = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
+        static let workWithUsSubtitle = NSLocalizedString("Join From Anywhere", comment: "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -253,7 +253,8 @@ class MeViewController: UITableViewController {
 
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
-            let controller = UnifiedAboutViewController(sharePresenter: self.sharePresenter)
+            let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
+            let controller = UnifiedAboutViewController(configuration: configuration)
             controller.modalPresentationStyle = .formSheet
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -253,7 +253,7 @@ class MeViewController: UITableViewController {
 
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
-            let controller = UnifiedAboutViewController()
+            let controller = UnifiedAboutViewController(sharePresenter: self.sharePresenter)
             controller.modalPresentationStyle = .formSheet
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -221,6 +221,10 @@
 		173D82E7238EE2A7008432DA /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */; };
 		173DF288274294DB007C64B5 /* OrientationLimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF287274294DB007C64B5 /* OrientationLimited.swift */; };
 		173DF289274294DB007C64B5 /* OrientationLimited.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF287274294DB007C64B5 /* OrientationLimited.swift */; };
+		173DF28E274513E1007C64B5 /* AboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF28D274513E1007C64B5 /* AboutScreenConfiguration.swift */; };
+		173DF28F274513E1007C64B5 /* AboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF28D274513E1007C64B5 /* AboutScreenConfiguration.swift */; };
+		173DF291274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF290274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift */; };
+		173DF292274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 173DF290274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift */; };
 		1746D7771D2165AE00B11D77 /* ForcePopoverPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */; };
 		1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1749965E2271BF08007021BD /* WordPressAppDelegate.swift */; };
 		174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 174C116E2624603400346EC6 /* MBarRouteTests.swift */; };
@@ -4811,6 +4815,8 @@
 		173BCE781CEB780800AE8817 /* Domain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Domain.swift; sourceTree = "<group>"; };
 		173D82E6238EE2A7008432DA /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		173DF287274294DB007C64B5 /* OrientationLimited.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrientationLimited.swift; sourceTree = "<group>"; };
+		173DF28D274513E1007C64B5 /* AboutScreenConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutScreenConfiguration.swift; sourceTree = "<group>"; };
+		173DF290274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAboutScreenConfiguration.swift; sourceTree = "<group>"; };
 		1746D7761D2165AE00B11D77 /* ForcePopoverPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ForcePopoverPresenter.swift; sourceTree = "<group>"; };
 		1749965E2271BF08007021BD /* WordPressAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAppDelegate.swift; sourceTree = "<group>"; };
 		174C116E2624603400346EC6 /* MBarRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MBarRouteTests.swift; sourceTree = "<group>"; };
@@ -9038,6 +9044,8 @@
 				17017EF12730508B0023A674 /* UnifiedAboutViewController.swift */,
 				17017EF42731983B0023A674 /* AutomatticAppLogosCell.swift */,
 				F15EEF802731FF9000B73E38 /* UnifiedAboutHeaderView.swift */,
+				173DF28D274513E1007C64B5 /* AboutScreenConfiguration.swift */,
+				173DF290274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift */,
 			);
 			path = About;
 			sourceTree = "<group>";
@@ -17612,6 +17620,7 @@
 				E14BCABB1E0BC817002E0603 /* Delay.swift in Sources */,
 				D83CA3A520842CAF0060E310 /* Pageable.swift in Sources */,
 				17E362EC22C40BE8000E0C79 /* AppIconViewController.swift in Sources */,
+				173DF28E274513E1007C64B5 /* AboutScreenConfiguration.swift in Sources */,
 				598DD1711B97985700146967 /* ThemeBrowserCell.swift in Sources */,
 				B5A05AD91CA48601002EC787 /* ImageCropViewController.swift in Sources */,
 				F93735F122D534FE00A3C312 /* LoggingURLRedactor.swift in Sources */,
@@ -17783,6 +17792,7 @@
 				E15644EB1CE0E4C500D96E64 /* FeatureItemRow.swift in Sources */,
 				F5A738BF244DF7E400EDE065 /* ReaderTagsTableViewController+Cells.swift in Sources */,
 				8B0732E9242BA1F000E7FBD3 /* PrepublishingHeaderView.swift in Sources */,
+				173DF291274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift in Sources */,
 				3F3CA65025D3003C00642A89 /* StatsWidgetsStore.swift in Sources */,
 				0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */,
 				C700F9EE257FD64E0090938E /* JetpackScanViewController.swift in Sources */,
@@ -19664,6 +19674,7 @@
 				FABB22812602FC2C00C8785C /* GutenbergRequestAuthenticator.swift in Sources */,
 				3FB1929626C79EC6000F5AA3 /* Date+TimeStrings.swift in Sources */,
 				FABB22822602FC2C00C8785C /* WPTableViewActivityCell.m in Sources */,
+				173DF28F274513E1007C64B5 /* AboutScreenConfiguration.swift in Sources */,
 				FABB22842602FC2C00C8785C /* PeopleViewController.swift in Sources */,
 				FABB22852602FC2C00C8785C /* ConfettiView.swift in Sources */,
 				FABB22862602FC2C00C8785C /* RegisterDomainSuggestionsViewController.swift in Sources */,
@@ -20548,6 +20559,7 @@
 				FABB25A52602FC2C00C8785C /* BlogToJetpackAccount.m in Sources */,
 				FABB25A62602FC2C00C8785C /* NotificationSettingsViewController.swift in Sources */,
 				FABB25A72602FC2C00C8785C /* ChangeUsernameViewController.swift in Sources */,
+				173DF292274522A1007C64B5 /* WordPressAboutScreenConfiguration.swift in Sources */,
 				FABB25A82602FC2C00C8785C /* RichTextView.swift in Sources */,
 				FABB25A92602FC2C00C8785C /* ScenePresenter.swift in Sources */,
 				FABB25AA2602FC2C00C8785C /* AccountSettingsStore.swift in Sources */,


### PR DESCRIPTION
Implements #17421. This PR adds the Share action to the unified about screen. I've used the same share presenter from the Me view controller and passed it into the About screen.

I've also made some tweaks to the `AboutItem` struct, and we'll likely need to change things a bit more for future actions. As it as declared as a static property, it wasn't possible to use the sharePresenter, so I've moved that logic out of the AboutItems and into the view controller itself. This way, the about items are simply about the presentation in the table rather than the logic.

**To test**

* Build and run
* Navigate to the new about screen
* Tap Share and check the share sheet appears

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
