### PR TITLE
My Site Dashboard: pull to refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -160,4 +160,5 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)uploadDroppedSiteIcon:(nonnull UIImage *)image onCompletion:(nullable void(^)(void))completion;
 - (void)updateTableViewAndHeader;
 - (void)preloadMetadata;
+- (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl  onCompletion:(nullable void(^)(void))completion;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -2034,18 +2034,20 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 }
 
 #pragma mark - Pull To Refresh
-
 - (void)pulledToRefresh {
-    __weak __typeof(self) weakSelf = self;
-    
+    [self pulledToRefreshWith:self.tableView.refreshControl onCompletion:^{}];
+}
+
+- (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl onCompletion:( void(^)(void))completion {
+
     [self updateTableViewAndHeader: ^{
         // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
         // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
         // down to refresh the site.
         dispatch_async(dispatch_get_main_queue(), ^(void){
-            __strong __typeof(weakSelf) strongSelf = weakSelf;
+            [refreshControl endRefreshing];
             
-            [strongSelf.tableView.refreshControl endRefreshing];
+            completion();
         });
     }];
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -309,7 +309,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     private func pulledToRefresh() {
-        blogDetailsViewController?.pulledToRefresh(with: refreshControl) {
+        blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
+            guard let self = self else {
+                return
+            }
+            
             self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -313,7 +313,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             guard let self = self else {
                 return
             }
-            
+
             self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -198,7 +198,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         NSLayoutConstraint.activate([
             scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             stackView.widthAnchor.constraint(equalTo: view.widthAnchor),
             segmentedControl.leadingAnchor.constraint(equalTo: segmentedControlContainerView.leadingAnchor,

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -20,6 +20,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.refreshControl = refreshControl
         return scrollView
     }()
 
@@ -43,6 +44,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         let segmentedControl = UISegmentedControl()
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         return segmentedControl
+    }()
+
+    private lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(pulledToRefresh), for: .valueChanged)
+        return refreshControl
     }()
 
     private let meScenePresenter: ScenePresenter
@@ -297,6 +304,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             finishSync()
         } failure: { (error) in
             finishSync()
+        }
+    }
+
+    @objc
+    private func pulledToRefresh() {
+        blogDetailsViewController?.pulledToRefresh(with: refreshControl) {
+            self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
         }
     }
 


### PR DESCRIPTION
Adds pull to refresh to `MySiteViewController`.

### To test

Open wordpress.com in a browser and go to your blog settings, keep it opened.

## How to test

### MSD feature flag disabled

1. Open the app
2. Change the name of your blog on your browser
3. Pull to refresh
4. The title change should be reflected

### MSD feature flag enabled

1. Open the app
2. Change the name of your blog on your browser
3. Pull to refresh
4. The title change should be reflected

## Regression Notes
1. Potential unintended areas of impact
Currently My Site.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
