### PR TITLE
Fix Reader detail headers with featured images on iOS 15

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -160,6 +160,11 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         _readerNavigationController.navigationBar.translucent = NO;
         _readerNavigationController.view.backgroundColor = [UIColor murielBasicBackground];
 
+        // Set a clear scroll edge background to allow for featured images that extend behind the navigation area.
+        UINavigationBarAppearance *appearance =_readerNavigationController.navigationBar.scrollEdgeAppearance;
+        appearance.backgroundColor = [UIColor clearColor];
+        _readerNavigationController.navigationBar.scrollEdgeAppearance = appearance;
+
         UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
         _readerNavigationController.tabBarItem.image = readerTabBarImage;
         _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;


### PR DESCRIPTION
This PR fixes an issue where Reader Detail navigation bars for posts with featured images were white, which meant that buttons on the bar weren't visible.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 11 54 25](https://user-images.githubusercontent.com/4780/144242848-80e95f29-1f90-47fa-8301-94f912036740.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-11-30 at 11 54 27](https://user-images.githubusercontent.com/4780/144242874-1c6566b7-ec65-46c3-b386-f90d771e5430.png) |

**To test**

* Build and run
* In Reader, head to Discover and find a post with a featured image at the top. Ensure that the navigation bar is clear and you can see the buttons.
* Test on iOS 14 as well as 15 to check everything still looks as it should.
* Double check some other areas of the Reader to see that this hasn't broken anything else there.

## Regression Notes

1. Potential unintended areas of impact

Other navigation bars in the Reader.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually checked through various sections of the Reader to see that the navigation bar still looked as I expected.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
