### PR TITLE
Notifications: Add confirmation action sheet for mark all as read button

### DIFF
--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -268,7 +268,7 @@ private extension NotificationActionsService {
 
         let notificationID = block.parent.notificationIdentifier
         DDLogInfo("Invalidating Cache and Force Sync'ing Notification with ID: \(notificationID)")
-        mediator.invalidateCacheForNotification(with: notificationID)
+        mediator.invalidateCacheForNotification(notificationID)
         mediator.syncNote(with: notificationID)
     }
 }

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -205,7 +205,7 @@ class NotificationSyncMediator {
                 // next successful sync.
                 //
                 // https://github.com/wordpress-mobile/WordPress-iOS/issues/7216
-                NotificationSyncMediator()?.invalidateCacheForNotifications(with: noteIDs)
+                NotificationSyncMediator()?.invalidateCacheForNotifications(noteIDs)
             }
 
             completion?(error)
@@ -232,7 +232,7 @@ class NotificationSyncMediator {
     ///     - completion: Callback to be executed on completion.
     ///
     func markAsReadAndSync(_ noteID: String, completion: ((Error?) -> Void)? = nil) {
-        invalidateCacheForNotification(with: noteID)
+        invalidateCacheForNotification(noteID)
         remote.updateReadStatus(noteID, read: true) { error in
             if let error = error {
                 DDLogError("Error marking note as read: \(error)")
@@ -281,13 +281,13 @@ class NotificationSyncMediator {
 
     /// Invalidates the local cache for the notification with the specified ID.
     ///
-    func invalidateCacheForNotification(with noteID: String) {
-        invalidateCacheForNotifications(with: [noteID])
+    func invalidateCacheForNotification(_ noteID: String) {
+        invalidateCacheForNotifications([noteID])
     }
 
     /// Invalidates the local cache for all the notifications with specified ID's in the array.
     ///
-    func invalidateCacheForNotifications(with noteIDs: [String]) {
+    func invalidateCacheForNotifications(_ noteIDs: [String]) {
         let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
 
         derivedContext.perform {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -893,7 +893,7 @@ private extension NotificationsViewController {
     /// Presents a confirmation action sheet for mark all as read action.
     @objc func showMarkAllAsReadConfirmation() {
         let title = NSLocalizedString(
-            "You are about to mark all notifications as read. Are you sure?",
+            "Mark all %1$@ notifications as read?",
             comment: "Confirmation title for marking all notifications as read."
         )
         let cancelTitle = NSLocalizedString(
@@ -901,11 +901,15 @@ private extension NotificationsViewController {
             comment: "Cancels the mark all as read action."
         )
         let markAllTitle = NSLocalizedString(
-            "Mark All As Read",
+            "Ok",
             comment: "Marks all notifications as read."
         )
 
-        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+        let alertController = UIAlertController(
+            title: String.localizedStringWithFormat(title, filter.confirmationMessageTitle),
+            message: nil,
+            preferredStyle: .alert
+        )
         alertController.view.accessibilityIdentifier = "mark-all-as-read-alert"
 
         alertController.addCancelActionWithTitle(cancelTitle)
@@ -1721,6 +1725,16 @@ private extension NotificationsViewController {
             case .comment:  return "Comments"
             case .follow:   return "Follows"
             case .like:     return "Likes"
+            }
+        }
+
+        var confirmationMessageTitle: String {
+            switch self {
+            case .none:     return NSLocalizedString("all", comment: "Filter all confirmation tab name")
+            case .unread:   return NSLocalizedString("unread", comment: "Filter unread confirmation tab name")
+            case .comment:  return NSLocalizedString("comment", comment: "Filter comments confirmation tab name")
+            case .follow:   return NSLocalizedString("follow", comment: "Filter follows confirmation tab name")
+            case .like:     return NSLocalizedString("like", comment: "Filter likes confirmation tab name")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -892,16 +892,28 @@ private extension NotificationsViewController {
 
     /// Presents a confirmation action sheet for mark all as read action.
     @objc func showMarkAllAsReadConfirmation() {
-        let title = NSLocalizedString(
-            "Mark all %1$@ notifications as read?",
-            comment: "Confirmation title for marking all notifications as read."
-        )
+        let title: String
+
+        switch filter {
+        case .none:
+            title = NSLocalizedString(
+                "Mark all notifications as read?",
+                comment: "Confirmation title for marking all notifications as read."
+            )
+
+        default:
+            title = NSLocalizedString(
+                "Mark all %1$@ notifications as read?",
+                comment: "Confirmation title for marking all notifications under a filter as read. %1$@ is replaced by the filter name."
+            )
+        }
+
         let cancelTitle = NSLocalizedString(
             "Cancel",
             comment: "Cancels the mark all as read action."
         )
         let markAllTitle = NSLocalizedString(
-            "Ok",
+            "OK",
             comment: "Marks all notifications as read."
         )
 
@@ -1730,11 +1742,11 @@ private extension NotificationsViewController {
 
         var confirmationMessageTitle: String {
             switch self {
-            case .none:     return NSLocalizedString("all", comment: "Filter all confirmation tab name")
-            case .unread:   return NSLocalizedString("unread", comment: "Filter unread confirmation tab name")
-            case .comment:  return NSLocalizedString("comment", comment: "Filter comments confirmation tab name")
-            case .follow:   return NSLocalizedString("follow", comment: "Filter follows confirmation tab name")
-            case .like:     return NSLocalizedString("like", comment: "Filter likes confirmation tab name")
+            case .none:     return ""
+            case .unread:   return NSLocalizedString("unread", comment: "Displayed in the confirmation alert when marking unread notifications as read.")
+            case .comment:  return NSLocalizedString("comment", comment: "Displayed in the confirmation alert when marking comment notifications as read.")
+            case .follow:   return NSLocalizedString("follow", comment: "Displayed in the confirmation alert when marking follow notifications as read.")
+            case .like:     return NSLocalizedString("like", comment: "Displayed in the confirmation alert when marking like notifications as read.")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -112,7 +112,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
             image: .gridicon(.checkmark),
             style: .plain,
             target: self,
-            action: #selector(markAllAsRead)
+            action: #selector(showMarkAllAsReadConfirmation)
         )
         markButton.accessibilityLabel = NSLocalizedString(
             "Mark All As Read",
@@ -888,6 +888,33 @@ private extension NotificationsViewController {
             ActionDispatcherFacade().dispatch(NoticeAction.post(notice))
             self?.updateMarkAllAsReadButton()
         })
+    }
+
+    /// Presents a confirmation action sheet for mark all as read action.
+    @objc func showMarkAllAsReadConfirmation() {
+        let title = NSLocalizedString(
+            "You are about to mark all notifications as read. Are you sure?",
+            comment: "Confirmation title for marking all notifications as read."
+        )
+        let cancelTitle = NSLocalizedString(
+            "Cancel",
+            comment: "Cancels the mark all as read action."
+        )
+        let markAllTitle = NSLocalizedString(
+            "Mark All As Read",
+            comment: "Marks all notifications as read."
+        )
+
+        let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
+        alertController.view.accessibilityIdentifier = "mark-all-as-read-alert"
+
+        alertController.addCancelActionWithTitle(cancelTitle)
+
+        alertController.addActionWithTitle(markAllTitle, style: .default) { [weak self] _ in
+            self?.markAllAsRead()
+        }
+
+        present(alertController, animated: true, completion: nil)
     }
 
     func markAsUnread(note: Notification) {


### PR DESCRIPTION
Ref #17135

This PR adds a confirmation action sheet to Mark All As Read button as @frosty suggested. Before the button would immediately mark as read but users will not immediately know the function of the button. So this will add a safety layer in between.

To test:
* Emable Mark All As Read feature flag
* Go to Notifications.
* Tap on checkmark button
* Check if a confirmation sheet is displayed. 
* Cancel action should cancel without any modification.
* Mark All As Read action should mark notifications under that filter as read.

## Regression Notes
1. Potential unintended areas of impact
One thing I noticed is that if one marks all notifications as read the NoticeView is displayed. As it takes some time to disappear, if we mark a notification as unread OR go to another filter and tap on the Mark button again, the sheet stays behind the NoticeView causing an ugly look. But I assume this is a known behavior as it appears on the top of the hierarchy.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
The change is in the UI layer. Testing the presentation would require refactoring outside of the scope this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.

https://user-images.githubusercontent.com/15968946/150876945-75068b45-dd71-4613-b3aa-5762b3c433f2.mp4

