### PR TITLE
Fix Share Sheet + image upload for images with copyright symbol from Photos app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]
 * [*] Self-hosted login: Improved error messages. [#17724]
 * [*] Block editor: Fixed an issue where video thumbnails could show when selecting images, and vice versa. [#17670]
+* [*] Share Sheet from Photos: Fix an issue where certain filenames would not upload or render in Post [#16773]
 
 19.0
 -----

--- a/WordPress/WordPressShareExtension/ShareExtractor.swift
+++ b/WordPress/WordPressShareExtension/ShareExtractor.swift
@@ -308,7 +308,7 @@ private extension TypeBasedExtensionContentExtractor {
     }
 
     func copyToSharedContainer(url: URL) -> URL? {
-        guard let newPath = tempPath(for: url.lastPathComponent) else {
+        guard let newPath = tempPath(for: url.pathExtension) else {
             return nil
         }
 


### PR DESCRIPTION
Fixes #16773

To test:
1. Take any standard JPEG or PNG file and rename it with the filename crown-house_©-francesco-russo_websize_002-1-1, keeping the file’s extension.
2. Ensure this above image is on your test simulator or device
3. In the Photos app, choose the photo and launch the Share Sheet.
4. Choose the WordPress iOS app so that this image is shared with the app.  Create a new post
5. Image with filename crown-house_©-francesco-russo_websize_002-1-1 should be uploaded to the chosen WordPress site and the image should render correctly on app and website in the Blog post


## Regression Notes
1. Potential unintended areas of impact
Image filenames with unusual characters or encoding might not be uploaded

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested images without the copyright symbol and other images and everything uploaded correctly

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
