### PR TITLE
Adds tracking to the Reader Filter Sheet and Manage view

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -113,7 +113,10 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)followTagNamed:(NSString *)tagName withSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)followTagNamed:(NSString *)tagName
+           withSuccess:(void (^)(void))success
+               failure:(void (^)(NSError *error))failure
+                source:(NSString *)source;
 
 /**
  Follow the tag with the specified slug

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -354,14 +354,17 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     }];
 }
 
-- (void)followTagNamed:(NSString *)topicName withSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure
+- (void)followTagNamed:(NSString *)topicName
+           withSuccess:(void (^)(void))success
+               failure:(void (^)(NSError *error))failure
+                source:(NSString *)source
 {
     topicName = [[topicName lowercaseString] trim];
 
     ReaderTopicServiceRemote *remoteService = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [remoteService followTopicNamed:topicName withSuccess:^(NSNumber *topicID) {
         [self fetchReaderMenuWithSuccess:^{
-            NSDictionary *properties = @{@"tag":topicName};
+            NSDictionary *properties = @{@"tag":topicName, @"source":source};
             [WPAnalytics trackReaderStat:WPAnalyticsStatReaderTagFollowed properties:properties];
             [self selectTopicWithID:topicID];
             if (success) {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -224,6 +224,16 @@ import Foundation
     case siteSwitcherSearchPerformed
     case siteSwitcherToggleBlogVisible
 
+    // Reader: Filter Sheet
+    case readerFilterSheetDisplayed
+    case readerFilterSheetDismissed
+    case readerFilterSheetItemSelected
+    case readerFilterSheetCleared
+
+    // Reader: Manage
+    case readerManageViewDisplayed
+    case readerManageViewDismissed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -613,6 +623,18 @@ import Foundation
         case .siteSwitcherToggleBlogVisible:
             return "site_switcher_toggle_blog_visible"
 
+        case .readerFilterSheetDisplayed:
+            return "reader_filter_sheet_displayed"
+        case .readerFilterSheetDismissed:
+            return "reader_filter_sheet_dismissed"
+        case .readerFilterSheetItemSelected:
+            return "reader_filter_sheet_item_selected"
+        case .readerFilterSheetCleared:
+            return "reader_filter_sheet_cleared"
+        case .readerManageViewDisplayed:
+            return "reader_manage_view_displayed"
+        case .readerManageViewDismissed:
+            return "reader_manage_view_dismissed"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterSheetViewController.swift
@@ -26,6 +26,10 @@ class FilterSheetViewController: UIViewController {
 }
 
 extension FilterSheetViewController: DrawerPresentable {
+    func handleDismiss() {
+        WPAnalytics.track(.readerFilterSheetDismissed)
+    }
+
     var scrollableView: UIScrollView? {
         return (view as? FilterSheetView)?.tableView
     }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -52,6 +52,8 @@ class ReaderManageScenePresenter: ScenePresenter {
         let navigationController = makeNavigationController()
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
+
+        WPAnalytics.track(.readerManageViewDisplayed)
     }
 }
 
@@ -64,6 +66,7 @@ private extension ReaderManageScenePresenter {
         let tabbedViewController = TabbedViewController(items: tabbedItems, onDismiss: {
             self.delegate?.didDismiss(presenter: self)
             NotificationCenter.default.post(name: .readerManageControllerWasDismissed, object: self)
+            WPAnalytics.track(.readerManageViewDismissed)
         })
         tabbedViewController.title =  NSLocalizedString("Manage", comment: "Title for the Reader Manage screen.")
         if let section = selectedSection, let firstSelection = sections.firstIndex(of: section) {

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -179,7 +179,7 @@ extension ReaderTagsTableViewModel {
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
             alert.presentFromRootViewController()
-        })
+        }, source: "manage")
     }
 
     /// Tells the ReaderTopicService to unfollow the specified topic.

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -123,6 +123,8 @@ extension ReaderTabViewModel {
         let bottomSheet = BottomSheetViewController(childViewController: viewController)
         bottomSheet.additionalSafeAreaInsetsRegular = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         bottomSheet.show(from: from, sourceView: sourceView, arrowDirections: .up)
+
+        WPAnalytics.track(.readerFilterSheetDisplayed)
     }
 
     func presentManage(from: UIViewController) {
@@ -139,12 +141,16 @@ extension ReaderTabViewModel {
     }
 
     func resetFilter(selectedItem: FilterTabBarItem) {
+        WPAnalytics.track(.readerFilterSheetCleared)
         if let content = (selectedItem as? ReaderTabItem)?.content {
             setContent?(content)
         }
     }
 
     func setFilterContent(topic: ReaderAbstractTopic) {
+        let type = ((topic as? ReaderSiteTopic) != nil) ? "site" : "topic"
+        WPAnalytics.track(.readerFilterSheetItemSelected, properties: ["type": type])
+
         setContent?(ReaderContent(topic: topic))
     }
 


### PR DESCRIPTION
Project: #17503

### Description
Adds new tracking to the Reader:

#### Filter Sheet
- When its displayed: `reader_filter_sheet_displayed`
- When its dismissed: `reader_filter_sheet_dismissed`
- When an item is selected: `reader_filter_sheet_item_selected`
- When the selected topic is cleared: `reader_filter_sheet_cleared`

#### Manage View
- When its displayed: `reader_manage_view_displayed`
- When its dismissed: `reader_manage_view_displayed`
- Changed the source from `unknown` to manage when following a tag

### To test:

#### Filter Sheet
1. Launch the app and go to the Reader
2. Tap on the following tab
3. Tap on the Filter bar
4. Verify you see `🔵 Tracked: reader_filter_sheet_displayed <>`
5. Select an item under the Sites tab
6. Verify you see `🔵 Tracked: reader_filter_sheet_item_selected <type: site>`
7. Verify you also see: `🔵 Tracked: reader_filter_sheet_dismissed <>`
8. Tap the X button to clear the filter
9. Verify you see `🔵 Tracked: reader_filter_sheet_cleared <>`
10. Tap the filter bar again
11. Switch the tab to 'Topics'
12. Tap on an item
13. Verify you see ` 🔵 Tracked: reader_filter_sheet_item_selected <type: topic>`

#### Manage
1. Launch the app and go to the Reader
2. Tap the cog in the top corner of the view
3. Verify you see `🔵 Tracked: reader_manage_view_displayed <>`
4. Tap the "Add a topic" item
5. Follow any topic
6. Verify you see: `🔵 Tracked: reader_reader_tag_followed <source: manage, subscription_count: YOUR_SUB_COUNT, tag: YOUR_TAG>`
7. Tap the 'Done' button
8. Verify you see `🔵 Tracked: reader_manage_view_dismissed <>` 

### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
