### PR TITLE
My Site Dashboard: Add feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -22,6 +22,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newCommentThread
     case postDetailsComments
     case commentThreadModerationMenu
+    case mySiteDashboard
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -72,6 +73,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .commentThreadModerationMenu:
             return false
+        case .mySiteDashboard:
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 
@@ -138,6 +141,8 @@ extension FeatureFlag {
             return "Post Details Comments"
         case .commentThreadModerationMenu:
             return "Comment Thread Moderation Menu"
+        case .mySiteDashboard:
+            return "My Site Dashboard"
         }
     }
 


### PR DESCRIPTION
Part of #17681 

## Description
This PR adds a new feature flag for the My Site Dashboard project.

## How to test
1. Go to Me > App Settings > Debug
2. ✅ Notice the `My Site Dashboard` feature flag at the bottom

<img src="https://user-images.githubusercontent.com/6711616/146756401-97db7129-67ac-4cbe-80b6-6c1e2a96005c.png" width=200>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
