### PR TITLE
Reader Post Details: add Comments table view

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -20,6 +20,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case followConversationViaNotifications
     case aboutScreen
     case newCommentThread
+    case postDetailsComments
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -65,6 +66,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .aboutScreen:
             return BuildConfiguration.current == .localDeveloper
         case .newCommentThread:
+            return false
+        case .postDetailsComments:
             return false
         }
     }
@@ -128,6 +131,8 @@ extension FeatureFlag {
             return "New Unified About Screen"
         case .newCommentThread:
             return "New Comment Thread"
+        case .postDetailsComments:
+            return "Post Details Comments"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -185,6 +185,13 @@ class ReaderDetailCoordinator {
                                 })
     }
 
+    /// Fetch Comments for the current post.
+    ///
+    func fetchComments(for post: ReaderPost) {
+        // TODO: fetch comments.
+        view?.updateComments()
+    }
+
     /// Share the current post
     ///
     func share(fromView anchorView: UIView) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -43,6 +43,14 @@
                                             <constraint firstAttribute="height" placeholder="YES" id="C8J-Hu-daf"/>
                                         </constraints>
                                     </view>
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6yS-ZE-nbR" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" placeholder="YES" id="hNK-J4-GC2"/>
+                                        </constraints>
+                                        <sections/>
+                                    </tableView>
                                     <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="CpT-U7-bfv" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -97,14 +105,17 @@
                                     <constraint firstItem="CpT-U7-bfv" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="6NH-H7-oE8"/>
                                     <constraint firstItem="O4e-BA-8jp" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="8SP-Rw-zUY"/>
                                     <constraint firstItem="iSu-TI-yew" firstAttribute="leading" secondItem="9JA-VQ-zzw" secondAttribute="leading" constant="16" placeholder="YES" id="9Vy-Wt-ZIb"/>
+                                    <constraint firstItem="6yS-ZE-nbR" firstAttribute="top" secondItem="qXQ-id-Ffz" secondAttribute="bottom" id="DJi-VX-sTS"/>
                                     <constraint firstAttribute="trailing" secondItem="iSu-TI-yew" secondAttribute="trailing" constant="16" placeholder="YES" id="FvD-7O-znG"/>
                                     <constraint firstItem="iSu-TI-yew" firstAttribute="top" secondItem="Xyq-y6-zPR" secondAttribute="bottom" constant="16" id="IET-mv-Ieo"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="top" secondItem="9JA-VQ-zzw" secondAttribute="top" id="JZU-vN-GKO"/>
+                                    <constraint firstItem="6yS-ZE-nbR" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="LmZ-4g-gFE"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="RTC-cI-v2j"/>
                                     <constraint firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" id="eFL-lL-cEF"/>
                                     <constraint firstItem="qXQ-id-Ffz" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="hjJ-VB-Pf0"/>
                                     <constraint firstItem="eXr-4k-Adq" firstAttribute="bottom" secondItem="O4e-BA-8jp" secondAttribute="bottom" constant="509" placeholder="YES" id="pTD-l7-TPF"/>
-                                    <constraint firstItem="CpT-U7-bfv" firstAttribute="top" secondItem="qXQ-id-Ffz" secondAttribute="bottom" id="vOe-88-MUA"/>
+                                    <constraint firstItem="6yS-ZE-nbR" firstAttribute="centerX" secondItem="iSu-TI-yew" secondAttribute="centerX" id="r3l-5t-XeA"/>
+                                    <constraint firstItem="CpT-U7-bfv" firstAttribute="top" secondItem="6yS-ZE-nbR" secondAttribute="bottom" id="sQt-BP-vDY"/>
                                     <constraint firstItem="CpT-U7-bfv" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" id="wUK-AO-ZOc"/>
                                     <constraint firstItem="Xyq-y6-zPR" firstAttribute="width" secondItem="iSu-TI-yew" secondAttribute="width" constant="32" id="xfj-7c-Lke"/>
                                 </constraints>
@@ -129,7 +140,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" verticalCompressionResistancePriority="250" insetsLayoutMarginsFromSafeArea="NO" axis="vertical" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="vGc-hu-x5V">
-                                        <rect key="frame" x="0.0" y="44" width="414" height="135"/>
+                                        <rect key="frame" x="0.0" y="44" width="414" height="131"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jeJ-N0-e8Q">
                                                 <rect key="frame" x="0.0" y="0.0" width="414" height="66"/>
@@ -160,14 +171,14 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Post Title" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="urB-nS-vfS">
-                                                <rect key="frame" x="0.0" y="70" width="414" height="41"/>
+                                                <rect key="frame" x="0.0" y="70" width="414" height="37"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xdF-0Y-F5a">
-                                                <rect key="frame" x="0.0" y="115" width="414" height="20"/>
+                                                <rect key="frame" x="0.0" y="111" width="414" height="20"/>
                                                 <subviews>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="PpC-lI-LMW" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                                         <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -237,28 +248,28 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EKd-IB-Upn">
-                                        <rect key="frame" x="0.0" y="211" width="414" height="213.5"/>
+                                        <rect key="frame" x="0.0" y="207" width="414" height="203"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i7W-OY-6MY">
-                                                <rect key="frame" x="0.0" y="0.0" width="414" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="414" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbt-ra-94i">
-                                                <rect key="frame" x="0.0" y="28.5" width="414" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="25" width="414" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UdQ-G5-Hl2">
-                                                <rect key="frame" x="0.0" y="57" width="414" height="20.5"/>
+                                                <rect key="frame" x="0.0" y="50" width="414" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xrm-JQ-hpv">
-                                                <rect key="frame" x="0.0" y="85.5" width="414" height="128"/>
+                                                <rect key="frame" x="0.0" y="75" width="414" height="128"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jvg-nM-lV9">
                                                         <rect key="frame" x="0.0" y="0.0" width="345" height="128"/>
@@ -313,11 +324,12 @@
                     <connections>
                         <outlet property="actionStackView" destination="O4e-BA-8jp" id="Ro3-aL-ekY"/>
                         <outlet property="attributionView" destination="Ewc-f7-89P" id="Pwq-Hm-VfQ"/>
+                        <outlet property="commentsTableView" destination="6yS-ZE-nbR" id="Va9-bB-B8V"/>
                         <outlet property="headerContainerView" destination="Xyq-y6-zPR" id="duy-5z-Fdl"/>
                         <outlet property="likesContainerView" destination="qXQ-id-Ffz" id="DL3-un-wtF"/>
                         <outlet property="loadingView" destination="qnQ-Ld-x9K" id="D1T-sa-IvL"/>
+                        <outlet property="relatedPostsTableView" destination="CpT-U7-bfv" id="Ndh-H4-FlR"/>
                         <outlet property="scrollView" destination="9JA-VQ-zzw" id="lCO-o1-bLB"/>
-                        <outlet property="tableView" destination="CpT-U7-bfv" id="rQo-rr-Bjb"/>
                         <outlet property="toolbarContainerView" destination="Qzd-gm-oIu" id="Esk-Iq-Wbd"/>
                         <outlet property="toolbarSafeAreaView" destination="ERb-e0-U8L" id="sVN-sI-9e5"/>
                         <outlet property="webView" destination="iSu-TI-yew" id="DQy-Fd-C3y"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -39,6 +39,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The table view that displays Comments
     @IBOutlet weak var commentsTableView: IntrinsicTableView!
+    var commentsTableViewDelegate: ReaderDetailCommentsTableViewDelegate?
+
     /// The table view that displays Related Posts
     @IBOutlet weak var relatedPostsTableView: IntrinsicTableView!
 
@@ -152,6 +154,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         configureNoResultsViewController()
         observeWebViewHeight()
         configureNotifications()
+
+        if FeatureFlag.postDetailsComments.enabled {
+            configureCommentsTable()
+        }
 
         coordinator?.start()
 
@@ -478,6 +484,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         likesSummary.removeFromSuperview()
         likesContainerView.frame.size.height = 0
         view.setNeedsDisplay()
+    }
+
+    private func configureCommentsTable() {
+        commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
+        commentsTableView.delegate = commentsTableViewDelegate
+        commentsTableView.dataSource = commentsTableViewDelegate
     }
 
     private func configureRelatedPosts() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -37,8 +37,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// WebView height constraint
     @IBOutlet weak var webViewHeight: NSLayoutConstraint!
 
+    /// The table view that displays Comments
+    @IBOutlet weak var commentsTableView: IntrinsicTableView!
     /// The table view that displays Related Posts
-    @IBOutlet weak var tableView: IntrinsicTableView!
+    @IBOutlet weak var relatedPostsTableView: IntrinsicTableView!
 
     /// Header container
     @IBOutlet weak var headerContainerView: UIView!
@@ -255,8 +257,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         let groupedPosts = Dictionary(grouping: posts, by: { $0.postType })
         let sections = groupedPosts.map { RelatedPostsSection(postType: $0.key, posts: $0.value) }
         relatedPosts = sections.sorted { $0.postType.rawValue < $1.postType.rawValue }
-        tableView.reloadData()
-        tableView.invalidateIntrinsicContentSize()
+        relatedPostsTableView.reloadData()
+        relatedPostsTableView.invalidateIntrinsicContentSize()
     }
 
     private func navigateToCommentIfNecessary() {
@@ -479,16 +481,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureRelatedPosts() {
-        tableView.isScrollEnabled = false
-        tableView.separatorStyle = .none
+        relatedPostsTableView.isScrollEnabled = false
+        relatedPostsTableView.separatorStyle = .none
 
-        tableView.register(ReaderRelatedPostsCell.defaultNib,
+        relatedPostsTableView.register(ReaderRelatedPostsCell.defaultNib,
                            forCellReuseIdentifier: ReaderRelatedPostsCell.defaultReuseID)
-        tableView.register(ReaderRelatedPostsSectionHeaderView.defaultNib,
+        relatedPostsTableView.register(ReaderRelatedPostsSectionHeaderView.defaultNib,
                            forHeaderFooterViewReuseIdentifier: ReaderRelatedPostsSectionHeaderView.defaultReuseID)
 
-        tableView.dataSource = self
-        tableView.delegate = self
+        relatedPostsTableView.dataSource = self
+        relatedPostsTableView.delegate = self
     }
 
     private func configureToolbar() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -1,0 +1,17 @@
+/// Table View delegate to handle the Comments table displayed in Reader Post details.
+///
+class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UITableViewDelegate {
+
+    func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 3
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1633,6 +1633,8 @@
 		985ED0E423C6950600B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
 		985ED0E723C6964500B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
 		985ED0E823C6964600B8D06A /* WidgetStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 985ED0E323C6950600B8D06A /* WidgetStyles.swift */; };
+		98622E9F274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98622E9E274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift */; };
+		98622EA0274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98622E9E274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift */; };
 		9865257D2194D77F0078B916 /* SiteStatsInsightsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */; };
 		98656BD82037A1770079DE67 /* SignupEpilogueViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */; };
 		986C908422319EFF00FC31E1 /* PostStatsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986C908322319EFF00FC31E1 /* PostStatsTableViewController.swift */; };
@@ -6283,6 +6285,7 @@
 		98579BC6203DD86E004086E4 /* EpilogueSectionHeaderFooter.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EpilogueSectionHeaderFooter.xib; sourceTree = "<group>"; };
 		985ED0E323C6950600B8D06A /* WidgetStyles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetStyles.swift; sourceTree = "<group>"; };
 		985F06B42303866200949733 /* WelcomeScreenLoginComponent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeScreenLoginComponent.swift; sourceTree = "<group>"; };
+		98622E9E274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCommentsTableViewDelegate.swift; sourceTree = "<group>"; };
 		9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteStatsInsightsViewModel.swift; sourceTree = "<group>"; };
 		98656BD72037A1770079DE67 /* SignupEpilogueViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignupEpilogueViewController.swift; sourceTree = "<group>"; };
 		986C908322319EFF00FC31E1 /* PostStatsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostStatsTableViewController.swift; sourceTree = "<group>"; };
@@ -11402,6 +11405,7 @@
 		8BD89F2C24D9E73600341C90 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				98622E9E274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift */,
 				3223393B24FEC18000BDD4BF /* ReaderDetailFeaturedImageView.swift */,
 				3223393D24FEC2A700BDD4BF /* ReaderDetailFeaturedImageView.xib */,
 				8B0CE7D02481CFE8004C4799 /* ReaderDetailHeaderView.swift */,
@@ -17106,6 +17110,7 @@
 				AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */,
 				8BBBCE702717651200B277AC /* JetpackModuleHelper.swift in Sources */,
 				319D6E8119E44C680013871C /* SuggestionsTableView.m in Sources */,
+				98622E9F274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift in Sources */,
 				40E728851FF3D9070010E7C9 /* PluginDetailViewHeaderCell.swift in Sources */,
 				46183D1F251BD6A0004F9AFD /* PageTemplateCategory+CoreDataClass.swift in Sources */,
 				40E7FED02211FFBC0032834E /* AllTimeStatsRecordValue+CoreDataProperties.swift in Sources */,
@@ -19512,6 +19517,7 @@
 				FABB21E72602FC2C00C8785C /* WPRichTextImage.swift in Sources */,
 				FABB21E82602FC2C00C8785C /* FormattableContentRange.swift in Sources */,
 				FABB21E92602FC2C00C8785C /* MenuItemSourceHeaderView.m in Sources */,
+				98622EA0274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift in Sources */,
 				FABB21EA2602FC2C00C8785C /* RestoreWarningView.swift in Sources */,
 				C7D30C652638B07A00A1695B /* JetpackPrologueStyleGuide.swift in Sources */,
 				FABB21EB2602FC2C00C8785C /* GutenbergWebNavigationViewController.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -335,6 +335,8 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
 
     func updateSelfLike(with avatarURLString: String?) { }
 
+    func updateComments() { }
+
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) { }
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {


### PR DESCRIPTION
Ref: #17511 

Several changes are included here to facilitate showing Comments in post details:
- Adds `postDetailsComments` feature flag.
- Renames the existing `tableView` to `relatedPostsTableView`.
- Adds `commentsTableView`.
- Adds a `ReaderDetailCommentsTableViewDelegate` to handle the comments table.
- Stub methods to update the comments table.

To test:

With `postDetailsComments` enabled:
- Go to Reader > post > details.
- Verify an empty table is displayed between Likes and Related Posts.

With `postDetailsComments` disabled:
- Go to Reader > post > details.
- Verify the empty table is not displayed.

| Disabled | Enabled |
|--------|-------|
| <img width="469" alt="disabled" src="https://user-images.githubusercontent.com/1816888/142952887-25d74822-55e5-4707-a512-5a057562352c.png"> | <img width="471" alt="enabled" src="https://user-images.githubusercontent.com/1816888/142952883-b3e71e41-d3e7-410b-825c-76ce5715c097.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
