### PR TITLE
Comment details: refactor Delete Permanently button into a reusable cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -1,0 +1,88 @@
+import UIKit
+
+// UITableViewCell that displays a full width button with a border.
+// Properties:
+// - normalColor: used for the button label and border.
+// - highlightedColor: used for the button label when the button is pressed.
+// - buttonInsets: used to provide margins around the button within the cell.
+// The delegate is notified when the button is tapped.
+
+protocol BorderedButtonTableViewCellDelegate: AnyObject {
+    func buttonTapped()
+}
+
+class BorderedButtonTableViewCell: UITableViewCell {
+
+    // MARK: - Properties
+
+    weak var delegate: BorderedButtonTableViewCellDelegate?
+
+    private var buttonTitle = String()
+    private var buttonInsets = Defaults.buttonInsets
+    private var titleFont = Defaults.titleFont
+    private var normalColor = Defaults.normalColor
+    private var highlightedColor = Defaults.highlightedColor
+
+    // MARK: - Configure
+
+    func configure(buttonTitle: String,
+                   titleFont: UIFont = Defaults.titleFont,
+                   normalColor: UIColor = Defaults.normalColor,
+                   highlightedColor: UIColor = Defaults.highlightedColor,
+                   buttonInsets: UIEdgeInsets = Defaults.buttonInsets) {
+        self.buttonTitle = buttonTitle
+        self.titleFont = titleFont
+        self.normalColor = normalColor
+        self.highlightedColor = highlightedColor
+        configureView()
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension BorderedButtonTableViewCell {
+
+    func configureView() {
+        selectionStyle = .none
+        accessibilityTraits = .button
+
+        let button = configuredButton()
+        contentView.addSubview(button)
+        contentView.pinSubviewToAllEdges(button, insets: buttonInsets)
+    }
+
+    func configuredButton() -> UIButton {
+        let button = UIButton()
+        let buttonColor = normalColor
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(buttonTitle, for: .normal)
+        button.setTitleColor(buttonColor, for: .normal)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: buttonColor), for: .normal)
+        button.setBackgroundImage(.renderBackgroundImage(fill: buttonColor, border: buttonColor), for: .highlighted)
+
+        button.titleLabel?.font = titleFont
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+
+        // Add constraints to the title label, so the button can contain it properly in multi-line cases.
+        if let label = button.titleLabel {
+            button.pinSubviewToAllEdgeMargins(label)
+        }
+
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.delegate?.buttonTapped()
+        }
+
+        return button
+    }
+
+    struct Defaults {
+        static let buttonInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
+        static let titleFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
+        static let normalColor: UIColor = .text
+        static let highlightedColor: UIColor = .white
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -102,40 +102,11 @@ class CommentDetailViewController: UIViewController {
         return cell
     }()
 
-    private lazy var deleteButton: UIButton = {
-        let button = UIButton()
-        let buttonColor = UIColor(light: .error, dark: .muriel(name: .red, .shade40))
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(.deleteButtonText, for: .normal)
-        button.setTitleColor(buttonColor, for: .normal)
-        button.setTitleColor(.white, for: .highlighted)
-        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: buttonColor), for: .normal)
-        button.setBackgroundImage(.renderBackgroundImage(fill: buttonColor, border: buttonColor), for: .highlighted)
-
-        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.numberOfLines = 0
-
-        // add constraints to the title label, so the button can contain it properly in multi-line cases.
-        if let label = button.titleLabel {
-            button.pinSubviewToAllEdgeMargins(label)
-        }
-
-        button.on(.touchUpInside) { [weak self] _ in
-            self?.deleteButtonTapped()
-        }
-
-        return button
-    }()
-
-    private lazy var deleteButtonCell: UITableViewCell = {
-        let cell = UITableViewCell()
-        cell.selectionStyle = .none
-        cell.accessibilityTraits = .button
-
-        cell.contentView.addSubview(deleteButton)
-        cell.contentView.pinSubviewToAllEdges(deleteButton, insets: Constants.deleteButtonInsets)
-
+    private lazy var deleteButtonCell: BorderedButtonTableViewCell = {
+        let cell = BorderedButtonTableViewCell()
+        cell.configure(buttonTitle: .deleteButtonText,
+                       normalColor: UIColor(light: .error, dark: .muriel(name: .red, .shade40)))
+        cell.delegate = self
         return cell
     }()
 
@@ -983,6 +954,16 @@ extension CommentDetailViewController: SuggestionsTableViewDelegate {
     func suggestionsTableView(_ suggestionsTableView: SuggestionsTableView, didSelectSuggestion suggestion: String?, forSearchText text: String) {
         replyTextView?.replaceTextAtCaret(text as NSString?, withText: suggestion)
         suggestionsTableView.hideSuggestions()
+    }
+
+}
+
+// MARK: - BorderedButtonTableViewCellDelegate
+
+extension CommentDetailViewController: BorderedButtonTableViewCellDelegate {
+
+    func buttonTapped() {
+        deleteButtonTapped()
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -235,8 +235,6 @@ private extension CommentDetailViewController {
         static let tableHorizontalInset: CGFloat = 20.0
         static let tableBottomMargin: CGFloat = 40.0
         static let replyIndicatorVerticalSpacing: CGFloat = 14.0
-
-        static let deleteButtonInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
     }
 
     /// Convenience computed variable for an inset setting that hides a cell's separator by pushing it off the edge of the screen.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1670,6 +1670,8 @@
 		98812967219CE42A0075FF33 /* StatsTotalRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98812965219CE42A0075FF33 /* StatsTotalRow.xib */; };
 		9881296E219CF1310075FF33 /* StatsCellHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9881296C219CF1300075FF33 /* StatsCellHeader.swift */; };
 		9881296F219CF1310075FF33 /* StatsCellHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9881296D219CF1310075FF33 /* StatsCellHeader.xib */; };
+		98830A922747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98830A912747043B0061A87C /* BorderedButtonTableViewCell.swift */; };
+		98830A932747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98830A912747043B0061A87C /* BorderedButtonTableViewCell.swift */; };
 		98880A4A22B2E5E400464538 /* TwoColumnCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98880A4822B2E5E400464538 /* TwoColumnCell.swift */; };
 		98880A4B22B2E5E400464538 /* TwoColumnCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98880A4922B2E5E400464538 /* TwoColumnCell.xib */; };
 		988AC37522F10DD900BC1433 /* FileDownloadsStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988AC37422F10DD900BC1433 /* FileDownloadsStatsRecordValue+CoreDataProperties.swift */; };
@@ -6307,6 +6309,7 @@
 		98812965219CE42A0075FF33 /* StatsTotalRow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsTotalRow.xib; sourceTree = "<group>"; };
 		9881296C219CF1300075FF33 /* StatsCellHeader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsCellHeader.swift; sourceTree = "<group>"; };
 		9881296D219CF1310075FF33 /* StatsCellHeader.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsCellHeader.xib; sourceTree = "<group>"; };
+		98830A912747043B0061A87C /* BorderedButtonTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BorderedButtonTableViewCell.swift; sourceTree = "<group>"; };
 		9884B143236224F80021D8E9 /* WordPressUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9884B145236225230021D8E9 /* WordPressUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WordPressUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		98880A4822B2E5E400464538 /* TwoColumnCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoColumnCell.swift; sourceTree = "<group>"; };
@@ -10994,6 +10997,7 @@
 		8320B5CF11FCA3EA00607422 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				98830A912747043B0061A87C /* BorderedButtonTableViewCell.swift */,
 				9F74696A209EFD0C0074D52B /* CheckmarkTableViewCell.swift */,
 				4034FDE92007C42400153B87 /* ExpandableCell.swift */,
 				4034FDED2007D4F700153B87 /* ExpandableCell.xib */,
@@ -18399,6 +18403,7 @@
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
+				98830A922747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */,
 				FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */,
 				E1CA0A6C1FA73053004C4BBE /* PluginStore.swift in Sources */,
 				FAB8F7AA25AD792500D5D54A /* JetpackBackupStatusViewController.swift in Sources */,
@@ -20568,6 +20573,7 @@
 				FABB25AD2602FC2C00C8785C /* SharingAuthorizationWebViewController.swift in Sources */,
 				3FB1929326C6C57A000F5AA3 /* TimeSelectionView.swift in Sources */,
 				FABB25AE2602FC2C00C8785C /* SearchWrapperView.swift in Sources */,
+				98830A932747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */,
 				FABB25AF2602FC2C00C8785C /* UserSettings.swift in Sources */,
 				FABB25B02602FC2C00C8785C /* MediaImportService.swift in Sources */,
 				FABB25B12602FC2C00C8785C /* NSAttributedStringKey+Conversion.swift in Sources */,


### PR DESCRIPTION
Fixes: n/a

This refactors the `Delete Permanently` button in comment details into a standalone `UITableViewCell` class so it can be reused. Basically, I just moved the cell and button code from `CommentDetailViewController` to `BorderedButtonTableViewCell`, with some tweaks.

This is in anticipation of showing comments in post details (pbArwn-38X), which will probably need the same type of button.

To test:
- Go to My Site > Comments.
- Select Spam or Trash filter.
- Verify the `Delete Permanently` button looks correct.
- Verify tapping it deletes the comment.

## Regression Notes
1. Potential unintended areas of impact
Should be none. This is the only view that uses this button.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified deleting comments works.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
