### PR TITLE
Reader Post Details Comments: show bell icon when user is subscribed to comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -391,15 +391,22 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func updateComments(_ comments: [Comment], totalComments: Int) {
+        guard let post = post else {
+            DDLogError("Missing post when updating Reader post detail comments.")
+            return
+        }
+
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
 
         commentsTableViewDelegate.updateWith(comments: comments,
                                              totalComments: totalComments,
-                                             commentsEnabled: post?.commentsOpen ?? false,
-                                             followingEnabled: post?.canSubscribeComments ?? false,
+                                             commentsEnabled: post.commentsOpen,
+                                             followingEnabled: post.canSubscribeComments,
+                                             isSubscribedComments: post.isSubscribedComments,
                                              buttonDelegate: self)
+
         commentsTableView.reloadData()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -12,13 +12,20 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
         }
     }
 
+    private var isSubscribedComments: Bool = false {
+        didSet {
+            configureButton()
+        }
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
     }
 
-    func configure(totalComments: Int, followConversationEnabled: Bool) {
+    func configure(totalComments: Int, followConversationEnabled: Bool, isSubscribedComments: Bool) {
         self.followConversationEnabled = followConversationEnabled
+        self.isSubscribedComments = isSubscribedComments
 
         titleLabel.text = {
             switch totalComments {
@@ -49,10 +56,17 @@ private extension ReaderDetailCommentsHeader {
     }
 
     func configureButton() {
-        followButton.setTitle(Titles.followButton, for: .normal)
-        followButton.setTitleColor(.primary, for: .normal)
-        followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
         followButton.addTarget(self, action: #selector(followButtonTapped), for: .touchUpInside)
+
+        if isSubscribedComments {
+            followButton.setImage(UIImage.init(systemName: "bell"), for: .normal)
+            followButton.setTitle(nil, for: .normal)
+        } else {
+            followButton.setTitle(Titles.followButton, for: .normal)
+            followButton.setTitleColor(.primary, for: .normal)
+            followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
+            followButton.setImage(nil, for: .normal)
+        }
     }
 
     @objc func followButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -7,6 +7,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private(set) var totalComments = 0
     private var commentsEnabled = true
     private var followingEnabled = true
+    private var isSubscribedComments = false
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
 
     private var totalRows = 0
@@ -37,12 +38,14 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                     totalComments: Int = 0,
                     commentsEnabled: Bool = true,
                     followingEnabled: Bool = true,
+                    isSubscribedComments: Bool = false,
                     buttonDelegate: BorderedButtonTableViewCellDelegate? = nil) {
         self.commentsEnabled = commentsEnabled
         self.followingEnabled = followingEnabled
         hideButton = (comments.count == 0 && !commentsEnabled)
         self.comments = comments
         self.totalComments = totalComments
+        self.isSubscribedComments = isSubscribedComments
         self.buttonDelegate = buttonDelegate
     }
 
@@ -86,7 +89,10 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             return nil
         }
 
-        header.configure(totalComments: totalComments, followConversationEnabled: commentsEnabled && followingEnabled)
+        header.configure(totalComments: totalComments,
+                         followConversationEnabled: commentsEnabled && followingEnabled,
+                         isSubscribedComments: isSubscribedComments)
+
         return header
     }
 


### PR DESCRIPTION
Ref: #17632 

If the user is subscribed to a post's comments, the Comments snippet header will display a bell icon.

Notes:
- The Follow button is not functional yet.
- If following is toggled from the Comments view, this button is not updated on-the-fly yet.

To test:
- Enable `followConversationPostDetails`.
- Go to the Reader. 
- Select a post that you are following comments on.
  - Verify a bell icon is displayed in the Comments header.
- Select a post that you are not following comments on.
  - Verify `Follow Conversation` is displayed in the Comments header.

| Subscribed | Not Subscribed |
|--------|-------|
| <img width="471" alt="bell" src="https://user-images.githubusercontent.com/1816888/148624955-62f875ae-34e1-4966-ab1f-06eae7110cdd.png"> | <img width="470" alt="follow" src="https://user-images.githubusercontent.com/1816888/148624956-f17f0b28-cede-4bf3-930e-02c09a31d67c.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
