### PR TITLE
About screen: Disable haptics when app logos cell isn't visible

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": "feature/haptics",
-          "revision": "70e8b1dde33eb1656cb6f60beee54eb79b76bb85",
-          "version": null
+          "branch": null,
+          "revision": "d3e8b4d8133984d9ae20936a55e747d27661e2a1",
+          "version": "1.1.1"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": "fix/rtl-layout",
-          "revision": "b37c5a69562e2df2776f9248f753f9e482beb9f8",
+          "branch": "feature/haptics",
+          "revision": "70e8b1dde33eb1656cb6f60beee54eb79b76bb85",
           "version": null
         }
       },

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24953,8 +24953,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				branch = feature/haptics;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
 			};
 		};
 		3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24953,7 +24953,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				branch = "fix/rtl-layout";
+				branch = feature/haptics;
 				kind = branch;
 			};
 		};


### PR DESCRIPTION
This PR can be used to test the associated AutomatticAbout-Swift PR: https://github.com/Automattic/AutomatticAbout-Swift/pull/4. It makes some changes to the haptics implementation in the about screen so that haptics are only active when the app logos cell on the new About screen is visible.

### To test

#### Presenting new screens

* Build and run on a device
* Navigate to the new About screen (in the Me menu)
* Ensure you can see the app logos cell containing the bubbles, and that you can feel the haptic feedback
* Tap the Legal and More menu item, which pushes a new screen. Check that you can no longer feel the haptics. Tap Back, and ensure that the haptics come back.
* Tap the Blog menu item, which presents a webview. Check that you can no longer feel the haptics. Tap Back, and ensure that the haptics come back.

#### Scrolling on and offscreen

* In Xcode, go to `AppAboutScreenConfiguration.swift` and add the following line about 10 times to the first sub-array in the `sections` property (line 31) to pad out the top section in the screen with a lot of extra content:

```
AboutItem(title: "Testing"),
```

(this should go above the existing `AboutItem(title: TextContent.rateUs, action: { [weak self] context in` line)

* Relaunch the app and navigate to the About screen again. The app logos cell should be offscreen and you shouldn't feel any haptics.
* Scroll down so that the logo cell is visible. You should start feeling haptics.
* Scroll back up so that the logo cell is no longer visible. You shouldn't feel the haptics any more.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
