### PR TITLE
Weekly Roundup Improvements (Core Data + Localization)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Signup: Fixed bug where username selection screen could be pushed twice. [#17624]
 * [**] Accessibility: VoiceOver improvements on Activity Log and Schedule Post calendars [#17756, #17761]
+* [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]
 
 19.0
 -----

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -192,14 +192,12 @@ class WeeklyRoundupDataProvider {
             NSSortDescriptor(key: "settings.name", ascending: true, selector: #selector(NSString.localizedCaseInsensitiveCompare(_:)))
         ]
 
-        let controller = NSFetchedResultsController<Blog>(fetchRequest: request, managedObjectContext: context, sectionNameKeyPath: nil, cacheName: nil)
         do {
-            try controller.performFetch()
+            let result = try context.fetch(request)
+            return .success(result)
         } catch {
             return .failure(DataRequestError.siteFetchingError(error))
         }
-
-        return .success(controller.fetchedObjects ?? [])
     }
 }
 

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreData
 
 /// The main data provider for Weekly Roundup information.
 ///
@@ -377,7 +378,8 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
             }
         }
 
-        let dataProvider = WeeklyRoundupDataProvider(context: ContextManager.shared.newDerivedContext(), onError: onError)
+        let context = ContextManager.shared.newDerivedContext()
+        let dataProvider = WeeklyRoundupDataProvider(context: context, onError: onError)
         var siteStats: [Blog: StatsSummaryData]? = nil
 
         let requestData = BlockOperation {
@@ -422,7 +424,8 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
                     views: stats.viewsCount,
                     comments: stats.commentsCount,
                     likes: stats.likesCount,
-                    periodEndDate: self.currentRunPeriodEndDate()) { result in
+                    periodEndDate: self.currentRunPeriodEndDate(),
+                    context: context) { result in
 
                     switch result {
                     case .success:
@@ -502,8 +505,8 @@ class WeeklyRoundupNotificationScheduler {
     }
 
     func scheduleStaticNotification(completion: @escaping (Result<Void, Error>) -> Void) {
-        let title = "Weekly Roundup"
-        let body = "Your weekly roundup is ready, tap here to see the details!"
+        let title = TextContent.staticNotificationTitle
+        let body = TextContent.staticNotificationBody
 
         scheduleNotification(
             identifier: staticNotificationIdentifier,
@@ -526,21 +529,31 @@ class WeeklyRoundupNotificationScheduler {
         comments: Int,
         likes: Int,
         periodEndDate: Date,
+        context: NSManagedObjectContext,
         completion: @escaping (Result<Void, Error>) -> Void) {
 
-        guard let dotComID = site.dotComID?.intValue else {
-            // Error
-            return
-        }
+            var siteTitle: String?
+            var dotComID: Int?
 
-        let title: String = {
-            if let siteTitle = site.title {
-                return "Weekly Roundup: \(siteTitle)"
-            } else {
-                return "Weekly Roundup"
+            context.performAndWait {
+                dotComID = site.dotComID?.intValue
+                siteTitle = site.title
             }
-        }()
-        let body = "Last week you had \(views) views, \(comments) comments and \(likes) likes."
+
+            guard let dotComID = dotComID else {
+                // Error
+                return
+            }
+
+            let title: String = {
+                if let siteTitle = siteTitle {
+                    return String(format: TextContent.dynamicNotificationTitle, siteTitle)
+                } else {
+                    return TextContent.staticNotificationTitle
+                }
+            }()
+
+        let body = String(format: TextContent.dynamicNotificationBody, views, comments, likes)
 
         // The dynamic notification date is defined by when the background task is run.
         // Since these lines of code execute when the BG Task is run, we can just schedule
@@ -563,13 +576,13 @@ class WeeklyRoundupNotificationScheduler {
             userInfo: userInfo,
             dateComponents: dateComponents) { result in
 
-            switch result {
-            case .success:
-                completion(.success(()))
-            case .failure(let error):
-                completion(.failure(NotificationSchedulingError.dynamicNotificationSchedulingError(error: error)))
+                switch result {
+                case .success:
+                    completion(.success(()))
+                case .failure(let error):
+                    completion(.failure(NotificationSchedulingError.dynamicNotificationSchedulingError(error: error)))
+                }
             }
-        }
     }
 
     private func scheduleNotification(
@@ -635,5 +648,12 @@ class WeeklyRoundupNotificationScheduler {
 
             completion(true)
         }
+    }
+
+    enum TextContent {
+        static let staticNotificationTitle = NSLocalizedString("Weekly Roundup", comment: "Title of Weekly Roundup push notification")
+        static let dynamicNotificationTitle = NSLocalizedString("Weekly Roundup: %@", comment: "Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites.")
+        static let staticNotificationBody = NSLocalizedString("Your weekly roundup is ready, tap here to see the details!", comment: "Prompt displayed as part of the stats Weekly Roundup push notification.")
+        static let dynamicNotificationBody = NSLocalizedString("Last week you had %1$d views, %2$d comments and %3$d likes.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views, comments, and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments, 3 is likes.")
     }
 }


### PR DESCRIPTION
This PR makes some changes to the Core Data usage in the Weekly Roundup background task, to hopefully fix #17765. 

The original issue was hard to reproduce, but my guess was that it was due to sometimes accessing the site managed objects on a different queue to the one their context belonged to. I was able to recreate it more consistently (but not every time) by wrapping the `scheduleNotification` and `requestData` `BlockOperations` in `WeeklyRoundupBackgroundTask` in separate `DispatchQueue.async` calls for different queues.

I also noticed that even without these changes the Weekly Roundup tester in **Me > App Settings > Debug > Weekly Roundup** didn't seem to work consistently. Sometimes it would fail entirely, other times I would only see the 'static' notification, and other times I would only see a notification for a single site.

With the changes in this PR, it appears to be working for me every time.

I also took the opportunity to localize the notification strings, as I noticed they weren't localized.

### To test

* Build and run on a device
* Navigate to **Me > App Settings > Debug > Weekly Roundup**, and tap **Schedule immediately**. I recommend using an a8c account and having the 'use a8c sites' option checked to ensure you have a lot of views.
* After a few moments you should see multiple notifications come in containing the view count etc for 5 sites.
* Repeat the test multiple times. Background tasks do seem a little flaky as we can't guarantee exactly when the OS will run things, but this did seem to be working for me most of the time.

## Regression Notes
1. Potential unintended areas of impact

This should only affect the weekly roundup background task.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
