### PR TITLE
Post Details Comments: add view all comments button to comments table

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -43,7 +43,7 @@
                                             <constraint firstAttribute="height" placeholder="YES" id="C8J-Hu-daf"/>
                                         </constraints>
                                     </view>
-                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6yS-ZE-nbR" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
+                                    <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="6yS-ZE-nbR" customClass="IntrinsicTableView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="16" y="238.5" width="414" height="0.0"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -393,6 +393,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // TODO: if there are no comments, hide the commentsTableView.
         commentsTableViewDelegate?.comments = comments
         commentsTableViewDelegate?.totalComments = totalComments
+        commentsTableViewDelegate?.buttonDelegate = self
         commentsTableView.reloadData()
         commentsTableView.invalidateIntrinsicContentSize()
     }
@@ -988,3 +989,14 @@ extension ReaderDetailViewController {
 // MARK: - DefinesVariableStatusBarStyle
 // Allows this VC to control the statusbar style dynamically
 extension ReaderDetailViewController: DefinesVariableStatusBarStyle {}
+
+// MARK: - BorderedButtonTableViewCellDelegate
+// For the `Show All Comments` button.
+extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
+    func buttonTapped() {
+        guard let post = post else {
+            return
+        }
+        ReaderCommentAction().execute(post: post, origin: self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -991,7 +991,7 @@ extension ReaderDetailViewController {
 extension ReaderDetailViewController: DefinesVariableStatusBarStyle {}
 
 // MARK: - BorderedButtonTableViewCellDelegate
-// For the `Show All Comments` button.
+// For the `View All Comments` button.
 extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
     func buttonTapped() {
         guard let post = post else {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -2,20 +2,50 @@
 ///
 class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UITableViewDelegate {
 
-    var comments: [Comment] = []
+    // MARK: - Public Properties
+
+    var comments: [Comment] = [] {
+        didSet {
+            // Add one for the button row.
+            totalRows = comments.count + 1
+        }
+    }
+
     var totalComments = 0
+    weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
+
+    // MARK: - Private Properties
+
+    private var totalRows = 0
+
+    // MARK: - Table Methods
 
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // Add one for the button row.
-        return comments.count + 1
+        return totalRows
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        if indexPath.row == (totalRows - 1) {
+            return showCommentsButtonCell()
+        }
+
         return UITableViewCell()
+    }
+
+}
+
+private extension ReaderDetailCommentsTableViewDelegate {
+
+    func showCommentsButtonCell() -> BorderedButtonTableViewCell {
+        let title = NSLocalizedString("View All Comments", comment: "Title for button on the post details page to show all comments when tapped.")
+        let cell = BorderedButtonTableViewCell()
+        cell.configure(buttonTitle: title)
+        cell.delegate = buttonDelegate
+        return cell
     }
 
 }


### PR DESCRIPTION
Ref: #17511 
Depends on: #17546

This displays a `View All Comments` button in the last row of the Comments table. Tapping it will display the threaded comments view.

Also, the comments table no longer shows separators or row selection.

Notes: 
- The design has the button border and label different colors. I'll add this functionality in a follow-up PR.
- There are still empty rows above the button where the Comments will eventually be displayed.

To test:
- Enable the `postDetailsComments` feature.
- Go to Reader > post > details.
- Verify the `View All Comments` button is displayed.
- Verify tapping it displays the threaded comments view. 

<kbd><img width="471" alt="view_all" src="https://user-images.githubusercontent.com/1816888/143158972-f8e23094-7273-405f-a6c0-e0524cc11b4f.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
