### PR TITLE
Upgrade XCUITestHelpers from version 0.3.0 to 0.4.0

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Automattic/XCUITestHelpers",
         "state": {
           "branch": null,
-          "revision": "3212ac32f0a58ea10604b5cf31fe5450f908ff65",
-          "version": "0.3.0"
+          "revision": "5179cb69d58b90761cc713bdee7740c4889d3295",
+          "version": "0.4.0"
         }
       }
     ]

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -1,5 +1,6 @@
 import ScreenObject
 import XCTest
+import XCUITestHelpers
 
 public class BlockEditorScreen: ScreenObject {
 
@@ -140,7 +141,7 @@ public class BlockEditorScreen: ScreenObject {
     public func dismissBlocksPickerIfNeeded() {
         // Determine whether the block picker is on screen using the visibility of the add block
         // button as a proxy
-        guard addBlockButton.isFullyVisibleOnScreen == false else { return }
+        guard addBlockButton.isFullyVisibleOnScreen() == false else { return }
 
         // Dismiss the block picker by swiping down
         app.swipeDown()
@@ -200,24 +201,5 @@ public class BlockEditorScreen: ScreenObject {
     public func closeBlockPicker() throws -> BlockEditorScreen {
         editorCloseButton.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0)).tap()
         return try BlockEditorScreen()
-    }
-}
-
-// TODO: Move this to XCUITestHelpers or ScreenObject
-extension XCUIElement {
-
-    func waitFor(
-        predicateString: String,
-        timeout: TimeInterval = 10
-    ) -> XCTWaiter.Result {
-        XCTWaiter.wait(
-            for: [
-                XCTNSPredicateExpectation(
-                    predicate: NSPredicate(format: predicateString),
-                    object: self
-                )
-            ],
-            timeout: timeout
-        )
     }
 }

--- a/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Scroll.swift
@@ -1,4 +1,5 @@
 import XCTest
+import XCUITestHelpers
 
 extension XCUIElement {
 
@@ -11,12 +12,12 @@ extension XCUIElement {
     public func scrollIntoView(within scrollView: XCUIElement, threshold: Int = 1000) {
         var iteration = 0
 
-        while !isFullyVisibleOnScreen && iteration < threshold {
+        while isFullyVisibleOnScreen() == false && iteration < threshold {
             scrollView.scroll(byDeltaX: 0, deltaY: 100)
             iteration += 1
         }
 
-        if !isFullyVisibleOnScreen {
+        if isFullyVisibleOnScreen() == false {
             XCTFail("Unable to scroll element into view")
         }
     }

--- a/WordPress/UITestsFoundation/XCUIElement+Utils.swift
+++ b/WordPress/UITestsFoundation/XCUIElement+Utils.swift
@@ -3,11 +3,6 @@ import XCTest
 // TODO: This should go XCUITestHelpers if not there already
 public extension XCUIElement {
 
-    var isFullyVisibleOnScreen: Bool {
-        guard self.exists && !self.frame.isEmpty && self.isHittable else { return false }
-        return XCUIApplication().windows.element(boundBy: 0).frame.contains(self.frame)
-    }
-
     func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
         let startCoordinate = self.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
         let destination = startCoordinate.withOffset(CGVector(dx: deltaX, dy: deltaY * -1))

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -24980,7 +24980,7 @@
 			repositoryURL = "https://github.com/Automattic/XCUITestHelpers";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.3.0;
+				minimumVersion = 0.4.0;
 			};
 		};
 		3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */ = {


### PR DESCRIPTION
Removes custom code, now part of the library:

- `isFullyVisibleOnScreen`
- `XCUIElement` "wait-for-predicate" extension

## Regression Notes
1. Potential unintended areas of impact
UI tests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the changes in isolation during the XCUITestHelpers work:

- https://github.com/Automattic/XCUITestHelpers/pull/5
- https://github.com/Automattic/XCUITestHelpers/pull/6

Plus, run UI tests in both CIs for this PR

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**