### PR TITLE
Reader Post Details Comments: hide Follow Conversation button if commenting is closed

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -397,7 +397,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         commentsTableViewDelegate.updateWith(comments: comments,
                                               totalComments: totalComments,
-                                              commentsEnabled: toolbar.commentButton.isEnabled,
+                                             commentsEnabled: post?.commentsOpen ?? false,
                                               buttonDelegate: self)
         commentsTableView.reloadData()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -394,11 +394,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
-
+        
         commentsTableViewDelegate.updateWith(comments: comments,
-                                              totalComments: totalComments,
+                                             totalComments: totalComments,
                                              commentsEnabled: post?.commentsOpen ?? false,
-                                              buttonDelegate: self)
+                                             buttonDelegate: self)
         commentsTableView.reloadData()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -394,7 +394,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
-        
+
         commentsTableViewDelegate.updateWith(comments: comments,
                                              totalComments: totalComments,
                                              commentsEnabled: post?.commentsOpen ?? false,

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -5,11 +5,31 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
     static let estimatedHeight: CGFloat = 80
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet private weak var followButton: UIButton!
-    private let buttonTitle = NSLocalizedString("Follow Conversation", comment: "Button title. Follow the comments on a post.")
+
+    private var commentsEnabled = true {
+        didSet {
+            followButton.isHidden = !FeatureFlag.followConversationPostDetails.enabled || !commentsEnabled
+        }
+    }
 
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
+    }
+
+    func configure(totalComments: Int, commentsEnabled: Bool) {
+        self.commentsEnabled = commentsEnabled
+
+        titleLabel.text = {
+            switch totalComments {
+            case 0:
+                return Titles.comments
+            case 1:
+                return String(format: Titles.singularCommentFormat, totalComments)
+            default:
+                return String(format: Titles.pluralCommentsFormat, totalComments)
+            }
+        }()
     }
 
 }
@@ -29,12 +49,7 @@ private extension ReaderDetailCommentsHeader {
     }
 
     func configureButton() {
-        guard FeatureFlag.followConversationPostDetails.enabled else {
-            followButton.isHidden = true
-            return
-        }
-
-        followButton.setTitle(buttonTitle, for: .normal)
+        followButton.setTitle(Titles.followButton, for: .normal)
         followButton.setTitleColor(.primary, for: .normal)
         followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
         followButton.addTarget(self, action: #selector(followButtonTapped), for: .touchUpInside)
@@ -42,6 +57,13 @@ private extension ReaderDetailCommentsHeader {
 
     @objc func followButtonTapped() {
         // TODO: implement following
+    }
+
+    struct Titles {
+        static let singularCommentFormat = NSLocalizedString("%1$d Comment", comment: "Singular label displaying number of comments. %1$d is a placeholder for the number of Comments.")
+        static let pluralCommentsFormat = NSLocalizedString("%1$d Comments", comment: "Plural label displaying number of comments. %1$d is a placeholder for the number of Comments.")
+        static let comments = NSLocalizedString("Comments", comment: "Comments table header label.")
+        static let followButton = NSLocalizedString("Follow Conversation", comment: "Button title. Follow the comments on a post.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -3,7 +3,7 @@ import UIKit
 class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 
     static let estimatedHeight: CGFloat = 80
-    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var followButton: UIButton!
 
     private var commentsEnabled = true {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -83,17 +83,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
-        header.titleLabel.text = {
-            switch totalComments {
-            case 0:
-                return Constants.comments
-            case 1:
-                return String(format: Constants.singularCommentFormat, totalComments)
-            default:
-                return String(format: Constants.pluralCommentsFormat, totalComments)
-            }
-        }()
-
+        header.configure(totalComments: totalComments, commentsEnabled: commentsEnabled)
         return header
     }
 
@@ -122,9 +112,6 @@ private extension ReaderDetailCommentsTableViewDelegate {
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
-        static let singularCommentFormat = NSLocalizedString("%1$d Comment", comment: "Singular label displaying number of comments. %1$d is a placeholder for the number of Comments.")
-        static let pluralCommentsFormat = NSLocalizedString("%1$d Comments", comment: "Plural label displaying number of comments. %1$d is a placeholder for the number of Comments.")
-        static let comments = NSLocalizedString("Comments", comment: "Comments table header label.")
         static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
     }
 }


### PR DESCRIPTION
Ref: #17632
Depends on: #17711

If Comments are closed on the post, the `Follow Conversation` button is hidden.

To test:

- Enable the `followConversationPostDetails` feature flag.
- Go to the Reader and select a post with commenting open.
  - Verify the `Follow Conversation` button appears in the `Comments` header.
- Go to the Reader and select a post that has no comments and commenting is closed.
  - Verify the `Follow Conversation` button does not appear in the `Comments` header.
- Go to the Reader and select a post that has comments and commenting is closed.
  - Verify the `Follow Conversation` button does not appear in the `Comments` header.


| Comments Open | Comments Closed with no Comments | Comments Closed with Comments |
|--------|-------|-------|
| <img width="480" alt="enabled" src="https://user-images.githubusercontent.com/1816888/148148188-06f861a2-806c-4458-abd1-84875036c357.png"> | <img width="482" alt="no_comments_disabled" src="https://user-images.githubusercontent.com/1816888/148148192-bf19b895-e228-4f9c-904e-9ad0676af911.png"> | <img width="481" alt="comments_disabled" src="https://user-images.githubusercontent.com/1816888/148148186-51ec50fe-d0b5-44fd-9a99-28e9da1dcebd.png"> |







## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
