### PR TITLE
Empty Stats: increase the threshold to 3000

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -12,7 +12,7 @@ final class SiteStatsPinnedItemStore {
             InsightType.customize
         ]
     }()
-    private let lowSiteViewsCountThreshold = 30
+    private let lowSiteViewsCountThreshold = 3000
     private let siteId: NSNumber
     private(set) var currentItem: SiteStatsPinnable?
 


### PR DESCRIPTION
Based on pbArwn-2HO-p2#comment-4413

This PR increases the maximum number of views to show the nudge cards to 3000.

### To test

1. Do a fresh install
2. Go to Stats
3. For any sites with less than 3000 visitors the nudge should be shown

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
