### PR TITLE
Comment moderation: update view correctly when selecting Next on confirmation notice

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -264,6 +264,7 @@ class CommentDetailViewController: UIViewController {
     @objc func displayComment(_ comment: Comment, isLastInList: Bool) {
         self.comment = comment
         self.isLastInList = isLastInList
+        replyTextView?.placeholder = String(format: .replyPlaceholderFormat, comment.authorForDisplay())
         refreshData()
     }
 }


### PR DESCRIPTION
Ref: #17290 

When moderating a comment in comment details and selecting `Next` on the confirmation notice, there were two issues:
1. The reply indicator cell was not added/removed for the next comment.

<img width="447" alt="reply_indicator" src="https://user-images.githubusercontent.com/1816888/153106056-59f55b6c-3ea7-4bf4-bf20-b9f02c03cdf9.png">


2. The author's name in the reply placeholder text was not updated for the next comment.

<img width="443" alt="reply_placeholder" src="https://user-images.githubusercontent.com/1816888/153106082-367a33ef-d7cc-4494-b683-cb52fcefe964.png">


This fixes both issues.

To test:

**Reply indicator:**
- Go to My Site > Comments.
- Select a comment where the next comment has a different reply status (i.e. you've replied to the first but not the second, or vice versa).
  - Verify the comment shows the correct reply status.
- Moderate the comment and select `Next` on the confirmation notice.
  - Verify the next comment's reply indicator is shown/hidden according to your reply status.
- Moderate several comments using `Next` to proceed. 
  - Verify the comments are displayed correctly, and the app doesn't crash due to differing table row counts. (Well, for any reason really, but mainly this. 😄 )

**Reply placeholder:**
- Go to My Site > Comments.
- Select a comment where the next comment has a different author.
- Tap the `Reply` button so the reply view appears at the bottom. Note the placeholder has this author's name.
- Moderate the comment and select `Next` on the confirmation notice.
- Verify the reply placeholder author name is updated.


## Regression Notes
1. Potential unintended areas of impact
Should be none. This is the only place (for now) you can `Next` through comments.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested comment moderation and display.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
