### PR TITLE
Adds tracking to the Add Site buttons

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -289,6 +289,8 @@ import Foundation
     // Preview WebKitView
     case previewWebKitViewDeviceChanged
 
+    case addSiteAlertDisplayed
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -777,6 +779,9 @@ import Foundation
 
         case .previewWebKitViewDeviceChanged:
             return "preview_webkitview_device_changed"
+
+        case .addSiteAlertDisplayed:
+            return "add_site_alert_displayed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
@@ -7,6 +7,7 @@ class AddSiteAlertFactory: NSObject {
 
     @objc
     func makeAddSiteAlert(
+        source: String?,
         canCreateWPComSite: Bool,
         createWPComSite: @escaping () -> Void,
         addSelfHostedSite: @escaping () -> Void) -> UIAlertController {
@@ -19,6 +20,8 @@ class AddSiteAlertFactory: NSObject {
 
         alertController.addAction(addSelfHostedSiteAction(handler: addSelfHostedSite))
         alertController.addAction(cancelAction())
+
+        WPAnalytics.track(.addSiteAlertDisplayed, properties: ["source": source ?? "unknown"])
 
         return alertController
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
@@ -6,6 +6,6 @@ extension BlogListViewController {
             return
         }
         present(wizard, animated: true)
-        WPAnalytics.track(.enhancedSiteCreationAccessed)
+        WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "my_sites"])
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -995,13 +995,15 @@ static NSInteger HideSearchMinSites = 3;
         [self setEditing:YES animated:YES];
     } else {
         AddSiteAlertFactory *factory = [AddSiteAlertFactory new];
-        UIAlertController *alertController = [factory makeAddSiteAlertWithCanCreateWPComSite:[self defaultWordPressComAccount]
-                                                                             createWPComSite:^{
+        BOOL canCreateWPComSite = [self defaultWordPressComAccount] ? YES : NO;
+        UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site"
+                                                              canCreateWPComSite:canCreateWPComSite
+                                                                 createWPComSite:^{
             [self launchSiteCreation];
         } addSelfHostedSite:^{
             [self showLoginControllerForAddingSelfHostedSite];
         }];
-        
+
         if ([source isKindOfClass:[UIView class]]) {
             UIView *sourceView = (UIView *)source;
             alertController.popoverPresentationController.sourceView = sourceView;

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -280,7 +280,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     func presentInterfaceForAddingNewSite() {
-        
         let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites", canCreateWPComSite: defaultAccount() != nil) { [weak self] in
             self?.launchSiteCreation(source: "my_site_no_sites")
         } addSelfHostedSite: {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -78,7 +78,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func subscribeToPostSignupNotifications() {
-        NotificationCenter.default.addObserver(self, selector: #selector(launchSiteCreation), name: .createSite, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(launchSiteCreationFromNotification), name: .createSite, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
     }
 
@@ -280,8 +280,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     func presentInterfaceForAddingNewSite() {
-        let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(canCreateWPComSite: defaultAccount() != nil) { [weak self] in
-            self?.launchSiteCreation()
+        
+        let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites", canCreateWPComSite: defaultAccount() != nil) { [weak self] in
+            self?.launchSiteCreation(source: "my_site_no_sites")
         } addSelfHostedSite: {
             WordPressAuthenticator.showLoginForSelfHostedSite(self)
         }
@@ -298,13 +299,17 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     @objc
-    func launchSiteCreation() {
+    func launchSiteCreationFromNotification() {
+        self.launchSiteCreation(source: "post_signup")
+    }
+
+    func launchSiteCreation(source: String) {
         let wizardLauncher = SiteCreationWizardLauncher()
         guard let wizard = wizardLauncher.ui else {
             return
         }
         present(wizard, animated: true)
-        WPAnalytics.track(.enhancedSiteCreationAccessed)
+        WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -300,7 +300,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     func launchSiteCreationFromNotification() {
-        self.launchSiteCreation(source: "post_signup")
+        self.launchSiteCreation(source: "signup_epilogue")
     }
 
     func launchSiteCreation(source: String) {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -389,6 +389,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             }
 
             navigationController.present(wizard, animated: true)
+            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "login_epilogue"])
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -146,7 +146,7 @@ class MySitesCoordinator: NSObject {
 
     func showSiteCreation() {
         showRootViewController()
-        mySiteViewController.launchSiteCreation()
+        mySiteViewController.launchSiteCreation(source: "my_site")
     }
 
     @objc


### PR DESCRIPTION
Project: #17503 

### Description
This adds a new event when the Add Site Alert is displayed that includes a source of where it was tapped from. This also modifies the `enhancedSiteCreationAccessed` event to include a source.

### To test:

1. Login to an account with sites added
2. Once you're logged in tap on the My Site tab
3. Tap on the down arrow to open the site switcher
4. Tap the + button
5. Verify you see: `🔵 Tracked: add_site_alert_displayed <source: my_site>`
6. Tap on the 'Create a WP.com Site' button
7. Verify you see `🔵 Tracked: enhanced_site_creation_accessed <source: my_sites>`
8. Exit out of the flow
9. Logout, and sign back into your account
10. Once you reach the new Login Epilogue to select a primary site, tap the 'Create Site'  button at the bottom
11. `🔵 Tracked: enhanced_site_creation_accessed <source: login_epilogue>`
12. Finish the flow, and logout again
13. Create a new account
14. Once you get to the post sign up epilogue view, tap the 'Create a WP.com site' button
15. Verify you see `🔵 Tracked: enhanced_site_creation_accessed <source: signup_epilogue>`
16. Exit out of the site creation flow
17. Tap on the My Site view
18. Tap on the 'Add Site' button
19. Verify you see: `🔵 Tracked: add_site_alert_displayed <source: my_site_no_sites>`

### Regression Notes
1. Potential unintended areas of impact
Objective-C null values being passed to nonnull Swift function.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Made the swift function nullable and added a check `??` check.

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
