### PR TITLE
Attempt to "fix" UI tests flakiness on CI

### DIFF
--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -10,6 +10,7 @@ extension XCTestCase {
         continueAfterFailure = false
 
         let app = XCUIApplication()
+        app.terminate()
         app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
         app.activate()
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -961,6 +961,7 @@ platform :ios do
       test_without_building: true,
       xctestrun: test_plan_path,
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
+      reset_simulator: true,
       result_bundle: true
     )
   end


### PR DESCRIPTION
This is a replay of #17886, minus all the test commits that would have made the history on `trunk` noisy.

All credits to @pachlava, see #17886.

Note: I marked this as ready for review but haven't enabled auto-merge. Waiting for @pachlava's input on whether to merge this or the original one [with certain tweaks to keep the history neat](https://github.com/wordpress-mobile/WordPress-iOS/pull/17886#pullrequestreview-877491416).