### PR TITLE
Demo PR for release automation differentiating between beta and stable builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -21,16 +21,18 @@ steps:
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 WordPress Release Build (App Center)"
-    command: ".buildkite/commands/release-build-wordpress-internal.sh"
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-    - slack: "#build-and-ship"
+  # All other steps disabled for test purposes
+  #
+  # - label: "🛠 WordPress Release Build (App Center)"
+  #   command: ".buildkite/commands/release-build-wordpress-internal.sh"
+  #   env: *common_env
+  #   plugins: *common_plugins
+  #   notify:
+  #   - slack: "#build-and-ship"
 
-  - label: "🛠 Jetpack Release Build (App Store Connect)"
-    command: ".buildkite/commands/release-build-jetpack.sh"
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-    - slack: "#build-and-ship"
+  # - label: "🛠 Jetpack Release Build (App Store Connect)"
+  #   command: ".buildkite/commands/release-build-jetpack.sh"
+  #   env: *common_env
+  #   plugins: *common_plugins
+  #   notify:
+  #   - slack: "#build-and-ship"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -484,6 +484,8 @@ platform :ios do
   #####################################################################################
   desc 'Builds and uploads for distribution to App Store Connect'
   lane :build_and_upload_app_store_connect do |options|
+    UI.user_error! "Failing the build for test purpose. Beta param was: #{options[:beta_release]}"
+
     ios_build_prechecks(
       skip_confirm: options[:skip_confirm],
       internal: options[:beta_release],


### PR DESCRIPTION
Builds on top of `PR I haven't submitted yet` with hacks to show that the beta flag is passed correctly from the `trigger_release_build` and `trigger_beta_build` Fastlane actions without actually going on to submit those builds.

Example of beta build triggered via `bundle exec fastlane trigger_beta_build branch_to_build:remove/circle-ci-and-fix-beta-builds-test`:

![image](https://user-images.githubusercontent.com/1218433/152518814-bc97d488-a1c3-48c0-863e-80a57cb7a0ff.png)
[Link to build](https://buildkite.com/automattic/wordpress-ios/builds/4909#e72866a1-404a-4cd4-afea-cdd06075cad3/2414-2456).

Example of beta build triggered via `bundle exec fastlane trigger_release_build branch_to_build:remove/circle-ci-and-fix-beta-builds-test`:

![image](https://user-images.githubusercontent.com/1218433/152521536-a3be5c54-4955-44af-b6b5-ba052829e37b.png)

[Link to build](https://buildkite.com/automattic/wordpress-ios/builds/4910#6c656d2c-886f-4c61-bca3-7af9621ff00d/2256-2298).

Notice that in both cases I could have seen the parameter propagation from the script call only:

![image](https://user-images.githubusercontent.com/1218433/152519185-9bcd7663-0695-48a2-8e74-77f68dad360a.png)

I decided to run the entire build up to the Fastlane value check to make sure that bit, too, worked.