### PR TITLE
Reader Comments: Handle content cell action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -12,13 +12,13 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     /// A closure that's called when the accessory button is tapped.
     /// The button's view is sent as the closure's parameter for reference.
-    var accessoryButtonAction: ((UIView) -> Void)? = nil
+    @objc var accessoryButtonAction: ((UIView) -> Void)? = nil
 
-    var replyButtonAction: (() -> Void)? = nil
+    @objc var replyButtonAction: (() -> Void)? = nil
 
-    var likeButtonAction: (() -> Void)? = nil
+    @objc var likeButtonAction: (() -> Void)? = nil
 
-    var contentLinkTapAction: ((URL) -> Void)? = nil
+    @objc var contentLinkTapAction: ((URL) -> Void)? = nil
 
     /// When set to true, the cell will always hide the moderation bar regardless of the user's moderating capabilities.
     var hidesModerationBar: Bool = false {
@@ -154,6 +154,16 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     }
 
     // MARK: Lifecycle
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        // reset all button actions.
+        accessoryButtonAction = nil
+        replyButtonAction = nil
+        likeButtonAction = nil
+        contentLinkTapAction = nil
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1194,6 +1194,10 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
             [weakSelf didTapLikeForComment:comment atIndexPath:indexPath];
         };
 
+        cell.contentLinkTapAction = ^(NSURL * _Nonnull url) {
+            [weakSelf interactWithURL:url];
+        };
+
         return;
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1036,6 +1036,34 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                     sourceBarButtonItem:self.navigationItem.rightBarButtonItem];
 }
 
+- (void)didTapReplyAtIndexPath:(NSIndexPath *)indexPath
+{
+    if (!indexPath) {
+        return;
+    }
+
+    // if a row is already selected don't allow selection of another
+    if (self.replyTextView.isFirstResponder) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-result"
+        [self.replyTextView resignFirstResponder];
+#pragma clang diagnostic pop
+        return;
+    }
+
+    if (!self.canComment) {
+        return;
+    }
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-result"
+    [self.replyTextView becomeFirstResponder];
+#pragma clang diagnostic pop
+
+    self.indexPathForCommentRepliedTo = indexPath;
+    [self.tableView selectRowAtIndexPath:self.indexPathForCommentRepliedTo animated:YES scrollPosition:UITableViewScrollPositionTop];
+    [self refreshReplyTextViewPlaceholder];
+}
 
 #pragma mark - Sync methods
 
@@ -1131,10 +1159,18 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
 
     if ([self newCommentThreadEnabled]) {
-        [self configureContentCell:aCell comment:comment tableView:self.tableView];
+        CommentContentTableViewCell *cell = (CommentContentTableViewCell *)aCell;
+        [self configureContentCell:cell comment:comment tableView:self.tableView];
 
         // show separator when the comment is the "last leaf" of its top-level comment.
-        aCell.separatorInset = [self shouldShowSeparatorForIndexPath:indexPath] ? UIEdgeInsetsZero : self.hiddenSeparatorInsets;
+        cell.separatorInset = [self shouldShowSeparatorForIndexPath:indexPath] ? UIEdgeInsetsZero : self.hiddenSeparatorInsets;
+
+        // configure button actions.
+        __weak __typeof(self) weakSelf = self;
+
+        cell.replyButtonAction = ^{
+            [weakSelf didTapReplyAtIndexPath:indexPath];
+        };
 
         return;
     }
@@ -1303,27 +1339,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)cell:(ReaderCommentCell *)cell didTapReply:(Comment *)comment
 {
-    // if a row is already selected don't allow selection of another
-    if (self.replyTextView.isFirstResponder) {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-result"
-        [self.replyTextView resignFirstResponder];
-#pragma clang diagnostic pop
-        return;
-    }
-
-    if (!self.canComment) {
-        return;
-    }
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wunused-result"
-    [self.replyTextView becomeFirstResponder];
-#pragma clang diagnostic pop
-
-    self.indexPathForCommentRepliedTo = [self.tableViewHandler.resultsController indexPathForObject:comment];
-    [self.tableView selectRowAtIndexPath:self.indexPathForCommentRepliedTo animated:YES scrollPosition:UITableViewScrollPositionTop];
-    [self refreshReplyTextViewPlaceholder];
+    [self didTapReplyAtIndexPath:[self.tableViewHandler.resultsController indexPathForObject:comment]];
 }
 
 - (void)cell:(ReaderCommentCell *)cell didTapLike:(Comment *)comment


### PR DESCRIPTION
Refs #17476

This adds functionality for the Reply and Like buttons when tapped. Additionally, when tapping links in the comment body, the destination URL should be presented in a web view. Some notes:

- When tapping the Reply button, it's not yet highlighted (as per the design). I'm confirming the exact colors just to be sure since the screen doesn't exist yet in Zeplin. Ref: `pbArwn-2ks#comment-4426`.
- Note that in the current implementation, like/unlike action is tracked after the network request succeeds. I'm planning to change this behavior in future PRs, such that the action is tracked regardless of the request result (similar to the comment detail in site comments). I'll also take a look later if an additional `commentID` parameter is needed, since currently only `siteID` and `postID` are tracked.
- As for the accessory button, I'll do it in a separate PR.

## To test

#### Reply functionality

- Ensure that the `newCommentThread` flag is enabled.
- Go to Reader > select any comment thread.
- Tap a Reply button on any comment.
- 🔍 Verify that the reply text view placeholder is updated with the comment author's name.
- Send the reply.
- 🔍 Verify that a new reply comment is added in the correct position.

#### Like functionality

- Tap the Like button on an unliked comment.
- 🔍 Verify that the Like button image is now highlighted and shows the correct number of likes.
- Go back to Reader, and enter the comment thread again.
- 🔍 Verify that the Like button for the previous comment is highlighted and still shows the correct number.
- Tap the Like button again to unlike.
- 🔍 Verify that the Like button image is now returned to its default state, and shows the correct number of likes.
- Go back to Reader, and enter the comment thread again.
- 🔍 Verify that the Like button for the previous comment is not highlighted and still shows the correct number.
- Switch the device to airplane mode (or turn off your wifi if using a Simulator).
- Tap on the Like button.
- 🔍 Verify that the app shows an alert, and the Like button remains unchanged.

#### Content links functionality

- (Don't forget to turn your connection on again! 😄 )
- Select any comment that contains a link, and tap the link.
- 🔍 Verify that a web view is presented, showing the contents of the link.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
