### PR TITLE
Update release-toolkit to 2.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,22 +1,3 @@
-GIT
-  remote: git@github.com:wordpress-mobile/release-toolkit
-  revision: 31187cfd1e671a6f686466066b9deb67f864358c
-  branch: develop
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (2.2.0)
-      activesupport (~> 5)
-      bigdecimal (~> 1.4)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      git (~> 1.3)
-      jsonlint (~> 0.3)
-      nokogiri (~> 1.11)
-      octokit (~> 4.18)
-      parallel (~> 1.14)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -184,6 +165,19 @@ GEM
       trainer
       xcodeproj
       xctest_list (>= 1.2.1)
+    fastlane-plugin-wpmreleasetoolkit (2.3.0)
+      activesupport (~> 5)
+      bigdecimal (~> 1.4)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      git (~> 1.3)
+      jsonlint (~> 0.3)
+      nokogiri (~> 1.11)
+      octokit (~> 4.18)
+      parallel (~> 1.14)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
     ffi (1.15.0)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -244,7 +238,7 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.6.1)
-    minitest (5.14.4)
+    minitest (5.15.0)
     molinillo (0.6.6)
     multi_json (1.15.0)
     multipart-post (2.0.0)
@@ -346,7 +340,7 @@ DEPENDENCIES
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
   fastlane-plugin-test_center
-  fastlane-plugin-wpmreleasetoolkit!
+  fastlane-plugin-wpmreleasetoolkit (~> 2.3)
   octokit (~> 4.0)
   rake
   rmagick (~> 3.2.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -84,6 +84,7 @@ platform :ios do
   ENV['DOWNLOAD_METADATA'] = './fastlane/download_metadata.swift'
   ENV['PROJECT_ROOT_FOLDER'] = PROJECT_ROOT_FOLDER + '/'
   ENV['APP_STORE_STRINGS_FILE_NAME'] = 'AppStoreStrings.po'
+  ENV['FL_RELEASE_TOOLKIT_DEFAULT_BRANCH'] = 'trunk'
 
   ########################################################################
   # Screenshots

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -6,9 +6,9 @@ group :screenshots, optional: true do
   gem 'rmagick', '~> 3.2.0'
 end
 
-# gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2.1'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2.3'
 # This comment avoids typing to switch to a development version for testing.
-gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'develop'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'develop'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -8,7 +8,7 @@ end
 
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2.3'
 # This comment avoids typing to switch to a development version for testing.
-#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'develop'
+#gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: 'trunk'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'


### PR DESCRIPTION
This PR is a smaller subset of https://github.com/wordpress-mobile/WordPress-iOS/pull/17626. We are making this change in the release branch as well to avoid any issues with the default branch being updated.

**Please DO NOT merge this PR until the default branch change is applied.**

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
