### PR TITLE
Onboarding Improvements: Fix font scaling for the Quick Start prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -70,7 +70,7 @@ final class QuickStartPromptViewController: UIViewController {
         siteDescriptionLabel.textColor = .textSubtle
 
         promptTitleLabel.numberOfLines = 0
-        promptTitleLabel.font = WPStyleGuide.fixedSerifFontForTextStyle(.title2, fontWeight: .semibold)
+        promptTitleLabel.font = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
         promptTitleLabel.adjustsFontForContentSizeCategory = true
         promptTitleLabel.adjustsFontSizeToFitWidth = true
         promptTitleLabel.textColor = .text
@@ -79,7 +79,6 @@ final class QuickStartPromptViewController: UIViewController {
         promptDescriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
         promptDescriptionLabel.adjustsFontForContentSizeCategory = true
         promptDescriptionLabel.adjustsFontSizeToFitWidth = true
-
         promptDescriptionLabel.textColor = .textSubtle
 
         showMeAroundButton.isPrimary = true

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
@@ -26,30 +26,52 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="wS6-OQ-uc5">
-                    <rect key="frame" x="20" y="124" width="374" height="110"/>
+                <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w31-gj-Dsv">
+                    <rect key="frame" x="20" y="124" width="374" height="586"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5oK-P9-biU">
-                            <rect key="frame" x="0.0" y="0.0" width="374" height="45"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="wS6-OQ-uc5">
+                            <rect key="frame" x="0.0" y="0.0" width="374" height="110"/>
                             <subviews>
-                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5pl-dB-rPb">
-                                    <rect key="frame" x="0.0" y="2.5" width="40" height="40"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="40" id="LBc-8A-qPF"/>
-                                        <constraint firstAttribute="width" secondItem="5pl-dB-rPb" secondAttribute="height" id="VjL-ts-OLa"/>
-                                    </constraints>
-                                </imageView>
-                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="lqh-pW-MOV">
-                                    <rect key="frame" x="50" y="0.0" width="324" height="45"/>
+                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="5oK-P9-biU">
+                                    <rect key="frame" x="0.0" y="0.0" width="374" height="45"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3V2-cy-NN5">
-                                            <rect key="frame" x="0.0" y="0.0" width="324" height="20.5"/>
+                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5pl-dB-rPb">
+                                            <rect key="frame" x="0.0" y="2.5" width="40" height="40"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="40" id="LBc-8A-qPF"/>
+                                                <constraint firstAttribute="width" secondItem="5pl-dB-rPb" secondAttribute="height" id="VjL-ts-OLa"/>
+                                            </constraints>
+                                        </imageView>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="lqh-pW-MOV">
+                                            <rect key="frame" x="50" y="0.0" width="324" height="45"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3V2-cy-NN5">
+                                                    <rect key="frame" x="0.0" y="0.0" width="324" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="T6b-Pg-T2k">
+                                                    <rect key="frame" x="0.0" y="24.5" width="324" height="20.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </stackView>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kWJ-TZ-NYM">
+                                    <rect key="frame" x="0.0" y="61" width="374" height="49"/>
+                                    <subviews>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="doQ-6M-3Uv">
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="T6b-Pg-T2k">
-                                            <rect key="frame" x="0.0" y="24.5" width="324" height="20.5"/>
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kqr-FO-d5M">
+                                            <rect key="frame" x="0.0" y="28.5" width="374" height="20.5"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -58,25 +80,15 @@
                                 </stackView>
                             </subviews>
                         </stackView>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kWJ-TZ-NYM">
-                            <rect key="frame" x="0.0" y="61" width="374" height="49"/>
-                            <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="doQ-6M-3Uv">
-                                    <rect key="frame" x="0.0" y="0.0" width="374" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Kqr-FO-d5M">
-                                    <rect key="frame" x="0.0" y="28.5" width="374" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
-                            </subviews>
-                        </stackView>
                     </subviews>
-                </stackView>
+                    <constraints>
+                        <constraint firstItem="wS6-OQ-uc5" firstAttribute="leading" secondItem="w31-gj-Dsv" secondAttribute="leading" id="5wb-KX-hO2"/>
+                        <constraint firstAttribute="bottom" secondItem="wS6-OQ-uc5" secondAttribute="bottom" id="Rqm-jQ-ZC6"/>
+                        <constraint firstAttribute="trailing" secondItem="wS6-OQ-uc5" secondAttribute="trailing" id="iWo-8u-bKd"/>
+                        <constraint firstItem="wS6-OQ-uc5" firstAttribute="top" secondItem="w31-gj-Dsv" secondAttribute="top" id="mIb-1N-DCT"/>
+                        <constraint firstItem="wS6-OQ-uc5" firstAttribute="width" secondItem="w31-gj-Dsv" secondAttribute="width" id="nHc-yp-wk9"/>
+                    </constraints>
+                </scrollView>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="88c-8d-UbI">
                     <rect key="frame" x="20" y="734" width="374" height="104"/>
                     <subviews>
@@ -106,12 +118,13 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstAttribute="trailingMargin" secondItem="wS6-OQ-uc5" secondAttribute="trailing" id="Ado-d7-g5C"/>
-                <constraint firstItem="wS6-OQ-uc5" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="MFc-W9-00A"/>
+                <constraint firstItem="w31-gj-Dsv" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="80" id="0uM-8v-xeM"/>
+                <constraint firstAttribute="trailingMargin" secondItem="w31-gj-Dsv" secondAttribute="trailing" id="51M-BA-Z8b"/>
                 <constraint firstAttribute="leadingMargin" secondItem="88c-8d-UbI" secondAttribute="leading" id="Qbc-f2-ZaH"/>
+                <constraint firstItem="88c-8d-UbI" firstAttribute="top" secondItem="w31-gj-Dsv" secondAttribute="bottom" constant="24" id="cEg-cI-kct"/>
                 <constraint firstAttribute="trailingMargin" secondItem="88c-8d-UbI" secondAttribute="trailing" id="daa-Gn-9WI"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="88c-8d-UbI" secondAttribute="bottom" constant="24" id="oQS-J2-RXn"/>
-                <constraint firstItem="wS6-OQ-uc5" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="80" id="vN3-dJ-56h"/>
+                <constraint firstItem="w31-gj-Dsv" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="pfX-zX-22J"/>
             </constraints>
             <point key="canvasLocation" x="132" y="76"/>
         </view>


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/17652#discussion_r766527491

## Description

This PR fixes
- The scaling for the serif label from #17648
- The text overlapping with the action buttons when the system font size is large

Thanks @dvdchr for pointing out these issues.

## Notes

### ⚠️ This PR should be merged into `develop`. It is temporarily pointing to ` merge/18.8-beta-4-into-develop`. 

### While this PR is ready to review, I'll wait until ` merge/18.8-beta-4-into-develop` gets merged to open the PR, so it doesn't accidentally get merged in to ` merge/18.8-beta-4-into-develop`.

- My fixes are dependent on some stuff in `merge/18.8-beta-4-into-develop`, which is why this PR is based on that branch
- Since these changes aren't needed in 18.8, `merge/18.8-beta-4-into-develop` can be merged in to `develop`, without this PR being merged into `merge/18.8-beta-4-into-develop` (Slack ref: p1639144141039900-slack-C027K4MNPGQ)
- Once `merge/18.8-beta-4-into-develop` gets merged in to `develop`, the base branch for this PR _should_ change to `develop` automatically, and my fixes can be part of 18.9

## How to test

1. Do a fresh install of wpios
2. Login
3. On the Login Epilogue, choose a site
4. Change the system font size to the **largest** size
5. ✅ The Quick Start prompt should be showing and the content should be scaled according to the selected font size
6. ✅ You should be able to scroll down to see any text that's larger than the frame of the scrollview

iPhone | iPad
-- | --
<img src="https://user-images.githubusercontent.com/6711616/145567855-fa48da01-100f-46e4-a9dd-0ceca98305af.png " width=200> | <img src= "https://user-images.githubusercontent.com/6711616/145568238-014dd6c3-7ab7-42bf-9dec-7f9b90891bde.png" width=500>



## Regression Notes
1. Potential unintended areas of impact
Quick Start iPad readable content width

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Check manually, see screenshot above

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
