### PR TITLE
Comments: Show loading message when fetching data

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -706,7 +706,13 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)adjustNoResultViewPlacement
 {
     // calling this too early results in wrong tableView frame used for initial state
-    if(self.noResultsViewController.view.window == nil) {
+    if (self.noResultsViewController.view.window == nil) {
+        if (!self.splitViewController) {
+            // when the view controller is displayed without a splitViewController, assign the view's frame instead.
+            // assigning the view's frame when it's embedded in a splitViewController causes the NRV to be centered in the splitView instead of the view.
+            self.noResultsViewController.view.frame = self.view.frame;
+        }
+
         return;
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -511,6 +511,8 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
+    [self refreshNoResultsView];
+    
     __typeof(self) __weak weakSelf = self;
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
     CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
@@ -692,18 +694,11 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
         return;
     }
 
-    if (self.noResultsViewController.view.window) {
-        // The view is already visible.  Nothing more to do.
-        [self adjustNoResultViewPlacement];
-        return;
-    }
-
     [self.noResultsViewController removeFromView];
     [self configureNoResults:self.noResultsViewController forNoConnection:NO];
-    
     [self addChildViewController:self.noResultsViewController];
     [self adjustNoResultViewPlacement];
-    [self.tableView addSubviewWithFadeAnimation:self.noResultsViewController.view];
+    [self.tableView addSubview:self.noResultsViewController.view];
     
     [self.noResultsViewController didMoveToParentViewController:self];
 }
@@ -769,19 +764,33 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
        attributedSubtitleConfiguration:nil
                                  image:@"wp-illustration-empty-results"
                          subtitleImage:nil
-                         accessoryView:nil];
+                         accessoryView:[self loadingAccessoryView]];
     
     viewController.delegate = self;
 }
 
 - (NSString *)noResultsTitle
 {
+    if (self.syncHelper.isSyncing) {
+        return NSLocalizedString(@"Fetching comments...",
+                                 @"A brief prompt shown when the comment list is empty, letting the user know the app is currently fetching new comments.");
+    }
+
     return NSLocalizedString(@"No comments yet", @"Displayed when there are no comments in the Comments views.");
 }
 
 - (NSString *)retryButtonTitle
 {
     return NSLocalizedString(@"Retry", comment: "A prompt to attempt the failed network request again.");
+}
+
+- (UIView *)loadingAccessoryView
+{
+    if (self.syncHelper.isSyncing) {
+        return [NoResultsViewController loadingAccessoryView];
+    }
+
+    return nil;
 }
 
 #pragma mark - NoResultsViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -705,14 +705,9 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
 - (void)adjustNoResultViewPlacement
 {
-    // calling this too early results in wrong tableView frame used for initial state
-    if (self.noResultsViewController.view.window == nil) {
-        if (!self.splitViewController) {
-            // when the view controller is displayed without a splitViewController, assign the view's frame instead.
-            // assigning the view's frame when it's embedded in a splitViewController causes the NRV to be centered in the splitView instead of the view.
-            self.noResultsViewController.view.frame = self.view.frame;
-        }
-
+    // calling this too early results in wrong tableView frame used for initial state.
+    // ensure that either the NRV or the table view is visible. Otherwise, skip the adjustment to prevent misplacements.
+    if (!self.noResultsViewController.view.window && !self.tableView.window) {
         return;
     }
 


### PR DESCRIPTION
Refs p1638917701278600-slack-C011BKNU1V5

As titled, this updates the `NoResultsViewController` to show a loading message (and image) while the view controller is fetching data. After the fetch completes, it should show the original "No comments yet" message. Here's a quick recording to show the new message in action:

https://user-images.githubusercontent.com/1299411/145228102-517c58a9-c9b0-4d33-a0f5-a419efd29f54.mp4

## To test

It's best to log out of the app (if you're already logged in) to wipe all the comments from Core Data. 

- Go to My Site > Comments.
- Verify that the comment list shows a "Fetching comments..." loading view before showing a list of comments.
- Tap on one of the filters where there are no comments, e.g. Spam or Trash.
- Verify that the "Fetching comments..." loading view is shown briefly, and a no results view is shown shortly after.
- Do a pull-to-refresh action on the current page.
- Verify that the "Fetching comments..." loading view is shown briefly, and a no results view is shown shortly after.

## Regression Notes
1. Potential unintended areas of impact
The message could be displayed in an incorrect state. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested various refresh scenarios.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
