### PR TITLE
Onboarding Improvements: Fix cell display logic for Epilogue screen

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -144,12 +144,11 @@ extension LoginEpilogueTableViewController {
         }
 
         // Create new site row
-        let siteRows = tableView.numberOfRows(inSection: indexPath.section)
-        let threshold = 4 // 3 site rows + 1 create site row
+        let siteRows = blogDataSource.tableView(tableView, numberOfRowsInSection: indexPath.section - 1)
 
         let isCreateNewSiteRow =
             showCreateNewSite &&
-            siteRows <= threshold &&
+            siteRows <= 3 &&
             indexPath.row == lastRowInSection(indexPath.section)
 
         if isCreateNewSiteRow {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -106,7 +106,7 @@ extension LoginEpilogueTableViewController {
             return siteRows
         }
 
-        if siteRows <= 3 {
+        if siteRows <= Constants.createNewSiteRowThreshold {
             parent.hideButtonPanel()
             return showCreateNewSite ? siteRows + 1 : siteRows
         } else {
@@ -148,7 +148,7 @@ extension LoginEpilogueTableViewController {
 
         let isCreateNewSiteRow =
             showCreateNewSite &&
-            siteRows <= 3 &&
+            siteRows <= Constants.createNewSiteRowThreshold &&
             indexPath.row == lastRowInSection(indexPath.section)
 
         if isCreateNewSiteRow {
@@ -192,6 +192,10 @@ extension LoginEpilogueTableViewController {
         let blog = blogDataSource.blog(at: wrappedPath)
 
         parent.onBlogSelected?(blog)
+    }
+
+    private enum Constants {
+        static let createNewSiteRowThreshold = 3
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -112,7 +112,7 @@ class LoginEpilogueViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        configurePanelBasedOnTableViewContents()
+        configureButtonPanel()
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -151,28 +151,12 @@ private extension LoginEpilogueViewController {
 
     /// Setup: Button Panel
     ///
-    func configurePanelBasedOnTableViewContents() {
-        guard let tableView = tableViewController?.tableView else {
-            return
-        }
-
+    func configureButtonPanel() {
         topLineHeightConstraint.constant = .hairlineBorderWidth
-
-        let contentSize = tableView.contentSize
-        let screenHeight = UIScreen.main.bounds.height
-        let panelHeight = buttonPanel.frame.height
-
-        if contentSize.height >= (screenHeight - panelHeight) {
-            buttonPanel.backgroundColor = .quaternaryBackground
-            topLine.isHidden = false
-            blurEffectView.effect = UIBlurEffect(style: blurEffect)
-            blurEffectView.isHidden = false
-        } else {
-            buttonPanel.backgroundColor = .basicBackground
-            topLine.isHidden = true
-            blurEffectView.isHidden = true
-        }
-
+        buttonPanel.backgroundColor = .quaternaryBackground
+        topLine.isHidden = false
+        blurEffectView.effect = UIBlurEffect(style: blurEffect)
+        blurEffectView.isHidden = false
         setupDividerLineIfNeeded()
     }
 


### PR DESCRIPTION
Fixes #17453 

## Description

This PR fixes an issue where the Epilogue screen was displaying a `Create a new site` cell instead of a Blog cell, if the account had exactly 4 blogs.

## Notes

This PR also simplifies the button panel configuration logic done in https://github.com/wordpress-mobile/WordPress-iOS/pull/13570.

We don't need to configure the button panel based on the content height anymore, since we're simply hiding the panel when there are 3 sites or less.

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/141371887-b236aafd-b835-47ab-bb14-381914d9ce61.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142230063-f5dcd3bc-e2b2-4956-ad4c-87d675cf7108.png" width=200>

## How to test

1. Log out, then log in to an account that has exactly 4 sites
2. ✅ 4 blog cells should be displayed, as well as the `Create a new site` bottom panel 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
