### PR TITLE
Hide Manage Insights button when not on Insights tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -83,11 +83,11 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNavBar()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedPeriodFromUserDefaults()
         addWillEnterForegroundObserver()
+        configureNavBar()
         view.accessibilityIdentifier = "stats-dashboard"
     }
 


### PR DESCRIPTION
This PR adds a small fix to the issue of adding a new gear (cog) icon to the NavBar upper right when on Stats Insights screen

When re-launching the app and the Stats screen is restored to a Period tab from userdefaults, the gear icon on the upper right should be hidden

Fixes #17845

To test:
1. Go to Stats screen and then click Insights tab
2. Cog (gear) icon should appear in top right
3. Tap the Days / Weeks / Months / Years tab.  Cog icon should not be visible
4. Ensure the tab selected is either Days / Weeks / Months and force quit the app
5. Re-launch the app
Go to Stats screen.  The tab selected should be the same tab that was selected on step 4.  Gear icon should be removed

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on Simulator and Device

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
