### PR TITLE
Test PR for #17915

### DIFF
--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -29,10 +29,8 @@ public class MySitesScreen: ScreenObject {
         )
     }
 
-    public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
+    public func addSelfHostedSite() throws {
         plusButtonGetter(app).tap()
-        addSelfHostedSiteButtonGetter(app).tap()
-        return try LoginSiteAddressScreen()
     }
 
     public func closeModal() throws -> MySiteScreen {

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -82,18 +82,6 @@ class LoginTests: XCTestCase {
             .showSiteSwitcher()
             .addSelfHostedSite()
 
-            // Then, go through the self-hosted login flow:
-            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-
-            // Login flow returns MySites modal, which needs to be closed.
-            .closeModal()
-
-            // TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com account.
-            // Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown().
-            // So, we remove the self-hosted site before tearDown() starts.
-            .removeSelfHostedSite()
-
-        XCTAssert(MySiteScreen.isLoaded())
+        XCTAssert(false)
     }
 }


### PR DESCRIPTION
This is a Test PR to test #17915 by forcing `testAddSelfHostedSiteAfterWPcomLogin()` to fail while Add self-hosted site button is still displayed. The test should fail but `tearDown` should handle the My Sites modal letting the following tests and retries to run.