### PR TITLE
Add more tracking to the Change Username flow

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -264,6 +264,7 @@ import Foundation
     // Notifications
     case notificationsPreviousTapped
     case notificationsNextTapped
+
     // Sharing Buttons
     case sharingButtonsEditSharingButtonsToggled
     case sharingButtonsEditMoreButtonToggled
@@ -289,7 +290,13 @@ import Foundation
     // Preview WebKitView
     case previewWebKitViewDeviceChanged
 
+    // Add Site
     case addSiteAlertDisplayed
+
+    // Change Username
+    case changeUsernameSearchPerformed
+    case changeUsernameDisplayed
+    case changeUsernameDismissed
 
     /// A String that represents the event
     var value: String {
@@ -782,6 +789,14 @@ import Foundation
 
         case .addSiteAlertDisplayed:
             return "add_site_alert_displayed"
+
+        // Change Username
+        case .changeUsernameSearchPerformed:
+            return "change_username_search_performed"
+        case .changeUsernameDisplayed:
+            return "change_username_displayed"
+        case .changeUsernameDismissed:
+            return "change_username_dismissed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -3,6 +3,9 @@ import WordPressAuthenticator
 class ChangeUsernameViewController: SignupUsernameTableViewController {
     typealias CompletionBlock = (String?) -> Void
 
+    override var analyticsSource: String {
+        return "account_settings"
+    }
     private let viewModel: ChangeUsernameViewModel
     private let completionBlock: CompletionBlock
     private lazy var saveBarButtonItem: UIBarButtonItem = {
@@ -41,6 +44,8 @@ class ChangeUsernameViewController: SignupUsernameTableViewController {
     override func startSearch(for searchTerm: String) {
         saveBarButtonItem.isEnabled = false
         viewModel.suggestUsernames(for: searchTerm, reloadingAllSections: false)
+
+        trackSearchPerformed()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -10,6 +10,10 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
     private var isSearching: Bool = false
     private var selectedCell: UITableViewCell?
 
+    var analyticsSource: String {
+        return "signup_epilogue"
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 
@@ -85,12 +89,21 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
         return description
     }
 
+    private var searchCount: Int = 0
+    func trackSearchPerformed() {
+        searchCount += 1
+
+        WPAnalytics.track(.changeUsernameSearchPerformed, properties: ["search_count": searchCount, "source": analyticsSource])
+    }
+
     // MARK: - SearchTableViewCellDelegate
 
     func startSearch(for searchTerm: String) {
         guard searchTerm.count > 0 else {
             return
         }
+
+        trackSearchPerformed()
 
         suggestUsernames(for: searchTerm) { [weak self] suggestions in
             self?.suggestions = suggestions

--- a/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupUsernameTableViewController.swift
@@ -24,6 +24,8 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        trackViewLoaded()
+
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         tableView.layoutMargins = WPStyleGuide.edgeInsetForLoginTextFields()
 
@@ -48,6 +50,8 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         SVProgressHUD.dismiss()
+
+        trackViewDismissed()
     }
 
     func registerNibs() {
@@ -87,6 +91,15 @@ class SignupUsernameTableViewController: UITableViewController, SearchTableViewC
         description.addAttribute(.font, value: boldFont, range: baseDescription.nsRange(from: rangeOfUsername))
         description.addAttribute(.font, value: boldFont, range: baseDescription.nsRange(from: rangeOfDisplayName))
         return description
+    }
+
+    // MARK: - Tracking
+    func trackViewLoaded() {
+        WPAnalytics.track(.changeUsernameDisplayed, properties: ["source": analyticsSource])
+    }
+
+    func trackViewDismissed() {
+        WPAnalytics.track(.changeUsernameDismissed, properties: ["source": analyticsSource])
     }
 
     private var searchCount: Int = 0


### PR DESCRIPTION
Project #17503

Closes: #17503 

### Description
This adds 3 new tracking events to the change username flow:
- when it's displayed, and the source
- when it's dismissed, and the source
- when a user performs a search, and the number of searches performed, and the source

Since the change username flow is use differently in parts of the app I added the tracking to the `SignupUsernameTableViewController` which is always used when changing the username. 

### To test:
1. Launch the app
2. Logout
3. Create a new account
4. Once you get to the 'Signup epilogue' tap the 'Change username' item
5. Verify you see `🔵 Tracked: change_username_displayed <source: signup_epilogue>`
6. Perform a search,
7. Verify you see `🔵 Tracked: change_username_search_performed <search_count: 1, source: signup_epilogue>`
8. Perform a few more searches and verify the search_count reflects the number of searches you performed
9. Tap the back button
10. Verify you see `🔵 Tracked: change_username_dismissed <source: signup_epilogue>`
11. Continue into the app
12. Tap the My Site tab
13. Tap your user icon in the top right corner of the view
14. Tap on the 'Account Settings' item
15. Tap on the Username item
16. Verify you see `🔵 Tracked: change_username_displayed <source: account_settings>`
17. Perform a series of searches
18. Verify you see `🔵 Tracked: change_username_search_performed <search_count: 1, source: account_settings>`
    - Make sure the search_count goes up each time
19. Tap back and verify you see `🔵 Tracked: change_username_displayed <source: account_settings>`


### Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
