### PR TITLE
Stats Revamp: Improve cache usage for Insights

### DIFF
--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -366,15 +366,19 @@ private extension StatsInsightsStore {
 
     func refreshInsights(forceRefresh: Bool = false) {
         guard shouldFetchOverview() else {
-            DDLogInfo("Stats Insights Overview refresh triggered while one was in progress.")
+            DDLogInfo("Stats: Insights Overview refresh triggered while one was in progress.")
             return
         }
 
         if FeatureFlag.statsPerformanceImprovements.enabled {
             guard forceRefresh || hasCacheExpired else {
-                DDLogInfo("Stats Insights Overview refresh requested but we still have valid cache data.")
+                DDLogInfo("Stats: Insights Overview refresh requested but we still have valid cache data.")
                 return
             }
+        }
+
+        if forceRefresh {
+            DDLogInfo("Stats: Forcing an Insights refresh.")
         }
 
         persistToCoreData()
@@ -721,8 +725,9 @@ private extension StatsInsightsStore {
         let interval = Date().timeIntervalSince(date)
         let expired = interval > StatsInsightsStore.cacheTTL
 
-        DDLogInfo("Insights: Has cache for site \(siteID) expired? \(expired)")
-        DDLogInfo("Insights: Seconds since last refresh: \(interval) (TTL: \(StatsInsightsStore.cacheTTL))")
+        let intervalLogMessage = "(\(String(format: "%.2f", interval))s since last refresh)"
+        DDLogInfo("Stats: Insights cache for site \(siteID) \(expired ? "has " : "")expired \(intervalLogMessage)")
+
         return expired
     }
 

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -726,7 +726,7 @@ private extension StatsInsightsStore {
         let expired = interval > StatsInsightsStore.cacheTTL
 
         let intervalLogMessage = "(\(String(format: "%.2f", interval))s since last refresh)"
-        DDLogInfo("Stats: Insights cache for site \(siteID) \(expired ? "has " : "")expired \(intervalLogMessage)")
+        DDLogInfo("Stats: Insights cache for site \(siteID) has \(expired ? "" : "not ")expired \(intervalLogMessage)")
 
         return expired
     }

--- a/WordPress/Classes/Stores/StatsInsightsStore.swift
+++ b/WordPress/Classes/Stores/StatsInsightsStore.swift
@@ -175,7 +175,7 @@ class StatsInsightsStore: QueryStore<InsightStoreState, InsightQuery> {
         }
 
         if !isFetchingOverview {
-            DDLogInfo("Stats: Insights Overview fetching operations finished.")
+            DDLogInfo("Stats: Insights Overview refreshing operations finished.")
         }
     }
 
@@ -726,7 +726,7 @@ private extension StatsInsightsStore {
         let expired = interval > StatsInsightsStore.cacheTTL
 
         let intervalLogMessage = "(\(String(format: "%.2f", interval))s since last refresh)"
-        DDLogInfo("Stats: Insights cache for site \(siteID) has \(expired ? "" : "not ")expired \(intervalLogMessage)")
+        DDLogInfo("Stats: Insights cache for site \(siteID) has \(expired ? "" : "not ")expired \(intervalLogMessage).")
 
         return expired
     }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -24,6 +24,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
     case notificationCommentDetails
+    case statsPerformanceImprovements
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -77,6 +78,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .notificationCommentDetails:
             return false
+        case .statsPerformanceImprovements:
+            return true
         }
     }
 
@@ -147,6 +150,8 @@ extension FeatureFlag {
             return "Media Picker Permissions Notice"
         case .notificationCommentDetails:
             return "Notification Comment Details"
+        case .statsPerformanceImprovements:
+            return "Stats Performance Improvements"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -79,7 +79,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .notificationCommentDetails:
             return false
         case .statsPerformanceImprovements:
-            return true
+            return BuildConfiguration.current == .localDeveloper
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -26,5 +26,4 @@ import Foundation
     func timeZoneMatchesDevice() -> Bool {
         return siteTimeZone == TimeZone.current
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -78,9 +78,9 @@ class SiteStatsInsightsTableViewController: UITableViewController, StoryboardLoa
         writeInsightsToUserDefaults()
     }
 
-    func refreshInsights() {
+    func refreshInsights(forceRefresh: Bool = false) {
         addViewModelListeners()
-        viewModel?.refreshInsights()
+        viewModel?.refreshInsights(forceRefresh: forceRefresh)
     }
 
     func showAddInsightView(source: String = "table_row") {
@@ -180,7 +180,7 @@ private extension SiteStatsInsightsTableViewController {
 
         refreshControl?.beginRefreshing()
         clearExpandedRows()
-        refreshInsights()
+        refreshInsights(forceRefresh: true)
         hideNoResults()
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -53,9 +53,14 @@ class SiteStatsInsightsViewModel: Observable {
 
     // MARK: - Refresh Data
 
-    func refreshInsights() {
+    /// This method will trigger a refresh of insights data, provided that we're not already
+    /// performing a refresh and that we haven't refreshed within the last 5 minutes.
+    /// To override this caching and request the latest data (for example, when as the result
+    /// of a pull to refresh action), you can pass a `forceRefresh` value of `true` here.
+    ///
+    func refreshInsights(forceRefresh: Bool = false) {
         if !insightsStore.isFetchingOverview {
-            ActionDispatcher.dispatch(InsightAction.refreshInsights)
+            ActionDispatcher.dispatch(InsightAction.refreshInsights(forceRefresh: forceRefresh))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -59,9 +59,7 @@ class SiteStatsInsightsViewModel: Observable {
     /// of a pull to refresh action), you can pass a `forceRefresh` value of `true` here.
     ///
     func refreshInsights(forceRefresh: Bool = false) {
-        if !insightsStore.isFetchingOverview {
-            ActionDispatcher.dispatch(InsightAction.refreshInsights(forceRefresh: forceRefresh))
-        }
+        ActionDispatcher.dispatch(InsightAction.refreshInsights(forceRefresh: forceRefresh))
     }
 
     // MARK: - Table Model
@@ -71,7 +69,7 @@ class SiteStatsInsightsViewModel: Observable {
         var tableRows = [ImmuTableRow]()
 
         if insightsToShow.isEmpty ||
-            (insightsStore.fetchingFailed(for: .insights) && !containsCachedData()) {
+            (fetchingFailed() && !containsCachedData()) {
             return ImmuTable.Empty
         }
 


### PR DESCRIPTION
Refs #17904. This PR makes some changes to the cache usage for the Insights view in Stats. Previously, we were loading the cache initially, but then always updating from the network every time the Insights screen was displayed.

The changes in this PR bring things more in line with Android, where the cached data for any given site will have a TTL (time to live) of 5 minutes. If you revisit the Insights screen for a given site within 5 minutes of the previous refresh, only the cached data will be displayed. If you pull to refresh, we'll force a full refresh from the network and reset the timeout on the cache.

### To test

If you'd like to make things easier to test, you can shorten the TTL for the cache (`StatsInsightsStore.cacheTTL`) – 30 seconds or so is probably about right. **You can also filter the Xcode console to "Stats:" to pick out only the relevant log messages.**

This set of testing instructions is one long sequence, but I've added some headings to make it clear what you're testing at each time. For bonus points, you could run the app through Charles Proxy to verify that network calls are / are not being  made.

#### Setup

* Build and run, and ensure you're logged into an account with multiple sites
* Visit Stats for one of your sites, and ensure that Insights is selected in the top filter bar
* Ensure that data is loaded into the stats view

#### Single site within TTL

* Tap one of the time periods in the top bar (Days / Weeks / etc), wait for it to finish loading (it'll be easier to see the console logs that way), then tap back to Insights
* Check the console, and you should see something similar to:

```
Stats: Insights cache for site 123456789 has not expired (8.59s since last refresh)
Stats Insights Overview refresh requested but we still have valid cache data.
```

* Tap back and forth again between the screens and check you see a similar message.

#### Single site expired

* Wait for the TTL timeout to be hit, then tap back and forth again. This time, you should see a message like this:

```
Stats: Insights cache for site 1234567890 expired (37.35s since last refresh)
```

* You should also see log messages indicating that the network calls have been made.

#### Pull to refresh

* Tap back and forth between different screens once more and check for the log message indicating that the cache has not expired.
* Pull-to-refresh on the Insights view. You should see a log message similar to the following:

```
Stats: Forcing an Insights refresh.
```

#### Multiple sites

* Switch to another site and then to Stats > Insights, and check that the data is loaded. Switch back and forth between different stats tabs and check the log again to ensure that the timeout is separate from the timeout for the first site you were looking at. You can switch between a couple of different sites and check you can load Insights while another site's cache is active.

## Regression Notes
1. Potential unintended areas of impact

Loading of stats data. These changes are fairly limited and feature flagged, so shouldn't affect other code. Tests still run as expected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Ran automated tests, and tested following steps similar to the above.

3. What automated tests I added (or what prevented me from doing so)

None – I'll look at adding some tests when I update the period store with similar functionality.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
