### PR TITLE
Notifications: enable mark all as read button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 19.2
 -----
 * [**] Some of the screens of the app has a new, fresh and more modern visual, including the initial one: My Site. [#17812]
-
+* [**] Notifications: added a button to mark all notifications in the selected filter as read. [#17840]
 
 19.1
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -69,7 +69,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mySiteDashboard:
             return false
         case .markAllNotificationsAsRead:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+            return true
         case .followConversationPostDetails:
             return true
         case .mediaPickerPermissionsNotice:


### PR DESCRIPTION
Fixes #17135

This enables the Notifications nav bar button to mark all notifications as read.

To test:
- Go to Notifications.
- Verify a checkmark icon now appears in the nav bar to the left of the settings button.
- For filters that do not have unread notifications, the checkmark is disabled.
- For filters that do have unread notifications, the checkmark is enabled.
- Tip: if you don't have any unread notifications, swipe right on a notification row to mark it unread.

| <img width="446" alt="read" src="https://user-images.githubusercontent.com/1816888/150582898-29123d0c-cca4-424a-a025-e83ab899a23f.png"> | <img width="448" alt="unread" src="https://user-images.githubusercontent.com/1816888/150582789-1344252a-c03d-49a5-aafd-efd2c0ab70fd.png"> |
|--------|-------|

- On a filter that has unread notifications, tap the checkmark button.
- On the alert:
  - Verify `Cancel` cancels the action.
  - Verify `OK` marks notifications in that filter as read, and the nav bar button is disabled.

| <img width="298" alt="comment_confirmation" src="https://user-images.githubusercontent.com/1816888/151625658-3808e653-63c7-495b-ac8c-ddf0c9b765bd.png"> | <img width="294" alt="like_confirmation" src="https://user-images.githubusercontent.com/1816888/151625656-2cae0d90-60cf-4ae0-a671-73435fe95f0f.png"> |
|--------|-------|

- Verify notifications in other filters are not.
- Note that, since the button applies to the selected filter, `All` and `Unread` will mark all unread notifications as read (thus affecting the other filters).

## Regression Notes
1. Potential unintended areas of impact
It's possible marking a single notification as read/unread could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified marking a single notification as read/unread still works as expected. And there are existing tests that passed.

3. What automated tests I added (or what prevented me from doing so)
Tests were added to WPKit.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
