### PR TITLE
Convert UI tests screens to be a ScreenObject subclasses – 6 of many

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -22,10 +22,10 @@ public class LinkOrPasswordScreen: ScreenObject {
         return try LoginPasswordScreen()
     }
 
-    public func proceedWithLink() -> LoginCheckMagicLinkScreen {
+    public func proceedWithLink() throws -> LoginCheckMagicLinkScreen {
         linkButtonGetter(app).tap()
 
-        return LoginCheckMagicLinkScreen()
+        return try LoginCheckMagicLinkScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -18,10 +18,10 @@ public class LinkOrPasswordScreen: BaseScreen {
         super.init(element: passwordOption)
     }
 
-    func proceedWithPassword() -> LoginPasswordScreen {
+    func proceedWithPassword() throws -> LoginPasswordScreen {
         passwordOption.tap()
 
-        return LoginPasswordScreen()
+        return try LoginPasswordScreen()
     }
 
     public func proceedWithLink() -> LoginCheckMagicLinkScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -1,36 +1,34 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let passwordOption = "Use Password"
-    static let linkButton = "Send Link Button"
-}
+public class LinkOrPasswordScreen: ScreenObject {
 
-public class LinkOrPasswordScreen: BaseScreen {
-    let passwordOption: XCUIElement
-    let linkButton: XCUIElement
+    let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Use Password"]
+    }
+    let linkButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Send Link Button"]
+    }
 
-    init() {
-        passwordOption = XCUIApplication().buttons[ElementStringIDs.passwordOption]
-        linkButton = XCUIApplication().buttons[ElementStringIDs.linkButton]
-
-        super.init(element: passwordOption)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [passwordOptionGetter, linkButtonGetter], app: app)
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        passwordOption.tap()
+        passwordOptionGetter(app).tap()
 
         return try LoginPasswordScreen()
     }
 
     public func proceedWithLink() -> LoginCheckMagicLinkScreen {
-        linkButton.tap()
+        linkButtonGetter(app).tap()
 
         return LoginCheckMagicLinkScreen()
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.passwordOption].exists
+        (try? LinkOrPasswordScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -1,24 +1,25 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let passwordOption = "Use Password"
-    static let mailButton = "Open Mail Button"
-}
+public class LoginCheckMagicLinkScreen: ScreenObject {
 
-public class LoginCheckMagicLinkScreen: BaseScreen {
-    let passwordOption: XCUIElement
-    let mailButton: XCUIElement
+    let passwordOptionGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Use Password"]
+    }
 
-    init() {
-        let app = XCUIApplication()
-        passwordOption = app.buttons[ElementStringIDs.passwordOption]
-        mailButton = app.buttons[ElementStringIDs.mailButton]
-
-        super.init(element: mailButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                passwordOptionGetter,
+                // swiftlint:disable:next opening_brace
+                { $0.buttons["Open Mail Button"] }
+            ],
+            app: app
+        )
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {
-        passwordOption.tap()
+        passwordOptionGetter(app).tap()
 
         return try LoginPasswordScreen()
     }
@@ -30,6 +31,6 @@ public class LoginCheckMagicLinkScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.mailButton].exists
+        (try? LoginCheckMagicLinkScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -17,10 +17,10 @@ public class LoginCheckMagicLinkScreen: BaseScreen {
         super.init(element: mailButton)
     }
 
-    func proceedWithPassword() -> LoginPasswordScreen {
+    func proceedWithPassword() throws -> LoginPasswordScreen {
         passwordOption.tap()
 
-        return LoginPasswordScreen()
+        return try LoginPasswordScreen()
     }
 
     public func openMagicLoginLink() -> LoginEpilogueScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -23,12 +23,12 @@ public class LoginEmailScreen: ScreenObject {
         )
     }
 
-    public func proceedWith(email: String) -> LinkOrPasswordScreen {
+    public func proceedWith(email: String) throws -> LinkOrPasswordScreen {
         emailTextField.tap()
         emailTextField.typeText(email)
         nextButton.tap()
 
-        return LinkOrPasswordScreen()
+        return try LinkOrPasswordScreen()
     }
 
     func goToSiteAddressLogin() -> LoginSiteAddressScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -31,10 +31,10 @@ public class LoginEmailScreen: ScreenObject {
         return try LinkOrPasswordScreen()
     }
 
-    func goToSiteAddressLogin() -> LoginSiteAddressScreen {
+    func goToSiteAddressLogin() throws -> LoginSiteAddressScreen {
         app.buttons["Self Hosted Login Button"].tap()
 
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -1,21 +1,16 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let passwordTextField = "Password"
-    static let loginButton = "Password Next Button"
-    static let errorLabel = "pswdErrorLabel"
-}
+class LoginPasswordScreen: ScreenObject {
 
-class LoginPasswordScreen: BaseScreen {
-    let passwordTextField: XCUIElement
-    let loginButton: XCUIElement
+    let passwordTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.secureTextFields["Password"]
+    }
 
-    init() {
-        passwordTextField = XCUIApplication().secureTextFields[ElementStringIDs.passwordTextField]
-        loginButton = XCUIApplication().buttons[ElementStringIDs.loginButton]
-        super.init(element: passwordTextField)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [passwordTextFieldGetter], app: app)
     }
 
     func proceedWith(password: String) -> LoginEpilogueScreen {
@@ -25,17 +20,19 @@ class LoginPasswordScreen: BaseScreen {
     }
 
     func tryProceed(password: String) -> LoginPasswordScreen {
+        let passwordTextField = passwordTextFieldGetter(app)
         passwordTextField.tap()
         passwordTextField.typeText(password)
+        let loginButton = app.buttons["Password next Button"]
         loginButton.tap()
         if loginButton.exists && !loginButton.isHittable {
-            waitFor(element: loginButton, predicate: "isEnabled == true")
+            XCTAssertEqual(loginButton.waitFor(predicateString: "isEnabled == true"), .completed)
         }
         return self
     }
 
     func verifyLoginError() -> LoginPasswordScreen {
-        let errorLabel = app.staticTexts[ElementStringIDs.errorLabel]
+        let errorLabel = app.staticTexts["pswdErrorLabel"]
         _ = errorLabel.waitForExistence(timeout: 2)
 
         XCTAssertTrue(errorLabel.exists)
@@ -43,6 +40,6 @@ class LoginPasswordScreen: BaseScreen {
     }
 
     static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.loginButton].exists
+        (try? LoginPasswordScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -1,3 +1,4 @@
+import ScreenObject
 import XCTest
 
 private struct ElementStringIDs {
@@ -13,16 +14,17 @@ private struct ElementStringIDs {
     static let siteAddressTextField = "Site address"
 }
 
-public class LoginSiteAddressScreen: BaseScreen {
-    let siteAddressTextField: XCUIElement
-    let nextButton: XCUIElement
+public class LoginSiteAddressScreen: ScreenObject {
 
-    init() {
-        let app = XCUIApplication()
-        siteAddressTextField = app.textFields[ElementStringIDs.siteAddressTextField]
-        nextButton = app.buttons[ElementStringIDs.nextButton]
+    let siteAddressTextFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Site address"]
+    }
 
-        super.init(element: siteAddressTextField)
+    var siteAddressTextField: XCUIElement { siteAddressTextFieldGetter(app) }
+    var nextButton: XCUIElement { app.buttons[ElementStringIDs.nextButton] }
+
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(expectedElementGetters: [siteAddressTextFieldGetter], app: app)
     }
 
     public func proceedWith(siteUrl: String) throws -> LoginUsernamePasswordScreen {
@@ -42,6 +44,6 @@ public class LoginSiteAddressScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.nextButton].exists
+        (try? LoginSiteAddressScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -42,12 +42,12 @@ public class GetStartedScreen: ScreenObject {
         )
     }
 
-    public func proceedWith(email: String) -> PasswordScreen {
+    public func proceedWith(email: String) throws -> PasswordScreen {
         emailTextField.tap()
         emailTextField.typeText(email)
         continueButton.tap()
 
-        return PasswordScreen()
+        return try PasswordScreen()
     }
 
     public func goBackToPrologue() {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -1,21 +1,14 @@
+import ScreenObject
 import XCTest
 
-private struct ElementStringIDs {
-    static let passwordTextField = "Password"
-    static let continueButton = "Continue Button"
-    static let errorLabel = "Password Error"
-}
+public class PasswordScreen: ScreenObject {
 
-public class PasswordScreen: BaseScreen {
-    let passwordTextField: XCUIElement
-    let continueButton: XCUIElement
-
-    public init() {
-        let app = XCUIApplication()
-        passwordTextField = app.secureTextFields[ElementStringIDs.passwordTextField]
-        continueButton = app.buttons[ElementStringIDs.continueButton]
-
-        super.init(element: passwordTextField)
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            // // swiftlint:disable:next opening_brace
+            expectedElementGetters: [ { $0.secureTextFields["Password"] } ],
+            app: app
+        )
     }
 
     public func proceedWith(password: String) -> LoginEpilogueScreen {
@@ -37,18 +30,20 @@ public class PasswordScreen: BaseScreen {
         //
         // Calling passwordTextField.doubleTap() prevents tests from failing by ensuring that the text field's
         // secureTextEntry property remains 'true'.
+        let passwordTextField = expectedElement
         passwordTextField.doubleTap()
 
         passwordTextField.typeText(password)
+        let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
         if continueButton.exists && !continueButton.isHittable {
-            waitFor(element: continueButton, predicate: "isEnabled == true")
+            XCTAssertEqual(continueButton.waitFor(predicateString: "isEnabled == true"), .completed)
         }
         return self
     }
 
     public func verifyLoginError() -> PasswordScreen {
-        let errorLabel = app.cells[ElementStringIDs.errorLabel]
+        let errorLabel = app.cells["Password Error"]
         _ = errorLabel.waitForExistence(timeout: 2)
 
         XCTAssertTrue(errorLabel.exists)
@@ -56,6 +51,6 @@ public class PasswordScreen: BaseScreen {
     }
 
     public static func isLoaded() -> Bool {
-        return XCUIApplication().buttons[ElementStringIDs.continueButton].exists
+        (try? PasswordScreen().isLoaded) ?? false
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -5,7 +5,7 @@ public class PasswordScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            // // swiftlint:disable:next opening_brace
+            // swiftlint:disable:next opening_brace
             expectedElementGetters: [ { $0.secureTextFields["Password"] } ],
             app: app
         )

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PrologueScreen.swift
@@ -28,10 +28,10 @@ public class PrologueScreen: ScreenObject {
         return try GetStartedScreen()
     }
 
-    public func selectSiteAddress() -> LoginSiteAddressScreen {
+    public func selectSiteAddress() throws -> LoginSiteAddressScreen {
         siteAddressButton.tap()
 
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 
     public static func isLoaded(app: XCUIApplication = XCUIApplication()) -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -26,10 +26,10 @@ public class WelcomeScreen: ScreenObject {
         return try WelcomeScreenSignupComponent()
     }
 
-    public func selectLogin() -> WelcomeScreenLoginComponent {
+    public func selectLogin() throws -> WelcomeScreenLoginComponent {
         logInButton.tap()
 
-        return WelcomeScreenLoginComponent()
+        return try WelcomeScreenLoginComponent()
     }
 
     static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -1,31 +1,32 @@
+import ScreenObject
 import XCTest
 
 // TODO: remove when unifiedAuth is permanent.
 
-private struct ElementStringIDs {
-    static let emailLoginButton = "Log in with Email Button"
-    static let siteAddressButton = "Self Hosted Login Button"
-}
+public class WelcomeScreenLoginComponent: ScreenObject {
 
-public class WelcomeScreenLoginComponent: BaseScreen {
-    let emailLoginButton: XCUIElement
-    let siteAddressButton: XCUIElement
+    let emailLoginButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Log in with Email Button"]
+    }
+    let siteAddressButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Self Hosted Login Button"]
+    }
 
-    init() {
-        emailLoginButton = XCUIApplication().buttons[ElementStringIDs.emailLoginButton]
-        siteAddressButton = XCUIApplication().buttons[ElementStringIDs.siteAddressButton]
-
-        super.init(element: emailLoginButton)
+    init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [emailLoginButtonGetter, siteAddressButtonGetter],
+            app: app
+        )
     }
 
     public func selectEmailLogin() throws -> LoginEmailScreen {
-        emailLoginButton.tap()
+        emailLoginButtonGetter(app).tap()
 
         return try LoginEmailScreen()
     }
 
     func goToSiteAddressLogin() -> LoginSiteAddressScreen {
-        siteAddressButton.tap()
+        siteAddressButtonGetter(app).tap()
 
         return LoginSiteAddressScreen()
     }

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -25,9 +25,9 @@ public class WelcomeScreenLoginComponent: ScreenObject {
         return try LoginEmailScreen()
     }
 
-    func goToSiteAddressLogin() -> LoginSiteAddressScreen {
+    func goToSiteAddressLogin() throws -> LoginSiteAddressScreen {
         siteAddressButtonGetter(app).tap()
 
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -24,10 +24,10 @@ public class MySitesScreen: ScreenObject {
         )
     }
 
-    public func addSelfHostedSite() -> LoginSiteAddressScreen {
+    public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
         plusButtonGetter(app).tap()
         app.buttons["Add self-hosted site"].tap()
-        return LoginSiteAddressScreen()
+        return try LoginSiteAddressScreen()
     }
 
     public func closeModal() throws -> MySiteScreen {

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -65,10 +65,6 @@ public struct EditorScreen {
         return XCUIApplication().navigationBars[aztecEditorElement].exists
     }
 
-    private var aztecEditor: AztecEditorScreen {
-        return AztecEditorScreen(mode: .rich)
-    }
-
     func dismissDialogsIfNeeded() throws {
         guard let blockEditor = try? BlockEditorScreen() else { return }
 
@@ -80,8 +76,8 @@ public struct EditorScreen {
             blockEditor.closeEditor()
         }
 
-        if isAztecEditor {
-            self.aztecEditor.closeEditor()
+        if let aztecEditor = try? AztecEditorScreen(mode: .rich) {
+            aztecEditor.closeEditor()
         }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -48,12 +48,12 @@ public class TabNavComponent: ScreenObject {
         return try MySiteScreen()
     }
 
-    public func gotoAztecEditorScreen() throws -> AztecEditorScreen {
+    public func goToAztecEditorScreen() throws -> AztecEditorScreen {
         let mySiteScreen = try goToMySiteScreen()
         let actionSheet = try mySiteScreen.gotoCreateSheet()
         actionSheet.goToBlogPost()
 
-        return AztecEditorScreen(mode: .rich)
+        return try AztecEditorScreen(mode: .rich)
     }
 
     public func gotoBlockEditorScreen() throws -> BlockEditorScreen {

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -11,7 +11,7 @@ class EditorAztecTests: XCTestCase {
         editorScreen = try EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()
-            .tabBar.gotoAztecEditorScreen()
+            .tabBar.goToAztecEditorScreen()
             .dismissNotificationAlertIfNeeded(.accept)
     }
 


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/17221, https://github.com/wordpress-mobile/WordPress-iOS/pull/17348, #17359, #17360, and #17361.

~~This might actually be the _last_ one 😅 .~~ I forgot about a couple more screens.

If the UI tests pass on both CircleCI and Buildkite, we should be good to merge.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
