### PR TITLE
Reader Comments: Update reaction bar logic

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -85,17 +85,18 @@ public class Comment: NSManagedObject {
         return !isReadOnly()
     }
 
+    // NOTE: Comment Likes could be disabled, but the API doesn't have that info yet. Let's update this once it's available.
     func canLike() -> Bool {
-        if let readerPost = post as? ReaderPost {
-            return readerPost.isLikesEnabled
+        if let _ = post as? ReaderPost {
+            return ReaderHelpers.isLoggedIn()
         }
 
         guard let blog = blog else {
-            // Likes feature is disabled for self-hosted sites.
+            // Disable likes feature for self-hosted sites.
             return false
         }
 
-        return blog.supports(.commentLikes)
+        return !isReadOnly() && blog.supports(.commentLikes)
     }
 }
 

--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -76,6 +76,27 @@ public class Comment: NSManagedObject {
               }
         return canModerate
     }
+
+    func canReply() -> Bool {
+        if let readerPost = post as? ReaderPost {
+            return readerPost.commentsOpen && ReaderHelpers.isLoggedIn()
+        }
+
+        return !isReadOnly()
+    }
+
+    func canLike() -> Bool {
+        if let readerPost = post as? ReaderPost {
+            return readerPost.isLikesEnabled
+        }
+
+        guard let blog = blog else {
+            // Likes feature is disabled for self-hosted sites.
+            return false
+        }
+
+        return blog.supports(.commentLikes)
+    }
 }
 
 private extension Comment {

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -52,7 +52,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var webView: WKWebView!
     @IBOutlet private weak var webViewHeightConstraint: NSLayoutConstraint!
 
-    @IBOutlet private weak var reactionBarView: UIView!
     @IBOutlet private weak var replyButton: UIButton!
     @IBOutlet private weak var likeButton: UIButton!
 
@@ -95,10 +94,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Visibility Control
 
-    /// Controls the visibility of the reaction bar view. Setting this to false disables Reply and Likes functionality.
-    private var isReactionEnabled: Bool = false {
+    private var isCommentReplyEnabled: Bool = false {
         didSet {
-            reactionBarView.isHidden = !isReactionEnabled
+            replyButton.isHidden = !isCommentReplyEnabled
         }
     }
 
@@ -119,6 +117,10 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         didSet {
             updateModerationBarVisibility()
         }
+    }
+
+    private var isReactionBarVisible: Bool {
+        return isCommentReplyEnabled || isCommentLikesEnabled
     }
 
     // MARK: Lifecycle
@@ -148,17 +150,17 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         updateLikeButton(liked: comment.isLiked, numberOfLikes: comment.numberOfLikes())
 
         // Configure feature availability.
-        isReactionEnabled = !comment.isReadOnly()
-        isCommentLikesEnabled = isReactionEnabled && (comment.blog?.supports(.commentLikes) ?? false)
+        isCommentReplyEnabled = comment.canReply()
+        isCommentLikesEnabled = comment.canLike()
         isAccessoryButtonEnabled = comment.isApproved()
         isModerationEnabled = comment.allowsModeration()
 
         // When reaction bar is hidden, add some space between the webview and the moderation bar.
-        containerStackView.setCustomSpacing(isReactionEnabled ? 0 : customBottomSpacing, after: webView)
+        containerStackView.setCustomSpacing(isReactionBarVisible ? 0 : customBottomSpacing, after: webView)
 
         // When both reaction bar and moderation bar is hidden, the custom spacing for the webview won't be applied since it's at the bottom of the stack view.
         // The reaction bar and the moderation bar have their own spacing, unlike the webview. Therefore, additional bottom spacing is needed.
-        containerStackBottomConstraint.constant = (isReactionEnabled || isModerationEnabled) ? 0 : customBottomSpacing
+        containerStackBottomConstraint.constant = (isReactionBarVisible || isModerationEnabled) ? 0 : customBottomSpacing
 
         if isModerationEnabled {
             moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -12,15 +12,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="168" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="168"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="225" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="225"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="168"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="225"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG">
-                        <rect key="frame" x="16" y="0.0" width="288" height="168"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
+                        <rect key="frame" x="16" y="0.0" width="288" height="225"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="167"/>
@@ -88,11 +88,11 @@
                                     <wkPreferences key="preferences"/>
                                 </wkWebViewConfiguration>
                             </wkWebView>
-                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ta5-Cz-flw" userLabel="Reaction Bar View">
-                                <rect key="frame" x="0.0" y="168" width="288" height="0.0"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
+                                <rect key="frame" x="0.0" y="168" width="288" height="57"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="0.0" width="60" height="0.0"/>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
+                                        <rect key="frame" x="0.0" y="8.5" width="174.5" height="40"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -105,11 +105,11 @@
                                             </preferredSymbolConfiguration>
                                         </state>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="60" y="0.0" width="78.5" height="0.0"/>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
+                                        <rect key="frame" x="179.5" y="8" width="53.5" height="41"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
-                                        <inset key="contentEdgeInsets" minX="5" minY="10" maxX="35" maxY="15"/>
+                                        <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
                                         <inset key="titleEdgeInsets" minX="2" minY="0.0" maxX="-2" maxY="0.0"/>
                                         <state key="normal" title="Like">
                                             <color key="titleColor" systemColor="secondaryLabelColor"/>
@@ -119,21 +119,17 @@
                                             </preferredSymbolConfiguration>
                                         </state>
                                     </button>
+                                    <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
+                                        <rect key="frame" x="238" y="0.0" width="50" height="57"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
+                                        </constraints>
+                                    </view>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstItem="X2J-8b-R5F" firstAttribute="top" secondItem="ta5-Cz-flw" secondAttribute="top" id="2nT-bm-PdY"/>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="X2J-8b-R5F" secondAttribute="trailing" id="BaU-wG-gvI"/>
-                                    <constraint firstItem="X2J-8b-R5F" firstAttribute="leading" secondItem="VoI-YI-Qgc" secondAttribute="trailing" id="EB0-u1-7Tg"/>
-                                    <constraint firstItem="VoI-YI-Qgc" firstAttribute="top" secondItem="ta5-Cz-flw" secondAttribute="top" id="Nec-gq-oLP"/>
-                                    <constraint firstAttribute="bottom" secondItem="VoI-YI-Qgc" secondAttribute="bottom" id="OHA-JJ-O5q"/>
-                                    <constraint firstItem="X2J-8b-R5F" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ta5-Cz-flw" secondAttribute="leading" id="Vix-Nc-fT5"/>
-                                    <constraint firstItem="VoI-YI-Qgc" firstAttribute="leading" secondItem="ta5-Cz-flw" secondAttribute="leading" id="eiP-L2-BU6"/>
-                                    <constraint firstAttribute="bottom" secondItem="X2J-8b-R5F" secondAttribute="bottom" id="kdD-9h-GEp"/>
-                                </constraints>
-                            </view>
+                            </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T1Z-LV-01Y" customClass="CommentModerationBar" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="168" width="288" height="83"/>
+                                <rect key="frame" x="0.0" y="225" width="288" height="83"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="83" id="qRm-Qi-IXu"/>
@@ -159,12 +155,11 @@
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="moderationBar" destination="T1Z-LV-01Y" id="YUL-ft-QkO"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>
-                <outlet property="reactionBarView" destination="ta5-Cz-flw" id="puY-Sa-fKk"/>
                 <outlet property="replyButton" destination="VoI-YI-Qgc" id="Z9J-Tp-bur"/>
                 <outlet property="webView" destination="Je0-5Q-ty6" id="YaD-wp-E6W"/>
                 <outlet property="webViewHeightConstraint" destination="dGD-8Q-LSr" id="rBk-4R-GCz"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="253.125"/>
+            <point key="canvasLocation" x="131.8840579710145" y="272.20982142857139"/>
         </tableViewCell>
     </objects>
     <resources>


### PR DESCRIPTION
Refs #17476
Depends on #17532

This PR updates the reaction bar logic to also consider Reader scenarios where the `comment` might not have a `Blog` reference. Some other notes:

- Updated the reaction bar to use a horizontal stack view instead. This is due to a case where the Like button could be shown while the Reply button is hidden – and I figured using a stack view would simplify things.
- Added convenient methods `canReply()` and `canLike()` on `Comment`, since the logic is a bit different for Reader, Site comments, and self-hosted.

Please note that Comment Likes can be toggled, but the API does not provide that info yet. Due to this, the Like button is still shown even when the feature is toggled off. This is legacy behavior, but I'll maintain this behavior for now.

## To Test

All of the test scenarios here require `newCommentThread` flag to be enabled. Here's a quick reminder on how to toggle post comments: Go to WordPress.com dashboard > Posts > Edit on a post > Discussion > Check/uncheck "Allow comments" > Update.

### WP.com site

#### With comments enabled 🟢 :

- Navigate to Reader, and go to any comment thread. 
- 🔍 Verify that the Reply and Like button is shown.
- Go to My Site > Comments, and select any comment.
- 🔍 Verify that the Reply and Like button is shown.

#### With comments disabled 🔴 :

- Navigate to Reader, and go to any comment thread. 
- 🔍 Verify that the Reply button is hidden, but the Like button is shown.
- Go to My Site > Comments, and select any comment.
- 🔍 Verify that the Reply and Like button is shown.
  - ⚠️ Note that the Reply button should be hidden here, but non-Reader comments currently do not provide comment status information, unlike `ReaderPost` (i.e. `commentsOpen`). While this is a bug, I think this is a legacy issue unrelated to this PR. I'll log this into a separate issue later.

### Self-hosted site

(Note that the comment status is not relevant in self-hosted sites, as it currently only affects Reader comments due to the bug I've described above.)

- Make sure that you're logged out from your WP.com account, and then log in to your self-hosted site.
- Navigate to Reader, and go to any comment thread.
- 🔍 Verify that both the Reply and Like button is hidden.
- Navigate to My Site > Comments, and select any comment.
- 🔍 Verify that the Reply button is shown, and the Like button is hidden.

## Regression Notes
1. Potential unintended areas of impact
This could impact Site Comments, since the `CommentContentTableViewCell` is modified.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested Site Comments to ensure that it is not impacted.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.