### PR TITLE
Onboarding Improvements: track events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -234,6 +234,10 @@ import Foundation
     case readerManageViewDisplayed
     case readerManageViewDismissed
 
+    // Login: Epilogue
+    case loginEpilogueChooseSiteTapped
+    case loginEpilogueCreateNewSiteTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -635,6 +639,12 @@ import Foundation
             return "reader_manage_view_displayed"
         case .readerManageViewDismissed:
             return "reader_manage_view_dismissed"
+
+        // Login: Epilogue
+        case .loginEpilogueChooseSiteTapped:
+            return "login_epilogue_choose_site_tapped"
+        case .loginEpilogueCreateNewSiteTapped:
+            return "login_epilogue_create_new_site_tapped"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -105,12 +105,16 @@ final class QuickStartPromptViewController: UIViewController {
     @IBAction private func showMeAroundButtonTapped(_ sender: Any) {
         onDismiss?(blog)
         dismiss(animated: true)
+
+        WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
     }
 
     @IBAction private func noThanksButtonTapped(_ sender: Any) {
         quickStartSettings.setPromptWasDismissed(true, for: blog)
         onDismiss?(blog)
         dismiss(animated: true)
+
+        WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -203,7 +203,7 @@ extension LoginEpilogueTableViewController {
         let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
         let blog = blogDataSource.blog(at: wrappedPath)
 
-        parent.onBlogSelected?(blog)
+        parent.blogSelected(blog)
     }
 
     private enum Constants {
@@ -217,7 +217,7 @@ extension LoginEpilogueTableViewController: LoginEpilogueCreateNewSiteCellDelega
         guard let parent = parent as? LoginEpilogueViewController else {
             return
         }
-        parent.onCreateNewSite?()
+        parent.createNewSite()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -161,6 +161,18 @@ class LoginEpilogueViewController: UIViewController {
     func showSkipButton() {
         skipButton.isHidden = false
     }
+
+    // MARK: - Actions
+
+    func createNewSite() {
+        onCreateNewSite?()
+        WPAnalytics.track(.loginEpilogueCreateNewSiteTapped)
+    }
+
+    func blogSelected(_ blog: Blog) {
+        onBlogSelected?(blog)
+        WPAnalytics.track(.loginEpilogueChooseSiteTapped, properties: [:], blog: blog)
+    }
 }
 
 // MARK: - Private Extension
@@ -237,7 +249,7 @@ private extension LoginEpilogueViewController {
     // MARK: - Actions
 
     @IBAction func createANewSite() {
-        onCreateNewSite?()
+        createNewSite()
     }
 
     @IBAction func dismissEpilogue() {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/17383

### To test

1. Login to an account
2. Tap "Create new site"
3. Make sure `login_epilogue_create_new_site_tapped` is fired
4. Dismiss the site creation flow
5. Tap any site
6. Make sure `login_epilogue_choose_site_tapped` is fired with a blog id property

**Important**: make sure to activate the events if they're being triggered correctly.

### Additional notes

Based on the Android PR (https://github.com/wordpress-mobile/WordPress-Android/pull/15075) it seems that the `unified_login_interaction` was also changed to take into account the `create_new_site` and `choose_site` steps.

However, in iOS, all this logic is inside `AuthenticatorAnalyticsTracker` which is inside the `WordPressAuthenticator` pod. It seems a little bit odd to add those steps there since they're completely WP-related and adapting this functionality to take into account these steps would be a little bit of work, so I'm leaving this outside of the scope of this task.

Please let me know if you have any ideas.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
