### PR TITLE
Comments: fix empty view vertical placement.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -717,7 +717,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
     // Adjust the NRV placement to accommodate for the filterTabBar.
     CGRect noResultsFrame = self.tableView.frame;
-    noResultsFrame.origin.y -= self.filterTabBar.frame.size.height;
+    noResultsFrame.origin.y = 0;
     self.noResultsViewController.view.frame = noResultsFrame;
 }
 


### PR DESCRIPTION
Ref: p5T066-2OL#comment-10627

This fixes an issue where sometimes the Comments empty view would be misplaced, resulting in a grey area at the top. It is caused by the `adjustNoResultViewPlacement` method sometimes being called before the table frame is updated, so the calculated vertical position was incorrect. This change simply sets the empty view's `origin.y` to `0` instead of trying to calculate it.

To test:
- Go to My Site > Comments.
- There are repro steps on the referenced post, but that didn't work for me. This did:
  - Go to a filter that has comments.
  - Moderate the comments so the filter is empty.
  - Return to the filtered list view.
  - Verify the empty view placement is correct.
- Test on iPhone and iPad.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/142472569-12fa8899-2006-442e-a302-41325e9464ff.png) | ![after](https://user-images.githubusercontent.com/1816888/142472577-2bd2ae8f-c95f-4f84-a064-303ac95cfaed.png) |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
