### PR TITLE
Unified About: Legal and More

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
@@ -9,7 +9,10 @@ protocol AboutScreenConfiguration {
     var sections: [AboutScreenSection] { get }
 
     /// A block that presents the provided URL in a web view
-    var presentURL: AboutScreenURLPresenterBlock? { get }
+    var presentURLBlock: AboutScreenURLPresenterBlock? { get }
+
+    /// A block that dismisses the about screen
+    var dismissBlock: ((AboutItemActionContext) -> Void) { get }
 }
 
 typealias AboutItemAction = ((AboutItemActionContext) -> Void)
@@ -20,6 +23,11 @@ struct AboutItemActionContext {
 
     /// If the action was triggered by the user interacting with a specific view, it'll be available here.
     let sourceView: UIView?
+
+    init(viewController: UIViewController, sourceView: UIView? = nil) {
+        self.viewController = viewController
+        self.sourceView = sourceView
+    }
 }
 
 /// An About Screen link contains a display title and url for a single link-based navigation item.

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -81,6 +81,11 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     // MARK: - View lifecycle
 
+    static func controller(configuration: AboutScreenConfiguration) -> UIViewController {
+        let controller = UnifiedAboutViewController(configuration: configuration)
+        return UINavigationController(rootViewController: controller)
+    }
+
     init(configuration: AboutScreenConfiguration) {
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
@@ -92,6 +97,8 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        navigationController?.setNavigationBarHidden(true, animated: false)
 
         view.backgroundColor = .systemGroupedBackground
 
@@ -205,9 +212,11 @@ extension UnifiedAboutViewController: UITableViewDelegate {
            let link = links.first?.url,
            let url = URL(string: link) {
             // If there's one link we'll display it directly
-            configuration.presentURL?(url, context)
+            configuration.presentURLBlock?(url, context)
         } else {
             // If there are multiple, we'll show an interstitial screen
+            let viewController = AboutLinkListViewController(configuration: configuration, item: item)
+            navigationController?.pushViewController(viewController, animated: true)
         }
     }
 }
@@ -245,4 +254,85 @@ private extension AboutItem {
             return .default
         }
     }
+}
+
+/// This view controller displays a simple list in a table view of links provided by an `AboutItem`.
+///
+private class AboutLinkListViewController: UITableViewController {
+    let configuration: AboutScreenConfiguration
+    let item: AboutItem
+
+    init(configuration: AboutScreenConfiguration, item: AboutItem) {
+        self.configuration = configuration
+        self.item = item
+        super.init(style: .insetGrouped)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = item.title
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(doneTapped))
+
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Self.cellIdentifier)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+
+        navigationController?.setNavigationBarHidden(false, animated: true)
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        navigationController?.setNavigationBarHidden(true, animated: true)
+    }
+
+    // MARK: - Actions
+
+    @objc private func doneTapped() {
+        let context = AboutItemActionContext(viewController: self)
+        configuration.dismissBlock(context)
+    }
+
+    // MARK: - Table view data source / delegate
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        1
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        item.links?.count ?? 0
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: Self.cellIdentifier, for: indexPath)
+        cell.textLabel?.text = item.links?[indexPath.row].title ?? ""
+
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        defer {
+            tableView.deselectRow(at: indexPath, animated: true)
+        }
+
+        guard let link = item.links?[indexPath.row],
+              let url = URL(string: link.url) else {
+            return
+        }
+
+        let context = AboutItemActionContext(viewController: self, sourceView: tableView.cellForRow(at: indexPath))
+        configuration.presentURLBlock?(url, context)
+
+    }
+
+    private static let cellIdentifier = "Cell"
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -14,7 +14,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
                 AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, accessoryType: .none, links: Links.twitter),
             ],
             [
-                AboutItem(title: TextContent.legalAndMore),
+                AboutItem(title: TextContent.legalAndMore, links: Links.legalAndMore),
             ],
             [
                 AboutItem(title: TextContent.automatticFamily, hidesSeparator: true),
@@ -26,10 +26,14 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
         ]
     }()
 
-    let presentURL: AboutScreenURLPresenterBlock? = { url, context in
+    let presentURLBlock: AboutScreenURLPresenterBlock? = { url, context in
         let webViewController = WebViewControllerFactory.controller(url: url)
         let navigationController = UINavigationController(rootViewController: webViewController)
         context.viewController.present(navigationController, animated: true, completion: nil)
+    }
+
+    let dismissBlock: ((AboutItemActionContext) -> Void) = { context in
+        context.viewController.presentingViewController?.dismiss(animated: true)
     }
 
     init(sharePresenter: ShareAppContentPresenter) {
@@ -47,7 +51,13 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
     }
 
     private enum Links {
-        static let twitter    = [AboutScreenLink(url: "https://twitter.com/WordPressiOS")]
-        static let workWithUs = [AboutScreenLink(url: "https://automattic.com/work-with-us")]
+        static let legalAndMore = [
+            AboutScreenLink("Terms of Service", url: WPAutomatticTermsOfServiceURL),
+            AboutScreenLink("Privacy Policy", url: WPAutomatticPrivacyURL),
+            AboutScreenLink("Source Code", url: WPGithubMainURL),
+            AboutScreenLink("Acknowledgements", url: Bundle.main.url(forResource: "acknowledgements", withExtension: "html")?.absoluteString ?? "")
+        ]
+        static let twitter      = [AboutScreenLink(url: "https://twitter.com/WordPressiOS")]
+        static let workWithUs   = [AboutScreenLink(url: "https://automattic.com/work-with-us")]
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,7 +254,7 @@ class MeViewController: UITableViewController {
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
             let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
-            let controller = UnifiedAboutViewController(configuration: configuration)
+            let controller = UnifiedAboutViewController.controller(configuration: configuration)
             controller.modalPresentationStyle = .formSheet
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)


### PR DESCRIPTION
Implements #17423. This PR adds the Legal and More navigation links to the unified about screen. It does this by adding support for lists of multiple links to be present in an `AboutItem`. If an about item has multiple links, a secondary screen will be pushed on the navigation stack containing a list of the titles of those links. Tapping on an item will display the URL associated with it.

![unified-about-2](https://user-images.githubusercontent.com/4780/142275201-623db399-8e1c-430a-ae02-d06be6114ddd.gif)

**To test**

* Build and run
* Navigate to the Legal and More section and to each item within it. Check that they load as expected.
* Ensure that you can dismiss the view from the legal and more section.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
