### PR TITLE
Threaded comment moderation: don't show non-approved cached comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -34,4 +34,6 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 
 // Comment moderation support.
 @property (nonatomic, assign, readwrite) BOOL commentModified;
+- (void)refreshAfterCommentModeration;
+
 @end

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -31,4 +31,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 /// Navigates to the specified comment when the view appears
 @property (nonatomic, strong) NSNumber *navigateToCommentID;
 
+
+// Comment moderation support.
+@property (nonatomic, assign, readwrite) BOOL commentModified;
 @end

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -144,6 +144,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 {
     [super viewDidLoad];
     self.view.backgroundColor = [UIColor murielBasicBackground];
+    self.commentModified = NO;
 
     [self checkIfLoggedIn];
 
@@ -195,6 +196,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 {
     [super viewWillDisappear:animated];
     [self dismissNotice];
+    
+    if (self.commentModified) {
+        // Don't post the notification until the view is being dismissed to avoid purging cached comments prematurely.
+        [self postCommentModifiedNotification];
+    }
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-result"

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -246,15 +246,10 @@ private extension ReaderCommentsViewController {
     func moderateComment(_ comment: Comment, status: CommentStatusType, handler: WPTableViewHandler) {
         let successBlock: (String) -> Void = { [weak self] noticeText in
             self?.commentModified = true
+            self?.refreshAfterCommentModeration()
 
-            // Adjust the ReaderPost's comment count.
-            if let post = self?.post, let commentCount = post.commentCount?.intValue {
-                let adjustment = (status == .approved) ? 1 : -1
-                post.commentCount = NSNumber(value: commentCount + adjustment)
-            }
-
-            // Refresh the UI. The table view handler is needed because the fetched results delegate is set to nil.
-            handler.refreshTableViewPreservingOffset()
+            // Dismiss any old notices to avoid stacked Undo notices.
+            self?.dismissNotice()
 
             // If the status is Approved, the user has undone a comment moderation.
             // So don't show the Undo option in this case.

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -196,13 +196,13 @@ private extension ReaderCommentsViewController {
         return [
             [
                 .unapprove { [weak self] in
-                    self?.moderateComment(comment, status: .pending, handler: handler)
+                    self?.moderateComment(comment, status: .pending)
                 },
                 .spam { [weak self] in
-                    self?.moderateComment(comment, status: .spam, handler: handler)
+                    self?.moderateComment(comment, status: .spam)
                 },
                 .trash { [weak self] in
-                    self?.moderateComment(comment, status: .unapproved, handler: handler)
+                    self?.moderateComment(comment, status: .unapproved)
                 }
             ],
             [
@@ -243,7 +243,7 @@ private extension ReaderCommentsViewController {
         present(navigationControllerToPresent, animated: true)
     }
 
-    func moderateComment(_ comment: Comment, status: CommentStatusType, handler: WPTableViewHandler) {
+    func moderateComment(_ comment: Comment, status: CommentStatusType) {
         let successBlock: (String) -> Void = { [weak self] noticeText in
             self?.commentModified = true
             self?.refreshAfterCommentModeration()
@@ -254,7 +254,7 @@ private extension ReaderCommentsViewController {
             // If the status is Approved, the user has undone a comment moderation.
             // So don't show the Undo option in this case.
             (status == .approved) ? self?.displayNotice(title: noticeText) :
-                                    self?.showActionableNotice(title: noticeText, comment: comment, handler: handler)
+                                    self?.showActionableNotice(title: noticeText, comment: comment)
         }
 
         switch status {
@@ -289,12 +289,12 @@ private extension ReaderCommentsViewController {
         }
     }
 
-    func showActionableNotice(title: String, comment: Comment, handler: WPTableViewHandler) {
+    func showActionableNotice(title: String, comment: Comment) {
         displayActionableNotice(title: title,
                                 actionTitle: .undoActionTitle,
                                 actionHandler: { [weak self] _ in
             // Set the Comment's status back to Approved when the user selects Undo on the notice.
-            self?.moderateComment(comment, status: .approved, handler: handler)
+            self?.moderateComment(comment, status: .approved)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -142,6 +142,12 @@ extension NSNotification.Name {
         WPAnalytics.trackReader(.readerArticleCommentsOpened, properties: properties)
     }
 
+    // MARK: - Notification
+
+    @objc func postCommentModifiedNotification() {
+        NotificationCenter.default.post(name: .ReaderCommentModifiedNotification, object: nil)
+    }
+
 }
 
 // MARK: - Popover Presentation Delegate
@@ -223,7 +229,7 @@ private extension ReaderCommentsViewController {
             CommentAnalytics.trackCommentEdited(comment: comment)
 
             self?.commentService.uploadComment(comment, success: {
-                NotificationCenter.default.post(name: .ReaderCommentModifiedNotification, object: nil)
+                self?.commentModified = true
 
                 // update the thread again in case the approval status changed.
                 tableView.reloadRows(at: [indexPath], with: .automatic)
@@ -239,7 +245,7 @@ private extension ReaderCommentsViewController {
 
     func moderateComment(_ comment: Comment, status: CommentStatusType, handler: WPTableViewHandler) {
         let successBlock: (String) -> Void = { [weak self] noticeText in
-            NotificationCenter.default.post(name: .ReaderCommentModifiedNotification, object: nil)
+            self?.commentModified = true
 
             // Adjust the ReaderPost's comment count.
             if let post = self?.post, let commentCount = post.commentCount?.intValue {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -383,7 +383,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         // Moderated comments could still be cached, so filter out non-approved comments.
-        let approvedComments = comments.filter({ $0.status == "approve"})
+        let approvedStatus = Comment.descriptionFor(.approved)
+        let approvedComments = comments.filter({ $0.status == approvedStatus})
 
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -382,12 +382,15 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             return
         }
 
+        // Moderated comments could still be cached, so filter out non-approved comments.
+        let approvedComments = comments.filter({ $0.status == "approve"})
+
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
 
         commentsTableViewDelegate.updateWith(post: post,
-                                             comments: comments,
+                                             comments: approvedComments,
                                              totalComments: totalComments,
                                              presentingViewController: self,
                                              buttonDelegate: self)


### PR DESCRIPTION
Fixes #17752
Ref: #17629, #17758, p5T066-2Wh#comment-11057

This fixes some issues with `Undo`ing moderated comments in the threaded comments view. 

As noted on the [previous](#17834) attempt to fix: The cause was that, to facilitate `Undo`ing comment moderation, the comment was kept in the cache. However, because it was in the cache, the table's `fetchedObjects` still contained it, thus the table tried to show it.

The previous approach of restoring the undone comment to cache failed miserably. So this goes the other way - leave the comment in the cache and update the applicable views to not display them. The moderated comments are removed from the cache when a full comment sync is performed, so they don't linger for very long.

To test:

- Go to the Reader. Select a post with comments and that you have permission to moderate comments on.
- Go to the Comments view.
- Comment moderation:
  - On any comment, tap the ellipsis button and select any status. 
  - Verify the comment is removed from the view, and the table updates correctly.
  - Go back to the post details view, and verify the Comments snippet count is correct.
- Comment moderation Undo:
  - On any comment, tap the ellipsis button and select any status. 
  - Verify the comment is removed from the view, and the table updates correctly.
  - Tap `Undo` on the confirmation notice.
  - Verify the comment is restored and has the same hierarchy as before.
- Moderate all comments:
  - Moderate all the comments on a post.
  - Verify the `Be the first to leave a comment` view is displayed.
  - Go back to the post details view, and verify the Comments snippet is empty.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is disabled.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
