### PR TITLE
My Site Dashboard: FAB + Quick Start tour auto-scroll

### DIFF
--- a/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
@@ -1,0 +1,49 @@
+import UIKit
+
+extension UIScrollView {
+
+    // Scroll to a specific view so that it's top is at the top our scrollview
+    @objc func scrollToView(_ view: UIView, animated: Bool) {
+        if let origin = view.superview {
+
+            // Get the Y position of your child view
+            let childStartPoint = origin.convert(view.frame.origin, to: self)
+
+            // Scroll to a rectangle starting at the Y of your subview, with a height of the scrollview safe area
+            // if the bottom of the rectangle is within the content size height.
+            //
+            // Otherwise, scroll all the way to the bottom.
+            //
+            if childStartPoint.y + safeAreaLayoutGuide.layoutFrame.height < contentSize.height {
+                let targetRect = CGRect(x: 0,
+                                        y: childStartPoint.y - Constants.yOffset,
+                                        width: Constants.targetRectWidth,
+                                        height: safeAreaLayoutGuide.layoutFrame.height)
+                scrollRectToVisible(targetRect, animated: animated)
+            } else {
+                scrollToBottom()
+            }
+
+            // This ensures scrolling to the correct position, especially when there are layout changes
+            //
+            // See: https://stackoverflow.com/a/35437399
+            //
+            layoutIfNeeded()
+        }
+    }
+
+    @objc func scrollToBottom() {
+        let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height + adjustedContentInset.bottom)
+        if bottomOffset.y > 0 {
+            setContentOffset(bottomOffset, animated: true)
+        }
+    }
+
+    private enum Constants {
+        /// An arbitrary placeholder value for the target rect -- must be some value larger than 0
+        static let targetRectWidth: CGFloat = 1
+
+        /// Vertical padding for the target rect
+        static let yOffset: CGFloat = 24
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -23,7 +23,13 @@ extension BlogDetailsViewController {
             if let info = notification.userInfo?[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
                 switch info {
                 case .noSuchElement:
-                    self?.additionalSafeAreaInsets = UIEdgeInsets.zero
+                    if FeatureFlag.mySiteDashboard.enabled,
+                       let parentVC = self?.parent as? MySiteViewController {
+                        parentVC.additionalSafeAreaInsets = UIEdgeInsets.zero
+                    } else {
+                        self?.additionalSafeAreaInsets = UIEdgeInsets.zero
+                    }
+
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view
                     self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -16,9 +16,6 @@ extension BlogDetailsViewController {
             self?.refreshSiteIcon()
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
-            if let element = QuickStartTourElement(rawValue: QuickStartTourGuide.shared.currentElementInt()) {
-                self?.scroll(to: element)
-            }
 
             if let info = notification.userInfo?[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
                 switch info {
@@ -33,7 +30,11 @@ extension BlogDetailsViewController {
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view
                     self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)
+                case .pages, .editHomepage, .sharing, .stats:
+                    self?.scroll(to: info)
                 case .viewSite:
+                    self?.scroll(to: info)
+
                     guard let self = self,
                         let navigationController = self.navigationController,
                         navigationController.visibleViewController != self else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -22,9 +22,9 @@ extension BlogDetailsViewController {
                 case .noSuchElement:
                     if FeatureFlag.mySiteDashboard.enabled,
                        let parentVC = self?.parent as? MySiteViewController {
-                        parentVC.additionalSafeAreaInsets = UIEdgeInsets.zero
+                        parentVC.additionalSafeAreaInsets = .zero
                     } else {
-                        self?.additionalSafeAreaInsets = UIEdgeInsets.zero
+                        self?.additionalSafeAreaInsets = .zero
                     }
 
                 case .siteIcon, .siteTitle:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -382,7 +382,18 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self startObservingQuickStart];
     [self addMeButtonToNavigationBarWithEmail:self.blog.account.email meScenePresenter:self.meScenePresenter];
     
-    [self.createButtonCoordinator addTo:self.view trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
+    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+        MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+        
+        [self.createButtonCoordinator addTo:parentVC.view
+                             trailingAnchor:parentVC.view.safeAreaLayoutGuide.trailingAnchor
+                               bottomAnchor:parentVC.view.safeAreaLayoutGuide.bottomAnchor];
+    } else {
+        [self.createButtonCoordinator addTo:self.view
+                             trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
+                               bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
+    }
+    
 }
 
 /// Resizes the `tableHeaderView` as necessary whenever its size changes.

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1710,13 +1710,25 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     int sectionCount = 0;
     int rowCount = 0;
+    
+    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+    
     for (BlogDetailsSection *section in self.tableSections) {
         rowCount = 0;
         for (BlogDetailsRow *row in section.rows) {
             if (row.quickStartIdentifier == element) {
-                self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+                
                 NSIndexPath *path = [NSIndexPath indexPathForRow:rowCount inSection:sectionCount];
-                [self.tableView scrollToRowAtIndexPath:path atScrollPosition:UITableViewScrollPositionTop animated:true];
+                
+                if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+                    parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+                    UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:path];
+                    [parentVC.scrollView scrollToView:cell animated:true];
+                } else {
+                    self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+                    [self.tableView scrollToRowAtIndexPath:path atScrollPosition:UITableViewScrollPositionTop animated:true];
+                }
+                
             }
             rowCount++;
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -421,9 +421,23 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [super viewWillAppear:animated];
 
     if ([[QuickStartTourGuide shared] currentElementInt] != NSNotFound) {
-        self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+        
+        if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+            MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+            parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+        } else {
+            self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+        }
+        
     } else {
-        self.additionalSafeAreaInsets = UIEdgeInsetsZero;
+        
+        if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+            MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+            parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
+        } else {
+            self.additionalSafeAreaInsets = UIEdgeInsetsZero;
+        }
+        
     }
 
     if (self.splitViewControllerIsHorizontallyCompact) {
@@ -1922,7 +1936,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [[QuickStartTourGuide shared] completeViewSiteTourForBlog:self.blog];
     }
 
-    self.additionalSafeAreaInsets = UIEdgeInsetsZero;
+    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
+        MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+        parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
+    } else {
+        self.additionalSafeAreaInsets = UIEdgeInsetsZero;
+    }    
 }
 
 - (void)showViewAdmin

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -21,7 +21,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         return segmentedControl.selectedSegmentIndex == Section.dashboard.rawValue
     }
 
-    private lazy var scrollView: UIScrollView = {
+    @objc
+    private(set) lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.refreshControl = refreshControl

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -193,16 +193,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         view.addSubview(scrollView)
+        view.pinSubviewToAllEdges(scrollView)
         scrollView.addSubview(stackView)
         scrollView.pinSubviewToAllEdges(stackView)
         segmentedControlContainerView.addSubview(segmentedControl)
         stackView.addArrangedSubviews([segmentedControlContainerView])
 
         NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
             stackView.widthAnchor.constraint(equalTo: view.widthAnchor),
             segmentedControl.leadingAnchor.constraint(equalTo: segmentedControlContainerView.leadingAnchor,
                                                       constant: Constants.segmentedControlXOffset),

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
@@ -25,7 +25,10 @@ extension SitePickerViewController {
                     self?.additionalSafeAreaInsets = UIEdgeInsets.zero
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view
-                    self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)
+                    guard let parentVC = self?.parent as? MySiteViewController else {
+                        return
+                    }
+                    parentVC.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)
                 default:
                     break
                 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -242,7 +242,10 @@ extension SitePickerViewController {
             tourGuide.completeViewSiteTour(forBlog: blog)
         }
 
-        additionalSafeAreaInsets = .zero
+        guard let parentVC = parent as? MySiteViewController else {
+            return
+        }
+        parentVC.additionalSafeAreaInsets = .zero
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2735,6 +2735,8 @@
 		FA1ACAA21BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */; };
 		FA1CEAC225CA9C2A005E7038 /* RestoreStatusFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1CEAC125CA9C2A005E7038 /* RestoreStatusFailedView.swift */; };
 		FA1CEAD425CA9C40005E7038 /* RestoreStatusFailedView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA1CEAD325CA9C40005E7038 /* RestoreStatusFailedView.xib */; };
+		FA20751427A86B73001A644D /* UIScrollView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */; };
+		FA20751527A86B73001A644D /* UIScrollView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */; };
 		FA25FA212609AA9C0005E08F /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
 		FA25FA342609AAAA0005E08F /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25FA332609AAAA0005E08F /* AppConfiguration.swift */; };
 		FA347AED26EB6E300096604B /* GrowAudienceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA347AEB26EB6E300096604B /* GrowAudienceCell.swift */; };
@@ -7495,6 +7497,7 @@
 		FA1ACAA11BC6E45D00DDDCE2 /* WPStyleGuide+Themes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Themes.swift"; sourceTree = "<group>"; };
 		FA1CEAC125CA9C2A005E7038 /* RestoreStatusFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreStatusFailedView.swift; sourceTree = "<group>"; };
 		FA1CEAD325CA9C40005E7038 /* RestoreStatusFailedView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RestoreStatusFailedView.xib; sourceTree = "<group>"; };
+		FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+Helpers.swift"; sourceTree = "<group>"; };
 		FA25F9FD2609AA830005E08F /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		FA25FA332609AAAA0005E08F /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
@@ -12757,6 +12760,7 @@
 				FE02F95E269DC14A00752A44 /* Comment+Interface.swift */,
 				C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */,
 				179A70EF2729834B006DAC0A /* Binding+OnChange.swift */,
+				FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -18186,6 +18190,7 @@
 				436110E022C4241A000773AD /* UIColor+MurielColorsObjC.swift in Sources */,
 				B5B68BD41C19AAED00EB59E0 /* InteractiveNotificationsManager.swift in Sources */,
 				46183CF5251BD658004F9AFD /* PageTemplateLayout+CoreDataProperties.swift in Sources */,
+				FA20751427A86B73001A644D /* UIScrollView+Helpers.swift in Sources */,
 				981D464825B0D4E7000AA65C /* ReaderSeenAction.swift in Sources */,
 				F57402A7235FF9C300374346 /* SchedulingDate+Helpers.swift in Sources */,
 				4395A15D2106718900844E8E /* QuickStartChecklistCell.swift in Sources */,
@@ -19724,6 +19729,7 @@
 				FABB22202602FC2C00C8785C /* CustomHighlightButton.m in Sources */,
 				FABB22212602FC2C00C8785C /* UniversalLinkRouter.swift in Sources */,
 				FABB22222602FC2C00C8785C /* LightNavigationController.swift in Sources */,
+				FA20751527A86B73001A644D /* UIScrollView+Helpers.swift in Sources */,
 				FABB22232602FC2C00C8785C /* PluginDirectoryCollectionViewCell.swift in Sources */,
 				FABB22242602FC2C00C8785C /* GutenbergNetworking.swift in Sources */,
 				FABB22252602FC2C00C8785C /* NavigationActionHelpers.swift in Sources */,


### PR DESCRIPTION
Fixes #17786

## Description
- Adds the FAB to the My Site screen, if MSD is enabled (previously stuck to the bottom of BlogDetailsVC)
- Refactors the scrollToElement method in BlogDetailsVC to scroll to the correct Quick Start element, if MSD is enabled

## Notes
- These changes are behind the My Site Dashboard feature flag
- If you switch to the dashboard, the FAB will not do anything when you tap it

## How to test

### Quick Start auto-scroll

1. Clean install
2. Log in
3. Tap "Show me around" in the post-epilogue Quick Start prompt
4. Make sure the MSD feature flag is enabled
5. Close then reopen the app
6. Go through every single Quick Start element for both check lists
7. ✅ Make sure the screen scrolls to the correct position for Quick Start elements in the site menu


https://user-images.githubusercontent.com/6711616/151860509-f90055f5-d002-4e5f-bc75-87b1c0189a4a.mp4



### FAB

1. Make sure the MSD feature flag is enabled
2. Go to My Site > Site menu
3. Tap on the FAB > Blog post
4. Create a draft post
5. ✅ Make sure that the draft post is there when you go to Posts > Drafts
6. Tap on the FAB > Site page
7. Create a draft page
8. ✅ Make sure the the draft page is there when you go to Pages > Drafts

https://user-images.githubusercontent.com/6711616/151860464-9c68e463-730a-44d3-b9d4-10f978870a5f.mp4


## Regression Notes
1. Potential unintended areas of impact
- Quick Start tour auto-scroll

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Made sure to wrap changes behind feature flags
- Tested the steps above 

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
