### PR TITLE
Reader post reply: fix background colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -271,7 +271,6 @@ import Gridicons
         textView.contentInset = .zero
         textView.textContainerInset = .zero
         textView.autocorrectionType = .yes
-        textView.backgroundColor = Style.backgroundColor
         textView.textColor = Style.textColor
         textView.textContainer.lineFragmentPadding = 0
         textView.layoutManager.allowsNonContiguousLayout = false

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
@@ -4,7 +4,6 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -56,7 +55,6 @@
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="wxv-ga-1LS" secondAttribute="bottom" id="EMu-Xg-vmD"/>
                                 <constraint firstItem="wxv-ga-1LS" firstAttribute="top" secondItem="OaT-BL-6lY" secondAttribute="top" id="lxs-W5-jNr"/>
@@ -69,30 +67,27 @@
                             <subviews>
                                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" bounces="NO" showsHorizontalScrollIndicator="NO" bouncesZoom="NO" textAlignment="natural" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfH-NN-dph">
                                     <rect key="frame" x="0.0" y="5" width="225" height="28"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                 </textView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Placeholder" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6Lf-XI-exE" userLabel="Placeholder">
                                     <rect key="frame" x="0.0" y="0.0" width="225" height="33"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                     <nil key="highlightedColor"/>
                                     <size key="shadowOffset" width="-1" height="-1"/>
                                 </label>
                             </subviews>
-                            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
-                                <constraint firstAttribute="trailingMargin" secondItem="gfH-NN-dph" secondAttribute="trailing" id="UsD-Qh-geJ"/>
-                                <constraint firstItem="gfH-NN-dph" firstAttribute="leading" secondItem="t6q-rh-Bzh" secondAttribute="leadingMargin" id="Wnr-UR-Oup"/>
+                                <constraint firstAttribute="trailing" secondItem="gfH-NN-dph" secondAttribute="trailing" id="6tb-kb-jpl"/>
+                                <constraint firstAttribute="bottom" secondItem="gfH-NN-dph" secondAttribute="bottom" id="HVi-Py-SH4"/>
+                                <constraint firstItem="gfH-NN-dph" firstAttribute="leading" secondItem="t6q-rh-Bzh" secondAttribute="leading" id="WEa-Si-qus"/>
                                 <constraint firstItem="6Lf-XI-exE" firstAttribute="leading" secondItem="t6q-rh-Bzh" secondAttribute="leading" id="cVC-qr-WEL"/>
                                 <constraint firstItem="6Lf-XI-exE" firstAttribute="top" secondItem="t6q-rh-Bzh" secondAttribute="top" id="coT-RG-6rz"/>
-                                <constraint firstItem="gfH-NN-dph" firstAttribute="top" secondItem="t6q-rh-Bzh" secondAttribute="topMargin" constant="5" id="f52-SP-Tv4"/>
                                 <constraint firstAttribute="trailing" secondItem="6Lf-XI-exE" secondAttribute="trailing" id="nk9-ec-6ee"/>
+                                <constraint firstItem="gfH-NN-dph" firstAttribute="top" secondItem="t6q-rh-Bzh" secondAttribute="top" constant="5" id="oW6-af-l7q"/>
                                 <constraint firstAttribute="bottom" secondItem="6Lf-XI-exE" secondAttribute="bottom" id="pZt-mP-ney"/>
-                                <constraint firstAttribute="bottomMargin" secondItem="gfH-NN-dph" secondAttribute="bottom" id="rqH-Tc-Wyo"/>
                             </constraints>
                             <edgeInsets key="layoutMargins" top="0.0" left="0.0" bottom="0.0" right="0.0"/>
                         </view>
@@ -114,7 +109,6 @@
                                     </connections>
                                 </button>
                             </subviews>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="8sg-79-AsR" secondAttribute="trailing" id="4MX-yD-sG2"/>
                                 <constraint firstItem="8sg-79-AsR" firstAttribute="width" secondItem="lA2-1V-bck" secondAttribute="width" id="UVG-FL-ebz"/>
@@ -142,8 +136,5 @@
     </objects>
     <resources>
         <image name="icon-nav-chevron-highlight" width="14" height="8"/>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
Fixes: n/a

This fixes an issue where the background colors in the Reply view would be incorrect sometimes, causing white areas in dark mode. The background colors for all elements are now `Default` in the xib, and the only color set in code is `contentView.backgroundColor`.

⚠️ Auto-merge enabled ⚠️ 

To test:
- Switch device to dark mode.
- Go to Reader > post > comments.
- Verify the background colors in the Reply view are correct (i.e. there are no white areas).
- Enter text in the reply field.
- Verify the background colors in the Reply view are still correct.

| Before | After |
|--------|-------|
| ![before placeholder](https://user-images.githubusercontent.com/1816888/143961050-8529e062-350b-4d44-8151-75075f18a194.png) | ![after placeholder](https://user-images.githubusercontent.com/1816888/143961042-0888b9e5-ce79-4ae9-9183-2f977655eed8.png) |
| ![before text](https://user-images.githubusercontent.com/1816888/143961047-d7b341c0-240a-413f-8834-b3e7a3e70860.png) | ![after text](https://user-images.githubusercontent.com/1816888/143961040-d6655dc5-5203-4e43-a1a4-707d2800de7a.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
