### PR TITLE
Onboarding Improvements: only show quick start prompt when adding a self-hosted site

### DIFF
--- a/WordPress/Classes/Models/Blog+Lookup.swift
+++ b/WordPress/Classes/Models/Blog+Lookup.swift
@@ -45,4 +45,17 @@ public extension Blog {
         // assemble the predicate as in `NSPredicate("blogID == %@")`
         try? lookup(withID: id.int64Value, in: context)
     }
+
+    /// Lookup a Blog by WP.ORG Credentials
+    ///
+    /// - Parameters:
+    ///   - username: The username associated with the blog.
+    ///   - xmlrpc: The xmlrpc URL address
+    ///   - context:  An NSManagedObjectContext containing the `Blog` object with the given `blogID`.
+    /// - Returns: The `Blog` object associated with the given `username` and `xmlrpc`, if it exists.
+    static func lookup(username: String, xmlrpc: String, in context: NSManagedObjectContext) -> Blog? {
+        let service = BlogService(managedObjectContext: context)
+
+        return service.findBlog(withXmlrpc: xmlrpc, andUsername: username)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -24,6 +24,9 @@ final class QuickStartPromptViewController: UIViewController {
 
     /// Closure to be executed upon dismissal.
     ///
+    /// - Parameters:
+    ///   - Blog: the blog for which the prompt was dismissed
+    ///   - Bool: `true` if Quick Start should start, otherwise `false`
     var onDismiss: ((Blog, Bool) -> Void)?
 
     // MARK: - Init

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -24,7 +24,7 @@ final class QuickStartPromptViewController: UIViewController {
 
     /// Closure to be executed upon dismissal.
     ///
-    var onDismiss: ((Blog) -> Void)?
+    var onDismiss: ((Blog, Bool) -> Void)?
 
     // MARK: - Init
 
@@ -108,7 +108,7 @@ final class QuickStartPromptViewController: UIViewController {
     // MARK: - IBAction
 
     @IBAction private func showMeAroundButtonTapped(_ sender: Any) {
-        onDismiss?(blog)
+        onDismiss?(blog, true)
         dismiss(animated: true)
 
         WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
@@ -116,7 +116,7 @@ final class QuickStartPromptViewController: UIViewController {
 
     @IBAction private func noThanksButtonTapped(_ sender: Any) {
         quickStartSettings.setPromptWasDismissed(true, for: blog)
-        onDismiss?(blog)
+        onDismiss?(blog, false)
         dismiss(animated: true)
 
         WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
@@ -10,6 +10,14 @@ final class QuickStartSettings {
         self.userDefaults = userDefaults
     }
 
+    // MARK: - Quick Start availability
+
+    func isQuickStartAvailable(for blog: Blog) -> Bool {
+        return blog.isUserCapableOf(.ManageOptions) &&
+            blog.isUserCapableOf(.EditThemeOptions) &&
+            !blog.isWPForTeams()
+    }
+
     // MARK: - User Defaults Storage
 
     func promptWasDismissed(for blog: Blog) -> Bool {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -526,7 +526,7 @@ private extension WordPressAuthenticationManager {
 
         // Otherwise, show the My Site screen for the specified blog and after a short delay,
         // trigger the Quick Start tour
-        self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
+        self.windowManager.showAppUI(for: blog, completion: {
             QuickStartTourGuide.shared.setupWithDelay(for: blog)
         })
     }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -353,6 +353,11 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 return
             }
 
+            guard self.quickStartSettings.isQuickStartAvailable(for: blog) else {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                return
+            }
+
             self.presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissQuickStartPrompt)
         }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressAuthenticator
 import Gridicons
+import UIKit
 
 
 // MARK: - WordPressAuthenticationManager
@@ -323,6 +324,17 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
+        let onDismissQuickStartPrompt: (Blog) -> Void = { [weak self] blog in
+            self?.onDismissQuickStartPrompt(for: blog, onDismiss: onDismiss)
+        }
+
+        // If adding a self-hosted site, skip the Epilogue
+        if let wporg = credentials.wporg,
+           let blog = Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: ContextManager.shared.mainContext) {
+            presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissQuickStartPrompt)
+            return
+        }
+
         if PostSignUpInterstitialViewController.shouldDisplay() {
             self.presentPostSignUpInterstitial(in: navigationController, onDismiss: onDismiss)
             return
@@ -336,50 +348,12 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.credentials = credentials
 
-        let onDismissQuickStartPrompt: (Blog) -> Void = { [weak self] blog in
-
-            guard let self = self else {
-                return
-            }
-
-            onDismiss()
-
-            // If the quick start prompt has already been dismissed,
-            // then show the My Site screen for the specified blog
-            guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
-                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
-                return
-            }
-
-            // Otherwise, show the My Site screen for the specified blog and after a short delay,
-            // trigger the Quick Start tour
-            self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
-                QuickStartTourGuide.shared.setupWithDelay(for: blog)
-            })
-        }
-
         epilogueViewController.onBlogSelected = { [weak self] blog in
             guard let self = self else {
                 return
             }
 
-            // If the quick start prompt has already been dismissed,
-            // then show the My Site screen for the specified blog
-            guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
-
-                if self.windowManager.isShowingFullscreenSignIn {
-                    self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
-                } else {
-                    navigationController.dismiss(animated: true)
-                }
-
-                return
-            }
-
-            // Otherwise, show the Quick Start prompt
-            let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-            quickstartPrompt.onDismiss = onDismissQuickStartPrompt
-            navigationController.pushViewController(quickstartPrompt, animated: true)
+            self.presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissQuickStartPrompt)
         }
 
         epilogueViewController.onCreateNewSite = {
@@ -445,7 +419,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     func shouldPresentSignupEpilogue() -> Bool {
         return true
     }
-
 
     /// Whenever a WordPress.com account has been created during the Auth flow, we'll add a new local WPCOM Account, and set it as
     /// the new DefaultWordPressComAccount.
@@ -516,6 +489,46 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func track(event: WPAnalyticsStat, error: Error) {
         WPAppAnalytics.track(event, error: error)
+    }
+}
+
+// MARK: - Quick Start Prompt
+private extension WordPressAuthenticationManager {
+    func presentQuickStartPrompt(for blog: Blog, in navigationController: UINavigationController, onDismiss: ((Blog) -> Void)?) {
+        // If the quick start prompt has already been dismissed,
+        // then show the My Site screen for the specified blog
+        guard !quickStartSettings.promptWasDismissed(for: blog) else {
+
+            if self.windowManager.isShowingFullscreenSignIn {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+            } else {
+                navigationController.dismiss(animated: true)
+            }
+
+            return
+        }
+
+        // Otherwise, show the Quick Start prompt
+        let quickstartPrompt = QuickStartPromptViewController(blog: blog)
+        quickstartPrompt.onDismiss = onDismiss
+        navigationController.pushViewController(quickstartPrompt, animated: true)
+    }
+
+    func onDismissQuickStartPrompt(for blog: Blog, onDismiss: @escaping () -> Void) {
+        onDismiss()
+
+        // If the quick start prompt has already been dismissed,
+        // then show the My Site screen for the specified blog
+        guard !self.quickStartSettings.promptWasDismissed(for: blog) else {
+            self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+            return
+        }
+
+        // Otherwise, show the My Site screen for the specified blog and after a short delay,
+        // trigger the Quick Start tour
+        self.windowManager.dismissFullscreenSignIn(blogToShow: blog, completion: {
+            QuickStartTourGuide.shared.setupWithDelay(for: blog)
+        })
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -324,7 +324,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
-        let onDismissQuickStartPrompt: (Blog) -> Void = { [weak self] blog in
+        let onDismissQuickStartPrompt: (Blog, Bool) -> Void = { [weak self] blog, _ in
             self?.onDismissQuickStartPrompt(for: blog, onDismiss: onDismiss)
         }
 
@@ -494,7 +494,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
 // MARK: - Quick Start Prompt
 private extension WordPressAuthenticationManager {
-    func presentQuickStartPrompt(for blog: Blog, in navigationController: UINavigationController, onDismiss: ((Blog) -> Void)?) {
+    func presentQuickStartPrompt(for blog: Blog, in navigationController: UINavigationController, onDismiss: ((Blog, Bool) -> Void)?) {
         // If the quick start prompt has already been dismissed,
         // then show the My Site screen for the specified blog
         guard !quickStartSettings.promptWasDismissed(for: blog) else {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -26,7 +26,7 @@ final class SiteAssemblyStep: WizardStep {
     ///   - creator: the in-flight creation instance
     ///   - service: the service to use for initiating site creation
     ///   - onDismiss: the closure to be executed upon dismissal of the SiteAssemblyWizardContent
-    init(creator: SiteCreator, service: SiteAssemblyService, onDismiss: ((Blog) -> Void)? = nil) {
+    init(creator: SiteCreator, service: SiteAssemblyService, onDismiss: ((Blog, Bool) -> Void)? = nil) {
         self.creator = creator
         self.service = service
         self.content = SiteAssemblyWizardContent(creator: creator, service: service, onDismiss: onDismiss)

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -36,7 +36,7 @@ final class SiteAssemblyWizardContent: UIViewController {
     private let quickStartSettings: QuickStartSettings
 
     /// Closure to be executed upon dismissal
-    private let onDismiss: ((Blog) -> Void)?
+    private let onDismiss: ((Blog, Bool) -> Void)?
 
     // MARK: SiteAssemblyWizardContent
 
@@ -50,7 +50,7 @@ final class SiteAssemblyWizardContent: UIViewController {
     init(creator: SiteCreator,
          service: SiteAssemblyService,
          quickStartSettings: QuickStartSettings = QuickStartSettings(),
-         onDismiss: ((Blog) -> Void)? = nil) {
+         onDismiss: ((Blog, Bool) -> Void)? = nil) {
         self.siteCreator = creator
         self.service = service
         self.quickStartSettings = quickStartSettings
@@ -258,7 +258,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         }
 
         let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-        quickstartPrompt.onDismiss = { blog in
+        quickstartPrompt.onDismiss = { blog, _ in
             QuickStartTourGuide.shared.setupWithDelay(for: blog)
         }
         tabBar.present(quickstartPrompt, animated: true)

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -258,8 +258,10 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
         }
 
         let quickstartPrompt = QuickStartPromptViewController(blog: blog)
-        quickstartPrompt.onDismiss = { blog, _ in
-            QuickStartTourGuide.shared.setupWithDelay(for: blog)
+        quickstartPrompt.onDismiss = { blog, showQuickStart in
+            if showQuickStart {
+                QuickStartTourGuide.shared.setupWithDelay(for: blog)
+            }
         }
         tabBar.present(quickstartPrompt, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -48,9 +48,9 @@ final class SiteCreationWizardLauncher {
 
     /// Closure to be executed upon dismissal of the SiteAssemblyWizardContent.
     ///
-    private let onDismiss: ((Blog) -> Void)?
+    private let onDismiss: ((Blog, Bool) -> Void)?
 
-    init(onDismiss: ((Blog) -> Void)? = nil) {
+    init(onDismiss: ((Blog, Bool) -> Void)? = nil) {
         self.onDismiss = onDismiss
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -49,6 +49,30 @@ public class LoginUsernamePasswordScreen: ScreenObject {
     }
 
     public func proceedWith(username: String, password: String) -> LoginEpilogueScreen {
+        fill(username: username, password: password)
+
+        return LoginEpilogueScreen()
+    }
+
+    public func proceedWithSelfHostedSiteAddedFromSitesList(username: String, password: String) throws -> MySitesScreen {
+        fill(username: username, password: password)
+        try dismissQuickStartPromptIfNeeded()
+
+        return try MySitesScreen()
+    }
+
+    public func proceedWithSelfHosted(username: String, password: String) throws -> MySiteScreen {
+        fill(username: username, password: password)
+        try dismissQuickStartPromptIfNeeded()
+
+        return try MySiteScreen()
+    }
+
+    public static func isLoaded() -> Bool {
+        (try? LoginUsernamePasswordScreen().isLoaded) ?? false
+    }
+
+    private func fill(username: String, password: String) {
         usernameTextField.tap()
         usernameTextField.typeText(username)
         passwordTextField.tap()
@@ -60,11 +84,15 @@ public class LoginUsernamePasswordScreen: ScreenObject {
             passwordTextField.typeText(password)
         }
         nextButton.tap()
-
-        return LoginEpilogueScreen()
     }
 
-    public static func isLoaded() -> Bool {
-        (try? LoginUsernamePasswordScreen().isLoaded) ?? false
+    private func dismissQuickStartPromptIfNeeded() throws {
+        try XCTContext.runActivity(named: "Dismiss quick start prompt if needed.") { (activity) in
+            if QuickStartPromptScreen.isLoaded() {
+                Logger.log(message: "Dismising quick start prompt...", event: .i)
+                _ = try QuickStartPromptScreen().selectNoThanks()
+                return
+            }
+        }
     }
 }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -54,9 +54,7 @@ class LoginTests: XCTestCase {
         try prologueScreen
             .selectSiteAddress()
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-            .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .continueWithSelectedSite()
+            .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .removeSelfHostedSite()
 
         XCTAssert(prologueScreen.isLoaded)
@@ -85,9 +83,7 @@ class LoginTests: XCTestCase {
 
             // Then, go through the self-hosted login flow:
             .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWith(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-            .verifyEpilogueDisplays(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .continueWithSelfHostedSiteAddedFromSitesList()
+            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
 
             // Login flow returns MySites modal, which needs to be closed.
             .closeModal()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/17564#issuecomment-979252223

This PR changes the Epilogue flow for when adding a self-hosted site.

### To test

Scenario: self-hosted

1. Do a clean install
2. Add a self-hosted site
3. Make sure that the prompt ("Want a little help...") is shown and the epilogue to select a site is *not shown*

Scenario: WP.com

1. Login with your .com account
2. Make sure that the epilogue appears
3. Tap a site and make sure the QuickStart prompt appears and behaves correctly

Scenario: creating a new site

1. Tap the site selector
2. Tap the "+" icon
3. Create a new site
4. When prompted for a little help tap "No Thanks"
5. Quick start should not start
6. Repeat the same steps but tapping "Show me around"
7. Quick start should start

**Important**: if the user taps "No thanks" the prompt shouldn't appear if they remove and then re-add the site.

## Regression Notes
1. Potential unintended areas of impact
Epilogue

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
