### PR TITLE
Add UI tests to check the ability to scroll reader content and interact with the items

### DIFF
--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -20,6 +20,50 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
+    public func openTheLastPostInApp() {
+        getTheLastPost().tap()
+    }
+
+    public func openTheLastPostInSafari() {
+        getTheLastPost().buttons["More"].tap()
+        app.buttons["Visit"].tap()
+    }
+
+    public func getTheLastPost() -> XCUIElement {
+        let postPosition = app.cells.count - 1
+        let post = app.cells.element(boundBy: postPosition)
+
+        scrollDownUntilElementIsHittable(element: post)
+        return post
+    }
+
+    private func scrollDownUntilElementIsHittable(element: XCUIElement) {
+        var loopCount = 0
+        while !element.waitForIsHittable(timeout: 3) && loopCount < 10 {
+            loopCount += 1
+            app.swipeUp(velocity: .fast)
+            print(loopCount)
+        }
+    }
+
+    public func postContentEquals(expected: String) -> Bool {
+        let equalsPostContent = NSPredicate(format: "label == %@", expected)
+        let isPostContentEqual = app.staticTexts.element(matching: equalsPostContent).waitForIsHittable(timeout: 3)
+
+        return isPostContentEqual
+    }
+
+    public func dismissPost() {
+        let backButton = app.buttons["Back"]
+        let dismissButton = app.buttons["Dismiss"]
+
+        if dismissButton.isHittable {
+            dismissButton.tap()
+        } else if backButton.isHittable {
+            backButton.tap()
+        }
+    }
+
     public static func isLoaded() -> Bool {
         (try? ReaderScreen().isLoaded) ?? false
     }

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -20,19 +20,17 @@ public class ReaderScreen: ScreenObject {
         )
     }
 
-    public func openTheLastPostInApp() {
-        getTheLastPost().tap()
+    public func openLastPost() {
+        getLastPost().tap()
     }
 
-    public func openTheLastPostInSafari() {
-        getTheLastPost().buttons["More"].tap()
+    public func openLastPostInSafari() {
+        getLastPost().buttons["More"].tap()
         app.buttons["Visit"].tap()
     }
 
-    public func getTheLastPost() -> XCUIElement {
-        let postPosition = app.cells.count - 1
-        let post = app.cells.element(boundBy: postPosition)
-
+    public func getLastPost() -> XCUIElement {
+        guard let post = app.cells.lastMatch else { fatalError("ReaderScreen: No posts loaded") }
         scrollDownUntilElementIsHittable(element: post)
         return post
     }
@@ -42,11 +40,10 @@ public class ReaderScreen: ScreenObject {
         while !element.waitForIsHittable(timeout: 3) && loopCount < 10 {
             loopCount += 1
             app.swipeUp(velocity: .fast)
-            print(loopCount)
         }
     }
 
-    public func postContentEquals(expected: String) -> Bool {
+    public func postContentEquals(_ expected: String) -> Bool {
         let equalsPostContent = NSPredicate(format: "label == %@", expected)
         let isPostContentEqual = app.staticTexts.element(matching: equalsPostContent).waitForIsHittable(timeout: 3)
 

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -54,11 +54,8 @@ public class ReaderScreen: ScreenObject {
         let backButton = app.buttons["Back"]
         let dismissButton = app.buttons["Dismiss"]
 
-        if dismissButton.isHittable {
-            dismissButton.tap()
-        } else if backButton.isHittable {
-            backButton.tap()
-        }
+        if dismissButton.isHittable { dismissButton.tap() }
+        if backButton.isHittable { backButton.tap() }
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2494,6 +2494,7 @@
 		E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
 		F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10465132554260600655194 /* BindableTapGestureRecognizer.swift */; };
 		F10D634F26F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
 		F10D635026F0B78E00E46CC7 /* Blog+Organization.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */; };
@@ -7341,6 +7342,7 @@
 		E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanFeature.swift; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
+		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EEF80689364FA9CAE10405E8 /* Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressNotificationServiceExtension/Pods-WordPressNotificationServiceExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		EF379F0A70B6AC45330EE287 /* Pods-WordPressTest.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release.xcconfig"; sourceTree = "<group>"; };
 		F10465132554260600655194 /* BindableTapGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BindableTapGestureRecognizer.swift; sourceTree = "<group>"; };
@@ -13119,6 +13121,7 @@
 		BEA101B61FF13F0500CE5C7D /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */,
 				6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */,
 				FF2716911CAAC87B0006E2D4 /* LoginTests.swift */,
 				CC7CB97222B1510900642EE9 /* SignupTests.swift */,
@@ -20725,6 +20728,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				FFA0B7D71CAC1F9F00533B9D /* MainNavigationTests.swift in Sources */,
+				EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */,
 				BED4D8301FF11DEF00A11345 /* EditorAztecTests.swift in Sources */,
 				3F2F856326FAF612000FCDA5 /* EditorGutenbergTests.swift in Sources */,
 				FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */,

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -1,0 +1,36 @@
+import UITestsFoundation
+import XCTest
+
+class ReaderTests: XCTestCase {
+    private var readerScreen: ReaderScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite()
+
+        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        readerScreen = try EditorFlow
+            .goToMySiteScreen()
+            .tabBar.goToReaderScreen()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        if readerScreen != nil && !TabNavComponent.isVisible() {
+            readerScreen.dismissPost()
+        }
+        try LoginFlow.logoutIfNeeded()
+        try super.tearDownWithError()
+    }
+
+    let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
+
+    func testViewPostInApp() {
+        readerScreen.openTheLastPostInApp()
+        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+    }
+
+    func testViewPostInSafari() {
+        readerScreen.openTheLastPostInSafari()
+        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+    }
+}

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -24,13 +24,13 @@ class ReaderTests: XCTestCase {
 
     let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
 
-    func testViewPostInApp() {
-        readerScreen.openTheLastPostInApp()
-        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+    func testViewPost() {
+        readerScreen.openLastPost()
+        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
     }
 
     func testViewPostInSafari() {
-        readerScreen.openTheLastPostInSafari()
-        XCTAssert(readerScreen.postContentEquals(expected: expectedPostContent))
+        readerScreen.openLastPostInSafari()
+        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
     }
 }


### PR DESCRIPTION
One of the identified critical flows to be automated was to open the Reader section, scroll content, open and close selections. This PR adds tests to cover the scenario.

To test:
ReaderTests must pass on CI.

## Regression Notes
1. Potential unintended areas of impact
None. The changes would only impact ReaderTests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N/A**
- [x] I have considered adding accessibility improvements for my changes. **N/A**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N/A**
