### PR TITLE
Onboarding Improvements: Fix UI tests

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -53,6 +53,7 @@ class LoginEpilogueTableViewController: UITableViewController {
         view.backgroundColor = .basicBackground
         tableView.backgroundColor = .basicBackground
         tableView.rowHeight = UITableView.automaticDimension
+        tableView.accessibilityIdentifier = "login-epilogue-table"
 
         //  Remove separator line on last row
         tableView.tableFooterView = UIView()

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -366,7 +366,13 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             // If the quick start prompt has already been dismissed,
             // then show the My Site screen for the specified blog
             guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
-                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+
+                if self.windowManager.isShowingFullscreenSignIn {
+                    self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                } else {
+                    navigationController.dismiss(animated: true)
+                }
+
                 return
             }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -3,40 +3,39 @@ import XCTest
 private struct ElementStringIDs {
     static let usernameField = "login-epilogue-username-label"
     static let siteUrlField = "siteUrl"
-    static let connectSiteButton = "connectSite"
-    static let continueButton = "Done"
+    static let loginEpilogueTable = "login-epilogue-table"
 }
 
 public class LoginEpilogueScreen: BaseScreen {
-    let continueButton: XCUIElement
-    let connectSiteButton: XCUIElement
     let usernameField: XCUIElement
     let siteUrlField: XCUIElement
+    let loginEpilogueTable: XCUIElement
 
     init() {
         let app = XCUIApplication()
         usernameField = app.staticTexts[ElementStringIDs.usernameField]
         siteUrlField = app.staticTexts[ElementStringIDs.siteUrlField]
-        connectSiteButton = app.cells[ElementStringIDs.connectSiteButton]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
+        loginEpilogueTable = app.tables[ElementStringIDs.loginEpilogueTable]
 
-        super.init(element: continueButton)
+        super.init(element: loginEpilogueTable)
     }
 
     public func continueWithSelectedSite() throws -> MySiteScreen {
-        continueButton.tap()
+        let firstSite = loginEpilogueTable.cells.element(boundBy: 2)
+        firstSite.tap()
+
+        try dismissQuickStartPromptIfNeeded()
         return try MySiteScreen()
     }
 
     // Used by "Self-Hosted after WordPress.com login" test. When a site is added from the Sites List, the Sites List modal (MySitesScreen)
     // remains active after the epilogue "done" button is tapped.
     public func continueWithSelfHostedSiteAddedFromSitesList() throws -> MySitesScreen {
-        continueButton.tap()
-        return try MySitesScreen()
-    }
+        let firstSite = loginEpilogueTable.cells.element(boundBy: 2)
+        firstSite.tap()
 
-    func connectSite() {
-        connectSiteButton.tap()
+        try dismissQuickStartPromptIfNeeded()
+        return try MySitesScreen()
     }
 
     public func verifyEpilogueDisplays(username: String? = nil, siteUrl: String) -> LoginEpilogueScreen {
@@ -60,5 +59,15 @@ public class LoginEpilogueScreen: BaseScreen {
         }
 
         return displayUrl
+    }
+
+    private func dismissQuickStartPromptIfNeeded() throws {
+        try XCTContext.runActivity(named: "Dismiss quick start prompt if needed.") { (activity) in
+            if QuickStartPromptScreen.isLoaded() {
+                Logger.log(message: "Dismising quick start prompt...", event: .i)
+                _ = try QuickStartPromptScreen().selectNoThanks()
+                return
+            }
+        }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
@@ -1,0 +1,25 @@
+import ScreenObject
+import XCTest
+
+public class QuickStartPromptScreen: ScreenObject {
+
+    private let noThanksButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["No thanks"]
+    }
+
+    var noThanksButton: XCUIElement { noThanksButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [noThanksButtonGetter], app: app)
+    }
+
+    public func selectNoThanks() throws -> MySiteScreen {
+        noThanksButton.tap()
+
+        return try MySiteScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        (try? QuickStartPromptScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2698,6 +2698,7 @@
 		FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */; };
 		FA4F661425946B8500EAA9F5 /* JetpackRestoreHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */; };
 		FA5C740F1C599BA7000B528C /* TableViewHeaderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */; };
+		FA612DDF274E9F730002B03A /* QuickStartPromptScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA612DDE274E9F730002B03A /* QuickStartPromptScreen.swift */; };
 		FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */; };
 		FA6FAB3525EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */; };
 		FA6FAB4725EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */; };
@@ -7541,6 +7542,7 @@
 		FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreHeaderView.swift; sourceTree = "<group>"; };
 		FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackRestoreHeaderView.xib; sourceTree = "<group>"; };
 		FA5C740E1C599BA7000B528C /* TableViewHeaderDetailView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableViewHeaderDetailView.swift; sourceTree = "<group>"; };
+		FA612DDE274E9F730002B03A /* QuickStartPromptScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartPromptScreen.swift; sourceTree = "<group>"; };
 		FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderRelatedPostsSectionHeaderView.swift; sourceTree = "<group>"; };
 		FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsSectionHeaderView.xib; sourceTree = "<group>"; };
@@ -13175,6 +13177,7 @@
 				CCE911BB221D8497007E1D4E /* LoginSiteAddressScreen.swift */,
 				CCE911BD221D85E4007E1D4E /* LoginUsernamePasswordScreen.swift */,
 				BE6DD32B1FD6782A00E55192 /* LoginEpilogueScreen.swift */,
+				FA612DDE274E9F730002B03A /* QuickStartPromptScreen.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -18548,6 +18551,7 @@
 				3FE39A3E26F8383E006E2B3A /* MediaScreen.swift in Sources */,
 				3F2F855F26FAF235000FCDA5 /* MeTabScreen.swift in Sources */,
 				3FE39A4226F838A0006E2B3A /* ActionSheetComponent.swift in Sources */,
+				FA612DDF274E9F730002B03A /* QuickStartPromptScreen.swift in Sources */,
 				3F2F854526FAEB86000FCDA5 /* MediaPickerAlbumScreen.swift in Sources */,
 				3F2F855526FAF227000FCDA5 /* TagsComponent.swift in Sources */,
 				3F2F855426FAF227000FCDA5 /* AztecEditorScreen.swift in Sources */,


### PR DESCRIPTION
Fixes #17390 

## Description

This PR fixes the broken UI tests in the Login flow. 
- Added a new QuickStart prompt Screen Object
- Added a method to dismiss the QuickStart prompt if needed

## How to test

### Local
1. Run `rake mocks`
2. Test the WordPressUITests target
3. ✅ Tests should succeed

### CI
1. ✅ Buildkite UI tests should be green

## Regression Notes
1. Potential unintended areas of impact
UI tests

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran the tests locally and confirmed they succeeded

3. What automated tests I added (or what prevented me from doing so)
UI tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
