### PR TITLE
Unified About: Work With Us

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
@@ -1,11 +1,15 @@
 import Foundation
 
 typealias AboutScreenSection = [AboutItem]
+typealias AboutScreenURLPresenterBlock = ((URL, AboutItemActionContext) -> Void)
 
 /// Users of UnifiedAboutViewController must provide a configuration conforming to this protocol.
-/// It provides a list of AboutItems, grouped into sections, which will be displayed in the about screen's table view.
 protocol AboutScreenConfiguration {
+    /// A list of AboutItems, grouped into sections, which will be displayed in the about screen's table view.
     var sections: [AboutScreenSection] { get }
+
+    /// A block that presents the provided URL in a web view
+    var presentURL: AboutScreenURLPresenterBlock? { get }
 }
 
 typealias AboutItemAction = ((AboutItemActionContext) -> Void)
@@ -16,6 +20,17 @@ struct AboutItemActionContext {
 
     /// If the action was triggered by the user interacting with a specific view, it'll be available here.
     let sourceView: UIView?
+}
+
+/// An About Screen link contains a display title and url for a single link-based navigation item.
+struct AboutScreenLink {
+    let title: String
+    let url: String
+
+    init(_ title: String = "", url: String) {
+        self.title = title
+        self.url = url
+    }
 }
 
 /// Defines a single row in the unified about screen.
@@ -41,13 +56,20 @@ struct AboutItem {
     /// and the source view that triggered the action.
     let action: AboutItemAction?
 
-    init(title: String, subtitle: String? = nil, cellStyle: AboutItemCellStyle = .default, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, hidesSeparator: Bool = false, action: AboutItemAction? = nil) {
+    /// An optional list of titles and URLs to be used for navigation.
+    /// If a single link is provided, the title is ignored in favour of the item's title, and tapping the item's table row will display the URL in a webview.
+    /// If multiple links are provided, an intermediary screen will be displayed containing a list of titles of each link.
+    /// If a title on this intermediary screen is tapped, the associated URL will be displayed in a webview.
+    let links: [AboutScreenLink]?
+
+    init(title: String, subtitle: String? = nil, cellStyle: AboutItemCellStyle = .default, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, hidesSeparator: Bool = false, action: AboutItemAction? = nil, links: [AboutScreenLink]? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.cellStyle = cellStyle
         self.accessoryType = accessoryType
         self.hidesSeparator = hidesSeparator
         self.action = action
+        self.links = links
     }
 
     enum AboutItemCellStyle: String {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -190,7 +190,25 @@ extension UnifiedAboutViewController: UITableViewDelegate {
         let context = AboutItemActionContext(viewController: self, sourceView: tableView.cellForRow(at: indexPath))
         item.action?(context)
 
+        // If the item contains links, we'll present them or show a menu
+        showLinks(for: item, with: context)
+
         tableView.deselectSelectedRowWithAnimation(true)
+    }
+
+    private func showLinks(for item: AboutItem, with context: AboutItemActionContext) {
+        guard let links = item.links else {
+            return
+        }
+
+        if links.count == 1,
+           let link = links.first?.url,
+           let url = URL(string: link) {
+            // If there's one link we'll display it directly
+            configuration.presentURL?(url, context)
+        } else {
+            // If there are multiple, we'll show an interstitial screen
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -11,7 +11,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
                 AboutItem(title: TextContent.share, accessoryType: .none, action: { [weak self] context in
                     self?.sharePresenter.present(for: .wordpress, in: context.viewController, source: .about, sourceView: context.sourceView)
                 }),
-                AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, accessoryType: .none),
+                AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, accessoryType: .none, links: Links.twitter),
             ],
             [
                 AboutItem(title: TextContent.legalAndMore),
@@ -47,6 +47,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
     }
 
     private enum Links {
+        static let twitter    = [AboutScreenLink(url: "https://twitter.com/WordPressiOS")]
         static let workWithUs = [AboutScreenLink(url: "https://automattic.com/work-with-us")]
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -18,7 +18,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
             ],
             [
                 AboutItem(title: TextContent.automatticFamily, hidesSeparator: true),
-                AboutItem(title: "", cellStyle: .appLogos)
+                AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
             ],
             [
                 AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, links: Links.workWithUs)

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
     let sharePresenter: ShareAppContentPresenter
@@ -20,10 +21,16 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
                 AboutItem(title: "", cellStyle: .appLogos)
             ],
             [
-                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle)
+                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, links: Links.workWithUs)
             ]
         ]
     }()
+
+    let presentURL: AboutScreenURLPresenterBlock? = { url, context in
+        let webViewController = WebViewControllerFactory.controller(url: url)
+        let navigationController = UINavigationController(rootViewController: webViewController)
+        context.viewController.present(navigationController, animated: true, completion: nil)
+    }
 
     init(sharePresenter: ShareAppContentPresenter) {
         self.sharePresenter = sharePresenter
@@ -37,5 +44,9 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
         static let automatticFamily   = NSLocalizedString("Automattic Family", comment: "Title of button that displays information about the other apps available from Automattic")
         static let workWithUs         = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
         static let workWithUsSubtitle = NSLocalizedString("Join From Anywhere", comment: "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world")
+    }
+
+    private enum Links {
+        static let workWithUs = [AboutScreenLink(url: "https://automattic.com/work-with-us")]
     }
 }


### PR DESCRIPTION
Implements #17425 and #17422 . This PR adds the Work With Us navigation item for the unified about screen, and also the Twitter link for WordPress. If we choose to add any future social links, they'll follow the same pattern and are only a line or two of code to add.

![unified-about-1](https://user-images.githubusercontent.com/4780/142274693-b5d7515c-9a2f-41e1-8806-6c6f38d48a04.gif)

**To test**

* Build and run
* Navigate to Unified About
* Tap on Work With Us and check you see the Automattic Work With Us page
* Tap on Twitter and check you see the WordPress iOS Twitter page

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
