### PR TITLE
Workaround for back button not being recognized by XCUITest

### DIFF
--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -2,16 +2,16 @@ import UIKit
 import XCTest
 import ScreenObject
 
-// TODO: This should maybe go in an `XCUIApplication` extension? Also, should it be computed rather
-// than stored as a reference? 🤔
-public let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
+// TODO: This should maybe go in an `XCUIApplication` extension?
+public var navBackButton: XCUIElement { XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0) }
 
 // Sometimes the Back Button in Navigation Bar is not recognized by XCUITest as an element.
 // This method identifies when it happens and uses a swipe back gesture instead of tapping the button.
 public func navigateBack() {
-    if XCUIApplication().navigationBars.element(boundBy: 0).buttons.count == 1 {
-        let leftEdge = XCUIApplication().coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
-        let center = XCUIApplication().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+    let app = XCUIApplication()
+    if app.navigationBars.element(boundBy: 0).buttons.count == 1 {
+        let leftEdge = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
+        let center = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
 
         leftEdge.press(forDuration: 0.01, thenDragTo: center)
     } else { navBackButton.tap() }

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -6,6 +6,17 @@ import ScreenObject
 // than stored as a reference? 🤔
 public let navBackButton = XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
 
+// Sometimes the Back Button in Navigation Bar is not recognized by XCUITest as an element.
+// This method identifies when it happens and uses a swipe back gesture instead of tapping the button.
+public func navigateBack() {
+    if XCUIApplication().navigationBars.element(boundBy: 0).buttons.count == 1 {
+        let leftEdge = XCUIApplication().coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
+        let center = XCUIApplication().coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+
+        leftEdge.press(forDuration: 0.01, thenDragTo: center)
+    } else { navBackButton.tap() }
+}
+
 extension ScreenObject {
 
     // TODO: This was implemented on the original `BaseScreen` and is here just as a copy-paste for the transition.

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -5,16 +5,23 @@ import ScreenObject
 // TODO: This should maybe go in an `XCUIApplication` extension?
 public var navBackButton: XCUIElement { XCUIApplication().navigationBars.element(boundBy: 0).buttons.element(boundBy: 0) }
 
+// This list has all the navBarButton labels currently covered by UI tests and must be updated when adding new ones.
+public let navBackButtonLabels = ["Post Settings", "Back", "Get Started"]
+
 // Sometimes the Back Button in Navigation Bar is not recognized by XCUITest as an element.
 // This method identifies when it happens and uses a swipe back gesture instead of tapping the button.
 public func navigateBack() {
     let app = XCUIApplication()
-    if app.navigationBars.element(boundBy: 0).buttons.count == 1 {
+    let isBackButonAvailableInNavigationBar = navBackButtonLabels.contains(navBackButton.label)
+
+    if isBackButonAvailableInNavigationBar {
+        navBackButton.tap()
+    } else {
         let leftEdge = app.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0.5))
         let center = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
 
         leftEdge.press(forDuration: 0.01, thenDragTo: center)
-    } else { navBackButton.tap() }
+    }
 }
 
 extension ScreenObject {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -79,7 +79,7 @@ public class EditorPostSettings: ScreenObject {
 
     /// - Note: Returns `Void` because the return screen depends on which editor the user is in.
     public func closePostSettings() {
-        navBackButton.tap()
+        navigateBack()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -15,7 +15,7 @@ public class CategoriesComponent: ScreenObject {
     }
 
     func goBackToSettings() throws -> EditorPostSettings {
-        navBackButton.tap()
+        navigateBack()
 
         return try EditorPostSettings()
     }

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -17,7 +17,7 @@ public class TagsComponent: ScreenObject {
     }
 
     func goBackToSettings() throws -> EditorPostSettings {
-        navBackButton.tap()
+        navigateBack()
 
         return try EditorPostSettings()
     }

--- a/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
@@ -34,7 +34,7 @@ public class SiteSettingsScreen: ScreenObject {
 
     public func goBackToMySite() throws -> MySiteScreen {
         if XCUIDevice.isPhone {
-            navBackButton.tap()
+            navigateBack()
         }
         return try MySiteScreen()
     }

--- a/WordPress/WordPressUITests/Flows/EditorFlow.swift
+++ b/WordPress/WordPressUITests/Flows/EditorFlow.swift
@@ -4,7 +4,7 @@ import XCTest
 class EditorFlow {
     static func returnToMainEditorScreen() {
         while EditorPostSettings.isLoaded() || CategoriesComponent.isLoaded() || TagsComponent.isLoaded() || MediaPickerAlbumListScreen.isLoaded() || MediaPickerAlbumScreen.isLoaded() {
-            navBackButton.tap()
+            navigateBack()
         }
     }
 

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -84,7 +84,7 @@ class LoginFlow {
                     if GetStartedScreen.isLoaded() && GetStartedScreen.isEmailEntered() {
                         try GetStartedScreen().emailTextField.clearText()
                     }
-                    navBackButton.tap()
+                    navigateBack()
                 }
             }
 


### PR DESCRIPTION
## Context
Looking into last month's UI Tests pipeline failures for `develop` and `release` branches , the most common error message (12 out of 19) really coming from the tests look like the one below and once it happens all the following tests do fail the same way.

> Failed to synthesize event: Failed to scroll to visible (by AX action) Button, {{2.0, 762.0}, {126.0, 48.0}}, identifier: 'mySitesTabButton', label: 'My Site', Selected, error: Error kAXErrorCannotComplete performing AXAction kAXScrollToVisibleAction on element AX element pid: 3066, elementOrHash.elementID: 140453558983040.361. (Underlying Error: Error kAXErrorCannotComplete performing AXAction kAXScrollToVisibleAction on element AX element pid: 3066, elementOrHash.elementID: 140453558983040.361)

Sometimes, for some unknown reason, the Back Button in the navigation bar is not recognized by XCUITest as an element making `navBackButton.tap()` actually tap what would be the second button in the navigation bar, Help button in some cases, breaking `tearDown` and `setUp` for all the tests.

### Evidences
#### Happy case
![image](https://user-images.githubusercontent.com/42008628/145590657-d72d500f-7278-4a9d-9826-f58ffc1b4c02.png)
>   ↪︎Find: Descendants matching type NavigationBar
    Output: {
      NavigationBar, {{0.0, 47.0}, {390.0, 44.0}}, identifier: 'Log In'
    }
    ↪︎Find: Element at index 0
      Output: {
        NavigationBar, {{0.0, 47.0}, {390.0, 44.0}}, identifier: 'Log In'
      }
      ↪︎Find: Descendants matching type Button
        Output: {
          **Button, {{0.0, 47.0}, {44.0, 44.0}}, label: 'Get Started'
          Button, {{331.0, 47.0}, {38.0, 44.0}}, identifier: 'authenticator-help-button', label: 'Help'**
        }
        ↪︎Find: Element at index 0
          Output: {
            **Button, {{0.0, 47.0}, {44.0, 44.0}}, label: 'Get Started'**
          }


#### Issue
https://user-images.githubusercontent.com/42008628/145590305-481e9417-e78a-4869-b5b1-c2068cb48074.mov

>   ↪︎Find: Descendants matching type NavigationBar
    Output: {
      NavigationBar, {{0.0, 47.0}, {390.0, 44.0}}, identifier: 'Log In'
    }
    ↪︎Find: Element at index 0
      Output: {
        NavigationBar, {{0.0, 47.0}, {390.0, 44.0}}, identifier: 'Log In'
      }
      ↪︎Find: Descendants matching type Button
        Output: {
          **Button, {{331.0, 47.0}, {38.0, 44.0}}, identifier: 'authenticator-help-button', label: 'Help'**
        }
        ↪︎Find: Element at index 0
          Output: {
            **Button, {{331.0, 47.0}, {38.0, 44.0}}, identifier: 'authenticator-help-button', label: 'Help'**
          }

## Objective
This PR adds a swipe back gesture as redundancy for the back button. 

## Testing
If CircleCI and Buildkite pass, it should be ok.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
