### PR TITLE
Reader Comments: Display the new comment header cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentHeaderTableViewCell.swift
@@ -6,6 +6,9 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
         /// Title for a top-level comment on a post.
         case post
 
+        /// Title for the comment threads.
+        case thread
+
         /// Title for a comment that's a reply to another comment.
         /// Requires a String describing the replied author's name.
         case reply(String)
@@ -14,6 +17,8 @@ class CommentHeaderTableViewCell: UITableViewCell, Reusable {
             switch self {
             case .post:
                 return .postCommentTitleText
+            case .thread:
+                return .commentThreadTitleText
             case .reply(let author):
                 return String(format: .replyCommentTitleFormat, author)
             }
@@ -70,4 +75,6 @@ private extension String {
     static let replyCommentTitleFormat = NSLocalizedString("Reply to %1$@", comment: "Provides hint that the screen displays a reply to a comment."
                                                            + "%1$@ is a placeholder for the comment author that's been replied to."
                                                            + "Example: Reply to Pamela Nguyen")
+    static let commentThreadTitleText = NSLocalizedString("Comments on", comment: "Sentence fragment. "
+                                                          + "The full phrase is 'Comments on' followed by the title of a post on a separate line.")
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -172,7 +172,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     [super viewDidAppear:animated];
     [self.tableView reloadData];
 
-    if(self.promptToAddComment) {
+    if (self.promptToAddComment) {
         [self.replyTextView becomeFirstResponder];
 
         // Reset the value to prevent prompting again if the user leaves and comes back

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -67,7 +67,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 /// A cached instance for the new comment header view.
 @property (nonatomic, strong) UIView *cachedHeaderView;
 
-/// Caches the post subscription state.
+/// Caches the post subscription state. Used to revert subscription state when the update request fails.
 @property (nonatomic, assign) BOOL subscribedToPost;
 
 @end
@@ -172,7 +172,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     [super viewDidAppear:animated];
     [self.tableView reloadData];
 
-    if(self.promptToAddComment){
+    if(self.promptToAddComment) {
         [self.replyTextView becomeFirstResponder];
 
         // Reset the value to prevent prompting again if the user leaves and comes back
@@ -290,8 +290,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)configurePostHeader
 {
-    // don't show the current post header view when the newCommentThread flag is enabled.
-    // the new header will be shown as one of the table view cell.
+    // Don't show the current post header view when the newCommentThread flag is enabled.
+    // the new header will displayed as a table section header.
     if ([self newCommentThreadEnabled]) {
         return;
     }
@@ -444,10 +444,10 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         @"replyTextView"    : self.replyTextView
     }];
 
-    NSString *verticalVisualFormatConstraints = @"V:|[postHeader][tableView][replyTextView]";
+    NSString *verticalVisualFormatString = @"V:|[postHeader][tableView][replyTextView]";
 
     if ([self newCommentThreadEnabled]) {
-        verticalVisualFormatConstraints = @"V:|[tableView][replyTextView]";
+        verticalVisualFormatString = @"V:|[tableView][replyTextView]";
     } else {
         [views setObject:self.postHeaderWrapper forKey:@"postHeader"];
 
@@ -457,7 +457,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }
 
     // TableView Contraints
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalVisualFormatConstraints
+    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalVisualFormatString
                                                                       options:0
                                                                       metrics:nil
                                                                         views:views]];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -444,12 +444,11 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
         @"replyTextView"    : self.replyTextView
     }];
 
-    NSString *verticalVisualFormatString = @"V:|[postHeader][tableView][replyTextView]";
+    NSString *verticalVisualFormatString = @"V:|[tableView][replyTextView]";
 
-    if ([self newCommentThreadEnabled]) {
-        verticalVisualFormatString = @"V:|[tableView][replyTextView]";
-    } else {
+    if (![self newCommentThreadEnabled]) {
         [views setObject:self.postHeaderWrapper forKey:@"postHeader"];
+        verticalVisualFormatString = @"V:|[postHeader][tableView][replyTextView]";
 
         // PostHeader Constraints
         [[self.postHeaderWrapper.leftAnchor constraintEqualToAnchor:self.tableView.leftAnchor] setActive:YES];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 @objc public extension ReaderCommentsViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
@@ -32,5 +33,32 @@ import Foundation
         case (.disableNotification, false):
             return NSLocalizedString("Could not disable notifications", comment: "The app failed to disable notifications for the subscription")
         }
+    }
+
+    // MARK: New Comment Threads
+
+    func configuredHeaderView(for tableView: UITableView) -> UIView {
+        guard let post = post else {
+            return .init()
+        }
+
+        let cell = CommentHeaderTableViewCell()
+        cell.backgroundColor = .systemBackground
+        cell.configure(for: .thread, subtitle: post.titleForDisplay(), showsDisclosureIndicator: false)
+
+        // the table view does not render separators for the section header views, so we need to create one.
+        let separatorView = UIView()
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        separatorView.backgroundColor = .separator
+
+        cell.contentView.addSubview(separatorView)
+        NSLayoutConstraint.activate([
+            separatorView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
+            separatorView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
+            separatorView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: tableView.separatorInset.left)
+        ])
+
+        return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -47,17 +47,7 @@ import UIKit
         cell.configure(for: .thread, subtitle: post.titleForDisplay(), showsDisclosureIndicator: false)
 
         // the table view does not render separators for the section header views, so we need to create one.
-        let separatorView = UIView()
-        separatorView.translatesAutoresizingMaskIntoConstraints = false
-        separatorView.backgroundColor = .separator
-
-        cell.contentView.addSubview(separatorView)
-        NSLayoutConstraint.activate([
-            separatorView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
-            separatorView.bottomAnchor.constraint(equalTo: cell.contentView.bottomAnchor),
-            separatorView.trailingAnchor.constraint(equalTo: cell.contentView.trailingAnchor),
-            separatorView.leadingAnchor.constraint(equalTo: cell.contentView.leadingAnchor, constant: tableView.separatorInset.left)
-        ])
+        cell.contentView.addBottomBorder(withColor: .separator, leadingMargin: tableView.separatorInset.left)
 
         return cell
     }


### PR DESCRIPTION
Refs #17475 

This PR implements the new comment header view in Reader Comments, with some notes:

- When the `newCommentThread` flag is on, `ReaderPostHeaderView` is no longer used. Instead, the new comment header cell will be displayed as a table section header. Ideally, this should be displayed as a regular table view cell in a separate section – but it's a bit complicated due to the dependency on `WPTableViewHandler`.
  - ⚠️  I just realized that the header is sticky due to it being a table section header 😅 . The only way that I can think of is to use the `tableHeaderView` – but it's tricky to make it work since it's still frame-based. Also, if this header cell is going to be removed later on, maybe this is okay for now? Anyways, I'll make the changes in a separate PR if needed.
- Impacts to the follow conversation logic. Some of the states are stored and read from the `ReaderPostHeaderView`, which will not be initialized when the `newCommentThread` flag is turned on. To preserve the original behavior, I've added a `subscribedToPost` property which replaces any calls to `postHeaderView.isSubscribedToPost` while maintaining behavior when the flag is turned off.
- Since the view controller now has two active flags: `followConversationViaNotifications` and `newCommentThread`, I've added support for when the comment thread flag is disabled, and when both flags are disabled. However, I did not handle the case where `followConversationViaNotifications` is turned OFF while `newCommentThread` is ON. Here are some screenshots:

Description | Screenshot
--|--
Both flags on | ![threads_both_on](https://user-images.githubusercontent.com/1299411/142221343-469a03ab-863d-4ff2-8379-4cbee7686d28.png)
`newCommentThread` disabled | ![threads_follow_on](https://user-images.githubusercontent.com/1299411/142221348-31e09930-6c8b-45a1-afcf-a45bdb41556d.png)
Both flags disabled | ![threads_legacy](https://user-images.githubusercontent.com/1299411/142221333-fb34f524-fe39-44c3-a3d7-a3bd81550cbc.png)

## To Test

#### With the `newCommentThread` flag enabled:

- Go to Reader > Reader Comments.
- 🔍 Verify that the new comment header is displayed without disclosure indicator and selection style.
- 🔍 Verify that the Follow Conversation flow works as expected (roughly following the testing steps described in #17363).

#### With the `newCommentThread` flag disabled:

- Go to Reader > Reader Comments.
- 🔍 Verify that the previous comment header is displayed.
- 🔍 Verify that the Follow Conversation flow works as expected (roughly following the testing steps described in #17363).

#### With both `newCommentThread` and `followConversationViaNotifications` flag disabled:

- Go to Reader > Reader Comments.
- 🔍 Verify that the previous comment header is displayed.
- 🔍 Verify that the "Follow conversation via email" button is shown, and works when tapped.

## Regression Notes
1. Potential unintended areas of impact
Follow Conversation flow might be impacted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that the flow works as expected (both with the flag ON and OFF).

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
