### PR TITLE
Fixes RTL layout in About screen

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": null,
-          "revision": "36700103dc6070bfead85c6b25ad688d8f8c37ee",
-          "version": "1.0.1"
+          "branch": "fix/rtl-layout",
+          "revision": "b37c5a69562e2df2776f9248f753f9e482beb9f8",
+          "version": null
         }
       },
       {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24951,8 +24951,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "fix/rtl-layout";
+				kind = branch;
 			};
 		};
 		3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {


### PR DESCRIPTION
The previous layout constraints for the app logo cell's SpriteKitView created an ambiguous horizontal layout. This had the result of the cell not having any width (and not being visible) in right-to-left layouts. 

This PR adds two extra constraints to ensure that the cell is visible in all cases.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-10 at 12 12 22](https://user-images.githubusercontent.com/4780/145573548-42ec9d80-4723-4301-a009-f445488a3877.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2021-12-10 at 11 38 52](https://user-images.githubusercontent.com/4780/145573552-e045cd14-11a3-410f-87eb-d7dc52aeabd6.png) |

**To test**

* Build and run
* Navigate to Me > About, and check you can see the app logos cell
* Stop the app
* In Xcode, edit the scheme (product > scheme > edit scheme, or Cmd+<) and under options change the app language to an RTL language or to 'right-to-left pseudo language'
* Build and run again, and navigate to the About screen again. Ensure that the logos cell is still visible.

## Regression Notes

1. Potential unintended areas of impact

LTR layout

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually tested in LTR layout that the cell was still visible, and ensured there were no constraint issues

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
