### PR TITLE
Update WPMediaPicker from version 1.7.2 to 1.8.0-beta.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -207,7 +207,7 @@ abstract_target 'Apps' do
 
     pod 'NSURL+IDN', '~> 0.4'
 
-    pod 'WPMediaPicker', '~> 1.7.2'
+    pod 'WPMediaPicker', '~> 1.8.0-beta.1'
     #pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :tag => '1.7.0'
     ## while PR is in review:
     # pod 'WPMediaPicker', :git => 'https://github.com/wordpress-mobile/MediaPicker-iOS.git', :branch => ''

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -464,7 +464,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.12.2)
-  - WPMediaPicker (1.7.2)
+  - WPMediaPicker (1.7.3)
   - wpxmlrpc (0.9.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.1)
@@ -814,7 +814,7 @@ SPEC CHECKSUMS:
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
-  WPMediaPicker: d5ae9a83cd5cc0e4de46bfc1c59120aa86658bc3
+  WPMediaPicker: 4af3fdfba06541ada2613178f8c01175671c38a8
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e
   ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -464,7 +464,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.12.2)
-  - WPMediaPicker (1.7.3)
+  - WPMediaPicker (1.8.0-beta.1)
   - wpxmlrpc (0.9.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.1)
@@ -557,7 +557,7 @@ DEPENDENCIES:
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0)
   - WordPressUI (~> 1.12.2)
-  - WPMediaPicker (~> 1.7.2)
+  - WPMediaPicker (~> 1.8.0-beta.1)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.67.0/third-party-podspecs/Yoga.podspec.json`)
   - ZendeskSupportSDK (= 5.3.0)
   - ZIPFoundation (~> 0.9.8)
@@ -814,7 +814,7 @@ SPEC CHECKSUMS:
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: c573f4b5c2e5d0ffcebe69ecf86ae75ab7b6ff4d
-  WPMediaPicker: 4af3fdfba06541ada2613178f8c01175671c38a8
+  WPMediaPicker: b71345bed88eb1b9ad6313e3410795e0f1182f47
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 982b1e7bf7c0873643955853293b269e4487890e
   ZendeskCommonUISDK: 5808802951ad2bb424f0bed4259dc3c0ce9b52ec
@@ -826,6 +826,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 22e47ac08ff376890a2371f01f5950f182d2bf06
+PODFILE CHECKSUM: 8c53e4d7f4095196157ab82d948b8f940075280f
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
This is a routine update prompted by a step in our release process checklist.

@jkmassel @joshheald @frosty you folks are the last to have interacted with the library. Jeremy and Josh [on Woo](https://github.com/woocommerce/woocommerce-ios/pull/5138) and [the lib itself](https://github.com/wordpress-mobile/MediaPicker-iOS/compare/1.7.2...1.7.3) and Frosty here, 0b3c392bfc. Can you tell me if there's a reason why this was never update, and no one raised an issue about it?

Two possibilities:

- I missed it since its release, or like in the previous release cycle, simply run out of time for this
- There's no reason to upgrade, so no dev did it

If it's the latter, then feel free to close this PR.

I also noticed @SergioEstevao [bumped](https://github.com/wordpress-mobile/MediaPicker-iOS/blob/56371391da9fc7ea1350b9808af8b4d2f67ecbfd/WPMediaPicker.podspec#L5) the library to 1.8.0-beta.1 (although, there's no tag for it, yet). So let me know if it would be better to use that beta here instead.

## Regression Notes
1. Potential unintended areas of impact
The media picking workflow, I guess? The version has been out for a while and used in Woo, so it should be safe-ish to adopt here, too.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**