### PR TITLE
My Site Dashboard: style the post cell

### DIFF
--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -60,7 +60,7 @@ class Post: AbstractPost {
             return
         }
 
-        buildContentPreview()
+        storedContentPreviewForDisplay = ""
     }
 
     // MARK: - Content Preview

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -49,6 +49,7 @@ private extension PostsCardViewController {
         view.pinSubviewToAllEdges(tableView)
         let postCompactCellNib = PostCompactCell.defaultNib
         tableView.register(postCompactCellNib, forCellReuseIdentifier: PostCompactCell.defaultReuseID)
+        tableView.separatorStyle = .none
     }
 
     func configureGhostableTableView() {
@@ -60,6 +61,7 @@ private extension PostsCardViewController {
         view.pinSubviewToAllEdges(ghostableTableView)
 
         ghostableTableView.isScrollEnabled = false
+        ghostableTableView.separatorStyle = .none
 
         let postCompactCellNib = PostCompactCell.defaultNib
         ghostableTableView.register(postCompactCellNib, forCellReuseIdentifier: PostCompactCell.defaultReuseID)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -151,11 +151,11 @@ extension PostsCardViewModel: UITableViewDataSource {
 
         let post: Post = fetchedResultsController.object(at: indexPath)
 
-        guard let configurablePostView = cell as? ConfigurablePostView else {
-                fatalError("Cell does not implement the required protocols")
+        guard let configurablePostView = cell as? PostCompactCell else {
+                fatalError("Cell is not a PostCompactCell")
         }
 
-        configurablePostView.configure(with: post)
+        configurablePostView.configureForDashboard(with: post)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -15,6 +15,8 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     @IBOutlet weak var progressView: UIProgressView!
     @IBOutlet weak var separator: UIView!
 
+    @IBOutlet weak var trailingContentConstraint: NSLayoutConstraint!
+
     private weak var actionSheetDelegate: PostActionSheetDelegate?
 
     lazy var imageLoader: ImageLoader = {
@@ -126,6 +128,15 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         timestampLabel.isHidden = false
     }
 
+    private func configureExcerpt() {
+        guard let post = post else {
+            return
+        }
+
+        timestampLabel.text = post.contentPreviewForDisplay()
+        timestampLabel.isHidden = false
+    }
+
     private func configureStatus() {
         guard let viewModel = viewModel else {
             return
@@ -172,6 +183,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         static let imageRadius: CGFloat = 2
         static let labelsVerticalAlignment: CGFloat = -1
         static let opacity: Float = 1
+        static let margin: CGFloat = 16
     }
 }
 
@@ -206,3 +218,17 @@ extension PostCompactCell: GhostableView {
 }
 
 extension PostCompactCell: NibReusable { }
+
+// MARK: - For display on the Posts Card (Dashboard)
+
+extension PostCompactCell {
+    /// Configure the cell to be displayed in the Posts Card
+    /// No "more" button and show a description, instead of a date
+    func configureForDashboard(with post: Post) {
+        configure(with: post)
+        configureExcerpt()
+        separator.isHidden = true
+        menuButton.isHidden = true
+        trailingContentConstraint.constant = Constants.margin
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -71,7 +71,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
         WPStyleGuide.configureLabel(timestampLabel, textStyle: .subheadline)
         WPStyleGuide.configureLabel(badgesLabel, textStyle: .subheadline)
 
-        titleLabel.font = WPStyleGuide.notoBoldFontForTextStyle(.headline)
+        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .bold)
         titleLabel.adjustsFontForContentSizeCategory = true
 
         titleLabel.textColor = .text

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -230,5 +230,6 @@ extension PostCompactCell {
         separator.isHidden = true
         menuButton.isHidden = true
         trailingContentConstraint.constant = Constants.margin
+        headerStackView.spacing = Constants.margin
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -31,16 +31,16 @@
                                         <rect key="frame" x="0.0" y="0.0" width="312" height="0.0"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ESK-bT-Bix">
-                                                <rect key="frame" x="0.0" y="-18" width="312" height="36"/>
+                                                <rect key="frame" x="0.0" y="-17.333333333333336" width="312" height="34.666666666666664"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6QQ-XY-q2l">
-                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="14.666666666666666"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="13.333333333333334"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="yxn-r2-waJ">
-                                                        <rect key="frame" x="0.0" y="22.666666666666664" width="192" height="13.333333333333336"/>
+                                                        <rect key="frame" x="0.0" y="21.333333333333336" width="192" height="13.333333333333336"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <nil key="textColor"/>
                                                         <nil key="highlightedColor"/>
@@ -172,6 +172,7 @@
                 <outlet property="separator" destination="y9d-AS-bhE" id="jTZ-52-pNX"/>
                 <outlet property="timestampLabel" destination="fEo-hS-PK1" id="Ih0-91-vRW"/>
                 <outlet property="titleLabel" destination="ZUq-Dg-elW" id="Dzt-PV-spZ"/>
+                <outlet property="trailingContentConstraint" destination="U3Z-UB-o0I" id="bo6-AM-2S7"/>
             </connections>
             <point key="canvasLocation" x="135" y="179.72222222222223"/>
         </tableViewCell>


### PR DESCRIPTION
Part of #17697

Style the cell to be displayed inside the posts card.

The references for this design can be find in the Zeplin project.

| Light mode | Dark mode |
| ----------- | ----------- |
| ![Simulator Screen Shot - iPhone 13 - 2022-01-14 at 14 53 44](https://user-images.githubusercontent.com/7040243/149562220-de2af6f0-33a6-4df9-97d4-6342cd1fb86d.png) | ![Simulator Screen Shot - iPhone 13 - 2022-01-14 at 14 53 35](https://user-images.githubusercontent.com/7040243/149562248-73d2f484-3a21-42db-915d-d82cbd02aa3e.png) |

## To test

First, Copy and paste the content of [this gist](https://gist.github.com/leandroalonso/6d597ea005d2c1e2252e29dcfdbd83b7) into `BlogDetailsViewController.m`

1. Do a fresh install, login and select a blog
2. When the posts appear compare it to the specified designs
3. Test light and dark mode, portrait and landscape

### Editing a post

1. Open a post
2. Change it's content and add an image (or set a featured image)
3. Tap X and "Update Draft"
4. Make sure the changes are reflected

### Editing a post in the post list

1. Open the posts list screen
2. Make sure that posts are not being displayed in the compact mode
3. Open a post and change the beginning of the content
4. Save it
5. Make sure the change is reflected on the post card

## Regression Notes
1. Potential unintended areas of impact
Posts list (I made a small change in the `Post` entity)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test.

3. What automated tests I added (or what prevented me from doing so)
I'll do in a follow-up PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
