### PR TITLE
Reader post comments following: move notification sheet handling to presenter

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -152,7 +152,6 @@ private extension ReaderCommentsFollowPresenter {
     }
 
     struct Messages {
-
         // Follow Conversation
         static let followSuccess = NSLocalizedString("Successfully followed conversation", comment: "The app successfully subscribed to the comments for the post")
         static let unfollowSuccess = NSLocalizedString("Successfully unfollowed conversation", comment: "The app successfully unsubscribed from the comments for the post")
@@ -168,6 +167,13 @@ private extension ReaderCommentsFollowPresenter {
         static let promptMessage = NSLocalizedString("Enable in-app notifications?", comment: "Hint for the action button that enables notification for new comments")
         static let enableActionTitle = NSLocalizedString("Enable", comment: "Button title to enable notifications for new comments")
         static let undoActionTitle = NSLocalizedString("Undo", comment: "Button title. Reverts the previous notification operation")
+    }
+
+    /// Enumerates the kind of actions available in relation to post subscriptions.
+    /// TODO: Add `followConversation` and `unfollowConversation` once the "Follow Conversation" feature flag is removed.
+    enum PostSubscriptionAction: Int {
+        case enableNotification
+        case disableNotification
     }
 
     func noticeTitle(forAction action: PostSubscriptionAction, success: Bool) -> String {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -34,7 +34,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
                                             WPContentSyncHelperDelegate,
                                             WPTableViewHandlerDelegate,
                                             SuggestionsTableViewDelegate,
-                                            ReaderCommentsNotificationSheetDelegate,
                                             ReaderCommentsFollowPresenterDelegate>
 
 @property (nonatomic, strong, readwrite) ReaderPost *post;
@@ -1076,13 +1075,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     self.indexPathForCommentRepliedTo = nil;
 }
 
-- (void)subscriptionSettingsButtonTapped
-{
-    [self showNotificationSheetWithNotificationsEnabled:self.post.receivesCommentNotifications
-                                               delegate:self
-                                    sourceBarButtonItem:self.navigationItem.rightBarButtonItem];
-}
-
 - (void)didTapReplyAtIndexPath:(NSIndexPath *)indexPath
 {
     // in the new comment thread, we want to allow tapping the Reply button again to un-highlight the row.
@@ -1536,147 +1528,30 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self presentViewController:navController animated:YES completion:nil];
 }
 
-
-#pragma mark - ReaderCommentsNotificationSheet Delegate Methods
-
-- (void)didToggleNotificationSwitch:(BOOL)isOn completion:(void (^)(BOOL))completion
-{
-    [self handleNotificationsButtonTappedWithUndo:NO completion:completion];
-}
-
-- (void)didTapUnfollowConversation
-{
-    [self handleFollowConversationButtonTapped];
-}
-
 #pragma mark - ReaderCommentsFollowPresenterDelegate Methods
 
-- (void)followingCompleteWithSuccess:(BOOL)success post:(ReaderPost *)post
+- (void)followConversationCompleteWithSuccess:(BOOL)success post:(ReaderPost *)post
 {
     self.post = post;
     [self refreshFollowButton];
 }
 
-#pragma mark - PostHeaderView helpers
+- (void)toggleNotificationCompleteWithSuccess:(BOOL)success post:(ReaderPost *)post
+{
+    self.post = post;
+}
+
+#pragma mark - Nav bar button helpers
 
 - (void)handleFollowConversationButtonTapped
 {
-    if ([Feature enabled:FeatureFlagFollowConversationPostDetails]) {
-        [self.readerCommentsFollowPresenter handleFollowConversationButtonTapped];
-        return;
-    }
-
-
-    __typeof(self) __weak weakSelf = self;
-
-    UINotificationFeedbackGenerator *generator = [UINotificationFeedbackGenerator new];
-    [generator prepare];
-
-    BOOL oldIsSubscribed = self.post.isSubscribedComments;
-    BOOL newIsSubscribed = !oldIsSubscribed;
-
-    // Define success block
-    void (^successBlock)(BOOL taskSucceeded) = ^void(BOOL taskSucceeded) {
-        if (taskSucceeded == NO) {
-            NSString *title = newIsSubscribed
-                ? NSLocalizedString(@"Unable to follow conversation", @"The app failed to subscribe to the comments for the post")
-                : NSLocalizedString(@"Failed to unfollow conversation", @"The app failed to unsubscribe from the comments for the post");
-
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [generator notificationOccurred:UINotificationFeedbackTypeSuccess];
-                [weakSelf displayNoticeWithTitle:title message:nil];
-            });
-        } else {
-            NSString *title = newIsSubscribed
-                ? NSLocalizedString(@"Successfully followed conversation", @"The app successfully subscribed to the comments for the post")
-                : NSLocalizedString(@"Successfully unfollowed conversation", @"The app successfully unsubscribed from the comments for the post");
-
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [generator notificationOccurred:UINotificationFeedbackTypeSuccess];
-                [weakSelf refreshFollowButton];
-
-                // only show the new notice with undo option when the user intends to subscribe.
-                if (newIsSubscribed) {
-                    [weakSelf displayActionableNoticeWithTitle:NSLocalizedString(@"Following this conversation",
-                                                                                 @"The app successfully subscribed to the comments for the post")
-                                                       message:NSLocalizedString(@"Enable in-app notifications?",
-                                                                                 @"Hint for the action button that enables notification for new comments")
-                                                   actionTitle:NSLocalizedString(@"Enable",
-                                                                                 @"Button title to enable notifications for new comments")
-                                                 actionHandler:^(BOOL accepted) {
-                        [weakSelf handleNotificationsButtonTappedWithUndo:YES completion:nil];
-                    }];
-                    return;
-                }
-
-                [weakSelf displayNoticeWithTitle:title message:nil];
-            });
-        }
-    };
-
-    // Define failure block
-    void (^failureBlock)(NSError *error) = ^void(NSError *error) {
-        DDLogError(@"Error toggling subscription status: %@", error);
-
-        NSString *title = newIsSubscribed
-            ? NSLocalizedString(@"Could not subscribe to comments", "The app failed to subscribe to the comments for the post")
-            : NSLocalizedString(@"Could not unsubscribe from comments", "The app failed to unsubscribe from the comments for the post");
-
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [generator notificationOccurred:UINotificationFeedbackTypeError];
-            [weakSelf displayNoticeWithTitle:title message:nil];
-        });
-    };
-
-    // Call the service to toggle the subscription status
-    [self.followCommentsService toggleSubscribed:oldIsSubscribed
-                                         success:successBlock
-                                         failure:failureBlock];
+    [self.readerCommentsFollowPresenter handleFollowConversationButtonTapped];
 }
 
-/// Toggles the state of comment subscription notifications. When enabled, the user will receive in-app notifications for new comments.
-///
-/// @param canUndo Boolean. When true, this provides a way for the user to revert their actions.
-- (void)handleNotificationsButtonTappedWithUndo:(BOOL)canUndo completion:(void (^ _Nullable)(BOOL))completion
+- (void)subscriptionSettingsButtonTapped
 {
-    if ([Feature enabled:FeatureFlagFollowConversationPostDetails]) {
-        [self.readerCommentsFollowPresenter handleNotificationsButtonTappedWithCanUndo:canUndo completion:completion];
-        return;
-    }
-
-
-    BOOL desiredState = !self.post.receivesCommentNotifications;
-    PostSubscriptionAction action = desiredState ? PostSubscriptionActionEnableNotification : PostSubscriptionActionDisableNotification;
-
-    __weak __typeof(self) weakSelf = self;
-    NSString* (^noticeTitle)(BOOL) = ^NSString* (BOOL success) {
-        return [weakSelf noticeTitleForAction:action success:success];
-    };
-
-    [self.followCommentsService toggleNotificationSettings:desiredState success:^{
-        if (completion) {
-            completion(YES);
-        }
-
-        if (!canUndo) {
-            [weakSelf displayNoticeWithTitle:noticeTitle(YES) message:nil];
-            return;
-        }
-
-        // show the undo notice with action button.
-        NSString *undoActionTitle = NSLocalizedString(@"Undo", @"Button title. Reverts the previous notification operation");
-        [weakSelf displayActionableNoticeWithTitle:noticeTitle(YES) message:nil actionTitle:undoActionTitle actionHandler:^(BOOL accepted) {
-            [weakSelf handleNotificationsButtonTappedWithUndo:NO completion:nil];
-        }];
-
-    } failure:^(NSError * _Nullable error) {
-        [weakSelf displayNoticeWithTitle:noticeTitle(NO) message:nil];
-        if (completion) {
-            completion(NO);
-        }
-    }];
+    [self.readerCommentsFollowPresenter showNotificationSheetWithSourceBarButtonItem:self.navigationItem.rightBarButtonItem];
 }
-
 
 #pragma mark - UITextViewDelegate methods
 
@@ -1692,7 +1567,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     BOOL showsSuggestions = [self.suggestionsTableView showSuggestionsForWord:word];
     self.tapOffKeyboardGesture.enabled = !showsSuggestions;
 }
-
 
 - (void)replyTextView:(ReplyTextView *)replyTextView willEnterFullScreen:(FullScreenCommentReplyViewController *)controller
 {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -2,33 +2,11 @@ import Foundation
 import UIKit
 import WordPressShared
 
-/// Enumerates the kind of actions available in relation to post subscriptions.
-/// TODO: Add `followConversation` and `unfollowConversation` once the "Follow Conversation" feature flag is removed.
-@objc public enum PostSubscriptionAction: Int {
-    case enableNotification
-    case disableNotification
-}
-
 
 @objc public extension ReaderCommentsViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
         guard let siteID = siteID, let blog = Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext) else { return false }
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
-    }
-
-    // MARK: Post Subscriptions
-
-    func noticeTitle(forAction action: PostSubscriptionAction, success: Bool) -> String {
-        switch (action, success) {
-        case (.enableNotification, true):
-            return NSLocalizedString("In-app notifications enabled", comment: "The app successfully enabled notifications for the subscription")
-        case (.enableNotification, false):
-            return NSLocalizedString("Could not enable notifications", comment: "The app failed to enable notifications for the subscription")
-        case (.disableNotification, true):
-            return NSLocalizedString("In-app notifications disabled", comment: "The app successfully disabled notifications for the subscription")
-        case (.disableNotification, false):
-            return NSLocalizedString("Could not disable notifications", comment: "The app failed to disable notifications for the subscription")
-        }
     }
 
     func handleHeaderTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -16,12 +16,6 @@ import WordPressShared
         return SuggestionService.shared.shouldShowSuggestions(for: blog)
     }
 
-    func showNotificationSheet(notificationsEnabled: Bool, delegate: ReaderCommentsNotificationSheetDelegate?, sourceBarButtonItem: UIBarButtonItem?) {
-        let sheetViewController = ReaderCommentsNotificationSheetViewController(isNotificationEnabled: notificationsEnabled, delegate: delegate)
-        let bottomSheet = BottomSheetViewController(childViewController: sheetViewController)
-        bottomSheet.show(from: self, sourceBarButtonItem: sourceBarButtonItem)
-    }
-
     // MARK: Post Subscriptions
 
     func noticeTitle(forAction action: PostSubscriptionAction, success: Bool) -> String {


### PR DESCRIPTION
Ref: #17632 

Presenting the `ReaderCommentsNotificationSheet` and handling its delegate methods is now done by `ReaderCommentsFollowPresenter`.

To test:
- Go to the Reader.
- Follow a post's comments.
- Tap the bell icon.
  - Verify the sheet is presented with the notifications toggle in the correct state.
  - Verify toggling notifications works.
  - Verify the correct notices are displayed.

## Regression Notes
1. Potential unintended areas of impact
Following conversations from Reader post comments could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested functionality to ensure following works as expected. (Full regression testing steps can be found [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17725).)

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
