### PR TITLE
Fix Core Data crash related to media errors

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [*] Block editor: Fix cut-off setting labels by properly wrapping the text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4475]
 * [*] Block editor: Highlight text: fix applying formatting for non-selected text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4471]
 * [**] Block editor: Fix Android handling of Hebrew and Indonesian translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4397]
+* [***] Self-hosted sites: Fixed a crash when saving media and no Internet connection was available. [#17759]
 
 19.0
 -----

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -261,4 +261,20 @@
     return self.mediaID.intValue != 0;
 }
 
+- (void)setError:(NSError *)value
+{
+    NSError *error;
+
+    if (value != nil) {
+        // Cherry pick keys that support secure coding. NSErrors thrown from the OS can
+        // contain types that don't adopt NSSecureCoding, leading to a Core Data exception and crash.
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: value.localizedDescription};
+        error = [[NSError alloc] initWithDomain:value.domain code:value.code userInfo:userInfo];
+    }
+
+    [self willChangeValueForKey:@"error"];
+    [self setPrimitiveValue:error forKey:@"error"];
+    [self didChangeValueForKey:@"error"];
+}
+
 @end

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -261,15 +261,13 @@
     return self.mediaID.intValue != 0;
 }
 
-- (void)setError:(NSError *)value
+- (void)setError:(NSError *)error
 {
-    NSError *error;
-
-    if (value != nil) {
+    if (error != nil) {
         // Cherry pick keys that support secure coding. NSErrors thrown from the OS can
         // contain types that don't adopt NSSecureCoding, leading to a Core Data exception and crash.
-        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: value.localizedDescription};
-        error = [[NSError alloc] initWithDomain:value.domain code:value.code userInfo:userInfo];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: error.localizedDescription};
+        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
     }
 
     [self willChangeValueForKey:@"error"];

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -267,7 +267,7 @@
         // Cherry pick keys that support secure coding. NSErrors thrown from the OS can
         // contain types that don't adopt NSSecureCoding, leading to a Core Data exception and crash.
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey: error.localizedDescription};
-        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
+        error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
     }
 
     [self willChangeValueForKey:@"error"];

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -425,7 +425,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
                 case NSURLErrorNetworkConnectionLost:
                 case NSURLErrorNotConnectedToInternet:
                     // Clear lack of device internet connection, notify the user
-                    customErrorMessage = NSLocalizedString(@"The internet connection appears to be offline.", @"Error message shown when a media upload fails because the user isn't connected to the internet.");
+                    customErrorMessage = NSLocalizedString(@"The Internet connection appears to be offline.", @"Error message shown when a media upload fails because the user isn't connected to the Internet.");
                     break;
                 default:
                     // Default NSURL error messaging, probably server-side, encourage user to try again
@@ -434,11 +434,13 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
             }
         }
     }
+
     if (customErrorMessage) {
-        NSMutableDictionary *userInfo = [[NSMutableDictionary alloc] init];
+        NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
         userInfo[NSLocalizedDescriptionKey] = customErrorMessage;
         error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
     }
+
     return error;
 }
 

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -438,7 +438,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
     if (customErrorMessage) {
         NSMutableDictionary *userInfo = [error.userInfo mutableCopy];
         userInfo[NSLocalizedDescriptionKey] = customErrorMessage;
-        error = [[NSError alloc] initWithDomain:error.domain code:error.code userInfo:userInfo];
+        error = [NSError errorWithDomain:error.domain code:error.code userInfo:userInfo];
     }
 
     return error;

--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -1322,7 +1322,7 @@
     // Media has an Error transformer
     Media *media1 = (Media *)[NSEntityDescription insertNewObjectForEntityForName:[Media entityName] inManagedObjectContext:context];
     media1.blog = blog1;
-    NSError *error1 = [NSError errorWithDomain:NSURLErrorDomain code:100 userInfo:@{ @"reason": @"test" }];
+    NSError *error1 = [NSError errorWithDomain:NSURLErrorDomain code:100 userInfo:@{ NSLocalizedDescriptionKey: @"test" }];
     media1.error = error1;
 
     [context save:&error];

--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -1322,7 +1322,10 @@
     // Media has an Error transformer
     Media *media1 = (Media *)[NSEntityDescription insertNewObjectForEntityForName:[Media entityName] inManagedObjectContext:context];
     media1.blog = blog1;
-    NSError *error1 = [NSError errorWithDomain:NSURLErrorDomain code:100 userInfo:@{ NSLocalizedDescriptionKey: @"test" }];
+    // The UserInfo dictionary of an NSError can contain types that can't be securely coded, which will throw a Core Data exception on save.
+    // We attach an NSUnderlyingError with the expectation that it won't be included when the error is encoded and persisted.
+    NSError *underlyingError = [NSError errorWithDomain:NSURLErrorDomain code:500 userInfo:nil];
+    NSError *error1 = [NSError errorWithDomain:NSURLErrorDomain code:100 userInfo:@{ NSLocalizedDescriptionKey: @"test", NSUnderlyingErrorKey: underlyingError }];
     media1.error = error1;
 
     [context save:&error];
@@ -1356,7 +1359,9 @@
 
     // Check that our properties persisted
     Media *fetchedMedia1 = [context fetch:@"Media" withPredicate:nil arguments:nil].firstObject;
-    XCTAssert([fetchedMedia1.error isEqual:error1]);
+    // The expected error is stripped of any keys not included in the Media.error setter
+    NSError *expectedError = [NSError errorWithDomain:NSURLErrorDomain code:100 userInfo:@{ NSLocalizedDescriptionKey: @"test" }];
+    XCTAssert([fetchedMedia1.error isEqual:expectedError]);
 
     Blog *fetchedBlog1 = [context fetch:@"Blog" withPredicate:@"blogID = %i" arguments:@[@123]].firstObject;
     XCTAssertNotNil(fetchedBlog1);


### PR DESCRIPTION
This PR aims to fix a Core Data crash when persisting Media errors due to underlying types in `UserInfo` that don't adopt `NSSecureCoding`.

The solution proposed here is to strip all but explicitly defined keys in the setter of `Media.error`.

### Overview example:

An NSError is thrown by iOS that there's no Internet connectivity. Its `UserInfo` dictionary contains an `NSUnderlyingError` which contains an object whose class doesn't conform to `NSSecureCoding`. It also contains other standard keys such as `NSLocalizedDescription`, and `NSErrorFailingURLKey`.

**Before this change:**

When saving the context, Core Data would throw an exception once it reached the object that couldn't be encoded, because it didn't adopt `NSSecureCoding`.

**After this change:**

When saving the context, Core Data only encodes `NSLocalizedDescription` with no error. The persisted error is a stripped down encodable version of the original.

Related:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/17488

**To test:**

On a self-hosted site not connected to Jetpack:

1. Create a new Post
2. Add an Image Block
3. Put the device in Airplane Mode
4. Tap "Add Image"
5. Choose a photo from the device or the camera
6. Observe that the image is added to the post with an overlay "Failed to insert media. Please tap for options."
7. Observe that when tapping on the overlay, a bottom sheet appears that reads "The Internet connection appears to be offline."
8. Tapping "Retry" does not crash the app.
9. Disabling Airplane Mode, tapping the image, and tapping "Retry" successfully uploads the image.

On a WordPress.com site:

1. Create a new Post
2. Add an Image Block
3. Put the device in Airplane Mode
4. Tap "Add Image"
5. Choose a photo from the device or the camera
6. Observe that the image is added to the post with an overlay "Failed to insert media. Please tap for options."
7. Observe that when tapping on the overlay, a bottom sheet appears that reads "The Internet connection appears to be offline."
8. Tapping "Retry" does not crash the app.
9. Disabling Airplane Mode, tapping the image, and tapping "Retry" successfully uploads the image.

### Other context

Exact error that would be produced:

```
CoreData: error: SQLCore dispatchRequest: exception handling request: <NSSQLSaveChangesRequestContext: 0x151fc5b90> , <shared NSSecureUnarchiveFromData transformer> threw while encoding a value. with userInfo of {
    NSUnderlyingError = "Error Domain=NSCocoaErrorDomain Code=4866 \"The data couldn\U2019t be written because it isn\U2019t in the correct format.\" UserInfo={NSUnderlyingError=0x155c23f60 {Error Domain=NSCocoaErrorDomain Code=4864 \"This decoder will only decode classes that adopt NSSecureCoding. Class 'NWConcrete_nw_path' does not adopt it.\" UserInfo={NSDebugDescription=This decoder will only decode classes that adopt NSSecureCoding. Class 'NWConcrete_nw_path' does not adopt it.}}}";
}
```

## Regression Notes
1. Potential unintended areas of impact
  - Different error scenarios:
    - Uploading media to a self-hosted site that's low on storage
    - Uploading media that's too large to a self-hosted site
    - Uploading media to a WP.com / Jetpack connected site in Airplane mode

Because we're only cherrypicking one field from the error now (`NSLocalizedDescription`), there's a possibility other fields were used somewhere else in the app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The testing steps above. I relied on the Core Data migration tests from version 103 to 104 of the data model.

3. What automated tests I added (or what prevented me from doing so)
I updated the Core Data migration tests to test that keys that aren't explicitly defined in the setter of Media.error aren't included.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
