### PR TITLE
Stats: fix navigation between Insights and other Stats tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Some of the screens of the app has a new, fresh and more modern visual, including the initial one: My Site. [#17812]
 * [**] Notifications: added a button to mark all notifications in the selected filter as read. [#17840]
+* [*] Stats: fix navigation between Stats tab. [#17856]
 
 19.1
 -----

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -194,10 +194,11 @@ private extension SiteStatsDashboardViewController {
         let selectedPeriodChanged = currentSelectedPeriod != oldSelectedPeriod
         let previousSelectedPeriodWasInsights = oldSelectedPeriod == .insights
         let pageViewControllerIsEmpty = pageViewController?.viewControllers?.isEmpty ?? true
+        let isGrowAudienceShowingOnInsights = insightsTableViewController.isGrowAudienceShowing
 
         switch currentSelectedPeriod {
         case .insights:
-            if selectedPeriodChanged || pageViewControllerIsEmpty {
+            if selectedPeriodChanged || pageViewControllerIsEmpty || isGrowAudienceShowingOnInsights {
                 pageViewController?.setViewControllers([insightsTableViewController],
                                                        direction: .forward,
                                                        animated: false)


### PR DESCRIPTION
Fixes #17764

### To test:

#### Navigation

1. Tap Stats
2. Check that Insights is shown
3. Tap Days
4. Check that the Days section is shown
5. Tap Insights
6. Insights should be shown
7. Tap Days again
8. Leave Stats
9. Tap Stats
10. Insights should be shown (not Days)

### Saving user preference

1. Dismiss all Empty Stats nudges (Publicize, Blogging Reminders and Reader)
2. Tap Days
3. Leave Stats
4. Open Stats again
5. Days should be shown (not Insights)

## Regression Notes
1. Potential unintended areas of impact
Stats navigation

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
