### PR TITLE
My Site Dashboard: handle local and remote cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -1,6 +1,10 @@
 import UIKit
 
-typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable
+typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable & BlogDashboardCardConfigurable
+
+protocol BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?)
+}
 
 final class BlogDashboardViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable
+
 final class BlogDashboardViewController: UIViewController {
 
     var blog: Blog

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -59,8 +59,9 @@ final class BlogDashboardViewController: UIViewController {
     private func setupCollectionView() {
         collectionView.isScrollEnabled = false
         collectionView.backgroundColor = .listBackground
-        collectionView.register(QuickLinksHostCell.self, forCellWithReuseIdentifier: QuickLinksHostCell.defaultReuseID)
-        collectionView.register(DashboardPostsCardCell.self, forCellWithReuseIdentifier: DashboardPostsCardCell.defaultReuseID)
+        DashboardCard.allCases.forEach {
+            collectionView.register($0.cell, forCellWithReuseIdentifier: $0.cell.defaultReuseID)
+        }
 
         view.addSubview(collectionView)
         view.pinSubviewToAllEdges(collectionView)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable & BlogDashboardCardConfigurable
 
 protocol BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?)
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?)
 }
 
 final class BlogDashboardViewController: UIViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewModel.swift
@@ -65,7 +65,11 @@ class BlogDashboardViewModel {
         viewController?.showLoading()
         applySnapshotForInitialData()
 
-        service.fetch(cards: ["posts", "todays_stats"], forBlogID: dotComID, success: { [weak self] _ in
+        let cardsToFetch: [String] = DashboardCard.allCases
+            .filter { $0.isRemote }
+            .map { $0.rawValue }
+
+        service.fetch(cards: cardsToFetch, forBlogID: dotComID, success: { [weak self] _ in
             self?.viewController?.stopLoading()
             self?.applySnapshotWithMockedData()
         }, failure: { _ in

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -1,7 +1,11 @@
 import UIKit
 
-class DashboardPostsCardCell: UICollectionViewCell, Reusable {
-    func configure(_ viewController: UIViewController, blog: Blog) {
+class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
+        guard let viewController = viewController else {
+            return
+        }
+
         let postsViewController = PostsCardViewController(blog: blog)
         viewController.addChild(postsViewController)
         contentView.addSubview(postsViewController.view)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
         guard let viewController = viewController else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -6,8 +6,8 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
             return
         }
 
-        let hasDrafts = (dataModel["draft"] as? Array<Any>)?.count ?? 0 > 0
-        let hasScheduled = (dataModel["scheduled"] as? Array<Any>)?.count ?? 0 > 0
+        let hasDrafts = dataModel["show_drafts"] as? Bool ?? false
+        let hasScheduled = dataModel["show_scheduled"] as? Bool ?? false
 
         let postsViewController = PostsCardViewController(blog: blog)
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -2,11 +2,21 @@ import UIKit
 
 class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
-        guard let viewController = viewController else {
+        guard let viewController = viewController, let dataModel = dataModel else {
             return
         }
 
+        let hasDrafts = (dataModel["draft"] as? Array<Any>)?.count ?? 0 > 0
+        let hasScheduled = (dataModel["scheduled"] as? Array<Any>)?.count ?? 0 > 0
+
         let postsViewController = PostsCardViewController(blog: blog)
+
+        if hasDrafts {
+            postsViewController.status = .draft
+        } else if hasScheduled {
+            postsViewController.status = .scheduled
+        }
+
         viewController.addChild(postsViewController)
         contentView.addSubview(postsViewController.view)
         postsViewController.view.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -13,7 +13,7 @@ import UIKit
     private var ghostableTableView: UITableView?
     private var errorView: DashboardCardInnerErrorView?
 
-    private let status: BasePost.Status = .draft
+    var status: BasePost.Status = .draft
 
     // TODO: add status as an init param
     @objc init(blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+class DashboardStatsCardCell: UICollectionViewCell, Reusable {
+    
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,5 +1,7 @@
 import UIKit
 
-class DashboardStatsCardCell: UICollectionViewCell, Reusable {
-    
+class DashboardStatsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
+        
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class DashboardStatsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
-        
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
+
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Describes all the available cards.
+///
+/// Notice that the order here matters and it will take
+/// precedence over the backend.
+enum DashboardCard: String, CaseIterable {
+    case quickActions
+    case posts
+    case todaysStats
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -31,7 +31,7 @@ enum DashboardCard: String, CaseIterable {
         case .posts:
             return DashboardPostsCardCell.self
         case .todaysStats:
-            return HostCollectionViewCell<QuickLinksView>.self
+            return DashboardStatsCardCell.self
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -34,4 +34,14 @@ enum DashboardCard: String, CaseIterable {
             return DashboardStatsCardCell.self
         }
     }
+
+    /// All cards that are remote
+    static var remoteCases: [DashboardCard] {
+        return DashboardCard.allCases.filter { $0.isRemote }
+    }
+
+    /// All cards that are local
+    static var localCases: [DashboardCard] {
+        return DashboardCard.allCases.filter { !$0.isRemote }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -12,7 +12,7 @@ enum DashboardCard: String, CaseIterable {
     case posts
     case todaysStats = "todays_stats"
 
-    /// If the card is backed by the API
+    /// If the card is backed by API data
     var isRemote: Bool {
         switch self {
         case .quickActions:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -4,8 +4,23 @@ import Foundation
 ///
 /// Notice that the order here matters and it will take
 /// precedence over the backend.
+///
+/// If the card `isRemote` the `String` should match its
+/// identifier on the backend.
 enum DashboardCard: String, CaseIterable {
     case quickActions
     case posts
-    case todaysStats
+    case todaysStats = "todays_stats"
+
+    /// If the card is backed by the API
+    var isRemote: Bool {
+        switch self {
+        case .quickActions:
+            return false
+        case .posts:
+            return true
+        case .todaysStats:
+            return true
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -23,4 +23,15 @@ enum DashboardCard: String, CaseIterable {
             return true
         }
     }
+
+    var cell: DashboardCollectionViewCell.Type {
+        switch self {
+        case .quickActions:
+            return HostCollectionViewCell<QuickLinksView>.self
+        case .posts:
+            return DashboardPostsCardCell.self
+        case .todaysStats:
+            return HostCollectionViewCell<QuickLinksView>.self
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
@@ -47,3 +47,9 @@ class HostCollectionViewCell<Content>: UICollectionViewCell, Hostable where Cont
 }
 
 extension HostCollectionViewCell: Reusable { }
+
+extension HostCollectionViewCell: BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
+        hostedView = QuickLinksView(title: "Quick Links") as? Content
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/HostCollectionViewCell.swift
@@ -49,7 +49,7 @@ class HostCollectionViewCell<Content>: UICollectionViewCell, Hostable where Cont
 extension HostCollectionViewCell: Reusable { }
 
 extension HostCollectionViewCell: BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
         hostedView = QuickLinksView(title: "Quick Links") as? Content
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -7,4 +7,16 @@ class BlogDashboardService {
     init(managedObjectContext: NSManagedObjectContext, remoteService: DashboardServiceRemote? = nil) {
         self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
     }
+
+    func fetch(wpComID: Int, completion: @escaping (DashboardSnapshot) -> Void) {
+        let cardsToFetch: [String] = DashboardCard.allCases
+            .filter { $0.isRemote }
+            .map { $0.rawValue }
+
+        remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { _ in
+            completion(DashboardSnapshot())
+        }, failure: { _ in
+
+        })
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -9,9 +9,7 @@ class BlogDashboardService {
     }
 
     func fetch(wpComID: Int, completion: @escaping (DashboardSnapshot) -> Void) {
-        let cardsToFetch: [String] = DashboardCard.allCases
-            .filter { $0.isRemote }
-            .map { $0.rawValue }
+        let cardsToFetch: [String] = DashboardCard.remoteCases.map { $0.rawValue }
 
         remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { [weak self] cards in
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -1,0 +1,10 @@
+import Foundation
+import WordPressKit
+
+class BlogDashboardService {
+    let remoteService: DashboardServiceRemote
+
+    init(managedObjectContext: NSManagedObjectContext, remoteService: DashboardServiceRemote? = nil) {
+        self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -40,6 +40,12 @@ class BlogDashboardService {
 
                     }
 
+                } else {
+                    let section = DashboardCardSection(id: card.rawValue)
+                    let item = DashboardCardModel(id: card)
+
+                    snapshot.appendSections([section])
+                    snapshot.appendItems([item], toSection: section)
                 }
 
             }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -17,12 +17,31 @@ class BlogDashboardService {
 
             var snapshot = DashboardSnapshot()
 
-            if let posts = cards["posts"] as? NSDictionary,
-               let (sections, items) = self?.parsePostCard(posts) {
-                snapshot.appendSections(sections)
-                sections.enumerated().forEach { key, section in
-                    snapshot.appendItems([items[key]], toSection: section)
+            DashboardCard.allCases.forEach { card in
+
+                if card.isRemote {
+
+                    if card == .posts,
+                       let posts = cards[DashboardCard.posts.rawValue] as? NSDictionary,
+                       let (sections, items) = self?.parsePostCard(posts) {
+                        snapshot.appendSections(sections)
+                        sections.enumerated().forEach { key, section in
+                            snapshot.appendItems([items[key]], toSection: section)
+                        }
+                    } else {
+
+                        if let viewModel = cards[card.rawValue] {
+                            let section = DashboardCardSection(id: card.rawValue)
+                            let item = DashboardCardModel(id: card, cellViewModel: viewModel as? NSDictionary)
+
+                            snapshot.appendSections([section])
+                            snapshot.appendItems([item], toSection: section)
+                        }
+
+                    }
+
                 }
+
             }
 
             completion(snapshot)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -58,7 +58,7 @@ class BlogDashboardService {
 }
 
 private extension BlogDashboardService {
-    /// Cards are a special case: they might not be a 1-1 relation
+    /// Posts are a special case: they might not be a 1-1 relation
     /// If the user has draft and scheduled posts, we show two cards
     /// One for each. This function takes care of this
     func parsePostCard(_ posts: NSDictionary) -> ([DashboardCardSection], [DashboardCardModel]) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -82,8 +82,12 @@ private extension BlogDashboardService {
             sections.append(DashboardCardSection(id: "posts", subtype: "scheduled"))
             items.append(DashboardCardModel(id: .posts, cellViewModel: scheduled as NSDictionary?))
         } else {
+            var postsWithFlags = posts.copy() as? [String: Any]
+            postsWithFlags?["show_drafts"] = hasDrafts
+            postsWithFlags?["show_scheduled"] = hasScheduled
+
             sections.append(DashboardCardSection(id: "posts"))
-            items.append(DashboardCardModel(id: .posts, cellViewModel: posts))
+            items.append(DashboardCardModel(id: .posts, cellViewModel: postsWithFlags as NSDictionary?))
         }
 
         return (sections, items)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -63,17 +63,22 @@ private extension BlogDashboardService {
         var sections: [DashboardCardSection] = []
         var items: [DashboardCardModel] = []
 
-        let hasDrafts = (posts["draft"] as? Array<Any>)?.count ?? 0 > 0
-        let hasScheduled = (posts["scheduled"] as? Array<Any>)?.count ?? 0 > 0
+        let draftsCount = (posts["draft"] as? Array<Any>)?.count ?? 0
+        let scheduledCount = (posts["scheduled"] as? Array<Any>)?.count ?? 0
+
+        let hasDrafts = draftsCount > 0
+        let hasScheduled = scheduledCount > 0
 
         if hasDrafts && hasScheduled {
-            var drafts = posts.copy() as? [String: Any]
-            drafts?["scheduled"] = []
+            var draft = posts.copy() as? [String: Any]
+            draft?["show_drafts"] = true
+            draft?["show_scheduled"] = false
             sections.append(DashboardCardSection(id: "posts", subtype: "draft"))
-            items.append(DashboardCardModel(id: .posts, cellViewModel: drafts as NSDictionary?))
+            items.append(DashboardCardModel(id: .posts, cellViewModel: draft as NSDictionary?))
 
             var scheduled = posts.copy() as? [String: Any]
-            scheduled?["draft"] = []
+            scheduled?["show_drafts"] = false
+            scheduled?["show_scheduled"] = true
             sections.append(DashboardCardSection(id: "posts", subtype: "scheduled"))
             items.append(DashboardCardModel(id: .posts, cellViewModel: scheduled as NSDictionary?))
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -33,6 +33,9 @@ class BlogDashboardService {
 }
 
 private extension BlogDashboardService {
+    /// Cards are a special case: they might not be a 1-1 relation
+    /// If the user has draft and scheduled posts, we show two cards
+    /// One for each. This function takes care of this
     func parsePostCard(_ posts: NSDictionary) -> ([DashboardCardSection], [DashboardCardModel]) {
         var sections: [DashboardCardSection] = []
         var items: [DashboardCardModel] = []

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -13,10 +13,48 @@ class BlogDashboardService {
             .filter { $0.isRemote }
             .map { $0.rawValue }
 
-        remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { _ in
-            completion(DashboardSnapshot())
+        remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { [weak self] cards in
+
+            var snapshot = DashboardSnapshot()
+
+            if let posts = cards["posts"] as? NSDictionary,
+               let (sections, items) = self?.parsePostCard(posts) {
+                snapshot.appendSections(sections)
+                sections.enumerated().forEach { key, section in
+                    snapshot.appendItems([items[key]], toSection: section)
+                }
+            }
+
+            completion(snapshot)
         }, failure: { _ in
 
         })
+    }
+}
+
+private extension BlogDashboardService {
+    func parsePostCard(_ posts: NSDictionary) -> ([DashboardCardSection], [DashboardCardModel]) {
+        var sections: [DashboardCardSection] = []
+        var items: [DashboardCardModel] = []
+
+        let hasDrafts = (posts["draft"] as? Array<Any>)?.count ?? 0 > 0
+        let hasScheduled = (posts["scheduled"] as? Array<Any>)?.count ?? 0 > 0
+
+        if hasDrafts && hasScheduled {
+            var drafts = posts.copy() as? [String: Any]
+            drafts?["scheduled"] = []
+            sections.append(DashboardCardSection(id: "posts", subtype: "draft"))
+            items.append(DashboardCardModel(id: .posts, cellViewModel: drafts as NSDictionary?))
+
+            var scheduled = posts.copy() as? [String: Any]
+            scheduled?["draft"] = []
+            sections.append(DashboardCardSection(id: "posts", subtype: "scheduled"))
+            items.append(DashboardCardModel(id: .posts, cellViewModel: scheduled as NSDictionary?))
+        } else {
+            sections.append(DashboardCardSection(id: "posts"))
+            items.append(DashboardCardModel(id: .posts, cellViewModel: posts))
+        }
+
+        return (sections, items)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -35,6 +35,7 @@ class BlogDashboardViewModel {
 
             let cellType = identifier.id.cell
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
+            (cell as? BlogDashboardCardConfigurable)?.configure(blog: blog, viewController: viewController)
             return cell
 
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -35,7 +35,7 @@ class BlogDashboardViewModel {
 
             let cellType = identifier.id.cell
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
-            (cell as? BlogDashboardCardConfigurable)?.configure(blog: blog, viewController: viewController)
+            (cell as? BlogDashboardCardConfigurable)?.configure(blog: blog, viewController: viewController, dataModel: identifier.cellViewModel)
             return cell
 
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -13,10 +13,6 @@ class BlogDashboardViewModel {
         case posts
     }
 
-    // FIXME: temporary placeholder
-    private let quickLinks = ["Quick Links"]
-    private let posts = ["Posts"]
-
     typealias QuickLinksHostCell = HostCollectionViewCell<QuickLinksView>
 
     private let managedObjectContext: NSManagedObjectContext

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -2,6 +2,9 @@ import Foundation
 import UIKit
 import CoreData
 
+typealias DashboardSnapshot = NSDiffableDataSourceSnapshot<DashboardCardSection, DashboardCardModel>
+typealias DashboardDataSource = UICollectionViewDiffableDataSource<DashboardCardSection, DashboardCardModel>
+
 class BlogDashboardViewModel {
     private weak var viewController: BlogDashboardViewController?
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -31,7 +31,11 @@ class BlogDashboardViewModel {
 
             let cellType = identifier.id.cell
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
-            (cell as? BlogDashboardCardConfigurable)?.configure(blog: blog, viewController: viewController, dataModel: identifier.cellViewModel)
+
+            if let cellConfigurable = cell as? BlogDashboardCardConfigurable {
+                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.cellViewModel)
+            }
+
             return cell
 
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Represents a card in the dashboard collection view
+class DashboardCardModel: Hashable {
+    let id: DashboardCard
+    let cellViewModel: NSDictionary?
+
+    init(id: DashboardCard, cellViewModel: NSDictionary? = nil) {
+        self.id = id
+        self.cellViewModel = cellViewModel
+    }
+
+    static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {
+        lhs.cellViewModel == rhs.cellViewModel
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(cellViewModel)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+/// Represents a section in the Dashboard Collection View
+class DashboardCardSection: Hashable {
+    let id: String
+    let subtype: String?
+
+    init(id: String, subtype: String? = nil) {
+        self.id = id
+        self.subtype = subtype
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+        hasher.combine(subtype)
+    }
+
+    static func == (lhs: DashboardCardSection, rhs: DashboardCardSection) -> Bool {
+        lhs.id == rhs.id && lhs.subtype == rhs.subtype
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1408,6 +1408,7 @@
 		8B36256625A60CCA00D7CCE3 /* BackupListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */; };
 		8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
+		8B45C12627B2A27400EA3257 /* dashboard-200-with-drafts-only.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B45C12527B2A27400EA3257 /* dashboard-200-with-drafts-only.json */; };
 		8B4DDF25278F44CC0022494D /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
 		8B4DDF26278F45180022494D /* HostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */; };
 		8B4DDF27278F451E0022494D /* QuickLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */; };
@@ -6084,6 +6085,7 @@
 		8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackupListViewController.swift; sourceTree = "<group>"; };
 		8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+mainWindow.swift"; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
+		8B45C12527B2A27400EA3257 /* dashboard-200-with-drafts-only.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-drafts-only.json"; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsCardCell.swift; sourceTree = "<group>"; };
 		8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardService.swift; sourceTree = "<group>"; };
@@ -11515,6 +11517,7 @@
 			isa = PBXGroup;
 			children = (
 				8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */,
+				8B45C12527B2A27400EA3257 /* dashboard-200-with-drafts-only.json */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -15979,6 +15982,7 @@
 				32110569250C0E960048446F /* 100x100-png in Resources */,
 				D848CC1320FF31BB00A9038F /* notifications-blockquote-range.json in Resources */,
 				D848CC0D20FF2D7C00A9038F /* notifications-post-range.json in Resources */,
+				8B45C12627B2A27400EA3257 /* dashboard-200-with-drafts-only.json in Resources */,
 				32110561250C027D0048446F /* 100x100.jpg in Resources */,
 				748437F11F1D4ECC00E8DDAF /* notifications-last-seen.json in Resources */,
 				74585B9D1F0D591D00E7E667 /* domain-service-all-domain-types.json in Resources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1423,6 +1423,7 @@
 		8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B6214E027B1AD9D001DF7B6 /* DashboardStatsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */; };
 		8B6214E327B1B2F3001DF7B6 /* BlogDashboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */; };
+		8B6214E627B1B446001DF7B6 /* BlogDashboardServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214E527B1B446001DF7B6 /* BlogDashboardServiceTests.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -1490,6 +1491,11 @@
 		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
+		8BEE845A27B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */; };
+		8BEE846227B1E0540001A93C /* DashboardCardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */; };
+		8BEE846327B1E0560001A93C /* DashboardCardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */; };
+		8BEE846427B1E05B0001A93C /* DashboardCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */; };
+		8BEE846527B1E05C0001A93C /* DashboardCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
 		8BF9E03327B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
 		8BF9E03427B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
@@ -6081,6 +6087,7 @@
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsCardCell.swift; sourceTree = "<group>"; };
 		8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardService.swift; sourceTree = "<group>"; };
+		8B6214E527B1B446001DF7B6 /* BlogDashboardServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardServiceTests.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
@@ -6143,6 +6150,9 @@
 		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
+		8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-drafts-and-scheduled.json"; sourceTree = "<group>"; };
+		8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardSection.swift; sourceTree = "<group>"; };
+		8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardModel.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
 		8BF9E03227B1A8A800915B27 /* DashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCard.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
@@ -11371,6 +11381,14 @@
 			path = Service;
 			sourceTree = "<group>";
 		};
+		8B6214E427B1B420001DF7B6 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				8B6214E527B1B446001DF7B6 /* BlogDashboardServiceTests.swift */,
+			);
+			path = Dashboard;
+			sourceTree = "<group>";
+		};
 		8B69F0E2255C2BC0006B1CEF /* Activity */ = {
 			isa = PBXGroup;
 			children = (
@@ -11491,6 +11509,24 @@
 				8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */,
 			);
 			name = "Prepublishing Nudges";
+			sourceTree = "<group>";
+		};
+		8BEE845627B1DC5E0001A93C /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */,
+			);
+			path = Dashboard;
+			sourceTree = "<group>";
+		};
+		8BEE845B27B1DD8E0001A93C /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
+				8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */,
+				8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */,
+			);
+			path = ViewModel;
 			sourceTree = "<group>";
 		};
 		8BF9E03627B1AD2100915B27 /* Stats */ = {
@@ -13727,6 +13763,7 @@
 				B5AEEC7F1ACAD099008BF2A4 /* Categories */,
 				572FB3FE223A800500933C76 /* Classes */,
 				B5AEEC731ACACF3B008BF2A4 /* Core Data */,
+				8B6214E427B1B420001DF7B6 /* Dashboard */,
 				175CC17327205BDC00622FB4 /* Domains */,
 				FF9A6E6F21F9359200D36D14 /* Gutenberg */,
 				32110548250BFC5A0048446F /* Image Dimension Parser */,
@@ -13918,6 +13955,7 @@
 				C8567490243F371D001A995E /* Tenor */,
 				D8A468DE2181C5B50094B82F /* Site Creation */,
 				7E442FC820F6783600DEACA5 /* ActivityLog */,
+				8BEE845627B1DC5E0001A93C /* Dashboard */,
 				B5DA8A5E20ADAA1C00D5BDE1 /* plugin-directory-jetpack.json */,
 				855408851A6F105700DDBD79 /* app-review-prompt-all-enabled.json */,
 				855408891A6F107D00DDBD79 /* app-review-prompt-global-disable.json */,
@@ -14613,8 +14651,8 @@
 			children = (
 				8B4DDF23278F3AED0022494D /* Cards */,
 				8B6214E127B1B2D6001DF7B6 /* Service */,
+				8BEE845B27B1DD8E0001A93C /* ViewModel */,
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
-				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
 				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
 				FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */,
 				FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */,
@@ -15917,6 +15955,7 @@
 				8554088A1A6F107D00DDBD79 /* app-review-prompt-global-disable.json in Resources */,
 				D8A468E02181C6450094B82F /* site-segment.json in Resources */,
 				7E4A772B20F7E5FD001C706D /* activity-log-site-content.json in Resources */,
+				8BEE845A27B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json in Resources */,
 				7EF2EEA0210A67B60007A76B /* notifications-unapproved-comment.json in Resources */,
 				175CC1772721814C00622FB4 /* domain-service-updated-domains.json in Resources */,
 				748437EC1F1D4A4800E8DDAF /* gallery-reader-post-public.json in Resources */,
@@ -17560,6 +17599,7 @@
 				E6D2E1671B8AAD8C0000ED14 /* ReaderTagStreamHeader.swift in Sources */,
 				321E292623A5F10900588610 /* FullScreenCommentReplyViewController.swift in Sources */,
 				E6D3B1431D1C702600008D4B /* ReaderFollowedSitesViewController.swift in Sources */,
+				8BEE846427B1E05B0001A93C /* DashboardCardModel.swift in Sources */,
 				3F6AD0562502A91400080F3B /* AnnouncementsCache.swift in Sources */,
 				43FF64EF20DAA0840060A69A /* GravatarUploader.swift in Sources */,
 				B5899ADE1B419C560075A3D6 /* NotificationSettingDetailsViewController.swift in Sources */,
@@ -17664,6 +17704,7 @@
 				738B9A5721B85CF20005062B /* TableDataCoordinator.swift in Sources */,
 				FA73D7E52798765B00DF24B3 /* SitePickerViewController.swift in Sources */,
 				B541276B1C0F7D610015CA80 /* SettingsMultiTextViewController.m in Sources */,
+				8BEE846327B1E0560001A93C /* DashboardCardSection.swift in Sources */,
 				3F810A5A2616870C00ADDCC2 /* UnifiedPrologueIntroContentView.swift in Sources */,
 				F5E6312B243BC83E0088229D /* FilterSheetViewController.swift in Sources */,
 				E6F2788021BC1A4A008B4DB5 /* Plan.swift in Sources */,
@@ -19296,6 +19337,7 @@
 				46B30B782582C7DD00A25E66 /* SiteAddressServiceTests.swift in Sources */,
 				C81CCD6C243AEFBF00A83E27 /* TenorReponseData.swift in Sources */,
 				570BFD902282418A007859A8 /* PostBuilder.swift in Sources */,
+				8B6214E627B1B446001DF7B6 /* BlogDashboardServiceTests.swift in Sources */,
 				C856749A243F4292001A995E /* TenorMockDataHelper.swift in Sources */,
 				D81C2F5820F86CEA002AE1F1 /* NetworkStatus.swift in Sources */,
 				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,
@@ -20198,6 +20240,7 @@
 				FABB23802602FC2C00C8785C /* ReaderCommentsViewController.m in Sources */,
 				FABB23812602FC2C00C8785C /* MySiteViewController.swift in Sources */,
 				46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */,
+				8BEE846227B1E0540001A93C /* DashboardCardSection.swift in Sources */,
 				FABB23822602FC2C00C8785C /* FooterContentGroup.swift in Sources */,
 				FABB23832602FC2C00C8785C /* BasePageListCell.m in Sources */,
 				F163541726DE2ECE008B625B /* NotificationEventTracker.swift in Sources */,
@@ -20696,6 +20739,7 @@
 				FABB253F2602FC2C00C8785C /* JetpackRestoreWarningViewController.swift in Sources */,
 				FABB25402602FC2C00C8785C /* SiteAssembly.swift in Sources */,
 				FABB25412602FC2C00C8785C /* ImageDimensionFetcher.swift in Sources */,
+				8BEE846527B1E05C0001A93C /* DashboardCardModel.swift in Sources */,
 				FABB25422602FC2C00C8785C /* AnimatedImageCache.swift in Sources */,
 				FABB25432602FC2C00C8785C /* PostListFilterSettings.swift in Sources */,
 				FABB25442602FC2C00C8785C /* FooterTextContent.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1421,6 +1421,7 @@
 		8B55FAAD2614FC87007D618E /* Text+BoldSubString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178810B42611D25600A98BD8 /* Text+BoldSubString.swift */; };
 		8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
+		8B6214E027B1AD9D001DF7B6 /* DashboardStatsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -6077,6 +6078,7 @@
 		8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+mainWindow.swift"; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
+		8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsCardCell.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
@@ -11342,6 +11344,7 @@
 		8B4DDF23278F3AED0022494D /* Cards */ = {
 			isa = PBXGroup;
 			children = (
+				8BF9E03627B1AD2100915B27 /* Stats */,
 				8B4DDF24278F3AF60022494D /* Posts */,
 				8B8E50B427A468E800C89979 /* Helpers */,
 			);
@@ -11478,6 +11481,14 @@
 				8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */,
 			);
 			name = "Prepublishing Nudges";
+			sourceTree = "<group>";
+		};
+		8BF9E03627B1AD2100915B27 /* Stats */ = {
+			isa = PBXGroup;
+			children = (
+				8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */,
+			);
+			path = Stats;
 			sourceTree = "<group>";
 		};
 		8F228031B2964AE9A667C735 /* Views */ = {
@@ -17632,6 +17643,7 @@
 				C76F48DC25BA202600BFEC87 /* JetpackScanHistoryViewController.swift in Sources */,
 				7E407121237163B8003627FA /* GutenbergStockPhotos.swift in Sources */,
 				F11C9F74243B3C3E00921DDC /* MediaHost+Blog.swift in Sources */,
+				8B6214E027B1AD9D001DF7B6 /* DashboardStatsCardCell.swift in Sources */,
 				E15644ED1CE0E4FE00D96E64 /* PlanListRow.swift in Sources */,
 				738B9A4E21B85CF20005062B /* SiteCreationWizard.swift in Sources */,
 				4054F4432213635000D261AB /* TopCommentsAuthorStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1489,6 +1489,8 @@
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
+		8BF9E03327B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
+		8BF9E03427B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
 		8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */; };
 		8C6A22E425783D2000A79950 /* JetpackScanService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C6A22E325783D2000A79950 /* JetpackScanService.swift */; };
@@ -6138,6 +6140,7 @@
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
+		8BF9E03227B1A8A800915B27 /* DashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCard.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
 		8C6A22E325783D2000A79950 /* JetpackScanService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackScanService.swift; sourceTree = "<group>"; };
@@ -14590,6 +14593,7 @@
 				8B4DDF23278F3AED0022494D /* Cards */,
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
 				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
+				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
 				FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */,
 				FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */,
 			);
@@ -18384,6 +18388,7 @@
 				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
 				1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
+				8BF9E03327B1A8A800915B27 /* DashboardCard.swift in Sources */,
 				7E4123C520F4097B00DF8486 /* FormattableContentAction.swift in Sources */,
 				D8A468E521828D940094B82F /* SiteVerticalsService.swift in Sources */,
 				3F8D988926153484003619E5 /* UnifiedPrologueBackgroundView.swift in Sources */,
@@ -20738,6 +20743,7 @@
 				FABB25802602FC2C00C8785C /* WPStyleGuide+Loader.swift in Sources */,
 				FABB25812602FC2C00C8785C /* MediaThumbnailService.swift in Sources */,
 				FABB25822602FC2C00C8785C /* MediaExporter.swift in Sources */,
+				8BF9E03427B1A8A800915B27 /* DashboardCard.swift in Sources */,
 				FABB25832602FC2C00C8785C /* ReaderRelatedPostsCell.swift in Sources */,
 				FABB25842602FC2C00C8785C /* NoResultsViewController+FollowedSites.swift in Sources */,
 				DC76668626FD9AC9009254DD /* TimeZoneTableViewCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1409,6 +1409,8 @@
 		8B3626F925A665E500D7CCE3 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B3DECAB2388506400A459C2 /* SentryStartupEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */; };
 		8B45C12627B2A27400EA3257 /* dashboard-200-with-drafts-only.json in Resources */ = {isa = PBXBuildFile; fileRef = 8B45C12527B2A27400EA3257 /* dashboard-200-with-drafts-only.json */; };
+		8B45C12727B2B08900EA3257 /* DashboardStatsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */; };
+		8B45C12827B2B0D500EA3257 /* BlogDashboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */; };
 		8B4DDF25278F44CC0022494D /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
 		8B4DDF26278F45180022494D /* HostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D8278DDD4B00DF24B3 /* HostCollectionViewCell.swift */; };
 		8B4DDF27278F451E0022494D /* QuickLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7DC278DDE0E00DF24B3 /* QuickLinksView.swift */; };
@@ -19591,6 +19593,7 @@
 				FABB213E2602FC2C00C8785C /* StatsRecord+CoreDataClass.swift in Sources */,
 				FABB213F2602FC2C00C8785C /* LatestPostSummaryCell.swift in Sources */,
 				FABB21402602FC2C00C8785C /* LoginEpilogueViewController.swift in Sources */,
+				8B45C12827B2B0D500EA3257 /* BlogDashboardService.swift in Sources */,
 				FABB21412602FC2C00C8785C /* QuickStartTours.swift in Sources */,
 				FABB21422602FC2C00C8785C /* RevisionsTableViewFooter.swift in Sources */,
 				FABB21432602FC2C00C8785C /* KanvasCameraAnalyticsHandler.swift in Sources */,
@@ -19768,6 +19771,7 @@
 				FABB21DD2602FC2C00C8785C /* NSAttributedString+StyledHTML.swift in Sources */,
 				FABB21DE2602FC2C00C8785C /* Accessible.swift in Sources */,
 				FABB21DF2602FC2C00C8785C /* PostingActivityCell.swift in Sources */,
+				8B45C12727B2B08900EA3257 /* DashboardStatsCardCell.swift in Sources */,
 				FABB21E02602FC2C00C8785C /* SupportTableViewController.swift in Sources */,
 				FABB21E12602FC2C00C8785C /* DetailDataCell.swift in Sources */,
 				C7F7AC75261CF1F300CE547F /* JetpackLoginErrorViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1422,6 +1422,7 @@
 		8B5FEAF125A746CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
 		8B6214E027B1AD9D001DF7B6 /* DashboardStatsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */; };
+		8B6214E327B1B2F3001DF7B6 /* BlogDashboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */; };
 		8B64B4B2247EC3A2009A1229 /* reader.css in Resources */ = {isa = PBXBuildFile; fileRef = 8B64B4B1247EC3A2009A1229 /* reader.css */; };
 		8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */; };
 		8B69F100255C4870006B1CEF /* ActivityStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */; };
@@ -6079,6 +6080,7 @@
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsCardCell.swift; sourceTree = "<group>"; };
+		8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardService.swift; sourceTree = "<group>"; };
 		8B64B4B1247EC3A2009A1229 /* reader.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = reader.css; sourceTree = "<group>"; };
 		8B69F0E3255C2C3F006B1CEF /* ActivityListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListViewModelTests.swift; sourceTree = "<group>"; };
 		8B69F0FF255C4870006B1CEF /* ActivityStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStoreTests.swift; sourceTree = "<group>"; };
@@ -11361,6 +11363,14 @@
 			path = Posts;
 			sourceTree = "<group>";
 		};
+		8B6214E127B1B2D6001DF7B6 /* Service */ = {
+			isa = PBXGroup;
+			children = (
+				8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */,
+			);
+			path = Service;
+			sourceTree = "<group>";
+		};
 		8B69F0E2255C2BC0006B1CEF /* Activity */ = {
 			isa = PBXGroup;
 			children = (
@@ -14602,6 +14612,7 @@
 			isa = PBXGroup;
 			children = (
 				8B4DDF23278F3AED0022494D /* Cards */,
+				8B6214E127B1B2D6001DF7B6 /* Service */,
 				FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */,
 				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
 				8BF9E03227B1A8A800915B27 /* DashboardCard.swift */,
@@ -18102,6 +18113,7 @@
 				731E88CB21C9A10B0055C014 /* ErrorStateViewController.swift in Sources */,
 				BE87E1A01BD4054F0075D45B /* WP3DTouchShortcutCreator.swift in Sources */,
 				742B7F3A209CB2B6002E3CC9 /* GIFPlaybackStrategy.swift in Sources */,
+				8B6214E327B1B2F3001DF7B6 /* BlogDashboardService.swift in Sources */,
 				F1D8C6E926BA94DF002E3323 /* WordPressBackgroundTaskEventHandler.swift in Sources */,
 				D8212CC520AA83F9008E8AE8 /* ReaderCommentAction.swift in Sources */,
 				FAD954B825B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -32,8 +32,8 @@ class BlogDashboardServiceTests: XCTestCase {
 
         service.fetch(wpComID: 123456) { snapshot in
             // Drafts and Scheduled section exists
-            let draftsSection = snapshot.sectionIdentifiers.first(where:  { $0.subtype == "draft" })
-            let scheduledSection = snapshot.sectionIdentifiers.first(where:  { $0.subtype == "scheduled" })
+            let draftsSection = snapshot.sectionIdentifiers.first(where: { $0.subtype == "draft" })
+            let scheduledSection = snapshot.sectionIdentifiers.first(where: { $0.subtype == "scheduled" })
             XCTAssertNotNil(draftsSection)
             XCTAssertNotNil(scheduledSection)
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -40,11 +40,13 @@ class BlogDashboardServiceTests: XCTestCase {
             // The id is posts
             XCTAssertEqual(snapshot.itemIdentifiers(inSection: draftsSection!).first?.id, .posts)
 
-            // For Drafts section, scheduled has 0 posts
-            XCTAssertEqual((snapshot.itemIdentifiers(inSection: draftsSection!).first?.cellViewModel?["scheduled"] as? [Any])?.count, 0)
+            // For Drafts section
+            XCTAssertFalse(snapshot.itemIdentifiers(inSection: draftsSection!).first?.cellViewModel?["show_scheduled"] as! Bool)
+            XCTAssertTrue(snapshot.itemIdentifiers(inSection: draftsSection!).first?.cellViewModel?["show_drafts"] as! Bool)
 
-            // For Scheduled, draft has 0 posts
-            XCTAssertEqual((snapshot.itemIdentifiers(inSection: scheduledSection!).first?.cellViewModel?["draft"] as? [Any])?.count, 0)
+            // For Scheduled section
+            XCTAssertFalse(snapshot.itemIdentifiers(inSection: scheduledSection!).first?.cellViewModel?["show_drafts"] as! Bool)
+            XCTAssertTrue(snapshot.itemIdentifiers(inSection: scheduledSection!).first?.cellViewModel?["show_scheduled"] as! Bool)
             expect.fulfill()
         }
 
@@ -63,11 +65,11 @@ class BlogDashboardServiceTests: XCTestCase {
             // The item identifier id is posts
             XCTAssertEqual(snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.id, .posts)
 
-            // For Drafts section, scheduled has 0 posts
-            XCTAssertEqual((snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.cellViewModel?["scheduled"] as? [Any])?.count, 0)
+            // For Drafts section, showScheduled is nil
+            XCTAssertFalse(snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.cellViewModel?["show_scheduled"] as! Bool)
 
             // For Drafts section, scheduled has 1 post
-            XCTAssertEqual((snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.cellViewModel?["draft"] as? [Any])?.count, 1)
+            XCTAssertTrue(snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.cellViewModel?["show_drafts"] as! Bool)
 
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -95,6 +95,27 @@ class BlogDashboardServiceTests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testLocalCards() {
+        let expect = expectation(description: "Return local cards stats")
+        remoteServiceMock.respondWith = .withDraftAndSchedulePosts
+
+        service.fetch(wpComID: 123456) { snapshot in
+            // Quick Actions exists
+            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == "quickActions" }
+            XCTAssertEqual(quickActionsSection.count, 1)
+
+            // The item identifier id is quick actions
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.id, .quickActions)
+
+            // It doesn't have a data source
+            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.cellViewModel)
+
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
 }
 
 class DashboardServiceRemoteMock: DashboardServiceRemote {

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -74,6 +74,27 @@ class BlogDashboardServiceTests: XCTestCase {
 
         waitForExpectations(timeout: 3, handler: nil)
     }
+
+    func testTodaysStats() {
+        let expect = expectation(description: "Parse todays stats")
+        remoteServiceMock.respondWith = .withDraftAndSchedulePosts
+
+        service.fetch(wpComID: 123456) { snapshot in
+            // Drafts and Scheduled section exists
+            let todaysStatsSection = snapshot.sectionIdentifiers.filter { $0.id == "todays_stats" }
+            XCTAssertEqual(todaysStatsSection.count, 1)
+
+            // The item identifier id is todaysStats
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: todaysStatsSection.first!).first?.id, .todaysStats)
+
+            // Todays Stats has the correct data source
+            XCTAssertEqual(snapshot.itemIdentifiers(inSection: todaysStatsSection.first!).first?.cellViewModel, ["views": 0, "visitors": 0, "likes": 0, "comments": 0])
+
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
 }
 
 class DashboardServiceRemoteMock: DashboardServiceRemote {

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+class BlogDashboardServiceTests: XCTestCase {
+    private var service: BlogDashboardService!
+    private var remoteServiceMock: DashboardServiceRemoteMock!
+
+    override func setUp() {
+        super.setUp()
+
+        remoteServiceMock = DashboardServiceRemoteMock()
+        service = BlogDashboardService(managedObjectContext: TestContextManager().newDerivedContext(), remoteService: remoteServiceMock)
+    }
+
+    func testCallServiceWithCorrectIDAndCards() {
+        let expect = expectation(description: "Request the correct ID")
+
+        service.fetch(wpComID: 123456) { _ in
+            XCTAssertEqual(self.remoteServiceMock.didCallWithBlogID, 123456)
+            XCTAssertEqual(self.remoteServiceMock.didRequestCards, ["posts", "todays_stats"])
+            expect.fulfill()
+        }
+
+        waitForExpectations(timeout: 3, handler: nil)
+    }
+}
+
+class DashboardServiceRemoteMock: DashboardServiceRemote {
+    var didCallWithBlogID: Int?
+    var didRequestCards: [String]?
+
+    override func fetch(cards: [String], forBlogID blogID: Int, success: @escaping (NSDictionary) -> Void, failure: @escaping (Error) -> Void) {
+        didCallWithBlogID = blogID
+        didRequestCards = cards
+        success([:])
+    }
+}

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -65,7 +65,7 @@ class BlogDashboardServiceTests: XCTestCase {
             // The item identifier id is posts
             XCTAssertEqual(snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.id, .posts)
 
-            // For Drafts section, showScheduled is nil
+            // For Drafts section, showScheduled is false
             XCTAssertFalse(snapshot.itemIdentifiers(inSection: draftsSection.first!).first?.cellViewModel?["show_scheduled"] as! Bool)
 
             // For Drafts section, scheduled has 1 post

--- a/WordPress/WordPressTest/Test Data/Dashboard/dashboard-200-with-drafts-and-scheduled.json
+++ b/WordPress/WordPressTest/Test Data/Dashboard/dashboard-200-with-drafts-and-scheduled.json
@@ -1,0 +1,37 @@
+{
+    "posts": {
+        "has_published": true,
+        "draft": [{
+            "id": 3246,
+            "title": "Foo",
+            "content": "",
+            "featured_image": null,
+            "date": "2022-01-13 00:30:56"
+        }, {
+            "id": 3120,
+            "title": "Bar",
+            "content": "",
+            "featured_image": null,
+            "date": "2021-03-05 21:04:44"
+        }, {
+            "id": 3109,
+            "title": "Foobar",
+            "content": "",
+            "featured_image": null,
+            "date": "0000-00-00 00:00:00"
+        }],
+        "scheduled": [{
+            "id": 3109,
+            "title": "Foobar",
+            "content": "",
+            "featured_image": null,
+            "date": "0000-00-00 00:00:00"
+        }]
+    },
+    "todays_stats": {
+        "views": 0,
+        "visitors": 0,
+        "likes": 0,
+        "comments": 0
+    }
+}

--- a/WordPress/WordPressTest/Test Data/Dashboard/dashboard-200-with-drafts-only.json
+++ b/WordPress/WordPressTest/Test Data/Dashboard/dashboard-200-with-drafts-only.json
@@ -1,0 +1,20 @@
+{
+    "posts": {
+        "has_published": true,
+        "draft": [{
+            "id": 3246,
+            "title": "Foo",
+            "content": "",
+            "featured_image": null,
+            "date": "2022-01-13 00:30:56"
+        }],
+        "scheduled": []
+    },
+    "todays_stats": {
+        "views": 0,
+        "visitors": 0,
+        "likes": 0,
+        "comments": 0
+    }
+}
+


### PR DESCRIPTION
Part of #17873

**Important: handling errors, persistence, update, pull to refresh, etc are not part of this task.**

<img src="https://user-images.githubusercontent.com/7040243/153008316-3f20d1e2-587d-4c58-9953-dbde674bb886.png" width="300">

This PR handles:

* Local cards
* Remote cards
* Configuring them

I will probably expand on the architecture in a future post, but the idea is quite simple: cards are registered in `DashboardCard` and they can be: 1) remote or 2) local. Remote cards are powered by remote data, while local cards aren't.

### To test

Make sure to run your sandbox with the 1.1 API diff applied and to have the My Site Dashboard flag enabled:

1. Open the app
2. Tap "Dashboard"
3. Notice that the Quick Actions row appear
4. Posts card might appear if 1) you have draft posts or 2) you have scheduled posts

For (4) you can play by creating drafts/scheduled posts and closing and reopening the app (updates are not handled yet).

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests for the parser.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the parser.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
