### PR TITLE
Media Detail Image Full screen improve accessibility and hints

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -246,6 +246,7 @@ static CGFloat const MinimumZoomScale = 0.1;
     [self.imageView sizeToFit];
     self.scrollView.contentSize = self.imageView.image.size;
     [self centerImage];
+    
 }
 
 - (void)loadImageFromURL
@@ -568,6 +569,14 @@ static CGFloat const MinimumZoomScale = 0.1;
 {
     self.imageView.isAccessibilityElement = YES;
     self.imageView.accessibilityTraits = UIAccessibilityTraitImage;
+    
+    if (self.media != nil && self.media.title != nil) {
+        self.imageView.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Fullscreen view of image %@. Double tap to dismiss the screen", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen. Paramater is the title of the image"), self.media.title];
+    }
+    else {
+        self.imageView.accessibilityLabel = NSLocalizedString(@"Fullscreen view of image. Double tap to dismiss the screen", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen");
+    }
+
 }
 
 - (BOOL)accessibilityPerformEscape

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -571,10 +571,10 @@ static CGFloat const MinimumZoomScale = 0.1;
     self.imageView.accessibilityTraits = UIAccessibilityTraitImage;
     
     if (self.media != nil && self.media.title != nil) {
-        self.imageView.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Fullscreen view of image %@. Double tap to dismiss the screen", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen. Paramater is the title of the image"), self.media.title];
+        self.imageView.accessibilityLabel = [NSString stringWithFormat:NSLocalizedString(@"Fullscreen view of image %@. Double tap to dismiss", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen. Placeholder is the title of the image"), self.media.title];
     }
     else {
-        self.imageView.accessibilityLabel = NSLocalizedString(@"Fullscreen view of image. Double tap to dismiss the screen", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen");
+        self.imageView.accessibilityLabel = NSLocalizedString(@"Fullscreen view of image. Double tap to dismiss", @"Accessibility label for when image is shown to user in full screen, with instructions on how to dismiss the screen");
     }
 
 }


### PR DESCRIPTION
Ref #12878 

To test:
1. Please test on device as Simulator gives inconsistent results
2. Go to Settings > General > Accessibility > VoiceOver and toggle the setting on.
3. In the WordPress app, go to My Site > Media.
4. Select an image and tap the image to open the image in full screen mode
5. VoiceOver for full screen should read as "Full screen view of image" + read the Image title name and hint to the user how to dismiss the screen

## Regression Notes
1. Potential unintended areas of impact
None


2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested on Device

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.