### PR TITLE
Disable domains feature flag for all configurations

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -61,7 +61,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             // NOTE: only applies to My Site > Comments.
             return true
         case .domains:
-            return BuildConfiguration.current == .localDeveloper
+            return false
         case .followConversationViaNotifications:
             return true
         case .aboutScreen:


### PR DESCRIPTION
Fixes #NA

This PR sets the Domains feature flag to false, so that the domains entry won't be visible in developer builds

To test:

- Build/run
- Go to "My Site"
- Make sure that there is no "Domains" entry in the "Configure" section, below "Site Settings"

## Regression Notes
1. Potential unintended areas of impact
None, this just disables a feature that was already disabled for other build configurations

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Just check that the "Domains" entry is not visible in "My Site"

3. What automated tests I added (or what prevented me from doing so)
4. none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ No user facing changes.
