### PR TITLE
Reader post comments: align content 

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -219,14 +219,21 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Self.resourceURL)
     }
 
-    /// Hide all actions for the comment.
-    /// NOTE: This must be called after configure or these values will be overwritten.
-    /// 
-    func hideAllActions() {
+    /// Configures the cell with a `Comment` object, to be displayed in the post details view.
+    ///
+    /// - Parameters:
+    ///   - comment: The `Comment` object to display.
+    ///   - onContentLoaded: Callback to be called once the content has been loaded. Provides the new content height as parameter.
+    func configureForPostDetails(with comment: Comment, onContentLoaded: ((CGFloat) -> Void)?) {
+        configure(with: comment, onContentLoaded: onContentLoaded)
+
         hidesModerationBar = true
         isCommentLikesEnabled = false
         isCommentReplyEnabled = false
         isAccessoryButtonEnabled = false
+
+        containerStackLeadingConstraint.constant = 0
+        containerStackTrailingConstraint.constant = 0
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -70,8 +70,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var containerStackView: UIStackView!
     @IBOutlet private weak var containerStackBottomConstraint: NSLayoutConstraint!
 
-    // used for indentation
     @IBOutlet private weak var containerStackLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var containerStackTrailingConstraint: NSLayoutConstraint!
+    private var defaultLeadingMargin: CGFloat = 0
 
     @IBOutlet private weak var avatarImageView: CircularImageView!
     @IBOutlet private weak var nameLabel: UILabel!
@@ -301,6 +302,9 @@ private extension CommentContentTableViewCell {
 
     // assign base styles for all the cell components.
     func configureViews() {
+        // Store default margin for use in content layout.
+        defaultLeadingMargin = containerStackLeadingConstraint.constant
+
         selectionStyle = .none
 
         nameLabel?.font = Style.nameFont
@@ -408,7 +412,7 @@ private extension CommentContentTableViewCell {
     }
 
     func updateContainerLeadingConstraint() {
-        containerStackLeadingConstraint?.constant = indentationWidth * CGFloat(indentationLevel)
+        containerStackLeadingConstraint?.constant = (indentationWidth * CGFloat(indentationLevel)) + defaultLeadingMargin
     }
 
     /// Updates the style and text of the Like button.

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -173,10 +173,10 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="hcN-S7-sLG" secondAttribute="trailing" id="2zy-oR-X5O"/>
+                    <constraint firstAttribute="trailing" secondItem="hcN-S7-sLG" secondAttribute="trailing" constant="16" id="2zy-oR-X5O"/>
                     <constraint firstItem="hcN-S7-sLG" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="esQ-oB-yxJ"/>
                     <constraint firstAttribute="bottom" secondItem="hcN-S7-sLG" secondAttribute="bottom" id="jAu-U3-I4N"/>
-                    <constraint firstItem="hcN-S7-sLG" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="uFL-PF-ffo"/>
+                    <constraint firstItem="hcN-S7-sLG" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="uFL-PF-ffo"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -186,6 +186,7 @@
                 <outlet property="badgeLabel" destination="hDo-cU-sWp" id="gVe-4c-TlR"/>
                 <outlet property="containerStackBottomConstraint" destination="jAu-U3-I4N" id="1Hk-Cp-fR5"/>
                 <outlet property="containerStackLeadingConstraint" destination="uFL-PF-ffo" id="6Ah-H9-d0b"/>
+                <outlet property="containerStackTrailingConstraint" destination="2zy-oR-X5O" id="dDR-lB-Nvs"/>
                 <outlet property="containerStackView" destination="hcN-S7-sLG" id="k9D-6a-BmR"/>
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -38,11 +38,10 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                   return UITableViewCell()
               }
 
-        cell.configure(with: comment) { _ in
+        cell.configureForPostDetails(with: comment) { _ in
             tableView.performBatchUpdates({})
         }
 
-        cell.hideAllActions()
         return cell
     }
 


### PR DESCRIPTION
Ref: #17511 , https://github.com/wordpress-mobile/WordPress-iOS/pull/17603#pullrequestreview-820339653

This fixes the content alignment in the Comments table cell so that the comment content is inline with the rest of the table content. 

Since `CommentContentTableViewCell` is used in a few places, I had to change the constraints:
- The container stack view leading and trailing constraints are no longer relative to margin, which means they are now 16 by default instead of 0.
- The leading margin value is now stored when the cell is created and used in the indentation calculation.
- The leading and trailing margins are set to 0 when used for post details.
  - There is now a `configureForPostDetails` method to do all the post details specific configuration.

To test:

---
**Reader post comments:**
- Go to Reader > post with comments > details.
  - Verify the leading and trailing edges of the comment line up with the header and button.

| Before | After |
|--------|-------|
| <img width="471" alt="before" src="https://user-images.githubusercontent.com/1816888/144336940-96b9ae31-895d-44aa-b786-be66d9529ab4.png"> | <img width="472" alt="after" src="https://user-images.githubusercontent.com/1816888/144336930-8e392840-53cb-45e3-bdad-bd1f79d35f99.png"> |

---
**Other comments:**
- Go to My Site > Comments > comment details.
  - Verify the leading and trailing margins are correct.
- Enable `newCommentThread`.
  - Go to Reader > post with comments > comments.
  - Verify the leading and trailing margins are correct.
  - Verify comments are indented correctly.

---
## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
