### PR TITLE
Enable login tests tearDown to close MySites modal

### DIFF
--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -47,11 +47,8 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable {
-            navigateBack()
-        }
-        if cancelButtonGetter(app).isHittable {
-            cancelButtonGetter(app).tap()
-        }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone { app.buttons["Cancel"].tap() }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
+        if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -47,10 +47,9 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
-            app.buttons.matching(identifier: "Cancel").element(boundBy: 1).tap()
+        if addSelfHostedSiteButtonGetter(app).isHittable {
+            app.children(matching: .window).element(boundBy: 0).tap()
         }
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -48,7 +48,7 @@ public class MySitesScreen: ScreenObject {
 
     public func closeModalIfNeeded() {
         if addSelfHostedSiteButtonGetter(app).isHittable {
-            addSelfHostedSiteButtonGetter(app).tap()
+            navigateBack()
         }
         if cancelButtonGetter(app).isHittable {
             cancelButtonGetter(app).tap()

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -47,7 +47,9 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone { app.buttons["Cancel"].tap() }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
+            app.buttons.matching(identifier: "Cancel").element(boundBy: 1)
+        }
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -12,7 +12,11 @@ public class MySitesScreen: ScreenObject {
         $0.buttons["add-site-button"]
     }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    let addSelfHostedSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Add self-hosted site"]
+    }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 // swiftlint:disable:next opening_brace
@@ -27,7 +31,7 @@ public class MySitesScreen: ScreenObject {
 
     public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
         plusButtonGetter(app).tap()
-        app.buttons["Add self-hosted site"].tap()
+        addSelfHostedSiteButtonGetter(app).tap()
         return try LoginSiteAddressScreen()
     }
 
@@ -40,5 +44,14 @@ public class MySitesScreen: ScreenObject {
     public func switchToSite(withTitle title: String) throws -> MySiteScreen {
         app.cells[title].tap()
         return try MySiteScreen()
+    }
+
+    public func closeModalIfNeeded() {
+        if addSelfHostedSiteButtonGetter(app).isHittable {
+            addSelfHostedSiteButtonGetter(app).tap()
+        }
+        if cancelButtonGetter(app).isHittable {
+            cancelButtonGetter(app).tap()
+        }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -48,7 +48,7 @@ public class MySitesScreen: ScreenObject {
 
     public func closeModalIfNeeded() {
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
-            app.buttons.matching(identifier: "Cancel").element(boundBy: 1)
+            app.buttons.matching(identifier: "Cancel").element(boundBy: 1).tap()
         }
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,6 +12,7 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
+        try MySitesScreen().closeModalIfNeeded()
         try LoginFlow.logoutIfNeeded()
         try super.tearDownWithError()
     }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,7 +12,7 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try MySitesScreen().closeModalIfNeeded()
+        try? MySitesScreen().closeModalIfNeeded()
         try LoginFlow.logoutIfNeeded()
         try super.tearDownWithError()
     }


### PR DESCRIPTION
An UI Tests issue recently identified happens when for some still unknown reason the My Site switch screen's `+`  or `Add self-hosted site` buttons are either not tapped or the tap does not take effect, the tests will then fail as expected, however the `tearDown()` and `setUp()` are not able to close the modal. All following tests would fail, including the automatic retries.

![image](https://user-images.githubusercontent.com/42008628/153088366-c6a8d4e0-b344-48ec-bddb-10b59f2b48a1.png)

This PR aims to enable `tearDown()` to handle this modal and hopefully allow the automatic retries to do their job.

To test:
* Test PR with changes to reproduce the issue: #17937  
* Test PR with UI Tests running 5 times: #17939 

## Regression Notes
1. Potential unintended areas of impact
Login UI Tests

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran them in CI

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
