### PR TITLE
Remove 1Password Usage

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -215,8 +215,8 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.42.1'
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
+    # pod 'WordPressAuthenticator', '~> 1.42.1'
+    pod 'WordPressAuthenticator', :git => 'https://github.com/hassaansaleh/WordPressAuthenticator-iOS.git', :branch => 'issue/17516-control-onePassword-with-config'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -552,7 +552,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.5)
-  - WordPressAuthenticator (~> 1.42.1)
+  - WordPressAuthenticator (from `https://github.com/hassaansaleh/WordPressAuthenticator-iOS.git`, branch `issue/17516-control-onePassword-with-config`)
   - WordPressKit (~> 4.44.0-beta)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0-beta.1)
@@ -564,7 +564,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
     - WordPressShared
     - WordPressUI
@@ -711,6 +710,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.67.0
+  WordPressAuthenticator:
+    :branch: issue/17516-control-onePassword-with-config
+    :git: https://github.com/hassaansaleh/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.67.0/third-party-podspecs/Yoga.podspec.json
 
@@ -726,6 +728,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.67.0
+  WordPressAuthenticator:
+    :commit: ca27fbfe2db5274b8a58a1966cc948f342b53fcf
+    :git: https://github.com/hassaansaleh/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   1PasswordExtension: f97cc80ae58053c331b2b6dc8843ba7103b33794
@@ -809,7 +814,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: f4bf3b343581a1beacdbf5fb1a8825bd5f05a4a4
   WordPress-Aztec-iOS: af36d9cb86a0109b568f516874870e2801ba1bd9
   WordPress-Editor-iOS: 446be349b94707c1a82a83d525b86dbcf18cf2c7
-  WordPressAuthenticator: 111793c08fa8e9d9a72aed5b33a094c91ff4fd82
+  WordPressAuthenticator: 9c6798897412ec02890097a7f4233a64971d9fe2
   WordPressKit: 7fe46752fe65808f80163ae135bb5c3f081d108b
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 3f365c6d5ae8fc1615f7f30aac7f9f78f1dd70fb
@@ -826,6 +831,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 63d141eadcb0ceade9f10349e2f5534f0f3e950b
+PODFILE CHECKSUM: 60962bc5c60f33991eb8d5495f4ae776c2bae111
 
 COCOAPODS: 1.10.1

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -68,8 +68,9 @@ extension WordPressAuthenticationManager {
                                                    enableSignUp: AppConfiguration.allowSignUp,
                                                    enableSignInWithApple: enableSignInWithApple,
                                                    enableSignupWithGoogle: AppConfiguration.allowSignUp,
-                                                   enableUnifiedAuth: true,
-                                                   enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled)
+                                                   enableUnifiedAuth: false,
+                                                   enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled,
+                                                   enableOnePassword: false)
     }
 
     private func authenticatorStyle() -> WordPressAuthenticatorStyle {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -68,7 +68,7 @@ extension WordPressAuthenticationManager {
                                                    enableSignUp: AppConfiguration.allowSignUp,
                                                    enableSignInWithApple: enableSignInWithApple,
                                                    enableSignupWithGoogle: AppConfiguration.allowSignUp,
-                                                   enableUnifiedAuth: false,
+                                                   enableUnifiedAuth: true,
                                                    enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled,
                                                    enableOnePassword: false)
     }


### PR DESCRIPTION
Fixes #17516

## Associated PRs
- https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/623
- https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/624

## To Test
1. Test the unified and old UI with 1Password enabled.
2. Test the unified and old UI with 1Password disabled (Toggle this from `WordPressAuthenticationManager`).
3. Please test on a physical device to see that 1Password is passed the domain correctly. I couldn’t test this specific part as I’m testing using a custom app ID to get around code signing issues, so the associated domain isn’t linked to my version of the app. However I checked the [association file here](https://wordpress.com/.well-known/apple-app-site-association) and it seems everything is setup as expected. 
4. For more detailed testing instructions, check the associated PRs

## Regression Notes
1. Potential unintended areas of impact
No changes of significance. All changes are inside WordPress Authenticator.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the UI changes in WordPress Authenticator manually and added unit tests inside the helper framework.

3. What automated tests I added (or what prevented me from doing so)
As AutoFill Password and 1Password are not available on simulators, I wasn’t able to add UITests to cover my changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
