### PR TITLE
Notifications > Comment Details: show new details view for cached comment

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -23,6 +23,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case followConversationPostDetails
     case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
+    case notificationCommentDetails
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -74,6 +75,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .mediaPickerPermissionsNotice:
             return true
+        case .notificationCommentDetails:
+            return false
         }
     }
 
@@ -142,6 +145,8 @@ extension FeatureFlag {
             return "Mark Notifications As Read"
         case .mediaPickerPermissionsNotice:
             return "Media Picker Permissions Notice"
+        case .notificationCommentDetails:
+            return "Notification Comment Details"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -20,10 +20,19 @@ class CommentDetailViewController: UIViewController {
 
     @objc weak var delegate: CommentDetailsDelegate?
     private var comment: Comment
-    private var isLastInList: Bool
+    private var isLastInList = true
     private var managedObjectContext: NSManagedObjectContext
     private var rows = [RowType]()
     private var moderationBar: CommentModerationBar?
+    private var notification: Notification?
+
+    private var isNotificationComment: Bool {
+        notification != nil
+    }
+
+    private var viewTitle: String? {
+        isNotificationComment ? notification?.title : nil
+    }
 
     private var viewIsVisible: Bool {
         return navigationController?.visibleViewController == self
@@ -163,11 +172,21 @@ class CommentDetailViewController: UIViewController {
 
     // MARK: Initialization
 
-    @objc required init(comment: Comment,
-                        isLastInList: Bool,
-                        managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+    @objc init(comment: Comment,
+               isLastInList: Bool,
+               managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
         self.comment = comment
         self.isLastInList = isLastInList
+        self.managedObjectContext = managedObjectContext
+        self.replyID = comment.replyID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    init(comment: Comment,
+         notification: Notification,
+         managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+        self.comment = comment
+        self.notification = notification
         self.managedObjectContext = managedObjectContext
         self.replyID = comment.replyID
         super.init(nibName: nil, bundle: nil)
@@ -280,6 +299,7 @@ private extension CommentDetailViewController {
         }
 
         navigationController?.navigationBar.isTranslucent = true
+        title = viewTitle
 
         configureEditButtonItem()
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+// This facilitates showing the CommentDetailViewController within the context of Notifications.
+
+class NotificationCommentDetailCoordinator: NSObject {
+
+    // MARK: - Properties
+
+    private let notification: Notification
+    private var comment: Comment?
+    private let managedObjectContext = ContextManager.shared.mainContext
+    private(set) var viewController: CommentDetailViewController?
+
+    private lazy var commentService: CommentService = {
+        return .init(managedObjectContext: managedObjectContext)
+    }()
+
+    // MARK: - Init
+
+    init(notification: Notification) {
+        self.notification = notification
+        super.init()
+        loadCommentFromCache()
+    }
+
+}
+
+// MARK: - Private Extension
+
+private extension NotificationCommentDetailCoordinator {
+
+    func loadCommentFromCache() {
+        guard let siteID = notification.metaSiteID,
+              let commentID = notification.metaCommentID,
+              let blog = Blog.lookup(withID: siteID, in: managedObjectContext),
+              let comment = commentService.findComment(withID: commentID, in: blog) else {
+                  DDLogError("Notification Comment: failed loading comment from cache.")
+                  return
+              }
+
+        self.comment = comment
+        viewController = CommentDetailViewController(comment: comment,
+                                                     notification: notification,
+                                                     managedObjectContext: managedObjectContext)
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1727,6 +1727,8 @@
 		988F073A23D0D16700AC67A6 /* WidgetUrlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988F073323D0CE8800AC67A6 /* WidgetUrlCell.swift */; };
 		988F073B23D0D16800AC67A6 /* WidgetUrlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988F073323D0CE8800AC67A6 /* WidgetUrlCell.swift */; };
 		988F073C23D0D16800AC67A6 /* WidgetUrlCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988F073323D0CE8800AC67A6 /* WidgetUrlCell.swift */; };
+		988FD74A279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988FD749279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift */; };
+		988FD74B279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988FD749279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift */; };
 		98906502237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989064FB237CC1DE00218CD2 /* WidgetUnconfiguredCell.swift */; };
 		98906503237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989064FB237CC1DE00218CD2 /* WidgetUnconfiguredCell.swift */; };
 		98906504237CC1DF00218CD2 /* WidgetUnconfiguredCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 989064FC237CC1DE00218CD2 /* WidgetUnconfiguredCell.xib */; };
@@ -6360,6 +6362,7 @@
 		988AD63726B089CE003552B4 /* WordPress 128.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 128.xcdatamodel"; sourceTree = "<group>"; };
 		988F073323D0CE8800AC67A6 /* WidgetUrlCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetUrlCell.swift; sourceTree = "<group>"; };
 		988F073423D0CE8800AC67A6 /* WidgetUrlCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = WidgetUrlCell.xib; sourceTree = "<group>"; };
+		988FD749279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCommentDetailCoordinator.swift; sourceTree = "<group>"; };
 		989064FB237CC1DE00218CD2 /* WidgetUnconfiguredCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetUnconfiguredCell.swift; sourceTree = "<group>"; };
 		989064FC237CC1DE00218CD2 /* WidgetUnconfiguredCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = WidgetUnconfiguredCell.xib; sourceTree = "<group>"; };
 		989064FD237CC1DE00218CD2 /* WidgetTwoColumnCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetTwoColumnCell.swift; sourceTree = "<group>"; };
@@ -12961,9 +12964,10 @@
 		B5E23BD919AD0CED000D6879 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
-				B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */,
 				B54075D31D3D7D5B0095C318 /* IntrinsicTableView.swift */,
 				B56695AF1D411EEB007E342F /* KeyboardDismissHelper.swift */,
+				988FD749279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift */,
+				B54E1DF31A0A7BBF00807537 /* NotificationMediaDownloader.swift */,
 				B5C0CF3C204DA41000DB0362 /* NotificationReplyStore.swift */,
 			);
 			path = Tools;
@@ -13043,15 +13047,15 @@
 		B5FD453E199D0F2800286FBB /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */,
+				B5120B371D47CC6C0059361A /* NotificationDetailsViewController.swift */,
+				B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */,
+				B52F8CD71B43260C00D36025 /* NotificationSettingStreamsViewController.swift */,
+				B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */,
+				B5F9959F1B59708C00AB0B3E /* NotificationSettingsViewController.xib */,
+				9F8E38BD209C6DE200454E3C /* NotificationSiteSubscriptionViewController.swift */,
 				B5DBE4FD1D21A700002E81D3 /* NotificationsViewController.swift */,
 				4388FEFD20A4E0B900783948 /* NotificationsViewController+AppRatings.swift */,
-				B5120B371D47CC6C0059361A /* NotificationDetailsViewController.swift */,
-				7E987F552108017B00CAFB88 /* NotificationContentRouter.swift */,
-				B522C4F71B3DA79B00E47B59 /* NotificationSettingsViewController.swift */,
-				B52F8CD71B43260C00D36025 /* NotificationSettingStreamsViewController.swift */,
-				B5899ADD1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift */,
-				9F8E38BD209C6DE200454E3C /* NotificationSiteSubscriptionViewController.swift */,
-				B5F9959F1B59708C00AB0B3E /* NotificationSettingsViewController.xib */,
 				8236EB4F2024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift */,
 				4388FEFF20A4E19C00783948 /* NotificationsViewController+PushPrimer.swift */,
 			);
@@ -18339,6 +18343,7 @@
 				E61084C01B9B47BA008050C5 /* ReaderListTopic.swift in Sources */,
 				E6374DC11C444D8B00F24720 /* PublicizeService.swift in Sources */,
 				7E4A773C20F80598001C706D /* ActivityContentFactory.swift in Sources */,
+				988FD74A279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift in Sources */,
 				C81CCD83243BF7A600A83E27 /* TenorDataLoader.swift in Sources */,
 				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
 				1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */,
@@ -20845,6 +20850,7 @@
 				FABB26092602FC2C00C8785C /* PostListFooterView.m in Sources */,
 				FABB260A2602FC2C00C8785C /* ThemeBrowserSearchHeaderView.swift in Sources */,
 				FABB260B2602FC2C00C8785C /* MenuItemInsertionView.m in Sources */,
+				988FD74B279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift in Sources */,
 				FABB260C2602FC2C00C8785C /* AllTimeStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB260D2602FC2C00C8785C /* GutenbergMediaEditorImage.swift in Sources */,
 				FABB260E2602FC2C00C8785C /* NoteBlockHeaderTableViewCell.swift in Sources */,


### PR DESCRIPTION
Ref: #17790 

This is the first step in showing the [new](https://github.com/wordpress-mobile/WordPress-iOS/issues/17087) Comment Details view for a Comment Notification. Specifically, when a comment notification is selected, if the comment is already cached, it will be displayed with the new view. 

Technical details: because `CommentDetailViewController` requires a `Comment` object, the `Comment` must first be loaded with information from the `Notification`. `NotificationCommentDetailCoordinator` has been added to facilitate comment loading, as well as other Notification specific functionality that will be added later.

Of course since this is the first step in showing this view, there are a number of outstanding tasks, which are listed in the referenced issue. 

To test:
- Enable the `notificationCommentDetails` feature.
- To cache comments, go to My Site > Comments. Pick a site that corresponds to the Notifications you'll be testing.
- Go to Notifications > Comments.
- Select a notification.
- If the comment is cached, the new view will be displayed.
- If the comment is not cached, the old view will be displayed. This is temporary. Fetching non-cached comments will be added later. 
- All the functionality in this view should work as expected (Moderation, Edit, Reply, Like, etc.), just like from My Site > Comments > comment details. 

| Cached / New | Not cached / Old |
|--------|-------|
| ![new](https://user-images.githubusercontent.com/1816888/151898402-e0da545c-99c5-414f-ac8a-5f77adf50a0a.png) | ![old](https://user-images.githubusercontent.com/1816888/151898399-a1416605-04e5-4627-acc7-de82b47c373f.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is incomplete and disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is incomplete and disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
