### PR TITLE
Use derived context for WeeklyRoundup background task

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -163,7 +163,7 @@ class WeeklyRoundupDataProvider {
     /// Filters the sites that have the Weekly Roundup notification setting enabled.
     ///
     private func filterWeeklyRoundupEnabledSites(_ sites: [Blog], result: @escaping (Result<[Blog], Error>) -> Void) {
-        let noteService = NotificationSettingsService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let noteService = NotificationSettingsService(managedObjectContext: context)
 
         noteService.getAllSettings { settings in
             let weeklyRoundupEnabledSites = sites.filter { site in
@@ -377,7 +377,7 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
             }
         }
 
-        let dataProvider = WeeklyRoundupDataProvider(context: ContextManager.shared.mainContext, onError: onError)
+        let dataProvider = WeeklyRoundupDataProvider(context: ContextManager.shared.newDerivedContext(), onError: onError)
         var siteStats: [Blog: StatsSummaryData]? = nil
 
         let requestData = BlockOperation {


### PR DESCRIPTION
Fixes #17639 

This attempts to fix a crash due to the managed object context being accessed from the wrong thread. The `WeeklyRoundupDataProvider` is now initialized with a derived context so all of its operations won't be running on the main context and hopefully prevents overlap with any operations running in the main queue.

To test:

Refer to the steps described in #17066 and #17116, and make sure everything works.

## Regression Notes
1. Potential unintended areas of impact
The Weekly Roundup feature might not work as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the scenarios described in #17066 and #17116.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
