### PR TITLE
Updates the Jetpack Connection URL to the new scheme

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -60,18 +60,25 @@ class JetpackConnectionWebViewController: UIViewController {
     }
 
     func startConnectionFlow() {
-        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
-        let url: URL
-        if let escapedSiteURL = blog.homeURL?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            url = URL(string: "https://wordpress.com/jetpack/connect/\(locale)?url=\(escapedSiteURL)&mobile_redirect=\(mobileRedirectURL)&from=mobile")!
-        } else {
-            url = URL(string: "https://wordpress.com/jetpack/connect/\(locale)?mobile_redirect=\(mobileRedirectURL)&from=mobile")!
+        guard let url = jetpackConnectionURL() else {
+            return
         }
 
         let request = URLRequest(url: url)
         webView.load(request)
 
         WPAnalytics.track(.installJetpackWebviewSelect)
+    }
+
+    private func jetpackConnectionURL() -> URL? {
+        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
+        var urlString = "https://wordpress.com/jetpack/connect/?mobile_redirect=\(mobileRedirectURL)&from=mobile&lang=\(locale)"
+
+        if let escapedSiteURL = blog.homeURL?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+            urlString = urlString + "&url=\(escapedSiteURL)"
+        }
+
+        return URL(string: urlString)
     }
 
     @objc func cancel() {


### PR DESCRIPTION
Project: #17721 

The Jetpack Connect URL structure changed and is causing a white screen to appear when a user is attempting to finish setting up the Jetpack connection. 

This updates the URL structure to move the locale from the URL path to the query scheme.

Before: `jetpack/connect/en`
After: `jetpack/connect/?lang=en`

### To test:

1. Launch the app
2. Add a self hosted site that is not connected to Jetpack
3. Tap on the My Sites tab
4. Tap on the Stats item
5. You should be asked if you want to install Jetpack
6. Tap the install button
7. Once its complete, tap the 'Set up' button
8. Verify you are brought to the Set Up Jetpack webview
9. Continue with the setup process to verify it works correctly

Note: The view will show a loading indicator, then pause for about 10 seconds, then you should be prompted to login. 
Note 2: Once you login you will probably need to tap the 'Activate' button twice since the first time will fail. 


### Regression Notes
1. Potential unintended areas of impact
This only effects a single button action. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
