### PR TITLE
Media Detail screen improve accessibility and hints

### DIFF
--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -94,7 +94,10 @@ struct EditableTextRow: ImmuTableRow {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value
         cell.accessibilityLabel = title
-        cell.accessibilityHint = value
+        cell.accessibilityValue = value
+        if cell.isUserInteractionEnabled {
+            cell.accessibilityHint = NSLocalizedString("Tap to edit", comment: "Accessibility hint prompting the user to tap a table row to edit its value.")
+        }
         cell.accessoryType = .disclosureIndicator
         if accessoryImage != nil {
             cell.accessoryView = UIImageView(image: accessoryImage)
@@ -132,7 +135,7 @@ struct TextRow: ImmuTableRow {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value
         cell.accessibilityLabel = title
-        cell.accessibilityHint = value
+        cell.accessibilityValue = value
 
         cell.selectionStyle = .none
 

--- a/WordPress/Classes/Utility/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/WPImmuTableRows.swift
@@ -93,6 +93,8 @@ struct EditableTextRow: ImmuTableRow {
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value
+        cell.accessibilityLabel = title
+        cell.accessibilityHint = value
         cell.accessoryType = .disclosureIndicator
         if accessoryImage != nil {
             cell.accessoryView = UIImageView(image: accessoryImage)
@@ -129,6 +131,9 @@ struct TextRow: ImmuTableRow {
     func configureCell(_ cell: UITableViewCell) {
         cell.textLabel?.text = title
         cell.detailTextLabel?.text = value
+        cell.accessibilityLabel = title
+        cell.accessibilityHint = value
+
         cell.selectionStyle = .none
 
         WPStyleGuide.configureTableViewCell(cell)

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -177,7 +177,7 @@ struct MediaImageRow: ImmuTableRow {
             cell.isVideo = media.mediaType == .video
             cell.accessibilityTraits = .button
             cell.accessibilityLabel = NSLocalizedString("Preview media", comment: "Accessibility label for media item preview for user's viewing an item in their media library")
-            cell.accessibilityHint = NSLocalizedString("Click to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
+            cell.accessibilityHint = NSLocalizedString("Tap to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
         }
     }
 
@@ -244,7 +244,7 @@ struct MediaDocumentRow: ImmuTableRow {
             cell.showIconForMedia(media)
             cell.accessibilityTraits = .button
             cell.accessibilityLabel = NSLocalizedString("Preview media", comment: "Accessibility label for media item preview for user's viewing an item in their media library")
-            cell.accessibilityHint = NSLocalizedString("Click to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
+            cell.accessibilityHint = NSLocalizedString("Tap to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -175,6 +175,9 @@ struct MediaImageRow: ImmuTableRow {
             setAspectRatioFor(cell)
             loadImageFor(cell)
             cell.isVideo = media.mediaType == .video
+            cell.accessibilityTraits = .button
+            cell.accessibilityLabel = NSLocalizedString("Preview media", comment: "Accessibility label for media item preview for user's viewing an item in their media library")
+            cell.accessibilityHint = NSLocalizedString("Click to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
         }
     }
 
@@ -239,6 +242,9 @@ struct MediaDocumentRow: ImmuTableRow {
         if let cell = cell as? MediaItemDocumentTableViewCell {
             cell.customImageView.tintColor = cell.textLabel?.textColor
             cell.showIconForMedia(media)
+            cell.accessibilityTraits = .button
+            cell.accessibilityLabel = NSLocalizedString("Preview media", comment: "Accessibility label for media item preview for user's viewing an item in their media library")
+            cell.accessibilityHint = NSLocalizedString("Click to view media in full screen", comment: "Accessibility hint for media item preview for user's viewing an item in their media library")
         }
     }
 }


### PR DESCRIPTION
Fixes #12878

To test:

1. Go to Settings > General > Accessibility > VoiceOver and toggle the setting on.
2. In the WordPress app, go to My Site > Media.
3. Select an image and tap to open media details.
4. VoiceOver through all the elements on screen.
5. Image should be marked as a button with an accessibility label and hint.
6. Editable fields have accessibility labels and hints added

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested in Simulator using Accessibility Inspector (I currently don't have ability to test / debug on Device)

Navigation bar accessibility was already added

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
