### PR TITLE
Follow Conversation: Fix cases where the follow button is missing

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -789,6 +789,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)refreshAndSync
 {
+    [self refreshFollowButton];
     [self refreshPostHeaderView];
     [self refreshSubscriptionStatusIfNeeded];
     [self refreshReplyTextView];


### PR DESCRIPTION
Refs `pbArwn-3hB-p2#comment-4533`

This fixes the case where the Follow button is missing due to the Post object not being available initially but is not refreshed after the Post object is obtained.

## To test

### Comment threads from Notifications

- Go to Notifications.
- Select any comment notification.
- Tap on the notification header to go to the comment threads.
- 🔍 Verify that the Follow button appears after the loading completes.

### Comment threads from Site Comments

- Go to My Sites > Comments.
- Select any reply comment.
- Tap on the comment header to go to the comment threads.
- 🔍 Verify that the Follow button appears after the loading completes.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that it is working properly.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
