### PR TITLE
Reader Comments: Implement moderation actions

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -913,7 +913,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
 
     comment.status = currentStatus;
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    id <CommentServiceRemote> remote = [self remoteForBlog:comment.blog];
+    id <CommentServiceRemote> remote = [self remoteForComment:comment];
     RemoteComment *remoteComment = [self remoteCommentWithComment:comment];
     NSManagedObjectID *commentID = comment.objectID;
     [remote moderateComment:remoteComment

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -157,7 +157,9 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self configureViewConstraints];
     [self configureKeyboardManager];
 
-    [self refreshAndSync];
+    if (![self newCommentThreadEnabled]) {
+        [self refreshAndSync];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -169,6 +171,10 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                              selector:@selector(handleApplicationDidBecomeActive:)
                                                  name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
+
+    if ([self newCommentThreadEnabled]) {
+        [self refreshAndSync];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1178,7 +1178,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
     if ([self newCommentThreadEnabled]) {
         CommentContentTableViewCell *cell = (CommentContentTableViewCell *)aCell;
-        [self configureContentCell:cell comment:comment indexPath:indexPath tableView:self.tableView];
+        [self configureContentCell:cell comment:comment indexPath:indexPath handler:self.tableViewHandler];
 
         // show separator when the comment is the "last leaf" of its top-level comment.
         cell.separatorInset = [self shouldShowSeparatorForIndexPath:indexPath] ? UIEdgeInsetsZero : self.hiddenSeparatorInsets;
@@ -1189,7 +1189,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
             if ([comment allowsModeration]) {
                 // NOTE: Remove when minimum version is bumped to iOS 14.
-                [self showMenuSheetFor:comment indexPath:indexPath tableView:weakSelf.tableView sourceView:sourceView];
+                [self showMenuSheetFor:comment indexPath:indexPath handler:weakSelf.tableViewHandler sourceView:sourceView];
             } else {
                 [self shareComment:comment sourceView:sourceView];
             }


### PR DESCRIPTION
Refs #17476
Depends on #17623

This PR adds functionality to the moderation menu items. 
- After a comment is moderated, it should be removed from the table view after the request succeeds. 
- Note that this only hides the moderated comment. The correct behavior is that all descendants of non-approved comments should be hidden, but the API request still returns approved descendants which could cause data inconsistency. Therefore I'll hold off on this implementation until we can also align with the backend side.
- I've also updated the `ReaderPost`'s comment count (decrementing it by 1) when a comment is moderated. 
  - Note that I've decided not to implement the other way around – i.e. incrementing the ReaderPost's comment count when the comment is approved through My Site > Comments. This is because I feel like it's less noticeable since the action is performed from different tabs, and the comment count will eventually get updated if the user opens the post or comment thread.

## To test

- Ensure that the `newCommentThread` flag is enabled.
- Navigate to Reader > any comment thread that you can moderate.
- Tap on the ellipsis button, and select "Unapprove". 
- Verify that the comment is removed from the table view, and a notice is shown.
- Go back to Reader.
- Verify that the comment count in the Reader list is decremented by one.
- Repeat the steps above for "Mark as spam", and "Move to trash" actions.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
