### PR TITLE
Notifications: Add mark all read functionality and network support

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.46.0-beta.1'
+    # pod 'WordPressKit', '~> 4.46.0-beta.1'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/17135-notifications_mark_all_read_support'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -465,7 +465,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.46.0-beta.1):
+  - WordPressKit (4.46.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -569,7 +569,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.7)
   - WordPressAuthenticator (~> 1.43.0-beta.2)
-  - WordPressKit (~> 4.46.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/17135-notifications_mark_all_read_support`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0)
   - WordPressUI (~> 1.12.3)
@@ -619,7 +619,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -732,6 +731,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0-alpha1
+  WordPressKit:
+    :branch: feature/17135-notifications_mark_all_read_support
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.70.0-alpha1/third-party-podspecs/Yoga.podspec.json
 
@@ -747,6 +749,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0-alpha1
+  WordPressKit:
+    :commit: 782ad5597607d5bacccc74c53bd594ed0e1d040b
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -833,7 +838,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 144f124148079084860368dfd27cb96e0952853e
   WordPress-Editor-iOS: 20551d5a5e51f29832064f08faaaae8e1da7e1e2
   WordPressAuthenticator: 0b3423546d92a976e3ce627d2e5a0350716b1f5b
-  WordPressKit: 52329b519bd0da6533cd4c79070424d0672ed7ee
+  WordPressKit: 8da2b07a7ca87004c065717e08f0eef1646ee1c5
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: 45591178e843ecb82e65e868ec766148befe9f9f
@@ -849,6 +854,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: f18b631a6b25713184495ced4e4387f59388c803
+PODFILE CHECKSUM: 886b3864790b9096a12725bcf639e1f1aaea3427
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -222,7 +222,6 @@ class NotificationSyncMediator {
         remote.updateReadStatusForNotifications(noteIDs, read: read) { error in
             if let error = error {
                 DDLogError("Error marking notifications as \(Self.readState(for: read)): \(error)")
-
                 NotificationSyncMediator()?.invalidateCacheForNotifications(with: noteIDs)
             }
 
@@ -314,19 +313,16 @@ class NotificationSyncMediator {
         }
     }
 
-    /// Invalidates the local cache for all the notifications with specified ID's in the array..
+    /// Invalidates the local cache for all the notifications with specified ID's in the array.
     ///
     func invalidateCacheForNotifications(with noteIDs: [String]) {
         let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
 
         derivedContext.perform {
-            for noteID in noteIDs {
-                // TODO Fix predicate
-                let predicate = NSPredicate(format: "(notificationId == %@)", noteID)
-                guard let notification = derivedContext.firstObject(ofType: Notification.self, matching: predicate) else {
-                    return
-                }
+            let predicate = NSPredicate(format: "(notificationId IN %@)", noteIDs)
+            let notifications = derivedContext.allObjects(ofType: Notification.self, matching: predicate)
 
+            for notification in notifications {
                 notification.notificationHash = nil
             }
 

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -294,9 +294,7 @@ class NotificationSyncMediator {
             let predicate = NSPredicate(format: "(notificationId IN %@)", noteIDs)
             let notifications = derivedContext.allObjects(ofType: Notification.self, matching: predicate)
 
-            for notification in notifications {
-                notification.notificationHash = nil
-            }
+            notifications.forEach { $0.notificationHash = nil }
 
             self.contextManager.save(derivedContext)
         }
@@ -421,9 +419,7 @@ private extension NotificationSyncMediator {
 
         let notes = mainContext.allObjects(ofType: Notification.self, matching: predicate)
 
-        for note in notes {
-            note.read = status
-        }
+        notes.forEach { $0.read = status }
         contextManager.saveContextAndWait(mainContext)
     }
 

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -167,7 +167,7 @@ class NotificationSyncMediator {
     /// - Note: This method should only be used on the main thread.
     ///
     /// - Parameters:
-    ///     - notifications: The notification that was just read.
+    ///     - notifications: Notifications that were marked as read.
     ///     - completion: Callback to be executed on completion.
     ///
     func markAsRead(_ notifications: [Notification], completion: ((Error?)-> Void)? = nil) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -840,6 +840,17 @@ private extension NotificationsViewController {
 // MARK: - Marking as Read
 //
 private extension NotificationsViewController {
+    private enum Localization {
+        static let markAllAsReadNoticeTitle = NSLocalizedString(
+            "Success",
+            comment: "Title for mark all as read success notice."
+        )
+
+        static let markAllAsReadNoticeMessage = NSLocalizedString(
+            "Notifications marked as read.",
+            comment: "Message for mark all as read success notice."
+        )
+    }
 
     func markSelectedNotificationAsRead() {
         guard let note = selectedNotification else {
@@ -869,7 +880,10 @@ private extension NotificationsViewController {
         }
 
         NotificationSyncMediator()?.markAsRead(unreadNotifications)
-        let notice = Notice(title: "Some title", message: "Mark all as read successful")
+        let notice = Notice(
+            title: Localization.markAllAsReadNoticeTitle,
+            message: Localization.markAllAsReadNoticeMessage
+        )
         ActionDispatcherFacade().dispatch(NoticeAction.post(notice))
         updateMarkAllAsReadTintColor()
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -880,13 +880,11 @@ private extension NotificationsViewController {
         }
 
         NotificationSyncMediator()?.markAsRead(unreadNotifications, completion: { [weak self] error in
-            guard let self = self else { return }
-
             let notice = Notice(
                 title: error != nil ? Localization.markAllAsReadNoticeFailure : Localization.markAllAsReadNoticeSuccess
             )
             ActionDispatcherFacade().dispatch(NoticeAction.post(notice))
-            self.updateMarkAllAsReadButton()
+            self?.updateMarkAllAsReadButton()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -879,14 +879,15 @@ private extension NotificationsViewController {
             !$0.read
         }
 
-        NotificationSyncMediator()?.markAsRead(unreadNotifications, completion: { error in
+        NotificationSyncMediator()?.markAsRead(unreadNotifications, completion: { [weak self] error in
+            guard let self = self else { return }
+
             let notice = Notice(
-                title: error != nil ? Localization.markAllAsReadNoticeFailure : Localization.markAllAsReadNoticeSuccess,
-                message: nil
+                title: error != nil ? Localization.markAllAsReadNoticeFailure : Localization.markAllAsReadNoticeSuccess
             )
             ActionDispatcherFacade().dispatch(NoticeAction.post(notice))
+            self.updateMarkAllAsReadButton()
         })
-        updateMarkAllAsReadButton()
     }
 
     func markAsUnread(note: Notification) {

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -175,6 +175,81 @@ class NotificationSyncMediatorTests: XCTestCase {
         waitForExpectations(timeout: timeout, handler: nil)
     }
 
+    /// Verifies that Mark Notifications as Read effectively toggles a Notifications' read flag
+    ///
+    func testMarkNotificationsAsReadEffectivelyTogglesNotificationsReadStatus() {
+        // Stub Endpoint
+        let endpoint = "notifications/read"
+        let stubPath = OHPathForFile("notifications-mark-as-read.json", type(of: self))!
+        HTTPStubs.stubRequest(forEndpoint: endpoint, withFileAtPath: stubPath)
+
+        // Inject Dummy Note
+        let path1 = "notifications-like.json"
+        let path2 = "notifications-new-follower.json"
+        let path3 = "notifications-unapproved-comment.json"
+        let note1 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path1) as! WordPress.Notification
+        let note2 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path2) as! WordPress.Notification
+        let note3 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path3) as! WordPress.Notification
+
+        XCTAssertFalse(note1.read)
+        XCTAssertFalse(note3.read)
+
+        XCTAssertTrue(note2.read)
+
+        // CoreData Expectations
+        manager.testExpectation = expectation(description: "Context save expectation")
+
+        // Mediator Expectations
+        let expect = expectation(description: "Mark as Read")
+
+        // Mark as Read!
+        mediator.markAsRead([note1, note3]) { success in
+            XCTAssertTrue(note1.read)
+            XCTAssertTrue(note2.read)
+            XCTAssertTrue(note3.read)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
+    /// Verifies that Mark Notifications as Read modifies only the specified notifications' read status
+    ///
+    func testMarkNotificationsAsReadTogglesOnlyTheReadStatusOfPassedInNotifications() {
+        // Stub Endpoint
+        let endpoint = "notifications/read"
+        let stubPath = OHPathForFile("notifications-mark-as-read.json", type(of: self))!
+        HTTPStubs.stubRequest(forEndpoint: endpoint, withFileAtPath: stubPath)
+
+        // Inject Dummy Note
+        let path1 = "notifications-like.json"
+        let path2 = "notifications-new-follower.json"
+        let path3 = "notifications-unapproved-comment.json"
+        let note1 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path1) as! WordPress.Notification
+        let note2 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path2) as! WordPress.Notification
+        let note3 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path3) as! WordPress.Notification
+
+        XCTAssertFalse(note1.read)
+        XCTAssertFalse(note3.read)
+
+        XCTAssertTrue(note2.read)
+
+        // CoreData Expectations
+        manager.testExpectation = expectation(description: "Context save expectation")
+
+        // Mediator Expectations
+        let expect = expectation(description: "Mark as Read")
+
+        // Mark as Read!
+        mediator.markAsRead([note1]) { success in
+            XCTAssertTrue(note1.read)
+            XCTAssertFalse(note3.read)
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+    }
+
 
     /// Verifies that updateLastSeen method effectively calls the callback with successfull flag
     ///


### PR DESCRIPTION
Ref: #17135

This PR implemented the functionality of the checkmark button via binding the button to service call.
* The mark all as read button is bound to a target to make a network call.
* As the case for single notification, the completion updates the `resultsController` which reflects the changes on UI.
* Unit tests are added for `NotificationSyncMediator` changes.
* Checkmark button's tint color is updated whenever the items displayed under a filter are updated. Thus, when all items are marked read, the button turns gray and is disabled. When a new notification appears, it is enabled again and changes the color back to primary blue.

To test:
1. Enable the Feature Flag: Settings -> AppSettings -> Debug -> Enable "Mark Notifications As Read"
Notifications Tab.
2. Navigate to Notifications tab and interact with the checkmark button. All unread notifications **under the selected filter** must be marked as read.
3. The button should be disabled when there is no unread message under the filter and must be enabled again once a notification is marked as unread.

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
I added unit tests for the new overload function to mark an array of notifications as read.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
