### PR TITLE
Unified About: Update footer view to scroll with table contents

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -84,6 +84,26 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     private static let appLogosIndexPath = IndexPath(row: 1, section: 2)
 
+
+    // MARK: - Views
+
+    private lazy var tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .insetGrouped)
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+
+        // Occasionally our hidden separator insets can cause the horizontal
+        // scrollbar to appear on rotation
+        tableView.showsHorizontalScrollIndicator = false
+
+        tableView.tableHeaderView = headerView
+        tableView.tableFooterView = footerView
+
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        return tableView
+    }()
+
     let headerView: UIView = {
         // These customizations are temporarily here, but if this VC is moved into a framework we'll need to move them
         // into the main App.
@@ -105,37 +125,29 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
         return headerView
     }()
 
-    // MARK: - Views
-
-    private lazy var tableView: UITableView = {
-        let tableView = UITableView(frame: .zero, style: .insetGrouped)
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-
-        // Occasionally our hidden separator insets can cause the horizontal
-        // scrollbar to appear on rotation
-        tableView.showsHorizontalScrollIndicator = false
-
-        tableView.tableHeaderView = headerView
-
-        tableView.dataSource = self
-        tableView.delegate = self
-
-        return tableView
-    }()
-
     private lazy var footerView: UIView = {
         let footerView = UIView()
-        footerView.translatesAutoresizingMaskIntoConstraints = false
         footerView.backgroundColor = .systemGroupedBackground
+
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        footerView.addSubview(containerView)
 
         let logo = UIImageView(image: UIImage(named: Images.automatticLogo))
         logo.translatesAutoresizingMaskIntoConstraints = false
-        footerView.addSubview(logo)
+        containerView.addSubview(logo)
 
         NSLayoutConstraint.activate([
-            logo.centerXAnchor.constraint(equalTo: footerView.centerXAnchor),
-            logo.centerYAnchor.constraint(equalTo: footerView.centerYAnchor)
+            containerView.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
+            containerView.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+            containerView.topAnchor.constraint(equalTo: footerView.topAnchor, constant: Metrics.footerVerticalOffset),
+            containerView.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
+            containerView.heightAnchor.constraint(equalToConstant: Metrics.footerHeight),
+            logo.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+            logo.centerYAnchor.constraint(equalTo: containerView.centerYAnchor)
         ])
+
+        footerView.frame.size = footerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
 
         return footerView
     }()
@@ -152,17 +164,12 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
         view.backgroundColor = .systemGroupedBackground
 
         view.addSubview(tableView)
-        view.addSubview(footerView)
 
         NSLayoutConstraint.activate([
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.bottomAnchor.constraint(equalTo: footerView.topAnchor),
-            footerView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: Metrics.footerVerticalOffset),
-            footerView.heightAnchor.constraint(equalToConstant: Metrics.footerHeight),
-            footerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            footerView.trailingAnchor.constraint(equalTo: view.trailingAnchor)
+            tableView.topAnchor.constraint(equalTo: view.safeTopAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
         ])
 
         tableView.reloadData()


### PR DESCRIPTION
This PR updates the Unified About screen footer to scroll with the tableview rather than being attached to the bottom of the screen.

|   |   |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-16 at 16 31 52](https://user-images.githubusercontent.com/4780/142027302-41dfd986-e64f-45c4-8099-d2b0d870a886.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-16 at 16 31 47](https://user-images.githubusercontent.com/4780/142027315-bc431d8a-8d9c-4453-af35-8da1673fa966.png) |

**To test**

* Build and run, observe the footer in the about screen. Check it's at the bottom of the view stays visible when scrolling to the bottom.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
