### PR TITLE
Automate copying the Jetpack en-US release notes into the metadata

### DIFF
--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -158,7 +158,14 @@ lane :download_jetpack_localized_app_store_metadata do
   # internally.
   sh './download_metadata.swift jetpack'
 
-  jetpack_metadata_glob = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata/**/*.txt')
+  # GlotPress doesn't have the English notes because, being already in English,
+  # they do not require a translation. As such, we simply copy the source of
+  # truth file into the Fastlane metadata folder.
+  metadata_directory = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata')
+  release_notes_source = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
+  sh "cp #{release_notes_source} #{File.join(metadata_directory, 'en-US', 'release_notes.txt')}"
+
+  jetpack_metadata_glob = File.join(metadata_directory, '**/*.txt')
 
   no_files_changed = sh "git status #{jetpack_metadata_glob}" do |_, output, _|
     output.include? 'nothing to commit'

--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -163,7 +163,7 @@ lane :download_jetpack_localized_app_store_metadata do
   # truth file into the Fastlane metadata folder.
   metadata_directory = File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'jetpack_metadata')
   release_notes_source = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
-  sh "cp #{release_notes_source} #{File.join(metadata_directory, 'en-US', 'release_notes.txt')}"
+  FileUtils.cp(release_notes_source, File.join(metadata_directory, 'en-US', 'release_notes.txt'))
 
   jetpack_metadata_glob = File.join(metadata_directory, '**/*.txt')
 


### PR DESCRIPTION
This should be the final step in fully automating the Jetpack en-US release notes management.

For WordPress, the `download_translation.swift` script downloads up-to-date release notes for the en-US locale from GlotPress.org. That doesn't happen for Jetpack.

I think the reason has to do with GlotPress.org having other English locales, and our automation [picking one as the en-US source](https://github.com/wordpress-mobile/WordPress-iOS/blob/2842e6eab3c4cfa5e775b468166361afbdcec88a/fastlane/download_metadata.swift#L81). The GlotPress.com instance for Jetpack doesn't have any other English locale, so that doesn't happen.

In such case, copying the source of truth file into the Jetpack Fastlane metadata folder seems like a decent approach. In the long run, ideally as part of the Localization Tooling improvements project, we shall address the fact that we have hard copies of what should be a single source of truth in the codebase. In the meantime, an automated `cp` will reduce the chances of manual error.

## To test

I added a `UI.user_error!` in the lane that downloads the metadata and verified it `cp`s the expected file in the expected location.

```diff
--- a/fastlane/Jetpack-Fastfile
+++ b/fastlane/Jetpack-Fastfile
@@ -165,6 +165,7 @@ lane :download_jetpack_localized_app_store_metadata do
   release_notes_source = File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Jetpack', 'Resources', 'release_notes.txt')
   sh "cp #{release_notes_source} #{File.join(metadata_directory, 'en-US', 'release_notes.txt')}"
 
+  UI.user_error! ':P'
   jetpack_metadata_glob = File.join(metadata_directory, '**/*.txt')
 
   no_files_changed = sh "git status #{jetpack_metadata_glob}" do |_, output, _|
```


## Regression Notes
1. Potential unintended areas of impact. N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on). N.A.
3. What automated tests I added (or what prevented me from doing so). N.A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
