### PR TITLE
Reader post details: don't show Comments table until fetching is successful.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -199,9 +199,8 @@ class ReaderDetailCoordinator {
                                    topLevelComments: commentsDisplayed,
                                             success: { [weak self] _, totalComments in
                                                 self?.updateCommentsFor(post: post, totalComments: totalComments?.intValue ?? 0)
-                                            }, failure: { [weak self] error in
+                                            }, failure: { error in
                                                 DDLogError("Failed fetching post detail comments: \(String(describing: error))")
-                                                self?.view?.updateComments([], totalComments: 0)
                                             })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -45,7 +45,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// The table view that displays Comments
     @IBOutlet weak var commentsTableView: IntrinsicTableView!
-    private var commentsTableViewDelegate: ReaderDetailCommentsTableViewDelegate?
+    private let commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
 
     /// The table view that displays Related Posts
     @IBOutlet weak var relatedPostsTableView: IntrinsicTableView!
@@ -390,7 +390,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateComments(_ comments: [Comment], totalComments: Int) {
-        commentsTableViewDelegate?.updateWith(comments: comments,
+        // Set the delegate here so the table isn't shown until fetching is complete.
+        commentsTableView.delegate = commentsTableViewDelegate
+        commentsTableView.dataSource = commentsTableViewDelegate
+
+        commentsTableViewDelegate.updateWith(comments: comments,
                                               totalComments: totalComments,
                                               commentsEnabled: toolbar.commentButton.isEnabled,
                                               buttonDelegate: self)
@@ -519,10 +523,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                                    forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
         commentsTableView.register(ReaderDetailNoCommentCell.defaultNib,
                                    forCellReuseIdentifier: ReaderDetailNoCommentCell.defaultReuseID)
-
-        commentsTableViewDelegate = ReaderDetailCommentsTableViewDelegate()
-        commentsTableView.delegate = commentsTableViewDelegate
-        commentsTableView.dataSource = commentsTableViewDelegate
     }
 
     private func configureRelatedPosts() {
@@ -1003,6 +1003,6 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
         guard let post = post else {
             return
         }
-        ReaderCommentAction().execute(post: post, origin: self, promptToAddComment: commentsTableViewDelegate?.totalComments == 0)
+        ReaderCommentAction().execute(post: post, origin: self, promptToAddComment: commentsTableViewDelegate.totalComments == 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -9,7 +9,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
 
     private var totalRows = 0
-    private var hideButton = false
+    private var hideButton = true
 
     private var comments: [Comment] = [] {
         didSet {


### PR DESCRIPTION
Ref: #17511 

The Comments table will not appear until fetching is successful. This matches the behavior of Likes and Related Posts.

To test:

- Go to Reader.
- With internet disconnected, select a post.
  - Verify the Comments table does not appear.
- With internet connected, select a post.
  - Verify the Comments table appears.
  
## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
