### PR TITLE
Re-enable UI Tests

### DIFF
--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -29,6 +29,7 @@
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
         "SignupTests\/testEmailSignup()",
+        "StatsTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -22,18 +22,13 @@
     {
       "skippedTests" : [
         "EditorAztecTests",
-        "EditorGutenbergTests",
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "LoginTests\/testEmailPasswordLoginLogout()",
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
-        "MainNavigationTests",
-        "ReaderTests",
         "SignupTests\/testEmailSignup()",
-        "StatsTests",
-        "SupportScreenTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {


### PR DESCRIPTION
This PR re-enables the UI Tests (except for Stats Tests) disabled while investigating and fixing issues that caused the tests to start failing on Buildkite.

_Note: Stats tests will need a dedicated PR to re-enable them._

To test:
Test PR with 50 passed out of 50 UI Tests runs: https://github.com/wordpress-mobile/WordPress-iOS/pull/17953
