### PR TITLE
Comment Threads: enable comment moderation menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,8 @@
 * [**] Notifications: added a button to mark all notifications in the selected filter as read. [#17840]
 * [**] People: you can now manage Email Followers on the People section! [#17854]
 * [*] Stats: fix navigation between Stats tab. [#17856]
-* [*] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855] 
+* [*] Quick Start: Fixed a bug where a user logging in via a self-hosted site not connected to Jetpack would see Quick Start when selecting "No thanks" on the Quick Start prompt. [#17855]
+* [**] Threaded comments: comments can now be moderated via a drop-down menu on each comment. [#17888]
 
 19.1
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -66,7 +66,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .postDetailsComments:
             return true
         case .commentThreadModerationMenu:
-            return false
+            return true
         case .mySiteDashboard:
             return false
         case .markAllNotificationsAsRead:


### PR DESCRIPTION
Ref #17629, #17752

This enables comment moderation from the threaded comments view. 

***NOTE*** Auto-merge is enabled.

To test:
- Go to the threaded comments view on a post that you have permission to moderate comments on.
- Verify the ellipsis icon is displayed on each comment instead of the share icon.
- Verify moderating/editing comments works as expected.

| Before | After |
|--------|-------|
| <img width="446" alt="Screen Shot 2022-02-01 at 11 45 46 AM" src="https://user-images.githubusercontent.com/1816888/152033155-e8a994bb-fdf9-4441-9033-f1f51072f70b.png"> | <img width="447" alt="Screen Shot 2022-02-01 at 11 46 29 AM" src="https://user-images.githubusercontent.com/1816888/152033149-e8c663b3-868f-4d2c-909b-5058e44fb8b9.png"> |

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
