### PR TITLE
Reader Comments: Hide comment thread moderation menu

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,6 +21,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case aboutScreen
     case newCommentThread
     case postDetailsComments
+    case commentThreadModerationMenu
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -69,6 +70,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .postDetailsComments:
             return true
+        case .commentThreadModerationMenu:
+            return false
         }
     }
 
@@ -133,6 +136,8 @@ extension FeatureFlag {
             return "New Comment Thread"
         case .postDetailsComments:
             return "Post Details Comments"
+        case .commentThreadModerationMenu:
+            return "Comment Thread Moderation Menu"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -1269,7 +1269,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         __weak __typeof(self) weakSelf = self;
 
         cell.accessoryButtonAction = ^(UIView * _Nonnull sourceView) {
-            if ([comment allowsModeration]) {
+            if (comment && [self isModerationMenuEnabledFor:comment]) {
                 // NOTE: Remove when minimum version is bumped to iOS 14.
                 [self showMenuSheetFor:comment indexPath:indexPath handler:weakSelf.tableViewHandler sourceView:sourceView];
             } else {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.swift
@@ -74,17 +74,17 @@ import WordPressShared
         cell.badgeTitle = comment.isFromPostAuthor() ? .authorBadgeText : nil
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
-        cell.accessoryButtonType = comment.allowsModeration() ? .ellipsis : .share
+        cell.accessoryButtonType = isModerationMenuEnabled(for: comment) ? .ellipsis : .share
         cell.hidesModerationBar = true
 
         // if the comment can be moderated, show the context menu when tapping the accessory button.
         // Note that accessoryButtonAction will be ignored when the menu is assigned.
         if #available (iOS 14.0, *) {
-            cell.accessoryButton.showsMenuAsPrimaryAction = comment.allowsModeration()
-            cell.accessoryButton.menu = comment.allowsModeration() ? menu(for: comment,
-                                                                             indexPath: indexPath,
-                                                                             handler: handler,
-                                                                             sourceView: cell.accessoryButton) : nil
+            cell.accessoryButton.showsMenuAsPrimaryAction = isModerationMenuEnabled(for: comment)
+            cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment,
+                                                                                     indexPath: indexPath,
+                                                                                     handler: handler,
+                                                                                     sourceView: cell.accessoryButton) : nil
         }
 
         cell.configure(with: comment, renderMethod: .richContent) { _ in
@@ -133,6 +133,10 @@ import WordPressShared
         }
 
         present(menuViewController, animated: true)
+    }
+
+    func isModerationMenuEnabled(for comment: Comment) -> Bool {
+        return comment.allowsModeration() && Feature.enabled(.commentThreadModerationMenu)
     }
 
     // MARK: - Tracking


### PR DESCRIPTION
Refs #17475
Depends on #17656

As titled, this hides the comment moderation menu.

## To test

- Ensure that the `commentThreadModerationMenu` is disabled.
- Select a site where you have moderation power.
- Go to any comment threads on the site.
- 🔍 Verify that the Share icon is shown (instead of the ellipsis icon).
- Tap on the Share icon.
- 🔍 Verify that the Share sheet is shown.
- Repeat the test above on iOS 13 (since it uses a different implementation with iOS 14+).

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is hidden behind a flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is hidden behind a flag.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is hidden behind a flag.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
