### PR TITLE
My Site Dashboard: Re-position site icon spotlight

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteIconView.swift
@@ -4,7 +4,7 @@ class SiteIconView: UIView {
         static let imageSize: CGFloat = 64
         static let borderRadius: CGFloat = 4
         static let imageRadius: CGFloat = 2
-        static let spotlightOffset: CGFloat = -8
+        static let spotlightOffset: CGFloat = 8
     }
 
     /// Whether or not to show the spotlight animation to illustrate tapping the icon.
@@ -92,8 +92,8 @@ class SiteIconView: UIView {
         addSubview(spotlightView)
 
         NSLayoutConstraint.activate([
-            trailingAnchor.constraint(equalTo: spotlightView.trailingAnchor, constant: Constants.spotlightOffset),
-            bottomAnchor.constraint(equalTo: spotlightView.bottomAnchor, constant: Constants.spotlightOffset)
+            leadingAnchor.constraint(equalTo: spotlightView.leadingAnchor, constant: Constants.spotlightOffset),
+            topAnchor.constraint(equalTo: spotlightView.topAnchor, constant: Constants.spotlightOffset)
         ])
 
         pinSubviewToAllEdges(button)


### PR DESCRIPTION
Part of #17805

## Description
This PR re-positions the  spotlight shown during the Site Icon Quick Start tour.

Previously, the spotlight was pinned to the bottom right corner of the SiteIconView. However, with the updated BlogHeaderDetailView, the spotlight gets cut off at the bottom.
    
To resolve this issue, I re-positioned the spotlight to appear on the top left corner.

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/152194377-97c3c387-85ba-48c6-a091-392352cfd8dd.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/152194369-dd123a05-0aac-420e-93e1-1c2b74f0b9d7.png" width=200>

## How to test

⚠️ Do a clean install, and make sure the MSD feature flag is **disabled** (should be disabled by default)

1. Log in
2. Tap "Show me around" in the post-epilogue Quick Start prompt
3. On the checklist, tap on "Choose a unique site icon"
4. ✅ The spotlight should be shown in the top left corner of the site icon view

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
Just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
