### PR TITLE
Reader Comments: Add fallback implementation for overflow menu on iOS 13

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/MenuSheetViewController.swift
@@ -1,0 +1,97 @@
+import UIKit
+import WordPressUI
+
+/// Provides a fallback implementation for showing `UIMenu` in iOS 13. Instead of showing a floating menu, this embeds
+/// the menu in a table view through `BottomSheetViewController`. Note that to simplify things, nested elements will be
+/// displayed as if `UIMenuOptions.displayInline` is applied.
+///
+/// In iOS 13, `UIMenu` can only appear through long press gesture. There is no way to make it appear programmatically
+/// or through different gestures. However, in iOS 14 menus can be configured to appear on tap events. Refer to
+/// `showsMenuAsPrimaryAction` for more details.
+///
+/// TODO: Remove this component (and its usage) in favor of `UIMenu` when the minimum version is bumped to iOS 14.
+///
+class MenuSheetViewController: UITableViewController {
+
+    struct MenuItem {
+        let title: String
+        let image: UIImage?
+        let handler: () -> Void
+    }
+
+    private let itemSource: [[MenuItem]]
+
+    // MARK: Lifecycle
+
+    required init(items: [[MenuItem]]) {
+        self.itemSource = items
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        configureTable()
+    }
+}
+
+// MARK: - Table View
+
+extension MenuSheetViewController {
+
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return itemSource.count
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        guard section < itemSource.count else {
+            return 0
+        }
+        return itemSource[section].count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let item = itemSource[indexPath.section][indexPath.row]
+        let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellIdentifier, for: indexPath)
+
+        cell.textLabel?.setText(item.title)
+        cell.accessoryView = UIImageView(image: item.image?.withTintColor(.text))
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+
+        let item = itemSource[indexPath.section][indexPath.row]
+        dismiss(animated: true) {
+            item.handler()
+        }
+    }
+}
+
+// MARK: - Drawer Presentable
+
+extension MenuSheetViewController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        false
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension MenuSheetViewController {
+    struct Constants {
+        static let cellIdentifier = "cell"
+    }
+
+    func configureTable() {
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellIdentifier)
+
+        // hide separators for the last row.
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: 1))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1244,6 +1244,10 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    if ([self newCommentThreadEnabled]) {
+        return UITableViewAutomaticDimension;
+    }
+
     NSNumber *cachedHeight = [self.estimatedRowHeights objectForKey:indexPath];
     if (cachedHeight.doubleValue) {
         return cachedHeight.doubleValue;

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1188,7 +1188,8 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
         cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
             if ([comment allowsModeration]) {
-                // TODO: Show menu in iOS 13.
+                // NOTE: Remove when minimum version is bumped to iOS 14.
+                [self showMenuSheetFor:comment tableView:weakSelf.tableView sourceView:sourceView];
             } else {
                 [self shareComment:comment sourceView:sourceView];
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -105,8 +105,8 @@ import UIKit
         })
     }
 
-    /// Shows the contextual menu through `BottomSheetViewController`. This is fallback for iOS 13 since the menu can't be shown on tap, or programmatically.
-    /// NOTE: Remove this once we bump the minimum version to iOS 14.
+    /// Shows the contextual menu through `UIPopoverPresentationController`. This is fallback for iOS 13 since the menu can't be shown on tap,
+    /// or programmatically. NOTE: Remove this once we bump the minimum version to iOS 14.
     ///
     func showMenuSheet(for comment: Comment, tableView: UITableView, sourceView: UIView?) {
         let commentMenus = commentMenu(for: comment, tableView: tableView, sourceView: sourceView)
@@ -114,8 +114,22 @@ import UIKit
             // Convert ReaderCommentMenu to MenuSheetViewController.MenuItem
             menuSection.map { $0.toMenuItem }
         })
-        let bottomSheet = BottomSheetViewController(childViewController: menuViewController)
-        bottomSheet.show(from: self, sourceView: sourceView)
+
+        menuViewController.modalPresentationStyle = .popover
+        if let popoverPresentationController = menuViewController.popoverPresentationController {
+            popoverPresentationController.delegate = self
+            popoverPresentationController.sourceView = sourceView
+            popoverPresentationController.sourceRect = sourceView?.bounds ?? .null
+        }
+
+        present(menuViewController, animated: true)
+    }
+}
+
+extension ReaderCommentsViewController: UIPopoverPresentationControllerDelegate {
+    // Force popover views to be presented as a popover (instead of being presented as a form sheet on iPhones).
+    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
@@ -117,6 +117,7 @@ private extension MenuSheetViewController {
 
     func configureTable() {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellIdentifier)
+        tableView.sectionHeaderHeight = 0
 
         // draw the separators from edge to edge.
         tableView.separatorInset = .zero

--- a/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
@@ -146,7 +146,7 @@ private extension MenuSheetViewController {
 
         dismiss(animated: true) {
             defer {
-                if let controller = popoverPresentationController {
+                if let controller = self.popoverPresentationController {
                     controller.delegate?.presentationControllerDidDismiss?(controller)
                 }
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4369,6 +4369,8 @@
 		FE23EB4C26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
 		FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
+		FE32EFFF275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
+		FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
 		FE39C135269C37C900EFB827 /* ListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE39C133269C37C900EFB827 /* ListTableViewCell.xib */; };
 		FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE39C134269C37C900EFB827 /* ListTableViewCell.swift */; };
 		FE3D057E26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */; };
@@ -7588,6 +7590,7 @@
 		FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = richCommentTemplate.html; path = Resources/HTML/richCommentTemplate.html; sourceTree = "<group>"; };
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
+		FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewController.swift; sourceTree = "<group>"; };
 		FE39C133269C37C900EFB827 /* ListTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ListTableViewCell.xib; sourceTree = "<group>"; };
 		FE39C134269C37C900EFB827 /* ListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentPresenterTests.swift; sourceTree = "<group>"; };
@@ -10071,6 +10074,7 @@
 				5D42A401175E76A1005CFF05 /* WPImageViewController.h */,
 				5D42A402175E76A2005CFF05 /* WPImageViewController.m */,
 				C7192ECE25E8432D00C3020D /* ReaderTopicsCardCell.xib */,
+				FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -17582,6 +17586,7 @@
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
 				2481B17F260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */,
 				7E3E9B702177C9DC00FD5797 /* GutenbergViewController.swift in Sources */,
+				FE32EFFF275914390040BE67 /* MenuSheetViewController.swift in Sources */,
 				3FC7F89E2612341900FD8728 /* UnifiedPrologueStatsContentView.swift in Sources */,
 				7D21280D251CF0850086DD2C /* EditPageViewController.swift in Sources */,
 				738B9A4F21B85CF20005062B /* SiteCreator.swift in Sources */,
@@ -19354,6 +19359,7 @@
 				FABB21612602FC2C00C8785C /* ReaderShowAttributionAction.swift in Sources */,
 				FABB21622602FC2C00C8785C /* LinkSettingsViewController.swift in Sources */,
 				9856A39E261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
+				FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */,
 				FABB21632602FC2C00C8785C /* FeatureItemCell.swift in Sources */,
 				FABB21642602FC2C00C8785C /* WPRichContentView.swift in Sources */,
 				FABB21652602FC2C00C8785C /* MediaFileManager.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -7944,6 +7944,7 @@
 				37EAAF4C1A11799A006D6306 /* CircularImageView.swift */,
 				ADF544C0195A0F620092213D /* CustomHighlightButton.h */,
 				ADF544C1195A0F620092213D /* CustomHighlightButton.m */,
+				FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */,
 				B5B410B51B1772B000CFCF8D /* NavigationTitleView.swift */,
 				982A4C3420227D6700B5518E /* NoResultsViewController.swift */,
 				98B33C87202283860071E1E2 /* NoResults.storyboard */,
@@ -10074,7 +10075,6 @@
 				5D42A401175E76A1005CFF05 /* WPImageViewController.h */,
 				5D42A402175E76A2005CFF05 /* WPImageViewController.m */,
 				C7192ECE25E8432D00C3020D /* ReaderTopicsCardCell.xib */,
-				FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";


### PR DESCRIPTION
Refs #17476 

This PR adds `MenuSheetViewController`, which is used to mimic the appearance of `UIContextMenu` in iOS 13. The main difference is that this can be fully customizable – can be triggered on tap, or shown programmatically – unlike `UIContextMenu` which can only be shown on long press.

The component is displayed using a `UIPopoverPresentationController` with a "forced" setting on iPhone such that it always shows the menu with `.popover` presentation style (instead of `.formSheet`). 

Here's a preview:

• | `UIMenu`, iOS 14+ | Fallback implementation, iOS 13
--|--|--
Light scheme | ![menu_light](https://user-images.githubusercontent.com/1299411/144654838-f0c522b3-61cd-4216-aa04-2d225924da76.png) | ![fallback_light](https://user-images.githubusercontent.com/1299411/144654835-52e12da9-5af6-4a7f-9ab7-ae6eeab9adf9.png)
Dark scheme | ![menu_dark](https://user-images.githubusercontent.com/1299411/144654814-59ea4ece-c2ae-40da-8b1c-71f4dea64fc5.png) | ![fallback_dark](https://user-images.githubusercontent.com/1299411/144654828-6d381180-e18f-4366-be18-115241df8241.png)

There are slight differences visually (positioning, caret, visual effects, shadows, etc.), but I'm thinking this is good enough to be implemented in a short amount of time.

## To Test

Ensure that the `newCommentThread` feature flag is enabled.

#### With iOS 14+:

- Go to any comment thread on a site that you can moderate. (For example, My Site > Comments > tap any comment reply > tap on the header.)
- Tap on the ellipsis button.
- 🔍  Verify that the `UIMenu` is shown.
- Tap on the Share menu.
- 🔍  Verify that the share sheet is presented.

#### With iOS 13:

(Tip: if you don't have iOS 13 simulator downloaded, you can temporarily disable the code in ReaderCommentsViewController.swift, particularly the if #available lines.)

- Go to any comment thread on a site that you can moderate. (For example, My Site > Comments > tap any comment reply > tap on the header.)
- Tap on the ellipsis button.
- 🔍  Verify that the menu is shown.
- Tap on the Share menu.
- 🔍  Verify that the share sheet is presented.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is unreleased.


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
