### PR TITLE
Reader Post Comment Following: add source to tracks

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -35,6 +35,8 @@ class ReaderCommentsFollowPresenter: NSObject {
     /// When enabled, the user will receive emails for new comments.
     ///
     @objc func handleFollowConversationButtonTapped() {
+        trackFollowToggled()
+
         let generator = UINotificationFeedbackGenerator()
         generator.prepare()
 
@@ -96,6 +98,8 @@ class ReaderCommentsFollowPresenter: NSObject {
     /// - Parameter completion: Block called as soon the view controller has been removed.
     ///
     @objc func handleNotificationsButtonTapped(canUndo: Bool, completion: ((Bool) -> Void)? = nil) {
+        trackNotificationsToggled()
+
         let desiredState = !self.post.receivesCommentNotifications
         let action: PostSubscriptionAction = desiredState ? .enableNotification : .disableNotification
 
@@ -194,6 +198,63 @@ private extension ReaderCommentsFollowPresenter {
             return NSLocalizedString("In-app notifications disabled", comment: "The app successfully disabled notifications for the subscription")
         case (.disableNotification, false):
             return NSLocalizedString("Could not disable notifications", comment: "The app failed to disable notifications for the subscription")
+        }
+    }
+
+    // MARK: - Tracks
+
+    func trackFollowToggled() {
+        var properties = [String: Any]()
+        let followAction: FollowAction = !post.isSubscribedComments ? .followed : .unfollowed
+        properties[WPAppAnalyticsKeyFollowAction] = followAction.rawValue
+        properties[WPAppAnalyticsKeyBlogID] = post.siteID
+        properties[WPAppAnalyticsKeySource] = sourceForTracks()
+        WPAnalytics.trackReader(.readerToggleFollowConversation, properties: properties)
+    }
+
+    func trackNotificationsToggled() {
+        var properties = [String: Any]()
+        properties[AnalyticsKeys.notificationsEnabled] = !post.receivesCommentNotifications
+        properties[WPAppAnalyticsKeyBlogID] = post.siteID
+        properties[WPAppAnalyticsKeySource] = sourceForTracks()
+        WPAnalytics.trackReader(.readerToggleCommentNotifications, properties: properties)
+    }
+
+    func sourceForTracks() -> String {
+        if presentingViewController is ReaderCommentsViewController {
+            return AnalyticsSource.comments.description()
+        }
+
+        if presentingViewController is ReaderDetailViewController {
+            return AnalyticsSource.postDetails.description()
+        }
+
+        return AnalyticsSource.unknown.description()
+    }
+
+    enum FollowAction: String {
+        case followed
+        case unfollowed
+    }
+
+    private struct AnalyticsKeys {
+        static let notificationsEnabled = "notifications_enabled"
+    }
+
+    private enum AnalyticsSource: String {
+        case comments
+        case postDetails
+        case unknown
+
+        func description() -> String {
+            switch self {
+            case .comments:
+                return "reader_threaded_comments"
+            case .postDetails:
+                return "reader_post_details_comments"
+            case .unknown:
+                return "unknown"
+            }
         }
     }
 


### PR DESCRIPTION
Ref: #17632 
Depends on: #17741


Tracking `reader_toggle_follow_conversation` and `reader_toggle_comment_notifications` analytics is moved from `FollowCommentsService` to `ReaderCommentsFollowPresenter` so that `source` can be added to the parameters. 

Sources:
- From post details: `reader_post_details_comments`
- From comments list: `reader_threaded_comments`

(These sources match [Android](https://github.com/wordpress-mobile/WordPress-Android/pull/15680)'s.)

To test:

Verify these tracks.

Follow:
- Toggle from post details:
  - `🔵 Tracked: reader_toggle_follow_conversation <blog_id: xxx, follow_action: followed, source: reader_post_details_comments, subscription_count: 63>`
  - `🔵 Tracked: reader_toggle_follow_conversation <blog_id: xxx, follow_action: unfollowed, source: reader_post_details_comments, subscription_count: 63>`
- Toggle from Comments:
  - `🔵 Tracked: reader_toggle_follow_conversation <blog_id: xxx, follow_action: followed, source: reader_threaded_comments, subscription_count: 63>`
  - `🔵 Tracked: reader_toggle_follow_conversation <blog_id: xxx, follow_action: unfollowed, source: reader_threaded_comments, subscription_count: 63>`

Notifications:
- Toggle from post details:
  - `🔵 Tracked: reader_toggle_comment_notifications <blog_id: xxx, notifications_enabled: 1, source: reader_post_details_comments, subscription_count: 63>`
  - `🔵 Tracked: reader_toggle_comment_notifications <blog_id: xxx, notifications_enabled: 0, source: reader_post_details_comments, subscription_count: 63>`
- Toggle from Comments:
  - `🔵 Tracked: reader_toggle_comment_notifications <blog_id: xxx, notifications_enabled: 1, source: reader_threaded_comments, subscription_count: 63>`
  - `🔵 Tracked: reader_toggle_comment_notifications <blog_id: xxx, notifications_enabled: 0, source: reader_threaded_comments, subscription_count: 63>`


## Regression Notes
1. Potential unintended areas of impact
Tracking from Comments could be incorrect.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified they are correct. 😄 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
