### PR TITLE
Reader post comments: no comments and commenting closed view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -390,9 +390,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateComments(_ comments: [Comment], totalComments: Int) {
-        commentsTableViewDelegate?.comments = comments
-        commentsTableViewDelegate?.totalComments = totalComments
-        commentsTableViewDelegate?.buttonDelegate = self
+        commentsTableViewDelegate?.updateWith(comments: comments,
+                                              totalComments: totalComments,
+                                              commentsEnabled: toolbar.commentButton.isEnabled,
+                                              buttonDelegate: self)
         commentsTableView.reloadData()
     }
 
@@ -1002,6 +1003,6 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
         guard let post = post else {
             return
         }
-        ReaderCommentAction().execute(post: post, origin: self, promptToAddComment: commentsTableViewDelegate?.comments.count == 0)
+        ReaderCommentAction().execute(post: post, origin: self, promptToAddComment: commentsTableViewDelegate?.totalComments == 0)
     }
 }


### PR DESCRIPTION
Ref: #17511

When a post has no comments and commenting is closed, the Comments table shows only a `Comments are closed` message.

To test:
Reader post details: verify these three scenarios display the correct view:
- post has no comments + commenting closed: `Comments are closed` and no button.
- post has no comments + commenting open: `No comments yet` and `Be the first to comment` button.
- post has comments: first comment and `View all comments` button.

| <img width="473" alt="no_comments_closed" src="https://user-images.githubusercontent.com/1816888/144945581-8bb5a915-1d1f-4faf-aafd-4bc756199ba6.png"> | <img width="470" alt="no_comments_open" src="https://user-images.githubusercontent.com/1816888/144945575-a415fb51-0106-4ada-97e5-9a0cafae6405.png"> | <img width="473" alt="comments" src="https://user-images.githubusercontent.com/1816888/144945579-5ca9f3a4-ba35-47ee-abab-a12539ae0dc7.png"> |
|--------|-------|-------|

## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
