### PR TITLE
Enable more features in the Jetpack app

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -126,7 +126,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
 
     id<AccountServiceRemote> remote = [self remoteForAccount:account];
     
-    BOOL filterJetpackSites = [AppConfiguration isJetpack];
+    BOOL filterJetpackSites = [AppConfiguration showJetpackSitesOnly];
 
     [remote getBlogs:filterJetpackSites success:^(NSArray *blogs) {
         [[[JetpackCapabilitiesService alloc] init] syncWithBlogs:blogs success:^(NSArray<RemoteBlog *> *blogs) {
@@ -622,7 +622,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
 {
     AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:account.wordPressComRestApi];
     
-    BOOL filterJetpackSites = [AppConfiguration isJetpack];
+    BOOL filterJetpackSites = [AppConfiguration showJetpackSitesOnly];
     
     [remote getBlogs:filterJetpackSites success:^(NSArray *remoteBlogs) {
 

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = false
+    @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = true
     @objc static let allowsConnectSite: Bool = true
     @objc static let allowSiteCreation: Bool = true

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -13,6 +13,7 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
+    @objc static let showAddSelfHostedSiteButton: Bool = true
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true

--- a/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Add Site/AddSiteAlertFactory.swift
@@ -10,6 +10,7 @@ class AddSiteAlertFactory: NSObject {
         source: String?,
         canCreateWPComSite: Bool,
         createWPComSite: @escaping () -> Void,
+        canAddSelfHostedSite: Bool,
         addSelfHostedSite: @escaping () -> Void) -> UIAlertController {
 
         let alertController = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
@@ -18,7 +19,10 @@ class AddSiteAlertFactory: NSObject {
             alertController.addAction(createWPComSiteAction(handler: createWPComSite))
         }
 
-        alertController.addAction(addSelfHostedSiteAction(handler: addSelfHostedSite))
+        if canAddSelfHostedSite {
+            alertController.addAction(addSelfHostedSiteAction(handler: addSelfHostedSite))
+        }
+
         alertController.addAction(cancelAction())
 
         WPAnalytics.track(.addSiteAlertDisplayed, properties: ["source": source ?? "unknown"])

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -998,6 +998,12 @@ static NSInteger HideSearchMinSites = 3;
         BOOL canCreateWPComSite = [self defaultWordPressComAccount] ? YES : NO;
         BOOL canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton;
 
+        // Launch directly into the add site process if we're only going to show one button
+        if(canCreateWPComSite && !canAddSelfHostedSite) {
+            [self launchSiteCreation];
+            return;
+        }
+
         UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site" canCreateWPComSite:canCreateWPComSite createWPComSite:^{
             [self launchSiteCreation];
         } canAddSelfHostedSite:canAddSelfHostedSite addSelfHostedSite:^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -1001,7 +1001,7 @@ static NSInteger HideSearchMinSites = 3;
         // Launch directly into the add site process if we're only going to show one button
         if(canCreateWPComSite && !canAddSelfHostedSite) {
             [self launchSiteCreation];
-            return;
+            return
         }
 
         UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site" canCreateWPComSite:canCreateWPComSite createWPComSite:^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -996,11 +996,11 @@ static NSInteger HideSearchMinSites = 3;
     } else {
         AddSiteAlertFactory *factory = [AddSiteAlertFactory new];
         BOOL canCreateWPComSite = [self defaultWordPressComAccount] ? YES : NO;
-        UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site"
-                                                              canCreateWPComSite:canCreateWPComSite
-                                                                 createWPComSite:^{
+        BOOL canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton;
+
+        UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site" canCreateWPComSite:canCreateWPComSite createWPComSite:^{
             [self launchSiteCreation];
-        } addSelfHostedSite:^{
+        } canAddSelfHostedSite:canAddSelfHostedSite addSelfHostedSite:^{
             [self showLoginControllerForAddingSelfHostedSite];
         }];
 
@@ -1017,7 +1017,7 @@ static NSInteger HideSearchMinSites = 3;
         self.addSiteAlertController = alertController;
 
         [WPAnalytics trackEvent:WPAnalyticsEventSiteSwitcherAddSiteTapped];
-
+//
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -1001,7 +1001,7 @@ static NSInteger HideSearchMinSites = 3;
         // Launch directly into the add site process if we're only going to show one button
         if(canCreateWPComSite && !canAddSelfHostedSite) {
             [self launchSiteCreation];
-            return
+            return;
         }
 
         UIAlertController *alertController = [factory makeAddSiteAlertWithSource:@"my_site" canCreateWPComSite:canCreateWPComSite createWPComSite:^{

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -460,11 +460,17 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     func presentInterfaceForAddingNewSite() {
-        let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites", canCreateWPComSite: defaultAccount() != nil) { [weak self] in
+        let canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton
+
+        let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites",
+                                                                  canCreateWPComSite: defaultAccount() != nil,
+                                                                  createWPComSite: { [weak self] in
             self?.launchSiteCreation(source: "my_site_no_sites")
-        } addSelfHostedSite: {
+        },
+                                                                  canAddSelfHostedSite: canAddSelfHostedSite,
+                                                                  addSelfHostedSite:  {
             WordPressAuthenticator.showLoginForSelfHostedSite(self)
-        }
+        })
 
         if let sourceView = noResultsViewController.actionButton,
            let popoverPresentationController = addSiteAlert.popoverPresentationController {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -466,9 +466,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                                                                   canCreateWPComSite: defaultAccount() != nil,
                                                                   createWPComSite: { [weak self] in
             self?.launchSiteCreation(source: "my_site_no_sites")
-        },
-                                                                  canAddSelfHostedSite: canAddSelfHostedSite,
-                                                                  addSelfHostedSite:  {
+        }, canAddSelfHostedSite: canAddSelfHostedSite, addSelfHostedSite:  {
             WordPressAuthenticator.showLoginForSelfHostedSite(self)
         })
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -467,7 +467,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         guard canAddSelfHostedSite else {
             addSite()
-            return;
+            return
         }
         let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites",
                                                                   canCreateWPComSite: defaultAccount() != nil,

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -461,11 +461,18 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     @objc
     func presentInterfaceForAddingNewSite() {
         let canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton
+        let addSite = {
+            self.launchSiteCreation(source: "my_site_no_sites")
+        }
 
+        guard canAddSelfHostedSite else {
+            addSite()
+            return;
+        }
         let addSiteAlert = AddSiteAlertFactory().makeAddSiteAlert(source: "my_site_no_sites",
                                                                   canCreateWPComSite: defaultAccount() != nil,
-                                                                  createWPComSite: { [weak self] in
-            self?.launchSiteCreation(source: "my_site_no_sites")
+                                                                  createWPComSite: {
+            addSite()
         }, canAddSelfHostedSite: canAddSelfHostedSite, addSelfHostedSite: {
             WordPressAuthenticator.showLoginForSelfHostedSite(self)
         })

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -466,7 +466,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                                                                   canCreateWPComSite: defaultAccount() != nil,
                                                                   createWPComSite: { [weak self] in
             self?.launchSiteCreation(source: "my_site_no_sites")
-        }, canAddSelfHostedSite: canAddSelfHostedSite, addSelfHostedSite:  {
+        }, canAddSelfHostedSite: canAddSelfHostedSite, addSelfHostedSite: {
             WordPressAuthenticator.showLoginForSelfHostedSite(self)
         })
 

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -13,6 +13,7 @@ import Foundation
     @objc static let allowsCustomAppIcons: Bool = false
     @objc static let showsReader: Bool = false
     @objc static let showsCreateButton: Bool = false
+    @objc static let showAddSelfHostedSiteButton: Bool = true
     @objc static let showsQuickActions: Bool = false
     @objc static let showsFollowedSitesSettings: Bool = false
     @objc static let showsWhatIsNew: Bool = false

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -6,15 +6,15 @@ import Foundation
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true
     @objc static let showJetpackSitesOnly: Bool = false
-    @objc static let allowsNewPostShortcut: Bool = false
-    @objc static let allowsConnectSite: Bool = false
-    @objc static let allowSiteCreation: Bool = false
-    @objc static let allowSignUp: Bool = false
-    @objc static let allowsCustomAppIcons: Bool = false
-    @objc static let showsReader: Bool = false
-    @objc static let showsCreateButton: Bool = false
-    @objc static let showAddSelfHostedSiteButton: Bool = true
-    @objc static let showsQuickActions: Bool = false
-    @objc static let showsFollowedSitesSettings: Bool = false
+    @objc static let allowsNewPostShortcut: Bool = true
+    @objc static let allowsConnectSite: Bool = true
+    @objc static let allowSiteCreation: Bool = true
+    @objc static let allowSignUp: Bool = true
+    @objc static let allowsCustomAppIcons: Bool = true
+    @objc static let showsReader: Bool = true
+    @objc static let showsCreateButton: Bool = true
+    @objc static let showAddSelfHostedSiteButton: Bool = false
+    @objc static let showsQuickActions: Bool = true
+    @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = false
 }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -10,7 +10,7 @@ import Foundation
     @objc static let allowsConnectSite: Bool = true
     @objc static let allowSiteCreation: Bool = true
     @objc static let allowSignUp: Bool = true
-    @objc static let allowsCustomAppIcons: Bool = true
+    @objc static let allowsCustomAppIcons: Bool = false
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showAddSelfHostedSiteButton: Bool = false

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true
+    @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = false
     @objc static let allowsConnectSite: Bool = false
     @objc static let allowSiteCreation: Bool = false

--- a/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/Login Error/JetpackLoginErrorViewController.swift
@@ -51,6 +51,7 @@ extension JetpackLoginErrorViewController {
 
     private func configureTitleLabel() {
         guard let title = viewModel.title else {
+            titleLabel.isHidden = true
             return
         }
 


### PR DESCRIPTION
This enables the WordPress app features in the Jetpack app (Reader, Site Creation, WP.com sites, etc)

### To test:
1. Launch the app
2. Sign out if you're signed in
3. Login with your WordPress.com account
4. 👁️ Notice on the site switcher all of your connected sites are displayed, not just Jetpack ones
5. Tap on a site to select it
6. 👁️ Notice the Reader tab is now available
7. Tap on the ▼ to open the site switcher
8. 👁️ Notice the + button is now visible
9. Tap the + button to add a site
10. 👁️ Notice that you are brought to the site creation flow without a prompt
11. Create a site and verify this flow works as expected
12. Tap on Reader
13. Tap through each of the areas to make sure everything works as intended
14. My Site
15. Tap through each of the areas to make sure everything works as intended

### Existing user testing
1. Launch the old version of the Jetpack app
2. Login and select a site
3. Upgrade to the latest version
4. Verify everything works as intended

### WordPress Testing
1. Launch the WordPress app
2. Verify all the features are working as intended

## Regression Notes
1. Potential unintended areas of impact
- Existing users opening the app after these features are enabled.
- Features may be effected by the new AppConfig in the WordPress App

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
