### PR TITLE
Better user error message when adding media with limited access to photos

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -608,6 +608,8 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
+        guard picker == self else { return false }
+
         let nserror = error as NSError
         if let mediaLibrary = self.blog.media, !mediaLibrary.isEmpty {
             let title = NSLocalizedString("Unable to Sync", comment: "Title of error prompt shown when a sync the user initiated fails.")


### PR DESCRIPTION
When a user restricts or revokes Photo's permission from the WordPress iOS app an unintuitive error message is displayed to the user

Fixes # [17470](https://github.com/wordpress-mobile/WordPress-iOS/issues/17470)

To test:
	1. In iOS Settings -> WordPress -> "Allow WordPress to Access" -> Photos -> Select "None" or "Add Photos Only" 
	2. My Site -> Media
	3. Tap the + at the top right
	4. Select "Choose from My Device"
Error message that appears should be the default error message from WPMediaPicker-iOS

<img width="400" alt="image" src="https://user-images.githubusercontent.com/88816724/148777971-25f98f51-302b-42b7-b4ad-a49b17ad05bd.png">


## Regression Notes
1. Potential unintended areas of impact
MediaLibraryViewController handleError might display an unintended error message for the user

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested triggering the Unable to Sync error message

To test Unable to sync error message

	1. In WordPress iOS navigate to My Site -> Site Settings
	2. If testing via simulator disable network on your Mac (or if testing on your device turn on Airplance model / disable network)
	3. Tap Media button
Unable to Sync error message will appear

<img width="371" alt="image" src="https://user-images.githubusercontent.com/88816724/148778460-b4038040-3f8c-4f02-8def-2619a46bbee2.png">


3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
