### PR TITLE
Remove an unused return statement from FeatureFlags

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -48,7 +48,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .siteIconCreator:
             return BuildConfiguration.current != .appStore
-            return true
         case .weeklyRoundup:
             return true
         case .weeklyRoundupStaticNotification:


### PR DESCRIPTION
This PR simply removes an extra return statement that was present in the FeatureFlags file, and which was causing warnings.

### To test

This is a very simple change, so I think we can just review the code and check the app builds and runs.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
