### PR TITLE
Use the correct step when tapping the create buttons on the post signup interstitial 

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -82,19 +82,20 @@ class PostSignUpInterstitialViewController: UIViewController {
 
     // MARK: - IBAction's
     @IBAction func createSite(_ sender: Any) {
-        dismiss?(.createSite)
-
         tracker.track(click: .createNewSite, ifTrackingNotEnabled: {
             WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "create_new_site"])
         })
+
+        dismiss?(.createSite)
+
     }
 
     @IBAction func addSelfHosted(_ sender: Any) {
-        dismiss?(.addSelfHosted)
-
         tracker.track(click: .addSelfHostedSite, ifTrackingNotEnabled: {
             WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "add_self_hosted_site"])
         })
+
+        dismiss?(.addSelfHosted)
     }
 
     @IBAction func cancel(_ sender: Any) {


### PR DESCRIPTION
Project: #17503

### Description
When tapping on one of the create buttons on the post signup interstitial the WPAuthenticator would incorrectly track:

`🔵 Tracked: unified_login_interaction <click: create_new_site, flow: login_magic_link, source: default, step: magic_link_requested >`

This changes the order of the tracking so it correctly tracks:

`🔵 Tracked: unified_login_interaction <click: create_new_site, flow: login_magic_link, source: default, step: success>`

### To test:

1. Launch the app
2. Logout if needed
3. Login with an account that has no sites, or create a new account
4. On the post sign up 'do you want to create a new site' view
5. Tap on the create wp.com button:
6. Verify you see `🔵 Tracked: unified_login_interaction <click: create_new_site, flow: login_magic_link, source: default, step: success>`
7. Repeat the steps but tap on the 'add self hosted site' button
8. Verify you see `🔵 Tracked: unified_login_interaction <click: add_self_hosted_site, flow: login_magic_link, source: default, step: success>`

###  Regression Notes
1. Potential unintended areas of impact
None. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None. 

3. What automated tests I added (or what prevented me from doing so)
None. 
### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
