### PR TITLE
Remove an unused variable assignment from `Fastfile`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -108,7 +108,7 @@ platform :ios do
   desc 'Creates a new release branch from the current develop'
   lane :code_freeze do |options|
     gutenberg_dep_check
-    old_version = ios_codefreeze_prechecks(options)
+    ios_codefreeze_prechecks(options)
 
     ios_bump_version_release(skip_deliver: true)
     new_version = ios_get_app_version


### PR DESCRIPTION
My editor noticed this while I was looking for something in the `Fastfile`.

To test: This is a trivial change that doesn't warrant testing. If there's any issue, I'll notice as when I run the next code freeze.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
