### PR TITLE
Stop logging MediaHost errors to Sentry

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -369,7 +369,7 @@ private extension ReaderPostCardCell {
         let mediaRequestAuthenticator = MediaRequestAuthenticator()
         let host = MediaHost(with: contentProvider, failure: { error in
             // We'll log the error, so we know it's there, but we won't halt execution.
-            WordPressAppDelegate.crashLogging?.logError(error)
+            DDLogError("ReaderPostCardCell MediaHost error: \(error.localizedDescription)")
         })
 
         mediaRequestAuthenticator.authenticatedRequest(


### PR DESCRIPTION
This PR 'downgrades' the logging of MediaHost errors when fetching site icons for the Reader. We were originally logging these to Sentry, but this isn't generally something we do now for non-crashes. So here, we're changing it to a standard `DDLogError`. The error here isn't a huge issue anyway, it's simply that we can't load a site icon for a private site. Worst case, we won't display an icon for the site in question.

Refs p1643675015736219-slack-C011BKNU1V5

### To test

* In ReaderPostCardCell, add a breakpoint on line 372.
* In MediaHost.swift, add the following to the top of the `init` method so we always return an error:

```
failure(Error.wpComPrivateSiteWithoutAuthToken)
self = .publicSite
return
```
* Build and run, and navigate to a post in the Reader. Your breakpoint should get hit.
* Step over the breakpoint and ensure the error gets logged.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
