### PR TITLE
Make `code_freeze` lane extract release notes for Jetpack

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -112,15 +112,37 @@ platform :ios do
 
     ios_bump_version_release(skip_deliver: true)
     new_version = ios_get_app_version
+
+    release_notes_source_path = File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt')
     extract_release_notes_for_version(
       version: new_version,
-      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'RELEASE-NOTES.txt'),
-      extracted_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt')
+      release_notes_file_path: release_notes_source_path,
+      extracted_notes_file_path: extracted_release_notes_file_path(app: :wordpress)
+    )
+    # It would be good to update the action so that it can:
+    #
+    # - Use a custom commit message, so that we can differentiate between
+    #   WordPress and Jetpack
+    # - Have some sort of interactive mode, where the file is extracted and
+    #   shown to the user and they can either confirm and let the lane commit,
+    #   or modify it manually first and then run through the
+    #   show-confirm-commit cycle again
+    #
+    # In the meantime, we can make due with a duplicated commit message and the
+    # `print_release_notes_reminder` at the end of the lane to remember to make
+    # updates to the files.
+    extract_release_notes_for_version(
+      version: new_version,
+      release_notes_file_path: release_notes_source_path,
+      extracted_notes_file_path: extracted_release_notes_file_path(app: :jetpack)
     )
     ios_update_release_notes(new_version: new_version)
+
     setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
     setfrozentag(repository: GHHELPER_REPO, milestone: new_version)
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))
+
+    print_release_notes_reminder
   end
 
   #####################################################################################
@@ -904,6 +926,34 @@ platform :ios do
 
     UI.message("Gutenberg version: #{(res.scan(/'([^']*)'/))[0][0]}")
   end
+end
+
+def extracted_release_notes_file_path(app:)
+  paths = {
+    wordpress: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
+    jetpack: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
+  }
+
+  # Good coding would have us handle the key not being found here. But, given
+  # this is a service method for an automation lane, we'd rather have the
+  # process break with a nil value and a human notice it immediately, than an
+  # incorrect file being used and the issue possibly going unnoticed for
+  # longer.
+  paths[app]
+end
+
+def print_release_notes_reminder
+  message = <<~MSG
+    The extracted release notes for WordPress and Jetpack were based on the same source.
+    Don't forget to remove any item that doesn't apply to the respective app before editorialization.
+
+    You can find the extracted notes at:
+
+    - #{extracted_release_notes_file_path(app: :wordpress)}
+    - #{extracted_release_notes_file_path(app: :jetpack)}
+  MSG
+
+  message.lines.each { |l| UI.important(l.chomp) }
 end
 
 # FIXME: This ought to be extracted into the release toolkit, ideally in an

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -933,13 +933,7 @@ def extracted_release_notes_file_path(app:)
     wordpress: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
     jetpack: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
   }
-
-  # Good coding would have us handle the key not being found here. But, given
-  # this is a service method for an automation lane, we'd rather have the
-  # process break with a nil value and a human notice it immediately, than an
-  # incorrect file being used and the issue possibly going unnoticed for
-  # longer.
-  paths[app]
+  paths[app.to_sym] || UI.user_error!("Invalid app name passed to lane: #{app}")
 end
 
 def print_release_notes_reminder


### PR DESCRIPTION
Also add a message at the end of the lane to remind the caller to check the extracted notes and adjust each to only contain the items for the respective app. Inspired by @AliSoftware's approach in WordPress Android ([here](https://github.com/wordpress-mobile/WordPress-Android/blob/9d41d753eedd1c8831ccd0cdd2ff21bed1a0fa37/fastlane/Fastfile#L148-L154) and [here](https://github.com/wordpress-mobile/WordPress-Android/blob/9d41d753eedd1c8831ccd0cdd2ff21bed1a0fa37/fastlane/Fastfile#L166)).

As I noted in the code comments, it would probably be best to have this logic handled at the release toolkit level, in particular now that iOS and Android both have it. I decided to begin from here because it's a good start to ensure we create the file. With the feature ticket, we can move with more care and make the change on the toolkit when we have bandwidth.

I tested this by:

1. Creating a [new branch](https://github.com/wordpress-mobile/WordPress-iOS/pull/17746) from this one
2. [Commenting](https://github.com/wordpress-mobile/WordPress-iOS/pull/17746/commits/b83862c685f18835857cd64804e1fe77faa519de) all the `code_freeze` lane other than the release note extraction logic and hardcoding the version to 19.1 (the next version at the time of writing)
3. Verifying that the files are extracted and committed ([WordPress](https://github.com/wordpress-mobile/WordPress-iOS/pull/17746/commits/d260d347a33160b75ec20c9fef336974dab88c55) and [Jetpack](https://github.com/wordpress-mobile/WordPress-iOS/pull/17746/commits/23bbe6ab76408da824b0eebc66344d08660a6af6))
4. Verifying the reminder message is printed

<img alt="image" src="https://user-images.githubusercontent.com/1218433/149173242-c05ab942-2ea8-4acb-a01c-927fd295bb71.png" width=400/>

## Regression Notes

1. Potential unintended areas of impact: The code freeze lane
2. What I did to test those areas of impact (or what existing automated tests I relied on): See test step above
3. What automated tests I added (or what prevented me from doing so): N.A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. N.A.
- [x] I have considered adding accessibility improvements for my changes. N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. N.A.
