### PR TITLE
Comments: Track comment editor opened.

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -530,6 +530,7 @@ private extension CommentDetailViewController {
             self?.updateComment()
         })
 
+        CommentAnalytics.trackCommentEditorOpened(comment: comment)
         let navigationControllerToPresent = UINavigationController(rootViewController: editCommentTableViewController)
         navigationControllerToPresent.modalPresentationStyle = .fullScreen
         present(navigationControllerToPresent, animated: true)


### PR DESCRIPTION
This fixes an issue where opening the new edit Comment view was not tracked.

To test:
- On a real device, go to My Site > Comments > Comment details > Edit.
- Verify this is logged: `🔵 Tracked: comment_editor_opened <blog_id: xxx, comment_id: xxx, context: sites, post_id: xxx, site_type: blog>`

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
