### PR TITLE
Reader Comments: Show ellipsis button when comment can be moderated

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -70,6 +70,10 @@ public class Comment: NSManagedObject {
     /// Convenience method to check if the current user can actually moderate.
     /// `canModerate` is only applicable when the site is dotcom-related (hosted or atomic). For self-hosted sites, default to true.
     func allowsModeration() -> Bool {
+        if let _ = post as? ReaderPost {
+            return canModerate
+        }
+
         guard let blog = blog,
               (blog.isHostedAtWPcom || blog.isAtomic()) else {
                   return true

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -72,6 +72,7 @@ import UIKit
 
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
+        cell.accessoryButtonType = comment.allowsModeration() ? .ellipsis : .share
         cell.hidesModerationBar = true
         cell.configure(with: comment) { _ in
             tableView.performBatchUpdates({})


### PR DESCRIPTION
Refs #17476
Depends on #17551

As titled, this shows the ellipsis icon instead of the share icon on the accessory button, when the user can moderate the site. Some notes:

- This configuration is done outside the content cell, so site comments should not be affected.
- Also, the `allowsModeration` method on the `Comment` is updated to account for comments fetched from the Reader endpoint.
- Note that tapping on the ellipsis does nothing for now. It will be implemented later.

## To Test

- Enable the `newCommentThread` feature flag.
- Make sure that you're logged in as a user that can moderate the site.
- Go to My Site > Comments, select any reply comments, and tap on the comment header.
- 🔍 Verify that the ellipsis accessory button is shown.
- Go to Reader > Discover, and open any comment thread.
- 🔍 Verify that the share button is shown.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
