### PR TITLE
Tweak UI tests to attempt addressing inconsistent failures

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -130,8 +130,8 @@ public class BlockEditorScreen: ScreenObject {
     }
 
     private func addBlock(_ blockLabel: String) {
-        let blockButton = app.buttons[blockLabel]
         addBlockButton.tap()
+        let blockButton = app.buttons[blockLabel]
         XCTAssertTrue(blockButton.waitForIsHittable(timeout: 3))
         blockButton.tap()
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -91,12 +91,11 @@ public class BlockEditorScreen: ScreenObject {
             editorCloseButton.tap()
 
             XCTContext.runActivity(named: "Discard any local changes") { (activity) in
-                let notSavedState = app.staticTexts["You have unsaved changes."]
-                if notSavedState.exists {
-                    Logger.log(message: "Discarding unsaved changes", event: .v)
-                    let discardButton = app.buttons["Discard"] // Uses a localized string
-                    discardButton.tap()
-                }
+                guard app.staticTexts["You have unsaved changes."].waitForIsHittable(timeout: 3) else { return }
+
+                Logger.log(message: "Discarding unsaved changes", event: .v)
+                let discardButton = app.buttons["Discard"] // Uses a localized string
+                discardButton.tap()
             }
 
             let editorNavBar = app.navigationBars["Gutenberg Editor Navigation Bar"]
@@ -134,6 +133,19 @@ public class BlockEditorScreen: ScreenObject {
         let blockButton = app.buttons[blockLabel]
         XCTAssertTrue(blockButton.waitForIsHittable(timeout: 3))
         blockButton.tap()
+    }
+
+    /// Some tests might fail during the block picking flow. In such cases, we need to dismiss the
+    /// block picker itself before being able to interact with the rest of the app again.
+    public func dismissBlocksPickerIfNeeded() {
+        // Determine whether the block picker is on screen using the visibility of the add block
+        // button as a proxy
+        guard addBlockButton.isFullyVisibleOnScreen == false else { return }
+
+        // Dismiss the block picker by swiping down
+        app.swipeDown()
+
+        XCTAssertTrue(addBlockButton.waitForIsHittable(timeout: 3))
     }
 
     /*

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -25,8 +25,8 @@ class EditorGutenbergTests: XCTestCase {
 
     func testTextPostPublish() throws {
 
-        let title = getRandomPhrase()
-        let content = getRandomContent()
+        let title = "Text post title"
+        let content = "Text post content"
         try editorScreen
             .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
@@ -39,8 +39,8 @@ class EditorGutenbergTests: XCTestCase {
 
     func testBasicPostPublish() throws {
 
-        let title = getRandomPhrase()
-        let content = getRandomContent()
+        let title = "Rich post title"
+        let content = "Some text, and more text"
         let category = getCategory()
         let tag = getTag()
         try editorScreen

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -15,7 +15,9 @@ class EditorGutenbergTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
+
         if editorScreen != nil && !TabNavComponent.isVisible() {
+            editorScreen.dismissBlocksPickerIfNeeded()
             EditorFlow.returnToMainEditorScreen()
             editorScreen.closeEditor()
         }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -24,10 +24,10 @@ extension XCTestCase {
     }
 
     public func takeScreenshotOfFailedTest() {
-        if let failureCount = testRun?.failureCount, failureCount > 0 {
-            XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { (activity) in
-                add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
-            }
+        guard let failuresCount = testRun?.failureCount, failuresCount > 0 else { return }
+
+        XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { activity in
+            add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
         }
     }
 


### PR DESCRIPTION
I've seen quite a few UI tests failures in CI over the past couple of weeks, e.g. [this](https://buildkite.com/wordpress-mobile/wordpress-ios/builds/3872) and [this](https://app.circleci.com/pipelines/github/wordpress-mobile/WordPress-iOS/26094/workflows/54c60844-a868-4955-b857-f5c3ffdbc48e/jobs/61817).

Based on the CI logs, I tracked down some of them to the editor block picker being still on screen after a test failure and hijacking the rest of the tests.

<img width="300" alt="Screen Shot 2021-12-01 at 9 25 49 am" src="https://user-images.githubusercontent.com/1218433/144179381-db03bf43-f783-4866-a244-381b173b77b9.png">
 
These changes are an attempt to make the tests robust against this kind of failure.

I developed them by forcing a failure in the `addBlock(_:)` method:

```diff
@@ -131,7 +131,7 @@ public class BlockEditorScreen: ScreenObject {
     private func addBlock(_ blockLabel: String) {
         addBlockButton.tap()
         let blockButton = app.buttons[blockLabel]
-        XCTAssertTrue(blockButton.waitForIsHittable(timeout: 3))
+        XCTAssertFalse(blockButton.waitForIsHittable(timeout: 3))
         blockButton.tap()
     }
```