### PR TITLE
Notifications > Comment Details: show previous/next comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1,7 +1,8 @@
 import UIKit
 import CoreData
 
-@objc protocol CommentDetailsDelegate: AnyObject {
+
+@objc protocol CommentDetailsModerationDelegate: AnyObject {
     func nextCommentSelected()
 }
 
@@ -23,7 +24,7 @@ class CommentDetailViewController: UIViewController {
     private var keyboardManager: KeyboardDismissHelper?
     private var dismissKeyboardTapGesture = UITapGestureRecognizer()
 
-    @objc weak var delegate: CommentDetailsDelegate?
+    @objc weak var moderationDelegate: CommentDetailsModerationDelegate?
     private var comment: Comment
     private var isLastInList = true
     private var managedObjectContext: NSManagedObjectContext
@@ -838,7 +839,7 @@ private extension CommentDetailViewController {
         }
 
         WPAnalytics.track(.commentSnackbarNext)
-        delegate?.nextCommentSelected()
+        moderationDelegate?.nextCommentSelected()
     }
 
     struct ModerationMessages {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -32,8 +32,7 @@ class CommentDetailViewController: UIViewController {
     private var moderationBar: CommentModerationBar?
     private var notification: Notification?
 
-    // This cannot be weak because by the time it is used for previous/next buttons, it will be nil.
-    private var notificationNavigationDelegate: CommentDetailsNotificationNavigationDelegate?
+    private weak var notificationNavigationDelegate: CommentDetailsNotificationNavigationDelegate?
 
     private var isNotificationComment: Bool {
         notification != nil

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -460,26 +460,26 @@ private extension CommentDetailViewController {
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
-        cell.configure(with: comment) { _ in
-            self.tableView.performBatchUpdates({})
+        cell.configure(with: comment) { [weak self] _ in
+            self?.tableView.performBatchUpdates({})
         }
 
-        cell.contentLinkTapAction = { url in
+        cell.contentLinkTapAction = { [weak self] url in
             // open all tapped links in web view.
             // TODO: Explore reusing URL handling logic from ReaderDetailCoordinator.
-            self.openWebView(for: url)
+            self?.openWebView(for: url)
         }
 
-        cell.accessoryButtonAction = { senderView in
-            self.shareCommentURL(senderView)
+        cell.accessoryButtonAction = { [weak self] senderView in
+            self?.shareCommentURL(senderView)
         }
 
-        cell.likeButtonAction = {
-            self.toggleCommentLike()
+        cell.likeButtonAction = { [weak self] in
+            self?.toggleCommentLike()
         }
 
-        cell.replyButtonAction = {
-            self.showReplyView()
+        cell.replyButtonAction = { [weak self] in
+            self?.showReplyView()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -14,7 +14,7 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
 static NSString *RestorableBlogIdKey = @"restorableBlogIdKey";
 static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
-@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate, UIViewControllerRestoration, NoResultsViewControllerDelegate, CommentDetailsDelegate>
+@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate, UIViewControllerRestoration, NoResultsViewControllerDelegate, CommentDetailsModerationDelegate>
 @property (nonatomic, strong) WPTableViewHandler        *tableViewHandler;
 @property (nonatomic, strong) WPContentSyncHelper       *syncHelper;
 @property (nonatomic, strong) NoResultsViewController   *noResultsViewController;
@@ -233,7 +233,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     self.commentDetailViewController = [[CommentDetailViewController alloc] initWithComment:comment
                                                                                isLastInList:[self isLastRow:indexPath]
                                                                        managedObjectContext:[ContextManager sharedInstance].mainContext];
-    self.commentDetailViewController.delegate = self;
+    self.commentDetailViewController.moderationDelegate = self;
     [self.navigationController pushViewController:self.commentDetailViewController animated:YES];
     [CommentAnalytics trackCommentViewedWithComment:comment];
 }
@@ -752,7 +752,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [self refreshNoConnectionView];
 }
 
-#pragma mark - CommentDetailsDelegate
+#pragma mark - CommentDetailsModerationDelegate
 
 - (void)nextCommentSelected
 {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -732,7 +732,7 @@ extension NotificationsViewController {
         DispatchQueue.main.async {
             if FeatureFlag.notificationCommentDetails.enabled,
                note.kind == .comment {
-                let notificationCommentDetailCoordinator = NotificationCommentDetailCoordinator(notification: note)
+                let notificationCommentDetailCoordinator = NotificationCommentDetailCoordinator(notification: note, notificationsNavigationDataSource: self)
 
                 notificationCommentDetailCoordinator.createViewController { commentDetailViewController in
                     guard let commentDetailViewController = commentDetailViewController else {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -83,6 +83,10 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     ///
     private var timestampBeforeUpdatesForSecondAlert: String?
 
+    private lazy var notificationCommentDetailCoordinator: NotificationCommentDetailCoordinator = {
+        return NotificationCommentDetailCoordinator(notificationsNavigationDataSource: self)
+    }()
+
     /// Activity Indicator to be shown when refreshing a Jetpack site status.
     ///
     let activityIndicator: UIActivityIndicatorView = {
@@ -729,12 +733,14 @@ extension NotificationsViewController {
 
         view.isUserInteractionEnabled = false
 
-        DispatchQueue.main.async {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                return
+            }
+
             if FeatureFlag.notificationCommentDetails.enabled,
                note.kind == .comment {
-                let notificationCommentDetailCoordinator = NotificationCommentDetailCoordinator(notification: note, notificationsNavigationDataSource: self)
-
-                notificationCommentDetailCoordinator.createViewController { commentDetailViewController in
+                self.notificationCommentDetailCoordinator.createViewController(with: note) { commentDetailViewController in
                     guard let commentDetailViewController = commentDetailViewController else {
                         // TODO: show error view
                         return

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -22,16 +22,17 @@ class NotificationCommentDetailCoordinator: NSObject {
 
     // MARK: - Init
 
-    init(notification: Notification,
-         notificationsNavigationDataSource: NotificationsNavigationDataSource? = nil) {
+    init(notificationsNavigationDataSource: NotificationsNavigationDataSource? = nil) {
         self.notificationsNavigationDataSource = notificationsNavigationDataSource
         super.init()
-        configureWith(notification: notification)
     }
 
     // MARK: - Public Methods
 
-    func createViewController(completion: @escaping (CommentDetailViewController?) -> Void) {
+    func createViewController(with notification: Notification,
+                              completion: @escaping (CommentDetailViewController?) -> Void) {
+        configureWith(notification: notification)
+
         if let comment = loadCommentFromCache() {
             createViewController(comment: comment)
             completion(viewController)

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -31,7 +31,7 @@ class NotificationCommentDetailCoordinator: NSObject {
 
     func createViewController(with notification: Notification,
                               completion: @escaping (CommentDetailViewController?) -> Void) {
-        configureWith(notification: notification)
+        configure(with: notification)
 
         if let comment = loadCommentFromCache() {
             createViewController(comment: comment)
@@ -57,7 +57,7 @@ class NotificationCommentDetailCoordinator: NSObject {
 
 private extension NotificationCommentDetailCoordinator {
 
-    func configureWith(notification: Notification) {
+    func configure(with notification: Notification) {
         self.notification = notification
         commentID = notification.metaCommentID
 
@@ -108,7 +108,7 @@ private extension NotificationCommentDetailCoordinator {
     func updateViewWith(notification: Notification) {
         if notification.kind == .comment {
             trackDetailsOpened(for: notification)
-            configureWith(notification: notification)
+            configure(with: notification)
             refreshViewController()
         } else {
             // TODO: handle other notification type

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -104,10 +104,10 @@ private extension NotificationCommentDetailCoordinator {
         updateNavigationButtonStates()
     }
 
-    func updateViewWith(newNotification: Notification) {
-        if newNotification.kind == .comment {
-            trackDetailsOpened(for: newNotification)
-            configureWith(notification: newNotification)
+    func updateViewWith(notification: Notification) {
+        if notification.kind == .comment {
+            trackDetailsOpened(for: notification)
+            configureWith(notification: notification)
             refreshViewController()
         } else {
             // TODO: handle other notification type
@@ -171,7 +171,7 @@ extension NotificationCommentDetailCoordinator: CommentDetailsNotificationNaviga
               }
 
         WPAnalytics.track(.notificationsPreviousTapped)
-        updateViewWith(newNotification: previousNotification)
+        updateViewWith(notification: previousNotification)
     }
 
     func nextNotificationTapped(current: Notification?) {
@@ -181,7 +181,7 @@ extension NotificationCommentDetailCoordinator: CommentDetailsNotificationNaviga
               }
 
         WPAnalytics.track(.notificationsNextTapped)
-        updateViewWith(newNotification: nextNotification)
+        updateViewWith(notification: nextNotification)
     }
 
 }


### PR DESCRIPTION
Ref: #17790 

In the Comment Notifications details view, the previous and next buttons now display the previous and next comments.

Note: this only works in the Comments filter. The All and Unread filters have not been updated yet.

To test:
- Enable the `notificationCommentDetails` feature.
- Go to Notifications > Comments. 
- Select a notification.
- Tap the previous and next arrows in the nav bar.
- Verify the previous and next comments are displayed. 

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
