### PR TITLE
Unified About: Remove dependencies

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
@@ -1,15 +1,20 @@
 import Foundation
 import SwiftUI
 
+
+/// Defines the content of the header that appears on the top level about screen.
+struct AboutScreenAppInfo {
+    /// The app's name
+    let name: String
+    /// The current build version of the app
+    let version: String
+    /// The app's icon
+    let icon: UIImage
+}
+
 final class UnifiedAboutHeaderView: UIView {
 
     // MARK: - Customization Support
-
-    struct AppInfo {
-        let icon: UIImage
-        let name: String
-        let version: String
-    }
 
     struct Spacing {
         let betweenAppIconAndAppNameLabel: CGFloat
@@ -40,14 +45,14 @@ final class UnifiedAboutHeaderView: UIView {
 
     // MARK: - View Customization
 
-    private let appInfo: AppInfo
+    private let appInfo: AboutScreenAppInfo
     private let spacing: Spacing
     private let sizing: Sizing
     private let fonts: Fonts
 
     // MARK: - Initializers
 
-    init(appInfo: AppInfo,
+    init(appInfo: AboutScreenAppInfo,
          sizing: Sizing = defaultSizing,
          spacing: Spacing = defaultSpacing,
          fonts: Fonts) {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 
 /// Defines the content of the header that appears on the top level about screen.
@@ -17,12 +16,13 @@ struct AboutScreenFonts {
     let appVersion: UIFont
 
     static let defaultFonts: AboutScreenFonts = {
+        // Title is serif semibold large title
         let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .largeTitle)
-        let fontDescriptorWithDesign = fontDescriptor.withDesign(.serif) ?? fontDescriptor
+        let serifFontDescriptor = fontDescriptor.withDesign(.serif) ?? fontDescriptor
         let traits = [UIFontDescriptor.TraitKey.weight: UIFont.Weight.semibold]
-        let finalDescriptor = fontDescriptorWithDesign.addingAttributes([.traits: traits])
+        let descriptor = serifFontDescriptor.addingAttributes([.traits: traits])
 
-        let font = UIFont(descriptor: finalDescriptor, size: finalDescriptor.pointSize)
+        let font = UIFont(descriptor: descriptor, size: descriptor.pointSize)
         return AboutScreenFonts(appName: font,
                                 appVersion: .preferredFont(forTextStyle: .callout))
     }()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutHeaderView.swift
@@ -12,6 +12,22 @@ struct AboutScreenAppInfo {
     let icon: UIImage
 }
 
+struct AboutScreenFonts {
+    let appName: UIFont
+    let appVersion: UIFont
+
+    static let defaultFonts: AboutScreenFonts = {
+        let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .largeTitle)
+        let fontDescriptorWithDesign = fontDescriptor.withDesign(.serif) ?? fontDescriptor
+        let traits = [UIFontDescriptor.TraitKey.weight: UIFont.Weight.semibold]
+        let finalDescriptor = fontDescriptorWithDesign.addingAttributes([.traits: traits])
+
+        let font = UIFont(descriptor: finalDescriptor, size: finalDescriptor.pointSize)
+        return AboutScreenFonts(appName: font,
+                                appVersion: .preferredFont(forTextStyle: .callout))
+    }()
+}
+
 final class UnifiedAboutHeaderView: UIView {
 
     // MARK: - Customization Support
@@ -25,11 +41,6 @@ final class UnifiedAboutHeaderView: UIView {
     struct Sizing {
         let appIconWidthAndHeight: CGFloat
         let appIconCornerRadius: CGFloat
-    }
-
-    struct Fonts {
-        let appName: UIFont
-        let appVersion: UIFont
     }
 
     // MARK: - Defaults
@@ -48,14 +59,14 @@ final class UnifiedAboutHeaderView: UIView {
     private let appInfo: AboutScreenAppInfo
     private let spacing: Spacing
     private let sizing: Sizing
-    private let fonts: Fonts
+    private let fonts: AboutScreenFonts
 
     // MARK: - Initializers
 
     init(appInfo: AboutScreenAppInfo,
          sizing: Sizing = defaultSizing,
          spacing: Spacing = defaultSpacing,
-         fonts: Fonts) {
+         fonts: AboutScreenFonts) {
 
         self.appInfo = appInfo
         self.sizing = sizing

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -3,6 +3,8 @@ import UIKit
 
 class UnifiedAboutViewController: UIViewController, OrientationLimited {
     private let appInfo: AboutScreenAppInfo?
+    private let fonts: AboutScreenFonts?
+
     private let configuration: AboutScreenConfiguration
     private let isSubmenu: Bool
 
@@ -46,13 +48,9 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
             return nil
         }
 
-        // These customizations are temporarily here, but if this VC is moved into a framework we'll need to move them
-        // into the main App.
-        let fonts = UnifiedAboutHeaderView.Fonts(
-            appName: WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold),
-            appVersion: WPStyleGuide.tableviewTextFont())
+        let headerFonts = fonts ?? AboutScreenFonts.defaultFonts
 
-        let headerView = UnifiedAboutHeaderView(appInfo: appInfo, fonts: fonts)
+        let headerView = UnifiedAboutHeaderView(appInfo: appInfo, fonts: headerFonts)
 
         // Setting the frame once is needed so that the table view header will show.
         // This seems to be a table view bug although I'm not entirely sure.
@@ -98,14 +96,16 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     // MARK: - View lifecycle
 
-    static func controller(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration) -> UIViewController {
+    static func controller(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil) -> UIViewController {
         let controller = UnifiedAboutViewController(appInfo: appInfo,
-                                                    configuration: configuration)
+                                                    configuration: configuration,
+                                                    fonts: fonts)
         return UINavigationController(rootViewController: controller)
     }
 
-    init(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, isSubmenu: Bool = false) {
+    init(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil, isSubmenu: Bool = false) {
         self.appInfo = appInfo
+        self.fonts = fonts
         self.configuration = configuration
         self.isSubmenu = isSubmenu
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -1,8 +1,8 @@
 import UIKit
-import WordPressShared
 
 
 class UnifiedAboutViewController: UIViewController, OrientationLimited {
+    private let appInfo: AboutScreenAppInfo?
     private let configuration: AboutScreenConfiguration
     private let isSubmenu: Bool
 
@@ -41,14 +41,13 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
         return tableView
     }()
 
-    let headerView: UIView = {
+    lazy var headerView: UIView? = {
+        guard let appInfo = appInfo else {
+            return nil
+        }
+
         // These customizations are temporarily here, but if this VC is moved into a framework we'll need to move them
         // into the main App.
-        let appInfo = UnifiedAboutHeaderView.AppInfo(
-            icon: UIImage(named: AppIcon.currentOrDefault.imageName) ?? UIImage(),
-            name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
-            version: Bundle.main.detailedVersionNumber() ?? "")
-
         let fonts = UnifiedAboutHeaderView.Fonts(
             appName: WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold),
             appVersion: WPStyleGuide.tableviewTextFont())
@@ -99,12 +98,14 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     // MARK: - View lifecycle
 
-    static func controller(configuration: AboutScreenConfiguration) -> UIViewController {
-        let controller = UnifiedAboutViewController(configuration: configuration)
+    static func controller(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration) -> UIViewController {
+        let controller = UnifiedAboutViewController(appInfo: appInfo,
+                                                    configuration: configuration)
         return UINavigationController(rootViewController: controller)
     }
 
-    init(configuration: AboutScreenConfiguration, isSubmenu: Bool = false) {
+    init(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, isSubmenu: Bool = false) {
+        self.appInfo = appInfo
         self.configuration = configuration
         self.isSubmenu = isSubmenu
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -96,13 +96,6 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
     // MARK: - View lifecycle
 
-    static func controller(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil) -> UIViewController {
-        let controller = UnifiedAboutViewController(appInfo: appInfo,
-                                                    configuration: configuration,
-                                                    fonts: fonts)
-        return UINavigationController(rootViewController: controller)
-    }
-
     init(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil, isSubmenu: Bool = false) {
         self.appInfo = appInfo
         self.fonts = fonts

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -11,6 +11,10 @@ struct WebViewPresenter {
 }
 
 class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
+    static let appInfo: AboutScreenAppInfo = AboutScreenAppInfo(name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
+                                                                version: Bundle.main.detailedVersionNumber() ?? "",
+                                                                icon: UIImage(named: AppIcon.currentOrDefault.imageName) ?? UIImage())
+
     let sharePresenter: ShareAppContentPresenter
     let webViewPresenter = WebViewPresenter()
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -11,9 +11,12 @@ struct WebViewPresenter {
 }
 
 class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
-    static let appInfo: AboutScreenAppInfo = AboutScreenAppInfo(name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
-                                                                version: Bundle.main.detailedVersionNumber() ?? "",
-                                                                icon: UIImage(named: AppIcon.currentOrDefault.imageName) ?? UIImage())
+    static let appInfo = AboutScreenAppInfo(name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
+                                            version: Bundle.main.detailedVersionNumber() ?? "",
+                                            icon: UIImage(named: AppIcon.currentOrDefault.imageName) ?? UIImage())
+
+    static let fonts = AboutScreenFonts(appName: WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold),
+                                        appVersion: WPStyleGuide.tableviewTextFont())
 
     let sharePresenter: ShareAppContentPresenter
     let webViewPresenter = WebViewPresenter()

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,7 +254,9 @@ class MeViewController: UITableViewController {
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
             let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
-            let controller = UnifiedAboutViewController.controller(appInfo: WordPressAboutScreenConfiguration.appInfo, configuration: configuration)
+            let controller = UnifiedAboutViewController.controller(appInfo: WordPressAboutScreenConfiguration.appInfo,
+                                                                   configuration: configuration,
+                                                                   fonts: WordPressAboutScreenConfiguration.fonts)
             controller.modalPresentationStyle = .formSheet
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,7 +254,7 @@ class MeViewController: UITableViewController {
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
             let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
-            let controller = UnifiedAboutViewController.controller(configuration: configuration)
+            let controller = UnifiedAboutViewController.controller(appInfo: WordPressAboutScreenConfiguration.appInfo, configuration: configuration)
             controller.modalPresentationStyle = .formSheet
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,11 +254,12 @@ class MeViewController: UITableViewController {
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
             let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
-            let controller = UnifiedAboutViewController.controller(appInfo: WordPressAboutScreenConfiguration.appInfo,
-                                                                   configuration: configuration,
-                                                                   fonts: WordPressAboutScreenConfiguration.fonts)
-            controller.modalPresentationStyle = .formSheet
-            self.present(controller, animated: true) {
+            let controller = UnifiedAboutViewController(appInfo: WordPressAboutScreenConfiguration.appInfo,
+                                                        configuration: configuration,
+                                                        fonts: WordPressAboutScreenConfiguration.fonts)
+            let navigationController = UINavigationController(rootViewController: controller)
+            navigationController.modalPresentationStyle = .formSheet
+            self.present(navigationController, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)
             }
         }


### PR DESCRIPTION
Refs #17498. This PR is part of the work required to extract the new About screen out into a reusable Swift package. It makes the app header information (title, version, and icon) and font selection configurable by the host app.

<img width="421" alt="Screenshot 2021-11-19 at 14 45 40" src="https://user-images.githubusercontent.com/4780/142644133-b8920fe5-bcf3-44ba-a7d7-32a5089422d3.png">

**To test**

* Build and run and ensure that the header in the about screen looks as expected
* Try changing the AppInfo and Fonts defined in `WordPressAboutScreenConfiguration` and check that your changes are reflected in the about screen. For example, you could change the fonts to:

```
static let fonts = AboutScreenFonts(appName: UIFont(name: "Zapfino", size: 28.0)!, appVersion: UIFont(name: "Chalkboard SE", size: 22.0)!)
```
to see the styles shown in the screenshot above.

## Regression Notes
1. Potential unintended areas of impact

The appearance of the header

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I ensured that the default styles match what we had previously.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
