### PR TITLE
Reader Comments: Remove feature flag for Follow Conversation

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case weeklyRoundupStaticNotification
     case newCommentDetail
     case domains
-    case followConversationViaNotifications
     case aboutScreen
     case newCommentThread
     case postDetailsComments
@@ -63,8 +62,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .domains:
             return false
-        case .followConversationViaNotifications:
-            return true
         case .aboutScreen:
             return true
         case .newCommentThread:
@@ -131,8 +128,6 @@ extension FeatureFlag {
             return "New Comment Detail"
         case .domains:
             return "Domain Purchases"
-        case .followConversationViaNotifications:
-            return "Follow Conversation via Notifications"
         case .aboutScreen:
             return "New Unified About Screen"
         case .newCommentThread:

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -317,9 +317,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     headerView.onClick = ^{
         [weakSelf handleHeaderTapped];
     };
-    headerView.onFollowConversationClick = ^{
-        [weakSelf handleFollowConversationButtonTapped];
-    };
     headerView.translatesAutoresizingMaskIntoConstraints = NO;
     headerView.showsDisclosureIndicator = self.allowsPushingPostDetails;
     [headerView setSubtitle:NSLocalizedString(@"Comments on", @"Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line.")];
@@ -632,15 +629,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     return _cachedHeaderView;
 }
 
-// NOTE: remove this when the `followConversationViaNotifications` flag is removed.
-- (void)setSubscribedToPost:(BOOL)subscribedToPost {
-    if (self.postHeaderView) {
-        self.postHeaderView.isSubscribedToPost = subscribedToPost;
-    }
-
-    _subscribedToPost = subscribedToPost;
-}
-
 - (UIBarButtonItem *)followBarButtonItem
 {
     if (!_followBarButtonItem) {
@@ -821,9 +809,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
             [self.postHeaderView setAvatarImage:image];
         }];
     }
-
-    // when the "follow via notifications" flag is enabled, the Follow button is moved into the navigation bar as a UIButtonBarItem.
-    self.postHeaderView.showsFollowConversationButton = self.canFollowConversation;
 }
 
 - (void)refreshFollowButton

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCommentsViewController.m
@@ -817,8 +817,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     self.navigationItem.rightBarButtonItem = self.post.isSubscribedComments ? self.subscriptionSettingsBarButtonItem : self.followBarButtonItem;
 }
 
-// NOTE: Remove this method once "follow via notifications" feature flag can be removed.
-// Subscription status is now available through ReaderPost's `isSubscribedComments` Boolean property.
 - (void)refreshSubscriptionStatusIfNeeded
 {
     __weak __typeof(self) weakSelf = self;
@@ -826,7 +824,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         // update the ReaderPost button to keep it in-sync.
         weakSelf.post.isSubscribedComments = isSubscribed;
         [ContextManager.sharedInstance saveContext:weakSelf.post.managedObjectContext];
-
     } failure:^(NSError *error) {
         DDLogError(@"Error fetching subscription status for post: %@", error);
     }];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.h
@@ -11,12 +11,6 @@ typedef void (^ReaderPostHeaderCallback)(void);
 @property (nonatomic, copy) ReaderPostHeaderCallback onClick;
 
 /**
- A ReaderPostHeaderFollowingCallback block to be executed whenever the user pressed this view.
- */
-typedef void (^ReaderPostHeaderFollowingCallback)(void);
-@property (nonatomic, copy) ReaderPostHeaderFollowingCallback onFollowConversationClick;
-
-/**
  A BOOL indicating whether if this view should display a disclosure indicator, or not.
  */
 @property (nonatomic, assign) BOOL showsDisclosureIndicator;
@@ -40,10 +34,5 @@ typedef void (^ReaderPostHeaderFollowingCallback)(void);
  A NSString representing the header's subtitle.
  */
 @property (nonatomic, strong) NSString *subtitle;
-
-/**
- A BOOL indicating whether the User is subscribed to the post, or not.
- */
-@property (nonatomic, assign, setter=setSubscribedToPost:) BOOL isSubscribedToPost;
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostHeaderView.m
@@ -5,7 +5,6 @@ const CGFloat PostHeaderViewAvatarSize = 32.0;
 const CGFloat PostHeaderViewLabelHeight = 18.0;
 const CGFloat PostHeaderDisclosureButtonWidth = 8.0;
 const CGFloat PostHeaderDisclosureButtonHeight = 13.0;
-const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 
 @interface ReaderPostHeaderView()
 
@@ -14,7 +13,6 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 @property (nonatomic, strong) UIStackView *labelsStackView;
 @property (nonatomic, strong) UILabel *titleLabel;
 @property (nonatomic, strong) UILabel *subtitleLabel;
-@property (nonatomic, strong) UIButton *followConversationButton;
 @property (nonatomic, strong) UIButton *disclosureButton;
 @property (nonatomic, strong) UITapGestureRecognizer *tapRecognizer;
 
@@ -36,7 +34,6 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
         [self setupLabelsStackView];
         [self setupSubtitleLabel];
         [self setupTitleLabel];
-        [self setupFollowConversationButton];
         [self setupDisclosureButton];
         [self setupTapGesture];
     }
@@ -130,37 +127,6 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
     self.titleLabel = label;
 }
 
-- (void)setupFollowConversationButton
-{
-    NSAssert(self.labelsStackView != nil, @"labelsStackView was nil");
-
-    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
-    button.translatesAutoresizingMaskIntoConstraints = NO;
-
-    [button addTarget:self
-               action:@selector(followConversationButtonTapped)
-     forControlEvents:UIControlEventTouchUpInside];
-
-    [WPStyleGuide applyReaderFollowConversationButtonStyle:button];
-
-    NSString *normalText = NSLocalizedString(@"Follow conversation by email", @"Verb. Button title. Follow the comments on a post.");
-    NSString *selectedText = NSLocalizedString(@"Following conversation by email", @"Verb. Button title. The user is following the comments on a post.");
-
-    [button setTitle:normalText forState:UIControlStateNormal];
-    [button setTitle:selectedText forState:UIControlStateSelected];
-    [button setTitle:selectedText forState:UIControlStateHighlighted];
-
-    // Default accessibility label and hint.
-    button.accessibilityLabel = button.isSelected ? selectedText : normalText;
-    button.accessibilityHint = NSLocalizedString(@"Follows the comments on a post by email.", @"VoiceOver accessibility hint, informing the user the button can be used to follow the comments a post.");
-    
-    NSLayoutConstraint *height = [button.heightAnchor constraintEqualToConstant:PostHeaderViewFollowConversationButtonHeight];
-    [NSLayoutConstraint activateConstraints:@[height]];
-    
-    [self.labelsStackView addArrangedSubview:button];
-    self.followConversationButton = button;
-}
-
 - (void)setupDisclosureButton
 {
     NSAssert(self.stackView != nil, @"stackView was nil");
@@ -199,12 +165,6 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
     self.disclosureButton.hidden = !showsDisclosure;
 }
 
-- (void)setShowsFollowConversationButton:(BOOL)showsFollowConversationButton
-{
-    _showsFollowConversationButton = showsFollowConversationButton;
-    self.followConversationButton.hidden = !showsFollowConversationButton;
-}
-
 - (UIImage *)avatarImage
 {
     return self.avatarImageView.image;
@@ -233,21 +193,6 @@ const CGFloat PostHeaderViewFollowConversationButtonHeight = 32.0;
 - (void)setSubtitle:(NSString *)title
 {
     self.subtitleLabel.text = title;
-}
-
-- (void)setSubscribedToPost:(BOOL)isSubscribedToPost
-{
-    _isSubscribedToPost = isSubscribedToPost;
-    [self.followConversationButton setSelected:isSubscribedToPost];
-}
-
-#pragma mark - Button Action Helpers
-
-- (void)followConversationButtonTapped
-{
-    if (self.onFollowConversationClick) {
-        self.onFollowConversationClick();
-    }
 }
 
 #pragma mark - Recognizer Helpers


### PR DESCRIPTION
Fixes n/a

As titled, this removes the feature flag for the Follow Conversation feature. This means the feature will be permanently moved from the header view to the navigation bar. In addition, I've also taken the liberty of removing unused code in Reader Comments and the header view.

## To test:

Similar testing steps from #17363 should be applicable for this:

- Go to Reader, and select any unsubscribed post.
- 🔍 Verify that the "Follow" button should be visible on the navigation bar.
- Tap the Follow button.
- 🔍 Verify that the snackbar with the "Enable" action button is shown.
- Tap on the "Enable" button.
- 🔍 Verify that a feedback notice with an "Undo" action button is shown.
- Tap on the "Undo" action button.
- 🔍 Verify that a feedback notice is shown.
- 🔍 Verify that the Follow button has turned into a bell icon button in the navigation bar.
- Go to Reader, and select any subscribed post.
- Tap on the bell icon button.
- 🔍 Verify that the bottom sheet is shown.
- Tap on the switch.
- Dismiss the bottom sheet.
- 🔍 Verify that a feedback notification is shown, and correctly represents the desired state.
- Tap the bell icon button again.
- Tap on the Unfollow Conversation button.
- 🔍 Verify that a feedback notification is shown.
- 🔍 Verify that the bell icon button has now turned back into "Follow".

## Regression Notes
1. Potential unintended areas of impact
The follow conversation flow may be impacted.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that the feature works as expected.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
