### PR TITLE
Onboarding Improvements: Fix Quick Start for self-hosted sites w/o Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [**] Some of the screens of the app has a new, fresh and more modern visual, including the initial one: My Site. [#17812]
 * [**] Notifications: added a button to mark all notifications in the selected filter as read. [#17840]
-* [**] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855] 
+* [*] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855] 
 
 19.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Some of the screens of the app has a new, fresh and more modern visual, including the initial one: My Site. [#17812]
 * [**] Notifications: added a button to mark all notifications in the selected filter as read. [#17840]
+* [**] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855] 
 
 19.1
 -----

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartSettings.swift
@@ -35,9 +35,7 @@ final class QuickStartSettings {
     }
 
     private func promptWasDismissedKey(for blog: Blog) -> String? {
-        guard let siteID = blog.dotComID?.intValue else {
-            return nil
-        }
+        let siteID = blog.dotComID?.intValue ?? 0
         return "QuickStartPromptWasDismissed-\(siteID)"
     }
 


### PR DESCRIPTION
Fixes #17849

## Description

This fixes an issue where the promptWasDismissedKey was returning nil for self-hosted sites not connected to Jetpack.

## How to test

0. On Jurassic Ninja go to More Options and uncheck Include Jetpack, then launch a single site
1. Open the app
2. Login with the newly created Jurassic Ninja site (a non-Jetpack connected self hosted site)
3. Continue with the onboarding to see the quick start prompt
4. Tap No Thanks
5. ✅ Quick start should NOT appear when the view is dismissed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
