### PR TITLE
Reader Post Details Comments: hide Follow Conversation button if subscribing is disabled

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -398,6 +398,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         commentsTableViewDelegate.updateWith(comments: comments,
                                              totalComments: totalComments,
                                              commentsEnabled: post?.commentsOpen ?? false,
+                                             followingEnabled: post?.canSubscribeComments ?? false,
                                              buttonDelegate: self)
         commentsTableView.reloadData()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -6,9 +6,9 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var followButton: UIButton!
 
-    private var commentsEnabled = true {
+    private var followConversationEnabled = true {
         didSet {
-            followButton.isHidden = !FeatureFlag.followConversationPostDetails.enabled || !commentsEnabled
+            followButton.isHidden = !FeatureFlag.followConversationPostDetails.enabled || !followConversationEnabled
         }
     }
 
@@ -17,8 +17,8 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
         configureView()
     }
 
-    func configure(totalComments: Int, commentsEnabled: Bool) {
-        self.commentsEnabled = commentsEnabled
+    func configure(totalComments: Int, followConversationEnabled: Bool) {
+        self.followConversationEnabled = followConversationEnabled
 
         titleLabel.text = {
             switch totalComments {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -6,6 +6,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 
     private(set) var totalComments = 0
     private var commentsEnabled = true
+    private var followingEnabled = true
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
 
     private var totalRows = 0
@@ -35,8 +36,10 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     func updateWith(comments: [Comment] = [],
                     totalComments: Int = 0,
                     commentsEnabled: Bool = true,
+                    followingEnabled: Bool = true,
                     buttonDelegate: BorderedButtonTableViewCellDelegate? = nil) {
         self.commentsEnabled = commentsEnabled
+        self.followingEnabled = followingEnabled
         hideButton = (comments.count == 0 && !commentsEnabled)
         self.comments = comments
         self.totalComments = totalComments
@@ -83,7 +86,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
-        header.configure(totalComments: totalComments, commentsEnabled: commentsEnabled)
+        header.configure(totalComments: totalComments, followConversationEnabled: commentsEnabled && followingEnabled)
         return header
     }
 


### PR DESCRIPTION
Ref: #17632

If comment subscribing is disabled on the post, the `Follow Conversation` button is hidden.

To test:

- Enable the `followConversationPostDetails` feature flag.
- Select a Reader post with subscribing enabled.
  - Verify the `Follow Conversation` button appears in the `Comments` header.
- Select a Reader post with subscribing disabled.
  - Verify the `Follow Conversation` button does not in the `Comments` header. 

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
