### PR TITLE
Reader Comments: Overflow dropdown menu

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -69,7 +69,7 @@ public class Comment: NSManagedObject {
 
     /// Convenience method to check if the current user can actually moderate.
     /// `canModerate` is only applicable when the site is dotcom-related (hosted or atomic). For self-hosted sites, default to true.
-    func allowsModeration() -> Bool {
+    @objc func allowsModeration() -> Bool {
         if let _ = post as? ReaderPost {
             return canModerate
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -77,7 +77,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var nameLabel: UILabel!
     @IBOutlet private weak var badgeLabel: BadgeLabel!
     @IBOutlet private weak var dateLabel: UILabel!
-    @IBOutlet private weak var accessoryButton: UIButton!
+    @IBOutlet private(set) weak var accessoryButton: UIButton!
 
     @IBOutlet private weak var webView: WKWebView!
     @IBOutlet private weak var webViewHeightConstraint: NSLayoutConstraint!

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1083,6 +1083,33 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     }];
 }
 
+- (void)presentMenuForComment:(Comment *)comment fromView:(UIView *)sourceView
+{
+    // create context menu.
+
+    UIAction *unapproveAction = [UIAction actionWithTitle:NSLocalizedString(@"Unapprove", @"Unapproves a comment")
+                                                    image:[UIImage systemImageNamed:@"x.circle"]
+                                               identifier:nil
+                                                  handler:^(__kindof UIAction * _Nonnull action) {
+        // TODO: Unapprove comment.
+    }];
+
+    UIAction *spamAction = [UIAction actionWithTitle:NSLocalizedString(@"Spam", @"Marks comment as spam")
+                                               image:[UIImage systemImageNamed:@"exclamationmark.octagon"]
+                                          identifier:nil
+                                             handler:^(__kindof UIAction * _Nonnull action) {
+        // TODO: Spam comment.
+    }];
+
+    UIAction *trashAction = [UIAction actionWithTitle:NSLocalizedString(@"Trash", @"Trashes the comment")
+                                                image:[UIImage systemImageNamed:@"trash"]
+                                           identifier:nil
+                                              handler:^(__kindof UIAction * _Nonnull action) {
+        // TODO: Trash comment.
+    }];
+
+}
+
 #pragma mark - Sync methods
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
@@ -1185,6 +1212,14 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
         // configure button actions.
         __weak __typeof(self) weakSelf = self;
+
+        cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
+            if ([comment allowsModeration]) {
+                // TODO: Show menu in iOS 13.
+            } else {
+                [self shareComment:comment sourceView:sourceView];
+            }
+        };
 
         cell.replyButtonAction = ^{
             [weakSelf didTapReplyAtIndexPath:indexPath];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1083,33 +1083,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     }];
 }
 
-- (void)presentMenuForComment:(Comment *)comment fromView:(UIView *)sourceView
-{
-    // create context menu.
-
-    UIAction *unapproveAction = [UIAction actionWithTitle:NSLocalizedString(@"Unapprove", @"Unapproves a comment")
-                                                    image:[UIImage systemImageNamed:@"x.circle"]
-                                               identifier:nil
-                                                  handler:^(__kindof UIAction * _Nonnull action) {
-        // TODO: Unapprove comment.
-    }];
-
-    UIAction *spamAction = [UIAction actionWithTitle:NSLocalizedString(@"Spam", @"Marks comment as spam")
-                                               image:[UIImage systemImageNamed:@"exclamationmark.octagon"]
-                                          identifier:nil
-                                             handler:^(__kindof UIAction * _Nonnull action) {
-        // TODO: Spam comment.
-    }];
-
-    UIAction *trashAction = [UIAction actionWithTitle:NSLocalizedString(@"Trash", @"Trashes the comment")
-                                                image:[UIImage systemImageNamed:@"trash"]
-                                           identifier:nil
-                                              handler:^(__kindof UIAction * _Nonnull action) {
-        // TODO: Trash comment.
-    }];
-
-}
-
 #pragma mark - Sync methods
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -75,9 +75,49 @@ import UIKit
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
         cell.accessoryButtonType = comment.allowsModeration() ? .ellipsis : .share
         cell.hidesModerationBar = true
+
+        // if the comment can be moderated, show the context menu when tapping the accessory button.
+        // Note that accessoryButtonAction will be ignored when the menu is assigned.
+        if #available (iOS 14.0, *) {
+            cell.accessoryButton.showsMenuAsPrimaryAction = comment.allowsModeration()
+            cell.accessoryButton.menu = comment.allowsModeration() ? menu(for: comment, tableView: tableView, sourceView: cell.accessoryButton) : nil
+        }
+
         cell.configure(with: comment) { _ in
             tableView.performBatchUpdates({})
         }
+    }
+
+    func shareComment(_ comment: Comment, sourceView: UIView) {
+        guard let commentURL = comment.commentURL() else {
+            return
+        }
+
+        let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = sourceView
+        present(activityViewController, animated: true, completion: nil)
+    }
+
+    func menu(for comment: Comment, tableView: UITableView, sourceView: UIView) -> UIMenu {
+        return UIMenu(title: "", options: .displayInline, children: [
+            ReaderCommentMenu.unapprove.action {
+                // TODO: Unapprove comment
+            },
+            ReaderCommentMenu.spam.action {
+                // TODO: Spam comment
+            },
+            ReaderCommentMenu.trash.action {
+                // TODO: Trash comment
+            },
+            UIMenu(title: "", options: .displayInline, children: [
+                ReaderCommentMenu.edit.action {
+                    // TODO: Edit comment
+                },
+                ReaderCommentMenu.share.action { [weak self] in
+                    self?.shareComment(comment, sourceView: sourceView)
+                }
+            ])
+        ])
     }
 }
 
@@ -88,5 +128,49 @@ private extension ReaderCommentsViewController {
 
         static let authorBadgeText = NSLocalizedString("Author", comment: "Title for a badge displayed beside the comment writer's name. "
                                                        + "Shown when the comment is written by the post author.")
+    }
+
+    enum ReaderCommentMenu {
+        case unapprove
+        case spam
+        case trash
+        case edit
+        case share
+
+        var title: String {
+            switch self {
+            case .unapprove:
+                return NSLocalizedString("Unapprove", comment: "Unapproves a comment")
+            case .spam:
+                return NSLocalizedString("Spam", comment: "Marks comment as spam")
+            case .trash:
+                return NSLocalizedString("Trash", comment: "Trashes the comment")
+            case .edit:
+                return NSLocalizedString("Edit", comment: "Edits the comment")
+            case .share:
+                return NSLocalizedString("Share", comment: "Shares the comment URL")
+            }
+        }
+
+        var image: UIImage? {
+            switch self {
+            case .unapprove:
+                return .init(systemName: "x.circle")
+            case .spam:
+                return .init(systemName: "exclamationmark.octagon")
+            case .trash:
+                return .init(systemName: "trash")
+            case .edit:
+                return .init(systemName: "pencil")
+            case .share:
+                return .init(systemName: "square.and.arrow.up")
+            }
+        }
+
+        func action(handler: @escaping () -> Void) -> UIAction {
+            return UIAction(title: title, image: image) { _ in
+                handler()
+            }
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -142,9 +142,9 @@ private extension ReaderCommentsViewController {
             case .unapprove:
                 return NSLocalizedString("Unapprove", comment: "Unapproves a comment")
             case .spam:
-                return NSLocalizedString("Spam", comment: "Marks comment as spam")
+                return NSLocalizedString("Mark as Spam", comment: "Marks comment as spam")
             case .trash:
-                return NSLocalizedString("Trash", comment: "Trashes the comment")
+                return NSLocalizedString("Move to Trash", comment: "Trashes the comment")
             case .edit:
                 return NSLocalizedString("Edit", comment: "Edits the comment")
             case .share:


### PR DESCRIPTION
Refs #17475 
Depends on #17600

This PR adds the overflow dropdown menu when the content cell's accessory button is tapped while using an account with moderation roles. Some notes:

- Please note that showing a context menu (i.e. `UIMenu`) on tap is only supported in iOS 14 and above. This can be achieved by setting the `showsMenuAsPrimaryAction` to `true` and assigning a `UIMenu` to the `menu` property of `UIButton`. Currently, tapping on the ellipsis button does nothing in iOS 13. I'll need to come up with a fallback implementation for iOS 13, and will address this in a separate PR.
- Most of the tap actions are not yet implemented (except the Share button). This will be addressed in a separate PR.

![Simulator Screen Shot - iPhone 12 - 2021-11-30 at 23 55 15](https://user-images.githubusercontent.com/1299411/144092339-e9422c76-1fa6-4882-8c18-853e388e1e89.png)

## To Test

Ensure that the `newCommentThread` flag is enabled.

#### With a moderator account:

- Go to Reader > any comment thread (from a site that you can moderate).
- Tap on the ellipsis button on any comment.
- 🔍 Verify that the context menu is correctly shown and anchored to the accessory view, with all the correct menu items.
- Tap on the Share menu.
- 🔍 Verify that a share sheet is presented, containing the comment's URL.

Note: As noted above, in iOS 13.0, tapping on the ellipsis button will do nothing for now.

#### With a non-moderator account:

- Go to Reader > any comment thread.
- Tap on the Share button on any comment.
- 🔍 Verify that a share sheet is presented, containing the comment's URL.

## Regression Notes
1. Potential unintended areas of impact
n/a. The feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. The feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. The feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
