### PR TITLE
Reader Comments: Show the author badge for comments from author

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -108,8 +108,7 @@ public class Comment: NSManagedObject {
     }
 
     func isFromPostAuthor() -> Bool {
-        guard let post = post,
-              let postAuthorID = post.authorID?.int32Value,
+        guard let postAuthorID = post?.authorID?.int32Value,
               postAuthorID > 0,
               authorID > 0 else {
                   return false

--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -106,6 +106,17 @@ public class Comment: NSManagedObject {
     @objc func isTopLevelComment() -> Bool {
         return depth == 0
     }
+
+    func isFromPostAuthor() -> Bool {
+        guard let post = post,
+              let postAuthorID = post.authorID?.int32Value,
+              postAuthorID > 0,
+              authorID > 0 else {
+                  return false
+              }
+
+        return authorID == postAuthorID
+    }
 }
 
 private extension Comment {

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -35,6 +35,20 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         }
     }
 
+    /// When supplied with a non-empty string, the cell will show a badge label beside the name label.
+    /// Note that the badge will be hidden when the title is nil or empty.
+    var badgeTitle: String? = nil {
+        didSet {
+            guard let badgeTitle = badgeTitle, !badgeTitle.isEmpty else {
+                badgeLabel.isHidden = true
+                return
+            }
+
+            badgeLabel.setText(badgeTitle.localizedUppercase)
+            badgeLabel.isHidden = false
+        }
+    }
+
     override var indentationWidth: CGFloat {
         didSet {
             updateContainerLeadingConstraint()
@@ -61,6 +75,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     @IBOutlet private weak var avatarImageView: CircularImageView!
     @IBOutlet private weak var nameLabel: UILabel!
+    @IBOutlet private weak var badgeLabel: BadgeLabel!
     @IBOutlet private weak var dateLabel: UILabel!
     @IBOutlet private weak var accessoryButton: UIButton!
 
@@ -269,6 +284,12 @@ private extension CommentContentTableViewCell {
 
         nameLabel?.font = Style.nameFont
         nameLabel?.textColor = Style.nameTextColor
+
+        badgeLabel?.font = Style.badgeFont
+        badgeLabel?.textColor = Style.badgeTextColor
+        badgeLabel?.backgroundColor = Style.badgeColor
+        badgeLabel?.adjustsFontForContentSizeCategory = true
+        badgeLabel?.adjustsFontSizeToFitWidth = true
 
         dateLabel?.font = Style.dateFont
         dateLabel?.textColor = Style.dateTextColor

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
         <capability name="Image references" minToolsVersion="12.0"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -12,18 +13,18 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="225" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="225"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="120" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="225"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
-                        <rect key="frame" x="16" y="0.0" width="288" height="225"/>
+                        <rect key="frame" x="16" y="0.0" width="288" height="120"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="167"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="119"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="9QY-3I-cxv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="20" width="38" height="38"/>
@@ -33,15 +34,48 @@
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="CzL-pe-Tnr">
-                                        <rect key="frame" x="48" y="20" width="208" height="31"/>
+                                        <rect key="frame" x="48" y="20" width="208" height="66.5"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpE-B7-6wr" userLabel="Name Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="14.5"/>
-                                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="po6-3F-ppN" userLabel="Name Container View">
+                                                <rect key="frame" x="0.0" y="0.0" width="208" height="50"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpE-B7-6wr" userLabel="Name Label">
+                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Badge" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDo-cU-sWp" userLabel="Badge Label" customClass="BadgeLabel" customModule="WordPress" customModuleProvider="target">
+                                                        <rect key="frame" x="174.5" y="-2" width="33.5" height="13.5"/>
+                                                        <color key="backgroundColor" name="Blue50"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <color key="textColor" name="White"/>
+                                                        <nil key="highlightedColor"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="horizontalPadding">
+                                                                <real key="value" value="5"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                                                <real key="value" value="3"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="verticalPadding">
+                                                                <real key="value" value="1"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                        </userDefinedRuntimeAttributes>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                <constraints>
+                                                    <constraint firstItem="HpE-B7-6wr" firstAttribute="top" secondItem="po6-3F-ppN" secondAttribute="top" id="1mu-S2-Bod"/>
+                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hDo-cU-sWp" secondAttribute="trailing" id="Kgn-8h-iRl"/>
+                                                    <constraint firstItem="HpE-B7-6wr" firstAttribute="leading" secondItem="po6-3F-ppN" secondAttribute="leading" id="a9I-ZO-CNF"/>
+                                                    <constraint firstAttribute="bottom" secondItem="HpE-B7-6wr" secondAttribute="bottom" id="d2g-ej-XWq"/>
+                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HpE-B7-6wr" secondAttribute="trailing" id="p0y-Cp-XXb"/>
+                                                    <constraint firstItem="hDo-cU-sWp" firstAttribute="firstBaseline" secondItem="HpE-B7-6wr" secondAttribute="firstBaseline" constant="-3" id="pzL-bf-kIJ"/>
+                                                    <constraint firstItem="hDo-cU-sWp" firstAttribute="leading" secondItem="HpE-B7-6wr" secondAttribute="trailing" constant="5" id="zBO-4n-va3"/>
+                                                </constraints>
+                                            </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
-                                                <rect key="frame" x="0.0" y="16.5" width="208" height="14.5"/>
+                                                <rect key="frame" x="0.0" y="52" width="208" height="14.5"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
@@ -79,7 +113,7 @@
                                 </constraints>
                             </view>
                             <wkWebView contentMode="scaleToFill" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="Je0-5Q-ty6">
-                                <rect key="frame" x="0.0" y="167" width="288" height="1"/>
+                                <rect key="frame" x="0.0" y="119" width="288" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" priority="999" constant="1" id="dGD-8Q-LSr"/>
                                 </constraints>
@@ -89,10 +123,10 @@
                                 </wkWebViewConfiguration>
                             </wkWebView>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
-                                <rect key="frame" x="0.0" y="168" width="288" height="57"/>
+                                <rect key="frame" x="0.0" y="120" width="288" height="0.0"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="8.5" width="170.5" height="40"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="174.5" height="0.0"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -106,7 +140,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="175.5" y="7" width="57.5" height="43.5"/>
+                                        <rect key="frame" x="179.5" y="0.0" width="53.5" height="0.0"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -120,7 +154,7 @@
                                         </state>
                                     </button>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
-                                        <rect key="frame" x="238" y="0.0" width="50" height="57"/>
+                                        <rect key="frame" x="238" y="0.0" width="50" height="0.0"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
@@ -129,7 +163,7 @@
                                 </subviews>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T1Z-LV-01Y" customClass="CommentModerationBar" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="225" width="288" height="83"/>
+                                <rect key="frame" x="0.0" y="120" width="288" height="83"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="83" id="qRm-Qi-IXu"/>
@@ -149,6 +183,7 @@
             <connections>
                 <outlet property="accessoryButton" destination="1G8-cc-t5d" id="kLS-Ag-hAG"/>
                 <outlet property="avatarImageView" destination="9QY-3I-cxv" id="lbp-Hv-zRm"/>
+                <outlet property="badgeLabel" destination="hDo-cU-sWp" id="gVe-4c-TlR"/>
                 <outlet property="containerStackBottomConstraint" destination="jAu-U3-I4N" id="1Hk-Cp-fR5"/>
                 <outlet property="containerStackLeadingConstraint" destination="uFL-PF-ffo" id="6Ah-H9-d0b"/>
                 <outlet property="containerStackView" destination="hcN-S7-sLG" id="k9D-6a-BmR"/>
@@ -160,7 +195,7 @@
                 <outlet property="webView" destination="Je0-5Q-ty6" id="YaD-wp-E6W"/>
                 <outlet property="webViewHeightConstraint" destination="dGD-8Q-LSr" id="rBk-4R-GCz"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="272.20982142857139"/>
+            <point key="canvasLocation" x="131.8840579710145" y="235.71428571428569"/>
         </tableViewCell>
     </objects>
     <resources>
@@ -168,6 +203,12 @@
         <image name="icon-reader-comment-reply" width="13" height="12"/>
         <image name="square.and.arrow.up" catalog="system" width="115" height="128"/>
         <image name="star" catalog="system" width="128" height="116"/>
+        <namedColor name="Blue50">
+            <color red="0.023529411764705882" green="0.45882352941176469" blue="0.7686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="White">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/WPStyleGuide+CommentDetail.swift
@@ -1,3 +1,4 @@
+import WordPressShared
 /// This class groups all of the styles used by the comment detail screen.
 ///
 extension WPStyleGuide {
@@ -27,6 +28,10 @@ extension WPStyleGuide {
 
             static let nameFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
             static let nameTextColor = CommentDetail.textColor
+
+            static let badgeFont = WPStyleGuide.fontForTextStyle(.caption2, fontWeight: .semibold)
+            static let badgeTextColor = UIColor.white
+            static let badgeColor = UIColor.muriel(name: .blue, .shade50)
 
             static let dateFont = CommentDetail.tertiaryTextFont
             static let dateTextColor = CommentDetail.secondaryTextColor

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -70,6 +70,7 @@ import UIKit
             return
         }
 
+        cell.badgeTitle = comment.isFromPostAuthor() ? Constants.authorBadgeText : nil
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
         cell.accessoryButtonType = comment.allowsModeration() ? .ellipsis : .share
@@ -84,5 +85,8 @@ private extension ReaderCommentsViewController {
     struct Constants {
         static let indentationWidth: CGFloat = 15.0
         static let maxIndentationLevel: Int = 4
+
+        static let authorBadgeText = NSLocalizedString("Author", comment: "Title for a badge displayed beside the comment writer's name. "
+                                                       + "Shown when the comment is written by the post author.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Views/BadgeLabel.swift
+++ b/WordPress/Classes/ViewRelated/Views/BadgeLabel.swift
@@ -8,6 +8,13 @@ class BadgeLabel: UILabel {
         }
     }
 
+    @IBInspectable var verticalPadding: CGFloat = 0 {
+        didSet {
+            invalidateIntrinsicContentSize()
+            setNeedsLayout()
+        }
+    }
+
     // MARK: Initialization
 
     override init(frame: CGRect) {
@@ -30,13 +37,14 @@ class BadgeLabel: UILabel {
     // MARK: Padding
 
     override func drawText(in rect: CGRect) {
-        let insets = UIEdgeInsets.init(top: 0, left: horizontalPadding, bottom: 0, right: horizontalPadding)
+        let insets = UIEdgeInsets.init(top: verticalPadding, left: horizontalPadding, bottom: verticalPadding, right: horizontalPadding)
         super.drawText(in: rect.inset(by: insets))
     }
 
     override var intrinsicContentSize: CGSize {
         var paddedSize = super.intrinsicContentSize
         paddedSize.width += 2 * horizontalPadding
+        paddedSize.height += 2 * verticalPadding
         return paddedSize
     }
 


### PR DESCRIPTION
Refs #17476 
Depends on #17566

As titled, this shows the author badge when the comment is from the post author's. The author badge is a view that's added beside the name label in the content cell, and configured to show when the public property `badgeTitle` is not nil. Here's a preview:

![Simulator Screen Shot - iPhone 12 - 2021-11-29 at 21 20 21](https://user-images.githubusercontent.com/1299411/143885311-aa4abac1-688b-4d78-a42e-3078c9a962a2.png)

Some notes:
- There's an issue with atomic sites causing the author badge to not appear sometimes. When fetching reader comments from an atomic site, the author ID could sometimes be 0, causing it to never match with the author ID from the post.
- In Zeplin, the author badge uses SFCompactText font. This is not possible to do in iOS since it's reserved for watchOS, so instead, I'm using the default system font.

## To test

- Enable `newCommentThread` flag.
- Go to Reader, and go to any comment threads. Ideally non-atomic sites, but there's no easy way to know that unfortunately 😅 It's probably an atomic site when the author comments are not showing the badge. In that case, please try again with another post.
- Verify that the author badge is visible for author comments. Also, the badge should be hidden for the other comments.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
