### PR TITLE
Use `sentry_check_cli_installed` to verify Sentry's CLI requirements

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1028,7 +1028,10 @@ def read_version_from_config
 end
 
 def ensure_sentry_installed
-    UI.user_error('sentry-cli not installed') unless sh('command -v sentry-cli')
+  # This is an action provided by the Sentry Fastlane plugin that verifies the
+  # CLI is installed and its version is compatible with the plugin's
+  # expectation.
+  sentry_check_cli_installed
 end
 
 # This function is Buildkite-specific


### PR DESCRIPTION
This is an action [provided by the Sentry Fastlane plugin](https://github.com/getsentry/sentry-fastlane-plugin/tree/3dff83c640a4ebb92beb74e6122cccd5e5e77429#checking-the-sentry-cli-is-installed) that verifies the CLI is installed and its version is compatible with the plugin's expectation.

_Opening against the release branch because we're more likely to run lanes using this check from here than from `trunk`._

## Extra context

I recently had to deploy some builds locally. The first time I tried, the process failed because my `sentry-cli` version was too old. We already had a custom check to ensure that the CLI is installed at the start of the lane, but that didn't cover the version. It was an annoying failure because it occurred after my machine was busy building and uploading... This should make us fail ASAP if the version is not the expected one, avoiding work that's doomed to be thrown away.

I went in search for this after bumping into a Sentry-related change in WooCommerce: https://github.com/woocommerce/woocommerce-ios/pull/6044#discussion_r800702937.

## Testing

This is the action output in the happy path:

![image](https://user-images.githubusercontent.com/1218433/152956848-975534bd-daad-4fba-b857-3aed2224630b.png)

If the CLI is missing, the lane will fail with the following output:

![image](https://user-images.githubusercontent.com/1218433/152957168-fbe484e6-5fa3-4d5b-bc62-2777149869ab.png)

I started looking into how to install an older version of the CLI to verify that path, too, but it proved to be a fiddly process. I gave up in the interest of not getting sidetracked, trusting that the plugin does what it's supposed to.

## Regression Notes
1. Potential unintended areas of impact
N.A.


2. What I did to test those areas of impact (or what existing automated tests I relied on)
N.A.

3. What automated tests I added (or what prevented me from doing so)
N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
