### PR TITLE
My Site Dashboard: Remove table header view from BlogDetailsViewController

### DIFF
--- a/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
@@ -21,7 +21,7 @@ extension UIScrollView {
                                         height: safeAreaLayoutGuide.layoutFrame.height)
                 scrollRectToVisible(targetRect, animated: animated)
             } else {
-                scrollToBottom()
+                scrollToBottom(animated: true)
             }
 
             // This ensures scrolling to the correct position, especially when there are layout changes
@@ -32,10 +32,15 @@ extension UIScrollView {
         }
     }
 
-    @objc func scrollToBottom() {
+    @objc func scrollToTop(animated: Bool) {
+        let topOffset = CGPoint(x: 0, y: -adjustedContentInset.top)
+        setContentOffset(topOffset, animated: animated)
+    }
+
+    @objc func scrollToBottom(animated: Bool) {
         let bottomOffset = CGPoint(x: 0, y: contentSize.height - bounds.size.height + adjustedContentInset.bottom)
         if bottomOffset.y > 0 {
-            setContentOffset(bottomOffset, animated: true)
+            setContentOffset(bottomOffset, animated: animated)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -12,8 +12,6 @@ extension BlogDetailsViewController {
             guard self?.blog.managedObjectContext != nil else {
                 return
             }
-            self?.toggleSpotlightForSiteTitle()
-            self?.refreshSiteIcon()
             self?.configureTableViewData()
             self?.reloadTableViewPreservingSelection()
 
@@ -114,9 +112,7 @@ extension BlogDetailsViewController {
     private func showQuickStart(with type: QuickStartType) {
         let checklist = QuickStartChecklistViewController(blog: blog, type: type)
         let navigationViewController = UINavigationController(rootViewController: checklist)
-        present(navigationViewController, animated: true) { [weak self] in
-            self?.toggleSpotlightOnHeaderView()
-        }
+        present(navigationViewController, animated: true)
 
         QuickStartTourGuide.shared.visited(.checklist)
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -20,12 +20,11 @@ extension BlogDetailsViewController {
             if let info = notification.userInfo?[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
                 switch info {
                 case .noSuchElement:
-                    if FeatureFlag.mySiteDashboard.enabled,
-                       let parentVC = self?.parent as? MySiteViewController {
-                        parentVC.additionalSafeAreaInsets = .zero
-                    } else {
-                        self?.additionalSafeAreaInsets = .zero
+                    guard let parentVC = self?.parent as? MySiteViewController else {
+                        return
                     }
+
+                    parentVC.additionalSafeAreaInsets = .zero
 
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -382,18 +382,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self startObservingQuickStart];
     [self addMeButtonToNavigationBarWithEmail:self.blog.account.email meScenePresenter:self.meScenePresenter];
     
-    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-        MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
-        
-        [self.createButtonCoordinator addTo:parentVC.view
-                             trailingAnchor:parentVC.view.safeAreaLayoutGuide.trailingAnchor
-                               bottomAnchor:parentVC.view.safeAreaLayoutGuide.bottomAnchor];
-    } else {
-        [self.createButtonCoordinator addTo:self.view
-                             trailingAnchor:self.view.safeAreaLayoutGuide.trailingAnchor
-                               bottomAnchor:self.view.safeAreaLayoutGuide.bottomAnchor];
-    }
+    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
     
+    [self.createButtonCoordinator addTo:parentVC.view
+                         trailingAnchor:parentVC.view.safeAreaLayoutGuide.trailingAnchor
+                           bottomAnchor:parentVC.view.safeAreaLayoutGuide.bottomAnchor];
+
 }
 
 /// Resizes the `tableHeaderView` as necessary whenever its size changes.
@@ -419,25 +413,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
+    
+    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
 
     if ([[QuickStartTourGuide shared] currentElementInt] != NSNotFound) {
-        
-        if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-            MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
-            parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
-        } else {
-            self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
-        }
-        
+        parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
     } else {
-        
-        if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-            MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
-            parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
-        } else {
-            self.additionalSafeAreaInsets = UIEdgeInsetsZero;
-        }
-        
+        parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
     }
 
     if (self.splitViewControllerIsHorizontallyCompact) {
@@ -1717,18 +1699,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         rowCount = 0;
         for (BlogDetailsRow *row in section.rows) {
             if (row.quickStartIdentifier == element) {
-                
                 NSIndexPath *path = [NSIndexPath indexPathForRow:rowCount inSection:sectionCount];
-                
-                if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-                    parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
-                    UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:path];
-                    [parentVC.scrollView scrollToView:cell animated:true];
-                } else {
-                    self.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
-                    [self.tableView scrollToRowAtIndexPath:path atScrollPosition:UITableViewScrollPositionTop animated:true];
-                }
-                
+                parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
+                UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:path];
+                [parentVC.scrollView scrollToView:cell animated:true];
             }
             rowCount++;
         }
@@ -1948,12 +1922,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [[QuickStartTourGuide shared] completeViewSiteTourForBlog:self.blog];
     }
 
-    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-        MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
-        parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
-    } else {
-        self.additionalSafeAreaInsets = UIEdgeInsetsZero;
-    }    
+    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+    parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
 }
 
 - (void)showViewAdmin

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -327,13 +327,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewDidLoad];
     
-    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-        _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
-        self.tableView.scrollEnabled = false;
-    } else {
-        _tableView = [[UITableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
-    }
-
+    _tableView = [[IntrinsicTableView alloc] initWithFrame:CGRectZero style:UITableViewStyleInsetGrouped];
+    self.tableView.scrollEnabled = false;
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     self.tableView.translatesAutoresizingMaskIntoConstraints = false;
@@ -377,8 +372,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                  name:NSManagedObjectContextObjectsDidChangeNotification
                                                object:context];
 
-    [self configureBlogDetailHeader];
-    [self.headerView setBlog:_blog];
     [self startObservingQuickStart];
     [self addMeButtonToNavigationBarWithEmail:self.blog.account.email meScenePresenter:self.meScenePresenter];
     
@@ -390,24 +383,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 }
 
-/// Resizes the `tableHeaderView` as necessary whenever its size changes.
 - (void)viewDidLayoutSubviews {
     [super viewDidLayoutSubviews];
     
     [self.createButtonCoordinator presentingTraitCollectionWillChange:self.traitCollection newTraitCollection:self.traitCollection];
-    
-    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-        return;
-    }
-    
-    UIView *headerView = self.tableView.tableHeaderView;
-    
-    CGSize size = [self.tableView.tableHeaderView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
-    if (headerView.frame.size.height != size.height) {
-        headerView.frame = CGRectMake(headerView.frame.origin.x, headerView.frame.origin.y, headerView.frame.size.width, size.height);
-        
-        self.tableView.tableHeaderView = headerView;
-    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -1094,98 +1073,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return [defaultAccount.dateCreated compare:hideWPAdminDate] == NSOrderedAscending;
 }
 
-#pragma mark - Configuration
-
-- (void)configureBlogDetailHeader
-{
-    if ([Feature enabled:FeatureFlagMySiteDashboard]) {
-        return;
-    }
-    
-    BlogDetailHeaderView *headerView = [self configureHeaderView];
-    headerView.delegate = self;
-
-    self.headerView = headerView;
-
-    self.tableView.tableHeaderView = headerView;
-    
-    [self.headerView setTranslatesAutoresizingMaskIntoConstraints:NO];
-    [NSLayoutConstraint activateConstraints:@[
-        [self.headerView.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-        [self.headerView.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor]
-    ]];
-}
-
-#pragma mark BlogDetailHeaderViewDelegate
-
-- (void)siteIconTapped
-{
-    if (![self siteIconShouldAllowDroppedImages]) {
-        // Gracefully ignore the tap for users that can not upload files or
-        // blogs that do not have capabilities since those will not support the REST API icon update
-        return;
-    }
-    [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconTapped];
-    
-    [NoticesDispatch lock];
-
-    if (![Feature enabled:FeatureFlagSiteIconCreator]) {
-        [self showUpdateSiteIconAlert];
-    }
-    
-    if (@available(iOS 14.0, *)) {
-        [self showSiteIconSelectionAlert];
-    } else {
-        [self showUpdateSiteIconAlert];
-    }
-}
-
-- (void)siteIconReceivedDroppedImage:(UIImage *)image
-{
-    if (![self siteIconShouldAllowDroppedImages]) {
-        // Gracefully ignore the drop for users that can not upload files or
-        // blogs that do not have capabilities since those will not support the REST API icon update
-        self.headerView.updatingIcon = NO;
-        return;
-    }
-    [self presentCropViewControllerForDroppedSiteIcon:image];
-}
-
-- (BOOL)siteIconShouldAllowDroppedImages
-{
-    if (!self.blog.isAdmin || !self.blog.isUploadingFilesAllowed) {
-        return NO;
-    }
-
-    return YES;
-}
-
-- (void)siteTitleTapped
-{
-    [self showSiteTitleSettings];
-}
-
-- (void)siteSwitcherTapped
-{
-    BlogListViewController* blogListViewController = [[BlogListViewController alloc] initWithMeScenePresenter:self.meScenePresenter];
-    __weak __typeof(self) weakSelf = self;
-    blogListViewController.blogSelected = ^(BlogListViewController* blogListViewController, Blog *blog) {
-        [weakSelf switchToBlog:blog];
-        [blogListViewController dismissViewControllerAnimated:true completion:nil];
-    };
-    
-    UINavigationController* navigationController = [[UINavigationController alloc] initWithRootViewController:blogListViewController];
-    navigationController.modalPresentationStyle = UIModalPresentationFormSheet;
-    [self presentViewController:navigationController animated:true completion:nil];
-
-    [WPAnalytics trackEvent:WPAnalyticsEventMySiteSiteSwitcherTapped];
-}
-
-- (void)visitSiteTapped
-{
-    [self showViewSiteFromSource:BlogDetailsNavigationSourceButton];
-}
-
 #pragma mark Site Switching
 
 - (void)switchToBlog:(Blog*)blog
@@ -1204,205 +1091,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     
     [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
-}
-
-#pragma mark Site Icon Update Management
-
-- (void)showUpdateSiteIconAlert
-{
-    UIAlertController *updateIconAlertController = [UIAlertController alertControllerWithTitle:nil
-                                                                                       message:nil
-                                                                                preferredStyle:UIAlertControllerStyleActionSheet];
-
-    updateIconAlertController.popoverPresentationController.sourceView = self.headerView.blavatarImageView.superview;
-    updateIconAlertController.popoverPresentationController.sourceRect = self.headerView.blavatarImageView.frame;
-    updateIconAlertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
-
-    [updateIconAlertController addDefaultActionWithTitle:NSLocalizedString(@"Change Site Icon", @"Change site icon button")
-                                                 handler:^(UIAlertAction *action) {
-                                                     [NoticesDispatch unlock];
-                                                     [self updateSiteIcon];
-                                                 }];
-    if (self.blog.hasIcon) {
-        [updateIconAlertController addDestructiveActionWithTitle:NSLocalizedString(@"Remove Site Icon", @"Remove site icon button")
-                                                         handler:^(UIAlertAction *action) {
-                                                             [NoticesDispatch unlock];
-                                                             [self removeSiteIcon];
-                                                         }];
-    }
-    [updateIconAlertController addCancelActionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")
-                                                handler:^(UIAlertAction *action) {
-                                                    [NoticesDispatch unlock];
-                                                    [self startAlertTimer];
-                                                }];
-
-    [self presentViewController:updateIconAlertController animated:YES completion:nil];
-}
-
-- (void)showSiteIconSelectionAlert
-{
-    UIAlertController *alertController = [UIAlertController alertControllerWithTitle:nil
-                                                                                       message:nil
-                                                                                preferredStyle:UIAlertControllerStyleActionSheet];
-
-    alertController.popoverPresentationController.sourceView = self.headerView.blavatarImageView.superview;
-    alertController.popoverPresentationController.sourceRect = self.headerView.blavatarImageView.frame;
-    alertController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
-
-    [alertController setTitle:NSLocalizedString(@"Update Site Icon", @"Title for sheet displayed allowing user to update their site icon")];
-
-    [alertController addDefaultActionWithTitle:NSLocalizedString(@"Choose Image From My Device", @"Button allowing the user to choose an image from their device to use as their site icon")
-                                       handler:^(UIAlertAction *action) {
-        [NoticesDispatch unlock];
-        [self updateSiteIcon];
-    }];
-
-    [alertController addDefaultActionWithTitle:NSLocalizedString(@"Create With Emoji", @"Button allowing the user to create a site icon by choosing an emoji character")
-                                       handler:^(UIAlertAction *action) {
-        [NoticesDispatch unlock];
-        [self showEmojiPicker];
-    }];
-
-    [alertController addDestructiveActionWithTitle:NSLocalizedString(@"Remove Site Icon", @"Remove site icon button")
-                                           handler:^(UIAlertAction *action) {
-        [NoticesDispatch unlock];
-        [self removeSiteIcon];
-    }];
-
-    [alertController addCancelActionWithTitle:NSLocalizedString(@"Cancel", @"Cancel button")
-                                      handler:^(UIAlertAction *action) {
-        [NoticesDispatch unlock];
-        [self startAlertTimer];
-    }];
-
-    [self presentViewController:alertController animated:YES completion:nil];
-}
-
-- (void)presentCropViewControllerForDroppedSiteIcon:(UIImage *)image
-{
-    self.imageCropViewController = [[ImageCropViewController alloc] initWithImage:image];
-    self.imageCropViewController.maskShape = ImageCropOverlayMaskShapeSquare;
-    self.imageCropViewController.shouldShowCancelButton = YES;
-
-    __weak __typeof(self) weakSelf = self;
-    self.imageCropViewController.onCancel = ^(void) {
-        [weakSelf dismissViewControllerAnimated:YES completion:nil];
-        weakSelf.headerView.updatingIcon = NO;
-    };
-
-    self.imageCropViewController.onCompletion = ^(UIImage *image, BOOL modified) {
-        [weakSelf dismissViewControllerAnimated:YES completion:nil];
-        [weakSelf uploadDroppedSiteIcon:image onCompletion:^{
-            weakSelf.headerView.blavatarImageView.image = image;
-            weakSelf.headerView.updatingIcon = NO;
-        }];
-    };
-    UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:self.imageCropViewController];
-    navController.modalPresentationStyle = UIModalPresentationFormSheet;
-    [self presentViewController:navController animated:YES completion:nil];
-}
-
-- (void)uploadDroppedSiteIcon:(UIImage *)image onCompletion:(void(^)(void))completion
-{
-    if (self.blog.objectID == nil) {
-        return;
-    }
-
-    __weak __typeof(self) weakSelf = self;
-    MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:[ContextManager sharedInstance].mainContext];
-    NSProgress *mediaCreateProgress;
-    [mediaService createMediaWith:image blog:self.blog post:nil progress:&mediaCreateProgress thumbnailCallback:nil completion:^(Media *media, NSError *error) {
-        if (media == nil || error != nil) {
-            return;
-        }
-        NSProgress *uploadProgress;
-        [mediaService uploadMedia:media
-                   automatedRetry:false
-                         progress:&uploadProgress
-                          success:^{
-            [weakSelf updateBlogIconWithMedia:media];
-            completion();
-        } failure:^(NSError * _Nonnull error) {
-            [weakSelf showErrorForSiteIconUpdate];
-            completion();
-        }];
-    }];
-}
-
-- (void)updateSiteIcon
-{
-    self.siteIconPickerPresenter = [[SiteIconPickerPresenter alloc]initWithBlog:self.blog];
-    __weak __typeof(self) weakSelf = self;
-    self.siteIconPickerPresenter.onCompletion = ^(Media *media, NSError *error) {
-        if (error) {
-            [weakSelf showErrorForSiteIconUpdate];
-        } else if (media) {
-            [weakSelf updateBlogIconWithMedia:media];
-        } else {
-            // If no media and no error the picker was canceled
-            [weakSelf dismissViewControllerAnimated:YES completion:nil];
-        }
-        weakSelf.siteIconPickerPresenter = nil;
-        [weakSelf startAlertTimer];
-    };
-    self.siteIconPickerPresenter.onIconSelection = ^() {
-        weakSelf.headerView.updatingIcon = YES;
-        [weakSelf dismissViewControllerAnimated:YES completion:nil];
-    };
-    [self.siteIconPickerPresenter presentPickerFrom:self];
-}
-
-- (void)removeSiteIcon
-{
-    self.headerView.updatingIcon = YES;
-    self.blog.settings.iconMediaID = @0;
-    [self updateBlogSettingsAndRefreshIcon];
-    [WPAnalytics track:WPAnalyticsStatSiteSettingsSiteIconRemoved];
-}
-
-- (void)refreshSiteIcon
-{
-    [self.headerView refreshIconImage];
-}
-
-- (void)toggleSpotlightForSiteTitle
-{
-    [self.headerView toggleSpotlightOnSiteTitle];
-}
-
-- (void)toggleSpotlightOnHeaderView
-{
-    [self.headerView toggleSpotlightOnSiteTitle];
-    [self.headerView toggleSpotlightOnSiteIcon];
-}
-
-- (void)updateBlogIconWithMedia:(Media *)media
-{
-    [[QuickStartTourGuide shared] completeSiteIconTourForBlog:self.blog];
-
-    self.blog.settings.iconMediaID = media.mediaID;
-    [self updateBlogSettingsAndRefreshIcon];
-}
-
-- (void)updateBlogSettingsAndRefreshIcon
-{
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:self.blog.managedObjectContext];
-    [blogService updateSettingsForBlog:self.blog
-                               success:^{
-        [blogService syncBlog:self.blog
-                      success:^{
-            self.headerView.updatingIcon = NO;
-            [self.headerView refreshIconImage];
-        } failure:nil];
-     } failure:^(NSError *error){
-         [self showErrorForSiteIconUpdate];
-     }];
-}
-
-- (void)showErrorForSiteIconUpdate
-{
-    [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Icon update failed", @"Message to show when site icon update failed")];
-    self.headerView.updatingIcon = NO;
 }
 
 #pragma mark - Table view data source
@@ -1908,9 +1596,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [self presentViewController:navController
                        animated:YES
-                     completion:^(void) {
-        [self toggleSpotlightOnHeaderView];
-    }];
+                     completion:nil];
 
     QuickStartTourGuide *guide = [QuickStartTourGuide shared];
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -93,10 +93,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         get {
-            guard FeatureFlag.mySiteDashboard.enabled else {
-                return blogDetailsViewController?.blog
-            }
-
             return sitePickerViewController?.blog
         }
     }
@@ -164,35 +160,23 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func updateSegmentedControl(for blog: Blog) {
-        guard FeatureFlag.mySiteDashboard.enabled else {
-            return
-        }
-
         // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device is an iPad
-        segmentedControlContainerView.isHidden = !blog.isAccessibleThroughWPCom() || UIDevice.isPad()
+        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || UIDevice.isPad()
     }
 
     private func setupView() {
         view.backgroundColor = .listBackground
     }
 
-    /// If the My Site Dashboard feature flag is enabled, then this method builds a layout with the following
-    /// view hierarchy:
+    /// This method builds a layout with the following view hierarchy:
     ///
     /// - Scroll view
     ///   - Stack view
     ///     - Segmented control container view
     ///       - Segmented control
     ///     - Child view controller
-    ///
-    /// Otherwise, if the My Site Dashboard feature flag is disabled, this method does nothing and the
-    /// child vc is added directly to the root view of the view controller in showBlogDetails.
     /// 
     private func setupConstraints() {
-        guard FeatureFlag.mySiteDashboard.enabled else {
-            return
-        }
-
         view.addSubview(scrollView)
         view.pinSubviewToAllEdges(scrollView)
         scrollView.addSubview(stackView)
@@ -527,13 +511,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         addMeButtonToNavigationBar(email: blog.account?.email, meScenePresenter: meScenePresenter)
 
-        if FeatureFlag.mySiteDashboard.enabled {
-            embedChildInStackView(blogDetailsViewController)
-        } else {
-            add(blogDetailsViewController)
-            blogDetailsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-            view.pinSubviewToAllEdges(blogDetailsViewController.view)
-        }
+        embedChildInStackView(blogDetailsViewController)
 
         blogDetailsViewController.showInitialDetailsForBlog()
     }
@@ -557,10 +535,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func addSitePickerIfNeeded(for blog: Blog) {
-        guard FeatureFlag.mySiteDashboard.enabled else {
-            return
-        }
-
         guard sitePickerViewController == nil else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
@@ -22,13 +22,14 @@ extension SitePickerViewController {
             if let info = notification.userInfo?[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
                 switch info {
                 case .noSuchElement:
-                    self?.additionalSafeAreaInsets = UIEdgeInsets.zero
+                    self?.additionalSafeAreaInsets = .zero
                 case .siteIcon, .siteTitle:
                     // handles the padding in case the element is not in the table view
                     guard let parentVC = self?.parent as? MySiteViewController else {
                         return
                     }
-                    parentVC.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: BlogDetailsViewController.bottomPaddingForQuickStartNotices, right: 0)
+                    parentVC.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPaddingForQuickStartNotices, right: 0)
+                    parentVC.scrollView.scrollToTop(animated: true)
                 default:
                     break
                 }
@@ -60,5 +61,9 @@ extension SitePickerViewController {
         if let tourToSuggest = QuickStartTourGuide.shared.tourToSuggest(for: blog) {
             QuickStartTourGuide.shared.suggest(tourToSuggest, for: blog)
         }
+    }
+
+    private enum Constants {
+        static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
     }
 }


### PR DESCRIPTION
Fixes #17805
Fixes #17853 / #16402

## Description

This PR removes the table header view from BlogDetailsViewController, and completely switches over to using the SitePickerViewController as an embedded child view controller (regardless of whether the My Site Dashboard is enabled or disabled).

This completes phase 1 of the My Site Dashboard project. (Ref: pbArwn-3mP-p2)

## How to test

⚠️ Do a clean install, and make sure the MSD feature flag is **disabled** (should be disabled by default)


### Quick Start auto scroll 

1. Log in
2. Tap "Show me around" in the post-epilogue Quick Start prompt
3. Go through every single Quick Start element for both check lists
4. ✅ Make sure the screen scrolls to the correct position for Quick Start elements in the site menu

### FAB

1. Go to My Site > Site menu
2. Tap on the FAB > Blog post
3. Create a draft post
4. ✅ Make sure that the draft post is there when you go to Posts > Drafts
5. Tap on the FAB > Site page
6. Create a draft page
7. ✅ Make sure the the draft page is there when you go to Pages > Drafts

### Site Picker

1. Tap on the site title
2. Change the title and tap Save
3. ✅ The site title should be updated
4. Tap on the site icon
5. Update your site icon (Choose image from device, Create with emoji, Remove site icon)
6. ✅ The site icon should be updated
7. Tap on the site url
8. ✅ A webview of your site should be displayed
9. Switch to a different site
10. ✅ The site switcher displays the selected site
11. ✅ The site menu (BlogDetailsVC) has updated to the selected blog

### Pull to refresh

1. Open the app
2. Change the name of your blog on your browser
3. Pull to refresh
4. ✅ The title change should be reflected


## Regression Notes
1. Potential unintended areas of impact
- Site Picker
- Pull to refresh 
- Quick Start auto scroll
- FAB

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps manually

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.