### PR TITLE
Reader Post comments button: fix default colors and behavior

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -17,6 +17,7 @@ class BorderedButtonTableViewCell: UITableViewCell {
 
     weak var delegate: BorderedButtonTableViewCellDelegate?
 
+    private var button = UIButton()
     private var buttonTitle = String()
     private var buttonInsets = Defaults.buttonInsets
     private var titleFont = Defaults.titleFont
@@ -38,6 +39,13 @@ class BorderedButtonTableViewCell: UITableViewCell {
         configureView()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+            updateButtonBorderColors()
+        }
+    }
+
 }
 
 // MARK: - Private Extension
@@ -48,20 +56,19 @@ private extension BorderedButtonTableViewCell {
         selectionStyle = .none
         accessibilityTraits = .button
 
-        let button = configuredButton()
+        configureButton()
         contentView.addSubview(button)
         contentView.pinSubviewToAllEdges(button, insets: buttonInsets)
     }
 
-    func configuredButton() -> UIButton {
+    func configureButton() {
         let button = UIButton()
-        let buttonColor = normalColor
+
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(buttonTitle, for: .normal)
-        button.setTitleColor(buttonColor, for: .normal)
+
+        button.setTitleColor(normalColor, for: .normal)
         button.setTitleColor(highlightedColor, for: .highlighted)
-        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: buttonColor), for: .normal)
-        button.setBackgroundImage(.renderBackgroundImage(fill: buttonColor, border: buttonColor), for: .highlighted)
 
         button.titleLabel?.font = titleFont
         button.titleLabel?.textAlignment = .center
@@ -76,14 +83,20 @@ private extension BorderedButtonTableViewCell {
             self?.delegate?.buttonTapped()
         }
 
-        return button
+        self.button = button
+        updateButtonBorderColors()
+    }
+
+    func updateButtonBorderColors() {
+        button.setBackgroundImage(UIImage.renderBackgroundImage(fill: .clear, border: normalColor), for: .normal)
+        button.setBackgroundImage(.renderBackgroundImage(fill: normalColor, border: normalColor), for: .highlighted)
     }
 
     struct Defaults {
         static let buttonInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
         static let titleFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         static let normalColor: UIColor = .text
-        static let highlightedColor: UIColor = .white
+        static let highlightedColor: UIColor = .textInverted
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -105,7 +105,8 @@ class CommentDetailViewController: UIViewController {
     private lazy var deleteButtonCell: BorderedButtonTableViewCell = {
         let cell = BorderedButtonTableViewCell()
         cell.configure(buttonTitle: .deleteButtonText,
-                       normalColor: UIColor(light: .error, dark: .muriel(name: .red, .shade40)),
+                       normalColor: Constants.deleteButtonNormalColor,
+                       highlightedColor: Constants.deleteButtonHighlightColor,
                        buttonInsets: Constants.deleteButtonInsets)
         cell.delegate = self
         return cell
@@ -237,6 +238,8 @@ private extension CommentDetailViewController {
         static let tableBottomMargin: CGFloat = 40.0
         static let replyIndicatorVerticalSpacing: CGFloat = 14.0
         static let deleteButtonInsets = UIEdgeInsets(top: 4, left: 20, bottom: 4, right: 20)
+        static let deleteButtonNormalColor = UIColor(light: .error, dark: .muriel(name: .red, .shade40))
+        static let deleteButtonHighlightColor: UIColor = .white
     }
 
     /// Convenience computed variable for an inset setting that hides a cell's separator by pushing it off the edge of the screen.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -7,6 +7,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        contentView.backgroundColor = .basicBackground
         titleLabel.textColor = .text
         titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
     }


### PR DESCRIPTION
Ref: #17511 

This fixes the default colors and behavior of the `BorderedButtonTableViewCell`:
- The default highlighted color is now `textInverted`.
  - Previously it was always `white` which didn't work in dark mode.
- The border colors are now updated automatically when the color appearance changes.
  - Previously, the border color did not change until the view was dismissed and reshown.

Bonus: the `XXX Comments` header background color should now be white/black instead of grey. (ref https://github.com/wordpress-mobile/WordPress-iOS/pull/17560#pullrequestreview-816613213)

To test:

---
**Reader Post Comments:**
- Go to Reader > Post details > Comments table.
- Verify:
  - The `XXX Comments` header background color is white in light mode, black in dark mode.
  - `View All Comments` text and border are black in light mode, white in dark mode.
  - `View All Comments` background is white in light mode, black in dark mode.
  - The button border color updates automatically when switching modes.
  - The text and background colors are inverted when highlighted.

| <img width="479" alt="light" src="https://user-images.githubusercontent.com/1816888/143973667-e987f11b-9415-4258-84f6-86441cc7f4ea.png"> | <img width="474" alt="dark" src="https://user-images.githubusercontent.com/1816888/143973664-c9268db8-bd0d-4e62-8fc2-748a93321fae.png"> |
|--------|-------|


https://user-images.githubusercontent.com/1816888/143973669-3c23c609-905b-4c20-be22-fb93325a7490.mp4

https://user-images.githubusercontent.com/1816888/143973675-e6e35374-fc9f-4949-96f8-540aba07e403.mp4

---
**My Site Comments:**
- Go to My Site > Comments.
- Select a Spam or Trash comment.
- Verify the `Delete Permanently` button colors are correct in light and dark modes, and when highlighted.

---
## Regression Notes
1. Potential unintended areas of impact
`Delete Permanently` button colors could be incorrect.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified `Delete Permanently` button colors are correct.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
