### PR TITLE
Fix checkmark fading animation when choosing a site design

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855]
 * [**] Threaded comments: comments can now be moderated via a drop-down menu on each comment. [#17888]
 * [*] Stats: Users can now add a new Insights card from the navigation bar. [#17867]
+* [*] Site creation: The checkbox that appears when choosing a design no longer flickers when toggled. [#17868]
 
 19.1
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
@@ -8,7 +8,7 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
     static let nib = UINib(nibName: "\(CollapsableHeaderCollectionViewCell.self)", bundle: Bundle.main)
     static let selectionAnimationSpeed: Double = 0.25
     @IBOutlet weak var imageView: UIImageView!
-    @IBOutlet weak var checkmarkBackground: UIView!
+    @IBOutlet weak var checkmarkContainerView: UIView!
     @IBOutlet weak var checkmarkImageView: UIImageView! {
         didSet {
             checkmarkImageView.image = UIImage(systemName: "checkmark.circle.fill")
@@ -118,25 +118,20 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
 
     private func checkmarkHidden(_ isHidden: Bool, animated: Bool = false) {
         guard animated else {
-            checkmarkImageView.isHidden = isHidden
-            checkmarkBackground.isHidden = isHidden
+            checkmarkContainerView.isHidden = isHidden
             return
         }
 
-        checkmarkImageView.isHidden = false
-        checkmarkBackground.isHidden = false
+        checkmarkContainerView.isHidden = false
 
         // Set the inverse of the animation destination
-        checkmarkImageView.alpha = isHidden ? 1 : 0
-        checkmarkBackground.alpha = isHidden ? 1 : 0
+        checkmarkContainerView.alpha = isHidden ? 1 : 0
         let targetAlpha: CGFloat = isHidden ? 0 : 1
 
         UIView.animate(withDuration: CollapsableHeaderCollectionViewCell.selectionAnimationSpeed, animations: {
-            self.checkmarkImageView.alpha = targetAlpha
-            self.checkmarkBackground.alpha = targetAlpha
+            self.checkmarkContainerView.alpha = targetAlpha
         }, completion: { (_) in
-            self.checkmarkImageView.isHidden = !self.isSelected
-            self.checkmarkBackground.isHidden = !self.isSelected
+            self.checkmarkContainerView.isHidden = !self.isSelected
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,36 +26,45 @@
                             </userDefinedRuntimeAttribute>
                         </userDefinedRuntimeAttributes>
                     </imageView>
-                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="apQ-T8-du2">
-                        <rect key="frame" x="119" y="15" width="26" height="26"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <userDefinedRuntimeAttributes>
-                            <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                <integer key="value" value="13"/>
-                            </userDefinedRuntimeAttribute>
-                        </userDefinedRuntimeAttributes>
-                    </view>
-                    <imageView hidden="YES" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hx0-n7-XEA">
+                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="laj-HC-L8x" userLabel="Checkmark Container View">
                         <rect key="frame" x="116" y="12" width="32" height="32"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="apQ-T8-du2" userLabel="Checkmark Background View">
+                                <rect key="frame" x="3" y="3" width="26" height="26"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <integer key="value" value="13"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </view>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="hx0-n7-XEA">
+                                <rect key="frame" x="0.0" y="0.0" width="32" height="32"/>
+                            </imageView>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" secondItem="hx0-n7-XEA" secondAttribute="height" multiplier="1:1" id="R5g-G9-uHa"/>
-                            <constraint firstAttribute="width" constant="32" id="qbg-FC-btk"/>
+                            <constraint firstItem="apQ-T8-du2" firstAttribute="bottom" secondItem="laj-HC-L8x" secondAttribute="bottom" constant="-3" id="4Oq-Oa-L56"/>
+                            <constraint firstItem="hx0-n7-XEA" firstAttribute="bottom" secondItem="laj-HC-L8x" secondAttribute="bottom" id="JwU-VE-hjG"/>
+                            <constraint firstItem="hx0-n7-XEA" firstAttribute="top" secondItem="laj-HC-L8x" secondAttribute="top" id="PJZ-WW-yRk"/>
+                            <constraint firstItem="apQ-T8-du2" firstAttribute="top" secondItem="laj-HC-L8x" secondAttribute="top" constant="3" id="SmU-ok-LgJ"/>
+                            <constraint firstItem="hx0-n7-XEA" firstAttribute="trailing" secondItem="laj-HC-L8x" secondAttribute="trailing" id="UeB-xi-zOK"/>
+                            <constraint firstAttribute="width" constant="32" id="ZRH-5B-0Ih"/>
+                            <constraint firstItem="apQ-T8-du2" firstAttribute="leading" secondItem="laj-HC-L8x" secondAttribute="leading" constant="3" id="ait-Ub-BdE"/>
+                            <constraint firstAttribute="width" secondItem="laj-HC-L8x" secondAttribute="height" multiplier="1:1" id="ijt-QC-a3J"/>
+                            <constraint firstItem="hx0-n7-XEA" firstAttribute="leading" secondItem="laj-HC-L8x" secondAttribute="leading" id="sJy-Qb-k7g"/>
+                            <constraint firstItem="apQ-T8-du2" firstAttribute="trailing" secondItem="laj-HC-L8x" secondAttribute="trailing" constant="-3" id="vg8-26-oiL"/>
                         </constraints>
-                    </imageView>
+                    </view>
                 </subviews>
             </view>
             <viewLayoutGuide key="safeArea" id="ZTg-uK-7eu"/>
             <constraints>
+                <constraint firstItem="laj-HC-L8x" firstAttribute="top" secondItem="XpQ-DC-DLe" secondAttribute="top" constant="12" id="2MK-HP-5J7"/>
                 <constraint firstItem="XpQ-DC-DLe" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" id="8aK-Nu-g20"/>
                 <constraint firstAttribute="trailing" secondItem="XpQ-DC-DLe" secondAttribute="trailing" id="BrN-ay-15v"/>
-                <constraint firstItem="apQ-T8-du2" firstAttribute="top" secondItem="hx0-n7-XEA" secondAttribute="top" constant="3" id="DMO-Ur-E0k"/>
+                <constraint firstItem="laj-HC-L8x" firstAttribute="trailing" secondItem="XpQ-DC-DLe" secondAttribute="trailing" constant="-12" id="FUz-7V-mZ2"/>
                 <constraint firstItem="XpQ-DC-DLe" firstAttribute="leading" secondItem="gTV-IL-0wX" secondAttribute="leading" id="Hly-4U-lPA"/>
-                <constraint firstAttribute="trailing" secondItem="hx0-n7-XEA" secondAttribute="trailing" constant="12" id="OJx-TX-oHu"/>
-                <constraint firstItem="apQ-T8-du2" firstAttribute="bottom" secondItem="hx0-n7-XEA" secondAttribute="bottom" constant="-3" id="Od3-sV-Hqg"/>
-                <constraint firstItem="apQ-T8-du2" firstAttribute="leading" secondItem="hx0-n7-XEA" secondAttribute="leading" constant="3" id="Q9C-cP-3Ez"/>
                 <constraint firstAttribute="bottom" secondItem="XpQ-DC-DLe" secondAttribute="bottom" id="juf-rq-F1x"/>
-                <constraint firstItem="apQ-T8-du2" firstAttribute="trailing" secondItem="hx0-n7-XEA" secondAttribute="trailing" constant="-3" id="nxN-Kr-1fY"/>
-                <constraint firstItem="hx0-n7-XEA" firstAttribute="top" secondItem="gTV-IL-0wX" secondAttribute="top" constant="12" id="oc5-Cd-UNM"/>
             </constraints>
             <size key="customSize" width="191" height="244"/>
             <userDefinedRuntimeAttributes>
@@ -64,7 +73,7 @@
                 </userDefinedRuntimeAttribute>
             </userDefinedRuntimeAttributes>
             <connections>
-                <outlet property="checkmarkBackground" destination="apQ-T8-du2" id="FaX-4x-APs"/>
+                <outlet property="checkmarkContainerView" destination="laj-HC-L8x" id="i9b-po-WdU"/>
                 <outlet property="checkmarkImageView" destination="hx0-n7-XEA" id="Yst-6N-Qcg"/>
                 <outlet property="imageView" destination="XpQ-DC-DLe" id="j69-db-QW7"/>
             </connections>


### PR DESCRIPTION
Fixes #16690

### Description

This PR corrects a minor issue where the white background view behind the blue checkmark image would cause a flickering effect due to how their opacities would blend. The solution proposed here is to combine both views into one container view.

<img width="350" alt="A 3D view of the view hierarchy" src="https://user-images.githubusercontent.com/2092798/152247030-61448b5c-3006-4a8e-a8c5-049f33deb98d.png">

### To test

**Choosing a design**

1. In the "My Sites" view, tap the "+" symbol at the top right.
2. Choose "Create WordPress.com site".
3. Tap different designs to toggle the checkmark icon animation.
4. Observe that the checkmark's location is the same relative location as before to the top right corner of its view.

**Choosing a layout**

Prerequisites: _This view may be shown with all configurations, but definitely works with WordPress.com sites and a theme from WordPress (e.g. Alves)_

1. In the "My Sites" view, tap Pages, then the blue button to create a new page.
2. Tap the blue button to show the "Choose a Layout" view.
3. Tap different layouts to toggle the checkmark icon animation.
4. Observe that the checkmark's location is the same relative location as before to the top right corner of its view.

**Before**

https://user-images.githubusercontent.com/2092798/152246523-795d040d-eb96-43d9-8a4a-ab87e3f8676d.mp4

**After**

https://user-images.githubusercontent.com/2092798/152246562-7296be56-15cb-41dd-a01d-f7db99cb3372.mp4

### Other notes

Eventually we can move to `UIImage.SymbolConfiguration` (needs iOS 15+) and define the symbol's colors, which is a simpler solution.

## Regression Notes
1. Potential unintended areas of impact
 - The site design picker when creating a new WordPress.com site from the app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested the steps above manually on a device.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
