### PR TITLE
My Site Dashboard (Phase 2): Fix blog details vc instantiation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -349,6 +349,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         hideBlogDetails()
+        blogDetailsViewController = nil
 
         guard noResultsViewController.view.superview == nil else {
             return
@@ -492,7 +493,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         remove(blogDetailsViewController)
-        self.blogDetailsViewController = nil
     }
 
     /// Shows the specified `BlogDetailsSubsection` for a `Blog`.

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -97,13 +97,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
-    /// The VC for the blog details.  This class is written in a way that this VC will only exist if it's being shown on screen.
-    /// Please keep this in mind when making modifications.
-    ///
+    private(set) var sitePickerViewController: SitePickerViewController?
     private(set) var blogDetailsViewController: BlogDetailsViewController?
     private(set) var blogDashboardViewController: BlogDashboardViewController?
-
-    private(set) var sitePickerViewController: SitePickerViewController?
 
     /// When we display a no results view, we'll do so in a scrollview so that
     /// we can allow pull to refresh to sync the user's list of sites.


### PR DESCRIPTION
Part of #17873

## Description
- Fixes an issue where the FAB was getting added to MySiteVC every time you switch between the dashboard and the site menu (See "before" image below)

## How to test

Make sure to run your sandbox with the 1.1 API diff applied and to have the My Site Dashboard flag enabled:

1. Go to My Site
2. Switch to the dashboard
3. Switch back to the site menu
4. Repeat steps 2 and 3 a couple of times
5. Open the View Debugger to make sure that there's only one FAB in the view hierarchy

Before | After
-- | --
<img width="200" alt="Screen Shot 2022-02-09 at 17 07 54" src="https://user-images.githubusercontent.com/6711616/153882580-5aa86f14-1d72-4f17-866c-49f782fae9fe.png"> | <img width="400" alt="Screen Shot 2022-02-14 at 14 36 06" src="https://user-images.githubusercontent.com/6711616/153884119-364d2bc4-d5c5-467b-9ae6-4aec29bfe187.png">


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
