### PR TITLE
Save xcode results as artifact in Buildkite

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -35,4 +35,5 @@ set -e
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
 
+echo "--- 🚦 Report Tests Exit Status
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -35,5 +35,5 @@ set -e
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
 
-echo "--- 🚦 Report Tests Exit Status
+echo "--- 🚦 Report Tests Exit Status"
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -27,4 +27,12 @@ install_cocoapods
 echo "--- 🧪 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
+set +e
 bundle exec fastlane test_without_building name:"$TEST_NAME" try_count:3 device:"$DEVICE" ios_version:"$IOS_VERSION"
+TESTS_EXIT_STATUS=$?
+set -e
+
+echo "--- 📦 Zipping test results"
+cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
+
+exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,9 @@ steps:
   # UI Tests
   #################
   - label: "🔬 UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+    command:
+      - .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+      - "zip -r build/results/WordPress.xcresult.zip build/results/WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -87,7 +89,9 @@ steps:
           context: "UI Tests (iPhone)"
 
   - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
+    command:
+      - .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
+      - "zip -r build/results/WordPress.xcresult.zip build/results/WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,7 +78,7 @@ steps:
   - label: "🔬 UI Tests (iPhone)"
     command:
       - .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
-      - "zip -rq WordPress.xcresult.zip build/results/WordPress.xcresult"
+      - "cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -91,7 +91,7 @@ steps:
   - label: "🔬 UI Tests (iPad)"
     command:
       - .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
-      - "zip -rq WordPress.xcresult.zip WordPress.xcresult"
+      - "cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,7 +81,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/"
+      - "build/results/**/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
@@ -92,7 +92,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/"
+      - "build/results/**/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -78,7 +78,7 @@ steps:
   - label: "🔬 UI Tests (iPhone)"
     command:
       - .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
-      - "zip -r build/results/WordPress.xcresult.zip build/results/WordPress.xcresult"
+      - "zip -rq WordPress.xcresult.zip build/results/WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -91,7 +91,7 @@ steps:
   - label: "🔬 UI Tests (iPad)"
     command:
       - .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
-      - "zip -r build/results/WordPress.xcresult.zip build/results/WordPress.xcresult"
+      - "zip -rq WordPress.xcresult.zip WordPress.xcresult"
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,9 +76,7 @@ steps:
   # UI Tests
   #################
   - label: "🔬 UI Tests (iPhone)"
-    command:
-      - .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
-      - "cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult"
+    command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
@@ -89,9 +87,7 @@ steps:
           context: "UI Tests (iPhone)"
 
   - label: "🔬 UI Tests (iPad)"
-    command:
-      - .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
-      - "cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult"
+    command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (4th generation)" 15.0
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -81,7 +81,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/**/*"
+      - "build/results/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPhone)"
@@ -92,7 +92,7 @@ steps:
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
-      - "build/results/**/*"
+      - "build/results/*"
     notify:
       - github_commit_status:
           context: "UI Tests (iPad)"

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -20,7 +20,6 @@ class SupportScreenTests: XCTestCase {
             .selectHelp()
             .contactSupport()
             .assertCanNotSendEmptyMessage()
-            .enterText("A")
             .assertCanSendMessage()
     }
 }

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -20,6 +20,7 @@ class SupportScreenTests: XCTestCase {
             .selectHelp()
             .contactSupport()
             .assertCanNotSendEmptyMessage()
+            .enterText("A")
             .assertCanSendMessage()
     }
 }


### PR DESCRIPTION
Saving Xcode results with logs and screenshots in Buildkite is the only way to avoid guessing what happened when a UI Test fails. 

To test:
Check if UI Tests step has the tests results in Artifacts tab.

## Regression Notes
1. Potential unintended areas of impact
Buildkite.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Checked the CI.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
