### PR TITLE
My Site Dashboard: Add site picker to MySite screen only once

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -79,7 +79,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         get {
-            return blogDetailsViewController?.blog
+            guard FeatureFlag.mySiteDashboard.enabled else {
+                return blogDetailsViewController?.blog
+            }
+
+            return sitePickerViewController?.blog
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -530,13 +530,27 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func makeSitePickerViewController(for blog: Blog) -> SitePickerViewController {
         let sitePickerViewController = SitePickerViewController(blog: blog, meScenePresenter: meScenePresenter)
 
-        sitePickerViewController.onBlogSwitched = { [weak self] in
-            self?.blogDetailsViewController?.showInitialDetailsForBlog()
-            self?.blogDetailsViewController?.tableView.reloadData()
-            self?.blogDetailsViewController?.preloadMetadata()
+        sitePickerViewController.onBlogSwitched = { [weak self] blog in
+            self?.updateChildViewController(for: blog)
         }
 
         return sitePickerViewController
+    }
+
+    private func updateChildViewController(for blog: Blog) {
+        guard let section = Section(rawValue: segmentedControl.selectedSegmentIndex) else {
+            return
+        }
+
+        switch section {
+        case .siteMenu:
+            blogDetailsViewController?.blog = blog
+            blogDetailsViewController?.tableView.reloadData()
+            blogDetailsViewController?.preloadMetadata()
+        case .dashboard:
+            // TODO: Update blog dashboard vc
+            break
+        }
     }
 
     func presentCreateSheet() {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -143,6 +143,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             segmentedControl.insertSegment(withTitle: section.title, at: section.rawValue, animated: false)
         }
         segmentedControl.selectedSegmentIndex = 0
+
+        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
     }
 
     /// If the My Site Dashboard feature flag is enabled, then this method builds a layout with the following
@@ -265,9 +267,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
-    // MARK: - IBAction
+    // MARK: - Segmented Control
 
-    @IBAction func segmentedControlValueChanged(_ sender: Any) {
+    @objc private func segmentedControlValueChanged(_ sender: Any) {
         guard let blog = blog,
               let section = Section(rawValue: segmentedControl.selectedSegmentIndex) else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -10,7 +10,7 @@ final class SitePickerViewController: UIViewController {
 
     var siteIconPresenter: SiteIconPickerPresenter?
     var siteIconPickerPresenter: SiteIconPickerPresenter?
-    var onBlogSwitched: (() -> Void)?
+    var onBlogSwitched: ((Blog) -> Void)?
 
     let meScenePresenter: ScenePresenter
     let blogService: BlogService
@@ -134,14 +134,9 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
 extension SitePickerViewController {
 
     private func switchToBlog(_ blog: Blog) {
-        guard let parent = parent as? MySiteViewController else {
-            return
-        }
-
         self.blog = blog
-        parent.blog = blog
         blogDetailHeaderView.blog = blog
-        onBlogSwitched?()
+        onBlogSwitched?(blog)
     }
 
     private func showSiteTitleSettings() {


### PR DESCRIPTION
Fixes #17813

## Description

This PR fixes the following:
- A bug where a site picker was getting added to the layout every time a user switched sites
- A bug where the switching to the dashboard on the segmented control wasn't displaying the dashboard

## How to test

Make sure the My Site Dash feature flag is **enabled**.

### Site Picker should be added only once

1. Log out
2. Log in
3. Select a blog on the Login Epilogue
4. ✅ The site picker should show the blog you picked in the Login Epilogue
5. Tap on the site picker and pick a different site
6. ✅ The site picker should show the new blog to picked, and only one site picker should be visible

https://user-images.githubusercontent.com/6711616/151045531-6b520212-3778-4319-81f5-1de9c1544186.mp4

### Switching to the dashboard

1. On the My Site screen, switch to the dashboard
2. ✅ Dashboard should be displayed
3. Select a different site on the Site Picker (the dashboard will not be updated -- updating will be handled in a different PR)
4. Switch back to the site menu
5. ✅ The site menu should reflect the new site you selected in step 3

https://user-images.githubusercontent.com/6711616/151198353-cf056222-3cce-420f-907a-f396696f8c53.mp4

## Regression Notes
1. Potential unintended areas of impact
- MSD flag enabled, site picker after login
- MSD flag enabled, switching sites on the site picker

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
