### PR TITLE
Test PR for #17915 

### DIFF
--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -47,11 +47,8 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable {
-            navigateBack()
-        }
-        if cancelButtonGetter(app).isHittable {
-            cancelButtonGetter(app).tap()
-        }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone { app.buttons["Cancel"].tap() }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
+        if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -48,7 +48,7 @@ public class MySitesScreen: ScreenObject {
 
     public func closeModalIfNeeded() {
         if addSelfHostedSiteButtonGetter(app).isHittable {
-            addSelfHostedSiteButtonGetter(app).tap()
+            navigateBack()
         }
         if cancelButtonGetter(app).isHittable {
             cancelButtonGetter(app).tap()

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -47,7 +47,9 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone { app.buttons["Cancel"].tap() }
+        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
+            app.buttons.matching(identifier: "Cancel").element(boundBy: 1)
+        }
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -29,10 +29,8 @@ public class MySitesScreen: ScreenObject {
         )
     }
 
-    public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
+    public func addSelfHostedSite() throws {
         plusButtonGetter(app).tap()
-        addSelfHostedSiteButtonGetter(app).tap()
-        return try LoginSiteAddressScreen()
     }
 
     public func closeModal() throws -> MySiteScreen {

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -12,7 +12,11 @@ public class MySitesScreen: ScreenObject {
         $0.buttons["add-site-button"]
     }
 
-    init(app: XCUIApplication = XCUIApplication()) throws {
+    let addSelfHostedSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["Add self-hosted site"]
+    }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [
                 // swiftlint:disable:next opening_brace
@@ -27,7 +31,7 @@ public class MySitesScreen: ScreenObject {
 
     public func addSelfHostedSite() throws -> LoginSiteAddressScreen {
         plusButtonGetter(app).tap()
-        app.buttons["Add self-hosted site"].tap()
+        addSelfHostedSiteButtonGetter(app).tap()
         return try LoginSiteAddressScreen()
     }
 
@@ -40,5 +44,14 @@ public class MySitesScreen: ScreenObject {
     public func switchToSite(withTitle title: String) throws -> MySiteScreen {
         app.cells[title].tap()
         return try MySiteScreen()
+    }
+
+    public func closeModalIfNeeded() {
+        if addSelfHostedSiteButtonGetter(app).isHittable {
+            addSelfHostedSiteButtonGetter(app).tap()
+        }
+        if cancelButtonGetter(app).isHittable {
+            cancelButtonGetter(app).tap()
+        }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -45,10 +45,9 @@ public class MySitesScreen: ScreenObject {
     }
 
     public func closeModalIfNeeded() {
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
-            app.buttons.matching(identifier: "Cancel").element(boundBy: 1).tap()
+        if addSelfHostedSiteButtonGetter(app).isHittable {
+            app.children(matching: .window).element(boundBy: 0).tap()
         }
-        if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }
     }
 }

--- a/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySitesScreen.swift
@@ -48,7 +48,7 @@ public class MySitesScreen: ScreenObject {
 
     public func closeModalIfNeeded() {
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPhone {
-            app.buttons.matching(identifier: "Cancel").element(boundBy: 1)
+            app.buttons.matching(identifier: "Cancel").element(boundBy: 1).tap()
         }
         if addSelfHostedSiteButtonGetter(app).isHittable && XCUIDevice.isPad { navigateBack() }
         if cancelButtonGetter(app).isHittable { cancelButtonGetter(app).tap() }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,6 +12,7 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
+        try MySitesScreen().closeModalIfNeeded()
         try LoginFlow.logoutIfNeeded()
         try super.tearDownWithError()
     }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,7 +12,7 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try MySitesScreen().closeModalIfNeeded()
+        try? MySitesScreen().closeModalIfNeeded()
         try LoginFlow.logoutIfNeeded()
         try super.tearDownWithError()
     }

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -82,18 +82,6 @@ class LoginTests: XCTestCase {
             .showSiteSwitcher()
             .addSelfHostedSite()
 
-            // Then, go through the self-hosted login flow:
-            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
-            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
-
-            // Login flow returns MySites modal, which needs to be closed.
-            .closeModal()
-
-            // TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com account.
-            // Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown().
-            // So, we remove the self-hosted site before tearDown() starts.
-            .removeSelfHostedSite()
-
-        XCTAssert(MySiteScreen.isLoaded())
+        XCTAssert(false)
     }
 }


### PR DESCRIPTION
This is a Test PR to test #17915 by forcing `testAddSelfHostedSiteAfterWPcomLogin() `to fail while Add self-hosted site button is still displayed. The test should fail but `tearDown()` should handle the My Sites modal allowing the following tests and retries to run.