### PR TITLE
Prevent double-push of edit username screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 19.1
 -----
-
+* [*] Signup: Fixed bug where username selection screen could be pushed twice. [#17624]
 
 19.0
 -----

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -5,7 +5,6 @@ import WordPressAuthenticator
 protocol SignupEpilogueCellDelegate {
     func updated(value: String, forType: EpilogueCellType)
     func changed(value: String, forType: EpilogueCellType)
-    func usernameSelected()
 }
 
 enum EpilogueCellType: Int {
@@ -105,6 +104,7 @@ class SignupEpilogueCell: UITableViewCell {
         configureAccessoryType(for: newCellType)
         configureTextContentTypeIfNeeded(for: newCellType)
         configureAccessibility(for: newCellType)
+        configureEditable(for: newCellType)
 
         addBottomBorder(withColor: .divider, leadingMargin: cellLabelLeadingConstraint.constant)
 
@@ -135,15 +135,6 @@ extension SignupEpilogueCell: UITextFieldDelegate {
             let updatedText = textField.text {
             delegate?.updated(value: updatedText, forType: cellType)
         }
-    }
-
-    func textFieldShouldBeginEditing(_ textField: UITextField) -> Bool {
-        if let cellType = cellType,
-            cellType == .username {
-            delegate?.usernameSelected()
-            return false
-        }
-        return true
     }
 
     func textFieldShouldReturn(_ textField: UITextField) -> Bool {
@@ -207,6 +198,14 @@ private extension SignupEpilogueCell {
             cellField.textContentType = .username
         case .password:
             cellField.textContentType = .newPassword
+        }
+    }
+
+    func configureEditable(for cellType: EpilogueCellType) {
+        if cellType == .username {
+            cellField.isEnabled = false
+        } else {
+            cellField.isEnabled = true
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueTableViewController.swift
@@ -139,6 +139,13 @@ class SignupEpilogueTableViewController: UITableViewController, EpilogueUserInfo
         return UITableView.automaticDimension
     }
 
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if let cellType = EpilogueCellType(rawValue: indexPath.row),
+           cellType == .username {
+            delegate?.usernameTapped(userInfo: epilogueUserInfo)
+        }
+    }
+
 }
 
 // MARK: - Private Extension
@@ -273,10 +280,6 @@ extension SignupEpilogueTableViewController: SignupEpilogueCellDelegate {
         } else if forType == .password {
             delegate?.passwordUpdated(newPassword: value)
         }
-    }
-
-    func usernameSelected() {
-        delegate?.usernameTapped(userInfo: epilogueUserInfo)
     }
 
 }


### PR DESCRIPTION
Fixes #17624 

## Description
The edit username screen on the SignupEpilogue screen was sometimes pushed twice when a user tapped on the username text field.

This navigation was triggered in the implementation of `UITextFieldDelegate.textFieldShouldBeginEditing`, which was under certain circumstances, called twice by the system. That delegate method is supposed to answer the question "should editing be allowed?" with a Bool, so navigating here could be considered a side-effect, which makes the delegate method unsafe to call more than once.

This change moves the responsibility for navigation to the TableViewController, in the `didSelectRowAtIndex` method.

The `UITextField` for username also needed to be disabled, to make it easier to tap the row. Without this change, the user would have to tap on the "Username:" label, or the disclosure indicator, and taps on the text field would be ignored. Prior to this commit, users would have to tap on the username value itself, taps elsewhere on the row were ignored.

## To test:

1. Launch app, make a new account
2. On sign up epilogue, tap on the username field. The screen will only be pushed once.
3. Tap back
4. Tap on the Display Name
5. Tap on the username field. The screen will still only be pushed once.


https://user-images.githubusercontent.com/2472348/148790063-76bebe3e-03f4-4f13-a807-e2a0425668e9.mp4



## Regression Notes
1. Potential unintended areas of impact
Editability of other `SignupEpilogueCell`s – the cell is not used on any other screens
Accessibility – action and label

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked that Password and Display Name were still editable, before and after pushing the username selection screen (and multiple repeats in case of cell reuse)

Checked accessibility label was useful and showed that the row was selectable ("button"). Accessibility action still pushes username screen.

3. What automated tests I added (or what prevented me from doing so)
None – no existing tests found, idempotent testing of signup is a high barrier to entry for this small change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
