### PR TITLE
Unified About: Ensures rotation is locked for about screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -1,7 +1,12 @@
 import UIKit
 
+class UnifiedAboutNavigationController: UINavigationController, OrientationLimited {
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+}
 
-class UnifiedAboutViewController: UIViewController, OrientationLimited {
+class UnifiedAboutViewController: UIViewController {
     private let appInfo: AboutScreenAppInfo?
     private let fonts: AboutScreenFonts?
 
@@ -87,10 +92,6 @@ class UnifiedAboutViewController: UIViewController, OrientationLimited {
 
         return footerView
     }()
-
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        return .portrait
-    }
 
     private var shouldShowNavigationBar: Bool {
         isSubmenu

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 
-class UnifiedAboutNavigationController: UINavigationController, OrientationLimited {
+// Required to prevent rotation in the About screen
+private class UnifiedAboutNavigationController: UINavigationController, OrientationLimited {
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
     }
@@ -98,6 +99,17 @@ class UnifiedAboutViewController: UIViewController {
     }
 
     // MARK: - View lifecycle
+
+    /// This is the preferred way to create an About screen to present, as a navigation controller is required.
+    static func controller(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil, isSubmenu: Bool = false) -> UIViewController {
+        let viewController = UnifiedAboutViewController(appInfo: appInfo,
+                                                        configuration: configuration,
+                                                        fonts: fonts,
+                                                        isSubmenu: isSubmenu)
+        let navigationController = UnifiedAboutNavigationController(rootViewController: viewController)
+        navigationController.modalPresentationStyle = .formSheet
+        return navigationController
+    }
 
     init(appInfo: AboutScreenAppInfo? = nil, configuration: AboutScreenConfiguration, fonts: AboutScreenFonts? = nil, isSubmenu: Bool = false) {
         self.appInfo = appInfo

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -257,7 +257,7 @@ class MeViewController: UITableViewController {
             let controller = UnifiedAboutViewController(appInfo: WordPressAboutScreenConfiguration.appInfo,
                                                         configuration: configuration,
                                                         fonts: WordPressAboutScreenConfiguration.fonts)
-            let navigationController = UINavigationController(rootViewController: controller)
+            let navigationController = UnifiedAboutNavigationController(rootViewController: controller)
             navigationController.modalPresentationStyle = .formSheet
             self.present(navigationController, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -254,12 +254,10 @@ class MeViewController: UITableViewController {
     private func pushAbout() -> ImmuTableAction {
         return { [unowned self] _ in
             let configuration = WordPressAboutScreenConfiguration(sharePresenter: self.sharePresenter)
-            let controller = UnifiedAboutViewController(appInfo: WordPressAboutScreenConfiguration.appInfo,
-                                                        configuration: configuration,
-                                                        fonts: WordPressAboutScreenConfiguration.fonts)
-            let navigationController = UnifiedAboutNavigationController(rootViewController: controller)
-            navigationController.modalPresentationStyle = .formSheet
-            self.present(navigationController, animated: true) {
+            let controller = UnifiedAboutViewController.controller(appInfo: WordPressAboutScreenConfiguration.appInfo,
+                                                                   configuration: configuration,
+                                                                   fonts: WordPressAboutScreenConfiguration.fonts)
+            self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)
             }
         }


### PR DESCRIPTION
This PR fixes an issue where the rotation lock we added to the new About screen stopped working once we wrapped the screen in a navigation controller. This PR adds the locking functionality to the navigation controller, and ensures that the screen is always presented with the correct type of navigation controller.

**To test**

* Build and run
* Navigate to the about screen on an iPhone
* Try rotating the device and ensure the screen doesn't rotate with your device

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
