### PR TITLE
Made mock UI tests credentials shorter.

### DIFF
--- a/WordPress/WordPressUITests/WPUITestCredentials.swift
+++ b/WordPress/WordPressUITests/WPUITestCredentials.swift
@@ -2,9 +2,9 @@ import UITestsFoundation
 
 // These are fake credentials used for the mocked UI tests
 struct WPUITestCredentials {
-    static let testWPcomUserEmail: String = "e2eflowtestingmobile@example.com"
+    static let testWPcomUserEmail: String = "tst@wp.com"
     static let testWPcomUsername: String = "e2eflowtestingmobile"
-    static let testWPcomPassword: String = "mocked_password"
+    static let testWPcomPassword: String = "pw"
     static let testWPcomSiteAddress: String =  "tricountyrealestate.wordpress.com"
     static let testWPcomSitePrimaryAddress: String =  "tricountyrealestate.wordpress.com"
     static let selfHostedUsername: String = "e2eflowtestingmobile"

--- a/WordPress/WordPressUITests/WPUITestCredentials.swift
+++ b/WordPress/WordPressUITests/WPUITestCredentials.swift
@@ -2,11 +2,11 @@ import UITestsFoundation
 
 // These are fake credentials used for the mocked UI tests
 struct WPUITestCredentials {
-    static let testWPcomUserEmail: String = "tst@wp.com"
+    static let testWPcomUserEmail: String = "t@wp.com"
     static let testWPcomUsername: String = "e2eflowtestingmobile"
     static let testWPcomPassword: String = "pw"
-    static let testWPcomSiteAddress: String =  "tricountyrealestate.wordpress.com"
-    static let testWPcomSitePrimaryAddress: String =  "tricountyrealestate.wordpress.com"
+    static let testWPcomSiteAddress: String = "tricountyrealestate.wordpress.com"
+    static let testWPcomSitePrimaryAddress: String = "tricountyrealestate.wordpress.com"
     static let selfHostedUsername: String = "e2eflowtestingmobile"
     static let selfHostedPassword: String = "mocked_password"
     static let selfHostedSiteAddress: String = "\(WireMock.URL().absoluteString)"


### PR DESCRIPTION
### Description
Entering text is one of the slowest parts of the UI tests workflow currently, especially in the latest Xcode 13.1 / iPhone 13 setup.

User email and password are two strings that are entered before every UI test, and the current values are not that short. These credentials are accepted by WireMock server, which does not care about their content (unless we make it do so), so we can make them shorter.

This change makes the login process 8 seconds faster.

P.S. There's no real user with such credentials, so we don't lose anything by changing them and "forgetting" about `e2eflowtestingmobile@example.com`. If it existed, it would make sense to keep them, because it simplifies mocks maintenance a lot.

### Test
- CI is green