### PR TITLE
Enable media picker permissions feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -71,7 +71,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .followConversationPostDetails:
             return true
         case .mediaPickerPermissionsNotice:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 


### PR DESCRIPTION
This PR enables the feature flag for the [new media picker permissions header](https://github.com/wordpress-mobile/WordPress-iOS/pull/17754).

### To test

* Build and run
* If you haven't already given permission to access your device's media, navigate to Media and tap the + button and then "Choose from my device". Somewhere along the way you'll be asked by a system dialog to grant access. Choose Select Photos, and pick a couple of images.
* In the media picker, ensure you see a header at the top shown in the PR linked above, prompting you to edit your photo selection.

* Alternatively, if you have already granted permission, head to System Settings > WordPress > Photos and ensure Selected Photos is selected.
* Back in the app, go to Media and tap the + button and then "Choose from my device". 
* In the media picker, ensure you see a header at the top shown in the PR linked above, prompting you to edit your photo selection.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
