### PR TITLE
Unified About: Add Automattic Family navigation

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 typealias AboutScreenSection = [AboutItem]
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -50,6 +50,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
             [
                 AboutItem(title: TextContent.automatticFamily, hidesSeparator: true, action: { [weak self] context in
                     self?.tracker.buttonPressed(.automatticFamily)
+                    self?.webViewPresenter.present(for: Links.automattic, context: context)
                 }),
                 AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
             ],
@@ -91,6 +92,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
     private enum Links {
         static let twitter    = URL(string: "https://twitter.com/WordPressiOS")!
         static let workWithUs = URL(string: "https://automattic.com/work-with-us")!
+        static let automattic = URL(string: "https://automattic.com")!
     }
 }
 


### PR DESCRIPTION
Implements #17424. This PR adds navigation for the Automattic Family row in the About screen. For now, it just navigates to automattic.com.

**To test**

* Build and run and go to the About screen
* Tap Automattic Family and check you're shown automattic.com in a webview

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
