### PR TITLE
Fix UserInfo Crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 18.8
 -----
-
+* [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
 
 18.7
 -----

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -435,9 +435,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         }
     }
     if (customErrorMessage) {
-        NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
-        userInfo[NSLocalizedDescriptionKey] = customErrorMessage;
-        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
+        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:error.key];
     }
     return error;
 }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -435,7 +435,10 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         }
     }
     if (customErrorMessage) {
-        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:error.key];
+        NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+        userInfo[NSLocalizedDescriptionKey] = customErrorMessage;
+
+        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
     }
     return error;
 }


### PR DESCRIPTION
Fixes a crash where cloning the `userInfo` of an `NSError` is causing a Core Data exception when trying to save the context.

```
2021-11-17 14:10:31:827 WordPress[1434:200461] Unresolved Core Data save error: Error Domain=NSCocoaErrorDomain Code=134060 "A Core Data error occurred." UserInfo={NSUnderlyingError=0x120604370 {Error Domain=NSCocoaErrorDomain Code=4866 "The data couldn’t be written because it isn’t in the correct format." UserInfo={NSUnderlyingError=0x120618770 {Error Domain=NSCocoaErrorDomain Code=4864 "This decoder will only decode classes that adopt NSSecureCoding. Class 'NWConcrete_nw_path' does not adopt it." UserInfo={NSDebugDescription=This decoder will only decode classes that adopt NSSecureCoding. Class 'NWConcrete_nw_path' does not adopt it.}}}}}
```

### To test:
**Prerequisites: iOS 15**

1. Go to a simple site.
2. Put the device into Airplane Mode.
3. Add an image block to a post.
4. Select an image from the device.
5. See that it doesn't crash and a "Failed to insert media. Please tap for options." message is displayed.

## Regression Notes
1. Potential unintended areas of impact
Error should still exist and show that there was a networking error, just without crashing.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Use the above steps to test.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
