### PR TITLE
Add Buildkite Release Builds

### DIFF
--- a/.buildkite/commands/installable-build-wordpress.sh
+++ b/.buildkite/commands/installable-build-wordpress.sh
@@ -14,4 +14,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_app_store_connect
+bundle exec fastlane build_and_upload_installable_build

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -19,4 +19,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:true
+bundle exec fastlane build_and_upload_jetpack_for_app_store

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+echo "--- :rubygems: Fixing Ruby Setup"
+gem install bundler
+
+echo "--- :arrow_down: Installing Release Dependencies"
+brew update # Update homebrew to temporarily fix a bintray issue
+brew install imagemagick
+brew install ghostscript
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :cocoapods: Setting up Pods"
+install_cocoapods
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:true

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -4,6 +4,11 @@
 echo "--- :rubygems: Fixing Ruby Setup"
 gem install bundler
 
+echo "--- :arrow_down: Installing Release Dependencies"
+brew update # Update homebrew to temporarily fix a bintray issue
+brew install imagemagick
+brew install ghostscript
+
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
@@ -14,4 +19,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_app_store_connect
+bundle exec fastlane build_and_upload_app_center skip_confirm:true

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -eu
+
+# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+echo "--- :rubygems: Fixing Ruby Setup"
+gem install bundler
+
+echo "--- :arrow_down: Installing Release Dependencies"
+brew update # Update homebrew to temporarily fix a bintray issue
+brew install imagemagick
+brew install ghostscript
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :cocoapods: Setting up Pods"
+install_cocoapods
+
+echo "--- :closed_lock_with_key: Installing Secrets"
+bundle exec fastlane run configure_apply
+
+echo "--- :hammer_and_wrench: Building"
+bundle exec fastlane build_and_upload_jetpack_for_app_store

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -19,4 +19,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:true
+bundle exec fastlane build_and_upload_app_store_connect skip_confirm:true create_gh_release:true

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -19,4 +19,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_jetpack_for_app_store
+bundle exec fastlane build_and_upload_beta_release skip_confirm:true create_gh_release:true

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -17,13 +17,19 @@ common_params:
 
 steps:
 
-  - label: "🛠 WordPress Release Build"
+  - label: "🛠 WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
+  - label: "🛠 WordPress Release Build (App Center)"
+    command: ".buildkite/commands/release-build-wordpress-internal.sh"
+    env: *common_env
+    plugins: *common_plugins
+    notify:
+    - slack: "#build-and-ship"
 
   - label: "🛠 Jetpack Release Build"
     command: ".buildkite/commands/release-build-jetpack.sh"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,8 +1,3 @@
-# This script is run via Buildkite's scheduled jobs feature.
-#
-# It's meant to rebuild various CI caches on a periodic async basis, so as
-# not to waste time on every CI job updating the cache.
-
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,3 +1,5 @@
+# This pipeline is meant to be run via the Buildkite API, and is only used for release builds
+
 # Nodes with values to reuse in the pipeline.
 common_params:
   # Common plugin settings to use with the `plugins` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -28,7 +28,7 @@ steps:
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 Jetpack Release Build"
+  - label: "🛠 Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,0 +1,33 @@
+# This script is run via Buildkite's scheduled jobs feature.
+#
+# It's meant to rebuild various CI caches on a periodic async basis, so as
+# not to waste time on every CI job updating the cache.
+
+# Nodes with values to reuse in the pipeline.
+common_params:
+  # Common plugin settings to use with the `plugins` key.
+  - &common_plugins
+    - automattic/bash-cache#v1.5.0
+    - automattic/git-s3-cache#v1.1.0:
+        bucket: "a8c-repo-mirrors"
+        repo: "wordpress-mobile/wordpress-ios/"
+  # Common environment values to use with the `env` key.
+  - &common_env
+    IMAGE_ID: xcode-13
+
+steps:
+
+  - label: "🛠 WordPress Release Build"
+    command: ".buildkite/commands/release-build-wordpress.sh"
+    env: *common_env
+    plugins: *common_plugins
+    notify:
+    - slack: "#build-and-ship"
+
+
+  - label: "🛠 Jetpack Release Build"
+    command: ".buildkite/commands/release-build-jetpack.sh"
+    env: *common_env
+    plugins: *common_plugins
+    notify:
+    - slack: "#build-and-ship"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -518,7 +518,7 @@ platform :ios do
   end
 
   #####################################################################################
-  # build_and_upload_release
+  # build_and_upload_release [deprecated]
   # -----------------------------------------------------------------------------------
   # This lane builds the app and uploads it for both internal and external distribution
   # -----------------------------------------------------------------------------------
@@ -534,14 +534,70 @@ platform :ios do
   #####################################################################################
   desc 'Builds and uploads for distribution'
   lane :build_and_upload_release do |options|
-    ios_build_prechecks(skip_confirm: options[:skip_confirm],
-                        internal: options[:beta_release],
-                        external: true)
+    build_and_upload_app_center(options) if options[:beta_release]
+    build_and_upload_app_store_connect(options)
+  end
+
+  #####################################################################################
+  # build_and_upload_app_store_connect
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app and uploads it for App Store Connect
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_app_store_connect [skip_confirm:<skip confirm>]
+  #  [create_gh_release:<create release on GH>] [beta_release:<is a beta release>]
+  #
+  # Example:
+  # bundle exec fastlane build_and_upload_app_store_connect
+  # bundle exec fastlane build_and_upload_app_store_connect skip_confirm:true
+  # bundle exec fastlane build_and_upload_app_store_connect create_gh_release:true
+  # bundle exec fastlane build_and_upload_app_store_connect beta_release:true
+  #####################################################################################
+  desc 'Builds and uploads for distribution to App Store Connect'
+  lane :build_and_upload_app_store_connect do |options|
+    ios_build_prechecks(
+      skip_confirm: options[:skip_confirm],
+      internal: options[:beta_release],
+      external: true
+    )
+
     ios_build_preflight
 
-    build_and_upload_internal(skip_prechecks: true, skip_confirm: options[:skip_confirm]) if options[:beta_release]
-    build_and_upload_itc(skip_prechecks: true, skip_confirm: options[:skip_confirm],
-                         beta_release: options[:beta_release], create_release: options[:create_gh_release])
+    build_and_upload_itc(
+      skip_prechecks: true,
+      skip_confirm: options[:skip_confirm],
+      beta_release: options[:beta_release],
+      create_release: options[:create_gh_release]
+    )
+
+  end
+
+  #####################################################################################
+  # build_and_upload_app_center
+  # -----------------------------------------------------------------------------------
+  # This lane builds the app and uploads it for App Center
+  # -----------------------------------------------------------------------------------
+  # Usage:
+  # bundle exec fastlane build_and_upload_app_center [skip_confirm:<skip confirm>]
+  #
+  # Example:
+  # bundle exec fastlane build_and_upload_app_center
+  # bundle exec fastlane build_and_upload_app_center skip_confirm:true
+  #####################################################################################
+  desc 'Builds and uploads for distribution to App Center'
+  lane :build_and_upload_app_center do |options|
+    ios_build_prechecks(
+      skip_confirm: options[:skip_confirm],
+      internal: true,
+      external: true
+    )
+
+    ios_build_preflight
+
+    build_and_upload_internal(
+      skip_prechecks: true,
+      skip_confirm: options[:skip_confirm]
+    )
   end
 
   #####################################################################################

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -518,7 +518,7 @@ platform :ios do
   end
 
   #####################################################################################
-  # build_and_upload_release [deprecated]
+  # build_and_upload_release [Deprecated - Can be removed once CircleCI is no longer in use]
   # -----------------------------------------------------------------------------------
   # This lane builds the app and uploads it for both internal and external distribution
   # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Adds to ability to produce release builds using Buildkite and the API. 

**To Test:**
Note that https://buildkite.com/wordpress-mobile/wordpress-ios/builds/4791 builds successfully, exiting with the error `This binary already exists`.

Best tested in combination with https://github.com/wordpress-mobile/release-toolkit/pull/333