### PR TITLE
Quick Start: fix header font

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
@@ -26,9 +26,9 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eUE-Sb-m3L">
-                    <rect key="frame" x="36" y="0.0" width="32.5" height="36"/>
+                    <rect key="frame" x="36" y="0.0" width="30.5" height="36"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" name="Gray50"/>
                     <nil key="highlightedColor"/>
                 </label>


### PR DESCRIPTION
Fixes the accessibility font for the custom header of Quick Start.

| Before | After |
| ------ | ----- |
| <img src="https://user-images.githubusercontent.com/7040243/153658125-e537191d-233a-44dd-886c-06d0c0c41837.png" width="300"> | <img src="https://user-images.githubusercontent.com/7040243/153658158-68cf4101-29bb-4617-8a3d-600ae657162c.png" width="300"> |

### To test

1. Increase the font size of your device
2. Open the app
3. Start Quick Start for any site
4. Compare the header font size (you can use the Xcode view hierarchy tool)

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
Visual fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
