### PR TITLE
Reader Comments: Implement edit action on the overflow menu

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -363,7 +363,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
               success:(void (^)(void))success
               failure:(void (^)(NSError *error))failure
 {
-    id<CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
+    id<CommentServiceRemote> remote = [self remoteForComment:comment];
     RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
 
     NSManagedObjectID *commentObjectID = comment.objectID;
@@ -892,6 +892,8 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 }
 
 
+
+
 #pragma mark - Blog centric methods
 // Generic moderation
 - (void)moderateComment:(Comment *)comment
@@ -1294,6 +1296,19 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 
 
 #pragma mark - Remotes
+
+- (id<CommentServiceRemote>)remoteForComment:(Comment *)comment
+{
+    // If the comment is fetched through the Reader API, the blog will always be nil.
+    // Try to find the Blog locally first, as it should exist if the user has a role on the site.
+    if (comment.post && [comment.post isKindOfClass:[ReaderPost class]]) {
+        ReaderPost *readerPost = (ReaderPost *)comment.post;
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.managedObjectContext];
+        return [self remoteForBlog:[blogService blogByHostname:readerPost.blogURL]];
+    }
+
+    return [self remoteForBlog:comment.blog];
+}
 
 - (id<CommentServiceRemote>)remoteForBlog:(Blog *)blog
 {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1178,7 +1178,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
     if ([self newCommentThreadEnabled]) {
         CommentContentTableViewCell *cell = (CommentContentTableViewCell *)aCell;
-        [self configureContentCell:cell comment:comment tableView:self.tableView];
+        [self configureContentCell:cell comment:comment indexPath:indexPath tableView:self.tableView];
 
         // show separator when the comment is the "last leaf" of its top-level comment.
         cell.separatorInset = [self shouldShowSeparatorForIndexPath:indexPath] ? UIEdgeInsetsZero : self.hiddenSeparatorInsets;
@@ -1189,7 +1189,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
             if ([comment allowsModeration]) {
                 // NOTE: Remove when minimum version is bumped to iOS 14.
-                [self showMenuSheetFor:comment tableView:weakSelf.tableView sourceView:sourceView];
+                [self showMenuSheetFor:comment indexPath:indexPath tableView:weakSelf.tableView sourceView:sourceView];
             } else {
                 [self shareComment:comment sourceView:sourceView];
             }


### PR DESCRIPTION
Refs #17476 
Depends on #17622

As titled, the Edit button should now be functional. 

I've made a small change to `CommentService`. Comments fetched from the reader endpoint don't have their `blog` property assigned, and this caused the `uploadComment:` method to fail silently due to an empty `comment.blog`. To solve this, I added `remoteForComment:` which can now create `CommentServiceRemote` for both Site comments and Reader comments.

If the user can update a comment from the comment thread, that means they have a moderator role assigned to their account. And that means they should have the blog/site synchronized locally before opening the comment thread.

## To test

- Ensure that `newCommentThread` feature flag is enabled.
- Go to any comment thread on a site that you can moderate. (For example, My Site > Comments > tap any comment reply > tap on the header.)
- Tap on the ellipsis button, and tap on the Edit menu.
- 🔍 Verify that the Edit Comment screen is shown.
- Edit the comment, and tap Save.
- 🔍 Verify that the edited comment in the comment thread is updated with the new value.
- Go back to My Site > Comments.
- 🔍 Verify that the comment is also updated in this list.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
