### PR TITLE
Adds tracking to the Post List Share option

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -224,6 +224,9 @@ import Foundation
     case siteSwitcherSearchPerformed
     case siteSwitcherToggleBlogVisible
 
+    // Post List
+    case postListShareAction
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -612,6 +615,8 @@ import Foundation
             return "site_switcher_search_performed"
         case .siteSwitcherToggleBlogVisible:
             return "site_switcher_toggle_blog_visible"
+        case .postListShareAction:
+            return "post_list_button_pressed"
 
         } // END OF SWITCH
     }
@@ -631,6 +636,8 @@ import Foundation
             return ["via": "tenor"]
         case .editorAddedPhotoViaTenor:
             return ["via": "tenor"]
+        case .postListShareAction:
+            return ["button": "share"]
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -732,6 +732,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
+        WPAnalytics.track(.postListShareAction, properties: propertiesForAnalytics())
+
         let shareController = PostSharingController()
         shareController.sharePost(post, fromView: view, inViewController: self)
     }


### PR DESCRIPTION
Project: #17503

### Description
Adds tracking when you tap the 'Share' option from the More menu on the post list view

### To test:

#### Filter Sheet
1. Launch the app
2. Tap on My Site
3. Tap on Posts
4. Tap the `⋯ More` button
5. Tap the Share item
6. Verify you see: `🔵 Tracked: post_list_button_pressed <blog_id: BLOG_ID, button: share, filter: Published, type: post>`

### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
