### PR TITLE
Reader Comments: Refactor content cell to have configurable render method

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -103,7 +103,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         return templateString
     }()
 
-    private var renderer: CommentContentRenderer?
+    private var renderer: CommentContentRenderer? = nil
 
     // MARK: Like Button State
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -13,15 +13,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="120" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="353" id="KGk-i7-Jjw" customClass="CommentContentTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="353"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="120"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="353"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
-                        <rect key="frame" x="16" y="0.0" width="288" height="120"/>
+                        <rect key="frame" x="16" y="0.0" width="288" height="353"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="119"/>
@@ -112,21 +112,18 @@
                                     <constraint firstAttribute="trailing" secondItem="1G8-cc-t5d" secondAttribute="trailing" constant="-12" id="xTt-ug-Tgu"/>
                                 </constraints>
                             </view>
-                            <wkWebView contentMode="scaleToFill" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="Je0-5Q-ty6">
-                                <rect key="frame" x="0.0" y="119" width="288" height="1"/>
+                            <view contentMode="scaleToFill" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="M0y-BK-TEh" userLabel="Content Container View">
+                                <rect key="frame" x="0.0" y="119" width="288" height="0.0"/>
+                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" priority="999" constant="1" id="dGD-8Q-LSr"/>
+                                    <constraint firstAttribute="height" id="t5W-a4-bo7"/>
                                 </constraints>
-                                <wkWebViewConfiguration key="configuration">
-                                    <audiovisualMediaTypes key="mediaTypesRequiringUserActionForPlayback" none="YES"/>
-                                    <wkPreferences key="preferences"/>
-                                </wkWebViewConfiguration>
-                            </wkWebView>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
-                                <rect key="frame" x="0.0" y="120" width="288" height="0.0"/>
+                                <rect key="frame" x="0.0" y="119" width="288" height="234"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="0.0" width="174.5" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="97" width="174.5" height="40"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -140,7 +137,7 @@
                                         </state>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="179.5" y="0.0" width="53.5" height="0.0"/>
+                                        <rect key="frame" x="179.5" y="96.5" width="53.5" height="41"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="contentEdgeInsets" minX="0.0" minY="10" maxX="15" maxY="15"/>
@@ -154,7 +151,7 @@
                                         </state>
                                     </button>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
-                                        <rect key="frame" x="238" y="0.0" width="50" height="0.0"/>
+                                        <rect key="frame" x="238" y="92" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
@@ -163,7 +160,7 @@
                                 </subviews>
                             </stackView>
                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T1Z-LV-01Y" customClass="CommentModerationBar" customModule="WordPress" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="120" width="288" height="83"/>
+                                <rect key="frame" x="0.0" y="353" width="288" height="83"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="83" id="qRm-Qi-IXu"/>
@@ -187,15 +184,15 @@
                 <outlet property="containerStackBottomConstraint" destination="jAu-U3-I4N" id="1Hk-Cp-fR5"/>
                 <outlet property="containerStackLeadingConstraint" destination="uFL-PF-ffo" id="6Ah-H9-d0b"/>
                 <outlet property="containerStackView" destination="hcN-S7-sLG" id="k9D-6a-BmR"/>
+                <outlet property="contentContainerHeightConstraint" destination="t5W-a4-bo7" id="2ox-vW-Kuh"/>
+                <outlet property="contentContainerView" destination="M0y-BK-TEh" id="bC5-Hn-XRQ"/>
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="moderationBar" destination="T1Z-LV-01Y" id="YUL-ft-QkO"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>
                 <outlet property="replyButton" destination="VoI-YI-Qgc" id="Z9J-Tp-bur"/>
-                <outlet property="webView" destination="Je0-5Q-ty6" id="YaD-wp-E6W"/>
-                <outlet property="webViewHeightConstraint" destination="dGD-8Q-LSr" id="rBk-4R-GCz"/>
             </connections>
-            <point key="canvasLocation" x="131.8840579710145" y="235.71428571428569"/>
+            <point key="canvasLocation" x="131.8840579710145" y="313.72767857142856"/>
         </tableViewCell>
     </objects>
     <resources>

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
@@ -2,7 +2,10 @@ protocol CommentContentRenderer {
     var delegate: CommentContentRendererDelegate? { get set }
 
     init(comment: Comment)
+
     func render() -> UIView
+
+    func matchesContent(from comment: Comment) -> Bool
 }
 
 protocol CommentContentRendererDelegate: AnyObject {

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
@@ -1,0 +1,15 @@
+protocol CommentContentRenderer {
+    var delegate: CommentContentRendererDelegate? { get set }
+
+    init(comment: Comment)
+    func render() -> UIView
+}
+
+protocol CommentContentRendererDelegate: AnyObject {
+    /// Called when the rendering process completes. Note that this method is only called when using complex rendering methods that involves
+    /// asynchronous operations, so the container can readjust its size at a later time.
+    func renderer(_ renderer: CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat)
+
+    /// Called whenever the user interacts with a URL within the rendered content.
+    func renderer(_ renderer: CommentContentRenderer, interactedWithURL url: URL)
+}

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/CommentContentRenderer.swift
@@ -1,10 +1,18 @@
+/// Defines methods related to Comment content rendering.
+///
 protocol CommentContentRenderer {
     var delegate: CommentContentRendererDelegate? { get set }
 
     init(comment: Comment)
 
+    /// Returns a view component that's configured to display the formatted content of the comment.
+    ///
+    /// Note that the renderer *might* return a view with the wrong sizing at first, but it should update its delegate with the correct height
+    /// through the `renderer(_:asyncRenderCompletedWithHeight:)` method.
     func render() -> UIView
 
+    /// Checks if the provided comment contains the same content as the current one that's processed by the renderer.
+    /// This is used as an optimization strategy by the caller to skip view creations if the rendered content matches the one provided in the parameter.
     func matchesContent(from comment: Comment) -> Bool
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -40,6 +40,15 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
         return webView
     }
+
+    func matchesContent(from comment: Comment) -> Bool {
+        // if content cache is still nil, then the comment hasn't been rendered yet.
+        guard let contentCache = commentContentCache else {
+            return false
+        }
+
+        return contentCache == comment.content
+    }
 }
 
 // MARK: - WKNavigationDelegate

--- a/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/ContentRenderer/WebCommentContentRenderer.swift
@@ -1,0 +1,142 @@
+import WebKit
+
+/// Renders the comment body with a web view. Provides the best visual experience but has the highest performance cost.
+///
+class WebCommentContentRenderer: NSObject, CommentContentRenderer {
+
+    // MARK: Properties
+
+    weak var delegate: CommentContentRendererDelegate?
+
+    private let comment: Comment
+
+    private let webView = WKWebView(frame: .zero)
+
+    /// Used to determine whether the cache is still valid or not.
+    private var commentContentCache: String? = nil
+
+    /// Caches the HTML content, to be reused when the orientation changed.
+    private var htmlContentCache: String? = nil
+
+    // MARK: Methods
+
+    required init(comment: Comment) {
+        self.comment = comment
+    }
+
+    func render() -> UIView {
+        // Do not reload if the content doesn't change.
+        if let contentCache = commentContentCache, contentCache == comment.content {
+            return webView
+        }
+
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        webView.scrollView.bounces = false
+        webView.scrollView.showsVerticalScrollIndicator = false
+        webView.isOpaque = false // gets rid of the white flash upon content load in dark mode.
+
+        webView.loadHTMLString(formattedHTMLString(for: comment.content), baseURL: Self.resourceURL)
+
+        return webView
+    }
+}
+
+// MARK: - WKNavigationDelegate
+
+extension WebCommentContentRenderer: WKNavigationDelegate {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        // Wait until the HTML document finished loading.
+        // This also waits for all of resources within the HTML (images, video thumbnail images) to be fully loaded.
+        webView.evaluateJavaScript("document.readyState") { complete, _ in
+            guard complete != nil else {
+                return
+            }
+
+            // To capture the content height, the methods to use is either `document.body.scrollHeight` or `document.documentElement.scrollHeight`.
+            // `document.body` does not capture margins on <body> tag, so we'll use `document.documentElement` instead.
+            webView.evaluateJavaScript("document.documentElement.scrollHeight") { height, _ in
+                guard let height = height as? CGFloat else {
+                    return
+                }
+
+                // reset the webview to opaque again so the scroll indicator is visible.
+                webView.isOpaque = true
+                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: height)
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        switch navigationAction.navigationType {
+        case .other:
+            // allow local file requests.
+            decisionHandler(.allow)
+        default:
+            decisionHandler(.cancel)
+            guard let destinationURL = navigationAction.request.url else {
+                return
+            }
+
+            self.delegate?.renderer(self, interactedWithURL: destinationURL)
+        }
+    }
+}
+
+// MARK: - Private Methods
+
+private extension WebCommentContentRenderer {
+    struct Constants {
+        static let emptyElementRegexPattern = "<[a-z]+>(<!-- [a-zA-Z0-9\\/: \"{}\\-\\.,\\?=\\[\\]]+ -->)+<\\/[a-z]+>"
+    }
+
+    /// Used for the web view's `baseURL`, to reference any local files (i.e. CSS) linked from the HTML.
+    static let resourceURL: URL? = {
+        Bundle.main.resourceURL
+    }()
+
+    /// Cache the HTML template format. We only need read the template once.
+    static let htmlTemplateFormat: String? = {
+        guard let templatePath = Bundle.main.path(forResource: "richCommentTemplate", ofType: "html"),
+              let templateString = try? String(contentsOfFile: templatePath) else {
+            return nil
+        }
+
+        return templateString
+    }()
+
+    /// Returns a formatted HTML string by loading the template for rich comment.
+    ///
+    /// The method will try to return cached content if possible, by detecting whether the content matches the previous content.
+    /// If it's different (e.g. due to edits), it will reprocess the HTML string.
+    ///
+    /// - Parameter content: The content value from the `Comment` object.
+    /// - Returns: Formatted HTML string to be displayed in the web view.
+    ///
+    func formattedHTMLString(for content: String) -> String {
+        // return the previous HTML string if the comment content is unchanged.
+        if let previousCommentContent = commentContentCache,
+           let previousHTMLString = htmlContentCache,
+           previousCommentContent == content {
+            return previousHTMLString
+        }
+
+        // otherwise: sanitize the content, cache it, and then return it.
+        guard let htmlTemplateFormat = Self.htmlTemplateFormat else {
+            DDLogError("WebCommentContentRenderer: Failed to load HTML template format for comment content.")
+            return String()
+        }
+
+        // remove empty HTML elements from the `content`, as the content often contains empty paragraph elements which adds unnecessary padding/margin.
+        // `rawContent` does not have this problem, but it's not used because `rawContent` gets rid of links (<a> tags) for mentions.
+        let htmlContent = String(format: htmlTemplateFormat, content
+                                    .replacingOccurrences(of: Constants.emptyElementRegexPattern, with: String(), options: [.regularExpression])
+                                    .trimmingCharacters(in: .whitespacesAndNewlines))
+
+        // cache the contents.
+        commentContentCache = content
+        htmlContentCache = htmlContent
+
+        return htmlContent
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -157,11 +157,9 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self configureViewConstraints];
     [self configureKeyboardManager];
 
-    [self refreshAndSync];
-
-//    if (![self newCommentThreadEnabled]) {
-//        [self refreshAndSync];
-//    }
+    if (![self newCommentThreadEnabled]) {
+        [self refreshAndSync];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -174,15 +172,15 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                                  name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
 
-//    if ([self newCommentThreadEnabled]) {
-//        [self refreshAndSync];
-//    }
+    if ([self newCommentThreadEnabled]) {
+        [self refreshAndSync];
+    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-//    [self.tableView reloadData];
+    [self.tableView reloadData];
 
     if (self.promptToAddComment) {
         [self.replyTextView becomeFirstResponder];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -157,9 +157,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self configureViewConstraints];
     [self configureKeyboardManager];
 
-    if (![self newCommentThreadEnabled]) {
-        [self refreshAndSync];
-    }
+    [self refreshAndSync];
+
+//    if (![self newCommentThreadEnabled]) {
+//        [self refreshAndSync];
+//    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -172,15 +174,15 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                                  name:UIApplicationDidBecomeActiveNotification
                                                object:nil];
 
-    if ([self newCommentThreadEnabled]) {
-        [self refreshAndSync];
-    }
+//    if ([self newCommentThreadEnabled]) {
+//        [self refreshAndSync];
+//    }
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    [self.tableView reloadData];
+//    [self.tableView reloadData];
 
     if (self.promptToAddComment) {
         [self.replyTextView becomeFirstResponder];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -87,6 +87,12 @@ import UIKit
         }
 
         cell.configure(with: comment) { _ in
+            // don't adjust cell height when it's already scrolled out of viewport.
+            guard let visibleIndexPaths = handler.tableView.indexPathsForVisibleRows,
+                  visibleIndexPaths.contains(indexPath) else {
+                      return
+                  }
+
             handler.tableView.performBatchUpdates({})
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -87,7 +87,6 @@ import UIKit
         }
 
         cell.configure(with: comment) { _ in
-            print(">>> CONFIGURE CELL: \(comment.commentID)")
             handler.tableView.performBatchUpdates({})
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -87,6 +87,7 @@ import UIKit
         }
 
         cell.configure(with: comment) { _ in
+            print(">>> CONFIGURE CELL: \(comment.commentID)")
             handler.tableView.performBatchUpdates({})
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichContentView.swift
@@ -178,6 +178,7 @@ private extension WPRichContentView {
             "em, i { font:-apple-system-body; font-family: 'Noto Serif'; font-weight: normal; font-style: italic; line-height:1.6; } " +
             "a { color: #\(style.linkColorHex); text-decoration: none; } " +
             "a:active { color: #\(style.linkColorActiveHex); } " +
+            "img.emoji { vertical-align: baseline; max-width: 1rem; } " +
             ".wp-block-table { margin: 0; padding: 0; } " +
             "table { border-collapse: collapse }" +
             "td { padding: 0.25em 0.25em 0.75em; min-width: 11em; vertical-align: top; } " +

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4371,6 +4371,10 @@
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE32EFFF275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
 		FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
+		FE32F002275F602E0040BE67 /* CommentContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */; };
+		FE32F003275F602E0040BE67 /* CommentContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */; };
+		FE32F006275F62620040BE67 /* WebCommentContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32F005275F62620040BE67 /* WebCommentContentRenderer.swift */; };
+		FE32F007275F62620040BE67 /* WebCommentContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32F005275F62620040BE67 /* WebCommentContentRenderer.swift */; };
 		FE39C135269C37C900EFB827 /* ListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE39C133269C37C900EFB827 /* ListTableViewCell.xib */; };
 		FE39C136269C37C900EFB827 /* ListTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE39C134269C37C900EFB827 /* ListTableViewCell.swift */; };
 		FE3D057E26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */; };
@@ -7591,6 +7595,8 @@
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
 		FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewController.swift; sourceTree = "<group>"; };
+		FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContentRenderer.swift; sourceTree = "<group>"; };
+		FE32F005275F62620040BE67 /* WebCommentContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCommentContentRenderer.swift; sourceTree = "<group>"; };
 		FE39C133269C37C900EFB827 /* ListTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ListTableViewCell.xib; sourceTree = "<group>"; };
 		FE39C134269C37C900EFB827 /* ListTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListTableViewCell.swift; sourceTree = "<group>"; };
 		FE3D057D26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentPresenterTests.swift; sourceTree = "<group>"; };
@@ -14599,6 +14605,15 @@
 			path = Sharing;
 			sourceTree = "<group>";
 		};
+		FE32F004275F60360040BE67 /* ContentRenderer */ = {
+			isa = PBXGroup;
+			children = (
+				FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */,
+				FE32F005275F62620040BE67 /* WebCommentContentRenderer.swift */,
+			);
+			path = ContentRenderer;
+			sourceTree = "<group>";
+		};
 		FE3D057C26C3D5A1002A51B0 /* Sharing */ = {
 			isa = PBXGroup;
 			children = (
@@ -14625,6 +14640,7 @@
 		FEA7948B26DD134400CEC520 /* Detail */ = {
 			isa = PBXGroup;
 			children = (
+				FE32F004275F60360040BE67 /* ContentRenderer */,
 				FE43DAAD26DFAD1C00CFF595 /* CommentContentTableViewCell.swift */,
 				FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */,
 				FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */,
@@ -17934,6 +17950,7 @@
 				8BCB83D124C21063001581BD /* ReaderStreamViewController+Ghost.swift in Sources */,
 				174C11932624C78900346EC6 /* Routes+Start.swift in Sources */,
 				FA347AED26EB6E300096604B /* GrowAudienceCell.swift in Sources */,
+				FE32F006275F62620040BE67 /* WebCommentContentRenderer.swift in Sources */,
 				B5CC05F61962150600975CAC /* Constants.m in Sources */,
 				4326191522FCB9DC003C7642 /* MurielColor.swift in Sources */,
 				436D562B2117312700CEAA33 /* RegisterDomainDetailsErrorSectionFooter.swift in Sources */,
@@ -18076,6 +18093,7 @@
 				9A8ECE0E2254A3260043C8DA /* JetpackConnectionWebViewController.swift in Sources */,
 				B06378C1253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift in Sources */,
 				4353BFB221A376BF0009CED3 /* UntouchableWindow.swift in Sources */,
+				FE32F002275F602E0040BE67 /* CommentContentRenderer.swift in Sources */,
 				FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */,
 				D8A3A5B5206A4C7800992576 /* StockPhotosPicker.swift in Sources */,
 				17F11EDB268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift in Sources */,
@@ -19772,6 +19790,7 @@
 				FABB22D22602FC2C00C8785C /* PostEditorState.swift in Sources */,
 				FABB22D32602FC2C00C8785C /* UICollectionViewCell+Tint.swift in Sources */,
 				FABB22D42602FC2C00C8785C /* ManagedPerson+CoreDataProperties.swift in Sources */,
+				FE32F003275F602E0040BE67 /* CommentContentRenderer.swift in Sources */,
 				FABB22D52602FC2C00C8785C /* TenorStrings.swift in Sources */,
 				FABB22D62602FC2C00C8785C /* PostEditor+MoreOptions.swift in Sources */,
 				FABB22D72602FC2C00C8785C /* NotificationSupportService.swift in Sources */,
@@ -20451,6 +20470,7 @@
 				3F3DD0B326FD176800F5F121 /* PresentationCard.swift in Sources */,
 				FABB253D2602FC2C00C8785C /* SiteVerticalsService.swift in Sources */,
 				FABB253E2602FC2C00C8785C /* ReaderBlockedSiteCell.swift in Sources */,
+				FE32F007275F62620040BE67 /* WebCommentContentRenderer.swift in Sources */,
 				FABB253F2602FC2C00C8785C /* JetpackRestoreWarningViewController.swift in Sources */,
 				FABB25402602FC2C00C8785C /* SiteAssembly.swift in Sources */,
 				FABB25412602FC2C00C8785C /* ImageDimensionFetcher.swift in Sources */,


### PR DESCRIPTION
Refs #17476

This PR refactors `CommentContentTableViewCell` so it could render its content in several different ways. 

- The web view in the cell is now replaced with an empty UIView. Depending on the rendering method, a WKWebView might be added to the UIView – or it could be a UITextView later on.
- No new method has been added just yet, so this should still render the web view as before.
- As this is a non-user facing change, please ensure that things look the same as before.

## To test

#### Site Comments

- Go to My Site > Comments.
- Select any comment.
- 🔍  Verify that the comment cell is displayed correctly and is not impacted by this change.

#### Comment Threads

- Ensure that the `newCommentThread` is enabled.
- Go to Reader > any comment threads.
- 🔍 Verify that the comment threads are rendered with the web view method (same as before), and not impacted by this change.

## Regression Notes
1. Potential unintended areas of impact
n/a. This feature is still hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. This feature is still hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
n/a. This feature is still hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
