### PR TITLE
Choose a design: Dismiss the device selection popover when Skip is pressed

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -115,6 +115,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     @objc func skipButtonTapped(_ sender: Any) {
+        presentedViewController?.dismiss(animated: true)
         SiteCreationAnalyticsHelper.trackSiteDesignSkipped()
         completion(nil)
     }


### PR DESCRIPTION
Fixes #17531

To test:
1. On the "My Sites" view, tap the "+" symbol and select "Create WordPress.com site".
2. On the "Choose a design" view, tap the device picker icon at the top right. It will show a popover list for Mobile, Tablet, or Desktop.
3. Press the "Skip" button at the top right.
4. Expect the popover to be dismissed before presenting the "Choose a domain" view.

https://user-images.githubusercontent.com/2092798/152627795-4f0a349f-7503-49d6-851c-c87bdcf7382b.mp4

## Regression Notes
1. Potential unintended areas of impact
Nothing should be affected outside of the "Choose a design" view.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Smoke tests on the "Choose a design" view.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
