### PR TITLE
Update CocoaPods gem to match the version used in Podfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'rake'
-gem 'cocoapods', '~> 1.10'
+gem 'cocoapods', '~> 1.11'
 gem 'xcpretty-travis-formatter'
 gem 'octokit', "~> 4.0"
 gem 'fastlane', "~> 2.174"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,10 +35,10 @@ GEM
     bigdecimal (1.4.4)
     chroma (0.2.0)
     claide (1.1.0)
-    cocoapods (1.10.1)
-      addressable (~> 2.6)
+    cocoapods (1.11.2)
+      addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.1)
+      cocoapods-core (= 1.11.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -49,26 +49,26 @@ GEM
       escape (~> 0.0.4)
       fourflusher (>= 2.3.0, < 3.0)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.6)
+      molinillo (~> 0.8.0)
       nap (~> 1.0)
-      ruby-macho (~> 1.4)
-      xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.1)
-      activesupport (> 5.0, < 6)
-      addressable (~> 2.6)
+      ruby-macho (>= 1.0, < 3.0)
+      xcodeproj (>= 1.21.0, < 2.0)
+    cocoapods-core (1.11.2)
+      activesupport (>= 5.0, < 7)
+      addressable (~> 2.8)
       algoliasearch (~> 1.0)
       concurrent-ruby (~> 1.1)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
       netrc (~> 0.11)
-      public_suffix
+      public_suffix (~> 4.0)
       typhoeus (~> 1.0)
-    cocoapods-deintegrate (1.0.4)
-    cocoapods-downloader (1.4.0)
+    cocoapods-deintegrate (1.0.5)
+    cocoapods-downloader (1.5.1)
     cocoapods-plugins (1.0.0)
       nap
-    cocoapods-search (1.0.0)
-    cocoapods-trunk (1.5.0)
+    cocoapods-search (1.0.1)
+    cocoapods-trunk (1.6.0)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
@@ -88,7 +88,7 @@ GEM
     dotenv (2.7.6)
     emoji_regex (3.2.3)
     escape (0.0.4)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     excon (0.90.0)
     faraday (1.9.3)
@@ -174,7 +174,7 @@ GEM
       progress_bar (~> 1.3)
       rake (>= 12.3, < 14.0)
       rake-compiler (~> 1.0)
-    ffi (1.15.0)
+    ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -222,7 +222,7 @@ GEM
     http-cookie (1.0.4)
       domain_name (~> 0.5)
     httpclient (2.8.3)
-    i18n (1.8.11)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.5.0)
     json (2.6.1)
@@ -234,8 +234,8 @@ GEM
     mini_magick (4.11.0)
     mini_mime (1.1.2)
     mini_portile2 (2.7.1)
-    minitest (5.14.4)
-    molinillo (0.6.6)
+    minitest (5.15.0)
+    molinillo (0.8.0)
     multi_json (1.15.0)
     multipart-post (2.0.0)
     nanaimo (0.3.0)
@@ -274,7 +274,7 @@ GEM
     rouge (2.0.7)
     ruby-enum (0.9.0)
       i18n
-    ruby-macho (1.4.0)
+    ruby-macho (2.5.1)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     sawyer (0.8.2)
@@ -325,7 +325,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  cocoapods (~> 1.10)
+  cocoapods (~> 1.11)
   commonmarker
   dotenv
   fastlane (~> 2.174)
@@ -338,4 +338,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.2.32
+   2.2.33


### PR DESCRIPTION
The version of CocoaPods used to generate the latest `Podfile.lock` (as seen at the very end of said `Podfile.lock`) is `1.11.2`, but the version of CocoaPods used in our `Gemfile.lock` was still locked to `1.10.1`.

This PR simply aligns the two, so that we ensure CI (and local builds) use a version of the gem (from `Gemfile.lock`) at least as recent as the one that was used to generate latest `Podfile.lock`.

h/t @leandroalonso for noticing this.