### PR TITLE
Remove duplicate tracks items

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1715,7 +1715,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showPeople
 {
-    [WPAppAnalytics track:WPAnalyticsStatOpenedPeople withBlog:self.blog];
     PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self showDetailViewController:controller sender:self];

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -169,7 +169,12 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         super.viewWillAppear(animated)
         tableView.deselectSelectedRowWithAnimation(true)
         refreshNoResultsView()
-        WPAnalytics.track(.openedPeople)
+
+        guard let blog = blog else {
+            return
+        }
+
+        WPAppAnalytics.track(.openedPeople, with: blog)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -170,7 +170,7 @@ import WordPressFlux
 
     var contentType: ReaderContentType = .topic {
         didSet {
-            if contentType == .saved {
+            if oldValue != .saved, contentType == .saved {
                 updateContent(synchronize: false)
                 trackSavedListAccessed()
             }


### PR DESCRIPTION
Project: #17503

### Description
Fixes a couple instances of tracks being duplicated when:

- The People view is accessed
- The Reader Saved list is accessed

### To test:

#### People list
1. Go to the My Site tab
2. Scroll down to the People item
3. Tap on the People item
4. Verify you see only 1: `🔵 Tracked: people_management_list_opened <blog_id: BLOG_ID, site_type: blog>` 

#### Reader Saved Accessed
1. Go to the Reader Tab
2. Tap on the 'Saved' item
3. Verify you see only 1: `🔵 Tracked: reader_saved_list_shown <source: reader_filter, subscription_count: COUNT>`

## Regression Notes
1. Potential unintended areas of impact
None, adding tracks to specific areas. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
