### PR TITLE
Unified About: Add Blog action

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenConfiguration.swift
@@ -66,7 +66,7 @@ struct AboutItem {
     /// and the source view that triggered the action.
     let action: AboutItemAction?
 
-    init(title: String, subtitle: String? = nil, cellStyle: AboutItemCellStyle = .default, accessoryType: UITableViewCell.AccessoryType = .disclosureIndicator, hidesSeparator: Bool = false, action: AboutItemAction? = nil) {
+    init(title: String, subtitle: String? = nil, cellStyle: AboutItemCellStyle = .default, accessoryType: UITableViewCell.AccessoryType = .none, hidesSeparator: Bool = false, action: AboutItemAction? = nil) {
         self.title = title
         self.subtitle = subtitle
         self.cellStyle = cellStyle

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
@@ -16,6 +16,7 @@ class AboutScreenTracker {
             case rateUs = "rate_us"
             case share
             case twitter
+            case blog
             case legal
             case automatticFamily = "automattic_family"
             case workWithUs = "work_with_us"

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -26,40 +26,40 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
     lazy var sections: [[AboutItem]] = {
         [
             [
-                AboutItem(title: TextContent.rateUs, accessoryType: .none, action: { [weak self] context in
+                AboutItem(title: TextContent.rateUs, action: { [weak self] context in
                     WPAnalytics.track(.appReviewsRatedApp)
                     self?.tracker.buttonPressed(.rateUs)
                     AppRatingUtility.shared.ratedCurrentVersion()
                     UIApplication.shared.open(AppRatingUtility.shared.appReviewUrl)
                 }),
-                AboutItem(title: TextContent.share, accessoryType: .none, action: { [weak self] context in
+                AboutItem(title: TextContent.share, action: { [weak self] context in
                     self?.tracker.buttonPressed(.share)
                     self?.sharePresenter.present(for: .wordpress, in: context.viewController, source: .about, sourceView: context.sourceView)
                 }),
-                AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, accessoryType: .none, action: { [weak self] context in
+                AboutItem(title: TextContent.twitter, subtitle: "@WordPressiOS", cellStyle: .value1, action: { [weak self] context in
                     self?.tracker.buttonPressed(.twitter)
                     self?.webViewPresenter.present(for: Links.twitter, context: context)
                 }),
-                AboutItem(title: TextContent.blog, subtitle: "blog.wordpress.com", cellStyle: .value1, accessoryType: .none, action: { [weak self] context in
+                AboutItem(title: TextContent.blog, subtitle: "blog.wordpress.com", cellStyle: .value1, action: { [weak self] context in
                     self?.tracker.buttonPressed(.blog)
                     self?.webViewPresenter.present(for: Links.blog, context: context)
                 })
             ],
             [
-                AboutItem(title: TextContent.legalAndMore, action: { [weak self] context in
+                AboutItem(title: TextContent.legalAndMore, accessoryType: .disclosureIndicator, action: { [weak self] context in
                     self?.tracker.buttonPressed(.legal)
                     context.showSubmenu(title: TextContent.legalAndMore, configuration: LegalAndMoreSubmenuConfiguration())
                 }),
             ],
             [
-                AboutItem(title: TextContent.automatticFamily, hidesSeparator: true, action: { [weak self] context in
+                AboutItem(title: TextContent.automatticFamily, accessoryType: .disclosureIndicator, hidesSeparator: true, action: { [weak self] context in
                     self?.tracker.buttonPressed(.automatticFamily)
                     self?.webViewPresenter.present(for: Links.automattic, context: context)
                 }),
                 AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
             ],
             [
-                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, action: { [weak self] context in
+                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
                     self?.tracker.buttonPressed(.workWithUs)
                     self?.webViewPresenter.present(for: Links.workWithUs, context: context)
                 }),
@@ -118,7 +118,7 @@ class LegalAndMoreSubmenuConfiguration: AboutScreenConfiguration {
     }()
 
     private func linkItem(title: String, link: URL, button: AboutScreenTracker.Event.Button) -> AboutItem {
-        AboutItem(title: title, accessoryType: .none, action: { [weak self] context in
+        AboutItem(title: title, action: { [weak self] context in
             self?.buttonPressed(link: link, context: context, button: button)
         })
     }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/WordPressAboutScreenConfiguration.swift
@@ -40,6 +40,10 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
                     self?.tracker.buttonPressed(.twitter)
                     self?.webViewPresenter.present(for: Links.twitter, context: context)
                 }),
+                AboutItem(title: TextContent.blog, subtitle: "blog.wordpress.com", cellStyle: .value1, accessoryType: .none, action: { [weak self] context in
+                    self?.tracker.buttonPressed(.blog)
+                    self?.webViewPresenter.present(for: Links.blog, context: context)
+                })
             ],
             [
                 AboutItem(title: TextContent.legalAndMore, action: { [weak self] context in
@@ -83,6 +87,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
         static let rateUs             = NSLocalizedString("Rate Us", comment: "Title for button allowing users to rate the app in the App Store")
         static let share              = NSLocalizedString("Share with Friends", comment: "Title for button allowing users to share information about the app with friends, such as via Messages")
         static let twitter            = NSLocalizedString("Twitter", comment: "Title of button that displays the app's Twitter profile")
+        static let blog               = NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress product blog")
         static let legalAndMore       = NSLocalizedString("Legal and More", comment: "Title of button which shows a list of legal documentation such as privacy policy and acknowledgements")
         static let automatticFamily   = NSLocalizedString("Automattic Family", comment: "Title of button that displays information about the other apps available from Automattic")
         static let workWithUs         = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
@@ -91,6 +96,7 @@ class WordPressAboutScreenConfiguration: AboutScreenConfiguration {
 
     private enum Links {
         static let twitter    = URL(string: "https://twitter.com/WordPressiOS")!
+        static let blog       = URL(string: "https://blog.wordpress.com")!
         static let workWithUs = URL(string: "https://automattic.com/work-with-us")!
         static let automattic = URL(string: "https://automattic.com")!
     }


### PR DESCRIPTION
This PR adds a blog row to the unified About screen. It also flips around the default for the `accessoryType` parameter so that `.none` is the default, as this is used by the majority of cells.

<img src="https://user-images.githubusercontent.com/4780/143564329-dc03a92a-e682-43ae-a537-487469a398f3.png" width=350>

**To test**

* Build and run
* Navigate to About
* Check that the blog row appears, and tapping it shows you the WordPress.com blog in a web view
* Also check that all the rows in the About screen have the accessory view you'd expect to see (see screenshot above)

## Regression Notes

1. Potential unintended areas of impact

Accidentally switching accessory types to the wrong one.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I checked the end result against the Figma design for this screen

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
