### PR TITLE
My Site Dashboard: Initial Structure

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -75,7 +75,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .commentThreadModerationMenu:
             return false
         case .mySiteDashboard:
-            return BuildConfiguration.current == .localDeveloper
+            return false
         case .followConversationPostDetails:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -1,9 +1,91 @@
 import UIKit
 
-class BlogDashboardViewController: UIViewController {
+final class BlogDashboardViewController: UIViewController {
+
+    enum Section: CaseIterable {
+        case quickLinks
+    }
+
+    // FIXME: temporary placeholder
+    private let quickLinks = ["Quick Links"]
+
+    typealias DataSource = UICollectionViewDiffableDataSource<Section, String>
+    typealias Snapshot = NSDiffableDataSourceSnapshot<Section, String>
+    typealias QuickLinksHostCell = HostCollectionViewCell<QuickLinksView>
+
+    private lazy var collectionView: UICollectionView = {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        return collectionView
+    }()
+
+    private lazy var dataSource: DataSource = {
+        return DataSource(collectionView: collectionView) { collectionView, indexPath, identifier in
+            let cell = collectionView.dequeueReusableCell(withReuseIdentifier: QuickLinksHostCell.defaultReuseID, for: indexPath) as? QuickLinksHostCell
+            cell?.hostedView = QuickLinksView(title: self.quickLinks[indexPath.item])
+            return cell
+        }
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupCollectionView()
+        applySnapshotForInitialData()
     }
 
+    private func setupCollectionView() {
+        collectionView.backgroundColor = .listBackground
+        collectionView.register(QuickLinksHostCell.self, forCellWithReuseIdentifier: QuickLinksHostCell.defaultReuseID)
+
+        view.addSubview(collectionView)
+        view.pinSubviewToAllEdges(collectionView)
+    }
+
+    private func applySnapshotForInitialData() {
+        var snapshot = Snapshot()
+        snapshot.appendSections(Section.allCases)
+        snapshot.appendItems(quickLinks, toSection: Section.quickLinks)
+        dataSource.apply(snapshot, animatingDifferences: false)
+    }
+}
+
+// MARK: - Collection view layout
+
+extension BlogDashboardViewController {
+
+    private func createLayout() -> UICollectionViewLayout {
+        let layout = UICollectionViewCompositionalLayout {
+            (sectionIndex: Int, layoutEnvironment: NSCollectionLayoutEnvironment) -> NSCollectionLayoutSection? in
+
+            return self.createQuickLinksSection()
+        }
+        return layout
+    }
+
+    private func createQuickLinksSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0),
+                                              heightDimension: .estimated(Constants.estimatedHeight))
+
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: itemSize, subitems: [item])
+
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: Constants.sectionInset,
+                                                        leading: Constants.sectionInset,
+                                                        bottom: Constants.sectionInset,
+                                                        trailing: Constants.sectionInset)
+        section.interGroupSpacing = Constants.interGroupSpacing
+
+        return section
+    }
+}
+
+extension BlogDashboardViewController {
+
+    private enum Constants {
+        static let estimatedHeight: CGFloat = 44
+        static let sectionInset: CGFloat = 16
+        static let interGroupSpacing: CGFloat = 8
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+class BlogDashboardViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
@@ -7,6 +7,10 @@ protocol Hostable {
     var hostedView: Content? { get set }
 }
 
+/// A generic UICollectionViewCell that hosts a SwiftUI view.
+///
+/// Create a HostCollectionViewCell when you want to integrate SwiftUI views into a UIKit view hierarchy.
+/// At creation time, specify the SwiftUI view you want to use as the content view for this cell.
 class HostCollectionViewCell<Content>: UICollectionViewCell, Hostable where Content: View {
 
     var hostController: UIHostingController<Content>?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
@@ -1,0 +1,45 @@
+import UIKit
+import SwiftUI
+
+protocol Hostable {
+    associatedtype Content: View
+    var hostController: UIHostingController<Content>? { get }
+    var hostedView: Content? { get set }
+}
+
+class HostCollectionViewCell<Content>: UICollectionViewCell, Hostable where Content: View {
+
+    var hostController: UIHostingController<Content>?
+
+    var hostedView: Content? {
+        willSet {
+            guard let view = newValue else {
+                return
+            }
+            hostController = UIHostingController(rootView: view)
+            if let hostView = hostController?.view {
+                contentView.addSubview(hostView)
+                hostView.translatesAutoresizingMaskIntoConstraints = false
+                contentView.pinSubviewToAllEdges(hostView)
+            }
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.contentView.layer.masksToBounds = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func prepareForReuse() {
+        if let hostView = hostController?.view {
+            hostView.removeFromSuperview()
+        }
+        hostController = nil
+    }
+}
+
+extension HostCollectionViewCell: Reusable { }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/QuickLinksView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/QuickLinksView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct QuickLinksView: View {
+    var title: String
+
+    var body: some View {
+        Text(title)
+            .padding()
+    }
+}
+
+struct QuickLinksView_Previews: PreviewProvider {
+    static var previews: some View {
+        QuickLinksView(title: "Title")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -93,6 +93,17 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func setupSegmentedControl() {
         segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled
+
+        let segmentTitles = [
+            NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen"),
+            NSLocalizedString("Dashboard", comment: "Title for dashboard view on the My Site screen")
+        ]
+
+        segmentedControl.removeAllSegments()
+        for (index, title) in segmentTitles.enumerated() {
+            segmentedControl.insertSegment(withTitle: title, at: index, animated: false)
+        }
+        segmentedControl.selectedSegmentIndex = 0
     }
 
     // MARK: - Navigation Item

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -2,6 +2,10 @@ import WordPressAuthenticator
 
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
+    @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var segmentedControl: UISegmentedControl!
+    @IBOutlet weak var containerView: UIView!
+
     private let meScenePresenter: ScenePresenter
 
     // MARK: - Initializers
@@ -349,10 +353,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         addMeButtonToNavigationBar(email: blog.account?.email, meScenePresenter: meScenePresenter)
 
-        add(blogDetailsViewController)
+        addChild(blogDetailsViewController)
+        containerView.addSubview(blogDetailsViewController.view)
+        blogDetailsViewController.didMove(toParent: self)
 
         blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToAllEdges(blogDetailsViewController.view)
+        containerView.pinSubviewToAllEdges(blogDetailsViewController.view)
 
         blogDetailsViewController.showInitialDetailsForBlog()
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -3,6 +3,20 @@ import UIKit
 
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
+    private enum Section: Int, CaseIterable {
+        case siteMenu
+        case dashboard
+
+        var title: String {
+            switch self {
+            case .siteMenu:
+                return NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen")
+            case .dashboard:
+                return NSLocalizedString("Dashboard", comment: "Title for dashboard view on the My Site screen")
+            }
+        }
+    }
+
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var segmentedControlContainerView: UIView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
@@ -94,14 +108,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func setupSegmentedControl() {
         segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled
 
-        let segmentTitles = [
-            NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen"),
-            NSLocalizedString("Dashboard", comment: "Title for dashboard view on the My Site screen")
-        ]
-
         segmentedControl.removeAllSegments()
-        for (index, title) in segmentTitles.enumerated() {
-            segmentedControl.insertSegment(withTitle: title, at: index, animated: false)
+        Section.allCases.forEach { section in
+            segmentedControl.insertSegment(withTitle: section.title, at: section.rawValue, animated: false)
         }
         segmentedControl.selectedSegmentIndex = 0
     }
@@ -199,22 +208,20 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - IBAction
 
     @IBAction func segmentedControlValueChanged(_ sender: Any) {
-        guard let blog = blog else {
+        guard let blog = blog,
+              let section = Section(rawValue: segmentedControl.selectedSegmentIndex) else {
             return
         }
 
-        if segmentedControl.selectedSegmentIndex == 0 {
-
+        switch section {
+        case .siteMenu:
             remove(blogDashboardViewController)
-
             showBlogDetails(for: blog)
-        } else {
+        case .dashboard:
             guard let blogDetailVC = blogDetailsViewController else {
                 return
             }
-
             remove(blogDetailVC)
-
             embedChildInContainerView(blogDashboardViewController)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1,4 +1,5 @@
 import WordPressAuthenticator
+import UIKit
 
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
@@ -45,6 +46,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     /// Please keep this in mind when making modifications.
     ///
     private var blogDetailsViewController: BlogDetailsViewController?
+
+    private let blogDashboardViewController = BlogDashboardViewController()
 
     /// When we display a no results view, we'll do so in a scrollview so that
     /// we can allow pull to refresh to sync the user's list of sites.
@@ -180,6 +183,40 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         } failure: { (error) in
             finishSync()
         }
+    }
+
+    // MARK: - IBAction
+
+    @IBAction func segmentedControlValueChanged(_ sender: Any) {
+        guard let blog = blog else {
+            return
+        }
+
+        if segmentedControl.selectedSegmentIndex == 0 {
+
+            remove(blogDashboardViewController)
+
+            showBlogDetails(for: blog)
+        } else {
+            guard let blogDetailVC = blogDetailsViewController else {
+                return
+            }
+
+            remove(blogDetailVC)
+
+            embedChildInContainerView(blogDashboardViewController)
+        }
+    }
+
+    // MARK: - Child VC logic
+
+    private func embedChildInContainerView(_ child: UIViewController) {
+        addChild(child)
+        containerView.addSubview(child.view)
+        child.didMove(toParent: self)
+
+        child.view.translatesAutoresizingMaskIntoConstraints = false
+        containerView.pinSubviewToAllEdges(child.view)
     }
 
     // MARK: - No Sites UI logic
@@ -359,12 +396,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         addMeButtonToNavigationBar(email: blog.account?.email, meScenePresenter: meScenePresenter)
 
-        addChild(blogDetailsViewController)
-        containerView.addSubview(blogDetailsViewController.view)
-        blogDetailsViewController.didMove(toParent: self)
-
-        blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        containerView.pinSubviewToAllEdges(blogDetailsViewController.view)
+        embedChildInContainerView(blogDetailsViewController)
 
         blogDetailsViewController.showInitialDetailsForBlog()
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -3,6 +3,7 @@ import WordPressAuthenticator
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @IBOutlet weak var stackView: UIStackView!
+    @IBOutlet weak var segmentedControlContainerView: UIView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
     @IBOutlet weak var containerView: UIView!
 
@@ -55,6 +56,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     override func viewDidLoad() {
         setupNavigationItem()
+        setupSegmentedControl()
         subscribeToPostSignupNotifications()
         subscribeToModelChanges()
     }
@@ -84,6 +86,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func subscribeToPostSignupNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(launchSiteCreationFromNotification), name: .createSite, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
+    }
+
+    private func setupSegmentedControl() {
+        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled
     }
 
     // MARK: - Navigation Item

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
@@ -13,6 +13,7 @@
             <connections>
                 <outlet property="containerView" destination="ipg-3I-gW6" id="7vc-ym-Tk6"/>
                 <outlet property="segmentedControl" destination="Kw9-5k-pSU" id="N7S-6X-8Nr"/>
+                <outlet property="segmentedControlContainerView" destination="ogs-P5-vac" id="foF-yM-5ds"/>
                 <outlet property="stackView" destination="Kbh-jP-Igg" id="wGb-EK-OtN"/>
                 <outlet property="view" destination="iN0-l3-epB" id="hJG-ot-fhZ"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
@@ -35,6 +35,9 @@
                                         <segment title="First"/>
                                         <segment title="Second"/>
                                     </segments>
+                                    <connections>
+                                        <action selector="segmentedControlValueChanged:" destination="-1" eventType="valueChanged" id="Ln9-0U-TGG"/>
+                                    </connections>
                                 </segmentedControl>
                             </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.xib
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MySiteViewController" customModule="WordPress" customModuleProvider="target">
+            <connections>
+                <outlet property="containerView" destination="ipg-3I-gW6" id="7vc-ym-Tk6"/>
+                <outlet property="segmentedControl" destination="Kw9-5k-pSU" id="N7S-6X-8Nr"/>
+                <outlet property="stackView" destination="Kbh-jP-Igg" id="wGb-EK-OtN"/>
+                <outlet property="view" destination="iN0-l3-epB" id="hJG-ot-fhZ"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Kbh-jP-Igg">
+                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ogs-P5-vac">
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="79"/>
+                            <subviews>
+                                <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="Kw9-5k-pSU">
+                                    <rect key="frame" x="141.5" y="24" width="131" height="32"/>
+                                    <segments>
+                                        <segment title="First"/>
+                                        <segment title="Second"/>
+                                    </segments>
+                                </segmentedControl>
+                            </subviews>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="Kw9-5k-pSU" firstAttribute="top" secondItem="ogs-P5-vac" secondAttribute="top" constant="24" id="0J2-XM-ZD8"/>
+                                <constraint firstItem="Kw9-5k-pSU" firstAttribute="centerX" secondItem="ogs-P5-vac" secondAttribute="centerX" id="7QI-Gz-3Vb"/>
+                                <constraint firstItem="Kw9-5k-pSU" firstAttribute="centerY" secondItem="ogs-P5-vac" secondAttribute="centerY" id="9SJ-h9-j2s"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ipg-3I-gW6">
+                            <rect key="frame" x="0.0" y="79" width="414" height="739"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        </view>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="Kbh-jP-Igg" firstAttribute="bottom" secondItem="vUN-kp-3ea" secondAttribute="bottom" id="1fv-8a-iKP"/>
+                <constraint firstItem="Kbh-jP-Igg" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="1hM-hu-Xds"/>
+                <constraint firstItem="Kbh-jP-Igg" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="I5g-vn-gOa"/>
+                <constraint firstItem="Kbh-jP-Igg" firstAttribute="trailing" secondItem="vUN-kp-3ea" secondAttribute="trailing" id="J1b-MO-faA"/>
+            </constraints>
+            <point key="canvasLocation" x="132" y="70"/>
+        </view>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2732,6 +2732,7 @@
 		FA6FAB3525EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */; };
 		FA6FAB4725EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */; };
 		FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
+		FA73D7D9278DDD4B00DF24B3 /* HostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA7AA45325BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */; };
 		FA7AA4A725BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */; };
@@ -7494,6 +7495,7 @@
 		FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderRelatedPostsSectionHeaderView.swift; sourceTree = "<group>"; };
 		FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsSectionHeaderView.xib; sourceTree = "<group>"; };
 		FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardViewController.swift; sourceTree = "<group>"; };
+		FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCollectionViewCell.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatDetailsViewController.swift; sourceTree = "<group>"; };
 		FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackScanThreatDetailsViewController.xib; sourceTree = "<group>"; };
@@ -14495,6 +14497,7 @@
 			isa = PBXGroup;
 			children = (
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
+				FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */,
 			);
 			path = "Blog Dashboard";
 			sourceTree = "<group>";
@@ -18435,6 +18438,7 @@
 				E66969E01B9E648100EC9C00 /* ReaderTopicToReaderDefaultTopic37to38.swift in Sources */,
 				F1DB8D2B2288C24500906E2F /* UploadsManager.swift in Sources */,
 				9856A3E4261FD27A008D6354 /* UserProfileSectionHeader.swift in Sources */,
+				FA73D7D9278DDD4B00DF24B3 /* HostCollectionViewCell.swift in Sources */,
 				8B0570D3243781100021A436 /* SchedulingCalendarViewController+PresentFrom.swift in Sources */,
 				82A062DE2017BCBA0084CE7C /* ActivityListSectionHeaderView.swift in Sources */,
 				73FEC871220B358500CEF791 /* WPAccount+RestApi.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2731,6 +2731,7 @@
 		FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */; };
 		FA6FAB3525EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */; };
 		FA6FAB4725EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */; };
+		FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA7AA45325BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */; };
 		FA7AA4A725BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */; };
@@ -7492,6 +7493,7 @@
 		FA681F8825CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseRestoreStatusFailedViewController.swift; sourceTree = "<group>"; };
 		FA6FAB3425EF7C5700666CED /* ReaderRelatedPostsSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderRelatedPostsSectionHeaderView.swift; sourceTree = "<group>"; };
 		FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsSectionHeaderView.xib; sourceTree = "<group>"; };
+		FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardViewController.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatDetailsViewController.swift; sourceTree = "<group>"; };
 		FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackScanThreatDetailsViewController.xib; sourceTree = "<group>"; };
@@ -12295,6 +12297,7 @@
 				1716AEFA25F2926C00CF49EC /* My Site */,
 				F1863714253E49B8003D4BEF /* Add Site */,
 				3F43603423F368BF001DEE70 /* Blog Details */,
+				FA73D7D7278D9E6300DF24B3 /* Blog Dashboard */,
 				3F43603523F368CA001DEE70 /* Blog List */,
 				3F43603623F36962001DEE70 /* Blog Selector */,
 				3F37609B23FD803300F0D87F /* Blog + Me */,
@@ -14486,6 +14489,14 @@
 				FAD95D2625B91BCF00F011B5 /* JetpackRestoreStatusFailedViewController.swift */,
 			);
 			path = "Restore Status Failed";
+			sourceTree = "<group>";
+		};
+		FA73D7D7278D9E6300DF24B3 /* Blog Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
+			);
+			path = "Blog Dashboard";
 			sourceTree = "<group>";
 		};
 		FAB8007625AEDDCE00D5D54A /* Restore Complete */ = {
@@ -17573,6 +17584,7 @@
 				E15644E91CE0E47C00D96E64 /* RoundedButton.swift in Sources */,
 				FFC6ADD41B56F295002F3C84 /* AboutViewController.swift in Sources */,
 				08CC67801C49B65A00153AD7 /* MenuLocation.m in Sources */,
+				FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */,
 				4349B0AF218A477F0034118A /* RevisionsTableViewCell.swift in Sources */,
 				738B9A5921B85CF20005062B /* KeyboardInfo.swift in Sources */,
 				E15644F31CE0E5A500D96E64 /* PlanDetailViewModel.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2733,6 +2733,7 @@
 		FA6FAB4725EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */; };
 		FA73D7D6278D9E5D00DF24B3 /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
 		FA73D7D9278DDD4B00DF24B3 /* HostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */; };
+		FA73D7DD278DDE0E00DF24B3 /* QuickLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */; };
 		FA77E02A1BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */; };
 		FA7AA45325BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */; };
 		FA7AA4A725BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */; };
@@ -7496,6 +7497,7 @@
 		FA6FAB4625EF7C6A00666CED /* ReaderRelatedPostsSectionHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderRelatedPostsSectionHeaderView.xib; sourceTree = "<group>"; };
 		FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardViewController.swift; sourceTree = "<group>"; };
 		FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostCollectionViewCell.swift; sourceTree = "<group>"; };
+		FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickLinksView.swift; sourceTree = "<group>"; };
 		FA77E0291BE17CFC006D45E0 /* ThemeBrowserHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserHeaderView.swift; sourceTree = "<group>"; };
 		FA7AA45225BFD9BC005E7200 /* JetpackScanThreatDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanThreatDetailsViewController.swift; sourceTree = "<group>"; };
 		FA7AA4A625BFE0A9005E7200 /* JetpackScanThreatDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackScanThreatDetailsViewController.xib; sourceTree = "<group>"; };
@@ -14498,6 +14500,7 @@
 			children = (
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
 				FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */,
+				FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */,
 			);
 			path = "Blog Dashboard";
 			sourceTree = "<group>";
@@ -17907,6 +17910,7 @@
 				467D3DFA25E4436000EB9CB0 /* SitePromptView.swift in Sources */,
 				FAB8AA2225AF031200F9F8A0 /* BaseRestoreCompleteViewController.swift in Sources */,
 				E616E4B31C480896002C024E /* SharingService.swift in Sources */,
+				FA73D7DD278DDE0E00DF24B3 /* QuickLinksView.swift in Sources */,
 				F5E032E82408D537003AF350 /* BottomSheetPresentationController.swift in Sources */,
 				AB758D9E25EFDF9C00961C0B /* LikesListController.swift in Sources */,
 				E1FD45E01C030B3800750F4C /* AccountSettingsService.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2740,6 +2740,8 @@
 		FA8E1F7725EEFA7300063673 /* ReaderPostService+RelatedPosts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E1F7625EEFA7300063673 /* ReaderPostService+RelatedPosts.swift */; };
 		FA90EFEF262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */; };
 		FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */; };
+		FA94D9E9278C83A900FC6CE3 /* MySiteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA94D9E8278C83A900FC6CE3 /* MySiteViewController.xib */; };
+		FA94D9EA278C83A900FC6CE3 /* MySiteViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA94D9E8278C83A900FC6CE3 /* MySiteViewController.xib */; };
 		FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE3F02615996E00BF29FE /* AppConstants.swift */; };
 		FAADE43A26159B2800BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE42726159B1300BF29FE /* AppConstants.swift */; };
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
@@ -7497,6 +7499,7 @@
 		FA7F92C925E61C9300502D2A /* ReaderTagsFooter.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderTagsFooter.xib; sourceTree = "<group>"; };
 		FA8E1F7625EEFA7300063673 /* ReaderPostService+RelatedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostService+RelatedPosts.swift"; sourceTree = "<group>"; };
 		FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JetpackWebViewControllerFactory.swift; path = Classes/Services/JetpackWebViewControllerFactory.swift; sourceTree = SOURCE_ROOT; };
+		FA94D9E8278C83A900FC6CE3 /* MySiteViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MySiteViewController.xib; sourceTree = "<group>"; };
 		FA978DDA26CEB37E009FB14F /* WordPress 132.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 132.xcdatamodel"; sourceTree = "<group>"; };
 		FAADE3F02615996E00BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		FAADE42726159B1300BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
@@ -8127,6 +8130,7 @@
 				1716AEFB25F2927600CF49EC /* MySiteViewController.swift */,
 				17C1D67B2670E3DC006C8970 /* SiteIconPickerView.swift */,
 				17C1D7DB26735631006C8970 /* EmojiRenderer.swift */,
+				FA94D9E8278C83A900FC6CE3 /* MySiteViewController.xib */,
 			);
 			path = "My Site";
 			sourceTree = "<group>";
@@ -8517,7 +8521,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -15289,7 +15293,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
@@ -15587,6 +15591,7 @@
 				436D562D2117312700CEAA33 /* RegisterDomainDetailsErrorSectionFooter.xib in Resources */,
 				5DFA7EC31AF7CB910072023B /* Pages.storyboard in Resources */,
 				F5A34D1025DF2F7F00C9654B /* Shrikhand-Regular.ttf in Resources */,
+				FA94D9E9278C83A900FC6CE3 /* MySiteViewController.xib in Resources */,
 				9A73CB082350DE4C002EF20C /* StatsGhostSingleRowCell.xib in Resources */,
 				1761F18E26209AEE000815EF /* hot-pink-icon-app-76x76@2x.png in Resources */,
 				596C03601B84F24000899EEB /* ThemeBrowser.storyboard in Resources */,
@@ -15897,6 +15902,7 @@
 				FABB20022602FC2C00C8785C /* StatsTableFooter.xib in Resources */,
 				FABB20032602FC2C00C8785C /* NotificationSettingsViewController.xib in Resources */,
 				C7F7AC76261CF1F300CE547F /* JetpackLoginErrorViewController.xib in Resources */,
+				FA94D9EA278C83A900FC6CE3 /* MySiteViewController.xib in Resources */,
 				FABB20052602FC2C00C8785C /* ThemeBrowserSectionHeaderView.xib in Resources */,
 				FABB20072602FC2C00C8785C /* SitePromptView.xib in Resources */,
 				FABB20082602FC2C00C8785C /* DeleteSite.storyboard in Resources */,


### PR DESCRIPTION
Part of #17740 

## Description

This PR lays out the initial structure for the My Site Dashboard project
- Adds a segmented control to the My Site screen
- Adds a container view to the My Site screen to display child VCs 
- Adds a basic dashboard view (to be refined in future PRs)

While the original plan was to introduce the segmented control as part of phase 2 of the MSD project, after some investigation we've come to the conclusion that it would make more sense to do so in phase 1. 

Implementing the segmented control design allows us to leverage the existing structure of `MySiteViewController` -- which already acts as a container view controller for `BlogDetailViewController`-- and lets us avoid a lot of the tricky issues that came from trying to embed a child vc directly into a tableview.

Before | After (Site menu) | After (Dashboard)
-- | -- | --
<img src="https://user-images.githubusercontent.com/6711616/148992372-87888c57-fc3d-4962-acae-62d071586036.png" width=300> |<img src="https://user-images.githubusercontent.com/6711616/148992394-5aa9d42c-2e4d-4fdb-a14e-f0f51268e341.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/148992398-6c6b5c2e-0eab-4a6e-bc0e-3da887114d88.png" width=300>

## Notes
- These changes are behind a feature flag.
- `HostCollectionViewCell` is a UICollectionViewCell that hosts a SwiftUI view. More info here: paNNhX-jW-p2
- The `BlogDetailHeaderView` is still part of the table view on `BlogDetailViewController`. I will move the header view into `MySiteViewController` in a future PR.
- The Quick Links card is a very basic view for now. I will refine the card in a future PR.

## How to test
1. Go to My Site
2. Switch to dashboard view on the segmented control
3. ✅ The container view should switch to the blog dashboard vc
4. Switch back to the site menu view on the segmented control
5. ✅ The container view should switch to the blog details vc
6. Go to Profile > App Settings > Debug and turn My Site Dashboard off
7. Quit then reopen wpios app
8. ✅ There should be no segmented control 

## Regression Notes
1. Potential unintended areas of impact
My Site screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above steps manually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.