### PR TITLE
Reader Post Details Comments: change the stack view to vertical for accessibility text size.

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -5,6 +5,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
     // MARK: - Properties
 
     static let estimatedHeight: CGFloat = 80
+    @IBOutlet private weak var contentStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var followButton: UIButton!
     private var post: ReaderPost?
@@ -81,6 +82,7 @@ private extension ReaderDetailCommentsHeader {
     }
 
     func configureButton() {
+        configureStackView()
         followButton.addTarget(self, action: #selector(followButtonTapped), for: .touchUpInside)
 
         if isSubscribedComments {
@@ -91,6 +93,22 @@ private extension ReaderDetailCommentsHeader {
             followButton.setTitleColor(.primary, for: .normal)
             followButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
             followButton.setImage(nil, for: .normal)
+        }
+    }
+
+    func configureStackView() {
+        // If isAccessibilityCategory, display the content vertically.
+        // This makes the Follow button "wrap" and appear under the title label.
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            contentStackView.axis = .vertical
+            contentStackView.alignment = .leading
+            contentStackView.distribution = .fill
+            contentStackView.spacing = 10
+        } else {
+            contentStackView.axis = .horizontal
+            contentStackView.alignment = .center
+            contentStackView.distribution = .fill
+            contentStackView.spacing = 0
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.xib
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <accessibilityOverrides isEnabled="YES" dynamicTypePreference="7"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
@@ -15,20 +16,23 @@
             <rect key="frame" x="0.0" y="0.0" width="394" height="69"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="st6-L0-qny">
+                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="st6-L0-qny" userLabel="Content Stack View">
                     <rect key="frame" x="0.0" y="16" width="394" height="43"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
-                            <rect key="frame" x="0.0" y="11.5" width="280" height="20.5"/>
+                            <rect key="frame" x="0.0" y="3" width="157" height="37"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle3"/>
                             <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <nil key="highlightedColor"/>
                         </label>
-                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZm-SW-a1v" userLabel="Follow Button">
-                            <rect key="frame" x="280" y="8" width="114" height="27"/>
+                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dZm-SW-a1v" userLabel="Follow Button">
+                            <rect key="frame" x="157" y="3.5" width="237" height="36"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                            <state key="normal" title="Follow Conversation">
+                            <state key="normal" title="Follow Conversation" image="bell">
                                 <color key="titleColor" systemColor="systemBlueColor"/>
+                                <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="font" scale="default">
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                </preferredSymbolConfiguration>
                             </state>
                         </button>
                     </subviews>
@@ -43,6 +47,7 @@
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="contentStackView" destination="st6-L0-qny" id="6gl-E7-3tT"/>
                 <outlet property="followButton" destination="dZm-SW-a1v" id="T1e-6U-kD8"/>
                 <outlet property="titleLabel" destination="QfN-CJ-PfS" id="TVn-gJ-PFg"/>
             </connections>
@@ -50,6 +55,7 @@
         </view>
     </objects>
     <resources>
+        <image name="bell" width="24" height="24"/>
         <systemColor name="systemBlueColor">
             <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>


### PR DESCRIPTION
Ref: #17632 
Depends on: #17741

For accessibility text size, the Comments snippet header stack view is switched to vertical, displaying the Follow button under the Comments title.

Note:
Initially, I was only going to toggle the stack view axis if the button displayed `Follow Conversation`. However, with _very_ large text, there is still a chance the label gets truncated:

<img width="200" alt="Screen Shot 2022-01-11 at 6 12 36 PM" src="https://user-images.githubusercontent.com/1816888/149047636-0ad7f249-4244-405c-97ad-34628eca5c6f.png">

So the stack view axis is toggled regardless of the button state.

To test:
- Go to Reader > post details.
- Increase text size to at least accessibility medium.
- Verify the Follow button appears under the Comments title.

| <img width="472" alt="follow" src="https://user-images.githubusercontent.com/1816888/149047797-078cff7b-cc85-49f0-8ba6-cf0659490723.png"> | <img width="470" alt="bell" src="https://user-images.githubusercontent.com/1816888/149047800-958032f3-b335-42de-b30b-a931ce067728.png"> |
|--------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
