### PR TITLE
Onboarding Improvements: persist the chosen site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -59,18 +59,26 @@ final class QuickStartPromptViewController: UIViewController {
     private func applyStyles() {
         siteTitleLabel.numberOfLines = 0
         siteTitleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        siteTitleLabel.adjustsFontForContentSizeCategory = true
+        siteTitleLabel.adjustsFontSizeToFitWidth = true
         siteTitleLabel.textColor = .text
 
         siteDescriptionLabel.numberOfLines = 0
         siteDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        siteDescriptionLabel.adjustsFontForContentSizeCategory = true
+        siteDescriptionLabel.adjustsFontSizeToFitWidth = true
         siteDescriptionLabel.textColor = .textSubtle
 
         promptTitleLabel.numberOfLines = 0
         promptTitleLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .medium)
+        promptTitleLabel.adjustsFontForContentSizeCategory = true
+        promptTitleLabel.adjustsFontSizeToFitWidth = true
         promptTitleLabel.textColor = .text
 
         promptDescriptionLabel.numberOfLines = 0
         promptDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        promptDescriptionLabel.adjustsFontForContentSizeCategory = true
+        promptDescriptionLabel.adjustsFontSizeToFitWidth = true
         promptDescriptionLabel.textColor = .textSubtle
 
         showMeAroundButton.isPrimary = true

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -17,12 +17,16 @@ class WordPressAuthenticationManager: NSObject {
 
     private let quickStartSettings: QuickStartSettings
 
+    private let recentSiteService: RecentSitesService
+
     init(windowManager: WindowManager,
          authenticationHandler: AuthenticationHandler? = nil,
-         quickStartSettings: QuickStartSettings = QuickStartSettings()) {
+         quickStartSettings: QuickStartSettings = QuickStartSettings(),
+         recentSiteService: RecentSitesService = RecentSitesService()) {
         self.windowManager = windowManager
         self.authenticationHandler = authenticationHandler
         self.quickStartSettings = quickStartSettings
+        self.recentSiteService = recentSiteService
     }
 
     /// Support is only available to the WordPress iOS App. Our Authentication Framework doesn't have direct access.
@@ -352,6 +356,8 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             guard let self = self else {
                 return
             }
+
+            self.recentSiteService.touch(blog: blog)
 
             guard self.quickStartSettings.isQuickStartAvailable(for: blog) else {
                 self.windowManager.dismissFullscreenSignIn(blogToShow: blog)


### PR DESCRIPTION
## Description

This PR fixes two issues found in Calls for Testing for 18.8
- After selecting site and starting a Quick Start, close the app and open it again. Some other site (maybe site selected before logout?) gets selected as your current site and QS is gone.
- Initial QS prompt content is not scaling with system font size.

Ref: p5T066-2Rr-p2#comment-10832

## How to test

1. Do a fresh install of wpios
2. Login
3. On the Login Epilogue, choose a site
4. Change the system font size
5. ✅ The Quick Start prompt should be showing and the content should be scaled according to the selected font size
6. Tap on the "Show me around" button
7. Close the Quick Start checklist
8. Close, then reopen the app
9. ✅ The selected site on My Site should be the site you selected in step 3
10. ✅ The Quick Start items should be shown in the menu

### Scaling font size
<img src="https://user-images.githubusercontent.com/6711616/145201611-8341db74-68e2-4f78-9247-f5b9eca05b8f.png" width=200>

### Persisting the selected site
https://user-images.githubusercontent.com/6711616/145201549-bd8d5985-68a1-48ec-a293-4e84e328cc3f.mp4



## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.