### PR TITLE
Fix a crashing issue in MediaService.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,9 @@
 18.8
 -----
-* [***] Fixes a crasher that was sometimes triggered when seeing the details for like notifications.
-
 * [*] Editor: Show a compact notice when switching between HTML or Visual mode. [https://github.com/wordpress-mobile/WordPress-iOS/pull/17521]
 * [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]
+* [***] Fixed crash that was sometimes triggered when deleting media. [#17559]
+* [***] Fixes a crasher that was sometimes triggered when seeing the details for like notifications. [#17529]
 
 18.7
 -----

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -453,6 +453,14 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     void (^successBlock)(void) = ^() {
         [self.managedObjectContext performBlock:^{
             Media *mediaInContext = (Media *)[self.managedObjectContext existingObjectWithID:mediaObjectID error:nil];
+
+            if (mediaInContext == nil) {
+                // Considering the intent of calling this method is to delete the media object,
+                // when it doesn't exist, we can simply signal success, since the intent is fulfilled.
+                success();
+                return;
+            }
+
             [self.managedObjectContext deleteObject:mediaInContext];
             [[ContextManager sharedInstance] saveContext:self.managedObjectContext
                                      withCompletionBlock:^{

--- a/WordPress/WordPressTest/MediaServiceTests.swift
+++ b/WordPress/WordPressTest/MediaServiceTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 @testable import WordPress
+import XCTest
 
 class MediaServiceTests: XCTestCase {
     private var contextManager: TestContextManager!
@@ -110,5 +111,30 @@ class MediaServiceTests: XCTestCase {
         let failedMediaForUpload = mediaService.failedMediaForUpload(in: post, automatedRetry: true)
 
         XCTAssertEqual(failedMediaForUpload.count, 0)
+    }
+
+    // MARK: - Deleting Media
+
+    func testDeletingLocalMediaThatDoesntExistInCoreData() {
+        let firstDeleteSucceeds = expectation(description: "The delete call succeeds even if the media object isn't saved.")
+        let secondDeleteSucceeds = expectation(description: "The delete call succeeds even if the media object isn't saved.")
+
+        let media = mediaBuilder
+            .with(remoteStatus: .failed)
+            .with(autoUploadFailureCount: Media.maxAutoUploadFailureCount).build()
+
+        mediaService.delete(media) {
+            firstDeleteSucceeds.fulfill()
+        } failure: { error in
+            XCTFail("Media deletion failed with error: \(error)")
+        }
+
+        mediaService.delete(media) {
+            secondDeleteSucceeds.fulfill()
+        } failure: { error in
+            XCTFail("Media deletion failed with error: \(error)")
+        }
+
+        waitForExpectations(timeout: 0.1)
     }
 }


### PR DESCRIPTION
Fixes https://sentry.io/share/issue/d23f080817634d9ba07292bf34369cc2/

Our `MediaService` class can crash when deleting a media object.

Also fixes a previous release note entry I added here: https://github.com/wordpress-mobile/WordPress-iOS/issues/17529

## To test:

1. Check out commit `a3b0d933512c58389e364660dc096a0fbc0e6817`, which only adds breaking unit tests to the code from `develop`.
2. Run the unit tests and verify that `testDeletingLocalMediaThatDoesntExistInCoreData` crashes.
3. Check out the latest from this branch, which aside from having the same tests offers a fix for the crashing issue.
4. Run the unit tests and verify that none fails.

## Regression Notes

1. Potential unintended areas of impact

Deleting media could be affected, although this PR is meant to fix existing crashing issues.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I added a unit test that will fail if the crashing issue is reintroduced.

3. What automated tests I added (or what prevented me from doing so)

I added `testDeletingLocalMediaThatDoesntExistInCoreData`, which takes care of controlling the crashing issue isn't reintroduced.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
