### PR TITLE
Fix a couple of About Screen issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutHeaderView.swift
@@ -99,6 +99,7 @@ final class AboutHeaderView: UIView {
         let appVersionLabel = makeAppVersionLabel()
         let closeButton = makeCloseButton()
 
+        translatesAutoresizingMaskIntoConstraints = false
         clipsToBounds = true
 
         stackView.addArrangedSubviews([
@@ -113,14 +114,11 @@ final class AboutHeaderView: UIView {
         addSubview(closeButton)
 
         NSLayoutConstraint.activate([
-            iconView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
             iconView.heightAnchor.constraint(equalToConstant: sizing.appIconWidthAndHeight),
             iconView.widthAnchor.constraint(equalToConstant: sizing.appIconWidthAndHeight),
 
-            appNameLabel.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
-            appVersionLabel.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
-
-            stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.edgeMargin),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Metrics.edgeMargin),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: spacing.aboveAndBelowHeaderView),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -spacing.aboveAndBelowHeaderView),
 
@@ -149,6 +147,7 @@ final class AboutHeaderView: UIView {
         appNameLabel.lineBreakMode = .byWordWrapping
         appNameLabel.numberOfLines = 1
         appNameLabel.font = fonts.appName
+        appNameLabel.adjustsFontForContentSizeCategory = true
         return appNameLabel
     }
 
@@ -156,10 +155,12 @@ final class AboutHeaderView: UIView {
         let appVersionLabel = UILabel()
 
         appVersionLabel.text = appInfo.version
+        appVersionLabel.textAlignment = .center
         appVersionLabel.lineBreakMode = .byWordWrapping
-        appVersionLabel.numberOfLines = 1
+        appVersionLabel.numberOfLines = 2
         appVersionLabel.font = fonts.appVersion
         appVersionLabel.textColor = .secondaryLabel
+        appVersionLabel.adjustsFontForContentSizeCategory = true
         return appVersionLabel
     }
 
@@ -202,5 +203,6 @@ final class AboutHeaderView: UIView {
         static let closeButtonRadius: CGFloat = 30
         static let closeButtonInset: CGFloat = 16
         static let closeButtonSymbolSize: CGFloat = 16
+        static let edgeMargin: CGFloat = 16.0
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAboutScreen.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAboutScreen.swift
@@ -62,7 +62,7 @@ class AutomatticAboutScreen: UIViewController {
 
         // Setting the frame once is needed so that the table view header will show.
         // This seems to be a table view bug although I'm not entirely sure.
-        headerView.frame.size = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        headerView.frame.size.height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
 
         return headerView
     }()
@@ -138,8 +138,14 @@ class AutomatticAboutScreen: UIViewController {
             tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             tableView.topAnchor.constraint(equalTo: view.safeTopAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
         ])
+
+        if let headerView = headerView {
+            headerView.widthAnchor.constraint(equalTo: view.widthAnchor).isActive = true
+        }
+
+        updateHeaderSize()
 
         tableView.reloadData()
     }
@@ -171,6 +177,23 @@ class AutomatticAboutScreen: UIViewController {
         if isMovingToParent {
             configuration.willShow(viewController: self)
         }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateHeaderSize()
+    }
+
+    private func updateHeaderSize() {
+        guard let headerView = headerView else {
+            return
+        }
+
+        headerView.layoutIfNeeded()
+
+        headerView.frame.size.height = headerView.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        tableView.tableHeaderView = headerView
     }
 
     // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AutomatticAppLogosCell.swift
@@ -21,6 +21,8 @@ class AutomatticAppLogosCell: UITableViewCell {
 
     func commonInit() {
         spriteKitView = SKView(frame: Metrics.sceneFrame)
+        spriteKitView.allowsTransparency = true
+
         logosScene = AppLogosScene()
 
         // Scene is resized to match the view


### PR DESCRIPTION
This PR fixes a couple of small issues with the new About screen.

1. On some devices (only on device, and it doesn't show up on screenshots), a faint shimmering outline was visible around the app logos view:

<img src="https://user-images.githubusercontent.com/4780/145231178-6fe81785-02bc-4ec7-a6f3-4cdc01fa790e.jpg" width=350>

I have only seen this on my 13 mini. This is now fixed by setting `allowsTransparency` to `true` on the SpriteKit view.

2. The text in the header view didn't respond to dynamic type changes, so I've improved that. There's still an issue for the largest accessibility text size where a very large version number can get slightly truncated, but I spent a little while on it and it's much improved from what we had before.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-08 at 15 46 37](https://user-images.githubusercontent.com/4780/145238968-20f27a9f-44f6-4363-b03a-fd9526e24b91.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-08 at 14 38 07](https://user-images.githubusercontent.com/4780/145238999-5262a338-441c-4500-88f9-2b513f823668.png) |

**To test**

* Build and run
* Navigate to Me > About
* Check the header looks as you'd expect, based on the Before screenshot above
* Try changing the dynamic font sizes and ensure it looks okay
* If you toggle it while the screen is visible, occasionally there may be a spacing issue below the header but it'll resolve itself if you reshow the view or change between other sizes.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

cc @mokagio 