### PR TITLE
Adds a check when trying to dismiss the quick start prompt on the login epilogue

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -329,7 +329,14 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         let onDismissQuickStartPrompt: (Blog, Bool) -> Void = { [weak self] blog, _ in
-            self?.onDismissQuickStartPrompt(for: blog, onDismiss: onDismiss)
+            guard let self = self else {
+                // If self is nil the user will be stuck on the login and not able to progress
+                // Trigger a fatal so we can track this better in Sentry.
+                // This case should be very rare.
+                fatalError("Could not get a reference to self when selecting the blog on the login epilogue")
+            }
+
+            self.onDismissQuickStartPrompt(for: blog, onDismiss: onDismiss)
         }
 
         // If adding a self-hosted site, skip the Epilogue


### PR DESCRIPTION
### Description
There was a recent report that the user got a new device and after signing in and seeing the quick start prompt none of the buttons did anything. 

I was not able to reproduce this even after much testing.

I suspect there could be an early deallocation that occured due to a memory issue (maybe low memory, or maybe a weird state after restoring from an iCloud backup) which resulted in `self?` reference in `onDismissQuickStartPrompt` to be nil. 

This is confirmed because even though the buttons did not dismiss the view, they did continue to track that they were tapped. 

**This PR introduces 2 things:**
- A strong self check to the  `onDismissQuickStartPrompt` closure. 
   - This itself may hopefully force the system to keep self in memory if this sort of situation happens again since there will be a local reference to it. 
- If for some reason self is nil, crash the app using a `fatalError`. 
    - Crashing the app is not ideal, and I explored a number of different options but none were reliable. 
    - The reason for crashing is because the user is effectively stuck in the app, in a potentially unknown state. Their only recourse is to force quit and relaunch the app. 
    - Triggering a fatal error allows us to "fix" this unexpected state and also keep track of it in Sentry

https://user-images.githubusercontent.com/793774/148114290-ade3254a-8612-497f-8e91-6e20ab51ff3b.mov

### To test:
#### Previous testing steps
Follow the steps in this PR to verify everything still works as intended: https://github.com/wordpress-mobile/WordPress-iOS/pull/17611

#### Reauthentication: Part 1
1. Login to the app
2. Go to https://wordpress.com/me/security/connected-applications
3. Locate WordPress iOS
4. Click 'Disconnect'
5. Go back to the app
6. Perform a network action (reload blogs, etc)
7. You should see a login presented
8. Follow the steps to login (enter password, 2fa)
9. Verify the Quick Start is displayed and dismissed correctly

#### Reauthentication: Part 2
1. Login to the app
2. Go to https://wordpress.com/me/security/connected-applications
3. Locate WordPress iOS
4. Click 'Disconnect'
5. Go back to the app
6. Perform a network action (reload blogs, etc)
7. You should see a login presented
8. Force quit the app
9. Relaunch the app
9. You should see a login asking for your password that is full screen. If not, relaunch the app a few more times
10. Follow the steps to see the Quick Start prompt, and verify it is dismissed correctly

#### Force self to be nil
1. Open `WordPressAuthenticationManager.swift` in Xcode
2. Place a breakpoint on line 332: `guard let self = self else {`
3. Right click the breakpoint, Click Edit
4. Click Add Action
5. Select `Debugger Command` in the dropdown
6. In the text field type: `po self = nil`
7. Check the automatically continue checkbox
8. Launch the app, login, to get to the quick start
9. Tap on either button
10. Verify you hit the fatal error 💥 

## Regression Notes
1. Potential unintended areas of impact
This is very localized to 1 specific action so there are no other areas of impact I can see.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
