### PR TITLE
Improve error messages when logging into self-hosted sites

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.45.0'
+    # pod 'WordPressKit', '~> 4.45.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0bd4dc8d4905b4f7130b380e82dbc7d175a70020'
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
@@ -218,9 +218,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    pod 'WordPressAuthenticator', '~> 1.42.2'
+    # pod 'WordPressAuthenticator', '~> 1.42.2'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '86290bba58d784e9962a05c1a2133a2d2ee1f4af'
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.45.0'
+    pod 'WordPressKit', '~> 4.46.0-beta.1'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => '0bd4dc8d4905b4f7130b380e82dbc7d175a70020'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end
 
@@ -218,9 +218,9 @@ abstract_target 'Apps' do
 
     pod 'Gridicons', '~> 1.1.0'
 
-    # pod 'WordPressAuthenticator', '~> 1.42.2'
+    pod 'WordPressAuthenticator', '~> 1.43.0-beta.2'
     # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
-    pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => '86290bba58d784e9962a05c1a2133a2d2ee1f4af'
+    # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
     # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
     pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -454,7 +454,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.7)
   - WordPress-Editor-iOS (1.19.7):
     - WordPress-Aztec-iOS (= 1.19.7)
-  - WordPressAuthenticator (1.42.2):
+  - WordPressAuthenticator (1.43.0-beta.2):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -465,7 +465,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.45.0):
+  - WordPressKit (4.46.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -568,8 +568,8 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.7)
-  - WordPressAuthenticator (~> 1.42.2)
-  - WordPressKit (~> 4.45.0)
+  - WordPressAuthenticator (~> 1.43.0-beta.2)
+  - WordPressKit (~> 4.46.0-beta.1)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0)
   - WordPressUI (~> 1.12.3)
@@ -832,8 +832,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: d0fee204f467dacf8808b7ac14ce43affeb271a5
   WordPress-Aztec-iOS: 144f124148079084860368dfd27cb96e0952853e
   WordPress-Editor-iOS: 20551d5a5e51f29832064f08faaaae8e1da7e1e2
-  WordPressAuthenticator: 93f704305a3ad13703f9f2e6375a2bcf8fb7c137
-  WordPressKit: 7d4ecdcb62b3826b491dad9fb9b6fb02ac9702b5
+  WordPressAuthenticator: 0b3423546d92a976e3ce627d2e5a0350716b1f5b
+  WordPressKit: 52329b519bd0da6533cd4c79070424d0672ed7ee
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: 45591178e843ecb82e65e868ec766148befe9f9f
@@ -849,6 +849,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: 1a8c4d354b3b437de71517e270897820e3efc7c0
+PODFILE CHECKSUM: f18b631a6b25713184495ced4e4387f59388c803
 
 COCOAPODS: 1.11.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 * [**] Reader post details Comments snippet: added ability to manage conversation subscription and notifications. [#17749]
 * [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756, #17761]
 * [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]
+* [*] Self-hosted login: Improved error messages. [#17724]
 
 19.0
 -----


### PR DESCRIPTION
Fixes #17119

**Related PRs:**
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/464
- https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/632

**To test:**

On a self-hosted site install the attached plugin (XML-RPC Tweak) which will aid in testing: [xml-rpc-tweak.zip](https://github.com/wordpress-mobile/WordPress-iOS/files/7936266/xml-rpc-tweak.zip)


Some steps will require the tester to log in using an invalid username and or password. This is only to overcome a limitation with how the plugin simulates certain failures.

**Test 1:**

1. Set XML-RPC Tweak to Mode 1
2. Log in to the self-hosted site
3. Observe error "XML-RPC services are disabled on this site."

| Before | After |
| ------  | ----- |
| ![Mode 1 - Before](https://user-images.githubusercontent.com/2092798/149269486-877aaed8-fd93-45a4-a946-09ad06184126.png) | ![Mode 1](https://user-images.githubusercontent.com/2092798/149269495-bb1bc9f2-2118-4c7a-a3e6-b3af4b191f55.png) |

**Test 2:**

1. Set XML-RPC Tweak to Mode 2
2. Log in to the self-hosted site **with an invalid username / password**
3. Observe error "Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ."

| Before | After |
| ------  | ----- |
| ![Mode 2 - Before](https://user-images.githubusercontent.com/2092798/149269735-64659e3a-16b5-49bf-80ba-591f27ff381f.png) | ![Mode 2 and 4](https://user-images.githubusercontent.com/2092798/149269782-1ca75f15-5982-4f49-b862-3401309b7845.png) |

**Test 3:**

1. Set XML-RPC Tweak to Mode 3
2. Log in to the self-hosted site **with an invalid username / password**
3. Observe error "There was a problem communicating with the site. An HTTP error code 401 was returned."

| Before | After |
| ------  | ----- |
| ![Mode 3 - Before](https://user-images.githubusercontent.com/2092798/149269875-2f10b763-d501-4565-b744-c1501e98e801.png) | ![Mode 3](https://user-images.githubusercontent.com/2092798/149269881-4305a0d1-797e-4361-b349-ef92029bb28f.png) |

**Test 4:**

1. Set XML-RPC Tweak to Mode 4
2. Log in to the self-hosted site
3. Observe error "Unable to read the WordPress site at that URL. Tap 'Need Help?' to view the FAQ."

| Before | After (no change) |
| ------  | ----- |
| ![Mode 4 - Before](https://user-images.githubusercontent.com/2092798/149269934-2cdc542f-66a7-4aee-8f10-6659961ecc3b.png) | ![Mode 2 and 4](https://user-images.githubusercontent.com/2092798/149269938-f1d861cb-e1b1-412c-a1c6-bd352a9dcdd9.png) |

## Regression Notes
1. Potential unintended areas of impact
- Regression in error messages when logging into self-hosted sites

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Executed the testing steps above.

3. What automated tests I added (or what prevented me from doing so)
- None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
