### PR TITLE
Include Core Data crash fix in 18.7

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 18.8
 -----
+* [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
 
 18.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 18.8
 -----
-* [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
 
 18.7
 -----
@@ -9,6 +8,7 @@
 * [***] Site Comments: Updated comment details with a fresh new look and capability to display rich contents. [#17466]
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
+* [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
 
 18.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 * [***] Site Comments: Updated comment details with a fresh new look and capability to display rich contents. [#17466]
 * [**] Block editor: Image block: Add ability to quickly link images to Media Files and Attachment Pages [https://github.com/wordpress-mobile/gutenberg-mobile/pull/3971]
 * [**] Block editor: Fixed a crash that could occur when copying lists from Microsoft Word. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4174]
-* [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
+* [***] Fixed an issue where trying to upload an image while offline crashes the app. [#17488]
 
 18.6
 -----

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -435,7 +435,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
         }
     }
     if (customErrorMessage) {
-        NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
+        NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
         userInfo[NSLocalizedDescriptionKey] = customErrorMessage;
         error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
     }


### PR DESCRIPTION
This adds the changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/17488 (which has been merged to `develop`) to the 18.7 release branch.

To test:

See #17488