### PR TITLE
Add notification type to userInfo for weekly roundup

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -553,6 +553,7 @@ class WeeklyRoundupNotificationScheduler {
         let userInfo: [AnyHashable: Any] = [
             InteractiveNotificationsManager.blogIDKey: dotComID,
             InteractiveNotificationsManager.dateKey: periodEndDate,
+            PushNotificationsManager.Notification.typeKey: NotificationEventTracker.NotificationType.weeklyRoundup.rawValue
         ]
 
         scheduleNotification(


### PR DESCRIPTION
This PR adds the correct notification type of `weekly_roundup` to Weekly Roundup notifications.

**To test**

* Build and run
* Set a breakpoint in `trackNotification(with:)` of `PushNotificationsManager`
* Use the Me > App Settings > Debug > Weekly Roundup menu to trigger an immediate set of weekly roundup notifications
* Your breakpoint should be hit, and you should be able to to see the notification type in the payload
* Wait a while (it doesn't update immediately) and check the live view on tracks to ensure you can see the event and its property

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
