### PR TITLE
Reader Post Details Comments: add Follow Conversation button

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -23,6 +23,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case postDetailsComments
     case commentThreadModerationMenu
     case mySiteDashboard
+    case followConversationPostDetails
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -75,6 +76,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .mySiteDashboard:
             return BuildConfiguration.current == .localDeveloper
+        case .followConversationPostDetails:
+            return false
         }
     }
 
@@ -143,6 +146,8 @@ extension FeatureFlag {
             return "Comment Thread Moderation Menu"
         case .mySiteDashboard:
             return "My Site Dashboard"
+        case .followConversationPostDetails:
+            return "Follow Conversation from Post Details"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -4,12 +4,44 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 
     static let estimatedHeight: CGFloat = 80
     @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet private weak var followButton: UIButton!
+    private let buttonTitle = NSLocalizedString("Follow Conversation", comment: "Button title. Follow the comments on a post.")
 
     override func awakeFromNib() {
         super.awakeFromNib()
+        configureView()
+    }
+
+}
+
+private extension ReaderDetailCommentsHeader {
+
+    func configureView() {
         contentView.backgroundColor = .basicBackground
+        addBottomBorder(withColor: .divider)
+        configureTitle()
+        configureButton()
+    }
+
+    func configureTitle() {
         titleLabel.textColor = .text
         titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
+    }
+
+    func configureButton() {
+        guard FeatureFlag.followConversationPostDetails.enabled else {
+            followButton.isHidden = true
+            return
+        }
+
+        followButton.setTitle(buttonTitle, for: .normal)
+        followButton.setTitleColor(.primary, for: .normal)
+        followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+        followButton.addTarget(self, action: #selector(followButtonTapped), for: .touchUpInside)
+    }
+
+    @objc func followButtonTapped() {
+        // TODO: implement following
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.xib
@@ -5,34 +5,53 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view userInteractionEnabled="NO" contentMode="scaleToFill" id="kPA-oR-TOp" customClass="ReaderDetailCommentsHeader" customModule="WordPress" customModuleProvider="target">
+        <view contentMode="scaleToFill" id="kPA-oR-TOp" customClass="ReaderDetailCommentsHeader" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="394" height="69"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
-                    <rect key="frame" x="0.0" y="20" width="394" height="39"/>
-                    <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
-                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="st6-L0-qny">
+                    <rect key="frame" x="0.0" y="16" width="394" height="43"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
+                            <rect key="frame" x="0.0" y="11.5" width="280" height="20.5"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
+                            <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZm-SW-a1v" userLabel="Follow Button">
+                            <rect key="frame" x="280" y="8" width="114" height="27"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                            <state key="normal" title="Follow Conversation">
+                                <color key="titleColor" systemColor="systemBlueColor"/>
+                            </state>
+                        </button>
+                    </subviews>
+                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="epR-21-48u"/>
             <constraints>
-                <constraint firstItem="QfN-CJ-PfS" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="6FS-1m-LFu"/>
-                <constraint firstAttribute="bottom" secondItem="QfN-CJ-PfS" secondAttribute="bottom" constant="10" id="RVn-Cf-JSe"/>
-                <constraint firstItem="QfN-CJ-PfS" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="VQC-4P-3s7"/>
-                <constraint firstAttribute="trailing" secondItem="QfN-CJ-PfS" secondAttribute="trailing" id="zK3-Y8-YOU"/>
+                <constraint firstAttribute="bottom" secondItem="st6-L0-qny" secondAttribute="bottom" constant="10" id="SVv-uo-3jT"/>
+                <constraint firstItem="st6-L0-qny" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="cq9-h9-LZl"/>
+                <constraint firstAttribute="trailing" secondItem="st6-L0-qny" secondAttribute="trailing" id="hmg-uy-OM6"/>
+                <constraint firstItem="st6-L0-qny" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="16" id="oyV-UY-eNS"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="followButton" destination="dZm-SW-a1v" id="T1e-6U-kD8"/>
                 <outlet property="titleLabel" destination="QfN-CJ-PfS" id="TVn-gJ-PFg"/>
             </connections>
             <point key="canvasLocation" x="36.231884057971016" y="81.361607142857139"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBlueColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -94,7 +94,6 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             }
         }()
 
-        header.addBottomBorder(withColor: .divider)
         return header
     }
 


### PR DESCRIPTION
Ref: #17632 

If the `followConversationPostDetails` feature flag is enabled, a `Follow Conversation` button is added to the post Comments snippet header.

Notes:
- The button is not functional yet.
- Accessibility text size will be addressed later.

To test:
- With the `followConversationPostDetails` feature flag disabled (the default):
  - Go to the Reader and select a post with comments.
  - Verify the `Follow Conversation` button does not appear in the `Comments` header.
- Enable the `followConversationPostDetails` feature flag.
  - Go to the Reader and select a post with comments.
  - Verify the `Follow Conversation` button appears in the `Comments` header.

| Disabled | Enabled |
|--------|-------|
| <img width="481" alt="disabled" src="https://user-images.githubusercontent.com/1816888/148142825-98f1e92f-79d0-43e2-9d6a-41aa01f74748.png"> | <img width="481" alt="enabled" src="https://user-images.githubusercontent.com/1816888/148142821-baa559b4-2e92-4fac-8f8a-10a5216c9e9b.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
