### PR TITLE
Reader post comments: show no comments view when there are no comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -390,17 +390,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateComments(_ comments: [Comment], totalComments: Int) {
-
-        guard totalComments > 0 else {
-            return
-        }
-
-        // Set the table delegate here, after the totalComments check,
-        // to prevent the table from showing if there are no comments.
-        commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
-        commentsTableView.delegate = commentsTableViewDelegate
-        commentsTableView.dataSource = commentsTableViewDelegate
-
         commentsTableViewDelegate?.comments = comments
         commentsTableViewDelegate?.totalComments = totalComments
         commentsTableViewDelegate?.buttonDelegate = self
@@ -527,6 +516,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                                    forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID)
         commentsTableView.register(CommentContentTableViewCell.defaultNib,
                                    forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
+
+        commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
+        commentsTableView.delegate = commentsTableViewDelegate
+        commentsTableView.dataSource = commentsTableViewDelegate
     }
 
     private func configureRelatedPosts() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -516,6 +516,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                                    forHeaderFooterViewReuseIdentifier: ReaderDetailCommentsHeader.defaultReuseID)
         commentsTableView.register(CommentContentTableViewCell.defaultNib,
                                    forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
+        commentsTableView.register(ReaderDetailNoCommentCell.defaultNib,
+                                   forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID)
 
         commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
         commentsTableView.delegate = commentsTableViewDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1002,6 +1002,6 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
         guard let post = post else {
             return
         }
-        ReaderCommentAction().execute(post: post, origin: self)
+        ReaderCommentAction().execute(post: post, origin: self, promptToAddComment: commentsTableViewDelegate?.comments.count == 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -95,11 +95,6 @@ private extension ReaderDetailCommentsTableViewDelegate {
         return cell
     }
 
-    func configureForNoComment(_ cell: UITableViewCell) -> UITableViewCell {
-        cell.textLabel?.text = Constants.noComments
-        return cell
-    }
-
     struct Constants {
         static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -6,8 +6,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 
     var comments: [Comment] = [] {
         didSet {
-            // Add one for the button row.
-            totalRows = comments.count + 1
+            // If there are no comments, 1 empty cell + 1 button.
+            // Otherwise add 1 for the button.
+            totalRows = comments.count == 0 ? 2 : comments.count + 1
         }
     }
 
@@ -33,16 +34,24 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return showCommentsButtonCell()
         }
 
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell,
-              let comment = comments[safe: indexPath.row] else {
-                  return UITableViewCell()
-              }
+        if let comment = comments[safe: indexPath.row] {
 
-        cell.configureForPostDetails(with: comment) { _ in
-            tableView.performBatchUpdates({})
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
+                return UITableViewCell()
+            }
+
+            cell.configureForPostDetails(with: comment) { _ in
+                tableView.performBatchUpdates({})
+            }
+
+            return cell
         }
 
-        return cell
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ReaderDetailNoCommentCell.defaultReuseID) as? ReaderDetailNoCommentCell else {
+            return UITableViewCell()
+        }
+
+        return configureForNoComment(cell)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -50,8 +59,18 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
-        let titleFormat = totalComments == 1 ? Constants.singularCommentFormat : Constants.pluralCommentsFormat
-        header.titleLabel.text = String(format: titleFormat, totalComments)
+        let title: String = {
+            switch totalComments {
+            case 0:
+                return Constants.comments
+            case 1:
+                return String(format: Constants.singularCommentFormat, totalComments)
+            default:
+                return String(format: Constants.pluralCommentsFormat, totalComments)
+            }
+        }()
+
+        header.titleLabel.text = title
         header.addBottomBorder(withColor: .divider)
         return header
     }
@@ -70,15 +89,24 @@ private extension ReaderDetailCommentsTableViewDelegate {
 
     func showCommentsButtonCell() -> BorderedButtonTableViewCell {
         let cell = BorderedButtonTableViewCell()
-        cell.configure(buttonTitle: Constants.buttonTitle, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
+        let title = comments.count == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
+        cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
         cell.delegate = buttonDelegate
         return cell
     }
 
+    func configureForNoComment(_ cell: UITableViewCell) -> UITableViewCell {
+        cell.textLabel?.text = Constants.noComments
+        return cell
+    }
+
     struct Constants {
-        static let buttonTitle = NSLocalizedString("View All Comments", comment: "Title for button on the post details page to show all comments when tapped.")
+        static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
+        static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
+        static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
         static let singularCommentFormat = NSLocalizedString("%1$d Comment", comment: "Singular label displaying number of comments. %1$d is a placeholder for the number of Comments.")
         static let pluralCommentsFormat = NSLocalizedString("%1$d Comments", comment: "Plural label displaying number of comments. %1$d is a placeholder for the number of Comments.")
+        static let comments = NSLocalizedString("Comments", comment: "Comments table header label.")
         static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -51,7 +51,8 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return UITableViewCell()
         }
 
-        return configureForNoComment(cell)
+        cell.titleLabel.text = Constants.noComments
+        return cell
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -60,7 +60,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
-        let title: String = {
+        header.titleLabel.text = {
             switch totalComments {
             case 0:
                 return Constants.comments
@@ -71,7 +71,6 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             }
         }()
 
-        header.titleLabel.text = title
         header.addBottomBorder(withColor: .divider)
         return header
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class ReaderDetailNoCommentCell: UITableViewCell, NibReusable {
+
+    @IBOutlet weak var titleLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        contentView.backgroundColor = .basicBackground
+        titleLabel.textColor = .textSubtle
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view userInteractionEnabled="NO" contentMode="scaleToFill" id="kPA-oR-TOp" customClass="ReaderDetailNoCommentCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="394" height="69"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
+                    <rect key="frame" x="0.0" y="20" width="394" height="49"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="epR-21-48u"/>
+            <constraints>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="6FS-1m-LFu"/>
+                <constraint firstAttribute="bottom" secondItem="QfN-CJ-PfS" secondAttribute="bottom" id="RVn-Cf-JSe"/>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="VQC-4P-3s7"/>
+                <constraint firstAttribute="trailing" secondItem="QfN-CJ-PfS" secondAttribute="trailing" id="zK3-Y8-YOU"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="titleLabel" destination="QfN-CJ-PfS" id="GBW-w4-V0a"/>
+            </connections>
+            <point key="canvasLocation" x="36.231884057971016" y="81.361607142857139"/>
+        </view>
+    </objects>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1759,6 +1759,10 @@
 		98D52C3222B1CFEC00831529 /* StatsTwoColumnRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98D52C3022B1CFEB00831529 /* StatsTwoColumnRow.swift */; };
 		98D52C3322B1CFEC00831529 /* StatsTwoColumnRow.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98D52C3122B1CFEC00831529 /* StatsTwoColumnRow.xib */; };
 		98D7ECCE23983D0800B87710 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98DE9A9E239835C800A88D01 /* MainInterface.storyboard */; };
+		98DCF4A5275945E00008630F /* ReaderDetailNoCommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DCF4A3275945DF0008630F /* ReaderDetailNoCommentCell.swift */; };
+		98DCF4A6275945E00008630F /* ReaderDetailNoCommentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DCF4A3275945DF0008630F /* ReaderDetailNoCommentCell.swift */; };
+		98DCF4A7275945E00008630F /* ReaderDetailNoCommentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98DCF4A4275945DF0008630F /* ReaderDetailNoCommentCell.xib */; };
+		98DCF4A8275945E00008630F /* ReaderDetailNoCommentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98DCF4A4275945DF0008630F /* ReaderDetailNoCommentCell.xib */; };
 		98E0829F2637545C00537BF1 /* PostService+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E0829E2637545C00537BF1 /* PostService+Likes.swift */; };
 		98E082A02637545C00537BF1 /* PostService+Likes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E0829E2637545C00537BF1 /* PostService+Likes.swift */; };
 		98E419DE2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98E419DD2399B5A700D8C822 /* Tracks+ThisWeekWidget.swift */; };
@@ -6356,6 +6360,8 @@
 		98D31BBC23971F4B009CFF43 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		98D52C3022B1CFEB00831529 /* StatsTwoColumnRow.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTwoColumnRow.swift; sourceTree = "<group>"; };
 		98D52C3122B1CFEC00831529 /* StatsTwoColumnRow.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsTwoColumnRow.xib; sourceTree = "<group>"; };
+		98DCF4A3275945DF0008630F /* ReaderDetailNoCommentCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderDetailNoCommentCell.swift; sourceTree = "<group>"; };
+		98DCF4A4275945DF0008630F /* ReaderDetailNoCommentCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ReaderDetailNoCommentCell.xib; sourceTree = "<group>"; };
 		98DD1EF2263337C400CF0440 /* WordPress 122.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 122.xcdatamodel"; sourceTree = "<group>"; };
 		98DE9A9E239835C800A88D01 /* MainInterface.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainInterface.storyboard; sourceTree = "<group>"; };
 		98E0829E2637545C00537BF1 /* PostService+Likes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "PostService+Likes.swift"; sourceTree = "<group>"; };
@@ -11388,6 +11394,8 @@
 				98ED5962265EBD0000A0B33E /* ReaderDetailLikesListController.swift */,
 				98E54FF1265C972900B4BE9A /* ReaderDetailLikesView.swift */,
 				98E55018265C977E00B4BE9A /* ReaderDetailLikesView.xib */,
+				98DCF4A3275945DF0008630F /* ReaderDetailNoCommentCell.swift */,
+				98DCF4A4275945DF0008630F /* ReaderDetailNoCommentCell.xib */,
 				8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */,
 				8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */,
 				FAC086D525EDFB1E00B94F2A /* ReaderRelatedPostsCell.swift */,
@@ -15294,6 +15302,7 @@
 				C700F9D2257FD63A0090938E /* JetpackScanViewController.xib in Resources */,
 				B5C66B741ACF071F00F68370 /* NoteBlockActionsTableViewCell.xib in Resources */,
 				FAE4CA6A2732C094003BFDFE /* QuickStartPromptViewController.xib in Resources */,
+				98DCF4A7275945E00008630F /* ReaderDetailNoCommentCell.xib in Resources */,
 				F5A34D1125DF2F7F00C9654B /* Pacifico-Regular.ttf in Resources */,
 				FA1CEAD425CA9C40005E7038 /* RestoreStatusFailedView.xib in Resources */,
 				1761F17B26209AEE000815EF /* open-source-icon-app-60x60@2x.png in Resources */,
@@ -15878,6 +15887,7 @@
 				FABB20212602FC2C00C8785C /* ReaderDetailToolbar.xib in Resources */,
 				FABB20222602FC2C00C8785C /* RewindStatusTableViewCell.xib in Resources */,
 				FABB20232602FC2C00C8785C /* PageListSectionHeaderView.xib in Resources */,
+				98DCF4A8275945E00008630F /* ReaderDetailNoCommentCell.xib in Resources */,
 				FABB20242602FC2C00C8785C /* JetpackScanThreatDetailsViewController.xib in Resources */,
 				FABB20252602FC2C00C8785C /* CollabsableHeaderFilterCollectionViewCell.xib in Resources */,
 				FABB20262602FC2C00C8785C /* ReplyTextView.xib in Resources */,
@@ -18074,6 +18084,7 @@
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
 				17F11EDB268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */,
+				98DCF4A5275945E00008630F /* ReaderDetailNoCommentCell.swift in Sources */,
 				F1112AA3255C2D4100F1F746 /* BlogDetailHeader.swift in Sources */,
 				176E194725C465F70058F1C5 /* UnifiedPrologueViewController.swift in Sources */,
 				E60C2ED71DE5075100488630 /* ReaderCommentCell.swift in Sources */,
@@ -19747,6 +19758,7 @@
 				98BAA7C426F925F70073A2F9 /* InlineEditableSingleLineCell.swift in Sources */,
 				FABB22C22602FC2C00C8785C /* PasswordAlertController.swift in Sources */,
 				FABB22C32602FC2C00C8785C /* ReaderTagsFooter.swift in Sources */,
+				98DCF4A6275945E00008630F /* ReaderDetailNoCommentCell.swift in Sources */,
 				FABB22C42602FC2C00C8785C /* ReaderPostCellActions.swift in Sources */,
 				FABB22C52602FC2C00C8785C /* ActivityStore.swift in Sources */,
 				FABB22C62602FC2C00C8785C /* NSAttributedString+WPRichText.swift in Sources */,


### PR DESCRIPTION
Ref: #17511 

When there are no comments:
- The Comments table is shown with a `No comments yet` message.
- The button title is changed to `Be the first to comment`.
- Tapping the button will display the comments view with the reply view as first responder.

Note: There is no design for this in Zeplin. I just emulated the Android example shown in the referenced issue.

To test:
---
- Select a post with no comments. Verify:
  - The Comments table is shown with a `No comments yet` message.
  - The button title is `Be the first to comment`.
  - Tapping the button displays the comments view with the reply view as first responder.

<kbd><img width="472" alt="no_comments" src="https://user-images.githubusercontent.com/1816888/144491186-2e9d6858-2daf-48ca-93f5-43ea89887717.png"></kbd>

<kbd>![reply_prompt](https://user-images.githubusercontent.com/1816888/144491439-c960b9d5-2275-4e54-9d44-3b005edc41ac.png)</kbd>

---
## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
