### PR TITLE
Onboarding Improvements: Add skip button to Epilogue if there are no sites yet

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FBE-8U-liw">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FBE-8U-liw">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -40,50 +40,50 @@
                                             <constraint firstAttribute="height" constant="0.5" id="kg0-Rj-t1o"/>
                                         </constraints>
                                     </view>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
+                                        <rect key="frame" x="20" y="40" width="335" height="44"/>
+                                        <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="44" id="8TV-5o-H50"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                        <state key="normal" title="Create a new site">
+                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        </state>
+                                        <state key="selected" backgroundImage="beveled-blue-button-down"/>
+                                        <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                        </state>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                        </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <action selector="createANewSite" destination="FBE-8U-liw" eventType="touchUpInside" id="pVd-x6-7g4"/>
+                                        </connections>
+                                    </button>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="E7v-Xt-6uK" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" id="4cD-GC-Ud9"/>
+                                    <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="40" id="TMQ-51-NeF"/>
                                     <constraint firstAttribute="trailing" secondItem="E7v-Xt-6uK" secondAttribute="trailing" id="YmO-ZG-PD3"/>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="84" id="bjg-yv-Bi5"/>
                                     <constraint firstAttribute="trailing" secondItem="aTr-q6-PbK" secondAttribute="trailing" id="cQt-u6-ypc"/>
                                     <constraint firstAttribute="bottom" secondItem="E7v-Xt-6uK" secondAttribute="bottom" id="mNZ-iM-0Uu"/>
                                     <constraint firstItem="aTr-q6-PbK" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="oAL-rY-TS7"/>
                                     <constraint firstItem="E7v-Xt-6uK" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="phn-sq-0JJ"/>
+                                    <constraint firstItem="51h-er-sEL" firstAttribute="centerX" secondItem="LF6-fg-TWa" secondAttribute="centerX" id="u3c-pn-hx5"/>
                                     <constraint firstItem="aTr-q6-PbK" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" id="zIw-8v-OFh"/>
                                 </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
-                                <rect key="frame" x="20" y="603" width="335" height="44"/>
-                                <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="8TV-5o-H50"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                <state key="normal" title="Create a new site">
-                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                </state>
-                                <state key="selected" backgroundImage="beveled-blue-button-down"/>
-                                <state key="highlighted" backgroundImage="beveled-blue-button-down">
-                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="createANewSite" destination="FBE-8U-liw" eventType="touchUpInside" id="pVd-x6-7g4"/>
-                                </connections>
-                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="NNF-sA-UQ4"/>
                         <constraints>
-                            <constraint firstItem="51h-er-sEL" firstAttribute="leading" secondItem="qDW-L0-z8a" secondAttribute="leading" constant="20" id="0rB-nq-HUv"/>
+                            <constraint firstItem="51h-er-sEL" firstAttribute="leading" secondItem="qDW-L0-z8a" secondAttribute="leading" constant="20" id="5Lj-HO-aLO"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="trailing" secondItem="NNF-sA-UQ4" secondAttribute="trailing" id="980-CW-Iwa"/>
-                            <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="40" id="M0r-84-tJ6"/>
+                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="51h-er-sEL" secondAttribute="bottom" constant="20" id="CsN-0S-KD9"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="ME9-0u-Vx1"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" id="au1-yD-v4h"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="bottom" secondItem="CSv-1Z-yIA" secondAttribute="bottom" id="ePC-QY-FqS"/>
-                            <constraint firstItem="qDW-L0-z8a" firstAttribute="trailing" secondItem="51h-er-sEL" secondAttribute="trailing" constant="20" id="gKl-WT-Qzi"/>
-                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="51h-er-sEL" secondAttribute="bottom" constant="20" id="jN3-1W-Vzo"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="qDW-L0-z8a" secondAttribute="bottom" constant="104" id="mVQ-Dg-W4g"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="NNF-sA-UQ4" secondAttribute="leading" id="pOP-pd-DMR"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="top" secondItem="NNF-sA-UQ4" secondAttribute="top" id="yLi-rM-L1b"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -66,7 +66,6 @@
                                     <constraint firstItem="E7v-Xt-6uK" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" id="4cD-GC-Ud9"/>
                                     <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="40" id="TMQ-51-NeF"/>
                                     <constraint firstAttribute="trailing" secondItem="E7v-Xt-6uK" secondAttribute="trailing" id="YmO-ZG-PD3"/>
-                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="84" id="bjg-yv-Bi5"/>
                                     <constraint firstAttribute="trailing" secondItem="aTr-q6-PbK" secondAttribute="trailing" id="cQt-u6-ypc"/>
                                     <constraint firstAttribute="bottom" secondItem="E7v-Xt-6uK" secondAttribute="bottom" id="mNZ-iM-0Uu"/>
                                     <constraint firstItem="aTr-q6-PbK" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="oAL-rY-TS7"/>
@@ -84,10 +83,16 @@
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="ME9-0u-Vx1"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" id="au1-yD-v4h"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="bottom" secondItem="CSv-1Z-yIA" secondAttribute="bottom" id="ePC-QY-FqS"/>
-                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="qDW-L0-z8a" secondAttribute="bottom" constant="104" id="mVQ-Dg-W4g"/>
+                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="qDW-L0-z8a" secondAttribute="bottom" id="mVQ-Dg-W4g"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="leading" secondItem="NNF-sA-UQ4" secondAttribute="leading" id="pOP-pd-DMR"/>
+                            <constraint firstItem="LF6-fg-TWa" firstAttribute="top" secondItem="qDW-L0-z8a" secondAttribute="bottom" id="wZ3-6e-hG6"/>
                             <constraint firstItem="qDW-L0-z8a" firstAttribute="top" secondItem="NNF-sA-UQ4" secondAttribute="top" id="yLi-rM-L1b"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="mVQ-Dg-W4g"/>
+                            </mask>
+                        </variation>
                     </view>
                     <extendedEdge key="edgesForExtendedLayout"/>
                     <simulatedStatusBarMetrics key="simulatedStatusBarMetrics"/>
@@ -95,7 +100,8 @@
                         <outlet property="blurEffectView" destination="E7v-Xt-6uK" id="RIm-YT-MPx"/>
                         <outlet property="buttonPanel" destination="LF6-fg-TWa" id="XBZ-Df-emN"/>
                         <outlet property="createANewSiteButton" destination="51h-er-sEL" id="703-qw-kKG"/>
-                        <outlet property="tableViewBottomContraint" destination="mVQ-Dg-W4g" id="IbU-ct-ltZ"/>
+                        <outlet property="tableViewBottomConstraintToButtonPanel" destination="wZ3-6e-hG6" id="a3q-GB-ads"/>
+                        <outlet property="tableViewBottomConstraintToSafeArea" destination="mVQ-Dg-W4g" id="IbU-ct-ltZ"/>
                         <outlet property="tableViewLeadingConstraint" destination="pOP-pd-DMR" id="Oat-2L-Iay"/>
                         <outlet property="tableViewTrailingConstraint" destination="au1-yD-v4h" id="jYm-53-dls"/>
                         <outlet property="topLine" destination="aTr-q6-PbK" id="IR4-UV-gef"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -81,6 +81,9 @@
                                                 <userDefinedRuntimeAttributes>
                                                     <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="dismissEpilogue" destination="FBE-8U-liw" eventType="touchUpInside" id="cRc-fJ-fcY"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                     </stackView>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogue.storyboard
@@ -17,18 +17,18 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <containerView opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qDW-L0-z8a">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="503"/>
                                 <connections>
                                     <segue destination="UFO-Sm-cpW" kind="embed" id="rhb-gY-oAu"/>
                                 </connections>
                             </containerView>
                             <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" insetsLayoutMarginsFromSafeArea="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LF6-fg-TWa">
-                                <rect key="frame" x="0.0" y="563" width="375" height="104"/>
+                                <rect key="frame" x="0.0" y="503" width="375" height="164"/>
                                 <subviews>
                                     <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E7v-Xt-6uK">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="104"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="164"/>
                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="TIz-aA-WwG">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="104"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="164"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         </view>
                                         <blurEffect style="regular"/>
@@ -40,46 +40,69 @@
                                             <constraint firstAttribute="height" constant="0.5" id="kg0-Rj-t1o"/>
                                         </constraints>
                                     </view>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="51h-er-sEL" customClass="FancyButton" customModule="WordPressUI">
-                                        <rect key="frame" x="20" y="40" width="335" height="44"/>
-                                        <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="44" id="8TV-5o-H50"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                                        <state key="normal" title="Create a new site">
-                                            <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        </state>
-                                        <state key="selected" backgroundImage="beveled-blue-button-down"/>
-                                        <state key="highlighted" backgroundImage="beveled-blue-button-down">
-                                            <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                        </state>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="createANewSite" destination="FBE-8U-liw" eventType="touchUpInside" id="pVd-x6-7g4"/>
-                                        </connections>
-                                    </button>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-06-TI5">
+                                        <rect key="frame" x="20" y="40" width="335" height="104"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uuX-qp-CAG" userLabel="Create A New Site Button" customClass="FancyButton" customModule="WordPressUI">
+                                                <rect key="frame" x="0.0" y="0.0" width="335" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="Fkq-k6-7rB"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <state key="normal" title="Create a new site">
+                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <state key="selected" backgroundImage="beveled-blue-button-down"/>
+                                                <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="createANewSite" destination="FBE-8U-liw" eventType="touchUpInside" id="RZn-Vp-EYc"/>
+                                                </connections>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TMx-Ec-Bv1" customClass="FancyButton" customModule="WordPressUI">
+                                                <rect key="frame" x="0.0" y="60" width="335" height="44"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="continueToSites"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="44" id="dFU-fI-cmv"/>
+                                                </constraints>
+                                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                <state key="normal" title="Skip">
+                                                    <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </state>
+                                                <state key="selected" backgroundImage="beveled-blue-button-down"/>
+                                                <state key="highlighted" backgroundImage="beveled-blue-button-down">
+                                                    <color key="titleColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                </state>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="boolean" keyPath="isPrimary" value="NO"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                    </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="E7v-Xt-6uK" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" id="4cD-GC-Ud9"/>
-                                    <constraint firstItem="51h-er-sEL" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="40" id="TMQ-51-NeF"/>
+                                    <constraint firstItem="NUJ-06-TI5" firstAttribute="centerX" secondItem="LF6-fg-TWa" secondAttribute="centerX" id="JBs-KR-HUs"/>
                                     <constraint firstAttribute="trailing" secondItem="E7v-Xt-6uK" secondAttribute="trailing" id="YmO-ZG-PD3"/>
                                     <constraint firstAttribute="trailing" secondItem="aTr-q6-PbK" secondAttribute="trailing" id="cQt-u6-ypc"/>
+                                    <constraint firstItem="NUJ-06-TI5" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" constant="40" id="hfz-ci-ga9"/>
                                     <constraint firstAttribute="bottom" secondItem="E7v-Xt-6uK" secondAttribute="bottom" id="mNZ-iM-0Uu"/>
                                     <constraint firstItem="aTr-q6-PbK" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="oAL-rY-TS7"/>
                                     <constraint firstItem="E7v-Xt-6uK" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="phn-sq-0JJ"/>
-                                    <constraint firstItem="51h-er-sEL" firstAttribute="centerX" secondItem="LF6-fg-TWa" secondAttribute="centerX" id="u3c-pn-hx5"/>
                                     <constraint firstItem="aTr-q6-PbK" firstAttribute="top" secondItem="LF6-fg-TWa" secondAttribute="top" id="zIw-8v-OFh"/>
                                 </constraints>
                             </view>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="NNF-sA-UQ4"/>
                         <constraints>
-                            <constraint firstItem="51h-er-sEL" firstAttribute="leading" secondItem="qDW-L0-z8a" secondAttribute="leading" constant="20" id="5Lj-HO-aLO"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="trailing" secondItem="NNF-sA-UQ4" secondAttribute="trailing" id="980-CW-Iwa"/>
-                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="51h-er-sEL" secondAttribute="bottom" constant="20" id="CsN-0S-KD9"/>
+                            <constraint firstItem="NUJ-06-TI5" firstAttribute="leading" secondItem="qDW-L0-z8a" secondAttribute="leading" constant="20" id="DFf-WH-AzB"/>
+                            <constraint firstItem="NNF-sA-UQ4" firstAttribute="bottom" secondItem="NUJ-06-TI5" secondAttribute="bottom" constant="20" id="GlE-sU-jXB"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="leading" secondItem="LF6-fg-TWa" secondAttribute="leading" id="ME9-0u-Vx1"/>
                             <constraint firstItem="NNF-sA-UQ4" firstAttribute="trailing" secondItem="qDW-L0-z8a" secondAttribute="trailing" id="au1-yD-v4h"/>
                             <constraint firstItem="LF6-fg-TWa" firstAttribute="bottom" secondItem="CSv-1Z-yIA" secondAttribute="bottom" id="ePC-QY-FqS"/>
@@ -99,7 +122,8 @@
                     <connections>
                         <outlet property="blurEffectView" destination="E7v-Xt-6uK" id="RIm-YT-MPx"/>
                         <outlet property="buttonPanel" destination="LF6-fg-TWa" id="XBZ-Df-emN"/>
-                        <outlet property="createANewSiteButton" destination="51h-er-sEL" id="703-qw-kKG"/>
+                        <outlet property="createANewSiteButton" destination="uuX-qp-CAG" id="asO-dI-cKy"/>
+                        <outlet property="skipButton" destination="TMx-Ec-Bv1" id="67M-pJ-u11"/>
                         <outlet property="tableViewBottomConstraintToButtonPanel" destination="wZ3-6e-hG6" id="a3q-GB-ads"/>
                         <outlet property="tableViewBottomConstraintToSafeArea" destination="mVQ-Dg-W4g" id="IbU-ct-ltZ"/>
                         <outlet property="tableViewLeadingConstraint" destination="pOP-pd-DMR" id="Oat-2L-Iay"/>
@@ -117,7 +141,7 @@
             <objects>
                 <tableViewController id="UFO-Sm-cpW" customClass="LoginEpilogueTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" rowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="bES-Rc-GFi">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="563"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="503"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="0.95294117649999999" green="0.96470588239999999" blue="0.97254901959999995" alpha="1" colorSpace="calibratedRGB"/>
                         <inset key="separatorInset" minX="20" minY="0.0" maxX="0.0" maxY="0.0"/>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueChooseSiteTableViewCell.swift
@@ -14,6 +14,19 @@ final class LoginEpilogueChooseSiteTableViewCell: UITableViewCell {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    func configure(hasSites: Bool) {
+        let title = hasSites
+            ? NSLocalizedString("Choose a site to open.", comment: "A text for title label on Login epilogue screen")
+            : NSLocalizedString("You don't have any sites yet.", comment: "A text for title label on Login epilogue screen when the user doesn't have any site yet")
+
+        let subtitle = hasSites
+            ? NSLocalizedString("You can switch sites at any time.", comment: "A text for subtitle label on Login epilogue screen")
+            : nil
+
+        titleLabel.text = title
+        subtitleLabel.text = subtitle
+    }
 }
 
 // MARK: - Private Methods
@@ -27,12 +40,10 @@ private extension LoginEpilogueChooseSiteTableViewCell {
     }
 
     func setupTitleLabel() {
-        titleLabel.text = NSLocalizedString("Choose a site to open.", comment: "A text for title label on Login epilogue screen")
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .medium)
     }
 
     func setupSubtitleLabel() {
-        subtitleLabel.text = NSLocalizedString("You can switch sites at any time.", comment: "A text for subtitle label on Login epilogue screen")
         subtitleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         subtitleLabel.textColor = .secondaryLabel
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -111,6 +111,7 @@ extension LoginEpilogueTableViewController {
             if !showCreateNewSite {
                 parent.hideCreateANewSiteButton()
             }
+            parent.configureButtonPanel(showBackground: false)
             parent.showSkipButton()
             return siteCount
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -119,6 +119,8 @@ extension LoginEpilogueTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
+        let siteRows = blogDataSource.tableView(tableView, numberOfRowsInSection: Sections.blogSection - 1)
+
         // User Info Row
         if indexPath.section == Sections.userInfoSection {
             if indexPath.row == 0 {
@@ -138,6 +140,7 @@ extension LoginEpilogueTableViewController {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: Settings.chooseSiteReuseIdentifier, for: indexPath) as? LoginEpilogueChooseSiteTableViewCell else {
                     return UITableViewCell()
                 }
+                cell.configure(hasSites: siteRows > 0)
                 removeSeparatorFor(cell)
                 return cell
             }
@@ -224,6 +227,7 @@ private extension LoginEpilogueTableViewController {
 
     enum Sections {
         static let userInfoSection = 0
+        static let blogSection = 1
     }
 
     enum Settings {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -97,8 +97,7 @@ extension LoginEpilogueTableViewController {
             return 2
         }
 
-        let correctedSection = section - 1
-        let siteRows = blogDataSource.tableView(tableView, numberOfRowsInSection: correctedSection)
+        let siteRows = numberOfSites()
 
         // Add one for Create new site cell
 
@@ -119,8 +118,6 @@ extension LoginEpilogueTableViewController {
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
-        let siteRows = blogDataSource.tableView(tableView, numberOfRowsInSection: Sections.blogSection - 1)
-
         // User Info Row
         if indexPath.section == Sections.userInfoSection {
             if indexPath.row == 0 {
@@ -140,18 +137,16 @@ extension LoginEpilogueTableViewController {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: Settings.chooseSiteReuseIdentifier, for: indexPath) as? LoginEpilogueChooseSiteTableViewCell else {
                     return UITableViewCell()
                 }
-                cell.configure(hasSites: siteRows > 0)
+                cell.configure(hasSites: numberOfSites() > 0)
                 removeSeparatorFor(cell)
                 return cell
             }
         }
 
         // Create new site row
-        let siteRows = blogDataSource.tableView(tableView, numberOfRowsInSection: indexPath.section - 1)
-
         let isCreateNewSiteRow =
             showCreateNewSite &&
-            siteRows <= Constants.createNewSiteRowThreshold &&
+            numberOfSites() <= Constants.createNewSiteRowThreshold &&
             indexPath.row == lastRowInSection(indexPath.section)
 
         if isCreateNewSiteRow {
@@ -223,6 +218,11 @@ private extension LoginEpilogueTableViewController {
 
     func removeSeparatorFor(_ cell: UITableViewCell) {
         cell.separatorInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: .greatestFiniteMagnitude)
+    }
+
+    func numberOfSites() -> Int {
+        let adjustedBlogSection = Sections.blogSection - 1
+        return blogDataSource.tableView(tableView, numberOfRowsInSection: adjustedBlogSection)
     }
 
     enum Sections {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -97,26 +97,39 @@ extension LoginEpilogueTableViewController {
             return 2
         }
 
-        let siteRows = numberOfSites()
+        let siteCount = numberOfSites()
 
         // Add one for Create new site cell
 
         guard let parent = parent as? LoginEpilogueViewController else {
-            return siteRows
+            return siteCount
         }
 
-        if siteRows <= Constants.createNewSiteRowThreshold {
+        switch siteCount {
+
+        case 0:
+            if !showCreateNewSite {
+                parent.hideCreateANewSiteButton()
+            }
+            parent.showSkipButton()
+            return siteCount
+
+        case 1...Constants.createNewSiteRowThreshold:
             parent.hideButtonPanel()
-            return showCreateNewSite ? siteRows + 1 : siteRows
-        } else {
+            return showCreateNewSite ? siteCount + 1 : siteCount
+
+        default:
             if !showCreateNewSite {
                 parent.hideButtonPanel()
             }
-            return siteRows
+            return siteCount
         }
     }
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        let siteCount = numberOfSites()
+        let hasSites = siteCount > 0
 
         // User Info Row
         if indexPath.section == Sections.userInfoSection {
@@ -137,7 +150,7 @@ extension LoginEpilogueTableViewController {
                 guard let cell = tableView.dequeueReusableCell(withIdentifier: Settings.chooseSiteReuseIdentifier, for: indexPath) as? LoginEpilogueChooseSiteTableViewCell else {
                     return UITableViewCell()
                 }
-                cell.configure(hasSites: numberOfSites() > 0)
+                cell.configure(hasSites: hasSites)
                 removeSeparatorFor(cell)
                 return cell
             }
@@ -146,7 +159,7 @@ extension LoginEpilogueTableViewController {
         // Create new site row
         let isCreateNewSiteRow =
             showCreateNewSite &&
-            numberOfSites() <= Constants.createNewSiteRowThreshold &&
+            siteCount <= Constants.createNewSiteRowThreshold &&
             indexPath.row == lastRowInSection(indexPath.section)
 
         if isCreateNewSiteRow {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -136,6 +136,10 @@ class LoginEpilogueViewController: UIViewController {
         tableViewBottomConstraintToSafeArea.isActive = true
     }
 
+    func hideCreateANewSiteButton() {
+        createANewSiteButton.isHidden = true
+    }
+
     func showSkipButton() {
         skipButton.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -85,6 +85,7 @@ class LoginEpilogueViewController: UIViewController {
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         setTableViewMargins(forWidth: view.frame.width)
         refreshInterface(with: credentials)
+        configureButtonPanel()
         WordPressAuthenticator.track(.loginEpilogueViewed)
 
         // If the user just signed in, refresh the A/B assignments
@@ -115,11 +116,6 @@ class LoginEpilogueViewController: UIViewController {
         return UIDevice.isPad() ? .all : .portrait
     }
 
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        configureButtonPanel()
-    }
-
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
         setTableViewMargins(forWidth: size.width)
@@ -128,6 +124,24 @@ class LoginEpilogueViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         setTableViewMargins(forWidth: view.frame.width)
+    }
+
+    /// Setup: Button Panel
+    ///
+    func configureButtonPanel(showBackground: Bool = true) {
+        if showBackground {
+            topLineHeightConstraint.constant = .hairlineBorderWidth
+            buttonPanel.backgroundColor = .quaternaryBackground
+            topLine.isHidden = false
+            blurEffectView.effect = UIBlurEffect(style: blurEffect)
+            blurEffectView.isHidden = false
+            setupDividerLineIfNeeded()
+        } else {
+            buttonPanel.backgroundColor = .basicBackground
+            topLine.isHidden = true
+            blurEffectView.isHidden = true
+            dividerView?.isHidden = true
+        }
     }
 
     func hideButtonPanel() {
@@ -173,17 +187,6 @@ private extension LoginEpilogueViewController {
 
         // Skip button should be hidden by default
         skipButton.isHidden = true
-    }
-
-    /// Setup: Button Panel
-    ///
-    func configureButtonPanel() {
-        topLineHeightConstraint.constant = .hairlineBorderWidth
-        buttonPanel.backgroundColor = .quaternaryBackground
-        topLine.isHidden = false
-        blurEffectView.effect = UIBlurEffect(style: blurEffect)
-        blurEffectView.isHidden = false
-        setupDividerLineIfNeeded()
     }
 
     func setTableViewMargins(forWidth viewWidth: CGFloat) {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -58,6 +58,10 @@ class LoginEpilogueViewController: UIViewController {
     ///
     var onCreateNewSite: (() -> Void)?
 
+    /// Closure to be executed upon dismissal.
+    ///
+    var onDismiss: (() -> Void)?
+
     /// Site that was just connected to our awesome app.
     ///
     var credentials: AuthenticatorCredentials? {
@@ -234,5 +238,11 @@ private extension LoginEpilogueViewController {
 
     @IBAction func createANewSite() {
         onCreateNewSite?()
+    }
+
+    @IBAction func dismissEpilogue() {
+        tracker.track(click: .continue)
+        onDismiss?()
+        navigationController?.dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -25,7 +25,8 @@ class LoginEpilogueViewController: UIViewController {
     /// Used to adjust the width on iPad.
     @IBOutlet var tableViewLeadingConstraint: NSLayoutConstraint!
     @IBOutlet var tableViewTrailingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var tableViewBottomContraint: NSLayoutConstraint!
+    @IBOutlet weak var tableViewBottomConstraintToSafeArea: NSLayoutConstraint!
+    @IBOutlet weak var tableViewBottomConstraintToButtonPanel: NSLayoutConstraint!
 
     private var defaultTableViewMargin: CGFloat = 0
 
@@ -127,8 +128,8 @@ class LoginEpilogueViewController: UIViewController {
 
     func hideButtonPanel() {
         buttonPanel.isHidden = true
-        createANewSiteButton.isHidden = true
-        tableViewBottomContraint.constant = 0
+        tableViewBottomConstraintToButtonPanel.isActive = false
+        tableViewBottomConstraintToSafeArea.isActive = true
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -19,7 +19,11 @@ class LoginEpilogueViewController: UIViewController {
 
     /// Create a new site button.
     ///
-    @IBOutlet var createANewSiteButton: UIButton!
+    @IBOutlet weak var createANewSiteButton: FancyButton!
+
+    /// Skip button.
+    ///
+    @IBOutlet weak var skipButton: FancyButton!
 
     /// Constraints on the table view container.
     /// Used to adjust the width on iPad.
@@ -131,6 +135,10 @@ class LoginEpilogueViewController: UIViewController {
         tableViewBottomConstraintToButtonPanel.isActive = false
         tableViewBottomConstraintToSafeArea.isActive = true
     }
+
+    func showSkipButton() {
+        skipButton.isHidden = false
+    }
 }
 
 // MARK: - Private Extension
@@ -141,13 +149,26 @@ private extension LoginEpilogueViewController {
     ///
     func refreshInterface(with credentials: AuthenticatorCredentials) {
         configureCreateANewSiteButton()
+        configureSkipButton()
     }
 
-    /// Setup: Buttons
+    /// Setup: Create a new site button
     ///
     func configureCreateANewSiteButton() {
-        createANewSiteButton.setTitle(NSLocalizedString("Create a new site", comment: "A button title"), for: .normal)
+        createANewSiteButton.isPrimary = false
+        createANewSiteButton.setTitle(NSLocalizedString("Create a new site", comment: "Title for the button that will show a prompt to create a new site."), for: .normal)
         createANewSiteButton.accessibilityIdentifier = "Create a new site"
+    }
+
+    /// Setup: Skip button
+    ///
+    func configureSkipButton() {
+        skipButton.isPrimary = true
+        skipButton.setTitle(NSLocalizedString("Skip", comment: "Title for the button that will skip creating a site and display the logged in view"), for: .normal)
+        skipButton.accessibilityIdentifier = "Skip"
+
+        // Skip button should be hidden by default
+        skipButton.isHidden = true
     }
 
     /// Setup: Button Panel

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -358,7 +358,19 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             })
         }
 
-        epilogueViewController.onBlogSelected = { blog in
+        epilogueViewController.onBlogSelected = { [weak self] blog in
+            guard let self = self else {
+                return
+            }
+
+            // If the quick start prompt has already been dismissed,
+            // then show the My Site screen for the specified blog
+            guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                return
+            }
+
+            // Otherwise, show the Quick Start prompt
             let quickstartPrompt = QuickStartPromptViewController(blog: blog)
             quickstartPrompt.onDismiss = onDismissQuickStartPrompt
             navigationController.pushViewController(quickstartPrompt, animated: true)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -373,6 +373,11 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             navigationController.present(wizard, animated: true)
         }
 
+        epilogueViewController.onDismiss = { [weak self] in
+            onDismiss()
+            self?.windowManager.dismissFullscreenSignIn()
+        }
+
         navigationController.pushViewController(epilogueViewController, animated: true)
     }
 


### PR DESCRIPTION
Fixes #17506 

## Description
This PR adds a skip button to the Epilogue screen if there are no sites yet 

Slack ref: p1637330082057200/1637317113.044600-slack-C027K4MNPGQ

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/142911973-dd3232bd-7ace-4198-8e4a-a25996539883.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911540-eafa6c2f-7d4f-4732-9cf3-5c775b4bcea5.png" width=200>

## How to test

1. Log out / log in to a site w no sites
2. Make sure you see the Post Signup Interstitial screen (see below for an example)

<img src="https://user-images.githubusercontent.com/6711616/142620725-b2153bdd-0c3b-44d8-8744-f7ac1ebea5f7.PNG" width=200>

3. ✅ The skip button should be showing
4. Tap the skip button
5. ✅ The Epilogue should be dismissed

Case | JP iPhone | WP iPhone | WP iPad
-- | -- | -- | --
No sites |  <img src="https://user-images.githubusercontent.com/6711616/142914263-27d5e4dd-6535-496f-97e4-d0ece9e57e6f.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911540-eafa6c2f-7d4f-4732-9cf3-5c775b4bcea5.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911681-604f8152-ba37-40bc-b437-72f1f465710f.png" width=200> 
1-3 sites | <img src="https://user-images.githubusercontent.com/6711616/142914261-4b81fd12-3d86-400a-9f70-252aab7c5ae4.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911544-d4339ab1-3aa7-4200-8301-d3506e1abb78.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911686-5ed325fc-e8f7-41c2-a811-4efa193a6bbc.png" width=200> 
4+ sites |  <img src="https://user-images.githubusercontent.com/6711616/142914254-2e822db0-ce83-47bf-b5ce-a0e914d77115.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911552-f155ffea-deb5-4f9c-8346-d2fcc6efdf56.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/142911690-c3502165-ea30-40b6-9122-2cc0e4a3e7e5.png" width=200> 


## Regression Notes
1. Potential unintended areas of impact
- iPad readable content width
- Epilogue for 1-3 sites
- Epilogue for 4+ sites
- Jetpack app (Create a site should NOT be showing in the Epilogue ever)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps manually

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.