### PR TITLE
Reader Post Details: fetch 2 top level comments

### DIFF
--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -103,9 +103,12 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 
 // Sync a list of comments sorted by hierarchy, restricted by the specified number of _top level_ comments.
 - (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
-                 numberTopLevelComments:(NSUInteger)number
+                 topLevelComments:(NSUInteger)number
                                 success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
                                 failure:(void (^)(NSError *error))failure;
+
+// Get the specified number of top level comments for the specified post.
+- (NSArray *)topLevelComments:(NSUInteger)number forPost:(ReaderPost *)post;
 
 // Counts and returns the number of full pages of hierarchcial comments synced for a post.
 // A partial set does not count toward the total number of pages. 

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -102,12 +102,16 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
                                 failure:(void (^)(NSError *error))failure;
 
 // Sync a list of comments sorted by hierarchy, restricted by the specified number of _top level_ comments.
+// This method is intended to get a small number of comments.
+// Therefore it is restricted to page 1 only.
 - (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
-                 topLevelComments:(NSUInteger)number
+                       topLevelComments:(NSUInteger)number
                                 success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
                                 failure:(void (^)(NSError *error))failure;
 
 // Get the specified number of top level comments for the specified post.
+// This method is intended to get a small number of comments.
+// Therefore it is restricted to page 1 only.
 - (NSArray *)topLevelComments:(NSUInteger)number forPost:(ReaderPost *)post;
 
 // Counts and returns the number of full pages of hierarchcial comments synced for a post.

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -517,26 +517,26 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 {
     [self syncHierarchicalCommentsForPost:post
                                      page:page
-                   numberTopLevelComments:WPTopLevelHierarchicalCommentsPerPage
+                         topLevelComments:WPTopLevelHierarchicalCommentsPerPage
                                   success:success
                                   failure:failure];
 }
 
 - (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
-                                 number:(NSUInteger)number
+                       topLevelComments:(NSUInteger)number
                                 success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
                                 failure:(void (^)(NSError *error))failure
 {
     [self syncHierarchicalCommentsForPost:post
                                      page:1
-                   numberTopLevelComments:number
+                         topLevelComments:number
                                   success:success
                                   failure:failure];
 }
 
 - (void)syncHierarchicalCommentsForPost:(ReaderPost *)post
                                    page:(NSUInteger)page
-                 numberTopLevelComments:(NSUInteger)number
+                       topLevelComments:(NSUInteger)number
                                 success:(void (^)(BOOL hasMore, NSNumber *totalComments))success
                                 failure:(void (^)(NSError *error))failure
 {
@@ -1193,6 +1193,13 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
         DDLogError(@"Error fetching top level comments for page %i : %@", page, error);
     }
     return fetchedObjects;
+}
+
+- (NSArray *)topLevelComments:(NSUInteger)number forPost:(ReaderPost *)post
+{
+    NSArray *comments = [self topLevelCommentsForPage:1 forPost:post];
+    NSInteger count = MIN(comments.count, number);
+    return [comments subarrayWithRange:NSMakeRange(0, count)];
 }
 
 - (Comment *)firstCommentForPage:(NSUInteger)page forPost:(ReaderPost *)post

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -197,11 +197,11 @@ class ReaderDetailCoordinator {
         commentService.syncHierarchicalComments(for: post,
                                                    topLevelComments: commentsDisplayed,
                                                    success: { [weak self] _, totalComments in
-                                                        self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
-                                                    }, failure: { [weak self] error in
-                                                        DDLogError("Failed fetching post detail comments: \(String(describing: error))")
-                                                        self?.view?.updateComments([], totalComments: 0)
-                                                    })
+            self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
+        }, failure: { [weak self] error in
+            DDLogError("Failed fetching post detail comments: \(String(describing: error))")
+            self?.view?.updateComments([], totalComments: 0)
+        })
     }
 
     func updateCommentsFor(post: ReaderPost, totalComments: Int) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -60,6 +60,10 @@ class ReaderDetailCoordinator {
     /// Post Service
     private let postService: PostService
 
+    /// Comment Service
+    private let commentService: CommentService
+    private let commentsDisplayed: UInt = 2
+
     /// Used for `RequestAuthenticator` creation and likes filtering logic.
     private let accountService: AccountService
 
@@ -106,6 +110,7 @@ class ReaderDetailCoordinator {
          readerPostService: ReaderPostService = ReaderPostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          topicService: ReaderTopicService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          postService: PostService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
+         commentService: CommentService = CommentService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          accountService: AccountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          sharingController: PostSharingController = PostSharingController(),
          readerLinkRouter: UniversalLinkRouter = UniversalLinkRouter(routes: UniversalLinkRouter.readerRoutes),
@@ -114,6 +119,7 @@ class ReaderDetailCoordinator {
         self.readerPostService = readerPostService
         self.topicService = topicService
         self.postService = postService
+        self.commentService = commentService
         self.accountService = accountService
         self.sharingController = sharingController
         self.readerLinkRouter = readerLinkRouter
@@ -188,8 +194,23 @@ class ReaderDetailCoordinator {
     /// Fetch Comments for the current post.
     ///
     func fetchComments(for post: ReaderPost) {
-        // TODO: fetch comments.
-        view?.updateComments()
+        commentService.syncHierarchicalComments(for: post,
+                                                   topLevelComments: commentsDisplayed,
+                                                   success: { [weak self] _, totalComments in
+                                                        self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
+                                                    }, failure: { [weak self] error in
+                                                        DDLogError("Failed fetching post detail comments: \(String(describing: error))")
+                                                        self?.view?.updateComments([], totalComments: 0)
+                                                    })
+    }
+
+    func updateCommentsFor(post: ReaderPost, totalComments: Int) {
+        guard let comments = commentService.topLevelComments(commentsDisplayed, for: post) as? [Comment] else {
+            view?.updateComments([], totalComments: 0)
+            return
+        }
+
+        view?.updateComments(comments, totalComments: totalComments)
     }
 
     /// Share the current post

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -195,13 +195,13 @@ class ReaderDetailCoordinator {
     ///
     func fetchComments(for post: ReaderPost) {
         commentService.syncHierarchicalComments(for: post,
-                                                   topLevelComments: commentsDisplayed,
-                                                   success: { [weak self] _, totalComments in
-            self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
-        }, failure: { [weak self] error in
-            DDLogError("Failed fetching post detail comments: \(String(describing: error))")
-            self?.view?.updateComments([], totalComments: 0)
-        })
+                                   topLevelComments: commentsDisplayed,
+                                            success: { [weak self] _, totalComments in
+                                                self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
+                                            }, failure: { [weak self] error in
+                                                DDLogError("Failed fetching post detail comments: \(String(describing: error))")
+                                                self?.view?.updateComments([], totalComments: 0)
+                                            })
     }
 
     func updateCommentsFor(post: ReaderPost, totalComments: Int) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -11,8 +11,6 @@ protocol ReaderDetailView: AnyObject {
     func scroll(to: String)
     func updateHeader()
 
-    func updateComments()
-
     /// Shows likes view containing avatars of users that liked the post.
     /// The number of avatars displayed is limited to `ReaderDetailView.maxAvatarDisplayed` plus the current user's avatar.
     /// Note that the current user's avatar is displayed through a different method.
@@ -26,6 +24,12 @@ protocol ReaderDetailView: AnyObject {
     /// Updates the likes view to append an additional avatar for the current user, indicating that the post is liked by current user.
     /// - Parameter avatarURLString: The URL string for the current user's avatar. Optional.
     func updateSelfLike(with avatarURLString: String?)
+
+    /// Updates comments table to display the post's comments.
+    /// - Parameters:
+    ///   - comments: Comments to be displayed.
+    ///   - totalComments: The total number of comments for this post.
+    func updateComments(_ comments: [Comment], totalComments: Int)
 }
 
 class ReaderDetailViewController: UIViewController, ReaderDetailView {
@@ -385,7 +389,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         likesSummary.addSelfAvatar(with: someURLString, animated: shouldAnimate)
     }
 
-    func updateComments() {
+    func updateComments(_ comments: [Comment], totalComments: Int) {
+        // TODO: if there are no comments, hide the commentsTableView.
+        commentsTableViewDelegate?.comments = comments
+        commentsTableViewDelegate?.totalComments = totalComments
         commentsTableView.reloadData()
         commentsTableView.invalidateIntrinsicContentSize()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -2,12 +2,16 @@
 ///
 class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UITableViewDelegate {
 
+    var comments: [Comment] = []
+    var totalComments = 0
+
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        // Add one for the button row.
+        return comments.count + 1
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {

--- a/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderDetailCoordinatorTests.swift
@@ -335,7 +335,7 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
 
     func updateSelfLike(with avatarURLString: String?) { }
 
-    func updateComments() { }
+    func updateComments(_ comments: [Comment], totalComments: Int) { }
 
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost]) { }
 


### PR DESCRIPTION
Ref: #17511 

This fetches the post's comments and provides them to the comment table delegate.
- `syncHierarchicalComments` fetches the comments and updates Core Data.
- `topLevelComments` gets the cached comments.
- `updateComments` passes the comments and total comment count to `ReaderDetailCommentsTableViewDelegate`.

The comments are not displayed yet, but the number of rows in the empty table should correspond to the number of comments, plus one for the button row. (i.e. there will be a minimum of 1 row, and a maximum of 3)

To test:
- Enable the `postDetailsComments` feature.
- Go to Reader and select a post without comments.
  - Verify an empty table is shown with one row (0 comment rows + button row).
- Select a post with more than 2 top level comments.
  - Verify an empty table is shown with three rows (2 comment rows + button row).

## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
