### PR TITLE
Add UI tests to check the ability to scroll reader content and interact with the items

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -16,6 +16,9 @@ cp -v fastlane/env/project.env-example .configure-files/project.env
 mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 
+echo "--- Installing Secrets"
+bundle exec fastlane run configure_apply
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_for_testing
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -19,10 +19,15 @@ public class GetStartedScreen: ScreenObject {
         $0.buttons["authenticator-help-button"]
     }
 
+    private let backButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Back"]
+    }
+
     var navBar: XCUIElement { navBarGetter(app) }
     public var emailTextField: XCUIElement { emailTextFieldGetter(app) }
     var continueButton: XCUIElement { continueButtonGetter(app) }
     var helpButton: XCUIElement { helpButtonGetter(app) }
+    var backButton: XCUIElement { backButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         // Notice we are not checking for the continue button, because that's visible but not
@@ -43,6 +48,10 @@ public class GetStartedScreen: ScreenObject {
         continueButton.tap()
 
         return PasswordScreen()
+    }
+
+    public func goBackToPrologue() {
+        backButton.tap()
     }
 
     public func selectHelp() throws -> SupportScreen {

--- a/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
@@ -1,0 +1,49 @@
+import ScreenObject
+import XCTest
+
+/// This screen object is for the Support section. In the app, it's a modal we can get to from Me
+/// > Help & Support > Contact Support, or, when logged out, from Prologue > tap either continue button > Help > Contact Support.
+public class ContactUsScreen: ScreenObject {
+
+    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["ZDKbackButton"]
+    }
+
+    private let sendButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["ZDKsendButton"]
+    }
+
+    private let attachButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["ZDKattachButton"]
+    }
+
+    private let messageTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["writeAMessage"]
+    }
+
+    var closeButton: XCUIElement { closeButtonGetter(app) }
+    var sendButton: XCUIElement { sendButtonGetter(app) }
+    var attachButton: XCUIElement { attachButtonGetter(app) }
+    var messageTextField: XCUIElement { messageTextFieldGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        // Notice we are not checking for the send button and message text field
+        // because they're visible but not enabled, and `ScreenObject` checks for enabled elements.
+        try super.init(
+            expectedElementGetters: [
+                closeButtonGetter,
+                attachButtonGetter,
+            ],
+            app: app
+        )
+    }
+
+    public func dismiss() throws -> SupportScreen {
+        closeButton.tap()
+        return try SupportScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        (try? SupportScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
@@ -17,18 +17,13 @@ public class ContactUsScreen: ScreenObject {
         $0.buttons["ZDKattachButton"]
     }
 
-    private let messageTextFieldGetter: (XCUIApplication) -> XCUIElement = {
-        $0.textFields["writeAMessage"]
-    }
-
     var closeButton: XCUIElement { closeButtonGetter(app) }
     var sendButton: XCUIElement { sendButtonGetter(app) }
     var attachButton: XCUIElement { attachButtonGetter(app) }
-    var messageTextField: XCUIElement { messageTextFieldGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        // Notice we are not checking for the send button and message text field
-        // because they're visible but not enabled, and `ScreenObject` checks for enabled elements.
+        // Notice we are not checking for the send button because it's visible but not enabled,
+        // and `ScreenObject` checks for enabled elements.
         try super.init(
             expectedElementGetters: [
                 closeButtonGetter,
@@ -36,6 +31,14 @@ public class ContactUsScreen: ScreenObject {
             ],
             app: app
         )
+    }
+
+    public func canSendMessage() -> Bool {
+        app.typeText("A")
+        let isSendButtonEnabled = sendButton.isEnabled
+        app.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 1))
+
+        return isSendButtonEnabled
     }
 
     public func dismiss() throws -> SupportScreen {

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -27,6 +27,21 @@ public class SupportScreen: ScreenObject {
         )
     }
 
+    public func contactSupport() throws -> ContactUsScreen {
+        app.cells["contact-support-button"].tap()
+        addContactInformationIfNeeded()
+        return try ContactUsScreen()
+    }
+
+    private func addContactInformationIfNeeded() {
+        let emailTextField = app.textFields["Email"]
+        if emailTextField.waitForExistence(timeout: 3) {
+            emailTextField.tap()
+            emailTextField.typeText("user@test.zzz")
+            app.buttons["OK"].tap()
+        }
+    }
+
     public func dismiss() {
         closeButton.tap()
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -20,6 +20,50 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
+    public func openTheLastPostInApp() {
+        getTheLastPost().tap()
+    }
+
+    public func openTheLastPostInSafari() {
+        getTheLastPost().buttons["More"].tap()
+        app.buttons["Visit"].tap()
+    }
+
+    public func getTheLastPost() -> XCUIElement {
+        let postPosition = app.cells.count - 1
+        let post = app.cells.element(boundBy: postPosition)
+
+        scrollDownUntilElementIsHittable(element: post)
+        return post
+    }
+
+    private func scrollDownUntilElementIsHittable(element: XCUIElement) {
+        var loopCount = 0
+        while !element.waitForIsHittable(timeout: 3) && loopCount < 10 {
+            loopCount += 1
+            app.swipeUp(velocity: .fast)
+            print(loopCount)
+        }
+    }
+
+    public func postContentEquals(expected: String) -> Bool {
+        let equalsPostContent = NSPredicate(format: "label == %@", expected)
+        let isPostContentEqual = app.staticTexts.element(matching: equalsPostContent).waitForIsHittable(timeout: 3)
+
+        return isPostContentEqual
+    }
+
+    public func dismissPost() {
+        let backButton = app.buttons["Back"]
+        let dismissButton = app.buttons["Dismiss"]
+
+        if dismissButton.isHittable {
+            dismissButton.tap()
+        } else if backButton.isHittable {
+            backButton.tap()
+        }
+    }
+
     public static func isLoaded() -> Bool {
         (try? ReaderScreen().isLoaded) ?? false
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2488,6 +2488,7 @@
 		E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		EAB10E3E2745462B000DA4C1 /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3D2745462B000DA4C1 /* ContactUsScreen.swift */; };
 		F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10465132554260600655194 /* BindableTapGestureRecognizer.swift */; };
 		F10D634F26F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
 		F10D635026F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
@@ -7332,6 +7333,7 @@
 		E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanFeature.swift; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
+		EAB10E3D2745462B000DA4C1 /* ContactUsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
 		EEF80689364FA9CAE10405E8 /* Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		EF379F0A70B6AC45330EE287 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
 		F10465132554260600655194 /* BindableTapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindableTapGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -13369,6 +13371,7 @@
 			isa = PBXGroup;
 			children = (
 				6EC71EC22689A67400ACC0A0 /* SupportScreen.swift */,
+				EAB10E3D2745462B000DA4C1 /* ContactUsScreen.swift */,
 			);
 			path = Me;
 			sourceTree = "<group>";
@@ -18531,6 +18534,7 @@
 				3F2F855026FAF227000FCDA5 /* SignupEmailScreen.swift in Sources */,
 				3F2F855826FAF227000FCDA5 /* SignupEpilogueScreen.swift in Sources */,
 				3F2F855726FAF227000FCDA5 /* WelcomeScreenSignupComponent.swift in Sources */,
+				EAB10E3E2745462B000DA4C1 /* ContactUsScreen.swift in Sources */,
 				3F2F855326FAF227000FCDA5 /* EditorPostSettings.swift in Sources */,
 				3FA640642670CED80064401E /* BaseScreen.swift in Sources */,
 				3F2F856026FAF235000FCDA5 /* NotificationsScreen.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2489,6 +2489,7 @@
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
 		EAB10E3E2745462B000DA4C1 /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3D2745462B000DA4C1 /* ContactUsScreen.swift */; };
+		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
 		F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10465132554260600655194 /* BindableTapGestureRecognizer.swift */; };
 		F10D634F26F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
 		F10D635026F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
@@ -7334,6 +7335,7 @@
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
 		EAB10E3D2745462B000DA4C1 /* ContactUsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
+		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EEF80689364FA9CAE10405E8 /* Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		EF379F0A70B6AC45330EE287 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
 		F10465132554260600655194 /* BindableTapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindableTapGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -13109,6 +13111,7 @@
 		BEA101B61FF13F0500CE5C7D /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */,
 				6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */,
 				FF2716911CAAC87B0006E2D4 /* LoginTests.swift */,
 				CC7CB97222B1510900642EE9 /* SignupTests.swift */,
@@ -20711,6 +20714,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */,
+				EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */,
 				BED4D8301FF11DEF00A11345 /* EditorAztecTests.swift in Sources */,
 				3F2F856326FAF612000FCDA5 /* EditorGutenbergTests.swift in Sources */,
 				FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */,

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -1,0 +1,36 @@
+import UITestsFoundation
+import XCTest
+
+class ReaderTests: XCTestCase {
+    private var readerScreen: ReaderScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite()
+
+        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        readerScreen = try EditorFlow
+            .goToMySiteScreen()
+            .tabBar.goToReaderScreen()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        if readerScreen != nil && !TabNavComponent.isVisible() {
+            readerScreen.dismissPost()
+        }
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
+    }
+
+    let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
+
+    func testViewPostInApp() {
+        readerScreen.openTheLastPostInApp()
+        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+    }
+
+    func testViewPostInSafari() {
+        readerScreen.openTheLastPostInSafari()
+        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+    }
+}

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -25,4 +25,18 @@ class SupportScreenTests: XCTestCase {
         //Dismiss because tearDown() can't handle modals currently
         supportScreen.dismiss()
     }
+
+    func testContactUsCanBeLoadedDuringLogin() throws {
+        let contactUsScreen = try PrologueScreen()
+            .selectContinue()
+            .selectHelp()
+            .contactSupport()
+
+        XCTAssert(contactUsScreen.isLoaded)
+
+        //Dismiss because tearDown() can't handle modals currently
+        try contactUsScreen.dismiss().dismiss()
+        //This extra step is actually handled by tearDown(), but adding it here cuts the execution time in half
+        try GetStartedScreen().goBackToPrologue()
+    }
 }

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -33,6 +33,7 @@ class SupportScreenTests: XCTestCase {
             .contactSupport()
 
         XCTAssert(contactUsScreen.isLoaded)
+        XCTAssert(contactUsScreen.canSendMessage())
 
         //Dismiss because tearDown() can't handle modals currently
         try contactUsScreen.dismiss().dismiss()


### PR DESCRIPTION
One of the identified critical flows to be automated was to open the Reader section, scroll content, open and close selections. This PR adds tests to cover the scenario.

To test:
ReaderTests must pass on CI.

## Regression Notes
1. Potential unintended areas of impact
None. The changes would only impact ReaderTests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N/A**
- [x] I have considered adding accessibility improvements for my changes. **N/A**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N/A**
