### PR TITLE
Reader Comments: Show disclosure when pushing detail is allowed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1483,18 +1483,6 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     }];
 }
 
-- (void)handleHeaderTapped
-{
-    if (!self.allowsPushingPostDetails) {
-        return;
-    }
-
-    // Note: Let's manually hide the comments button, in order to prevent recursion in the flow
-    ReaderDetailViewController *controller = [ReaderDetailViewController controllerWithPost:self.post];
-    controller.shouldHideComments = YES;
-    [self.navigationController pushFullscreenViewController:controller animated:YES];
-}
-
 
 #pragma mark - UITextViewDelegate methods
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -44,11 +44,23 @@ import UIKit
 
         let cell = CommentHeaderTableViewCell()
         cell.backgroundColor = .systemBackground
-        cell.configure(for: .thread, subtitle: post.titleForDisplay(), showsDisclosureIndicator: false)
+        cell.configure(for: .thread, subtitle: post.titleForDisplay(), showsDisclosureIndicator: allowsPushingPostDetails)
+        cell.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(handleHeaderTapped)))
 
         // the table view does not render separators for the section header views, so we need to create one.
         cell.contentView.addBottomBorder(withColor: .separator, leadingMargin: tableView.separatorInset.left)
 
         return cell
+    }
+
+    func handleHeaderTapped() {
+        guard let post = post,
+              allowsPushingPostDetails else {
+            return
+        }
+
+        let controller = ReaderDetailViewController.controllerWithPost(post)
+        controller.shouldHideComments = true
+        navigationController?.pushFullscreenViewController(controller, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -59,6 +59,7 @@ import UIKit
             return
         }
 
+        // Note: Let's manually hide the comments button, in order to prevent recursion in the flow
         let controller = ReaderDetailViewController.controllerWithPost(post)
         controller.shouldHideComments = true
         navigationController?.pushFullscreenViewController(controller, animated: true)


### PR DESCRIPTION
Refs #17475

When `allowsPushingPostDetails` is true (e.g. when tapping the comment thread from notification comments, site comments), show the disclosure indicator on the comment header. Tapping on it should navigate to the post screen.

Also: moved the `handleHeaderTapped` method to Swift, so this introduced a little side effect while the feature flag is off.

## To Test

#### With the `newCommentThread` flag enabled:

- Go to reader comments from the Reader page.
- 🔍 Verify that the disclosure indicator is NOT shown, and the cell does nothing when tapped.
- Go to Notifications and select a comment notification. 
- Tap on the notification header to navigate to reader comments.
- 🔍 Verify that the disclosure indicator is shown.
- 🔍 Verify that the app navigates to the post screen when the comment header is tapped.

#### With the `newCommentThread` flag disabled:

- Go to Notifications and select a comment notification. 
- Tap on the notification header to navigate to reader comments.
- 🔍 Verify that the app navigates to the post screen when the comment header is tapped.

## Regression Notes
1. Potential unintended areas of impact
Might impact the behavior of the current comment header. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that things work correctly while the `newCommentThread` is turned off.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
