### PR TITLE
Update AutomatticAbout Swift package to include recent fixes

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": "fix/misc-fixes",
-          "revision": "149f68dfb3c1084b6553d1ac36b7e2915a8a1469",
-          "version": null
+          "branch": null,
+          "revision": "36700103dc6070bfead85c6b25ad688d8f8c37ee",
+          "version": "1.0.1"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": null,
-          "revision": "403f0855c7b7df567bb89d1ddada069b1dae62f8",
-          "version": "1.0.0"
+          "branch": "fix/misc-fixes",
+          "revision": "149f68dfb3c1084b6553d1ac36b7e2915a8a1469",
+          "version": null
         }
       },
       {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24951,8 +24951,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "fix/misc-fixes";
+				kind = branch;
 			};
 		};
 		3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24951,8 +24951,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				branch = "fix/misc-fixes";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {


### PR DESCRIPTION
A [recent PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/17646) for the frozen build of WPiOS made some fixes to the About screen. Those fixes have now been [integrated into the About screen Swift package](https://github.com/Automattic/AutomatticAbout-Swift/pull/1). This PR updates the Swift package reference to include those fixes (I'll bump it back to a proper release version once I've merged the PR on the package repo).

**To test**

* Build and run
* Visit Me > About and ensure both of the previous fixes are still working – dynamic type on the header text, and no border visible around the SpriteKit view containing the app logos

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
