### PR TITLE
My Site Dashboard: track interaction with posts content

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -303,6 +303,9 @@ import Foundation
     case changeUsernameDisplayed
     case changeUsernameDismissed
 
+    // My Site Dashboard
+    case dashboardCardItemTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -810,6 +813,10 @@ import Foundation
             return "change_username_displayed"
         case .changeUsernameDismissed:
             return "change_username_dismissed"
+
+        // My Site Dashboard
+        case .dashboardCardItemTapped:
+            return "my_site_dashboard_card_item_tapped"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -69,6 +69,12 @@ class AztecPostViewController: UIViewController, PostEditor {
         mediaCoordinator.cancelUploadOfAllMedia(for: post)
     }
 
+    var entryPoint: PostEditorEntryPoint = .unknown {
+        didSet {
+            editorSession.entryPoint = entryPoint
+        }
+    }
+
     /// For autosaving - The debouncer will execute local saving every defined number of seconds.
     /// In this case every 0.5 second
     ///

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -96,7 +96,7 @@ extension PostsCardViewController: UITableViewDelegate {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": "post", "sub_type": status.rawValue])
 
-        PostListEditorPresenter.handle(post: post, in: self)
+        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .dashboard)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -93,6 +93,9 @@ extension PostsCardViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let post = viewModel.postAt(indexPath)
 
+        WPAnalytics.track(.dashboardCardItemTapped,
+                          properties: ["type": "post", "sub_type": status.rawValue])
+
         PostListEditorPresenter.handle(post: post, in: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -70,6 +70,12 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         }
     }
 
+    var entryPoint: PostEditorEntryPoint = .unknown {
+        didSet {
+            editorSession.entryPoint = entryPoint
+        }
+    }
+
     /// Maintainer of state for editor - like for post button
     ///
     private(set) lazy var postEditorStateContext: PostEditorStateContext = {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -17,6 +17,8 @@ class EditPostViewController: UIViewController {
     var insertedMedia: [Media]? = nil
     /// is editing a reblogged post
     var postIsReblogged = false
+    /// the entry point for the editor
+    var entryPoint: PostEditorEntryPoint = .unknown
 
     private let loadAutosaveRevision: Bool
 
@@ -139,6 +141,7 @@ class EditPostViewController: UIViewController {
                 self?.replaceEditor(editor: editor, replacement: replacement)
         })
         editor.postIsReblogged = postIsReblogged
+        editor.entryPoint = entryPoint
         showEditor(editor)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -100,8 +100,12 @@ protocol PostEditor: PublishingEditor, UIViewControllerTransitioningDelegate {
     var replaceEditor: (EditorViewController, EditorViewController) -> () { get }
 
     var autosaver: Autosaver { get set }
+
     /// true if the post is the result of a reblog
     var postIsReblogged: Bool { get set }
+
+    /// From where the editor was shown (for analytics reporting)
+    var entryPoint: PostEditorEntryPoint { get set }
 }
 
 extension PostEditor {
@@ -143,4 +147,10 @@ extension PostEditor {
     var prepublishingIdentifiers: [PrepublishingIdentifier] {
         return [.visibility, .schedule, .tags, .categories]
     }
+}
+
+enum PostEditorEntryPoint: String {
+    case unknown
+    case list
+    case dashboard
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -151,6 +151,6 @@ extension PostEditor {
 
 enum PostEditorEntryPoint: String {
     case unknown
-    case list
+    case postsList
     case dashboard
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -10,6 +10,7 @@ struct PostEditorAnalyticsSession {
     var currentEditor: Editor
     var hasUnsupportedBlocks = false
     var outcome: Outcome? = nil
+    var entryPoint: PostEditorEntryPoint?
     private let startTime = DispatchTime.now().uptimeNanoseconds
 
     init(editor: Editor, post: AbstractPost) {
@@ -48,6 +49,8 @@ struct PostEditorAnalyticsSession {
         } else {
             properties[Property.unstableGalleryWithImageBlocks] = "unknown"
         }
+
+        properties[Property.entryPoint] = (entryPoint ?? .unknown).rawValue
 
         return properties.merging(commonProperties, uniquingKeysWith: { $1 })
     }
@@ -92,6 +95,7 @@ private extension PostEditorAnalyticsSession {
         static let template = "template"
         static let startupTime = "startup_time_ms"
         static let unstableGalleryWithImageBlocks = "unstable_gallery_with_image_blocks"
+        static let entryPoint = "entry_point"
     }
 
     var commonProperties: [String: String] {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -75,7 +75,10 @@ struct PostEditorAnalyticsSession {
 
     func end(outcome endOutcome: Outcome) {
         let outcome = self.outcome ?? endOutcome
-        let properties: [String: Any] = [ Property.outcome: outcome.rawValue ].merging(commonProperties, uniquingKeysWith: { $1 })
+        let properties: [String: Any] = [
+            Property.outcome: outcome.rawValue,
+            Property.entryPoint: (entryPoint ?? .unknown).rawValue
+        ].merging(commonProperties, uniquingKeysWith: { $1 })
 
         WPAppAnalytics.track(.editorSessionEnd, withProperties: properties)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -65,7 +65,7 @@ struct PostListEditorPresenter {
         // Open Editor
         let editor = EditPostViewController(post: newPost, loadAutosaveRevision: false)
         editor.modalPresentationStyle = .fullScreen
-        editor.entryPoint = .list
+        editor.entryPoint = .postsList
         postListViewController.present(editor, animated: false)
         // Track Analytics event
         WPAppAnalytics.track(.postListDuplicateAction, withProperties: postListViewController.propertiesForAnalytics(), with: post)

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -14,16 +14,16 @@ protocol EditorAnalyticsProperties: AnyObject {
 /// Analytics are also tracked.
 struct PostListEditorPresenter {
 
-    static func handle(post: Post, in postListViewController: EditorPresenterViewController) {
+    static func handle(post: Post, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
 
         // Autosaves are ignored for posts with local changes.
         if !post.hasLocalChanges(), post.hasAutosaveRevision, let saveDate = post.dateModified, let autosaveDate = post.autosaveModifiedDate {
             let autosaveViewController = autosaveOptionsViewController(forSaveDate: saveDate, autosaveDate: autosaveDate, didTapOption: { loadAutosaveRevision in
-                openEditor(with: post, loadAutosaveRevision: loadAutosaveRevision, in: postListViewController)
+                openEditor(with: post, loadAutosaveRevision: loadAutosaveRevision, in: postListViewController, entryPoint: entryPoint)
             })
             postListViewController.present(autosaveViewController, animated: true)
         } else {
-            openEditor(with: post, loadAutosaveRevision: false, in: postListViewController)
+            openEditor(with: post, loadAutosaveRevision: false, in: postListViewController, entryPoint: entryPoint)
         }
     }
 
@@ -46,9 +46,10 @@ struct PostListEditorPresenter {
         }
     }
 
-    private static func openEditor(with post: Post, loadAutosaveRevision: Bool, in postListViewController: EditorPresenterViewController) {
+    private static func openEditor(with post: Post, loadAutosaveRevision: Bool, in postListViewController: EditorPresenterViewController, entryPoint: PostEditorEntryPoint = .unknown) {
         let editor = EditPostViewController(post: post, loadAutosaveRevision: loadAutosaveRevision)
         editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = entryPoint
         postListViewController.present(editor, animated: false)
     }
 
@@ -64,6 +65,7 @@ struct PostListEditorPresenter {
         // Open Editor
         let editor = EditPostViewController(post: newPost, loadAutosaveRevision: false)
         editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = .list
         postListViewController.present(editor, animated: false)
         // Track Analytics event
         WPAppAnalytics.track(.postListDuplicateAction, withProperties: postListViewController.propertiesForAnalytics(), with: post)

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -50,7 +50,6 @@ struct PostListEditorPresenter {
         let editor = EditPostViewController(post: post, loadAutosaveRevision: loadAutosaveRevision)
         editor.modalPresentationStyle = .fullScreen
         postListViewController.present(editor, animated: false)
-        WPAppAnalytics.track(.postListEditAction, withProperties: postListViewController.propertiesForAnalytics(), with: post)
     }
 
     private static func openEditorWithCopy(with post: Post, in postListViewController: EditorPresenterViewController) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -576,6 +576,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
+        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
         PostListEditorPresenter.handle(post: post, in: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -563,7 +563,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func createPost() {
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
-        editor.entryPoint = .list
+        editor.entryPoint = .postsList
         present(editor, animated: false, completion: nil)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "post"], with: blog)
     }
@@ -578,7 +578,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
-        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .list)
+        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
     }
 
     private func editDuplicatePost(apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -563,6 +563,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     override func createPost() {
         let editor = EditPostViewController(blog: blog)
         editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = .list
         present(editor, animated: false, completion: nil)
         WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "post"], with: blog)
     }
@@ -577,7 +578,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
-        PostListEditorPresenter.handle(post: post, in: self)
+        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .list)
     }
 
     private func editDuplicatePost(apost: AbstractPost) {


### PR DESCRIPTION
Part of #17697 

* Track events when interacting with posts on the dashboard
* Add `entry_point` property to editor start/end events so we can have more information from where the user is starting the editor

**Important**: I recommend reviewing this one commit by commit to understand the flow, we have quite a few different entities to inject the entry point.😅Also, I recommend testing the current `trunk` side by side with these changes to make sure no events were removed.

### To test

### Drafts

1. Open the app
2. Go to the dashboard
3. Tap on a post
4. Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: draft, type: post`

### Scheduled

1. Change `PostsCardViewController.status` to `scheduled`
2. Go to the dashboard
3. Tap on a post
4. Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: future, type: post`

**Important**: if the above is verified, please validate `my_site_dashboard_card_item_tapped`

### Entry point: Dashboard

1. Open any post from the dashboard
2. Make sure that `editor_session_start` and `editor_session_end` have an `entry_point: dashboard` property

### Entry point: Posts List

1. Open any post from the posts list screen
2. Make sure that `editor_session_start` and `editor_session_end` have an `entry_point: postsList` property

### Entry point: Any other flow

1. Open the editor from the FAB
2. Make sure that `editor_session_start` and `editor_session_end` have an `entry_point: unknown` property

We have a few different entry points (more than I imagined!) and filling the `entry_point` for each one of them is out of scope for this task. 

## Regression Notes
1. Potential unintended areas of impact
Editor analytics

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
