### PR TITLE
Calendar Accessibility: Prevent VoiceOver Calendar Scrollback

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 19.1
 -----
 * [*] Signup: Fixed bug where username selection screen could be pushed twice. [#17624]
-* [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756]
+* [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756, #17761]
 
 19.0
 -----

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/CalendarCollectionView.swift
@@ -67,6 +67,33 @@ class CalendarCollectionView: WPJTACMonthView {
         calendarDataSource = calDataSource
         calendarDelegate = calDataSource
     }
+
+    /// VoiceOver scrollback workaround
+    /// When using VoiceOver, moving focus from the surrounding elements (usually the next month button) to the calendar DateCells, a
+    /// scrollback to 0 was triggered by the system. This appears to be expected (though irritating) behaviour with a paging UICollectionView.
+    /// The impact of this scrollback for the month view calendar (as used to schedule a post) is that the calendar jumps to 1951-01-01, with
+    /// the only way to navigate forwards being to tap the "next month" button repeatedly.
+    /// Ignoring these scrolls back to 0 when VoiceOver is in use prevents this issue, while not impacting other use of the calendar.
+    /// Similar behaviour sometimes occurs with the non-paging year view calendar (as used for activity log filtering) which is harder to reproduce,
+    /// but also remedied by this change.
+    override func setContentOffset(_ contentOffset: CGPoint, animated: Bool) {
+        if shouldPreventAccessibilityFocusScrollback(for: contentOffset) {
+            return
+        }
+        super.setContentOffset(contentOffset, animated: animated)
+    }
+
+    func shouldPreventAccessibilityFocusScrollback(for newContentOffset: CGPoint) -> Bool {
+        if UIAccessibility.isVoiceOverRunning {
+            switch style {
+            case .month:
+                return newContentOffset.x == 0 && contentOffset.x > 0
+            case .year:
+                return newContentOffset.y == 0 && contentOffset.y > 0
+            }
+        }
+        return false
+    }
 }
 
 class CalendarDataSource: JTACMonthViewDataSource {


### PR DESCRIPTION
Fixes #17760 

# Description
Previously, when moving VoiceOver focus from the next button to the Date Cells on the Schedule Post popover, the calendar would scroll back to 1 Jan 1951.

This automated scrollback is a probably-intentional part of UICollectionView (to enable VoiceOver to read everything in a collection view) but it is not appropriate in its use here as a calendar.

This change prevents that automated scrollback, and only makes any change when the relevant accessibility features are in use.

The same issue happened sporadically on the year view calendar; I wasn't able to find repro steps for that, but this change should improve the behaviour there as well.

# To test:
## On the Schedule Post screen:

1. Open the calendar with VoiceOver enabled
2. Swipe left repeatedly until you get to a date cell
3. Observe that the first date cell you reach is the first visible cell, rather than 1 Jan 1951

## Screenshots

https://user-images.githubusercontent.com/2472348/149466985-3e1e71c2-1235-4fb9-92b4-83b852ecf1ce.mp4



## Regression Notes
1. Potential unintended areas of impact
General use of the calendar should be unaffected; the `UIAccessibility.isVoiceOverRunning` check which gates the changes will prevent issues when VoiceOver is not in use.
Anywhere which scrolls the calendar automatically should be tested carefully. The Next/Previous Month buttons are examples of those, and other possibilities are layout changes, e.g. portrait/landscape, iPad size class changes. 

Note that even without these changes, the calendar does not respond well to layout changes (the months stop fitting on the screen).

Also note, I do not have a physical iPad to test these changes on, so they have only been tested on a physical phone and an iPad simulator. To test on an iPad simulator, I had to change the condition in `CalendarCollectionView.shouldPreventAccessibilityFocusScrollback(for:)` to be `if UIAccessibility.isVoiceOverRunning || UIDevice.isPad()` and use the Accessibility Inspector to move between elements, as the Inspector does not count as voiceover.

The calendar is used both on the Activity Log date filter, and the Schedule Post date selector.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Extensive VoiceOver and Switch Control use of the calendar

3. What automated tests I added (or what prevented me from doing so)
None

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
