### PR TITLE
Disabled some of the UI tests while investigating the reasons.

### DIFF
--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -21,13 +21,18 @@
   "testTargets" : [
     {
       "skippedTests" : [
+        "EditorAztecTests",
+        "EditorGutenbergTests",
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "LoginTests\/testEmailPasswordLoginLogout()",
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
+        "ReaderTests",
         "SignupTests\/testEmailSignup()",
+        "StatsTests",
+        "SupportScreenTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -29,6 +29,7 @@
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
+        "MainNavigationTests",
         "ReaderTests",
         "SignupTests\/testEmailSignup()",
         "StatsTests",


### PR DESCRIPTION
Disabled several groups of tests (well, all besides `Login` and `Signup`) that started failing on Buildkite frequently recently. They'll be enabled back once we know the reason.

To test:
- CI is green

## Regression Notes
1. Potential unintended areas of impact
This PR disables the failing UI tests, so impact should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
This PR disables the failing UI tests, so this question is not applicable here.

3. What automated tests I added (or what prevented me from doing so)
This PR disables the failing UI tests, so this question is not applicable here.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
