### PR TITLE
Custom calendar VoiceOver improvements

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 19.1
 -----
 * [*] Signup: Fixed bug where username selection screen could be pushed twice. [#17624]
+* [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756]
 
 19.0
 -----

--- a/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/CalendarViewController.swift
@@ -11,6 +11,7 @@ class CalendarViewController: UIViewController {
     private var startDateLabel: UILabel!
     private var separatorDateLabel: UILabel!
     private var endDateLabel: UILabel!
+    private var header: UIStackView!
     private let gradient = GradientView()
 
     private var startDate: Date?
@@ -27,6 +28,17 @@ class CalendarViewController: UIViewController {
     private enum Constants {
         static let headerPadding: CGFloat = 16
         static let endDateLabel = NSLocalizedString("End Date", comment: "Placeholder for the end date in calendar range selection")
+        static let startDateLabel = NSLocalizedString("Start Date", comment: "Placeholder for the start date in calendar range selection")
+        static let rangeSummaryAccessibilityLabel = NSLocalizedString(
+            "Selected range: %1$@ to %2$@",
+            comment: "Accessibility label for summary of currently selected range. %1$@ is the start date, %2$@ is " +
+            "the end date.")
+        static let singleDateRangeSummaryAccessibilityLabel = NSLocalizedString(
+            "Selected range: %1$@ only",
+            comment: "Accessibility label for summary of currently single date. %1$@ is the date")
+        static let noRangeSelectedAccessibilityLabelPlaceholder = NSLocalizedString(
+            "No date range selected",
+            comment: "Accessibility label for no currently selected range.")
     }
 
     /// Creates a full screen year calendar controller
@@ -57,7 +69,7 @@ class CalendarViewController: UIViewController {
         )
 
         // Configure headers and add the calendar to the view
-        let header = startEndDateHeader()
+        configureHeader()
         let stackView = UIStackView(arrangedSubviews: [
                                             header,
                                             calendarCollectionView
@@ -136,13 +148,21 @@ class CalendarViewController: UIViewController {
             endDateLabel.textColor = .textSubtle
             separatorDateLabel.textColor = .textSubtle
         }
+
+        header.accessibilityLabel = accessibilityLabelForRangeSummary(startDate: startDate, endDate: endDate)
     }
 
-    private func startEndDateHeader() -> UIView {
+    private func configureHeader() {
+        header = startEndDateHeader()
+        resetLabels()
+    }
+
+    private func startEndDateHeader() -> UIStackView {
         let header = UIStackView(frame: .zero)
         header.distribution = .fill
 
         let startDate = UILabel()
+        startDate.isAccessibilityElement = false
         startDateLabel = startDate
         startDate.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         if view.effectiveUserInterfaceLayoutDirection == .leftToRight {
@@ -156,6 +176,7 @@ class CalendarViewController: UIViewController {
         startDate.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.47).isActive = true
 
         let separator = UILabel()
+        separator.isAccessibilityElement = false
         separatorDateLabel = separator
         separator.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         separator.textAlignment = .center
@@ -163,6 +184,7 @@ class CalendarViewController: UIViewController {
         separator.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.06).isActive = true
 
         let endDate = UILabel()
+        endDate.isAccessibilityElement = false
         endDateLabel = endDate
         endDate.font = WPStyleGuide.fontForTextStyle(.title3, fontWeight: .semibold)
         if view.effectiveUserInterfaceLayoutDirection == .leftToRight {
@@ -175,7 +197,8 @@ class CalendarViewController: UIViewController {
         header.addArrangedSubview(endDate)
         endDate.widthAnchor.constraint(equalTo: header.widthAnchor, multiplier: 0.47).isActive = true
 
-        resetLabels()
+        header.isAccessibilityElement = true
+        header.accessibilityTraits = [.header, .summaryElement]
 
         return header
     }
@@ -200,7 +223,7 @@ class CalendarViewController: UIViewController {
     }
 
     private func resetLabels() {
-        startDateLabel.text = NSLocalizedString("Start Date", comment: "Placeholder for the start date in calendar range selection")
+        startDateLabel.text = Constants.startDateLabel
 
         separatorDateLabel.text = "-"
 
@@ -209,6 +232,22 @@ class CalendarViewController: UIViewController {
         [startDateLabel, separatorDateLabel, endDateLabel].forEach { label in
             label?.textColor = .textSubtle
             label?.font = WPStyleGuide.fontForTextStyle(.title3)
+        }
+
+        header.accessibilityLabel = accessibilityLabelForRangeSummary(startDate: nil, endDate: nil)
+    }
+
+    private func accessibilityLabelForRangeSummary(startDate: Date?, endDate: Date?) -> String {
+        switch (startDate, endDate) {
+        case (nil, _):
+            return Constants.noRangeSelectedAccessibilityLabelPlaceholder
+        case (.some(let startDate), nil):
+            let startDateString = formatter.string(from: startDate)
+            return String.localizedStringWithFormat(Constants.singleDateRangeSummaryAccessibilityLabel, startDateString)
+        case (.some(let startDate), .some(let endDate)):
+            let startDateString = formatter.string(from: startDate)
+            let endDateString = formatter.string(from: endDate)
+            return String.localizedStringWithFormat(Constants.rangeSummaryAccessibilityLabel, startDateString, endDateString)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -379,6 +379,7 @@ class CalendarYearHeaderView: JTACMonthReusableView {
         titleLabel.font = .preferredFont(forTextStyle: .headline)
         titleLabel.textAlignment = .center
         titleLabel.textColor = Constants.titleColor
+        titleLabel.accessibilityTraits = .header
 
         let weekdaysView = WeekdaysHeaderView(calendar: Calendar.current)
         stackView.addArrangedSubview(weekdaysView)

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -304,6 +304,10 @@ extension DateCell {
         rightPlaceholder.backgroundColor = .clear
         dateLabel.backgroundColor = .clear
         textColor = .text
+        dateLabel.accessibilityTraits = .button
+        if state.isSelected {
+            dateLabel.accessibilityTraits.insert(.selected)
+        }
 
         switch position(for: state.date, startDate: startDate, endDate: endDate) {
         case .middle:

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -287,7 +287,7 @@ extension DateCell {
 
         dateLabel.text = state.text
 
-        dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+        dateFormatter.setLocalizedDateFormatFromTemplate("EEE MMM d, yyyy")
         dateLabel.accessibilityLabel = dateFormatter.string(from: state.date)
         dateLabel.accessibilityTraits = .button
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
@@ -192,6 +192,7 @@ class WeekdaysHeaderView: UIStackView {
             label.textAlignment = .center
             label.font = UIFont.preferredFont(forTextStyle: .caption1)
             label.textColor = .neutral(.shade30)
+            label.isAccessibilityElement = false
             return label
         }))
         self.distribution = .fillEqually

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarMonthView.swift
@@ -130,6 +130,12 @@ class CalendarHeaderView: UIStackView {
         static let buttonSize = CGSize(width: 24, height: 24)
         static let titeLabelColor: UIColor = .neutral(.shade60)
         static let dateFormat = "MMMM, YYYY"
+        static let previousMonthButtonAccessibilityLabel = NSLocalizedString(
+            "Previous month",
+            comment: "Accessibility label for the button which shows the previous month in the monthly calendar view")
+        static let nextMonthButtonAccessibilityLabel = NSLocalizedString(
+            "Next month",
+            comment: "Accessibility label for the button which shows the previous month in the monthly calendar view")
     }
 
     typealias TargetSelector = (target: Any?, selector: Selector)
@@ -153,9 +159,11 @@ class CalendarHeaderView: UIStackView {
         let previousButton = UIButton(frame: CGRect(origin: .zero, size: Constants.buttonSize))
         previousButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         previousButton.setImage(UIImage.gridicon(.chevronLeft).imageFlippedForRightToLeftLayoutDirection(), for: .normal)
+        previousButton.accessibilityLabel = Constants.previousMonthButtonAccessibilityLabel
 
         let forwardButton = UIButton(frame: CGRect(origin: .zero, size: Constants.buttonSize))
         forwardButton.setImage(UIImage.gridicon(.chevronRight).imageFlippedForRightToLeftLayoutDirection(), for: .normal)
+        forwardButton.accessibilityLabel = Constants.nextMonthButtonAccessibilityLabel
 
         forwardButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
 


### PR DESCRIPTION
Part of #15722

## Description
This improves the VoiceOver announcements for the calendars in a variety of ways. Each commit covers one of the five areas detailed below, and the commit message gives details on exactly what changes are made, what the previous state was, and why the changes are improvements. Testing notes below cover the changes which I made.

### Addresses:
- [x] Calendar accessibility: Add heading trait to month headings for navigation
- [x] Calendar accessibility: Announce selected dates as selected
- [x] Calendar accessibility: Announce weekday for selectable dates, instead of as headings
- [x] Calendar accessibility: Announce current selection as a date range
- [x] Calendar accessibility: Give descriptive accessibilityLabels to the previous/next month buttons on Schedule Post

## To test:
### On the Activity Log for a site with filters available:
#### Scenario 1
1. Open the date filter with VoiceOver enabled
2. Swipe left repeatedly until you get to a date cell
3. Observe that the date range heading is announced as a heading, as "No date range selected"
4. Observe that you do not land on the Weekday headings (M,T,W,T,F,S,S) in this process.

#### Scenario 2
1. Select heading navigation in the rotor
2. Swipe up with 2 fingers to start at the top of the screen
3. Swipe down with 1 finger to go from one heading to the next
4. Observe that the cursor stops at each of the month headings within the calendar

#### Scenario 3
1. While on a month heading, swipe right with 1 finger to go to a date cell
2. Observe that the weekday is read out at the start of the date
3. Observe that the control is specified as a button in the announcement

#### Scenario 4
1. Double tap to select a date
2. Observe that the date is announced with the word "selected" in the announcement
3. Swipe up with 2 fingers to read the screen from the top
4. Observe that the date range heading is read as "Selected range: {date} only"
5. Double tap on the first date cell it gets to
6. Repeat from step 3, and observe that the date range heading is read as "Selected range: {date1} to {date2}"


### On the Schedule Post calendar:
#### Scenario 5
1. Open the date filter with VoiceOver enabled
2. Swipe left repeatedly until you get to a date cell (major known issue - it will be Jan 1 1951!)
3. Observe that the previous/next month headers are announced as "Previous month" and "Next month"
4. Observe that you do not land on the Weekday headings (M,T,W,T,F,S,S) in this process.

#### Scenario 6
1. Tap on a date cell
2. Observe that the weekday is read out at the start of the date
3. Observe that the control is specified as a button in the announcement

#### Scenario 7
1. Double tap to select a date
2. Observe that the date is announced with the word "selected" in the announcement


## Screenshots
This video covers the above testing scenarios in order. Sound on!

https://user-images.githubusercontent.com/2472348/149352933-8c5b83d5-0c77-4676-bb5f-9980e2cc8dc5.mp4


## Regression Notes
1. Potential unintended areas of impact
There are no other areas where the Calendar is used, and both uses have been carefully tested for these changes. The calendars do behave differently but share code, so both should be tested.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Navigating, selecting, changing dates using Voiceover.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
