### PR TITLE
My Site Dashboard: Hide segmented control for self-hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -152,7 +152,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func setupSegmentedControl(for blog: Blog) {
-        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isHostedAtWPcom
+        guard FeatureFlag.mySiteDashboard.enabled else {
+            return
+        }
+        segmentedControlContainerView.isHidden = !blog.isHostedAtWPcom || UIDevice.isPad()
+
     }
 
     private func setupView() {
@@ -566,6 +570,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         switch section {
         case .siteMenu:
             blogDetailsViewController?.blog = blog
+            blogDetailsViewController?.showInitialDetailsForBlog()
             blogDetailsViewController?.tableView.reloadData()
             blogDetailsViewController?.preloadMetadata()
         case .dashboard:

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -77,7 +77,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
             addSitePickerIfNeeded(for: newBlog)
             showBlogDetails(for: newBlog)
-            setupSegmentedControl(for: newBlog)
+            updateSegmentedControl(for: newBlog)
         }
 
         get {
@@ -151,12 +151,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
     }
 
-    private func setupSegmentedControl(for blog: Blog) {
+    private func updateSegmentedControl(for blog: Blog) {
         guard FeatureFlag.mySiteDashboard.enabled else {
             return
         }
-        segmentedControlContainerView.isHidden = !blog.isHostedAtWPcom || UIDevice.isPad()
 
+        // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device is an iPad
+        segmentedControlContainerView.isHidden = !blog.isAccessibleThroughWPCom() || UIDevice.isPad()
     }
 
     private func setupView() {
@@ -279,7 +280,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         addSitePickerIfNeeded(for: mainBlog)
         showBlogDetails(for: mainBlog)
-        setupSegmentedControl(for: mainBlog)
+        updateSegmentedControl(for: mainBlog)
     }
 
     @objc
@@ -556,6 +557,14 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         let sitePickerViewController = SitePickerViewController(blog: blog, meScenePresenter: meScenePresenter)
 
         sitePickerViewController.onBlogSwitched = { [weak self] blog in
+
+            let isShowingDashboard = self?.segmentedControl.selectedSegmentIndex == Section.dashboard.rawValue
+            if !blog.isAccessibleThroughWPCom() && isShowingDashboard {
+                self?.segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
+                self?.segmentedControl.sendActions(for: .valueChanged)
+            }
+
+            self?.updateSegmentedControl(for: blog)
             self?.updateChildViewController(for: blog)
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -40,8 +40,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }()
 
     private lazy var segmentedControl: UISegmentedControl = {
-        let segmentedControl = UISegmentedControl()
+        let segmentedControl = UISegmentedControl(items: Section.allCases.map { $0.title })
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
+        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
+        segmentedControl.selectedSegmentIndex = 0
         return segmentedControl
     }()
 
@@ -75,6 +77,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
             addSitePickerIfNeeded(for: newBlog)
             showBlogDetails(for: newBlog)
+            setupSegmentedControl(for: newBlog)
         }
 
         get {
@@ -107,7 +110,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         setupView()
         setupConstraints()
         setupNavigationItem()
-        setupSegmentedControl()
         subscribeToPostSignupNotifications()
         subscribeToModelChanges()
     }
@@ -149,16 +151,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
     }
 
-    private func setupSegmentedControl() {
-        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled
-
-        segmentedControl.removeAllSegments()
-        Section.allCases.forEach { section in
-            segmentedControl.insertSegment(withTitle: section.title, at: section.rawValue, animated: false)
-        }
-        segmentedControl.selectedSegmentIndex = 0
-
-        segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
+    private func setupSegmentedControl(for blog: Blog) {
+        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isHostedAtWPcom
     }
 
     private func setupView() {
@@ -281,6 +275,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         addSitePickerIfNeeded(for: mainBlog)
         showBlogDetails(for: mainBlog)
+        setupSegmentedControl(for: mainBlog)
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -17,6 +17,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
+    private var isShowingDashboard: Bool {
+        return segmentedControl.selectedSegmentIndex == Section.dashboard.rawValue
+    }
+
     private lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
@@ -558,14 +562,17 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         sitePickerViewController.onBlogSwitched = { [weak self] blog in
 
-            let isShowingDashboard = self?.segmentedControl.selectedSegmentIndex == Section.dashboard.rawValue
-            if !blog.isAccessibleThroughWPCom() && isShowingDashboard {
-                self?.segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
-                self?.segmentedControl.sendActions(for: .valueChanged)
+            guard let self = self else {
+                return
             }
 
-            self?.updateSegmentedControl(for: blog)
-            self?.updateChildViewController(for: blog)
+            if !blog.isAccessibleThroughWPCom() && self.isShowingDashboard {
+                self.segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
+                self.segmentedControl.sendActions(for: .valueChanged)
+            }
+
+            self.updateSegmentedControl(for: blog)
+            self.updateChildViewController(for: blog)
         }
 
         return sitePickerViewController


### PR DESCRIPTION
Fixes #17825 

## Description

This PR hides the segmented control on the My Site screen for:
- self-hosted sites w/o Jetpack
- iPad devices

This PR also adds a call to the `showInitialDetailsForBlog` method when switching sites via the site picker. This call ensures that the correct details vc will be shown when switching sites on an iPad.

## How to test

Make sure the My Site Dashboard feature flag is **enabled**.

### Self-hosted sites: Flow 1
1. Log out
2. Login into a **self-hosted site w/o Jetpack**
3. ✅ The segmented control should be hidden
4. Close the app then reopen it

<details>
  <summary>Click to expand for video</summary>
  
  https://user-images.githubusercontent.com/6711616/151529512-b6fe85e9-e91f-438a-b271-dcfd07945a60.mp4
</details>

### Self-hosted sites: Flow 2

1. Log out
2. Log into with your WP.com account
3. Switch to a **WP.com** site
4. ✅ The segmented control should be visible
5. Switch to an **Atomic** site
6. ✅ The segmented control should be visible
7. Switch to a **self-hosted site with Jetpack**
8. ✅ The segmented control should be visible
9. On the segmented control, switch to the **dashboard**
10. Switch to a **self-hosted site w/o Jetpack**
11. ✅ The segmented control should be hidden and the site menu should be displayed
12. Switch to a WP.com/Atomic/Jetpack site
13. ✅ The segmented control should be visible

<details>
  <summary>Click to expand for video</summary>
  
  https://user-images.githubusercontent.com/6711616/151529294-97c59a86-16f8-4ba5-a780-61ea1c801344.mp4
</details>

### iPads
1. Log out
2. Log in with your WP.com account
3. ✅ The segmented control should be hidden
4. Close the app then reopen it
5. ✅ The segmented control should be hidden
6. Select a different site on the site switcher
7. ✅ The detail vc should reflect the newly selected site

<details>
  <summary>Click to expand for video</summary>

  https://user-images.githubusercontent.com/6711616/151532084-fc2fc2e6-d3b2-4ea8-a5e4-dff8a82fd2f9.mp4

</details>


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [X] I have completed the Regression Notes.
- [X] I have considered adding unit tests for my changes.
- [X] I have considered adding accessibility improvements for my changes.
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
