### PR TITLE
Add tracking to the Pages list 

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -226,6 +226,8 @@ import Foundation
 
     // Post List
     case postListShareAction
+    case postListSetAsPostsPageAction
+    case postListSetHomePageAction
 
     // Reader: Filter Sheet
     case readerFilterSheetDisplayed
@@ -644,6 +646,10 @@ import Foundation
             return "site_switcher_toggle_blog_visible"
         case .postListShareAction:
             return "post_list_button_pressed"
+        case .postListSetAsPostsPageAction:
+            return "post_list_button_pressed"
+        case .postListSetHomePageAction:
+            return "post_list_button_pressed"
 
         // Reader: Filter Sheet
         case .readerFilterSheetDisplayed:
@@ -704,6 +710,10 @@ import Foundation
             return ["via": "tenor"]
         case .postListShareAction:
             return ["button": "share"]
+        case .postListSetAsPostsPageAction:
+            return ["button": "set_posts_page"]
+        case .postListSetHomePageAction:
+            return ["button": "set_homepage"]
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -908,6 +908,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         controller.addActionWithTitle(setPostsPageButtonTitle, style: .default, handler: { [weak self] _ in
             if let pageID = page.postID?.intValue {
                 self?.beginRefreshingManually()
+                WPAnalytics.track(.postListSetAsPostsPageAction)
                 self?.homepageSettingsService?.setHomepageType(.page,
                                                                withPostsPageID: pageID, success: {
                                                                 self?.refreshAndReload()

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -875,6 +875,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         controller.addActionWithTitle(setHomepageButtonTitle, style: .default, handler: { [weak self] _ in
             if let pageID = page.postID?.intValue {
                 self?.beginRefreshingManually()
+                WPAnalytics.track(.postListSetHomePageAction)
                 self?.homepageSettingsService?.setHomepageType(.page,
                                                                homePageID: pageID, success: {
                                                                 self?.refreshAndReload()


### PR DESCRIPTION
Project: #17503

### Description
Adds tracking when you tap the 'Set as Posts Page' and 'Set as Homepage' items

### To test:
1. Launch the app
2. Tap My Site
3. Tap Pages
4. Tap the ellipsis button ⋯
5. Tap 'Set as Posts Page'
6. Verify you see: `🔵 Tracked: post_list_button_pressed <button: set_posts_page>`
7. Tap the ellipsis button ⋯ again
8. Tap the 'Set as homepage' 
9. Verify you see `🔵 Tracked: post_list_button_pressed <button: set_homepage>`

### Regression Notes
1. Potential unintended areas of impact
None, adding tracking.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
