### PR TITLE
Onboarding Improvements: Update quickstart copy

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -127,8 +127,8 @@ struct QuickStartThemeTour: QuickStartTour {
 struct QuickStartShareTour: QuickStartTour {
     let key = "quick-start-share-tour"
     let analyticsKey = "share_site"
-    let title = NSLocalizedString("Enable post sharing", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Enable post sharing", comment: "The Quick Start Tour title after the user finished the step.")
+    let title = NSLocalizedString("Social sharing", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Social sharing", comment: "The Quick Start Tour title after the user finished the step.")
     let description = NSLocalizedString("Automatically share new posts to your social media accounts.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.share)
     let suggestionNoText = Strings.notNow
@@ -154,7 +154,7 @@ struct QuickStartPublishTour: QuickStartTour {
     let analyticsKey = "publish_post"
     let title = NSLocalizedString("Publish a post", comment: "Title of a Quick Start Tour")
     let titleMarkedCompleted = NSLocalizedString("Completed: Publish a post", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("It's time! Draft and publish your very first post.", comment: "Description of a Quick Start Tour")
+    let description = NSLocalizedString("Draft and publish a post.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.create)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -204,8 +204,8 @@ struct QuickStartFollowTour: QuickStartTour {
 struct QuickStartSiteTitleTour: QuickStartTour {
     let key = "quick-start-site-title-tour"
     let analyticsKey = "site_title"
-    let title = NSLocalizedString("Set your site title", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Set your site title", comment: "The Quick Start Tour title after the user finished the step.")
+    let title = NSLocalizedString("Check your site title", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Check your site title", comment: "The Quick Start Tour title after the user finished the step.")
     let description = NSLocalizedString("Give your site a name that reflects its personality and topic. First impressions count!",
                                         comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.pencil)
@@ -225,9 +225,9 @@ struct QuickStartSiteTitleTour: QuickStartTour {
 struct QuickStartSiteIconTour: QuickStartTour {
     let key = "quick-start-site-icon-tour"
     let analyticsKey = "site_icon"
-    let title = NSLocalizedString("Upload a site icon", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Upload a site icon", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Your visitors will see your icon in their browser. Add a custom icon for a polished, pro look.", comment: "Description of a Quick Start Tour")
+    let title = NSLocalizedString("Choose a unique site icon", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Choose a unique site icon", comment: "The Quick Start Tour title after the user finished the step.")
+    let description = NSLocalizedString("Shown in your visitor's browser tab and other places online.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.globe)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe


### PR DESCRIPTION
Fixes #17387

## Description

This PR updates the copy for Quick Start steps.

Ref: pbArwn-32R-p2

<img width="681" alt="Screen Shot 2021-10-28 at 16 44 48" src="https://user-images.githubusercontent.com/6711616/139290356-50c28a84-a489-4953-81bf-e0a68db3413b.png">

## How to test

1. Log out, then log in
2. On the Epilogue screen, tap **Create a new site**
3. Choose a design and tap **Choose**
4. Choose a domain and tap **Create Site**
5. On the Site Created success screen, tap **Done**
6. On the Quick Start prompt, tap **Show me around**
7. ✅ The Customize Your Site checklist has the new updated copy
8. On the Quick Start checklist, tap the **X button**
9. On My Site, tap on Grow Your Audience
10. ✅ The Grow Your Audience checklist has the new updated copy

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/142181538-5e1e549d-0fba-47e4-b77a-1cdefc4a7e09.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142183027-a706a707-9aa2-408e-aca5-2d0b723ff306.png" width=200>
<img src="https://user-images.githubusercontent.com/6711616/142181547-28bed86c-2ee3-4a73-9946-c32f6a0e53e7.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142183033-5378b4f8-a6a3-42ee-8e5c-953f9b9d0016.png" width=200>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
