### PR TITLE
Replace 🧪 with 🔬 as the Buildkite test step emoji

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -49,7 +49,7 @@ steps:
   #################
   # Run Unit Tests
   #################
-  - label: "🧪 Unit Tests"
+  - label: "🔬 Unit Tests"
     command: ".buildkite/commands/run-unit-tests.sh"
     depends_on: "build"
     env: *common_env
@@ -75,7 +75,7 @@ steps:
   #################
   # UI Tests
   #################
-  - label: "🧪 UI Tests (iPhone)"
+  - label: "🔬 UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
     depends_on: "build"
     env: *common_env
@@ -86,7 +86,7 @@ steps:
       - github_commit_status:
           context: "UI Tests (iPhone)"
 
-  - label: "🧪 UI Tests (iPad)"
+  - label: "🔬 UI Tests (iPad)"
     command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
     depends_on: "build"
     env: *common_env


### PR DESCRIPTION
It's been pointed out that the green color could be confused for a sign of success for the step, in particular when the observer is not appropriately caffeinated.

Unfortunately, green is the only available color for the test tube emoji. I decide to use `:microscope:` to represent the action of looking at the individual facets of the app's behavior.

Fun fact: Buildkite has a page where it shows [all the emojis it supports](https://github.com/buildkite/emojis#emoji-reference), standard and custom.