### PR TITLE
Remove unused `fastlane-plugin-test_center` resulting in CI failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,6 @@ GEM
     cocoapods-try (1.2.0)
     colored (1.2)
     colored2 (3.1.2)
-    colorize (0.8.1)
     commander (4.6.0)
       highline (~> 2.0.0)
     commonmarker (0.21.2)
@@ -162,13 +161,6 @@ GEM
       xcpretty-travis-formatter (>= 0.0.3)
     fastlane-plugin-appcenter (1.11.1)
     fastlane-plugin-sentry (1.11.0)
-    fastlane-plugin-test_center (3.15.3)
-      colorize
-      json
-      plist
-      trainer
-      xcodeproj
-      xctest_list (>= 1.2.1)
     fastlane-plugin-wpmreleasetoolkit (2.3.0)
       activesupport (~> 5)
       bigdecimal (~> 1.4)
@@ -302,9 +294,6 @@ GEM
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     trailblazer-option (0.1.2)
-    trainer (0.9.1)
-      fastlane (>= 2.25.0)
-      plist (>= 3.1.0, < 4.0.0)
     tty-cursor (0.7.1)
     tty-screen (0.8.1)
     tty-spinner (0.9.3)
@@ -331,7 +320,6 @@ GEM
       rouge (~> 2.0.7)
     xcpretty-travis-formatter (1.0.1)
       xcpretty (~> 0.2, >= 0.0.7)
-    xctest_list (1.2.1)
 
 PLATFORMS
   ruby
@@ -343,7 +331,6 @@ DEPENDENCIES
   fastlane (~> 2.174)
   fastlane-plugin-appcenter (~> 1.8)
   fastlane-plugin-sentry
-  fastlane-plugin-test_center
   fastlane-plugin-wpmreleasetoolkit (~> 2.3)
   octokit (~> 4.0)
   rake

--- a/fastlane/Pluginfile
+++ b/fastlane/Pluginfile
@@ -12,4 +12,3 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 2.3'
 
 gem 'fastlane-plugin-sentry'
 gem 'fastlane-plugin-appcenter', '~> 1.8'
-gem 'fastlane-plugin-test_center'


### PR DESCRIPTION
It became unused in 75f87334ee967e1ae8c00d8ccfbecef28fef237d, but I clearly forgot to remove it.

The plugin brings along a version of `trainer` that may be resulting in failures, e.g.:
https://buildkite.com/automattic/wordpress-ios/builds/5104#b3657e48-bdea-4d77-9a44-dc411828deb5/664-2548


## Regression Notes
1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
