### PR TITLE
Make "anytime" two words when setting reminders

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -607,7 +607,7 @@ private enum TextContent {
     static let settingsPrompt = NSLocalizedString("Select the days you want to blog on",
                                                   comment: "Prompt shown on the Blogging Reminders Settings screen.")
 
-    static let settingsUpdatePrompt = NSLocalizedString("You can update this anytime",
+    static let settingsUpdatePrompt = NSLocalizedString("You can update this any time",
                                                         comment: "Prompt shown on the Blogging Reminders Settings screen.")
 
     static let nextButtonTitle = NSLocalizedString("Notify me", comment: "Title of button to navigate to the next screen of the blogging reminders flow, setting up push notifications.")


### PR DESCRIPTION
To test: Set/change blogging reminder, and observe the screen. It will use the new string, which is "You can update this any time"

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
