### PR TITLE
Add tracking to the site switcher

### DIFF
--- a/WordPress/Classes/Categories/NSObject+Helpers.h
+++ b/WordPress/Classes/Categories/NSObject+Helpers.h
@@ -6,4 +6,5 @@
 
 + (nonnull NSString *)classNameWithoutNamespaces;
 
+- (void)debounce:(SEL)selector afterDelay:(NSTimeInterval)timeInterval;
 @end

--- a/WordPress/Classes/Categories/NSObject+Helpers.m
+++ b/WordPress/Classes/Categories/NSObject+Helpers.m
@@ -11,4 +11,14 @@
     return [[NSStringFromClass(self) componentsSeparatedByString:@"."] lastObject];
 }
 
+- (void)debounce:(SEL)selector afterDelay:(NSTimeInterval)timeInterval
+{
+  __weak __typeof(self) weakSelf = self;
+  [NSObject cancelPreviousPerformRequestsWithTarget:weakSelf
+                                           selector:selector
+                                             object:nil];
+  [weakSelf performSelector:selector
+                 withObject:nil
+                 afterDelay:timeInterval];
+}
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -605,7 +605,7 @@ import Foundation
         case .siteSwitcherDismissed:
             return "site_switcher_dismissed"
         case .siteSwitcherToggleEditTapped:
-            return "site_switcher_toggled_edit_tapped"
+            return "site_switcher_toggle_edit_tapped"
         case .siteSwitcherAddSiteTapped:
             return "site_switcher_add_site_tapped"
         case .siteSwitcherSearchPerformed:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -215,6 +215,15 @@ import Foundation
     case mySiteNoSitesViewActionTapped
     case mySiteNoSitesViewHidden
 
+    // Site Switcher
+    case mySiteSiteSwitcherTapped
+    case siteSwitcherDisplayed
+    case siteSwitcherDismissed
+    case siteSwitcherToggleEditTapped
+    case siteSwitcherAddSiteTapped
+    case siteSwitcherSearchPerformed
+    case siteSwitcherToggleBlogVisible
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -587,7 +596,24 @@ import Foundation
             return "my_site_no_sites_view_action_tapped"
         case .mySiteNoSitesViewHidden:
             return "my_site_no_sites_view_hidden"
-        }
+
+        // Site Switcher
+        case .mySiteSiteSwitcherTapped:
+            return "my_site_site_switcher_tapped"
+        case .siteSwitcherDisplayed:
+            return "site_switcher_displayed"
+        case .siteSwitcherDismissed:
+            return "site_switcher_dismissed"
+        case .siteSwitcherToggleEditTapped:
+            return "site_switcher_toggled_edit_tapped"
+        case .siteSwitcherAddSiteTapped:
+            return "site_switcher_add_site_tapped"
+        case .siteSwitcherSearchPerformed:
+            return "site_switcher_search_performed"
+        case .siteSwitcherToggleBlogVisible:
+            return "site_switcher_toggle_blog_visible"
+
+        } // END OF SWITCH
     }
 
     /**

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1155,6 +1155,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     UINavigationController* navigationController = [[UINavigationController alloc] initWithRootViewController:blogListViewController];
     navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
     [self presentViewController:navigationController animated:true completion:nil];
+
+    [WPAnalytics trackEvent:WPAnalyticsEventMySiteSiteSwitcherTapped];
 }
 
 - (void)visitSiteTapped

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -800,12 +800,19 @@ static NSInteger HideSearchMinSites = 3;
 - (void)searchBar:(UISearchBar *)searchBar textDidChange:(NSString *)searchText
 {
     self.dataSource.searchQuery = searchText;
+
+    [self debounce:@selector(trackSearchPerformed) afterDelay:0.5f];
 }
 
 - (void)searchBarTextDidBeginEditing:(UISearchBar *)searchBar
 {
     self.dataSource.searching = YES;
     [searchBar setShowsCancelButton:YES animated:YES];
+}
+
+- (void)trackSearchPerformed
+{
+    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherSearchPerformed];
 }
 
 - (void)searchBarTextDidEndEditing:(UISearchBar *)searchBar

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -863,6 +863,8 @@ static NSInteger HideSearchMinSites = 3;
         [self updateViewsForCurrentSiteCount];
         [self updateSearchVisibility];
     }
+    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherToggleEditTapped properties: @{ @"state": editing ? @"edit" : @"done"}];
+
 }
 
 - (BOOL)shouldShowAddSiteButton

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -154,6 +154,8 @@ static NSInteger HideSearchMinSites = 3;
 
     [self registerForAccountChangeNotification];
     [self registerForPostSignUpNotifications];
+
+    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherDisplayed];
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -963,6 +963,9 @@ static NSInteger HideSearchMinSites = 3;
     }
     AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] mainContext]];
     [accountService setVisibility:visible forBlogs:@[blog]];
+
+    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherToggleBlogVisible properties:@{ @"visible": @(visible)} blog:blog];
+
 }
 
 #pragma mark - Data Listener

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -188,6 +188,8 @@ static NSInteger HideSearchMinSites = 3;
         [self.searchBar resignFirstResponder];
     }
     self.visible = NO;
+
+    [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherDismissed];
 }
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -1013,6 +1013,9 @@ static NSInteger HideSearchMinSites = 3;
 
         [self presentViewController:alertController animated:YES completion:nil];
         self.addSiteAlertController = alertController;
+
+        [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherAddSiteTapped];
+
     }
 }
 


### PR DESCRIPTION
Project: #17503

### Description
Adds tracking to the site switcher when:

- The My Site Site switcher is tapped
- The site switcher is displayed
- The site switcher is dismissed
- The edit / done button is toggled
- The add site button is tapepd
- A search is performed
- A blogs visible is changed

### To test:

1. Launch the app and sign in with an account with multiple blogs enabled
2. Tap the down arrow to open the site switcher:
3. Verify you see: ` 🔵 Tracked: my_site_site_switcher_tapped`
4. Verify you see: ` 🔵 Tracked: site_switcher_displayed`
5. Perform a search and verify you see: `🔵 Tracked: site_switcher_search_performed`
6. Tap the Edit button
7. Verify you see: ` 🔵 Tracked: site_switcher_toggled_edit_tapped <state: edit>` 
8. Tap the switch button to change a blogs visibility to hidden
9. Verify you see `🔵 Tracked: site_switcher_toggle_blog_visible <blog_id: BLOG_ID, site_type: blog, visible: 0>` 
8. Tap the switch button to change a blogs visibility to visible
10. Verify you see `🔵 Tracked: site_switcher_toggle_blog_visible <blog_id: BLOG_ID, site_type: blog, visible: 1>` 
11. Tap the 'Done' button
12. Verify you see `🔵 Tracked: site_switcher_toggled_edit_tapped <state: done>`
13. Tap the + button to add a site
14. Verify you see `🔵 Tracked: site_switcher_add_site_tapped`
15. Tap the 'Cancel' button
16. Verify you see `🔵 Tracked: site_switcher_dismissed`

## Regression Notes
1. Potential unintended areas of impact
None, adding tracks to specific areas. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
