### PR TITLE
Comment Threads: disable comment moderation menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
 19.1
 -----
 * [*] Signup: Fixed bug where username selection screen could be pushed twice. [#17624]
-* [**] Threaded comments: comments can now be moderated via a drop-down menu on each comment. [#17758]
 * [**] Reader post details Comments snippet: added ability to manage conversation subscription and notifications. [#17749]
 * [**] Accessibility: VoiceOver and Dynamic Type improvements on Activity Log and Schedule Post calendars [#17756, #17761, #17780]
 * [*] Weekly Roundup: Fix a crash which was preventing weekly roundup notifications from appearing [#17765]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -65,7 +65,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .postDetailsComments:
             return true
         case .commentThreadModerationMenu:
-            return true
+            return false
         case .mySiteDashboard:
             return false
         case .followConversationPostDetails:


### PR DESCRIPTION
Ref: #17758, #17834

This disables comment moderation from the threaded comments view due to issues with the `Undo` functionality.

***NOTE*** Auto-merge is enabled.

To test:
- Go to the threaded comments view on a post that you have permission to moderate comments on.
- Verify the share icon is displayed on each comment instead of the ellipsis icon.

| Before | After |
|--------|-------|
| <img width="447" alt="Screen Shot 2022-02-01 at 11 46 29 AM" src="https://user-images.githubusercontent.com/1816888/152033149-e8c663b3-868f-4d2c-909b-5058e44fb8b9.png"> | <img width="446" alt="Screen Shot 2022-02-01 at 11 45 46 AM" src="https://user-images.githubusercontent.com/1816888/152033155-e8a994bb-fdf9-4441-9033-f1f51072f70b.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
