### PR TITLE
Update English App Store metadata for ASO experiment

### DIFF
--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -57,6 +57,22 @@ let languages = [
     "zh-Hant": "zh-tw",
 ]
 
+func shouldUpdateSubtitle(locale: String) -> Bool {
+    return isIn20211210Experiment(locale: locale) == false
+}
+
+func shouldUpdateKeywords(locale: String) -> Bool {
+    return isIn20211210Experiment(locale: locale) == false
+}
+
+func isIn20211210Experiment(locale: String) -> Bool {
+    // The experiment should run on every English locale.
+    //
+    // We could have an allow list, but given the mostly static nature of
+    // locale codes, the following check seems enough.
+    return locale.starts(with: "en")
+}
+
 func downloadTranslation(
     config: Config = .config(for: CommandLine.arguments.second),
     languageCode: String,
@@ -141,9 +157,16 @@ func downloadTranslation(
                 try FileManager.default.removeItem(at: URL(fileURLWithPath: releaseNotesPath))
             }
 
-            try subtitle?.write(toFile: "\(languageFolder)/subtitle.txt", atomically: true, encoding: .utf8)
+            if shouldUpdateSubtitle(locale: languageCode) {
+                try subtitle?.write(toFile: "\(languageFolder)/subtitle.txt", atomically: true, encoding: .utf8)
+            }
+
             try whatsNew?.write(toFile: "\(languageFolder)/release_notes.txt", atomically: true, encoding: .utf8)
-            try keywords?.write(toFile: "\(languageFolder)/keywords.txt", atomically: true, encoding: .utf8)
+
+            if shouldUpdateSubtitle(locale: languageCode) {
+                try keywords?.write(toFile: "\(languageFolder)/keywords.txt", atomically: true, encoding: .utf8)
+            }
+
             try storeDescription?.write(toFile: "\(languageFolder)/description.txt", atomically: true, encoding: .utf8)
         } catch {
             print("  Error writing: \(error)")

--- a/fastlane/download_metadata.swift
+++ b/fastlane/download_metadata.swift
@@ -66,7 +66,7 @@ func shouldUpdateKeywords(locale: String) -> Bool {
 }
 
 func isIn20211210Experiment(locale: String) -> Bool {
-    // The experiment should run on every English locale.
+    // The experiment should run on every English locale. See details in P2 post ref `pcbrnV-440-p2`.
     //
     // We could have an allow list, but given the mostly static nature of
     // locale codes, the following check seems enough.

--- a/fastlane/metadata/en-AU/keywords.txt
+++ b/fastlane/metadata/en-AU/keywords.txt
@@ -1,1 +1,1 @@
-social,network,notes,jetpack,photos,writing,geotagging,media,blog,wordpress,website,blogging,design
+blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs

--- a/fastlane/metadata/en-AU/name.txt
+++ b/fastlane/metadata/en-AU/name.txt
@@ -1,1 +1,1 @@
-WordPress
+WordPress – Website Builder

--- a/fastlane/metadata/en-AU/subtitle.txt
+++ b/fastlane/metadata/en-AU/subtitle.txt
@@ -1,1 +1,1 @@
-Manage your website anywhere
+Design a site, build a blog

--- a/fastlane/metadata/en-CA/keywords.txt
+++ b/fastlane/metadata/en-CA/keywords.txt
@@ -1,1 +1,1 @@
-social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal
+blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs

--- a/fastlane/metadata/en-CA/name.txt
+++ b/fastlane/metadata/en-CA/name.txt
@@ -1,1 +1,1 @@
-WordPress
+WordPress – Website Builder

--- a/fastlane/metadata/en-CA/subtitle.txt
+++ b/fastlane/metadata/en-CA/subtitle.txt
@@ -1,1 +1,1 @@
-Build a website or blog
+Design a site, build a blog

--- a/fastlane/metadata/en-GB/keywords.txt
+++ b/fastlane/metadata/en-GB/keywords.txt
@@ -1,1 +1,1 @@
-social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal
+blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs

--- a/fastlane/metadata/en-GB/name.txt
+++ b/fastlane/metadata/en-GB/name.txt
@@ -1,1 +1,1 @@
-WordPress
+WordPress – Website Builder

--- a/fastlane/metadata/en-GB/subtitle.txt
+++ b/fastlane/metadata/en-GB/subtitle.txt
@@ -1,1 +1,1 @@
-Build a website or blog
+Design a site, build a blog

--- a/fastlane/metadata/en-US/keywords.txt
+++ b/fastlane/metadata/en-US/keywords.txt
@@ -1,1 +1,1 @@
-social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal
+blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs

--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-WordPress
+WordPress – Website Builder

--- a/fastlane/metadata/en-US/subtitle.txt
+++ b/fastlane/metadata/en-US/subtitle.txt
@@ -1,1 +1,1 @@
-Build a website or blog
+Design a site, build a blog


### PR DESCRIPTION
This PR against the `release/18.9` branch updates the name, subtitle, and keywords metadata as requested in pcbrnV-440-p2 .

The biggest gotcha with editing App Store metadata manually is that our automation will override those edits every time it downloads fresh localizations from GlotPress as part of the release finalization process. Because of that, I updated the local script that downloads localizations to skip the English locales for the metadata touched here.

## Testing

This is the kind of change one can only truly test during the release process, but I did two things to verify my changes.

1) Run `bundle exec fastlane update_wordpress_metadata_on_app_store_connect` to verify the data that will reach App Store Connect was successfully changed.

![image](https://user-images.githubusercontent.com/1218433/148168277-adf4fd36-c430-4925-a7a1-42f75a47fa64.png)


2) Run the download script from a different folder than the one it expects (i.e. I run it from the project root) to make it create a whole new `metadata/` tree and verified there were no `subtitle.txt` or `keywords.txt` for the English locales

The result (see below) is a bit confusing because certain folders are empty, but that's consistent to a lack of translation on GlotPress. For our purposes that is irrelevant because `update_wordpress_metadata_on_app_store_connect` will use the file modified in this PR anyway.

<details>
<summary>Click to see my test `tree` output</summary>


```
metadata
├── ar-SA
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── da
├── de-DE
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── default
│   ├── description.txt
│   └── release_notes.txt
├── en-AU
├── en-CA
│   └── description.txt
├── en-GB
│   ├── description.txt
│   └── release_notes.txt
├── en-US
│   ├── description.txt
│   └── release_notes.txt
├── es-ES
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── es-MX
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── fr-FR
│   ├── description.txt
│   └── subtitle.txt
├── he
│   ├── description.txt
│   └── subtitle.txt
├── id
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── it
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── ja
│   ├── description.txt
│   └── subtitle.txt
├── ko
│   ├── description.txt
│   └── subtitle.txt
├── nl-NL
│   ├── description.txt
│   └── subtitle.txt
├── no
│   └── description.txt
├── pt-BR
│   ├── description.txt
│   └── subtitle.txt
├── pt-PT
├── ru
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── sv
│   ├── description.txt
│   ├── release_notes.txt
│   └── subtitle.txt
├── th
├── tr
│   ├── description.txt
│   └── subtitle.txt
├── zh-Hans
│   ├── description.txt
│   └── subtitle.txt
└── zh-Hant
    ├── description.txt
    └── subtitle.txt

26 directories, 50 files
```

</details>

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**