### PR TITLE
Threaded comment moderation: update post's Comment snippet

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -2,6 +2,11 @@ import Foundation
 import UIKit
 import WordPressShared
 
+// Notification sent when a comment is moderated/edited to allow views that display Comments to update if necessary.
+// Specifically, the Comments snippet on ReaderDetailViewController.
+extension NSNotification.Name {
+    static let ReaderCommentModifiedNotification = NSNotification.Name(rawValue: "ReaderCommentModifiedNotification")
+}
 
 @objc public extension ReaderCommentsViewController {
     func shouldShowSuggestions(for siteID: NSNumber?) -> Bool {
@@ -218,6 +223,8 @@ private extension ReaderCommentsViewController {
             CommentAnalytics.trackCommentEdited(comment: comment)
 
             self?.commentService.uploadComment(comment, success: {
+                NotificationCenter.default.post(name: .ReaderCommentModifiedNotification, object: nil)
+
                 // update the thread again in case the approval status changed.
                 tableView.reloadRows(at: [indexPath], with: .automatic)
             }, failure: { _ in
@@ -232,6 +239,8 @@ private extension ReaderCommentsViewController {
 
     func moderateComment(_ comment: Comment, status: CommentStatusType, handler: WPTableViewHandler) {
         let successBlock: (String) -> Void = { [weak self] noticeText in
+            NotificationCenter.default.post(name: .ReaderCommentModifiedNotification, object: nil)
+
             // Adjust the ReaderPost's comment count.
             if let post = self?.post, let commentCount = post.commentCount?.intValue {
                 let adjustment = (status == .approved) ? 1 : -1

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -169,6 +169,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         // Fixes swipe to go back not working when leftBarButtonItem is set
         navigationController?.interactivePopGestureRecognizer?.delegate = self
+
+        // When comments are moderated or edited from the Comments view, update the Comments snippet here.
+        NotificationCenter.default.addObserver(self, selector: #selector(fetchComments), name: .ReaderCommentModifiedNotification, object: nil)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -229,10 +232,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         toolbar.configure(for: post, in: self)
         header.configure(for: post)
         fetchLikes()
-
-        if FeatureFlag.postDetailsComments.enabled {
-            fetchComments()
-        }
+        fetchComments()
 
         if let postURLString = post.permaLink,
            let postURL = URL(string: postURLString) {
@@ -528,10 +528,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         view.setNeedsDisplay()
     }
 
-    private func fetchComments() {
-        guard let post = post else {
-            return
-        }
+    @objc private func fetchComments() {
+        guard FeatureFlag.postDetailsComments.enabled,
+              let post = post else {
+                  return
+              }
 
         coordinator?.fetchComments(for: post)
     }


### PR DESCRIPTION
Ref: #17629, #17511, #17834

When a post comment is moderated/edited in the threaded comments view, the post's Comment snippet is now updated to reflect the changes.

To test:
- Verify `commentThreadModerationMenu` is enabled.
- Go to the Reader. Select a post with comments and that you have permission to moderate comments on.
- Note the comment displayed in the Comments snippet.
- Go to the Comments view.
- On the first comment, tap the ellipsis button and select any status. 
  - Go back to the post details.
  - Verify the Comments snippet shows the next top level comment.
- Return to the Comments view.
- On the first comment, tap the ellipsis button and Edit the comment. 
  - Go back to the post details.
  - Verify the Comments snippet shows the updated comment.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
