### PR TITLE
Adds tracking for all of the site settings areas

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -244,9 +244,11 @@ import Foundation
     case accountCloseTapped
     case accountCloseCompleted
 
+    // App Settings
     case appSettingsClearMediaCacheTapped
     case appSettingsClearSpotlightIndexTapped
     case appSettingsClearSiriSuggestionsTapped
+    case appSettingsOpenDeviceSettingsTapped
 
     // Privacy Settings
     case privacySettingsOpened
@@ -668,6 +670,9 @@ import Foundation
             return "app_settings_clear_spotlight_index_tapped"
         case .appSettingsClearSiriSuggestionsTapped:
             return "app_settings_clear_siri_suggestions_tapped"
+        case .appSettingsOpenDeviceSettingsTapped:
+            return "app_settings_open_device_settings_tapped"
+
         // Privacy Settings
         case .privacySettingsOpened:
             return "privacy_settings_opened"

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -244,6 +244,7 @@ import Foundation
     case accountCloseTapped
     case accountCloseCompleted
 
+    case appSettingsClearMediaCacheTapped
     /// A String that represents the event
     var value: String {
         switch self {
@@ -654,6 +655,8 @@ import Foundation
         // App Settings
         case .settingsDidChange:
             return "settings_did_change"
+        case .appSettingsClearMediaCacheTapped:
+            return "app_settings_clear_media_cache_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -248,6 +248,10 @@ import Foundation
     case appSettingsClearSpotlightIndexTapped
     case appSettingsClearSiriSuggestionsTapped
 
+    // Privacy Settings
+    case privacySettingsOpened
+    case privacySettingsReportCrashesToggled
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -664,6 +668,11 @@ import Foundation
             return "app_settings_clear_spotlight_index_tapped"
         case .appSettingsClearSiriSuggestionsTapped:
             return "app_settings_clear_siri_suggestions_tapped"
+        // Privacy Settings
+        case .privacySettingsOpened:
+            return "privacy_settings_opened"
+        case .privacySettingsReportCrashesToggled:
+            return "privacy_settings_report_crashes_toggled"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -242,7 +242,6 @@ import Foundation
 
     // Account Close
     case accountCloseTapped
-    case accountCloseCancel
     case accountCloseCompleted
 
     /// A String that represents the event
@@ -659,8 +658,6 @@ import Foundation
         // Account Close
         case .accountCloseTapped:
             return "account_close_tapped"
-        case .accountCloseCancel:
-            return "account_close_cancel"
         case .accountCloseCompleted:
             return "account_close_completed"
         } // END OF SWITCH

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -847,9 +847,13 @@ extension WPAnalytics {
         }
     }
 
-    @objc static func trackSettingsChange(page: String, fieldName: String, value: Any? = nil) {
+    @objc static func trackSettingsChange(_ page: String, fieldName: String) {
+        Self.trackSettingsChange(page, fieldName: fieldName, value: nil)
+    }
+
+    @objc static func trackSettingsChange(_ page: String, fieldName: String, value: Any?) {
         var properties: [AnyHashable: Any] = ["page": page, "field_name": fieldName]
-        
+
         if let value = value {
             let additionalProperties: [AnyHashable: Any] = ["value": value]
             properties.merge(additionalProperties) { (_, new) in new }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -847,4 +847,14 @@ extension WPAnalytics {
         }
     }
 
+    @objc static func trackSettingsChange(page: String, fieldName: String, value: Any? = nil) {
+        var properties: [AnyHashable: Any] = ["page": page, "field_name": fieldName]
+        
+        if let value = value {
+            let additionalProperties: [AnyHashable: Any] = ["value": value]
+            properties.merge(additionalProperties) { (_, new) in new }
+        }
+
+        WPAnalytics.track(.settingsDidChange, properties: properties)
+    }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -237,6 +237,14 @@ import Foundation
     case readerManageViewDisplayed
     case readerManageViewDismissed
 
+    // App Settings
+    case settingsDidChange
+
+    // Account Close
+    case accountCloseTapped
+    case accountCloseCancel
+    case accountCloseCompleted
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -628,6 +636,7 @@ import Foundation
         case .postListShareAction:
             return "post_list_button_pressed"
 
+        // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:
             return "reader_filter_sheet_displayed"
         case .readerFilterSheetDismissed:
@@ -636,10 +645,24 @@ import Foundation
             return "reader_filter_sheet_item_selected"
         case .readerFilterSheetCleared:
             return "reader_filter_sheet_cleared"
+
+        // Reader: Manage View
         case .readerManageViewDisplayed:
             return "reader_manage_view_displayed"
         case .readerManageViewDismissed:
             return "reader_manage_view_dismissed"
+
+        // App Settings
+        case .settingsDidChange:
+            return "settings_did_change"
+
+        // Account Close
+        case .accountCloseTapped:
+            return "account_close_tapped"
+        case .accountCloseCancel:
+            return "account_close_cancel"
+        case .accountCloseCompleted:
+            return "account_close_completed"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -245,6 +245,7 @@ import Foundation
     case accountCloseCompleted
 
     case appSettingsClearMediaCacheTapped
+    case appSettingsClearSpotlightIndexTapped
     /// A String that represents the event
     var value: String {
         switch self {
@@ -657,6 +658,8 @@ import Foundation
             return "settings_did_change"
         case .appSettingsClearMediaCacheTapped:
             return "app_settings_clear_media_cache_tapped"
+        case .appSettingsClearSpotlightIndexTapped:
+            return "app_settings_clear_spotlight_index_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -246,6 +246,8 @@ import Foundation
 
     case appSettingsClearMediaCacheTapped
     case appSettingsClearSpotlightIndexTapped
+    case appSettingsClearSiriSuggestionsTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -660,6 +662,8 @@ import Foundation
             return "app_settings_clear_media_cache_tapped"
         case .appSettingsClearSpotlightIndexTapped:
             return "app_settings_clear_spotlight_index_tapped"
+        case .appSettingsClearSiriSuggestionsTapped:
+            return "app_settings_clear_siri_suggestions_tapped"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -80,12 +80,14 @@ struct EditableTextRow: ImmuTableRow {
     let value: String
     let accessoryImage: UIImage?
     let action: ImmuTableAction?
+    let fieldName: String?
 
-    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?) {
+    init(title: String, value: String, accessoryImage: UIImage? = nil, action: ImmuTableAction?, fieldName: String? = nil) {
         self.title = title
         self.value = value
         self.accessoryImage = accessoryImage
         self.action = action
+        self.fieldName = fieldName
     }
 
     func configureCell(_ cell: UITableViewCell) {

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gridicons
+import WordPressShared
 
 final class SiteTagsViewController: UITableViewController {
     private struct TableConstants {
@@ -309,6 +310,7 @@ extension SiteTagsViewController {
         newTag.tagDescription = data.subtitle
 
         save(newTag)
+        WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "add_tag")
     }
 
     private func updateTag(_ tag: PostTag, updatedData: SettingsTitleSubtitleController.Content) {
@@ -323,6 +325,7 @@ extension SiteTagsViewController {
         tag.tagDescription = updatedData.subtitle
 
         save(tag)
+        WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "edit_tag")
     }
 
     private func existingTagForData(_ data: SettingsTitleSubtitleController.Content) -> PostTag? {

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
@@ -310,7 +310,7 @@ extension SiteTagsViewController {
         newTag.tagDescription = data.subtitle
 
         save(newTag)
-        WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "add_tag")
+        WPAnalytics.trackSettingsChange("site_tags", fieldName: "add_tag")
     }
 
     private func updateTag(_ tag: PostTag, updatedData: SettingsTitleSubtitleController.Content) {
@@ -325,7 +325,7 @@ extension SiteTagsViewController {
         tag.tagDescription = updatedData.subtitle
 
         save(tag)
-        WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "edit_tag")
+        WPAnalytics.trackSettingsChange("site_tags", fieldName: "edit_tag")
     }
 
     private func existingTagForData(_ data: SettingsTitleSubtitleController.Content) -> PostTag? {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -135,6 +135,7 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
                 if let newDateFormat = selected as? String {
                     self?.settings.dateFormat = newDateFormat
                     self?.saveSettings()
+                    WPAnalytics.trackSettingsChange("date_format", fieldName: "date_format")
                 }
             }
 
@@ -168,6 +169,8 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
                 if let newTimeFormat = selected as? String {
                     self?.settings.timeFormat = newTimeFormat
                     self?.saveSettings()
+                    WPAnalytics.trackSettingsChange("date_format", fieldName: "time_format")
+
                 }
             }
 
@@ -187,6 +190,9 @@ open class DateAndTimeFormatSettingsViewController: UITableViewController {
                 if let newStartOfWeek = selected as? String {
                     self?.settings.startOfWeek = newStartOfWeek
                     self?.saveSettings()
+                    WPAnalytics.trackSettingsChange("date_format",
+                                                    fieldName: "start_of_week",
+                                                    value: newStartOfWeek as Any)
                 }
             }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -7,6 +7,8 @@ import WordPressShared
 /// allow the user to tune those settings, as required.
 ///
 open class DiscussionSettingsViewController: UITableViewController {
+    private let tracksDiscussionSettingsKey = "site_settings_discussion"
+
     // MARK: - Initializers / Deinitializers
     @objc public convenience init(blog: Blog) {
         self.init(style: .grouped)
@@ -183,7 +185,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "allow_comments", value: enabled as Any)
+        trackSettingsChange(fieldName: "allow_comments", value: enabled as Any)
         settings.commentsAllowed = enabled
     }
 
@@ -192,7 +194,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "receive_pingbacks", value: enabled as Any)
+        trackSettingsChange(fieldName: "receive_pingbacks", value: enabled as Any)
         settings.pingbackInboundEnabled = enabled
     }
 
@@ -201,7 +203,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "send_pingbacks", value: enabled as Any)
+        trackSettingsChange(fieldName: "send_pingbacks", value: enabled as Any)
         settings.pingbackOutboundEnabled = enabled
     }
 
@@ -210,7 +212,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "require_name_and_email", value: enabled as Any)
+        trackSettingsChange(fieldName: "require_name_and_email", value: enabled as Any)
         settings.commentsRequireNameAndEmail = enabled
     }
 
@@ -219,7 +221,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "require_registration", value: enabled as Any)
+        trackSettingsChange(fieldName: "require_registration", value: enabled as Any)
         settings.commentsRequireRegistration = enabled
     }
 
@@ -241,7 +243,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             self?.settings.commentsCloseAutomaticallyAfterDays = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "close_commenting", value: value)
+            self?.trackSettingsChange(fieldName: "close_commenting", value: value)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -258,7 +260,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                 return
             }
 
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_sort_by", value: selected as Any)
+            self?.trackSettingsChange(fieldName: "comments_sort_by", value: selected as Any)
             self?.settings.commentsSorting = newSortOrder
         }
 
@@ -277,7 +279,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             }
 
             self?.settings.commentsThreading = newThreadingDepth
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_threading", value: selected as Any)
+            self?.trackSettingsChange(fieldName: "comments_threading", value: selected as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -299,7 +301,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             self?.settings.commentsPageSize = newValue as NSNumber
 
             let value: Any = enabled ? newValue : "disabled"
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_paging", value: value)
+            self?.trackSettingsChange(fieldName: "comments_paging", value: value)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -318,7 +320,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             }
 
             self?.settings.commentsAutoapproval = newApprovalStatus
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_automatically_approve", value: selected as Any)
+            self?.trackSettingsChange(fieldName: "comments_automatically_approve", value: selected as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -335,7 +337,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsMaximumLinks = newValue as NSNumber
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_links", value: newValue as Any)
+            self?.trackSettingsChange(fieldName: "comments_links", value: newValue as Any)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -351,8 +353,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                                                                     comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
             self?.settings.commentsModerationKeys = updated
-
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_hold_for_moderation", value: updated.count as Any)
+            self?.trackSettingsChange(fieldName: "comments_hold_for_moderation", value: updated.count as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -368,13 +369,18 @@ open class DiscussionSettingsViewController: UITableViewController {
                                                                     comment: "Text rendered at the bottom of the Discussion Blocklist Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
             self?.settings.commentsBlocklistKeys = updated
-            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_block_list", value: updated.count as Any)
+            self?.trackSettingsChange(fieldName: "comments_block_list", value: updated.count as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
     }
 
+    private func trackSettingsChange(fieldName: String, value: Any?) {
+        WPAnalytics.trackSettingsChange(tracksDiscussionSettingsKey,
+                                        fieldName: fieldName,
+                                        value: value)
 
+    }
 
     // MARK: - Computed Properties
     fileprivate var sections: [Section] {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -183,6 +183,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "allow_comments", value: enabled as Any)
         settings.commentsAllowed = enabled
     }
 
@@ -191,6 +192,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "send_pingbacks", value: enabled as Any)
         settings.pingbackInboundEnabled = enabled
     }
 
@@ -199,6 +201,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "receive_pingbacks", value: enabled as Any)
         settings.pingbackOutboundEnabled = enabled
     }
 
@@ -207,6 +210,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "require_name_and_email", value: enabled as Any)
         settings.commentsRequireNameAndEmail = enabled
     }
 
@@ -215,6 +219,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "require_registration", value: enabled as Any)
         settings.commentsRequireRegistration = enabled
     }
 
@@ -234,6 +239,9 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsCloseAutomatically = enabled
             self?.settings.commentsCloseAutomaticallyAfterDays = newValue as NSNumber
+
+            let value: Any = enabled ? newValue : "disabled"
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "close_commenting", value: value)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -250,6 +258,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                 return
             }
 
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_sort_by", value: selected as Any)
             self?.settings.commentsSorting = newSortOrder
         }
 
@@ -268,6 +277,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             }
 
             self?.settings.commentsThreading = newThreadingDepth
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_threading", value: selected as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -287,6 +297,9 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsPagingEnabled = enabled
             self?.settings.commentsPageSize = newValue as NSNumber
+
+            let value: Any = enabled ? newValue : "disabled"
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_paging", value: value)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -305,6 +318,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             }
 
             self?.settings.commentsAutoapproval = newApprovalStatus
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_automatically_approve", value: selected as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -321,6 +335,7 @@ open class DiscussionSettingsViewController: UITableViewController {
         pickerViewController.pickerSelectedValue = settings.commentsMaximumLinks as? Int
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.settings.commentsMaximumLinks = newValue as NSNumber
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_links", value: newValue as Any)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -336,6 +351,8 @@ open class DiscussionSettingsViewController: UITableViewController {
                                                                     comment: "Text rendered at the bottom of the Discussion Moderation Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
             self?.settings.commentsModerationKeys = updated
+
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_hold_for_moderation", value: updated.count as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)
@@ -351,6 +368,7 @@ open class DiscussionSettingsViewController: UITableViewController {
                                                                     comment: "Text rendered at the bottom of the Discussion Blocklist Keys editor")
         settingsViewController.onChange         = { [weak self] (updated: Set<String>) in
             self?.settings.commentsBlocklistKeys = updated
+            WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "comments_block_list", value: updated.count as Any)
         }
 
         navigationController?.pushViewController(settingsViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DiscussionSettingsViewController.swift
@@ -192,7 +192,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "send_pingbacks", value: enabled as Any)
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "receive_pingbacks", value: enabled as Any)
         settings.pingbackInboundEnabled = enabled
     }
 
@@ -201,7 +201,7 @@ open class DiscussionSettingsViewController: UITableViewController {
             return
         }
 
-        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "receive_pingbacks", value: enabled as Any)
+        WPAnalytics.trackSettingsChange("site_settings_discussion", fieldName: "send_pingbacks", value: enabled as Any)
         settings.pingbackOutboundEnabled = enabled
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -276,6 +276,8 @@ import WordPressShared
         /// If there is already an in progress change (i.e. bad network), don't push the view controller and deselect the selection immediately.
         tableView.allowsSelection = false
 
+        WPAnalytics.track(.settingsDidChange, properties: ["page": "homepage_settings", "field_name": "homepage_type", "value": (homepageType == .page) ? "page" : "posts"])
+
         /// Send the remove service call
         let service = HomepageSettingsService(blog: blog, context: blog.managedObjectContext!)
         service?.setHomepageType(homepageType,

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -276,7 +276,7 @@ import WordPressShared
         /// If there is already an in progress change (i.e. bad network), don't push the view controller and deselect the selection immediately.
         tableView.allowsSelection = false
 
-        WPAnalytics.trackSettingsChange(page: "homepage_settings",
+        WPAnalytics.trackSettingsChange("homepage_settings",
                                         fieldName: "homepage_type",
                                         value: (homepageType == .page) ? "page" : "posts")
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -276,7 +276,9 @@ import WordPressShared
         /// If there is already an in progress change (i.e. bad network), don't push the view controller and deselect the selection immediately.
         tableView.allowsSelection = false
 
-        WPAnalytics.track(.settingsDidChange, properties: ["page": "homepage_settings", "field_name": "homepage_type", "value": (homepageType == .page) ? "page" : "posts"])
+        WPAnalytics.trackSettingsChange(page: "homepage_settings",
+                                        fieldName: "homepage_type",
+                                        value: (homepageType == .page) ? "page" : "posts")
 
         /// Send the remove service call
         let service = HomepageSettingsService(blog: blog, context: blog.managedObjectContext!)

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/Related Posts/RelatedPostsSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/Related Posts/RelatedPostsSettingsViewController.m
@@ -190,6 +190,8 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
         _relatedPostsEnabledCell.name = NSLocalizedString(@"Show Related Posts", @"Label for configuration switch to enable/disable related posts");
         __weak RelatedPostsSettingsViewController *weakSelf = self;
         _relatedPostsEnabledCell.onChange = ^(BOOL value){
+            [WPAnalytics trackSettingsChange:@"related_posts" fieldName:@"show_related_posts" value:@(value)];
+
             [weakSelf updateRelatedPostsSettings:nil];
         };
     }
@@ -203,6 +205,7 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
         _relatedPostsShowHeaderCell.name = NSLocalizedString(@"Show Header", @"Label for configuration switch to show/hide the header for the related posts section");
         __weak RelatedPostsSettingsViewController *weakSelf = self;
         _relatedPostsShowHeaderCell.onChange = ^(BOOL value){
+            [WPAnalytics trackSettingsChange:@"related_posts" fieldName:@"show_related_posts_header" value:@(value)];
             [weakSelf updateRelatedPostsSettings:nil];
         };
     }
@@ -217,6 +220,8 @@ typedef NS_ENUM(NSInteger, RelatedPostsSettingsOptions) {
         _relatedPostsShowThumbnailsCell.name = NSLocalizedString(@"Show Images", @"Label for configuration switch to show/hide images thumbnail for the related posts");
         __weak RelatedPostsSettingsViewController *weakSelf = self;
         _relatedPostsShowThumbnailsCell.onChange = ^(BOOL value){
+            [WPAnalytics trackSettingsChange:@"related_posts" fieldName:@"show_related_posts_thumbnail" value:@(value)];
+
             [weakSelf updateRelatedPostsSettings:nil];
         };
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -412,7 +412,7 @@ extension SiteSettingsViewController {
     }
 
     func trackSettingsChange(fieldName: String, value: Any? = nil) {
-        WPAnalytics.trackSettingsChange(page: "site_settings",
+        WPAnalytics.trackSettingsChange("site_settings",
                                         fieldName: fieldName,
                                         value: value)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -80,7 +80,7 @@ extension SiteSettingsViewController {
             self?.blog.settings?.timezoneString = newValue.timezoneString
             self?.saveSettings()
             self?.trackSettingsChange(fieldName: "timezone",
-                                      properties: ["value": newValue.value as Any])
+                                      value: newValue.value as Any)
         }
         navigationController?.pushViewController(controller, animated: true)
     }
@@ -107,7 +107,7 @@ extension SiteSettingsViewController {
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.blog.settings?.postsPerPage = newValue as NSNumber?
             self?.saveSettings()
-            self?.trackSettingsChange(fieldName: "posts_per_page", properties: ["value": newValue as Any])
+            self?.trackSettingsChange(fieldName: "posts_per_page", value: newValue as Any)
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -411,10 +411,9 @@ extension SiteSettingsViewController {
         tableView.deselectRow(at: indexPath, animated: true)
     }
 
-    func trackSettingsChange(fieldName: String, properties: [AnyHashable: Any]? = nil) {
-        var props: [AnyHashable: Any] = ["page": "site_settings", "field_name": fieldName]
-        props.merge(properties ?? [:]) { (_, new) in new }
-
-        WPAnalytics.track(.settingsDidChange, properties: props)
+    func trackSettingsChange(fieldName: String, value: Any? = nil) {
+        WPAnalytics.trackSettingsChange(page: "site_settings",
+                                        fieldName: fieldName,
+                                        value: value)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -79,6 +79,8 @@ extension SiteSettingsViewController {
             self?.blog.settings?.gmtOffset = newValue.gmtOffset as NSNumber?
             self?.blog.settings?.timezoneString = newValue.timezoneString
             self?.saveSettings()
+            self?.trackSettingsChange(fieldName: "timezone",
+                                      properties: ["value": newValue.value as Any])
         }
         navigationController?.pushViewController(controller, animated: true)
     }
@@ -105,6 +107,7 @@ extension SiteSettingsViewController {
         pickerViewController.onChange           = { [weak self] (enabled: Bool, newValue: Int) in
             self?.blog.settings?.postsPerPage = newValue as NSNumber?
             self?.saveSettings()
+            self?.trackSettingsChange(fieldName: "posts_per_page", properties: ["value": newValue as Any])
         }
 
         navigationController?.pushViewController(pickerViewController, animated: true)
@@ -355,6 +358,8 @@ extension SiteSettingsViewController {
             if value != self.blog.settings?.name {
                 self.blog.settings?.name = value
                 self.saveSettings()
+
+                self.trackSettingsChange(fieldName: "site_title")
             }
         }
 
@@ -385,6 +390,8 @@ extension SiteSettingsViewController {
             if normalizedTagline != self.blog.settings?.tagline {
                 self.blog.settings?.tagline = normalizedTagline
                 self.saveSettings()
+
+                self.trackSettingsChange(fieldName: "tagline")
             }
         }
 
@@ -402,5 +409,12 @@ extension SiteSettingsViewController {
         }
 
         tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    func trackSettingsChange(fieldName: String, properties: [AnyHashable: Any]? = nil) {
+        var props: [AnyHashable: Any] = ["page": "site_settings", "field_name": fieldName]
+        props.merge(properties ?? [:]) { (_, new) in new }
+
+        WPAnalytics.track(.settingsDidChange, properties: props)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -438,6 +438,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     _ampSettingCell.onChange = ^(BOOL value){
         weakSelf.blog.settings.ampEnabled = value;
         [weakSelf saveSettings];
+        [WPAnalytics trackSettingsChange:@"site_settings" fieldName:@"amp_enabled" value:@(value)];
     };
 
     return _ampSettingCell;
@@ -751,6 +752,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
             if (weakSelf.blog.siteVisibility != newSiteVisibility) {
                 weakSelf.blog.siteVisibility = newSiteVisibility;
                 [weakSelf saveSettings];
+                [WPAnalytics trackSettingsChange:@"site_settings" fieldName:@"privacy" value:status];
             }
         }
     };
@@ -768,6 +770,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     languageViewController.onChange = ^(NSNumber *newLanguageID){
         weakSelf.blog.settings.languageID = newLanguageID;
         [weakSelf saveSettings];
+        [WPAnalytics trackSettingsChange:@"site_settings" fieldName:@"language" value:newLanguageID];
     };
     
     [self.navigationController pushViewController:languageViewController animated:YES];

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -832,7 +832,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
                                       SettingsSelectionValuesKey         : formats,
                                       SettingsSelectionCurrentValueKey   : currentDefaultPostFormat
                                       };
-    
+
     SettingsSelectionViewController *vc = [[SettingsSelectionViewController alloc] initWithDictionary:postFormatsDict];
     __weak __typeof__(self) weakSelf = self;
     vc.onItemSelected = ^(NSString *status) {
@@ -840,6 +840,9 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         if ([status isKindOfClass:[NSString class]]) {
             if (weakSelf.blog.settings.defaultPostFormat != status) {
                 weakSelf.blog.settings.defaultPostFormat = status;
+
+//                WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "add_tag")
+
                 if ([weakSelf savingWritingDefaultsIsAvailable]) {
                     [weakSelf saveSettings];
                 }
@@ -1149,10 +1152,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     self.blog.settings.defaultCategoryID = category.categoryID;
     self.defaultCategoryCell.detailTextLabel.text = category.categoryName;
     if ([self savingWritingDefaultsIsAvailable]) {
-        NSDictionary *properties = @{@"page": @"site_settings", @"field_name": @"default_category"};
-        [WPAnalytics trackEvent:WPAnalyticsEventSettingsDidChange
-                     properties:properties];
-
+        [WPAnalytics trackSettingsChange:@"site_settings"
+                               fieldName:@"default_category"];
 
         [self saveSettings];
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -1149,6 +1149,11 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     self.blog.settings.defaultCategoryID = category.categoryID;
     self.defaultCategoryCell.detailTextLabel.text = category.categoryName;
     if ([self savingWritingDefaultsIsAvailable]) {
+        NSDictionary *properties = @{@"page": @"site_settings", @"field_name": @"default_category"};
+        [WPAnalytics trackEvent:WPAnalyticsEventSettingsDidChange
+                     properties:properties];
+
+
         [self saveSettings];
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -841,9 +841,9 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
             if (weakSelf.blog.settings.defaultPostFormat != status) {
                 weakSelf.blog.settings.defaultPostFormat = status;
 
-//                WPAnalytics.trackSettingsChange(page: "site_tags", fieldName: "add_tag")
-
                 if ([weakSelf savingWritingDefaultsIsAvailable]) {
+                    [WPAnalytics trackSettingsChange:@"site_settings" fieldName:@"default_post_format"];
+
                     [weakSelf saveSettings];
                 }
             }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -187,6 +187,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func jetpackMonitorEnabledValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "monitor_enabled", value: newValue as Any)
             self.settings.jetpackMonitorEnabled = newValue
             self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
@@ -199,6 +200,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func sendNotificationsByEmailValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "send_notification_by_email", value: newValue as Any)
             self.settings.jetpackMonitorEmailNotifications = newValue
             self.service.updateJetpackMonitorSettingsForBlog(self.blog,
                                                              success: {},
@@ -210,6 +212,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func sendPushNotificationsValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "send_push_notifications", value: newValue as Any)
             self.settings.jetpackMonitorPushNotifications = newValue
             self.service.updateJetpackMonitorSettingsForBlog(self.blog,
                                                              success: {},
@@ -221,6 +224,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func blockMaliciousLoginAttemptsValueChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "block_malicious_logins", value: newValue as Any)
             self.settings.jetpackBlockMaliciousLoginAttempts = newValue
             self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
@@ -268,6 +272,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func ssoEnabledChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "wpcom_login_allowed", value: newValue as Any)
             self.settings.jetpackSSOEnabled = newValue
             self.reloadViewModel()
             self.service.updateJetpackSettingsForBlog(self.blog,
@@ -280,6 +285,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func matchAccountsUsingEmailChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "match_accounts_using_email", value: newValue as Any)
             self.settings.jetpackSSOMatchAccountsByEmail = newValue
             self.service.updateJetpackSettingsForBlog(self.blog,
                                                       success: {},
@@ -291,6 +297,7 @@ open class JetpackSettingsViewController: UITableViewController {
 
     fileprivate func requireTwoStepAuthenticationChanged() -> (_ newValue: Bool) -> Void {
         return { [unowned self] newValue in
+            WPAnalytics.trackSettingsChange("jetpack_settings", fieldName: "require_two_step_auth", value: newValue as Any)
             self.settings.jetpackSSORequireTwoStepAuthentication = newValue
             self.service.updateJetpackSettingsForBlog(self.blog,
                                                       success: {},

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -90,6 +90,8 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
         return { [unowned self] newValue in
             self.settings.jetpackServeImagesFromOurServers = newValue
             self.reloadViewModel()
+            WPAnalytics.trackSettingsChange("jetpack_speed_up_site", fieldName: "serve_images", value: newValue as Any)
+
             self.service.updateJetpackServeImagesFromOurServersModuleSettingForBlog(self.blog,
                                                                                     success: {},
                                                                                     failure: { [weak self] (_) in
@@ -102,6 +104,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
         return { [unowned self] newValue in
             self.settings.jetpackLazyLoadImages = newValue
             self.reloadViewModel()
+            WPAnalytics.trackSettingsChange("jetpack_speed_up_site", fieldName: "lazy_load_images", value: newValue as Any)
             self.service.updateJetpackLazyImagesModuleSettingForBlog(self.blog,
                                                                      success: {},
                                                                      failure: { [weak self] (_) in

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -234,6 +234,8 @@ private class AccountSettingsController: SettingsController {
             let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber?,
                                                                     successHandler: { (dotComID: NSNumber?) in
                                                                         if let dotComID = dotComID?.intValue {
+                                                                            WPAnalytics.track(.settingsDidChange, properties: ["page": self.trackingKey, "field_name": "primary_site"])
+
                                                                             let change = AccountSettingsChange.primarySite(dotComID)
                                                                             service.saveChange(change)
                                                                         }

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -234,7 +234,7 @@ private class AccountSettingsController: SettingsController {
             let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber?,
                                                                     successHandler: { (dotComID: NSNumber?) in
                                                                         if let dotComID = dotComID?.intValue {
-                                                                            WPAnalytics.trackSettingsChange(page: self.trackingKey, fieldName: "primary_site")
+                                                                            WPAnalytics.trackSettingsChange(self.trackingKey, fieldName: "primary_site")
 
                                                                             let change = AccountSettingsChange.primarySite(dotComID)
                                                                             service.saveChange(change)

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -19,6 +19,10 @@ func AccountSettingsViewController(accountSettingsService: AccountSettingsServic
 }
 
 private class AccountSettingsController: SettingsController {
+    var trackingKey: String {
+        return "account_settings"
+    }
+
     let title = NSLocalizedString("Account Settings", comment: "Account Settings Title")
 
     var immuTableRows: [ImmuTableRow.Type] {

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -95,14 +95,16 @@ private class AccountSettingsController: SettingsController {
         let editableUsername = EditableTextRow(
             title: NSLocalizedString("Username", comment: "Account Settings Username label"),
             value: settings?.username ?? "",
-            action: presenter.push(changeUsername(with: settings, service: service))
+            action: presenter.push(changeUsername(with: settings, service: service)),
+            fieldName: "username"
         )
 
         let email = EditableTextRow(
             title: NSLocalizedString("Email", comment: "Account Settings Email label"),
             value: settings?.emailForDisplay ?? "",
             accessoryImage: emailAccessoryImage(),
-            action: presenter.push(editEmailAddress(settings, service: service))
+            action: presenter.push(editEmailAddress(settings, service: service)),
+            fieldName: "email"
         )
 
         var primarySiteName = settings.flatMap { service.primarySiteNameForSettings($0) } ?? ""
@@ -116,19 +118,22 @@ private class AccountSettingsController: SettingsController {
         let primarySite = EditableTextRow(
             title: NSLocalizedString("Primary Site", comment: "Primary Web Site"),
             value: primarySiteName,
-            action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service)))
+            action: presenter.present(insideNavigationController(editPrimarySite(settings, service: service))),
+            fieldName: "primary_site"
         )
 
         let webAddress = EditableTextRow(
             title: NSLocalizedString("Web Address", comment: "Account Settings Web Address label"),
             value: settings?.webAddress ?? "",
-            action: presenter.push(editWebAddress(service))
+            action: presenter.push(editWebAddress(service)),
+            fieldName: "web_address"
         )
 
         let password = EditableTextRow(
             title: Constants.title,
             value: "",
-            action: presenter.push(changePassword(with: settings, service: service))
+            action: presenter.push(changePassword(with: settings, service: service)),
+            fieldName: "password"
         )
 
         let closeAccount = DestructiveButtonRow(

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -234,7 +234,7 @@ private class AccountSettingsController: SettingsController {
             let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: settings?.primarySiteID as NSNumber?,
                                                                     successHandler: { (dotComID: NSNumber?) in
                                                                         if let dotComID = dotComID?.intValue {
-                                                                            WPAnalytics.track(.settingsDidChange, properties: ["page": self.trackingKey, "field_name": "primary_site"])
+                                                                            WPAnalytics.trackSettingsChange(page: self.trackingKey, fieldName: "primary_site")
 
                                                                             let change = AccountSettingsChange.primarySite(dotComID)
                                                                             service.saveChange(change)

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
@@ -114,8 +114,11 @@ open class AppIconViewController: UITableViewController {
 
         UIApplication.shared.setAlternateIconName(iconName, completionHandler: { [weak self] error in
             if error == nil {
-                let event: WPAnalyticsStat = isOriginalIcon ? .appIconReset : .appIconChanged
-                WPAppAnalytics.track(event)
+                if isOriginalIcon {
+                    WPAppAnalytics.track(.appIconReset)
+                } else {
+                    WPAppAnalytics.track(.appIconChanged, withProperties: ["icon_name": iconName ?? "default"])
+                }
             }
 
             self?.tableView.reloadData()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -133,6 +133,8 @@ class AppSettingsViewController: UITableViewController {
     }
 
     fileprivate func clearMediaCache() {
+        WPAnalytics.track(.appSettingsClearMediaCacheTapped)
+
         setMediaCacheRowDescription(status: .clearingCache)
         MediaFileManager.clearAllMediaCacheFiles(onCompletion: { [weak self] in
             self?.updateMediaCacheSize()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -269,6 +269,8 @@ class AppSettingsViewController: UITableViewController {
 
     func openPrivacySettings() -> ImmuTableAction {
         return { [weak self] _ in
+            WPAnalytics.track(.privacySettingsOpened)
+
             let controller = PrivacySettingsViewController()
             self?.navigationController?.pushViewController(controller, animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -278,6 +278,8 @@ class AppSettingsViewController: UITableViewController {
 
     func openApplicationSettings() -> ImmuTableAction {
         return { [weak self] row in
+            WPAnalytics.track(.appSettingsOpenDeviceSettingsTapped)
+
             if let targetURL = URL(string: UIApplication.openSettingsURLString) {
                 UIApplication.shared.open(targetURL)
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -289,6 +289,8 @@ class AppSettingsViewController: UITableViewController {
 
     func clearSiriActivityDonations() -> ImmuTableAction {
         return { [tableView] _ in
+            WPAnalytics.track(.appSettingsClearSiriSuggestionsTapped)
+
             tableView?.deselectSelectedRowWithAnimation(true)
 
             if #available(iOS 12.0, *) {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -302,6 +302,8 @@ class AppSettingsViewController: UITableViewController {
 
     func clearSpotlightCache() -> ImmuTableAction {
         return { [weak self] row in
+            WPAnalytics.track(.appSettingsClearSpotlightIndexTapped)
+
             self?.tableView.deselectSelectedRowWithAnimation(true)
             SearchManager.shared.deleteAllSearchableItems()
             let notice = Notice(title: NSLocalizedString("Successfully cleared spotlight index", comment: "Notice displayed to the user after clearing the spotlight index in app settings."),

--- a/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/PrivacySettingsViewController.swift
@@ -160,6 +160,9 @@ class PrivacySettingsViewController: UITableViewController {
 
     func crashReportingChanged(_ enabled: Bool) {
         UserSettings.userHasOptedOutOfCrashLogging = !enabled
+
+        WPAnalytics.track(.privacySettingsReportCrashesToggled, properties: ["enabled": enabled])
+
         WordPressAppDelegate.crashLogging?.setNeedsDataRefresh()
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
@@ -44,6 +44,9 @@ private func makeHeaderView(account: WPAccount) -> MyProfileHeaderView {
 /// To avoid problems, it's marked private and should only be initialized using the
 /// `MyProfileViewController` factory functions.
 private class MyProfileController: SettingsController {
+    var trackingKey: String {
+        return "my_profile"
+    }
 
     // MARK: - Private Properties
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
@@ -114,24 +114,28 @@ private class MyProfileController: SettingsController {
         let firstNameRow = EditableTextRow(
             title: NSLocalizedString("First Name", comment: "My Profile first name label"),
             value: settings?.firstName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.firstName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.firstName, service: service)),
+            fieldName: "first_name")
 
         let lastNameRow = EditableTextRow(
             title: NSLocalizedString("Last Name", comment: "My Profile last name label"),
             value: settings?.lastName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.lastName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.lastName, service: service)),
+            fieldName: "last_name")
 
         let displayNameRow = EditableTextRow(
             title: NSLocalizedString("Display Name", comment: "My Profile display name label"),
             value: settings?.displayName ?? "",
-            action: presenter.push(editText(AccountSettingsChange.displayName, service: service)))
+            action: presenter.push(editText(AccountSettingsChange.displayName, service: service)),
+            fieldName: "display_name")
 
         let aboutMeRow = EditableTextRow(
             title: NSLocalizedString("About Me", comment: "My Profile 'About me' label"),
             value: settings?.aboutMe ?? "",
             action: presenter.push(editMultilineText(AccountSettingsChange.aboutMe,
                 hint: NSLocalizedString("Tell us a bit about you.", comment: "My Profile 'About me' hint text"),
-                service: service)))
+                service: service)),
+            fieldName: "about_me")
 
         return ImmuTable(sections: [
             ImmuTableSection(rows: [

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishSettingsViewController.swift
@@ -123,6 +123,9 @@ private struct DateAndTimeRow: ImmuTableRow {
 }
 
 @objc class PublishSettingsController: NSObject, SettingsController {
+    var trackingKey: String {
+        return "publish_settings"
+    }
 
     @objc class func viewController(post: AbstractPost) -> ImmuTableViewController {
         let controller = PublishSettingsController(post: post)

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -93,6 +93,6 @@ extension SettingsController {
             return
         }
 
-        WPAnalytics.track(.settingsDidChange, properties: ["page": trackingKey, "field_name": fieldName])
+        WPAnalytics.trackSettingsChange(page: trackingKey, fieldName: fieldName)
     }
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -57,6 +57,8 @@ extension SettingsController {
             let change = changeType(value)
             service.saveChange(change)
             DDLogDebug("\(title) changed: \(value)")
+
+            trackChangeIfNeeded(row)
         }
 
         return controller
@@ -78,8 +80,19 @@ extension SettingsController {
             let change = changeType(value)
             service.saveChange(change)
             DDLogDebug("\(title) changed: \(value)")
+
+            trackChangeIfNeeded(row)
         }
 
         return controller
+    }
+
+    private func trackChangeIfNeeded(_ row: EditableTextRow) {
+        // Don't track if the field name isn't specified
+        guard let fieldName = row.fieldName else {
+            return
+        }
+
+        WPAnalytics.track(.settingsDidChange, properties: ["page": trackingKey, "field_name": fieldName])
     }
 }

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -2,7 +2,9 @@ import UIKit
 import WordPressKit
 import CocoaLumberjack
 
-protocol SettingsController: ImmuTableController {}
+protocol SettingsController: ImmuTableController {
+    var trackingKey: String { get }
+}
 
 // MARK: - Actions
 extension SettingsController {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -93,6 +93,6 @@ extension SettingsController {
             return
         }
 
-        WPAnalytics.trackSettingsChange(page: trackingKey, fieldName: fieldName)
+        WPAnalytics.trackSettingsChange(trackingKey, fieldName: fieldName)
     }
 }


### PR DESCRIPTION
Project: #17503

⚠️ Depends on: https://github.com/wordpress-mobile/WordPress-iOS/pull/17539
View only this PRs [changes here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17545/files/b1803c087a1f29c4a8d24116579f02ad999eb58c..87a15d908ab723ccfda37652e5abb3224a41f8e7)


### Description
Adds tracking for **every** option in Site Settings and its encompassing settings

### To test:
This affects every item on Site Settings that did not already have tracks

1. Launch the app
2. Tap on the My Site tab
3. Tap on Site Settings
4. Go through each setting on the main view, and the sub views and verify you see for each of the settings changed:
    - `🔵 Tracked: settings_did_change <field_name: FIELD_NAME, page: PAGE_NAME>`

Note: Areas with existing tracks were not changed, and tracking was not added to those areas

### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
