### PR TITLE
My Site Dashboard: change how API response is parsed and injected into cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable & BlogDashboardCardConfigurable
 
 protocol BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?)
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?)
 }
 
 final class BlogDashboardViewController: UIViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 typealias DashboardCollectionViewCell = UICollectionViewCell & Reusable & BlogDashboardCardConfigurable
 
 protocol BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?)
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?)
 }
 
 final class BlogDashboardViewController: UIViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -3,7 +3,7 @@ import UIKit
 class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
     private var postsViewController: PostsCardViewController?
 
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
         guard let viewController = viewController, let dataModel = dataModel else {
             return
         }
@@ -14,11 +14,11 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
             self.postsViewController = postsViewController
 
             // Update with the correct blog and status
-            updatePosts(dataModel, blog: blog)
+//            updatePosts(dataModel, blog: blog)
 
             embedChildPostsViewController(to: viewController)
         } else {
-            updatePosts(dataModel, blog: blog)
+//            updatePosts(dataModel, blog: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -24,13 +24,13 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
-        guard let viewController = viewController, let dataModel = dataModel else {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        guard let viewController = viewController, let apiResponse = apiResponse else {
             return
         }
 
-        let hasDrafts = (dataModel.posts?.draft?.count ?? 0) > 0
-        let hasScheduled = (dataModel.posts?.scheduled?.count ?? 0) > 0
+        let hasDrafts = (apiResponse.posts?.draft?.count ?? 0) > 0
+        let hasScheduled = (apiResponse.posts?.scheduled?.count ?? 0) > 0
 
         removeAllChildVCs()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -1,51 +1,86 @@
 import UIKit
 
 class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    private var postsViewController: PostsCardViewController?
+    private var draftPostsViewController: PostsCardViewController?
+
+    private var schedulePostsViewController: PostsCardViewController?
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 20
+        return stackView
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(stackView)
+        contentView.pinSubviewToAllEdges(stackView)
+    }
+
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
         guard let viewController = viewController, let dataModel = dataModel else {
             return
         }
 
-        /// Create the Child VC in case it doesn't exist
-        if postsViewController == nil {
-            let postsViewController = PostsCardViewController(blog: blog, status: .draft)
-            self.postsViewController = postsViewController
+        let hasDrafts = (dataModel.posts?.draft?.count ?? 0) > 0
+        let hasScheduled = (dataModel.posts?.scheduled?.count ?? 0) > 0
 
-            // Update with the correct blog and status
-//            updatePosts(dataModel, blog: blog)
+        removeAllChildVCs()
 
-            embedChildPostsViewController(to: viewController)
-        } else {
-//            updatePosts(dataModel, blog: blog)
-        }
-    }
-
-    /// Updates the child VC to display draft or scheduled based on the dataModel
-    private func updatePosts(_ dataModel: NSDictionary, blog: Blog) {
-        let hasDrafts = dataModel["show_drafts"] as? Bool ?? false
-        let hasScheduled = dataModel["show_scheduled"] as? Bool ?? false
-
-        if hasDrafts {
-            postsViewController?.update(blog: blog, status: .draft)
-        } else if hasScheduled {
-            postsViewController?.update(blog: blog, status: .scheduled)
-        } else {
+        if !hasDrafts && !hasScheduled {
             // Temporary: it should display "write your next post"
-            postsViewController?.update(blog: blog, status: .draft)
+            let postsViewController = PostsCardViewController(blog: blog, status: .draft)
+            draftPostsViewController = postsViewController
+
+            embed(child: postsViewController, to: viewController)
+        } else {
+            if hasDrafts {
+                let postsViewController = PostsCardViewController(blog: blog, status: .draft)
+                draftPostsViewController = postsViewController
+
+                embed(child: postsViewController, to: viewController)
+            }
+
+            if hasScheduled {
+                let postsViewController = PostsCardViewController(blog: blog, status: .scheduled)
+                schedulePostsViewController = postsViewController
+
+                embed(child: postsViewController, to: viewController)
+            }
         }
     }
 
-    private func embedChildPostsViewController(to viewController: UIViewController) {
-        guard let postsViewController = postsViewController else {
-            return
+    private func removeAllChildVCs() {
+        stackView.removeAllSubviews()
+
+        if let draftPostsViewController = draftPostsViewController {
+            remove(child: draftPostsViewController)
         }
 
-        viewController.addChild(postsViewController)
-        contentView.addSubview(postsViewController.view)
-        postsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(postsViewController.view)
-        postsViewController.didMove(toParent: viewController)
+        if let schedulePostsViewController = schedulePostsViewController {
+            remove(child: schedulePostsViewController)
+        }
+
+        draftPostsViewController = nil
+        schedulePostsViewController = nil
+    }
+
+    private func embed(child childViewController: UIViewController, to viewController: UIViewController) {
+        viewController.addChild(childViewController)
+        stackView.addArrangedSubview(childViewController.view)
+        childViewController.didMove(toParent: viewController)
+    }
+
+    private func remove(child childViewController: UIViewController) {
+        childViewController.willMove(toParent: nil)
+        childViewController.view.removeFromSuperview()
+        childViewController.removeFromParent()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -3,7 +3,7 @@ import UIKit
 class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
     private var draftPostsViewController: PostsCardViewController?
 
-    private var schedulePostsViewController: PostsCardViewController?
+    private var scheduledPostsViewController: PostsCardViewController?
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
@@ -50,7 +50,7 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
 
             if hasScheduled {
                 let postsViewController = PostsCardViewController(blog: blog, status: .scheduled)
-                schedulePostsViewController = postsViewController
+                scheduledPostsViewController = postsViewController
 
                 embed(child: postsViewController, to: viewController)
             }
@@ -64,12 +64,12 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
             remove(child: draftPostsViewController)
         }
 
-        if let schedulePostsViewController = schedulePostsViewController {
+        if let schedulePostsViewController = scheduledPostsViewController {
             remove(child: schedulePostsViewController)
         }
 
         draftPostsViewController = nil
-        schedulePostsViewController = nil
+        scheduledPostsViewController = nil
     }
 
     private func embed(child childViewController: UIViewController, to viewController: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -57,7 +57,7 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, BlogD
         fatalError("Not implemented")
     }
 
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         guard let viewController = viewController else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -57,7 +57,7 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, BlogD
         fatalError("Not implemented")
     }
 
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
         guard let viewController = viewController else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class DashboardStatsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: NSDictionary?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
 
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 class DashboardStatsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, dataModel: BlogDashboardRemoteEntity?) {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
 
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
@@ -7,11 +7,11 @@ struct BlogDashboardRemoteEntity: Decodable {
 
     struct BlogDashboardPosts: Decodable {
         var hasPublished: Bool?
-        var draft: [BlogDashboardPosts]?
-        var scheduled: [BlogDashboardPosts]?
+        var draft: [BlogDashboardPost]?
+        var scheduled: [BlogDashboardPost]?
 
         // We don't rely on the data from the API to show posts
-        struct BlogDashboardPosts: Decodable { }
+        struct BlogDashboardPost: Decodable { }
     }
 
     struct BlogDashboardStats: Decodable {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardRemoteEntity.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct BlogDashboardRemoteEntity: Decodable {
+
+    var posts: BlogDashboardPosts?
+    var todaysStats: BlogDashboardStats?
+
+    struct BlogDashboardPosts: Decodable {
+        var hasPublished: Bool?
+        var draft: [BlogDashboardPosts]?
+        var scheduled: [BlogDashboardPosts]?
+
+        // We don't rely on the data from the API to show posts
+        struct BlogDashboardPosts: Decodable { }
+    }
+
+    struct BlogDashboardStats: Decodable {
+        var views: Int?
+        var visitors: Int?
+        var likes: Int?
+        var comments: Int?
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -58,7 +58,7 @@ private extension BlogDashboardService {
             if card.isRemote {
                 if let viewModel = cardsDictionary[card.rawValue] {
                     let section = DashboardCardSection(id: card)
-                    let item = DashboardCardModel(id: card, cellViewModel: viewModel as? NSDictionary, entity: cards)
+                    let item = DashboardCardModel(id: card, apiResponseDictionary: viewModel as? NSDictionary, entity: cards)
 
                     snapshot.appendSections([section])
                     snapshot.appendItems([item], toSection: section)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -57,14 +57,14 @@ private extension BlogDashboardService {
 
             if card.isRemote {
                 if let viewModel = cardsDictionary[card.rawValue] {
-                    let section = DashboardCardSection(id: card.rawValue)
+                    let section = DashboardCardSection(id: card)
                     let item = DashboardCardModel(id: card, cellViewModel: viewModel as? NSDictionary, entity: cards)
 
                     snapshot.appendSections([section])
                     snapshot.appendItems([item], toSection: section)
                 }
             } else {
-                let section = DashboardCardSection(id: card.rawValue)
+                let section = DashboardCardSection(id: card)
                 let item = DashboardCardModel(id: card)
 
                 snapshot.appendSections([section])

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -16,20 +16,16 @@ class BlogDashboardService {
 
         remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { [weak self] cardsDictionary in
 
-            do {
-                let decoder = JSONDecoder()
-                decoder.keyDecodingStrategy = .convertFromSnakeCase
-                let data = try JSONSerialization.data(withJSONObject: cardsDictionary, options: [])
-                let cards = try decoder.decode(BlogDashboardRemoteEntity.self, from: data)
+            if let cards = self?.decode(cardsDictionary) {
 
                 self?.persistence.persist(cards: cardsDictionary, for: wpComID)
 
-                guard let snapshot = self?.parse(cardsDictionary) else {
+                guard let snapshot = self?.parse(cardsDictionary, cards: cards) else {
                     return
                 }
 
                 completion(snapshot)
-            } catch {
+            } else {
                 failure?()
             }
 
@@ -40,8 +36,10 @@ class BlogDashboardService {
 
     /// Fetch cards from local
     func fetchLocal(wpComID: Int) -> DashboardSnapshot {
-        if let cards = persistence.getCards(for: wpComID) {
-            let snapshot = parse(cards)
+        if let cardsDictionary = persistence.getCards(for: wpComID),
+            let cards = decode(cardsDictionary) {
+
+            let snapshot = parse(cardsDictionary, cards: cards)
             return snapshot
         }
 
@@ -50,32 +48,21 @@ class BlogDashboardService {
 }
 
 private extension BlogDashboardService {
-    func parse(_ cardsDictionary: NSDictionary) -> DashboardSnapshot {
+    /// We use the `BlogDashboardRemoteEntity` to inject it into cells
+    /// The `NSDictionary` is used for `Hashable` purposes
+    func parse(_ cardsDictionary: NSDictionary, cards: BlogDashboardRemoteEntity) -> DashboardSnapshot {
         var snapshot = DashboardSnapshot()
 
         DashboardCard.allCases.forEach { card in
 
             if card.isRemote {
+                if let viewModel = cardsDictionary[card.rawValue] {
+                    let section = DashboardCardSection(id: card.rawValue)
+                    let item = DashboardCardModel(id: card, cellViewModel: viewModel as? NSDictionary, entity: cards)
 
-                if card == .posts,
-                   let posts = cardsDictionary[DashboardCard.posts.rawValue] as? NSDictionary {
-                    let (sections, items) = parsePostCard(posts)
-                    snapshot.appendSections(sections)
-                    sections.enumerated().forEach { key, section in
-                        snapshot.appendItems([items[key]], toSection: section)
-                    }
-                } else {
-
-                    if let viewModel = cardsDictionary[card.rawValue] {
-                        let section = DashboardCardSection(id: card.rawValue)
-                        let item = DashboardCardModel(id: card, cellViewModel: viewModel as? NSDictionary)
-
-                        snapshot.appendSections([section])
-                        snapshot.appendItems([item], toSection: section)
-                    }
-
+                    snapshot.appendSections([section])
+                    snapshot.appendItems([item], toSection: section)
                 }
-
             } else {
                 let section = DashboardCardSection(id: card.rawValue)
                 let item = DashboardCardModel(id: card)
@@ -89,40 +76,13 @@ private extension BlogDashboardService {
         return snapshot
     }
 
-    /// Posts are a special case: they might not be a 1-1 relation
-    /// If the user has draft and scheduled posts, we show two cards
-    /// One for each. This function takes care of this
-    func parsePostCard(_ posts: NSDictionary) -> ([DashboardCardSection], [DashboardCardModel]) {
-        var sections: [DashboardCardSection] = []
-        var items: [DashboardCardModel] = []
-
-        let draftsCount = (posts["draft"] as? Array<Any>)?.count ?? 0
-        let scheduledCount = (posts["scheduled"] as? Array<Any>)?.count ?? 0
-
-        let hasDrafts = draftsCount > 0
-        let hasScheduled = scheduledCount > 0
-
-        if hasDrafts && hasScheduled {
-            var draft = posts.copy() as? [String: Any]
-            draft?["show_drafts"] = true
-            draft?["show_scheduled"] = false
-            sections.append(DashboardCardSection(id: "posts", subtype: "draft"))
-            items.append(DashboardCardModel(id: .posts, cellViewModel: draft as NSDictionary?))
-
-            var scheduled = posts.copy() as? [String: Any]
-            scheduled?["show_drafts"] = false
-            scheduled?["show_scheduled"] = true
-            sections.append(DashboardCardSection(id: "posts", subtype: "scheduled"))
-            items.append(DashboardCardModel(id: .posts, cellViewModel: scheduled as NSDictionary?))
-        } else {
-            var postsWithFlags = posts.copy() as? [String: Any]
-            postsWithFlags?["show_drafts"] = hasDrafts
-            postsWithFlags?["show_scheduled"] = hasScheduled
-
-            sections.append(DashboardCardSection(id: "posts"))
-            items.append(DashboardCardModel(id: .posts, cellViewModel: postsWithFlags as NSDictionary?))
+    func decode(_ cardsDictionary: NSDictionary) -> BlogDashboardRemoteEntity? {
+        guard let data = try? JSONSerialization.data(withJSONObject: cardsDictionary, options: []) else {
+            return nil
         }
 
-        return (sections, items)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try? decoder.decode(BlogDashboardRemoteEntity.self, from: data)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -26,7 +26,7 @@ class BlogDashboardViewModel {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
 
             if let cellConfigurable = cell as? BlogDashboardCardConfigurable {
-                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.entity)
+                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.apiResponse)
             }
 
             return cell

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -26,7 +26,7 @@ class BlogDashboardViewModel {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
 
             if let cellConfigurable = cell as? BlogDashboardCardConfigurable {
-                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.apiResponse)
+                cellConfigurable.configure(blog: blog, viewController: viewController, apiResponse: identifier.apiResponse)
             }
 
             return cell

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -26,7 +26,7 @@ class BlogDashboardViewModel {
             let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath)
 
             if let cellConfigurable = cell as? BlogDashboardCardConfigurable {
-                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.cellViewModel)
+                cellConfigurable.configure(blog: blog, viewController: viewController, dataModel: identifier.entity)
             }
 
             return cell

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -4,12 +4,12 @@ import Foundation
 class DashboardCardModel: Hashable {
     let id: DashboardCard
     let cellViewModel: NSDictionary?
-    let entity: BlogDashboardRemoteEntity?
+    let apiResponse: BlogDashboardRemoteEntity?
 
     init(id: DashboardCard, cellViewModel: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
         self.id = id
         self.cellViewModel = cellViewModel
-        self.entity = entity
+        self.apiResponse = entity
     }
 
     static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -4,10 +4,12 @@ import Foundation
 class DashboardCardModel: Hashable {
     let id: DashboardCard
     let cellViewModel: NSDictionary?
+    let entity: BlogDashboardRemoteEntity?
 
-    init(id: DashboardCard, cellViewModel: NSDictionary? = nil) {
+    init(id: DashboardCard, cellViewModel: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
         self.id = id
         self.cellViewModel = cellViewModel
+        self.entity = entity
     }
 
     static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -3,20 +3,22 @@ import Foundation
 /// Represents a card in the dashboard collection view
 class DashboardCardModel: Hashable {
     let id: DashboardCard
-    let cellViewModel: NSDictionary?
     let apiResponse: BlogDashboardRemoteEntity?
 
-    init(id: DashboardCard, cellViewModel: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
+    // Used as the `Hashable` to check if the cell should be updated or not
+    let apiResponseDictionary: NSDictionary?
+
+    init(id: DashboardCard, apiResponseDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
         self.id = id
-        self.cellViewModel = cellViewModel
+        self.apiResponseDictionary = apiResponseDictionary
         self.apiResponse = entity
     }
 
     static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {
-        lhs.cellViewModel == rhs.cellViewModel
+        lhs.apiResponseDictionary == rhs.apiResponseDictionary
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(cellViewModel)
+        hasher.combine(apiResponseDictionary)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
@@ -3,19 +3,16 @@ import Foundation
 /// Represents a section in the Dashboard Collection View
 class DashboardCardSection: Hashable {
     let id: String
-    let subtype: String?
 
-    init(id: String, subtype: String? = nil) {
+    init(id: String) {
         self.id = id
-        self.subtype = subtype
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(subtype)
     }
 
     static func == (lhs: DashboardCardSection, rhs: DashboardCardSection) -> Bool {
-        lhs.id == rhs.id && lhs.subtype == rhs.subtype
+        lhs.id == rhs.id
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardSection.swift
@@ -2,9 +2,9 @@ import Foundation
 
 /// Represents a section in the Dashboard Collection View
 class DashboardCardSection: Hashable {
-    let id: String
+    let id: DashboardCard
 
-    init(id: String) {
+    init(id: DashboardCard) {
         self.id = id
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1452,6 +1452,8 @@
 		8BA77BCB2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA77BCA2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib */; };
 		8BA77BCD248340CE00E1EBBF /* ReaderDetailToolbar.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */; };
 		8BA77BCF2483415400E1EBBF /* ReaderDetailToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */; };
+		8BAC9D9E27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */; };
+		8BAC9D9F27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */; };
 		8BAD272C241FEF3300E9D105 /* PrepublishingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */; };
 		8BAD53D6241922B900230F4B /* WPAnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */; };
 		8BADF16524801BCE005AD038 /* ReaderWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BADF16424801BCE005AD038 /* ReaderWebView.swift */; };
@@ -6116,6 +6118,7 @@
 		8BA77BCA2482C52A00E1EBBF /* ReaderCardDiscoverAttributionView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderCardDiscoverAttributionView.xib; sourceTree = "<group>"; };
 		8BA77BCC248340CE00E1EBBF /* ReaderDetailToolbar.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderDetailToolbar.xib; sourceTree = "<group>"; };
 		8BA77BCE2483415400E1EBBF /* ReaderDetailToolbar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailToolbar.swift; sourceTree = "<group>"; };
+		8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardRemoteEntity.swift; sourceTree = "<group>"; };
 		8BAD272B241FEF3300E9D105 /* PrepublishingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrepublishingViewController.swift; sourceTree = "<group>"; };
 		8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAnalyticsEvent.swift; sourceTree = "<group>"; };
 		8BADF16424801BCE005AD038 /* ReaderWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderWebView.swift; sourceTree = "<group>"; };
@@ -11380,6 +11383,7 @@
 			children = (
 				8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */,
 				8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */,
+				8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */,
 			);
 			path = Service;
 			sourceTree = "<group>";
@@ -17360,6 +17364,7 @@
 				D8212CBF20AA7B7F008E8AE8 /* ReaderShowAttributionAction.swift in Sources */,
 				FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */,
 				E15644F11CE0E56600D96E64 /* FeatureItemCell.swift in Sources */,
+				8BAC9D9E27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,
 				9856A39D261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				08B6E51A1F036CAD00268F57 /* MediaFileManager.swift in Sources */,
@@ -20498,6 +20503,7 @@
 				FABB245F2602FC2C00C8785C /* Menu+ViewDesign.m in Sources */,
 				FABB24602602FC2C00C8785C /* BlogDetailsViewController+DomainCredit.swift in Sources */,
 				17C1D67D2670E3DC006C8970 /* SiteIconPickerView.swift in Sources */,
+				8BAC9D9F27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
 				FABB24612602FC2C00C8785C /* KeyringAccountHelper.swift in Sources */,
 				FABB24622602FC2C00C8785C /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				FABB24632602FC2C00C8785C /* PushAuthenticationService.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -43,13 +43,13 @@ class BlogDashboardServiceTests: XCTestCase {
             XCTAssertEqual(postsCardItem.id, .posts)
 
             // Has published is `true`
-            XCTAssertTrue(postsCardItem.entity!.posts!.hasPublished!)
+            XCTAssertTrue(postsCardItem.apiResponse!.posts!.hasPublished!)
 
             // 3 scheduled item
-            XCTAssertEqual(postsCardItem.entity!.posts!.draft!.count, 3)
+            XCTAssertEqual(postsCardItem.apiResponse!.posts!.draft!.count, 3)
 
             // 1 scheduled item
-            XCTAssertEqual(postsCardItem.entity!.posts!.scheduled!.count, 1)
+            XCTAssertEqual(postsCardItem.apiResponse!.posts!.scheduled!.count, 1)
 
             // cell view model is a `NSDictionary`
             XCTAssertTrue(postsCardItem.cellViewModel!["has_published"] as! Bool)
@@ -75,10 +75,10 @@ class BlogDashboardServiceTests: XCTestCase {
             XCTAssertEqual(todaysStatsItem.id, .todaysStats)
 
             // Entity has the correct values
-            XCTAssertEqual(todaysStatsItem.entity!.todaysStats!.views, 0)
-            XCTAssertEqual(todaysStatsItem.entity!.todaysStats!.visitors, 0)
-            XCTAssertEqual(todaysStatsItem.entity!.todaysStats!.likes, 0)
-            XCTAssertEqual(todaysStatsItem.entity!.todaysStats!.comments, 0)
+            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.views, 0)
+            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.visitors, 0)
+            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.likes, 0)
+            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.comments, 0)
 
             // Todays Stats has the correct NSDictionary
             XCTAssertEqual(todaysStatsItem.cellViewModel, ["views": 0, "visitors": 0, "likes": 0, "comments": 0])

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -52,7 +52,7 @@ class BlogDashboardServiceTests: XCTestCase {
             XCTAssertEqual(postsCardItem.apiResponse!.posts!.scheduled!.count, 1)
 
             // cell view model is a `NSDictionary`
-            XCTAssertTrue(postsCardItem.cellViewModel!["has_published"] as! Bool)
+            XCTAssertTrue(postsCardItem.apiResponseDictionary!["has_published"] as! Bool)
 
             expect.fulfill()
         }
@@ -81,7 +81,7 @@ class BlogDashboardServiceTests: XCTestCase {
             XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.comments, 0)
 
             // Todays Stats has the correct NSDictionary
-            XCTAssertEqual(todaysStatsItem.cellViewModel, ["views": 0, "visitors": 0, "likes": 0, "comments": 0])
+            XCTAssertEqual(todaysStatsItem.apiResponseDictionary, ["views": 0, "visitors": 0, "likes": 0, "comments": 0])
 
             expect.fulfill()
         }
@@ -101,11 +101,11 @@ class BlogDashboardServiceTests: XCTestCase {
             // The item identifier id is quick actions
             XCTAssertEqual(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.id, .quickActions)
 
-            // It doesn't have a data source
-            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.cellViewModel)
+            // It doesn't have an api response dictionary
+            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.apiResponseDictionary)
 
-            // It doesn't have an entity
-            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.entity)
+            // It doesn't have an api response entity
+            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.apiResponse)
 
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -95,7 +95,7 @@ class BlogDashboardServiceTests: XCTestCase {
 
         service.fetch(wpComID: 123456) { snapshot in
             // Quick Actions exists
-            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == .quickAction }
+            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == .quickActions }
             XCTAssertEqual(quickActionsSection.count, 1)
 
             // The item identifier id is quick actions

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -33,7 +33,7 @@ class BlogDashboardServiceTests: XCTestCase {
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         service.fetch(wpComID: 123456) { snapshot in
-            let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == "posts" })
+            let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .posts })
             let postsCardItem: DashboardCardModel = snapshot.itemIdentifiers(inSection: postsSection!).first!
 
             // Posts section exists
@@ -65,7 +65,7 @@ class BlogDashboardServiceTests: XCTestCase {
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
 
         service.fetch(wpComID: 123456) { snapshot in
-            let todaysStatsSection = snapshot.sectionIdentifiers.first(where: { $0.id == "todays_stats" })
+            let todaysStatsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .todaysStats })
             let todaysStatsItem: DashboardCardModel = snapshot.itemIdentifiers(inSection: todaysStatsSection!).first!
 
             // Todays stats section exists
@@ -95,7 +95,7 @@ class BlogDashboardServiceTests: XCTestCase {
 
         service.fetch(wpComID: 123456) { snapshot in
             // Quick Actions exists
-            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == "quickActions" }
+            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == .quickAction }
             XCTAssertEqual(quickActionsSection.count, 1)
 
             // The item identifier id is quick actions
@@ -133,7 +133,7 @@ class BlogDashboardServiceTests: XCTestCase {
 
         let snapshot = service.fetchLocal(wpComID: 123456)
 
-        let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == "posts" })
+        let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .posts })
         XCTAssertNotNil(postsSection)
         XCTAssertEqual(persistenceMock.didCallGetCardsWithWpComID, 123456)
     }


### PR DESCRIPTION
Part of #17873

This is a technical refactor to:

* Use `Decodable` to parse the API response instead of `NSDictionary`
* Inject the entity into the cards
* Adjust naming of a few parameters
* Display only one single cell for posts, which might contain one or more cards

### To test

**Important: make sure to run the API on your sandbox and to have My Site Dashboard flag enabled.**

1. Run the app
2. Tap Dashboard
3. Check that the dashboard is loaded
4. Switch sites a few times

### Instruments: Allocations

1. Run Instruments > Allocations
2. Run the app
3. Start recording
4. Switch blogs (while displaying the dashboard a few times)
5. Compare the number of `PostsCardViewController` and `DashboardPostsCardCell`. The number of `Persistent` for the VC should never be bigger than the number of the `cells * 2` (ideally we will have a maximum of 2, but this will be tackled in a subsequent task)

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
Updated already existent tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
