### PR TITLE
Onboarding Improvements: make text larger on Quick Start prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -66,11 +66,11 @@ final class QuickStartPromptViewController: UIViewController {
         siteDescriptionLabel.textColor = .textSubtle
 
         promptTitleLabel.numberOfLines = 0
-        promptTitleLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .medium)
+        promptTitleLabel.font = WPStyleGuide.fixedSerifFontForTextStyle(.title2, fontWeight: .semibold)
         promptTitleLabel.textColor = .text
 
         promptDescriptionLabel.numberOfLines = 0
-        promptDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        promptDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
         promptDescriptionLabel.textColor = .textSubtle
 
         showMeAroundButton.isPrimary = true


### PR DESCRIPTION
Ref: p5T066-2Rr-p2#comment-10831

<img width="375" alt="Screen Shot 2021-12-08 at 16 11 22" src="https://user-images.githubusercontent.com/6711616/145242756-51432349-bd6d-42ad-9d30-cd66987c2a33.png">

## Description
This PR makes the text on the Quick Start prompt larger, per suggestion from Calls for Testing WPiOS 18.8

## To test
1. Do a fresh install of WPiOS
2. Login
3. Choose a site
4. ✅ Notice "Want a little help..." and "Learn the basics..." is in a larger font size

Before | After
-- | --
![Simulator Screen Shot - iPhone 13 - 2021-12-08 at 16 04 39](https://user-images.githubusercontent.com/6711616/145242925-d4fe95b2-445a-46c5-b4ce-fa61e03de0a9.png) | ![Simulator Screen Shot - iPhone 13 - 2021-12-08 at 16 14 53](https://user-images.githubusercontent.com/6711616/145243439-f8ff5fcf-b1f0-4c5e-9f21-d70d9b33644f.png)



## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.