### PR TITLE
Unified About: Enable feature flag for all

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 18.8
 -----
+* [*] Added a new About screen, with links to rate the app, share it with others, visit our Twitter profile, view our other apps, and more. [https://github.com/orgs/wordpress-mobile/projects/107]
 * [*] Editor: Show a compact notice when switching between HTML or Visual mode. [https://github.com/wordpress-mobile/WordPress-iOS/pull/17521]
 * [*] Onboarding Improvements: Need a little help after login? We're here for you. We've made a few changes to the login flow that will make it easier for you to start managing your site or create a new one. [#17564]
 * [***] Fixed crash where uploading image when offline crashes iOS app. [#17488]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -64,7 +64,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .followConversationViaNotifications:
             return true
         case .aboutScreen:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         case .newCommentThread:
             return false
         case .postDetailsComments:


### PR DESCRIPTION
This PR enables the Unified About Screen feature flag for everybody, ready for release.

**To test**

* Build and run
* Ensure you can navigate to the new about screen and that the old one no longer appears at the bottom of the App Settings screen
* Optional: trigger an installable build of this PR and ensure that the about screen is visible there too

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
