### PR TITLE
Prevents the image size change from tracking each value continuously

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -148,11 +148,18 @@ class AppSettingsViewController: UITableViewController {
             MediaSettings().maxImageSizeSetting = value
             ShareExtensionService.configureShareExtensionMaximumMediaDimension(value)
 
-            var properties = [String: AnyObject]()
-            properties["enabled"] = (value != Int.max) as AnyObject
-            properties["value"] = value as Int as AnyObject
-            WPAnalytics.track(.appSettingsImageOptimizationChanged, withProperties: properties)
+            self.debounce(#selector(self.trackImageSizeChanged), afterDelay: 0.5)
         }
+    }
+
+    @objc func trackImageSizeChanged() {
+        let value = MediaSettings().maxImageSizeSetting
+
+        var properties = [String: AnyObject]()
+        properties["enabled"] = (value != Int.max) as AnyObject
+        properties["value"] = value as Int as AnyObject
+
+        WPAnalytics.track(.appSettingsImageOptimizationChanged, withProperties: properties)
     }
 
     func pushVideoResolutionSettings() -> ImmuTableAction {


### PR DESCRIPTION
Project: #17503

### Description
Prevents the image size change from tracking each value continuously

### To test:

1. Launch the app
2. Tap My Site
3. Tap your profile icon
4. App App Settings
5. Change the value of 'Max Image Upload Size' repeatedly without lifting up your finger
6. Verify the value doesn't change
7. Stop moving the slider
8. Verify you see `🔵 Tracked: app_settings_image_optimization_changed <enabled: 1, value: VALUE>`
9. Verify the value is the value you stopped on IE: 1400x1400px should log `value: 1400`


### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
