### PR TITLE
Onboarding Improvements: Fix self-hosted login -> wpcom login flow

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -360,7 +360,11 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             self.recentSiteService.touch(blog: blog)
 
             guard self.quickStartSettings.isQuickStartAvailable(for: blog) else {
-                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                if self.windowManager.isShowingFullscreenSignIn {
+                    self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+                } else {
+                    self.windowManager.showAppUI(for: blog)
+                }
                 return
             }
 


### PR DESCRIPTION
Slack ref: p1638980656034000-slack-C027K4MNPGQ

## Description

This PR fixes an issue for the self-hosted login -> wpcom login flow, where tapping on a p2 site in the login epilogue for the wpcom login would not take the user to the my site screen.

Thanks to @osullivanchris for finding this 🙏 

## To test

1. Create a site on jurassic.ninja
2. Log out from the WordPress app
3. Log in using site address for jurassic.ninja site
4. Now you are logged into that self hosted site but not logged into WordPress.com
5. Login to WordPress.com
6. Tap on a p2 site
7. ✅ The app should transition to the My Site screen for the selected site

## Regression Notes
1. Potential unintended areas of impact
wpcom login then tapping on a p2 site

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.