### PR TITLE
Notifications: Add tracking for mark all read button

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -264,6 +264,7 @@ import Foundation
     // Notifications
     case notificationsPreviousTapped
     case notificationsNextTapped
+    case notificationsMarkAllReadTapped
 
     // Sharing Buttons
     case sharingButtonsEditSharingButtonsToggled
@@ -751,6 +752,8 @@ import Foundation
             return "notifications_previous_tapped"
         case .notificationsNextTapped:
             return "notifications_next_tapped"
+        case .notificationsMarkAllReadTapped:
+            return "notifications_mark_all_read_tapped"
 
         // Sharing
         case .sharingButtonsEditSharingButtonsToggled:

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -875,6 +875,8 @@ private extension NotificationsViewController {
             return
         }
 
+        WPAnalytics.track(.notificationsMarkAllReadTapped)
+
         let unreadNotifications = notes.filter {
             !$0.read
         }


### PR DESCRIPTION
Ref #17135

Adds the tracking event to Mark All Read button in Notifications Screen.
A new event named `notificationsMarkAllReadTapped` is added and must be triggered when the "Mark All Read" button is tapped.

To test:
* Enable the Feature Flag: Settings -> AppSettings -> Debug -> Enable "Mark Notifications As Read"
* Navigate to Notifications Tab.
* Tap the Checkmark button on navigation and validate if an event is being triggered.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
The Tracker must be injected to `NotificationsViewController`. As the file does not have unit tests in place and strongly coupled with UI as its nature, testing the newly added logic is not very straightforward.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
