### PR TITLE
Reader Post Details Comments: update button state

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -73,7 +73,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mySiteDashboard:
             return BuildConfiguration.current == .localDeveloper
         case .followConversationPostDetails:
-            return false
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -174,6 +174,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         setupFeaturedImage()
+        updateFollowButtonState()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -392,6 +393,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                                              buttonDelegate: self)
 
         commentsTableView.reloadData()
+    }
+
+    private func updateFollowButtonState() {
+        guard let post = post else {
+            return
+        }
+
+        commentsTableViewDelegate.updateFollowButtonState(post: post)
     }
 
     deinit {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -173,22 +173,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-
-        configureFeaturedImage()
-
-        featuredImage.configure(scrollView: scrollView,
-                                navigationBar: navigationController?.navigationBar)
-
-        featuredImage.applyTransparentNavigationBarAppearance(to: navigationController?.navigationBar)
-
-        guard !featuredImage.isLoaded else {
-            return
-        }
-
-        // Load the image
-        featuredImage.load { [unowned self] in
-            self.hideLoading()
-        }
+        setupFeaturedImage()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -455,6 +440,24 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
                 self?.webViewHeight.constant = min(height, webViewHeight)
             })
+        }
+    }
+
+    private func setupFeaturedImage() {
+        configureFeaturedImage()
+
+        featuredImage.configure(scrollView: scrollView,
+                                navigationBar: navigationController?.navigationBar)
+
+        featuredImage.applyTransparentNavigationBarAppearance(to: navigationController?.navigationBar)
+
+        guard !featuredImage.isLoaded else {
+            return
+        }
+
+        // Load the image
+        featuredImage.load { [unowned self] in
+            self.hideLoading()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -45,6 +45,11 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
                                                                            presentingViewController: presentingViewController)
     }
 
+    func updateFollowButtonState(post: ReaderPost) {
+        self.post = post
+        configureButton()
+    }
+
 }
 
 // MARK: - Private Extension

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -9,6 +9,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private var post: ReaderPost?
     private var presentingViewController: UIViewController?
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
+    private var headerView: ReaderDetailCommentsHeader?
 
     private var totalRows = 0
     private var hideButton = true
@@ -49,6 +50,11 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         self.totalComments = totalComments
         self.presentingViewController = presentingViewController
         self.buttonDelegate = buttonDelegate
+    }
+
+    func updateFollowButtonState(post: ReaderPost) {
+        self.post = post
+        headerView?.updateFollowButtonState(post: post)
     }
 
     // MARK: - Table Methods
@@ -94,6 +100,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         }
 
         header.configure(post: post, totalComments: totalComments, presentingViewController: presentingViewController)
+        headerView = header
         return header
     }
 


### PR DESCRIPTION
Ref: #17632 
Depends on: #17739

The Follow button state in the Comments snippet is now updated on `viewWillAppear`. 

Also, since the feature is functionally complete, I enabled `followConversationPostDetails` for develop.

To test:
- Go to a Reader post.
- View post details.
- Go to the Comments from here.
- Toggle the `Follow` state.
- Return to the post details.
- Verify the Follow button in the Comments header is updated accordingly.

| ![before](https://user-images.githubusercontent.com/1816888/149024379-74c6a225-e874-4729-b1dd-fd6e1f6af621.png) | ![changed](https://user-images.githubusercontent.com/1816888/149024377-f5e84bde-63bf-4757-b4cb-39c2c8bdac2c.png) | ![after](https://user-images.githubusercontent.com/1816888/149024371-7cefda80-42f1-4a85-9a04-506d564432e0.png) |
|--------|-------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
