### PR TITLE
Hierarchical Comments: add fetch method to provide count

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.43.0'
+    # pod 'WordPressKit', '~> 4.43.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/17511-return_comments_count'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.43.0'
+    pod 'WordPressKit', '~> 4.44.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/17511-return_comments_count'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.5)
   - WordPressAuthenticator (~> 1.42.1)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/17511-return_comments_count`)
+  - WordPressKit (~> 4.44.0-beta)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.2)
   - WordPressUI (~> 1.12.2)
@@ -565,6 +565,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -710,9 +711,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.66.0
-  WordPressKit:
-    :branch: feature/17511-return_comments_count
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.66.0/third-party-podspecs/Yoga.podspec.json
 
@@ -728,9 +726,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.66.0
-  WordPressKit:
-    :commit: 2dc43ee25c91886ae7a1959d56c2779493006e03
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -815,7 +810,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: af36d9cb86a0109b568f516874870e2801ba1bd9
   WordPress-Editor-iOS: 446be349b94707c1a82a83d525b86dbcf18cf2c7
   WordPressAuthenticator: 111793c08fa8e9d9a72aed5b33a094c91ff4fd82
-  WordPressKit: 74fcc8ab2f338997d015cb9e0fac95cbf8484f19
+  WordPressKit: 7fe46752fe65808f80163ae135bb5c3f081d108b
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 6f4d949aa3ec8c3b9c24f5aa601473f087badd24
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
@@ -831,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: cfe0ee270060185f1f0c15ee8cfb65d86be841cd
+PODFILE CHECKSUM: 70e2c1b2bb057852c4af271041294e98678f6963
 
 COCOAPODS: 1.10.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -452,7 +452,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.43.0):
+  - WordPressKit (4.44.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -553,7 +553,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.5)
   - WordPressAuthenticator (~> 1.42.1)
-  - WordPressKit (~> 4.43.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/17511-return_comments_count`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.16.2)
   - WordPressUI (~> 1.12.2)
@@ -565,7 +565,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressUI
   trunk:
     - 1PasswordExtension
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.66.0
+  WordPressKit:
+    :branch: feature/17511-return_comments_count
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.66.0/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.66.0
+  WordPressKit:
+    :commit: 2dc43ee25c91886ae7a1959d56c2779493006e03
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -810,7 +815,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: af36d9cb86a0109b568f516874870e2801ba1bd9
   WordPress-Editor-iOS: 446be349b94707c1a82a83d525b86dbcf18cf2c7
   WordPressAuthenticator: 111793c08fa8e9d9a72aed5b33a094c91ff4fd82
-  WordPressKit: ea1b285bae9156e387ddcbe2a7f919c0783a9b91
+  WordPressKit: 74fcc8ab2f338997d015cb9e0fac95cbf8484f19
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 6f4d949aa3ec8c3b9c24f5aa601473f087badd24
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 05f1d233304eca44dd7b86f86e966d786c29c86f
+PODFILE CHECKSUM: cfe0ee270060185f1f0c15ee8cfb65d86be841cd
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -95,10 +95,16 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
               success:(void (^)(void))success
               failure:(void (^)(NSError *error))failure;
 
-// Sync a list of comments sorted by hierarchy
+// Sync a list of comments sorted by hierarchy, fetched by page number.
 - (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
                                    page:(NSUInteger)page
-                                success:(void (^)(NSInteger count, BOOL hasMore))success
+                                success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
+                                failure:(void (^)(NSError *error))failure;
+
+// Sync a list of comments sorted by hierarchy, restricted by the specified number of _top level_ comments.
+- (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
+                 numberTopLevelComments:(NSUInteger)number
+                                success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
                                 failure:(void (^)(NSError *error))failure;
 
 // Counts and returns the number of full pages of hierarchcial comments synced for a post.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -978,7 +978,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 {
     self.failedToFetchComments = NO;
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
-    [service syncHierarchicalCommentsForPost:self.post page:1 success:^(NSInteger count, BOOL hasMore) {
+    [service syncHierarchicalCommentsForPost:self.post page:1 success:^(BOOL hasMore, NSNumber *totalComments) {
         if (success) {
             success(hasMore);
         }
@@ -993,7 +993,7 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
-    [service syncHierarchicalCommentsForPost:self.post page:page success:^(NSInteger count, BOOL hasMore) {
+    [service syncHierarchicalCommentsForPost:self.post page:page success:^(BOOL hasMore, NSNumber *totalComments) {
         if (success) {
             success(hasMore);
         }


### PR DESCRIPTION
Ref: #17511
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/468

This change does two things:
- Uses the WPKit changes to surface the `totalComments` count from the API.
- Adds a new `syncHierarchicalCommentsForPost` method variant to specify the number of _top level_ comments to fetch. The default is 20, but only 2 will be needed for the post details comments.

To test:

The `totalCount` and new method are not used yet, so just verify threaded comments are fetched as expected.
- Go to Reader and select a post with comments.
- Verify the comments shown are as expected.

## Regression Notes
1. Potential unintended areas of impact
Comment fetching could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified comments are fetched as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
