### PR TITLE
Filter media types when presenting the Media Picker for Mobile Gutenberg

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756, #17761]
 * [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]
 * [*] Self-hosted login: Improved error messages. [#17724]
+* [*] Block editor: Fixed an issue where videos thumbnails could show when selecting images, and vice versa. [#17670]
 
 19.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 * [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756, #17761]
 * [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]
 * [*] Self-hosted login: Improved error messages. [#17724]
-* [*] Block editor: Fixed an issue where videos thumbnails could show when selecting images, and vice versa. [#17670]
+* [*] Block editor: Fixed an issue where video thumbnails could show when selecting images, and vice versa. [#17670]
 
 19.0
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -1,7 +1,9 @@
 import Foundation
 import CoreServices
-import WPMediaPicker
+import UIKit
 import Photos
+import WordPressShared
+import WPMediaPicker
 import Gutenberg
 
 public typealias GutenbergMediaPickerHelperCallback = ([WPMediaAsset]?) -> Void
@@ -39,18 +41,6 @@ class GutenbergMediaPickerHelper: NSObject {
         self.post = post
     }
 
-    fileprivate func defaultMediaPickerOptions() -> WPMediaPickerOptions {
-        let options = WPMediaPickerOptions()
-        options.showMostRecentFirst = true
-        options.filter = [.image]
-        options.allowCaptureOfMedia = false
-        options.showSearchBar = true
-        options.badgedUTTypes = [String(kUTTypeGIF)]
-        options.allowMultipleSelection = false
-        options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
-        return options
-    }
-
     func presentMediaPickerFullScreen(animated: Bool,
                                       filter: WPMediaType,
                                       dataSourceType: MediaPickerDataSourceType = .device,
@@ -59,10 +49,7 @@ class GutenbergMediaPickerHelper: NSObject {
 
         didPickMediaCallback = callback
 
-        let mediaPickerOptions = defaultMediaPickerOptions()
-        mediaPickerOptions.filter = filter
-        mediaPickerOptions.allowMultipleSelection = allowMultipleSelection
-
+        let mediaPickerOptions = WPMediaPickerOptions.withDefaults(filter: filter, allowMultipleSelection: allowMultipleSelection)
         let picker = WPNavigationMediaPickerViewController(options: mediaPickerOptions)
         navigationPicker = picker
         switch dataSourceType {
@@ -93,7 +80,7 @@ class GutenbergMediaPickerHelper: NSObject {
 
     private lazy var cameraPicker: WPMediaPickerViewController = {
         let cameraPicker = WPMediaPickerViewController()
-        cameraPicker.options = defaultMediaPickerOptions()
+        cameraPicker.options = WPMediaPickerOptions.withDefaults()
         cameraPicker.mediaPickerDelegate = self
         cameraPicker.dataSource = WPPHAssetDataSource.sharedInstance()
         return cameraPicker
@@ -253,4 +240,27 @@ extension GutenbergMediaPickerHelper {
                     picker.actionBar?.isHidden = false
             })
         }
+}
+
+fileprivate extension WPMediaPickerOptions {
+    static func withDefaults(
+        showMostRecentFirst: Bool = true,
+        filter: WPMediaType = [.image],
+        allowCaptureOfMedia: Bool = false,
+        showSearchBar: Bool = true,
+        badgedUTTypes: Set<String> = [String(kUTTypeGIF)],
+        allowMultipleSelection: Bool = false,
+        preferredStatusBarStyle: UIStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
+    ) -> WPMediaPickerOptions {
+        let options = WPMediaPickerOptions()
+        options.showMostRecentFirst = showMostRecentFirst
+        options.filter = filter
+        options.allowCaptureOfMedia = allowCaptureOfMedia
+        options.showSearchBar = showSearchBar
+        options.badgedUTTypes = badgedUTTypes
+        options.allowMultipleSelection = allowMultipleSelection
+        options.preferredStatusBarStyle = preferredStatusBarStyle
+
+        return options
+    }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -32,7 +32,14 @@ class GutenbergMediaPickerHelper: NSObject {
     ///
     fileprivate lazy var devicePhotoLibraryDataSource = WPPHAssetDataSource()
 
-    fileprivate lazy var mediaPickerOptions: WPMediaPickerOptions = {
+    var didPickMediaCallback: GutenbergMediaPickerHelperCallback?
+
+    init(context: UIViewController, post: AbstractPost) {
+        self.context = context
+        self.post = post
+    }
+
+    fileprivate func defaultMediaPickerOptions() -> WPMediaPickerOptions {
         let options = WPMediaPickerOptions()
         options.showMostRecentFirst = true
         options.filter = [.image]
@@ -42,13 +49,6 @@ class GutenbergMediaPickerHelper: NSObject {
         options.allowMultipleSelection = false
         options.preferredStatusBarStyle = WPStyleGuide.preferredStatusBarStyle
         return options
-    }()
-
-    var didPickMediaCallback: GutenbergMediaPickerHelperCallback?
-
-    init(context: UIViewController, post: AbstractPost) {
-        self.context = context
-        self.post = post
     }
 
     func presentMediaPickerFullScreen(animated: Bool,
@@ -59,7 +59,11 @@ class GutenbergMediaPickerHelper: NSObject {
 
         didPickMediaCallback = callback
 
-        let picker = WPNavigationMediaPickerViewController()
+        let mediaPickerOptions = defaultMediaPickerOptions()
+        mediaPickerOptions.filter = filter
+        mediaPickerOptions.allowMultipleSelection = allowMultipleSelection
+
+        let picker = WPNavigationMediaPickerViewController(options: mediaPickerOptions)
         navigationPicker = picker
         switch dataSourceType {
         case .device:
@@ -73,8 +77,6 @@ class GutenbergMediaPickerHelper: NSObject {
         }
 
         picker.selectionActionTitle = Constants.mediaPickerInsertText
-        mediaPickerOptions.filter = filter
-        mediaPickerOptions.allowMultipleSelection = allowMultipleSelection
         picker.mediaPicker.options = mediaPickerOptions
         picker.delegate = self
         picker.mediaPicker.registerClass(forReusableCellOverlayViews: DisabledVideoOverlay.self)
@@ -91,7 +93,7 @@ class GutenbergMediaPickerHelper: NSObject {
 
     private lazy var cameraPicker: WPMediaPickerViewController = {
         let cameraPicker = WPMediaPickerViewController()
-        cameraPicker.options = mediaPickerOptions
+        cameraPicker.options = defaultMediaPickerOptions()
         cameraPicker.mediaPickerDelegate = self
         cameraPicker.dataSource = WPPHAssetDataSource.sharedInstance()
         return cameraPicker


### PR DESCRIPTION
Fixes:
- https://github.com/wordpress-mobile/gutenberg-mobile/issues/4371

## To test:

### Images
1. Ensure at least one image and one video exist in the Photos app and that the WordPress app has appropriate access (configure access to Photos in iOS Settings -> WordPress). It's simplest to allow access to All Photos.
2. Start a new Post and add an Image block
3. Tap "Add Image".
4. Tap "Choose from device".
5. Thumbnails of videos should not be shown
6. Videos should so a count of 0

### Videos
1. Ensure at least one image and one video exist in the Photos app and that the WordPress app has appropriate access (configure access to Photos in iOS Settings -> WordPress). It's simplest to allow access to All Photos.
2. Start a new Post and add an Video block
3. Tap "Add Video".
4. Tap "Choose from device".
5. Thumbnails of images should not be shown

## Screenshots

### Before
| Before | After |
| ------ | ----- |
| <video src="https://user-images.githubusercontent.com/2092798/145693360-7cc002a9-6518-4d68-affe-f8a4ce7a3dbe.MP4" /> | <video src="https://user-images.githubusercontent.com/2092798/145693367-3454e8d8-22ba-4f46-9027-f7f654e52757.MP4"> |

## Regression Notes
1. Potential unintended areas of impact
Any blocks that allow uploading media from the device such as the Image, Gallery, Video, and Media & Text blocks.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I manually tested this on a device.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
