### PR TITLE
Comments: Add tracking for comment sharing intent

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -270,6 +270,10 @@ import Foundation
     case sharingButtonsEditMoreButtonToggled
     case sharingButtonsLabelChanged
 
+    // Comment Sharing
+    case readerArticleCommentShared
+    case siteCommentsCommentShared
+
     // People
     case peopleFilterChanged
     case peopleUserInvited
@@ -755,6 +759,12 @@ import Foundation
             return "sharing_buttons_edit_more_button_toggled"
         case .sharingButtonsLabelChanged:
             return "sharing_buttons_label_changed"
+
+        // Comment Sharing
+        case .readerArticleCommentShared:
+            return "reader_article_comment_shared"
+        case .siteCommentsCommentShared:
+            return "site_comments_comment_shared"
 
         // People
         case .peopleFilterChanged:

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -590,6 +590,9 @@ private extension CommentDetailViewController {
             return
         }
 
+        // track share intent.
+        WPAnalytics.track(.siteCommentsCommentShared)
+
         let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = senderView
         present(activityViewController, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WordPressShared
 
 @objc public extension ReaderCommentsViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
@@ -103,6 +104,9 @@ import UIKit
         guard let commentURL = comment.commentURL() else {
             return
         }
+
+        // track share intent.
+        WPAnalytics.track(.readerArticleCommentShared)
 
         let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
         activityViewController.popoverPresentationController?.sourceView = sourceView


### PR DESCRIPTION
Refs #17475

As titled, adds tracking for comment share intents:

- `reader_article_comment_shared` when shared from the comment threads.
- `site_comments_comment_shared` when shared from Site Comments.

## To test

### Site comments

- Go to My Site > select any approved comments.
- Tap on the Share button.
- 🔍 Verify that this appears console: `🔵 Tracked: site_comments_comment_shared <>`

### Reader comments

- Enable the `newCommentThread` feature flag.
- Go to Notifications > select any comment notification.
- Tap on the notification header to go to the comment threads.
- Tap the share button (or if you can moderate, tap ellipsis button > Share).
- 🔍  Verify that this appears in the console: `🔵 Tracked: reader_article_comment_shared <>`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that the tracks are sent correctly.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
