### PR TITLE
Enable post details comments.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 18.9
 -----
-
+* [**] Reader post details: a Comments snippet is now displayed after the post content. [#17650]
 
 18.8
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -68,7 +68,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newCommentThread:
             return false
         case .postDetailsComments:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 


### PR DESCRIPTION
Ref: #17511 

This enables the Comments snippet on the post details view for release.

To test:
- Go to Reader > post > details.
- Verify the Comments table is displayed.


| <img width="473" alt="no_comments_closed" src="https://user-images.githubusercontent.com/1816888/144945581-8bb5a915-1d1f-4faf-aafd-4bc756199ba6.png"> | <img width="470" alt="no_comments_open" src="https://user-images.githubusercontent.com/1816888/144945575-a415fb51-0106-4ada-97e5-9a0cafae6405.png"> | <img width="473" alt="comments" src="https://user-images.githubusercontent.com/1816888/144945579-5ca9f3a4-ba35-47ee-abab-a12539ae0dc7.png"> |
|--------|-------|-------|

## Regression Notes
1. Potential unintended areas of impact
N/A.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
