### PR TITLE
Ensure the `cache-builder.yml` Buildkite pipeline uses Bundler 2.3.x+

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -26,6 +26,9 @@ steps:
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
       echo "--- :rubygems: Setting up Gems"
+      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
+      gem install bundler:2.3.6
+
       install_gems
 
       echo "--- :cocoapods: Rebuilding Pod Cache"


### PR DESCRIPTION
Otherwise, it will fail like here: https://buildkite.com/automattic/wordpress-ios/builds/4987#6c299e02-acc8-44fa-821c-51d68c59a734

![image](https://user-images.githubusercontent.com/1218433/152816804-d4ffcfcc-3b5f-4c49-8626-006c30f17d80.png)


To verify the fix, see this other build: https://buildkite.com/automattic/wordpress-ios/builds/4989

![image](https://user-images.githubusercontent.com/1218433/152816804-d4ffcfcc-3b5f-4c49-8626-006c30f17d80.png)


## Context

Reviewing https://buildkite.com/automattic/wordpress-ios/builds/4989 made me realize the cache builder schedule here wasn't on 🤔

Before reactivating it, I scheduled a build and it failed (see above). This PR fixes the issue.

I activated the schedule anyways, under the assumption this PR will be merged soon.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**