### PR TITLE
My Site Dashboard: open the editor from the post cards list

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -35,18 +35,6 @@ import UIKit
     }
 }
 
-// MARK: - PostsCardView
-
-extension PostsCardViewController: PostsCardView {
-    func showLoading() {
-        configureGhostableTableView()
-    }
-
-    func hideLoading() {
-        removeGhostableTableView()
-    }
-}
-
 // MARK: - Private methods
 
 private extension PostsCardViewController {
@@ -91,6 +79,18 @@ private extension PostsCardViewController {
 
     enum Constants {
         static let numberOfPosts = 3
+    }
+}
+
+// MARK: - PostsCardView
+
+extension PostsCardViewController: PostsCardView {
+    func showLoading() {
+        configureGhostableTableView()
+    }
+
+    func hideLoading() {
+        removeGhostableTableView()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -31,6 +31,7 @@ import UIKit
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         tableView.dataSource = viewModel
+        tableView.delegate = self
         viewModel.refresh()
     }
 }
@@ -82,6 +83,15 @@ private extension PostsCardViewController {
     }
 }
 
+// MARK: - UITableViewDelegate
+extension PostsCardViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let post = viewModel.postAt(indexPath)
+
+        PostListEditorPresenter.handle(post: post, in: self)
+    }
+}
+
 // MARK: - PostsCardView
 
 extension PostsCardViewController: PostsCardView {
@@ -98,6 +108,15 @@ extension PostsCardViewController: PostsCardView {
 
 extension PostsCardViewController: EditorAnalyticsProperties {
     func propertiesForAnalytics() -> [String: AnyObject] {
-        [:]
+        var properties = [String: AnyObject]()
+
+        properties["type"] = PostServiceType.post.rawValue as AnyObject?
+        properties["filter"] = viewModel.currentPostStatus() as AnyObject?
+
+        if let dotComID = blog.dotComID {
+            properties[WPAppAnalyticsKeyBlogID] = dotComID
+        }
+
+        return properties
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -35,6 +35,8 @@ import UIKit
     }
 }
 
+// MARK: - PostsCardView
+
 extension PostsCardViewController: PostsCardView {
     func showLoading() {
         configureGhostableTableView()
@@ -44,6 +46,8 @@ extension PostsCardViewController: PostsCardView {
         removeGhostableTableView()
     }
 }
+
+// MARK: - Private methods
 
 private extension PostsCardViewController {
     func configureView() {
@@ -87,5 +91,13 @@ private extension PostsCardViewController {
 
     enum Constants {
         static let numberOfPosts = 3
+    }
+}
+
+// MARK: - EditorAnalyticsProperties
+
+extension PostsCardViewController: EditorAnalyticsProperties {
+    func propertiesForAnalytics() -> [String: AnyObject] {
+        [:]
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -50,6 +50,16 @@ class PostsCardViewModel: NSObject {
         createFetchedResultsController()
         sync()
     }
+
+    /// Return the post at the given IndexPath
+    func postAt(_ indexPath: IndexPath) -> Post {
+        fetchedResultsController.object(at: indexPath)
+    }
+
+    /// The status of post being presented (Draft, Published)
+    func currentPostStatus() -> String {
+        filterSettings.currentPostListFilter().title
+    }
 }
 
 // MARK: - Private methods

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1183,6 +1183,8 @@ extension AbstractPostListViewController: NetworkStatusDelegate {
     }
 }
 
+extension AbstractPostListViewController: EditorAnalyticsProperties { }
+
 // MARK: - NoResultsViewControllerDelegate
 
 extension AbstractPostListViewController: NoResultsViewControllerDelegate {

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -14,7 +14,7 @@ protocol EditorAnalyticsProperties: AnyObject {
 /// Analytics are also tracked.
 struct PostListEditorPresenter {
 
-    static func handle(post: Post, in postListViewController: PostListViewController) {
+    static func handle(post: Post, in postListViewController: EditorPresenterViewController) {
 
         // Autosaves are ignored for posts with local changes.
         if !post.hasLocalChanges(), post.hasAutosaveRevision, let saveDate = post.dateModified, let autosaveDate = post.autosaveModifiedDate {
@@ -27,7 +27,7 @@ struct PostListEditorPresenter {
         }
     }
 
-    static func handleCopy(post: Post, in postListViewController: PostListViewController) {
+    static func handleCopy(post: Post, in postListViewController: EditorPresenterViewController) {
         // Autosaves are ignored for posts with local changes.
         if !post.hasLocalChanges(), post.hasAutosaveRevision {
             let conflictsResolutionViewController = copyConflictsResolutionViewController(didTapOption: { copyLocal, cancel in
@@ -46,14 +46,14 @@ struct PostListEditorPresenter {
         }
     }
 
-    private static func openEditor(with post: Post, loadAutosaveRevision: Bool, in postListViewController: PostListViewController) {
+    private static func openEditor(with post: Post, loadAutosaveRevision: Bool, in postListViewController: EditorPresenterViewController) {
         let editor = EditPostViewController(post: post, loadAutosaveRevision: loadAutosaveRevision)
         editor.modalPresentationStyle = .fullScreen
         postListViewController.present(editor, animated: false)
         WPAppAnalytics.track(.postListEditAction, withProperties: postListViewController.propertiesForAnalytics(), with: post)
     }
 
-    private static func openEditorWithCopy(with post: Post, in postListViewController: PostListViewController) {
+    private static func openEditorWithCopy(with post: Post, in postListViewController: EditorPresenterViewController) {
         // Copy Post
         let context = ContextManager.sharedInstance().mainContext
         let postService = PostService(managedObjectContext: context)

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -1,4 +1,12 @@
 import Foundation
+import UIKit
+
+typealias EditorPresenterViewController = UIViewController & EditorAnalyticsProperties
+
+/// Provide properties for when showing the editor (like type of post, filter, etc)
+protocol EditorAnalyticsProperties: AnyObject {
+    func propertiesForAnalytics() -> [String: AnyObject]
+}
 
 /// Handle a user tapping a post in the post list. If an autosave revision is available, give the
 /// user the option through a dialog alert to load the autosave (or just load the regular post) into


### PR DESCRIPTION
Part of #17697

**Important**: this is targeting `issue/17697_msd_sync_posts` because UI tests keeps failing there. As soon as its all green I'll go ahead and merge it.

This PR implements the ability to go to the editor directly from the posts cards list.

### To test

First, Copy and paste the content of [this gist](https://gist.github.com/leandroalonso/9853c23769c2a33c8e41e1680438f3c1) into `BlogDetailsViewController.m`

#### Editing a post

1. Tap any post
2. Edit the title
3. Tap the "X" and tap "Update Draft"
4. Check that the post is uploaded and its title is updated

#### Discarding changes to a post

1. Tap any post
2. Edit the title
3. Tap the "X" and tap "Discard"
4. The editor is dismissed and the title is kept

#### Create a new post

1. Tap the FAB
2. Tap Blog post
3. Create a post
4. Add a title
5. Tap "X"
6. Tap "Save Draft"
7. Check that the post is uploaded and its title is updated

#### Post list

1. Perform all the tests above from the Post list
2. The behavior should be the same

Ps.: If you cancel this flow (either by discarding the post or just tapping X) the post list will have only 2 posts after that. I don't think this is a big issue but I'll check later.

## Events

The current flow fires `post_list_button_pressed`. We have two possible options:

1. Create a new event for this flow
2. Add a property showing that the flow is originated from the posts card

I'll leave that for the events task.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
I haven't yet.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
