### PR TITLE
Adds more tracking to the app settings view

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -244,9 +244,11 @@ import Foundation
     case accountCloseTapped
     case accountCloseCompleted
 
+    // App Settings
     case appSettingsClearMediaCacheTapped
     case appSettingsClearSpotlightIndexTapped
     case appSettingsClearSiriSuggestionsTapped
+    case appSettingsOpenDeviceSettingsTapped
 
     // Privacy Settings
     case privacySettingsOpened
@@ -668,6 +670,9 @@ import Foundation
             return "app_settings_clear_spotlight_index_tapped"
         case .appSettingsClearSiriSuggestionsTapped:
             return "app_settings_clear_siri_suggestions_tapped"
+        case .appSettingsOpenDeviceSettingsTapped:
+            return "app_settings_open_device_settings_tapped"
+
         // Privacy Settings
         case .privacySettingsOpened:
             return "privacy_settings_opened"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -244,6 +244,7 @@ import Foundation
     case accountCloseTapped
     case accountCloseCompleted
 
+    case appSettingsClearMediaCacheTapped
     /// A String that represents the event
     var value: String {
         switch self {
@@ -654,6 +655,8 @@ import Foundation
         // App Settings
         case .settingsDidChange:
             return "settings_did_change"
+        case .appSettingsClearMediaCacheTapped:
+            return "app_settings_clear_media_cache_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -248,6 +248,10 @@ import Foundation
     case appSettingsClearSpotlightIndexTapped
     case appSettingsClearSiriSuggestionsTapped
 
+    // Privacy Settings
+    case privacySettingsOpened
+    case privacySettingsReportCrashesToggled
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -664,6 +668,11 @@ import Foundation
             return "app_settings_clear_spotlight_index_tapped"
         case .appSettingsClearSiriSuggestionsTapped:
             return "app_settings_clear_siri_suggestions_tapped"
+        // Privacy Settings
+        case .privacySettingsOpened:
+            return "privacy_settings_opened"
+        case .privacySettingsReportCrashesToggled:
+            return "privacy_settings_report_crashes_toggled"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -242,7 +242,6 @@ import Foundation
 
     // Account Close
     case accountCloseTapped
-    case accountCloseCancel
     case accountCloseCompleted
 
     /// A String that represents the event
@@ -659,8 +658,6 @@ import Foundation
         // Account Close
         case .accountCloseTapped:
             return "account_close_tapped"
-        case .accountCloseCancel:
-            return "account_close_cancel"
         case .accountCloseCompleted:
             return "account_close_completed"
         } // END OF SWITCH

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -237,6 +237,14 @@ import Foundation
     case readerManageViewDisplayed
     case readerManageViewDismissed
 
+    // App Settings
+    case settingsDidChange
+
+    // Account Close
+    case accountCloseTapped
+    case accountCloseCancel
+    case accountCloseCompleted
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -628,6 +636,7 @@ import Foundation
         case .postListShareAction:
             return "post_list_button_pressed"
 
+        // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:
             return "reader_filter_sheet_displayed"
         case .readerFilterSheetDismissed:
@@ -636,10 +645,24 @@ import Foundation
             return "reader_filter_sheet_item_selected"
         case .readerFilterSheetCleared:
             return "reader_filter_sheet_cleared"
+
+        // Reader: Manage View
         case .readerManageViewDisplayed:
             return "reader_manage_view_displayed"
         case .readerManageViewDismissed:
             return "reader_manage_view_dismissed"
+
+        // App Settings
+        case .settingsDidChange:
+            return "settings_did_change"
+
+        // Account Close
+        case .accountCloseTapped:
+            return "account_close_tapped"
+        case .accountCloseCancel:
+            return "account_close_cancel"
+        case .accountCloseCompleted:
+            return "account_close_completed"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -245,6 +245,7 @@ import Foundation
     case accountCloseCompleted
 
     case appSettingsClearMediaCacheTapped
+    case appSettingsClearSpotlightIndexTapped
     /// A String that represents the event
     var value: String {
         switch self {
@@ -657,6 +658,8 @@ import Foundation
             return "settings_did_change"
         case .appSettingsClearMediaCacheTapped:
             return "app_settings_clear_media_cache_tapped"
+        case .appSettingsClearSpotlightIndexTapped:
+            return "app_settings_clear_spotlight_index_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -246,6 +246,8 @@ import Foundation
 
     case appSettingsClearMediaCacheTapped
     case appSettingsClearSpotlightIndexTapped
+    case appSettingsClearSiriSuggestionsTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -660,6 +662,8 @@ import Foundation
             return "app_settings_clear_media_cache_tapped"
         case .appSettingsClearSpotlightIndexTapped:
             return "app_settings_clear_spotlight_index_tapped"
+        case .appSettingsClearSiriSuggestionsTapped:
+            return "app_settings_clear_siri_suggestions_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -80,12 +80,14 @@ struct EditableTextRow: ImmuTableRow {
     let value: String
     let accessoryImage: UIImage?
     let action: ImmuTableAction?
+    let fieldName: String?
 
-    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?) {
+    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?, fieldName: String? = nil) {
         self.title = title
         self.value = value
         self.accessoryImage = accessoryImage
         self.action = action
+        self.fieldName = fieldName
     }
 
     func configureCell(_ cell: UITableViewCell) {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -234,6 +234,8 @@ private class AccountSettingsController: SettingsController {
             let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber?,
                                                                     successHandler: { (dotComID: NSNumber?) in
                                                                         if let dotComID = dotComID?.intValue {
+                                                                            WPAnalytics.track(.settingsDidChange, properties: ["page": self.trackingKey, "field_name": "primary_site"])
+
                                                                             let change = AccountSettingsChange.primarySite(dotComID)
                                                                             service.saveChange(change)
                                                                         }

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -19,6 +19,10 @@ func AccountSettingsViewController(accountSettingsService: AccountSettingsServic
 }
 
 private class AccountSettingsController: SettingsController {
+    var trackingKey: String {
+        return "account_settings"
+    }
+
     let title = NSLocalizedString("Account Settings", comment: "Account Settings Title")
 
     var immuTableRows: [ImmuTableRow.Type] {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -95,14 +95,16 @@ private class AccountSettingsController: SettingsController {
         let editableUsername = EditableTextRow(
             title: NSLocalizedString("Username", comment: "Account Settings Username label"),
             value: settings?.username ?? "",
-            action: presenter.push(changeUsername(with: settings, service: service))
+            action: presenter.push(changeUsername(with: settings, service: service)),
+            fieldName: "username"
         )
 
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.emailForDisplay ?? "",
             accessoryImage: emailAccessoryImage(),
-            action: presenter.push(editEmailAddress(settings, service: service))
+            action: presenter.push(editEmailAddress(settings, service: service)),
+            fieldName: "email"
         )
 
         var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) } ?? ""
@@ -116,19 +118,22 @@ private class AccountSettingsController: SettingsController {
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
             value: primarySiteName,
-            action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service)))
+            action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service))),
+            fieldName: "primary_site"
         )
 
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.push(editWebAddress(service))
+            action: presenter.push(editWebAddress(service)),
+            fieldName: "web_address"
         )
 
         let password = EditableTextRow(
             title: Constants.title,
             value: "",
-            action: presenter.push(changePassword(with: settings, service: service))
+            action: presenter.push(changePassword(with: settings, service: service)),
+            fieldName: "password"
         )
 
         let closeAccount = DestructiveButtonRow(

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
@@ -114,8 +114,11 @@ open class AppIconViewController: UITableViewController {
 
         UIApplication.shared.setAlternateIconName(iconName, completionHandler: { [weak self] error in
             if error == nil {
-                let event: WPAnalyticsStat = isOriginalIcon ? .appIconReset : .appIconChanged
-                WPAppAnalytics.track(event)
+                if isOriginalIcon {
+                    WPAppAnalytics.track(.appIconReset)
+                } else {
+                    WPAppAnalytics.track(.appIconChanged, withProperties: ["icon_name": iconName ?? "default"])
+                }
             }
 
             self?.tableView.reloadData()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -133,6 +133,8 @@ class AppSettingsViewController: UITableViewController {
     }
 
     fileprivate func clearMediaCache() {
+        WPAnalytics.track(.appSettingsClearMediaCacheTapped)
+
         setMediaCacheRowDescription(status: .clearingCache)
         MediaFileManager.clearAllMediaCacheFiles(onCompletion: { [weak self] in
             self?.updateMediaCacheSize()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -269,6 +269,8 @@ class AppSettingsViewController: UITableViewController {
 
     func openPrivacySettings() -> ImmuTableAction {
         return { [weak self] _ in
+            WPAnalytics.track(.privacySettingsOpened)
+
             let controller = PrivacySettingsViewController()
             self?.navigationController?.pushViewController(controller, animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -278,6 +278,8 @@ class AppSettingsViewController: UITableViewController {
 
     func openApplicationSettings() -> ImmuTableAction {
         return { [weak self] row in
+            WPAnalytics.track(.appSettingsOpenDeviceSettingsTapped)
+
             if let targetURL = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(targetURL)
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -289,6 +289,8 @@ class AppSettingsViewController: UITableViewController {
 
     func clearSiriActivityDonations() -> ImmuTableAction {
         return { [tableView] _ in
+            WPAnalytics.track(.appSettingsClearSiriSuggestionsTapped)
+
             tableView?.deselectSelectedRowWithAnimation(true)
 
             if #available(iOS 12.0, *) {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -302,6 +302,8 @@ class AppSettingsViewController: UITableViewController {
 
     func clearSpotlightCache() -> ImmuTableAction {
         return { [weak self] row in
+            WPAnalytics.track(.appSettingsClearSpotlightIndexTapped)
+
             self?.tableView.deselectSelectedRowWithAnimation(true)
             SearchManager.shared.deleteAllSearchableItems()
             let notice = Notice(title: NSLocalizedString("Successfully cleared spotlight index", comment: "Notice displayed to the user after clearing the spotlight index in app settings."),

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -160,6 +160,9 @@ class PrivacySettingsViewController: UITableViewController {
 
     func crashReportingChanged(_ enabled: Bool) {
         UserSettings.userHasOptedOutOfCrashLogging = !enabled
+
+        WPAnalytics.track(.privacySettingsReportCrashesToggled, properties: ["enabled": enabled])
+
         WordPressAppDelegate.crashLogging?.setNeedsDataRefresh()
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
@@ -44,6 +44,9 @@ private func makeHeaderView(account: WPAccount) -> MyProfileHeaderView {
 /// To avoid problems, it's marked private and should only be initialized using the
 /// `MyProfileViewController` factory functions.
 private class MyProfileController: SettingsController {
+    var trackingKey: String {
+        return "my_profile"
+    }
 
     // MARK: - Private Properties
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
@@ -114,24 +114,28 @@ private class MyProfileController: SettingsController {
         let firstNameRow = EditableTextRow(
             title: NSLocalizedString("First Name", comment: "My Profile first name label"),
             value: settings?.firstName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.firstName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.firstName, service: service)),
+            fieldName: "first_name")
 
         let lastNameRow = EditableTextRow(
             title: NSLocalizedString("Last Name", comment: "My Profile last name label"),
             value: settings?.lastName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.lastName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.lastName, service: service)),
+            fieldName: "last_name")
 
         let displayNameRow = EditableTextRow(
             title: NSLocalizedString("Display Name", comment: "My Profile display name label"),
             value: settings?.displayName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.displayName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.displayName, service: service)),
+            fieldName: "display_name")
 
         let aboutMeRow = EditableTextRow(
             title: NSLocalizedString("About Me", comment: "My Profile 'About me' label"),
             value: settings?.aboutMe ?? "",
             action: presenter.push(editMultilineText(AccountSettingsChange.aboutMe,
                 hint: NSLocalizedString("Tell us a bit about you.", comment: "My Profile 'About me' hint text"),
-                service: service)))
+                service: service)),
+            fieldName: "about_me")
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: [

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -123,6 +123,9 @@ private struct DateAndTimeRow: ImmuTableRow {
 }
 
 @objc class PublishSettingsController: NSObject, SettingsController {
+    var trackingKey: String {
+        return "publish_settings"
+    }
 
     @objc class func viewController(post: AbstractPost) -> ImmuTableViewController {
         let controller = PublishSettingsController(post: post)

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -57,6 +57,8 @@ extension SettingsController {
             let change = changeType(value)
             service.saveChange(change)
             DDLogDebug("\(title) changed: \(value)")
+
+            trackChangeIfNeeded(row)
         }
 
         return controller
@@ -78,8 +80,19 @@ extension SettingsController {
             let change = changeType(value)
             service.saveChange(change)
             DDLogDebug("\(title) changed: \(value)")
+
+            trackChangeIfNeeded(row)
         }
 
         return controller
+    }
+
+    private func trackChangeIfNeeded(_ row: EditableTextRow) {
+        // Don't track if the field name isn't specified
+        guard let fieldName = row.fieldName else {
+            return
+        }
+
+        WPAnalytics.track(.settingsDidChange, properties: ["page": trackingKey, "field_name": fieldName])
     }
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -2,7 +2,9 @@ import UIKit
 import WordPressKit
 import CocoaLumberjack
 
-protocol SettingsController: ImmuTableController {}
+protocol SettingsController: ImmuTableController {
+    var trackingKey: String { get }
+}
 
 // MARK: - Actions
 extension SettingsController {


### PR DESCRIPTION
Project: #17503

### Description
Adds new tracking to the My Profile, Account Settings, and App Settings:

- You edit any value on the My Profile view
    - `🔵 Tracked: settings_did_change <field_name: FIELD_NAME, page: my_profile>`
- Account Settings
    - You edit any value on the Account Settings view
        - `🔵 Tracked: settings_did_change <field_name: FIELD_NAME, page: account_settings>`
    - You tap the 'Close Account' button on the Account Settings view
    - You close your account
- App Settings
    - You tap the 'Clear Device Media Cache' button
        - `🔵 Tracked: app_settings_clear_media_cache_tapped <>`
    - You tap the 'Clear Spotlight Index' button
        - `🔵 Tracked: app_settings_clear_spotlight_index_tapped <>`
    - You tap the 'Clear Siri Shortcut Suggestions' button
        - `🔵 Tracked: app_settings_clear_siri_suggestions_tapped <>`
    - You tap the 'Open Device Settings' button
        - `🔵 Tracked: app_settings_open_device_settings_tapped <>`
- Privacy Settings:
    - You open the Privacy Settings
        - `🔵 Tracked: privacy_settings_opened <>`
    - You toggle the 'Crash Reports' switch
        - `🔵 Tracked: privacy_settings_report_crashes_toggled <enabled: VALUE>`
- App Icon
   - The name of the app icon is now sent on change
       - `🔵 Tracked: app_icon_changed <icon_name: ICON_NAME>`

### To test:

#### My Profile
1. Launch the app
2. Tap the your profile icon in the top corner
3. Tap the 'My Profile' item
4. Change your first name, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: first_name, page: my_profile>` 
4. Change your last name, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: last_name, page: my_profile>` 
4. Change your display name, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: display_name, page: my_profile>` 
4. Change your about me, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: about_me, page: my_profile>` 

#### Account Settings
1. Launch the app
2. Tap the your profile icon in the top corner
3. Tap the 'Account Settings' item
4. Change your email, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: email, page: account_settings>` 
4. Change your primary site, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: primary_site, page: account_settings>` 
4. Change your web address, and verify you see:
    - `🔵 Tracked: settings_did_change <field_name: web_address, page: account_settings>` 
4. Tap the 'Close Account' button and verify you see:
   - `🔵 Tracked: account_close_tapped <has_atomic: HAS_ATOMIC>` 
   - HAS_ATOMIC is 0 or 1 if you have atomic sites on your account
5. Enter your username and tap the close account button, verify you see: 
   - `🔵 Tracked: account_close_completed <status: success>`

#### App Settings

1. Launch the app
2. Tap the your profile icon in the top corner
3. Tap the 'Account Settings' item
4. Tap the 'Clear Device Media Cache' button, and verify you see: 
        - `🔵 Tracked: app_settings_clear_media_cache_tapped <>`
5. Tap the 'Clear Spotlight Index' button, and verify you see: 
        - `🔵 Tracked: app_settings_clear_spotlight_index_tapped <>`
6. Tap the 'Clear Siri Shortcut Suggestions' button, and verify you see: 
        - `🔵 Tracked: app_settings_clear_siri_suggestions_tapped <>`
7. Tap the 'Open Device Settings' button, and verify you see: 
        - `🔵 Tracked: app_settings_open_device_settings_tapped <>`
8. Tap the 'Privacy Settings' item, and verify you see: 
   - `🔵 Tracked: privacy_settings_opened <>`
9. Toggle the 'Crash Reports' item and verify you see
   - `🔵 Tracked: privacy_settings_report_crashes_toggled <enabled: 0>`
10. Tap Back, and Tap on 'App Icon'
11. Change the app icon and verify you see:
   - `🔵 Tracked: app_icon_changed <icon_name: SELECTED_ICON_NAME>`

### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
