### PR TITLE
Adds the Sharing row back to Me view controller

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,8 +10,8 @@
 * [**] Block editor: Add Jetpack and Layout Grid translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4359]
 * [**] Block editor: Fix text formatting mode lost after backspace is used [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423]
 * [*] Block editor: Add missing translations of unsupported block editor modal [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4410]
-
 * [**] Time zone suggester: we have a new time zone selection screen that suggests the time zone based on the device, and improves search.
+* [*] Added the "Share WordPress with a friend" row back to the Me screen.
 
 18.9
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,14 +4,14 @@
 
 19.0
 -----
-* [**] Video uploads: video upload is now limited to 5 minutes per video on free plans.
+* [**] Video uploads: video upload is now limited to 5 minutes per video on free plans. [#17689]
 * [*] Block editor: Give multi-line block names central alignment in inserter [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4343]
 * [**] Block editor: Fix missing translations by refactoring the editor initialization code [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4332]
 * [**] Block editor: Add Jetpack and Layout Grid translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4359]
 * [**] Block editor: Fix text formatting mode lost after backspace is used [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4423]
 * [*] Block editor: Add missing translations of unsupported block editor modal [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4410]
-* [**] Time zone suggester: we have a new time zone selection screen that suggests the time zone based on the device, and improves search.
-* [*] Added the "Share WordPress with a friend" row back to the Me screen.
+* [**] Time zone suggester: we have a new time zone selection screen that suggests the time zone based on the device, and improves search. [#17699]
+* [*] Added the "Share WordPress with a friend" row back to the Me screen. [#17748]
 
 18.9
 -----

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -158,19 +158,23 @@ class MeViewController: UITableViewController {
             // middle section
             .init(rows: {
                 var rows: [ImmuTableRow] = [helpAndSupportIndicator]
-                if FeatureFlag.aboutScreen.enabled {
-                    rows.append(NavigationItemRow(title: RowTitles.about,
-                                                  icon: UIImage.gridicon(.mySites),
-                                                  accessoryType: .disclosureIndicator,
-                                                  action: pushAbout(),
-                                                  accessibilityIdentifier: "About"))
-                } else if isRecommendAppRowEnabled {
+
+                if isRecommendAppRowEnabled {
                     rows.append(NavigationItemRow(title: ShareAppContentPresenter.RowConstants.buttonTitle,
                                                   icon: ShareAppContentPresenter.RowConstants.buttonIconImage,
                                                   accessoryType: accessoryType,
                                                   action: displayShareFlow(),
                                                   loading: sharePresenter.isLoading))
                 }
+
+                if FeatureFlag.aboutScreen.enabled {
+                    rows.append(NavigationItemRow(title: RowTitles.about,
+                                                  icon: UIImage.gridicon(.mySites),
+                                                  accessoryType: .disclosureIndicator,
+                                                  action: pushAbout(),
+                                                  accessibilityIdentifier: "About"))
+                }
+
                 return rows
             }()),
 


### PR DESCRIPTION
This PR reintroduces the Sharing row back into the Me view controller.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-01-12 at 20 14 56](https://user-images.githubusercontent.com/4780/149214909-4ad4ddd2-f282-4980-89df-b687f50158cd.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-01-12 at 20 09 33](https://user-images.githubusercontent.com/4780/149214902-804f7e6d-8669-47a0-8df8-72c0c623015e.png) |

**To test**

* Build and run
* Navigate to the Me screen (tap the avatar in the top right of the My Site screen)
* Ensure you can see the "Share WordPress with a friend" row near the bottom of the screen
* Check that you can interact with the row and Share info about the app

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
