### PR TITLE
Reader Comments: Display the new content cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -20,6 +20,13 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     var contentLinkTapAction: ((URL) -> Void)? = nil
 
+    /// When set to true, the cell will always hide the moderation bar regardless of the user's moderating capabilities.
+    var hidesModerationBar: Bool = false {
+        didSet {
+            updateModerationBarVisibility()
+        }
+    }
+
     /// Encapsulate the accessory button image assignment through an enum, to apply a standardized image configuration.
     /// See `accessoryIconConfiguration` in `WPStyleGuide+CommentDetail`.
     var accessoryButtonType: AccessoryButtonType = .share {
@@ -110,7 +117,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     /// Controls the visibility of the moderation bar view.
     private var isModerationEnabled: Bool = false {
         didSet {
-            moderationBar.isHidden = !isModerationEnabled
+            updateModerationBarVisibility()
         }
     }
 
@@ -335,6 +342,10 @@ private extension CommentContentTableViewCell {
         htmlContentCache = htmlContent
 
         return htmlContent
+    }
+
+    func updateModerationBarVisibility() {
+        moderationBar.isHidden = !isModerationEnabled || hidesModerationBar
     }
 
     /// Updates the style and text of the Like button.

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -24,6 +24,7 @@ static CGFloat const CommentIndentationWidth = 40.0;
 
 static NSString *CommentCellIdentifier = @"CommentDepth0CellIdentifier";
 static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
+static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 
 @interface ReaderCommentsViewController () <NSFetchedResultsControllerDelegate,
@@ -354,8 +355,13 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
     self.tableView.backgroundColor = [UIColor murielBasicBackground];
     [self.view addSubview:self.tableView];
 
-    UINib *commentNib = [UINib nibWithNibName:@"ReaderCommentCell" bundle:nil];
-    [self.tableView registerNib:commentNib forCellReuseIdentifier:CommentCellIdentifier];
+    if ([self newCommentThreadEnabled]) {
+        UINib *nib = [UINib nibWithNibName:[CommentContentTableViewCell classNameWithoutNamespaces] bundle:nil];
+        [self.tableView registerNib:nib forCellReuseIdentifier:CommentContentCellIdentifier];
+    } else {
+        UINib *commentNib = [UINib nibWithNibName:@"ReaderCommentCell" bundle:nil];
+        [self.tableView registerNib:commentNib forCellReuseIdentifier:CommentCellIdentifier];
+    }
 
     self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
     self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
@@ -1063,10 +1069,14 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (void)configureCell:(UITableViewCell *)aCell atIndexPath:(NSIndexPath *)indexPath
 {
-    ReaderCommentCell *cell = (ReaderCommentCell *)aCell;
-
     Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
 
+    if ([self newCommentThreadEnabled]) {
+        [self configureContentCell:aCell comment:comment tableView:self.tableView];
+        return;
+    }
+
+    ReaderCommentCell *cell = (ReaderCommentCell *)aCell;
     cell.indentationWidth = CommentIndentationWidth;
     cell.indentationLevel = MIN(comment.depth, MaxCommentDepth);
     cell.delegate = self;
@@ -1119,7 +1129,8 @@ static NSString *RestorablePostObjectIDURLKey = @"RestorablePostObjectIDURLKey";
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    ReaderCommentCell *cell = (ReaderCommentCell *)[self.tableView dequeueReusableCellWithIdentifier:CommentCellIdentifier];
+    NSString *cellIdentifier = [self newCommentThreadEnabled] ? CommentContentCellIdentifier : CommentCellIdentifier;
+    ReaderCommentCell *cell = (ReaderCommentCell *)[self.tableView dequeueReusableCellWithIdentifier:cellIdentifier];
     [self configureCell:cell atIndexPath:indexPath];
     return cell;
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -64,4 +64,14 @@ import UIKit
         controller.shouldHideComments = true
         navigationController?.pushFullscreenViewController(controller, animated: true)
     }
+
+    func configureContentCell(_ cell: UITableViewCell, comment: Comment, tableView: UITableView) {
+        guard let cell = cell as? CommentContentTableViewCell else {
+            return
+        }
+
+        cell.configure(with: comment) { _ in
+            tableView.performBatchUpdates({})
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -35,6 +35,18 @@ import UIKit
         }
     }
 
+    func handleHeaderTapped() {
+        guard let post = post,
+              allowsPushingPostDetails else {
+            return
+        }
+
+        // Note: Let's manually hide the comments button, in order to prevent recursion in the flow
+        let controller = ReaderDetailViewController.controllerWithPost(post)
+        controller.shouldHideComments = true
+        navigationController?.pushFullscreenViewController(controller, animated: true)
+    }
+
     // MARK: New Comment Threads
 
     func configuredHeaderView(for tableView: UITableView) -> UIView {
@@ -53,23 +65,12 @@ import UIKit
         return cell
     }
 
-    func handleHeaderTapped() {
-        guard let post = post,
-              allowsPushingPostDetails else {
-            return
-        }
-
-        // Note: Let's manually hide the comments button, in order to prevent recursion in the flow
-        let controller = ReaderDetailViewController.controllerWithPost(post)
-        controller.shouldHideComments = true
-        navigationController?.pushFullscreenViewController(controller, animated: true)
-    }
-
     func configureContentCell(_ cell: UITableViewCell, comment: Comment, tableView: UITableView) {
         guard let cell = cell as? CommentContentTableViewCell else {
             return
         }
 
+        cell.hidesModerationBar = true
         cell.configure(with: comment) { _ in
             tableView.performBatchUpdates({})
         }


### PR DESCRIPTION
Refs #17476
Depends on #17517

This PR shows the new content cell in Reader Comments when `newCommentThread` feature flag is enabled. Some other notes:

- Added a public boolean property `hidesModerationBar` to always hide the moderation bar when this is set to `true`. In the comment threads, the moderation bar is never shown even if the current user has moderating capabilities. Note that moderating actions will be available through the overflow dropdown menu later on.
- There are some noticeable performance and cell sizing issues when the flag is enabled, particularly for posts with a lot of comments _and_ content-rich comments. I'll address these later on after I've covered all the features for the new comment threads.

## To Test

#### With the `newCommentThread` flag is enabled:

- Go to Reader > comment threads.
- 🔍  Verify that the new comment cell is displayed. 

#### With the `newCommentThread` flag disabled:

- Make sure that the account has moderating capabilities on the site.
- Go to My Site > Comments and select any comment.
- 🔍  Verify that the moderation bar is shown and functional.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
