### PR TITLE
Onboarding Improvements: Don't show quick start for P2s

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
@@ -10,6 +10,14 @@ final class QuickStartSettings {
         self.userDefaults = userDefaults
     }
 
+    // MARK: - Quick Start availability
+
+    func isQuickStartAvailable(for blog: Blog) -> Bool {
+        return blog.isUserCapableOf(.ManageOptions) &&
+            blog.isUserCapableOf(.EditThemeOptions) &&
+            !blog.isWPForTeams()
+    }
+
     // MARK: - User Defaults Storage
 
     func promptWasDismissed(for blog: Blog) -> Bool {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -353,6 +353,11 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 return
             }
 
+            guard self.quickStartSettings.isQuickStartAvailable(for: blog) else {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                return
+            }
+
             self.presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissQuickStartPrompt)
         }
 


### PR DESCRIPTION
Part of #17383

## Context

Android does not show the quick start prompt when a user selects a P2 from the Login Epilogue, but iOS does

Slack ref: p1638355030019800-slack-C027K4MNPGQ


## Description

This PR updates the logic for showing / not showing the Quick Start prompt when a user selects a site from the Login Epilogue screen.

The quick start availability logic is now aligned with Android
```
    @JvmStatic
    fun isQuickStartAvailableForTheSite(siteModel: SiteModel): Boolean {
        return (siteModel.hasCapabilityManageOptions &&
                themeBrowserUtils.isAccessible(siteModel) &&
                SiteUtils.isAccessedViaWPComRest(siteModel))
    }
```

https://github.com/wordpress-mobile/WordPress-Android/blob/c02191f5b7dfb82845f8c85585d971211988aa7c/WordPress/src/main/java/org/wordpress/android/util/QuickStartUtils.kt#L196-L201

## How to test

### P2 site
1. Do a clean install
2. Log in to an account w a p2 site
3. Tap on a p2 site in the Login Epilogue
4. ✅ The quick start prompt isn't shown

### Non-P2 site
1. Do a clean install
2. Log in to an account w a non p2 site
3. Tap on a non p2 site in the Login Epilogue
4. ✅ The quick start prompt is shown

## Regression Notes
1. Potential unintended areas of impact
Login Epilogue

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above steps

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.