### PR TITLE
Fix Jetpack `en-US` release notes not being uploaded to ASC

### DIFF
--- a/fastlane/jetpack_metadata/en-US/description.txt
+++ b/fastlane/jetpack_metadata/en-US/description.txt
@@ -1,0 +1,3 @@
+Get powerful security and performance tools in your pocket with Jetpack for iOS.
+
+Restore your site from anywhere if something goes wrong. Scan for threats and resolve them with a tap. Keep tabs on site activity to see who changed what and when. Check your stats to see what new countries today’s visitors are coming from.

--- a/fastlane/jetpack_metadata/en-US/keywords.txt
+++ b/fastlane/jetpack_metadata/en-US/keywords.txt
@@ -1,0 +1,1 @@
+social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal

--- a/fastlane/jetpack_metadata/en-US/name.txt
+++ b/fastlane/jetpack_metadata/en-US/name.txt
@@ -1,0 +1,1 @@
+Jetpack

--- a/fastlane/jetpack_metadata/en-US/name.txt
+++ b/fastlane/jetpack_metadata/en-US/name.txt
@@ -1,1 +1,0 @@
-Jetpack

--- a/fastlane/jetpack_metadata/en-US/release_notes.txt
+++ b/fastlane/jetpack_metadata/en-US/release_notes.txt
@@ -1,6 +1,12 @@
-Made a New Year's resolution to publish more content on your site? We made a few updates to the Block Editor to help you do just that.
+What time is it? Our brand-new time zone selection screen knows. Get a suggested time zone based on your device and improve search while you’re at it.
 
-- When you're editing Paragraph blocks, you can highlight specific text in any color you'd like.
-- Brand-new Gallery blocks will default to the new design. You can also auto-convert any old galleries to the new format without a hitch.
-- The editor now auto-scrolls, so you can always see what you're typing. No more disappearing text, no more guesswork.
-- We squashed a bug where the background color wasn't showing up for pre-formatted blocks on sites that use standard themes.
+If you’re using a free plan, video uploads are now limited to five minutes per file. Don’t worry, that won’t affect any videos you’ve already uploaded to your site.
+
+We’ve also made some changes to the block editor:
+
+- We solved translation issues that caused some user interface elements (like text alignment information and the block editor modal window) to only appear in English.
+- We added language translation for Jetpack and Layout Grid blocks.
+- We fixed a bug that would reset text formatting to default after hitting backspace. Bold on, friends.
+- Multi-line block titles are now center-aligned in the inserter menu.
+
+Finally, the “Share WordPress with a friend” row is back where it belongs on the Me screen. Reunited and it feels so good.

--- a/fastlane/jetpack_metadata/en-US/subtitle.txt
+++ b/fastlane/jetpack_metadata/en-US/subtitle.txt
@@ -1,0 +1,1 @@
+Faster, safer WordPress


### PR DESCRIPTION
As @oguzkocer noticed in #17730, we've (always?) had an issue with the en-US release notes not reaching ASC. This PR fixes it. 

I added localized files for `en-US` to match what the other locales have and now the data appears in the preview. I haven't actually run the upload, but I'm pretty confident that would succeed since nothing has changed from that point of view.

To test: Run `bundle exec fastlane update_jetpack_metadata_on_app_store_connect` and verify the preview file that will open in your browser contains the `en-US` data as well as all the other expected locales:

<img width="1162" alt="Screen Shot 2022-01-21 at 7 20 34 am" src="https://user-images.githubusercontent.com/1218433/150476661-ff5e8949-6e61-4257-b01b-473adf8e9e90.png">

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
