### PR TITLE
UI tests dismiss my sites failure

### DIFF
--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -12,7 +12,11 @@ public class MySitesScreen: ScreenObject {
         $0.buttons["add-site-button"]
     }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    let addSelfHostedSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Add self-hosted site"]
+    }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 // swiftlint:disable:next opening_brace
@@ -27,7 +31,7 @@ public class MySitesScreen: ScreenObject {
 
     public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
         plusButtonGetter(app).tap()
-        app.buttons["Add self-hosted site"].tap()
+        addSelfHostedSiteButtonGetter(app).tap()
         return try LoginSiteAddressScreen()
     }
 
@@ -40,5 +44,14 @@ public class MySitesScreen: ScreenObject {
     public func switchToSite(withTitle title: String) throws -> MySiteScreen {
         app.cells[title].tap()
         return try MySiteScreen()
+    }
+
+    public func closeModalIfNeeded() {
+        if addSelfHostedSiteButtonGetter(app).isHittable {
+            addSelfHostedSiteButtonGetter(app).tap()
+        }
+        if cancelButtonGetter(app).isHittable {
+            cancelButtonGetter(app).tap()
+        }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -13,7 +13,7 @@ public class MySitesScreen: ScreenObject {
     }
 
     let addSelfHostedSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Add self-hosted site"]
+        $0.buttons["INTRODUCED_FAILURE"]
     }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,6 +12,7 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
+        try MySitesScreen().closeModalIfNeeded()
         try LoginFlow.logoutIfNeeded()
         try super.tearDownWithError()
     }


### PR DESCRIPTION
This is a Test PR to test #17915 forcing UI Tests to neve fin `Add self-hosted site` button. The UI Tests should be able to fail but still let the following tests and retries run.