### PR TITLE
Feature Announcement: add icons property to Feature struct

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.46.0-beta.1'
+    # pod 'WordPressKit', '~> 4.46.0-beta.1'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/update_announcement_feature_properties'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.46.0-beta.1'
+    pod 'WordPressKit', '~> 4.46.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'issue/update_announcement_feature_properties'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -465,7 +465,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.46.0-beta.1):
+  - WordPressKit (4.46.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -569,7 +569,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.7)
   - WordPressAuthenticator (~> 1.43.0-beta.2)
-  - WordPressKit (~> 4.46.0-beta.1)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/update_announcement_feature_properties`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0)
   - WordPressUI (~> 1.12.3)
@@ -619,7 +619,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -732,6 +731,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0
+  WordPressKit:
+    :branch: issue/update_announcement_feature_properties
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.70.0/third-party-podspecs/Yoga.podspec.json
 
@@ -747,6 +749,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0
+  WordPressKit:
+    :commit: 9d4821aed4bcd05186fc8d05c844f0aca2fd721e
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -833,7 +838,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 144f124148079084860368dfd27cb96e0952853e
   WordPress-Editor-iOS: 20551d5a5e51f29832064f08faaaae8e1da7e1e2
   WordPressAuthenticator: 0b3423546d92a976e3ce627d2e5a0350716b1f5b
-  WordPressKit: 52329b519bd0da6533cd4c79070424d0672ed7ee
+  WordPressKit: 8da2b07a7ca87004c065717e08f0eef1646ee1c5
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: 45591178e843ecb82e65e868ec766148befe9f9f
@@ -849,6 +854,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: cf4b842b6fd0d700b0f0ded040967877822e8daa
+PODFILE CHECKSUM: afc46586a24022fcf0ece7882c0b100698446af1
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -750,7 +750,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.70.0
   WordPressKit:
-    :commit: 9d4821aed4bcd05186fc8d05c844f0aca2fd721e
+    :commit: 15cc6dadae14ab973d3092500c2414a4713675ea
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -569,7 +569,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.7)
   - WordPressAuthenticator (~> 1.43.0-beta.2)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `issue/update_announcement_feature_properties`)
+  - WordPressKit (~> 4.46.0-beta)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.0)
   - WordPressUI (~> 1.12.3)
@@ -581,6 +581,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -731,9 +732,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0
-  WordPressKit:
-    :branch: issue/update_announcement_feature_properties
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.70.0/third-party-podspecs/Yoga.podspec.json
 
@@ -749,9 +747,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.70.0
-  WordPressKit:
-    :commit: 15cc6dadae14ab973d3092500c2414a4713675ea
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -838,7 +833,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 144f124148079084860368dfd27cb96e0952853e
   WordPress-Editor-iOS: 20551d5a5e51f29832064f08faaaae8e1da7e1e2
   WordPressAuthenticator: 0b3423546d92a976e3ce627d2e5a0350716b1f5b
-  WordPressKit: 8da2b07a7ca87004c065717e08f0eef1646ee1c5
+  WordPressKit: e623ffb39b2b9d7730a9be63e26fa77929e6e43b
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: a4b0308a6345d4dda20c8f7ad9317df4246b4a00
   WordPressUI: 45591178e843ecb82e65e868ec766148befe9f9f
@@ -854,6 +849,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: e27423c004a5a1410c15933407747374e7c6cb6e
 
-PODFILE CHECKSUM: afc46586a24022fcf0ece7882c0b100698446af1
+PODFILE CHECKSUM: ebdcdd2b30dd680be23e92f8167141254e055594
 
 COCOAPODS: 1.11.2

--- a/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
+++ b/WordPress/WordPressTest/What's New/Data store/AnnouncementsDataStoreTests.swift
@@ -11,21 +11,23 @@ struct MockAnnouncementsCache: AnnouncementsCache {
     var date: Date?
 
     private let localAnnouncements = [Announcement(appVersionName: "0.0",
-                                           minimumAppVersion: "1.0",
-                                           maximumAppVersion: "3.0",
-                                           appVersionTargets: [],
-                                           detailsUrl: "http://wordpress.org",
-                                           announcementVersion: "1.0",
-                                           isLocalized: false,
-                                           responseLocale: "",
-                                           features: [WordPressKit.Feature(title: "first cached feature",
-                                                                           subtitle: "this is a mock cached feature",
-                                                                           iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-personal.png",
-                                                                           iconBase64: nil),
-                                                      WordPressKit.Feature(title: "second cached feature",
-                                                                           subtitle: "this is a mock cached feature",
-                                                                           iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-personal.png",
-                                                                           iconBase64: nil)])]
+                                                   minimumAppVersion: "1.0",
+                                                   maximumAppVersion: "3.0",
+                                                   appVersionTargets: [],
+                                                   detailsUrl: "http://wordpress.org",
+                                                   announcementVersion: "1.0",
+                                                   isLocalized: false,
+                                                   responseLocale: "",
+                                                   features: [WordPressKit.Feature(title: "first cached feature",
+                                                                                   subtitle: "this is a mock cached feature",
+                                                                                   icons: nil,
+                                                                                   iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-personal.png",
+                                                                                   iconBase64: nil),
+                                                              WordPressKit.Feature(title: "second cached feature",
+                                                                                   subtitle: "this is a mock cached feature",
+                                                                                   icons: nil,
+                                                                                   iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-personal.png",
+                                                                                   iconBase64: nil)])]
 
     init(localCacheIsValid: Bool = true) {
         self.announcements = localCacheIsValid ? localAnnouncements : nil
@@ -47,6 +49,7 @@ class MockAnnouncementsService: AnnouncementServiceRemote {
                                                                                       responseLocale: "",
                                                                                       features: [WordPressKit.Feature(title: "mock feature",
                                                                                                                       subtitle: "this is a mock feature",
+                                                                                                                      icons: nil,
                                                                                                                       iconUrl: "https://s0.wordpress.com/i/store/mobile/plans-personal.png",
                                                                                                                       iconBase64: nil)])])
 


### PR DESCRIPTION
Fixes #n/a
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/475

cc @develric 

An `icons` property will be added to the Feature Announcement json to accommodate Woo's need for multiple icons. WPKit adds an optional `icons` property to the `Feature` struct so decoding doesn't crash if it is present. This updates WPKit and the `AnnouncementsDataStoreTests`.

To test:
Getting the Feature Announcement to show will require a little hacking since we don't have one for the current release.
- To force the feature announcement to show on app launch:
  - In `WhatIsNewScenePresenter:shouldPresentWhatIsNew`, `return true`.
  - In `AnnouncementsStore`, set `appVersion` to a version that has a Feature Announcement (e.g. "17.7").
```
static var appVersion: String {
      "17.7"
      // Bundle.main.shortVersionString() ?? ""
}
```

- To show the feature announcement in App Settings > Other:
  - In `AppSettingsViewController:otherTableSection`, comment out `presenter.versionHasAnnouncements` when adding the `whatIsNewRow` row.

```
if let presenter = WPTabBarController.sharedInstance()?.whatIsNewScenePresenter as? WhatIsNewScenePresenter,
      //presenter.versionHasAnnouncements,
      AppConfiguration.showsWhatIsNew {
```

- Run the app.
- Verify the feature announcement is displayed correctly. For 17.7 it should be:

![Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-20 at 16 20 34](https://user-images.githubusercontent.com/1816888/150440948-2cf3bb63-aa17-4069-a2e1-665815c60ed2.png)

## Regression Notes
1. Potential unintended areas of impact
Feature Announcement could not get parsed correctly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified Feature Announcement is displayed correctly.

3. What automated tests I added (or what prevented me from doing so)
Updated existing tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
