### PR TITLE
Jetpack: when using SIWA to create an account, show the no Jetpack sites screen

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -5,6 +5,8 @@ protocol AuthenticationHandler {
 
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, windowManager: WindowManager, onDismiss: @escaping () -> Void) -> Bool
 
+    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?)
+
     // WPAuthenticator style overrides
     var statusBarStyle: UIStatusBarStyle { get }
     var prologueViewController: UIViewController? { get }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -386,6 +386,11 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Presents the Signup Epilogue, in the specified NavigationController.
     ///
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+        if let authenticationHandler = authenticationHandler {
+            authenticationHandler.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
+            return
+        }
+
         let storyboard = UIStoryboard(name: "SignupEpilogue", bundle: .main)
         guard let epilogueViewController = storyboard.instantiateInitialViewController() as? SignupEpilogueViewController else {
             fatalError()

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -65,6 +65,14 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
         return true
     }
 
+    // If the user signs up using the Jetpack app (through SIWA, for example)
+    // We show right away the screen explaining that they do not have Jetpack sites
+    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+        let viewModel = JetpackNoSitesErrorViewModel()
+        let controller = errorViewController(with: viewModel)
+        navigationController.present(controller, animated: true)
+    }
+
     // MARK: - Private: Helpers
     private func isValidJetpack(for site: WordPressComSiteInfo) -> Bool {
         return site.hasJetpack &&

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -68,9 +68,13 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
     // If the user signs up using the Jetpack app (through SIWA, for example)
     // We show right away the screen explaining that they do not have Jetpack sites
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
+        let windowManager = WordPressAppDelegate.shared?.windowManager
+
+        windowManager?.dismissFullscreenSignIn()
+
         let viewModel = JetpackNoSitesErrorViewModel()
         let controller = errorViewController(with: viewModel)
-        navigationController.present(controller, animated: true)
+        windowManager?.show(controller, completion: nil)
     }
 
     // MARK: - Private: Helpers


### PR DESCRIPTION
This PR adds an additional check for Jetpack login. If SIWA is used and a new account is created, the user will see the "No Jetpack sites found" screen

<img src="https://user-images.githubusercontent.com/7040243/146064715-a5872cc6-e9b8-4c80-ae00-4ebde1ea3439.png" width="300">

### To test

It's not possible to test this flow with a debug build. In this case I recommend:

1. Change `AppConfiguration.swift`, `allowSignUp` should be `true`
2. Tap Continue with WP.com
3. Enter an email like youremail+something@yourmail.com
4. Copy/paste the magic link to the Safari in the simulator
5. Make sure the "No Jetpack sites found" screen appear

## Regression Notes
1. Potential unintended areas of impact
Jetpack login

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
