### PR TITLE
Publicize: Fix Facebook auth success detection

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 * [*] Block editor: Highlight text: fix applying formatting for non-selected text [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4471]
 * [**] Block editor: Fix Android handling of Hebrew and Indonesian translations [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4397]
 * [***] Self-hosted sites: Fixed a crash when saving media and no Internet connection was available. [#17759]
+* [*] Publicize: Fixed an issue where a successful login was not automatically detected when connecting a Facebook account to Publicize. [#17803]
 
 19.0
 -----

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
@@ -25,20 +25,23 @@ class SharingAuthorizationWebViewController: WPWebViewController {
     }
 
     private static let loginURL = "https://wordpress.com/wp-login.php"
-    private static let authorizationPrefix = "https://public-api.wordpress.com/connect/"
-    private static let requestActionParameter = "action=request"
-    private static let verifyActionParameter = "action=verify"
-    private static let denyActionParameter = "action=deny"
 
-    // Special handling for the inconsistent way that services respond to a user's choice to decline
-    // oauth authorization.
-    // Right now we have no clear way to know if Tumblr fails.  This is something we should try
-    // fixing moving forward.
-    // Path does not set the action param or call the callback. It forwards to its own URL ending in /decline.
-    private static let declinePath = "/decline"
-    private static let userRefused = "oauth_problem=user_refused"
-    private static let authorizationDenied = "denied="
-    private static let accessDenied = "error=access_denied"
+    private enum AuthorizeURLComponents {
+        static let verifyActionParameter = "action=verify"
+        static let denyActionParameter = "action=deny"
+        static let requestActionParameter = "action=request"
+
+        static let declinePath = "/decline"
+        static let authorizationPrefix = "https://public-api.wordpress.com/connect/"
+        static let accessDenied = "error=access_denied"
+
+        // Special handling for the inconsistent way that services respond to a user's choice to decline
+        // oauth authorization.
+        // Right now we have no clear way to know if Tumblr fails.  This is something we should try
+        // fixing moving forward.
+        // Path does not set the action param or call the callback. It forwards to its own URL ending in /decline.
+        static let userRefused = "oauth_problem=user_refused"
+    }
 
     /// Verification loading -- dismiss on completion
     ///
@@ -148,37 +151,37 @@ class SharingAuthorizationWebViewController: WPWebViewController {
         let requested = url.absoluteString
 
         // Path oauth declines are handled by a redirect to a path.com URL, so check this first.
-        if requested.range(of: SharingAuthorizationWebViewController.declinePath) != nil {
+        if requested.range(of: AuthorizeURLComponents.declinePath) != nil {
             return .deny
         }
 
-        if !requested.hasPrefix(SharingAuthorizationWebViewController.authorizationPrefix) {
+        if !requested.hasPrefix(AuthorizeURLComponents.authorizationPrefix) {
             return .none
         }
 
-        if requested.range(of: SharingAuthorizationWebViewController.requestActionParameter) != nil {
+        if requested.range(of: AuthorizeURLComponents.requestActionParameter) != nil {
             return .request
         }
 
         // Check the rest of the various decline ranges
-        if requested.range(of: SharingAuthorizationWebViewController.denyActionParameter) != nil {
+        if requested.range(of: AuthorizeURLComponents.denyActionParameter) != nil {
             return .deny
         }
 
         // LinkedIn
-        if requested.range(of: SharingAuthorizationWebViewController.userRefused) != nil {
+        if requested.range(of: AuthorizeURLComponents.userRefused) != nil {
             return .deny
         }
 
         // Facebook and Google+
-        if requested.range(of: SharingAuthorizationWebViewController.accessDenied) != nil {
+        if requested.range(of: AuthorizeURLComponents.accessDenied) != nil {
             return .deny
         }
 
         // If we've made it this far and verifyRange is found then we're *probably*
         // verifying the oauth request.  There are edge cases ( :cough: tumblr :cough: )
         // where verification is declined and we get a false positive.
-        if requested.range(of: SharingAuthorizationWebViewController.verifyActionParameter) != nil {
+        if requested.range(of: AuthorizeURLComponents.verifyActionParameter) != nil {
             return .verify
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationWebViewController.swift
@@ -35,6 +35,10 @@ class SharingAuthorizationWebViewController: WPWebViewController {
         case authorizationPrefix = "https://public-api.wordpress.com/connect/"
         case accessDenied = "error=access_denied"
 
+        case state = "state"
+        case code = "code"
+        case error = "error"
+
         // Special handling for the inconsistent way that services respond to a user's choice to decline
         // oauth authorization.
         // Right now we have no clear way to know if Tumblr fails.  This is something we should try
@@ -186,9 +190,16 @@ class SharingAuthorizationWebViewController: WPWebViewController {
         if AuthorizeURLComponents.verifyActionParameter.containedIn(url) {
             return .verify
         }
+
+        // Facebook
+        if AuthorizeURLComponents.state.containedIn(url) && AuthorizeURLComponents.code.containedIn(url) {
             return .verify
         }
 
+        // Facebook failure
+        if AuthorizeURLComponents.state.containedIn(url) && AuthorizeURLComponents.error.containedIn(url) {
+            return .unknown
+        }
 
         return .unknown
     }


### PR DESCRIPTION
Fixes #17794. The URL used to determine success for the Facebook Publicize connection flow has changed. This PR updates the check used to determine a Facebook success so that it matches the new URL (see final commit for those changes), as well as some slight refactoring to improve the existing code in this section.

The new URL should contain `state` and `code` values if it is a Facebook login, and `state` and `error` if it was unsuccessful. All other login types should be unaffected.

Please see the original issue for more detail about the problem.

### To test

-  Open the app and select a WP.com or Jetpack site.
-  On the My Site screen, scroll down to the Configuration section.
-  Tap "Sharing".
-  Tap "Facebook".
-  Tap "Connect".
-  Login with a Facebook account that has at least one page.
-  Accept all Facebook permissions.
-  Ensure that the webview is dismissed and you are asked which account you would like to connect.

Also ensure that you can still connect some other account types such as Twitter.

## Regression Notes
1. Potential unintended areas of impact

Other account types connecting, as I refactored some of that code slightly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I manually tested connecting to other account types. I also ensured all tests pass, although I can't see that we have tests for publicize currently.

3. What automated tests I added (or what prevented me from doing so)

 We could add some to check these various success and failure URLs, but I wanted to merge this soon and it would be a reasonable amount of work to compile a list of all of the various URLs we're checking for.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
