### PR TITLE
Add transition animation between login epilogue and quick start prompt screens

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -19,8 +19,8 @@ final class QuickStartPromptViewController: UIViewController {
 
     /// Constraints
     @IBOutlet private(set) weak var scrollViewTopVerticalConstraint: NSLayoutConstraint!
-    @IBOutlet weak var scrollViewLeadingConstraint: NSLayoutConstraint!
-    @IBOutlet weak var scrollViewTrailingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var scrollViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet private weak var scrollViewTrailingConstraint: NSLayoutConstraint!
 
     // MARK: - Properties
 
@@ -105,7 +105,7 @@ final class QuickStartPromptViewController: UIViewController {
     }
 
     private func setupScrollViewMargins() {
-        let margin = view.getHorizontalMargin() + 20.0
+        let margin = view.getHorizontalMargin() + Constants.marginPadding
         scrollViewLeadingConstraint.constant = margin
         scrollViewTrailingConstraint.constant = margin
     }
@@ -158,6 +158,10 @@ extension QuickStartPromptViewController {
         static let promptDescription = NSLocalizedString("Learn the basics with a quick walk through.", comment: "Description for a prompt asking if users want to try out the quick start checklist.")
         static let showMeAroundButtonTitle = NSLocalizedString("Show me around", comment: "Button title. When tapped, the quick start checklist will be shown.")
         static let noThanksButtonTitle = NSLocalizedString("No thanks", comment: "Button title. When tapped, the quick start checklist will not be shown, and the prompt will be dismissed.")
+    }
+
+    private enum Constants {
+        static let marginPadding = 20.0
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -19,6 +19,8 @@ final class QuickStartPromptViewController: UIViewController {
 
     /// Constraints
     @IBOutlet private(set) weak var scrollViewTopVerticalConstraint: NSLayoutConstraint!
+    @IBOutlet weak var scrollViewLeadingConstraint: NSLayoutConstraint!
+    @IBOutlet weak var scrollViewTrailingConstraint: NSLayoutConstraint!
 
     // MARK: - Properties
 
@@ -57,6 +59,11 @@ final class QuickStartPromptViewController: UIViewController {
         UIAccessibility.post(notification: .layoutChanged, argument: promptTitleLabel)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        setupScrollViewMargins()
+    }
+
     // MARK: - Styling
 
     private func applyStyles() {
@@ -91,9 +98,16 @@ final class QuickStartPromptViewController: UIViewController {
     // MARK: - Setup
 
     private func setup() {
+        setupScrollViewMargins()
         setupSiteInfoViews()
         setupPromptInfoViews()
         setupButtons()
+    }
+
+    private func setupScrollViewMargins() {
+        let margin = view.getHorizontalMargin() + 20.0
+        scrollViewLeadingConstraint.constant = margin
+        scrollViewTrailingConstraint.constant = margin
     }
 
     private func setupSiteInfoViews() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -10,12 +10,15 @@ final class QuickStartPromptViewController: UIViewController {
     @IBOutlet private weak var siteDescriptionLabel: UILabel!
 
     /// Prompt info
-    @IBOutlet private weak var promptTitleLabel: UILabel!
-    @IBOutlet private weak var promptDescriptionLabel: UILabel!
+    @IBOutlet private(set) weak var promptTitleLabel: UILabel!
+    @IBOutlet private(set) weak var promptDescriptionLabel: UILabel!
 
     /// Buttons
-    @IBOutlet private weak var showMeAroundButton: FancyButton!
-    @IBOutlet private weak var noThanksButton: FancyButton!
+    @IBOutlet private(set) weak var showMeAroundButton: FancyButton!
+    @IBOutlet private(set) weak var noThanksButton: FancyButton!
+
+    /// Constraints
+    @IBOutlet private(set) weak var scrollViewTopVerticalConstraint: NSLayoutConstraint!
 
     // MARK: - Properties
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
@@ -14,6 +14,7 @@
                 <outlet property="noThanksButton" destination="2uc-tK-alt" id="EyT-E0-oLS"/>
                 <outlet property="promptDescriptionLabel" destination="Kqr-FO-d5M" id="lbG-CU-xOm"/>
                 <outlet property="promptTitleLabel" destination="doQ-6M-3Uv" id="i5m-E1-5kU"/>
+                <outlet property="scrollViewTopVerticalConstraint" destination="0uM-8v-xeM" id="9iv-st-GfW"/>
                 <outlet property="showMeAroundButton" destination="0WF-fO-mti" id="MyR-dp-DjP"/>
                 <outlet property="siteDescriptionLabel" destination="T6b-Pg-T2k" id="Jbd-bS-EqF"/>
                 <outlet property="siteIconView" destination="5pl-dB-rPb" id="ovD-LF-JHV"/>
@@ -119,12 +120,12 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="w31-gj-Dsv" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="80" id="0uM-8v-xeM"/>
-                <constraint firstAttribute="trailingMargin" secondItem="w31-gj-Dsv" secondAttribute="trailing" id="51M-BA-Z8b"/>
-                <constraint firstAttribute="leadingMargin" secondItem="88c-8d-UbI" secondAttribute="leading" id="Qbc-f2-ZaH"/>
+                <constraint firstAttribute="trailing" secondItem="w31-gj-Dsv" secondAttribute="trailing" constant="20" id="51M-BA-Z8b"/>
+                <constraint firstItem="88c-8d-UbI" firstAttribute="leadingMargin" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="Qbc-f2-ZaH"/>
                 <constraint firstItem="88c-8d-UbI" firstAttribute="top" secondItem="w31-gj-Dsv" secondAttribute="bottom" constant="24" id="cEg-cI-kct"/>
-                <constraint firstAttribute="trailingMargin" secondItem="88c-8d-UbI" secondAttribute="trailing" id="daa-Gn-9WI"/>
+                <constraint firstAttribute="trailing" secondItem="88c-8d-UbI" secondAttribute="trailing" constant="20" id="daa-Gn-9WI"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="88c-8d-UbI" secondAttribute="bottom" constant="24" id="oQS-J2-RXn"/>
-                <constraint firstItem="w31-gj-Dsv" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leadingMargin" id="pfX-zX-22J"/>
+                <constraint firstItem="w31-gj-Dsv" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="pfX-zX-22J"/>
             </constraints>
             <point key="canvasLocation" x="132" y="76"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.xib
@@ -14,7 +14,9 @@
                 <outlet property="noThanksButton" destination="2uc-tK-alt" id="EyT-E0-oLS"/>
                 <outlet property="promptDescriptionLabel" destination="Kqr-FO-d5M" id="lbG-CU-xOm"/>
                 <outlet property="promptTitleLabel" destination="doQ-6M-3Uv" id="i5m-E1-5kU"/>
+                <outlet property="scrollViewLeadingConstraint" destination="pfX-zX-22J" id="dpf-mm-9K0"/>
                 <outlet property="scrollViewTopVerticalConstraint" destination="0uM-8v-xeM" id="9iv-st-GfW"/>
+                <outlet property="scrollViewTrailingConstraint" destination="51M-BA-Z8b" id="xdo-jm-Gb6"/>
                 <outlet property="showMeAroundButton" destination="0WF-fO-mti" id="MyR-dp-DjP"/>
                 <outlet property="siteDescriptionLabel" destination="T6b-Pg-T2k" id="Jbd-bS-EqF"/>
                 <outlet property="siteIconView" destination="5pl-dB-rPb" id="ovD-LF-JHV"/>
@@ -120,10 +122,10 @@
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="w31-gj-Dsv" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" constant="80" id="0uM-8v-xeM"/>
-                <constraint firstAttribute="trailing" secondItem="w31-gj-Dsv" secondAttribute="trailing" constant="20" id="51M-BA-Z8b"/>
-                <constraint firstItem="88c-8d-UbI" firstAttribute="leadingMargin" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="Qbc-f2-ZaH"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="w31-gj-Dsv" secondAttribute="trailing" constant="20" id="51M-BA-Z8b"/>
                 <constraint firstItem="88c-8d-UbI" firstAttribute="top" secondItem="w31-gj-Dsv" secondAttribute="bottom" constant="24" id="cEg-cI-kct"/>
-                <constraint firstAttribute="trailing" secondItem="88c-8d-UbI" secondAttribute="trailing" constant="20" id="daa-Gn-9WI"/>
+                <constraint firstItem="88c-8d-UbI" firstAttribute="trailing" secondItem="w31-gj-Dsv" secondAttribute="trailing" id="cNO-Zd-ImM"/>
+                <constraint firstItem="88c-8d-UbI" firstAttribute="leading" secondItem="w31-gj-Dsv" secondAttribute="leading" id="gQ4-1g-2Mu"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="88c-8d-UbI" secondAttribute="bottom" constant="24" id="oQS-J2-RXn"/>
                 <constraint firstItem="w31-gj-Dsv" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" constant="20" id="pfX-zX-22J"/>
             </constraints>

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueAnimator.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueAnimator.swift
@@ -1,0 +1,88 @@
+import UIKit
+
+final class LoginEpilogueAnimator: NSObject, UIViewControllerAnimatedTransitioning {
+
+    private enum Constants {
+        static let loginAnimationDuration = 0.3
+        static let loginAnimationScaleX = 1.0
+        static let loginAnimationScaleY = 1.2
+        static let quickStartAnimationDuration = 0.3
+        static let quickStartPromptStartAlpha = 0.2
+        static let quickStartTopEndConstraint = 80.0
+        static let hiddenAlpha = 0.0
+        static let visibleAlpha = 1.0
+    }
+
+    func transitionDuration(using transitionContext: UIViewControllerContextTransitioning?) -> TimeInterval {
+        return Constants.loginAnimationDuration + Constants.quickStartAnimationDuration
+    }
+
+    func animateTransition(using transitionContext: UIViewControllerContextTransitioning) {
+        guard let loginEpilogueViewController = transitionContext.viewController(forKey: .from) as? LoginEpilogueViewController,
+              let quickStartPromptViewController = transitionContext.viewController(forKey: .to) as? QuickStartPromptViewController,
+              let selectedCell = loginEpilogueViewController.tableViewController?.selectedCell else {
+                  return
+              }
+
+        let containerView = transitionContext.containerView
+        containerView.backgroundColor = loginEpilogueViewController.view.backgroundColor
+
+        let cellSnapshot = selectedCell.contentView.snapshotView(afterScreenUpdates: false)
+        let cellSnapshotFrame = containerView.convert(selectedCell.contentView.frame, from: selectedCell)
+        cellSnapshot?.frame = cellSnapshotFrame
+        selectedCell.contentView.alpha = Constants.hiddenAlpha
+
+        let loginContainer = UIView(frame: loginEpilogueViewController.view.frame)
+        let loginSnapshot = loginEpilogueViewController.view.snapshotView(afterScreenUpdates: true)
+        loginContainer.backgroundColor = loginEpilogueViewController.view.backgroundColor
+
+        if let loginSnapshot = loginSnapshot {
+            loginSnapshot.layer.anchorPoint = CGPoint(x: 0.5, y: cellSnapshotFrame.origin.y / loginContainer.bounds.height)
+            loginSnapshot.frame = loginContainer.frame
+            loginContainer.addSubview(loginSnapshot)
+            containerView.addSubview(loginContainer)
+        }
+
+        if let cellSnapshot = cellSnapshot {
+            containerView.addSubview(cellSnapshot)
+        }
+
+        quickStartPromptViewController.view.alpha = Constants.hiddenAlpha
+        let safeAreaTop = loginEpilogueViewController.view.safeAreaInsets.top
+        quickStartPromptViewController.scrollViewTopVerticalConstraint.constant = cellSnapshotFrame.origin.y - safeAreaTop
+        quickStartPromptViewController.promptTitleLabel.alpha = Constants.quickStartPromptStartAlpha
+        quickStartPromptViewController.promptDescriptionLabel.alpha = Constants.quickStartPromptStartAlpha
+        quickStartPromptViewController.showMeAroundButton.alpha = Constants.hiddenAlpha
+        quickStartPromptViewController.noThanksButton.alpha = Constants.hiddenAlpha
+        quickStartPromptViewController.view.layoutIfNeeded()
+        containerView.addSubview(quickStartPromptViewController.view)
+
+        let quickStartAnimator = UIViewPropertyAnimator(duration: Constants.quickStartAnimationDuration, curve: .easeInOut) {
+            quickStartPromptViewController.promptTitleLabel.alpha = Constants.visibleAlpha
+            quickStartPromptViewController.promptDescriptionLabel.alpha = Constants.visibleAlpha
+            quickStartPromptViewController.showMeAroundButton.alpha = Constants.visibleAlpha
+            quickStartPromptViewController.noThanksButton.alpha = Constants.visibleAlpha
+            quickStartPromptViewController.scrollViewTopVerticalConstraint.constant = Constants.quickStartTopEndConstraint
+            quickStartPromptViewController.view.layoutIfNeeded()
+        }
+
+        quickStartAnimator.addCompletion { position in
+            cellSnapshot?.alpha = Constants.hiddenAlpha
+            selectedCell.contentView.alpha = Constants.visibleAlpha
+            transitionContext.completeTransition(position == .end)
+        }
+
+        let loginAnimator = UIViewPropertyAnimator(duration: Constants.loginAnimationDuration, curve: .easeOut) {
+            loginSnapshot?.alpha = Constants.hiddenAlpha
+            loginSnapshot?.transform = CGAffineTransform(scaleX: Constants.loginAnimationScaleX, y: Constants.loginAnimationScaleY)
+        }
+
+        loginAnimator.addCompletion { _ in
+            quickStartPromptViewController.view.alpha = Constants.visibleAlpha
+            quickStartAnimator.startAnimation()
+        }
+
+        loginAnimator.startAnimation()
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueTableViewController.swift
@@ -7,6 +7,10 @@ import WordPressAuthenticator
 //
 class LoginEpilogueTableViewController: UITableViewController {
 
+    /// Currently selected cell
+    ///
+    private(set) weak var selectedCell: LoginEpilogueBlogCell?
+
     /// TableView's Datasource
     ///
     private let blogDataSource = BlogListDataSource()
@@ -185,13 +189,14 @@ extension LoginEpilogueTableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let parent = parent as? LoginEpilogueViewController,
-              tableView.cellForRow(at: indexPath) is LoginEpilogueBlogCell else {
+              let cell = tableView.cellForRow(at: indexPath) as? LoginEpilogueBlogCell else {
             return
         }
 
         let wrappedPath = IndexPath(row: indexPath.row, section: indexPath.section - 1)
         let blog = blogDataSource.blog(at: wrappedPath)
 
+        selectedCell = cell
         parent.blogSelected(blog)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -78,7 +78,7 @@ class LoginEpilogueViewController: UIViewController {
         view.backgroundColor = .basicBackground
         topLine.backgroundColor = .divider
         defaultTableViewMargin = tableViewLeadingConstraint.constant
-        setTableViewMargins(forWidth: view.frame.width)
+        setTableViewMargins()
         refreshInterface(with: credentials)
         WordPressAuthenticator.track(.loginEpilogueViewed)
 
@@ -117,12 +117,12 @@ class LoginEpilogueViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        setTableViewMargins(forWidth: size.width)
+        setTableViewMargins()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        setTableViewMargins(forWidth: view.frame.width)
+        setTableViewMargins()
     }
 
     func hideButtonPanel() {
@@ -172,22 +172,9 @@ private extension LoginEpilogueViewController {
         setupDividerLineIfNeeded()
     }
 
-    func setTableViewMargins(forWidth viewWidth: CGFloat) {
-        guard traitCollection.horizontalSizeClass == .regular &&
-            traitCollection.verticalSizeClass == .regular else {
-                tableViewLeadingConstraint.constant = defaultTableViewMargin
-                tableViewTrailingConstraint.constant = defaultTableViewMargin
-                return
-        }
-
-        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
-            TableViewMarginMultipliers.ipadLandscape :
-            TableViewMarginMultipliers.ipadPortrait
-
-        let margin = viewWidth * marginMultiplier
-
-        tableViewLeadingConstraint.constant = margin
-        tableViewTrailingConstraint.constant = margin
+    func setTableViewMargins() {
+        tableViewLeadingConstraint.constant = view.getHorizontalMargin(compactMargin: defaultTableViewMargin)
+        tableViewTrailingConstraint.constant = view.getHorizontalMargin(compactMargin: defaultTableViewMargin)
     }
 
     func setupDividerLineIfNeeded() {
@@ -202,11 +189,6 @@ private extension LoginEpilogueViewController {
             dividerView.topAnchor.constraint(equalTo: buttonPanel.topAnchor),
             dividerView.heightAnchor.constraint(equalToConstant: Constants.dividerViewHeight)
         ])
-    }
-
-    enum TableViewMarginMultipliers {
-        static let ipadPortrait: CGFloat = 0.1667
-        static let ipadLandscape: CGFloat = 0.25
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueViewController.swift
@@ -39,7 +39,7 @@ class LoginEpilogueViewController: UIViewController {
 
     /// Links to the Epilogue TableViewController
     ///
-    private var tableViewController: LoginEpilogueTableViewController?
+    private(set) var tableViewController: LoginEpilogueTableViewController?
 
     /// Analytics Tracker
     ///
@@ -218,4 +218,18 @@ private extension LoginEpilogueViewController {
     @IBAction func createANewSite() {
         createNewSite()
     }
+}
+
+// MARK: - UINavigationControllerDelegate
+
+extension LoginEpilogueViewController: UINavigationControllerDelegate {
+
+    func navigationController(_ navigationController: UINavigationController, animationControllerFor operation: UINavigationController.Operation, from fromVC: UIViewController, to toVC: UIViewController) -> UIViewControllerAnimatedTransitioning? {
+        guard operation == .push, fromVC is LoginEpilogueViewController, toVC is QuickStartPromptViewController else {
+            return nil
+        }
+
+        return LoginEpilogueAnimator()
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueViewController.swift
@@ -42,7 +42,7 @@ class SignupEpilogueViewController: UIViewController {
         view.backgroundColor = .basicBackground
         defaultTableViewMargin = tableViewLeadingConstraint.constant
         configureDoneButton()
-        setTableViewMargins(forWidth: view.frame.width)
+        setTableViewMargins()
 
         WordPressAuthenticator.track(.signupEpilogueViewed, properties: tracksProperties())
     }
@@ -54,12 +54,12 @@ class SignupEpilogueViewController: UIViewController {
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
-        setTableViewMargins(forWidth: size.width)
+        setTableViewMargins()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        setTableViewMargins(forWidth: view.frame.width)
+        setTableViewMargins()
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
@@ -142,23 +142,9 @@ private extension SignupEpilogueViewController {
         doneButton.accessibilityIdentifier = ButtonTitle.accessibilityId
     }
 
-    func setTableViewMargins(forWidth viewWidth: CGFloat) {
-
-        guard traitCollection.horizontalSizeClass == .regular &&
-            traitCollection.verticalSizeClass == .regular else {
-                tableViewLeadingConstraint.constant = defaultTableViewMargin
-                tableViewTrailingConstraint.constant = defaultTableViewMargin
-                return
-        }
-
-        let marginMultiplier = UIDevice.current.orientation.isLandscape ?
-            TableViewMarginMultipliers.ipadLandscape :
-            TableViewMarginMultipliers.ipadPortrait
-
-        let margin = viewWidth * marginMultiplier
-
-        tableViewLeadingConstraint.constant = margin
-        tableViewTrailingConstraint.constant = margin
+    func setTableViewMargins() {
+        tableViewLeadingConstraint.constant = view.getHorizontalMargin(compactMargin: defaultTableViewMargin)
+        tableViewTrailingConstraint.constant = view.getHorizontalMargin(compactMargin: defaultTableViewMargin)
     }
 
     @IBAction func doneButtonPressed() {
@@ -315,11 +301,6 @@ private extension SignupEpilogueViewController {
         }()
 
         return ["source": source]
-    }
-
-    enum TableViewMarginMultipliers {
-        static let ipadPortrait: CGFloat = 0.1667
-        static let ipadLandscape: CGFloat = 0.25
     }
 
     enum ButtonTitle {

--- a/WordPress/Classes/ViewRelated/NUX/UIView+Margins.swift
+++ b/WordPress/Classes/ViewRelated/NUX/UIView+Margins.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+extension UIView {
+
+    func getHorizontalMargin(compactMargin: CGFloat = 0.0) -> CGFloat {
+        guard traitCollection.verticalSizeClass == .regular,
+              traitCollection.horizontalSizeClass == .regular else {
+                  return compactMargin
+              }
+
+        let isLandscape = UIDevice.current.orientation.isLandscape
+        let multiplier: CGFloat = isLandscape ? .ipadLandscape : .ipadPortrait
+
+        return frame.width * multiplier
+    }
+
+}
+
+private extension CGFloat {
+
+    static let ipadPortrait: CGFloat = 0.1667
+    static let ipadLandscape: CGFloat = 0.25
+
+}

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -388,6 +388,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "login_epilogue"])
         }
 
+        navigationController.delegate = epilogueViewController
         navigationController.pushViewController(epilogueViewController, animated: true)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1356,6 +1356,8 @@
 		82FC612C1FA8B7FC00A1757E /* ActivityListRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FC612B1FA8B7FC00A1757E /* ActivityListRow.swift */; };
 		82FFBF4D1F434BDA00F4573F /* ThemeIdHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82FFBF4C1F434BDA00F4573F /* ThemeIdHelper.swift */; };
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
+		830A58D82793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
+		830A58D92793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
@@ -5967,6 +5969,7 @@
 		82FFBF4C1F434BDA00F4573F /* ThemeIdHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeIdHelper.swift; sourceTree = "<group>"; };
 		82FFBF4E1F45E03D00F4573F /* WordPress 66.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 66.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
+		830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueAnimator.swift; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
 		834CE7331256D0DE0046A4A3 /* CFNetwork.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
@@ -8508,7 +8511,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -13991,6 +13994,7 @@
 			isa = PBXGroup;
 			children = (
 				B560914B208A671E00399AE4 /* WPStyleGuide+SiteCreation.swift */,
+				830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */,
 				E6158AC91ECDF518005FA441 /* LoginEpilogueUserInfo.swift */,
 				B5E51B7A203477DF00151ECD /* WordPressAuthenticationManager.swift */,
 				B5326E6E203F554C007392C3 /* WordPressSupportSourceTag+Helpers.swift */,
@@ -15299,7 +15303,7 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
@@ -17234,6 +17238,7 @@
 				D816C1EE20E0892200C4D82F /* Follow.swift in Sources */,
 				3F3DD0B226FD176800F5F121 /* PresentationCard.swift in Sources */,
 				822D60B91F4CCC7A0016C46D /* BlogJetpackSettingsService.swift in Sources */,
+				830A58D82793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */,
 				08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */,
 				B526DC291B1E47FC002A8C5F /* WPStyleGuide+WebView.m in Sources */,
 				3F6DA04125646F96002AB88F /* HomeWidgetData.swift in Sources */,
@@ -20194,6 +20199,7 @@
 				FABB24232602FC2C00C8785C /* JetpackRestoreService.swift in Sources */,
 				FABB24242602FC2C00C8785C /* DateAndTimeFormatSettingsViewController.swift in Sources */,
 				FABB24252602FC2C00C8785C /* WPContentSyncHelper.swift in Sources */,
+				830A58D92793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */,
 				FABB24262602FC2C00C8785C /* SiteAssemblyStep.swift in Sources */,
 				FABB24272602FC2C00C8785C /* SiteSettingsViewController+Swift.swift in Sources */,
 				FABB24282602FC2C00C8785C /* FilterTableData.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1362,6 +1362,8 @@
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
+		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
+		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
@@ -5982,6 +5984,7 @@
 		835E2402126E66E50085940B /* AssetsLibrary.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		8370D10811FA499A009D650F /* WPTableViewActivityCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableViewActivityCell.h; sourceTree = "<group>"; };
 		8370D10911FA499A009D650F /* WPTableViewActivityCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableViewActivityCell.m; sourceTree = "<group>"; };
+		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
@@ -13998,6 +14001,7 @@
 				E6158AC91ECDF518005FA441 /* LoginEpilogueUserInfo.swift */,
 				B5E51B7A203477DF00151ECD /* WordPressAuthenticationManager.swift */,
 				B5326E6E203F554C007392C3 /* WordPressSupportSourceTag+Helpers.swift */,
+				839B150A2795DEE0009F5E77 /* UIView+Margins.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -17131,6 +17135,7 @@
 				9A2B28EE2191B50500458F2A /* RevisionsTableViewFooter.swift in Sources */,
 				F5A34BCB25DF244F00C9654B /* KanvasCameraAnalyticsHandler.swift in Sources */,
 				8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */,
+				839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */,
 				17F52DB72315233300164966 /* WPStyleGuide+FilterTabBar.swift in Sources */,
 				E1DD4CCB1CAE41B800C3863E /* PagedViewController.swift in Sources */,
 				B549BA681CF7447E0086C608 /* InvitePersonViewController.swift in Sources */,
@@ -20259,6 +20264,7 @@
 				FABB24572602FC2C00C8785C /* CheckmarkTableViewCell.swift in Sources */,
 				FABB24582602FC2C00C8785C /* ReaderManageScenePresenter.swift in Sources */,
 				FABB24592602FC2C00C8785C /* MediaService.swift in Sources */,
+				839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */,
 				FABB245A2602FC2C00C8785C /* TopViewedPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB245B2602FC2C00C8785C /* PostMetaButton.m in Sources */,
 				FABB245C2602FC2C00C8785C /* PluginStore+Persistence.swift in Sources */,


### PR DESCRIPTION
Original PR: #17778

See #17647

To test:

- Fresh install the app
- Login to your WordPress account
- Select personal blog from list
- Observe transition animation to the quick start prompt

## Preview

https://user-images.githubusercontent.com/2454408/149838404-bfe799b9-7b8b-4df7-89c2-1d8f1a3d9d98.mp4

https://user-images.githubusercontent.com/2454408/149838599-2e354af1-4485-42ff-a34c-c9f21285e0a0.mp4

## Regression Notes

1. Potential unintended areas of impact
Margins for the login and sign up screens from the refactor

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked the screens on both an iPhone and iPad to verify the margins are still correct.

3. What automated tests I added (or what prevented me from doing so)
None. Unfortunately, testing animations is rather difficult and doesn't add much value.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.