### PR TITLE
My Site Dashboard: Convert rootview to scrollview

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -17,8 +17,8 @@ final class BlogDashboardViewController: UIViewController {
     typealias Snapshot = NSDiffableDataSourceSnapshot<Section, String>
     typealias QuickLinksHostCell = HostCollectionViewCell<QuickLinksView>
 
-    private lazy var collectionView: UICollectionView = {
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+    private lazy var collectionView: IntrinsicCollectionView = {
+        let collectionView = IntrinsicCollectionView(frame: .zero, collectionViewLayout: createLayout())
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         return collectionView
     }()
@@ -50,6 +50,9 @@ final class BlogDashboardViewController: UIViewController {
         setupCollectionView()
         applySnapshotForInitialData()
         addHeightObservers()
+
+        // Force the view to update its layout immediately, so the content size is calculated correctly
+        collectionView.layoutIfNeeded()
     }
 
     private func setupCollectionView() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -56,6 +56,7 @@ final class BlogDashboardViewController: UIViewController {
     }
 
     private func setupCollectionView() {
+        collectionView.isScrollEnabled = false
         collectionView.backgroundColor = .listBackground
         collectionView.register(QuickLinksHostCell.self, forCellWithReuseIdentifier: QuickLinksHostCell.defaultReuseID)
         collectionView.register(DashboardPostsCardCell.self, forCellWithReuseIdentifier: DashboardPostsCardCell.defaultReuseID)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -137,7 +137,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic, strong, nonnull) Blog * blog;
 @property (nonatomic, strong) id<ScenePresenter> _Nonnull meScenePresenter;
 @property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;
-@property (nonatomic, strong, readwrite) IntrinsicTableView * _Nonnull tableView;
+@property (nonatomic, strong, readwrite) UITableView * _Nonnull tableView;
 @property (nonatomic, strong, readonly) BlogDetailHeaderView * _Nonnull headerView;
 @property (nonatomic) BOOL shouldScrollToViewSite;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -3,6 +3,7 @@
 @class Blog;
 @class BlogDetailHeaderView;
 @class CreateButtonCoordinator;
+@class IntrinsicTableView;
 @protocol BlogDetailHeader;
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
@@ -136,7 +137,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic, strong, nonnull) Blog * blog;
 @property (nonatomic, strong) id<ScenePresenter> _Nonnull meScenePresenter;
 @property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;
-@property (nonatomic, strong, readwrite) UITableView * _Nonnull tableView;
+@property (nonatomic, strong, readwrite) IntrinsicTableView * _Nonnull tableView;
 @property (nonatomic, strong, readonly) BlogDetailHeaderView * _Nonnull headerView;
 @property (nonatomic) BOOL shouldScrollToViewSite;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -326,7 +326,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidLoad];
     
-    _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+    _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -327,6 +327,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [super viewDidLoad];
     
     _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+    self.tableView.scrollEnabled = false;
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -326,8 +326,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidLoad];
     
-    _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
-    self.tableView.scrollEnabled = false;
+    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+        _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+        self.tableView.scrollEnabled = false;
+    } else {
+        _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleGrouped];
+    }
+    
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -17,6 +17,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        return scrollView
+    }()
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -38,12 +44,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         let segmentedControl = UISegmentedControl()
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         return segmentedControl
-    }()
-
-    private lazy var containerView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
     }()
 
     private let meScenePresenter: ScenePresenter
@@ -105,6 +105,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - View Lifecycle
 
     override func viewDidLoad() {
+        view.backgroundColor = .listBackground
         setupConstraints()
         setupNavigationItem()
         setupSegmentedControl()
@@ -154,28 +155,32 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     /// If the My Site Dashboard feature flag is enabled, then this method builds a layout with the following
     /// view hierarchy:
     ///
-    /// - Stack view
-    ///   - Segmented control container view
-    ///      - Segmented control
-    ///   - Container view (for a child vc)
+    /// - Scroll view
+    ///   - Stack view
+    ///     - Segmented control container view
+    ///       - Segmented control
+    ///     - Child view controller
     ///
     /// Otherwise, if the My Site Dashboard feature flag is disabled, this method does nothing and the
-    /// child vc get added directly to the root view of the view controller in showBlogDetails.
+    /// child vc is added directly to the root view of the view controller in showBlogDetails.
     /// 
     private func setupConstraints() {
         guard FeatureFlag.mySiteDashboard.enabled else {
             return
         }
 
-        view.addSubview(stackView)
+        view.addSubview(scrollView)
+        scrollView.addSubview(stackView)
+        scrollView.pinSubviewToAllEdges(stackView)
         segmentedControlContainerView.addSubview(segmentedControl)
-        stackView.addArrangedSubviews([segmentedControlContainerView, containerView])
+        stackView.addArrangedSubviews([segmentedControlContainerView])
 
         NSLayoutConstraint.activate([
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            stackView.widthAnchor.constraint(equalTo: view.widthAnchor),
             segmentedControl.centerXAnchor.constraint(equalTo: segmentedControlContainerView.centerXAnchor),
             segmentedControl.centerYAnchor.constraint(equalTo: segmentedControlContainerView.centerYAnchor),
             segmentedControl.topAnchor.constraint(equalTo: segmentedControlContainerView.topAnchor, constant: 24)
@@ -289,19 +294,16 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             }
             remove(blogDetailVC)
             blogDashboardViewController.blog = blog
-            embedChildInContainerView(blogDashboardViewController)
+            embedChildInStackView(blogDashboardViewController)
         }
     }
 
     // MARK: - Child VC logic
 
-    private func embedChildInContainerView(_ child: UIViewController) {
+    private func embedChildInStackView(_ child: UIViewController) {
         addChild(child)
-        containerView.addSubview(child.view)
+        stackView.addArrangedSubview(child.view)
         child.didMove(toParent: self)
-
-        child.view.translatesAutoresizingMaskIntoConstraints = false
-        containerView.pinSubviewToAllEdges(child.view)
     }
 
     // MARK: - No Sites UI logic
@@ -482,7 +484,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         addMeButtonToNavigationBar(email: blog.account?.email, meScenePresenter: meScenePresenter)
 
         if FeatureFlag.mySiteDashboard.enabled {
-            embedChildInContainerView(blogDetailsViewController)
+            embedChildInStackView(blogDetailsViewController)
         } else {
             add(blogDetailsViewController)
             blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -36,7 +36,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private lazy var segmentedControlContainerView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.backgroundColor = .basicBackground
         return view
     }()
 
@@ -181,9 +180,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             stackView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            segmentedControl.leadingAnchor.constraint(equalTo: segmentedControlContainerView.leadingAnchor,
+                                                      constant: Constants.segmentedControlXOffset),
             segmentedControl.centerXAnchor.constraint(equalTo: segmentedControlContainerView.centerXAnchor),
-            segmentedControl.centerYAnchor.constraint(equalTo: segmentedControlContainerView.centerYAnchor),
-            segmentedControl.topAnchor.constraint(equalTo: segmentedControlContainerView.topAnchor, constant: 24)
+            segmentedControl.topAnchor.constraint(equalTo: segmentedControlContainerView.topAnchor,
+                                                  constant: Constants.segmentedControlYOffset),
+            segmentedControl.bottomAnchor.constraint(equalTo: segmentedControlContainerView.bottomAnchor)
         ])
     }
 
@@ -629,6 +631,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         self.blog = blog
+    }
+
+    private enum Constants {
+        static let segmentedControlXOffset: CGFloat = 16
+        static let segmentedControlYOffset: CGFloat = 24
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -656,7 +656,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private enum Constants {
-        static let segmentedControlXOffset: CGFloat = 16
+        static let segmentedControlXOffset: CGFloat = 20
         static let segmentedControlYOffset: CGFloat = 24
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -9,7 +9,7 @@ import Foundation
 ///     -   https://developer.apple.com/library/ios/technotes/tn2154/_index.html#//apple_ref/doc/uid/DTS40013309
 ///     -   http://stackoverflow.com/questions/17334478/uitableview-within-uiscrollview-using-autolayout
 ///
-class IntrinsicTableView: UITableView {
+@objc class IntrinsicTableView: UITableView {
     override var contentSize: CGSize {
         didSet {
             self.invalidateIntrinsicContentSize()

--- a/WordPress/Classes/ViewRelated/Views/IntrinsicCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Views/IntrinsicCollectionView.swift
@@ -1,0 +1,17 @@
+import UIKit
+
+/// This UICollectionView subclass allows us to use UIStackView along with Collection Views. Intrinsic Content Size
+/// will be automatically calculated, based on the Collection View's Content Size.
+///
+@objc class IntrinsicCollectionView: UICollectionView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        if bounds.size != intrinsicContentSize {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    override var intrinsicContentSize: CGSize {
+        return collectionViewLayout.collectionViewContentSize
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2719,6 +2719,8 @@
 		FA1A544025A6E3080033967D /* RestoreWarningView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1A543F25A6E3080033967D /* RestoreWarningView.xib */; };
 		FA1A55EF25A6F0740033967D /* RestoreStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */; };
 		FA1A55FF25A6F07F0033967D /* RestoreStatusView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1A55FE25A6F07F0033967D /* RestoreStatusView.xib */; };
+		FA1A5FD427A1A920001A38D8 /* IntrinsicCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A5FD327A1A91F001A38D8 /* IntrinsicCollectionView.swift */; };
+		FA1A5FD527A1A920001A38D8 /* IntrinsicCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1A5FD327A1A91F001A38D8 /* IntrinsicCollectionView.swift */; };
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA1CEAC225CA9C2A005E7038 /* RestoreStatusFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1CEAC125CA9C2A005E7038 /* RestoreStatusFailedView.swift */; };
 		FA1CEAD425CA9C40005E7038 /* RestoreStatusFailedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1CEAD325CA9C40005E7038 /* RestoreStatusFailedView.xib */; };
@@ -7472,6 +7474,7 @@
 		FA1A543F25A6E3080033967D /* RestoreWarningView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreWarningView.xib; sourceTree = "<group>"; };
 		FA1A55EE25A6F0740033967D /* RestoreStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusView.swift; sourceTree = "<group>"; };
 		FA1A55FE25A6F07F0033967D /* RestoreStatusView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreStatusView.xib; sourceTree = "<group>"; };
+		FA1A5FD327A1A91F001A38D8 /* IntrinsicCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntrinsicCollectionView.swift; sourceTree = "<group>"; };
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA1CEAC125CA9C2A005E7038 /* RestoreStatusFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusFailedView.swift; sourceTree = "<group>"; };
 		FA1CEAD325CA9C40005E7038 /* RestoreStatusFailedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreStatusFailedView.xib; sourceTree = "<group>"; };
@@ -7948,6 +7951,7 @@
 				32F2565F25012D3F006B8BC4 /* LinearGradientView.swift */,
 				F18CB8952642E58700B90794 /* FixedSizeImageView.swift */,
 				FADFBD25265F580500039C41 /* MultilineButton.swift */,
+				FA1A5FD327A1A91F001A38D8 /* IntrinsicCollectionView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -17736,6 +17740,7 @@
 				9A1A67A622B2AD4E00FF8422 /* CountriesMap.swift in Sources */,
 				439F4F3A219B715300F8D0C7 /* RevisionsNavigationController.swift in Sources */,
 				40F46B6A22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift in Sources */,
+				FA1A5FD427A1A920001A38D8 /* IntrinsicCollectionView.swift in Sources */,
 				17D5C3F71FFCF2D800EB70FF /* MediaProgressCoordinatorNoticeViewModel.swift in Sources */,
 				46F584822624DCC80010A723 /* BlockEditorSettingsService.swift in Sources */,
 				984B139221F66AC60004B6A2 /* SiteStatsPeriodViewModel.swift in Sources */,
@@ -20685,6 +20690,7 @@
 				FABB25A02602FC2C00C8785C /* UINavigationBar+Appearance.swift in Sources */,
 				FABB25A12602FC2C00C8785C /* QuickStartChecklistViewController.swift in Sources */,
 				FABB25A22602FC2C00C8785C /* MenuItemsViewController.m in Sources */,
+				FA1A5FD527A1A920001A38D8 /* IntrinsicCollectionView.swift in Sources */,
 				FABB25A32602FC2C00C8785C /* ReachabilityUtils+OnlineActions.swift in Sources */,
 				FABB25A42602FC2C00C8785C /* TableViewKeyboardObserver.swift in Sources */,
 				FABB25A52602FC2C00C8785C /* BlogToJetpackAccount.m in Sources */,


### PR DESCRIPTION
Part of #17786

## Description

This PR converts the root view of the MySiteVC from a stack view to a scroll view. The new view tree looks like this:

```
 - Scroll view
     - Stack view
         - Site Picker view controller 
         - Segmented control container view
             - Segmented control
         - Child view controller (either Blog Details or Blog Dashboard)
```

Since the root view is now a scroll view, this means two things:
1. The table view in BlogDetailsVC and the collection view in BlogDashboardVC are now self-sizing (i.e. IntrinsicTableView / IntrinsicCollectionView)
2. The scroll for the table view / collection view have been disabled

## Notes
- Changes are hidden behind a feature flag
- **To be addressed later:** Quick start tours don't scroll to the correct row in the BlogDetailsVC
- **To be addressed later:** The FAB is only visible if you scroll all the way to the bottom of BlogDetailsVC
- **Known issue:** When you first switch to the dashboard, the quick links cell layout is incorrect. The layout fixes itself when you switch back to the site menu, then go back to the dashboard. Since the quick links cell is a placeholder, I'll investigate this issue when I start working on quick links.

## How to test

### MSD feature flag disabled

1. Scroll around on My Site
2. ✅ No regressions

https://user-images.githubusercontent.com/6711616/151217200-465c2102-ec01-4ec2-bebd-6c742eb3f1c9.mp4


### MSD feature flag enabled

1. Scroll on My Site
2. ✅ Notice that the whole screen scrolls
3. Tap around on some cells
4. ✅ The correct screen should be displayed
5. Switch to the dashboard
6. ✅ The dashboard should load the quick links cell and the posts cells

https://user-images.githubusercontent.com/6711616/151217039-295e4b81-b9ae-43f6-9aa8-7101ae391050.mp4


## Regression Notes
1. Potential unintended areas of impact
- MSD flag disabled -> My Site screen scrolling, FAB position
- MSD flag enabled -> Child vc's not being displayed correctly

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps manually

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
