### PR TITLE
Set `waitTimeout` to 7 for most of screen objects

### DIFF
--- a/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/ActionSheetComponent.swift
@@ -16,7 +16,11 @@ public class ActionSheetComponent: ScreenObject {
     var sitePageButton: XCUIElement { Self.getSitePageButton(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [Self.getBlogPostButton, Self.getSitePageButton])
+        try super.init(
+            expectedElementGetters: [Self.getBlogPostButton, Self.getSitePageButton],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func goToBlogPost() {

--- a/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ActivityLogScreen.swift
@@ -4,6 +4,10 @@ import XCTest
 public class ActivityLogScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [ { $0.otherElements.firstMatch } ])
+        try super.init(
+            expectedElementGetters: [ { $0.otherElements.firstMatch } ],
+            app: app,
+            waitTimeout: 7
+        )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/AztecEditorScreen.swift
@@ -49,7 +49,8 @@ public class AztecEditorScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ textViewGetter(textField) ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
 
         showOptionsStrip()

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -22,7 +22,8 @@ public class BlockEditorScreen: ScreenObject {
         // expect to encase the screen.
         try super.init(
             expectedElementGetters: [ addBlockButtonGetter, editorCloseButtonGetter ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorNoticeComponent.swift
@@ -19,7 +19,8 @@ public class EditorNoticeComponent: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ noticeTitleGetter, noticeActionGetter ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -14,7 +14,8 @@ public class EditorPostSettings: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["SettingsTable"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPublishEpilogueScreen.swift
@@ -22,7 +22,8 @@ public class EditorPublishEpilogueScreen: ScreenObject {
 
         try super.init(
             expectedElementGetters: [ getDoneButton, getViewButton, publishedPostStatusGetter ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/CategoriesComponent.swift
@@ -4,7 +4,11 @@ import XCTest
 public class CategoriesComponent: ScreenObject {
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [ { $0.tables["CategoriesList"] } ], app: app)
+        try super.init(
+            expectedElementGetters: [ { $0.tables["CategoriesList"] } ],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func selectCategory(name: String) -> CategoriesComponent {

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorSettingsComponents/TagsComponent.swift
@@ -7,7 +7,11 @@ public class TagsComponent: ScreenObject {
     var tagsField: XCUIElement { expectedElement }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [ { $0.textViews["add-tags"] } ], app: app)
+        try super.init(
+            expectedElementGetters: [ { $0.textViews["add-tags"] } ],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     func addTag(name: String) -> TagsComponent {

--- a/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/FeaturedImageScreen.swift
@@ -9,7 +9,8 @@ public class FeaturedImageScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.navigationBars.buttons["Remove Featured Image"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupOptionsScreen.swift
@@ -6,7 +6,8 @@ public class JetpackBackupOptionsScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.otherElements.firstMatch } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
@@ -11,7 +11,11 @@ public class JetpackBackupScreen: ScreenObject {
     var downloadBackupButton: XCUIElement { app.sheets.buttons.element(boundBy: 1) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [ellipsisButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [ellipsisButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func goToBackupOptions() throws -> JetpackBackupOptionsScreen {

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackScanScreen.swift
@@ -6,7 +6,8 @@ public class JetpackScanScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.otherElements.firstMatch } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 }

--- a/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LinkOrPasswordScreen.swift
@@ -13,7 +13,11 @@ public class LinkOrPasswordScreen: ScreenObject {
     }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [passwordOptionGetter, linkButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [passwordOptionGetter, linkButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     func proceedWithPassword() throws -> LoginPasswordScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginCheckMagicLinkScreen.swift
@@ -14,7 +14,8 @@ public class LoginCheckMagicLinkScreen: ScreenObject {
                 // swiftlint:disable:next opening_brace
                 { $0.buttons["Open Mail Button"] }
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEmailScreen.swift
@@ -19,7 +19,8 @@ public class LoginEmailScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailTextFieldGetter, nextButtonGetter],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -10,7 +10,11 @@ public class LoginEpilogueScreen: ScreenObject {
     var loginEpilogueTable: XCUIElement { loginEpilogueTableGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [loginEpilogueTableGetter], app: app)
+        try super.init(
+            expectedElementGetters: [loginEpilogueTableGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func continueWithSelectedSite() throws -> MySiteScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginPasswordScreen.swift
@@ -10,7 +10,11 @@ class LoginPasswordScreen: ScreenObject {
     }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [passwordTextFieldGetter], app: app)
+        try super.init(
+            expectedElementGetters: [passwordTextFieldGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     func proceedWith(password: String) throws -> LoginEpilogueScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginSiteAddressScreen.swift
@@ -24,7 +24,11 @@ public class LoginSiteAddressScreen: ScreenObject {
     var nextButton: XCUIElement { app.buttons[ElementStringIDs.nextButton] }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [siteAddressTextFieldGetter], app: app)
+        try super.init(
+            expectedElementGetters: [siteAddressTextFieldGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func proceedWith(siteUrl: String) throws -> LoginUsernamePasswordScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginUsernamePasswordScreen.swift
@@ -44,7 +44,8 @@ public class LoginUsernamePasswordScreen: ScreenObject {
                 usernameTextFieldGetter,
                 passwordTextFieldGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/QuickStartPromptScreen.swift
@@ -10,7 +10,11 @@ public class QuickStartPromptScreen: ScreenObject {
     var noThanksButton: XCUIElement { noThanksButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [noThanksButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [noThanksButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func selectNoThanks() throws -> MySiteScreen {

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/GetStartedScreen.swift
@@ -38,7 +38,8 @@ public class GetStartedScreen: ScreenObject {
                 emailTextFieldGetter,
                 helpButtonGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -7,7 +7,8 @@ public class PasswordScreen: ScreenObject {
         try super.init(
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [ { $0.secureTextFields["Password"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreen.swift
@@ -17,7 +17,11 @@ public class WelcomeScreen: ScreenObject {
     var logInButton: XCUIElement { logInButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [logInButtonGetter, signupButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [logInButtonGetter, signupButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func selectSignup() throws -> WelcomeScreenSignupComponent {

--- a/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/WelcomeScreenLoginComponent.swift
@@ -15,7 +15,8 @@ public class WelcomeScreenLoginComponent: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [emailLoginButtonGetter, siteAddressButtonGetter],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/ContactUsScreen.swift
@@ -34,7 +34,8 @@ public class ContactUsScreen: ScreenObject {
                 closeButtonGetter,
                 attachButtonGetter,
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -38,7 +38,8 @@ public class SupportScreen: ScreenObject {
                 { $0.cells["activity-logs-button"] }
                 // swiftlint:enable opening_brace
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MeTabScreen.swift
@@ -20,7 +20,8 @@ public class MeTabScreen: ScreenObject {
 
         try super.init(
             expectedElementGetter: { $0.cells["appSettings"] },
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumListScreen.swift
@@ -10,7 +10,8 @@ public class MediaPickerAlbumListScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetter: albumListGetter,
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
@@ -7,7 +7,11 @@ public class MediaPickerAlbumScreen: ScreenObject {
     }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [mediaCollectionGetter], app: app)
+        try super.init(
+            expectedElementGetters: [mediaCollectionGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func selectImage(atIndex index: Int) {

--- a/WordPress/UITestsFoundation/Screens/MediaScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MediaScreen.swift
@@ -6,7 +6,8 @@ public class MediaScreen: ScreenObject {
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.collectionViews["MediaCollection"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -66,7 +66,8 @@ public class MySiteScreen: ScreenObject {
                 mediaButtonGetter,
                 createButtonGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -20,7 +20,8 @@ public class MySitesScreen: ScreenObject {
                 cancelButtonGetter,
                 plusButtonGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -6,7 +6,8 @@ public class NotificationsScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.tables["Notifications Table"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/PostsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PostsScreen.swift
@@ -11,7 +11,11 @@ public class PostsScreen: ScreenObject {
     private var currentlyFilteredPostStatus: PostStatus = .published
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [ { $0.tables["PostsTable"] } ], app: app)
+        try super.init(
+            expectedElementGetters: [ { $0.tables["PostsTable"] } ],
+            app: app,
+            waitTimeout: 7
+        )
         showOnly(.published)
     }
 

--- a/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/ReaderScreen.swift
@@ -16,7 +16,8 @@ public class ReaderScreen: ScreenObject {
                 { $0.tables["Reader"] },
                 discoverButtonGetter
             ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupCheckMagicLinkScreen.swift
@@ -7,7 +7,8 @@ public class SignupCheckMagicLinkScreen: ScreenObject {
         try super.init(
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.buttons["Open Mail Button"] }],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEmailScreen.swift
@@ -17,7 +17,11 @@ public class SignupEmailScreen: ScreenObject {
     var nextButton: XCUIElement { nextButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [emailTextFieldGetter, nextButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [emailTextFieldGetter, nextButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func proceedWith(email: String) throws -> SignupCheckMagicLinkScreen {

--- a/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/SignupEpilogueScreen.swift
@@ -6,7 +6,8 @@ public class SignupEpilogueScreen: ScreenObject {
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ { $0.staticTexts["New Account Header"] } ],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 

--- a/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/Signup/WelcomeScreenSignupComponent.swift
@@ -12,7 +12,11 @@ public class WelcomeScreenSignupComponent: ScreenObject {
     var emailSignupButton: XCUIElement { emailSignupButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [emailSignupButtonGetter], app: app)
+        try super.init(
+            expectedElementGetters: [emailSignupButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     public func selectEmailSignup() throws -> SignupEmailScreen {

--- a/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/SiteSettingsScreen.swift
@@ -14,7 +14,11 @@ public class SiteSettingsScreen: ScreenObject {
     var blockEditorToggle: XCUIElement { blockEditorToggleGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
-        try super.init(expectedElementGetters: [blockEditorToggleGetter], app: app)
+        try super.init(
+            expectedElementGetters: [blockEditorToggleGetter],
+            app: app,
+            waitTimeout: 7
+        )
     }
 
     @discardableResult

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -19,7 +19,8 @@ public class StatsScreen: ScreenObject {
         try super.init(
             // swiftlint:disable:next opening_brace
             expectedElementGetters: [{ $0.otherElements.firstMatch }],
-            app: app
+            app: app,
+            waitTimeout: 7
         )
     }
 


### PR DESCRIPTION
### Description
See woocommerce/woocommerce-ios/pull/5753.

Three screens already contained a non-default wait timeout (3 seconds), I left it as it is, and set 7 for the rest.

Local execution on iPhone 13 iOS 15 went down by 210 seconds (1691 ~> 1481).

### Testing instructions
- CI is green.

## Regression Notes
1. Potential unintended areas of impact
The only possible impact is lower stability of UI tests, which is very unlikely to happen with the chosen timeout.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Executed all automated tests.

3. What automated tests I added (or what prevented me from doing so)
Executing the existing automated tests is enough to have this change tested continuously.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
