### PR TITLE
Unified About: Fix an issue where nav bar should be hidden

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/UnifiedAboutViewController.swift
@@ -126,7 +126,6 @@ class UnifiedAboutViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationController?.setNavigationBarHidden(!shouldShowNavigationBar, animated: false)
         if isSubmenu {
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissAboutScreen))
         }
@@ -166,6 +165,8 @@ class UnifiedAboutViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        navigationController?.setNavigationBarHidden(!shouldShowNavigationBar, animated: true)
 
         if isMovingToParent {
             configuration.willShow(viewController: self)


### PR DESCRIPTION
I noticed an issue in the Unified About screen where the navigation bar wasn't getting hidden after navigating away from the Legal and More screen. This PR fixes that by moving the call to set up the navigation bar's appearance.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-26 at 14 12 24](https://user-images.githubusercontent.com/4780/143593751-75661534-8739-425b-b06a-ed4805398ba6.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-26 at 14 04 35](https://user-images.githubusercontent.com/4780/143593760-c7d9a4fa-14b8-4e31-bee2-c0f68054f856.png) |

**To test**

* Build and run
* Navigate to the new About screen
* Tap Legal and More, notice the navigation bar appears
* Tap < Back to return to the top level
* Ensure that the navigation bar is no longer visible

If you perform these steps on `develop`, the navigation bar remains visible.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
