### PR TITLE
[Tooling] Disable widgets script on L10n download

### DIFF
--- a/Scripts/update-translations.rb
+++ b/Scripts/update-translations.rb
@@ -162,7 +162,3 @@ langs.each do |code,local|
   # Clean up after ourselves
   FileUtils.rm_f backup_destination
 end
-
-extract_framework_translations_script_path = File.join(script_root, 'extract-framework-translations.swift')
-
-system extract_framework_translations_script_path if strings_filter.empty? 


### PR DESCRIPTION
As mentioned in https://github.com/wordpress-mobile/WordPress-iOS/pull/17672#discussion_r768283419

⚠️  This PR targets the release branch, so that this fix would be applied before the next `new_beta_release` or `finalize_release`.

cc @jkmassel @mokagio  You'll need to land this before running the next `new_beta_release` — otherwise the lane will likely crash (on not finding the strings files for widgets anymore)

## Why?

Now that the Widgets & ShareExtension don't use their own `*.lproj/Localizable.strings` files (but instead reference the app bundle's one) — see #17630 & #17636 — this means we don't need to "redistribute" the strings downloaded from GlotPress from the main `.strings` to the ones in the Widget target's subfolders (as those don't exist anymore).

I am still working on porting the "download-from-glotpress-and-postprocess" part of the tooling to the release-toolkit and modernizing it by cleaning up the logic, but in the meantime, this PR just disables the call to `extract-framework-translations.swift` which was responsible for that "redistribution" of strings to Widgets, because it would otherwise fail and crash during `new_beta_release` and `finalize_release` when fetching the latest translations.

This is because the `extract-framework-translations.swift` script [references the `Base.lproj/Localizable.strings` files](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/Scripts/extract-framework-translations.swift#L51) from the [Widget and ShareExtension subfolders](https://github.com/wordpress-mobile/WordPress-iOS/blob/develop/Scripts/extract-framework-translations.swift#L10-L13) (so that it knew which keys to copy over), but those files no longer exists since #17630, #17636 and #17672, so the script would not be happy with them missing.

Since all this logic will soon be replaced by new actions I'm working on in the release-toolkit, I only focused on disabling what would crash for now, while still keeping the rest of the current tooling around until the new stuff is ready.