### PR TITLE
Notifications: show new Comment detail from previous/next buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1389,6 +1389,7 @@ extension NotificationDetailsViewController {
                 return
             }
 
+            self.notificationCommentDetailCoordinator?.onSelectedNoteChange = self.onSelectedNoteChange
             weak var navigationController = self.navigationController
 
             self.dismiss(animated: true, completion: {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -87,7 +87,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
     /// Used to present CommentDetailViewController when previous/next notification is a Comment.
     ///
-    var notificationCommentDetailCoordinator: NotificationCommentDetailCoordinator?
+    weak var notificationCommentDetailCoordinator: NotificationCommentDetailCoordinator?
 
     /// Notification being displayed
     ///

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -16,6 +16,7 @@ protocol NotificationsNavigationDataSource: AnyObject {
 // MARK: - Renders a given Notification entity, onscreen
 //
 class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
+
     // MARK: - Properties
 
     let formatter = FormattableContentFormatter()
@@ -84,7 +85,11 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
     ///
     weak var dataSource: NotificationsNavigationDataSource?
 
-    /// Notification to-be-displayed
+    /// Used to present CommentDetailViewController when previous/next notification is a Comment.
+    ///
+    var notificationCommentDetailCoordinator: NotificationCommentDetailCoordinator?
+
+    /// Notification being displayed
     ///
     var note: Notification! {
         didSet {
@@ -99,7 +104,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
         }
     }
 
-    /// Wether a confetti animation was presented on this notification or not
+    /// Whether a confetti animation was presented on this notification or not
     ///
     private var confettiWasShown = false
 
@@ -1349,8 +1354,8 @@ extension NotificationDetailsViewController {
             return
         }
 
-        refreshView(with: previous)
         WPAnalytics.track(.notificationsPreviousTapped)
+        refreshView(with: previous)
     }
 
     @IBAction func nextNotificationWasPressed() {
@@ -1358,16 +1363,40 @@ extension NotificationDetailsViewController {
             return
         }
 
-        refreshView(with: next)
         WPAnalytics.track(.notificationsNextTapped)
+        refreshView(with: next)
     }
 
     private func refreshView(with note: Notification) {
-        hideNoResults()
         onSelectedNoteChange?(note)
+
+        if FeatureFlag.notificationCommentDetails.enabled,
+           note.kind == .comment {
+            showCommentDetails(with: note)
+            return
+        }
+
+        hideNoResults()
         self.note = note
         showConfettiIfNeeded()
         trackDetailsOpened(for: note)
+    }
+
+    private func showCommentDetails(with note: Notification) {
+        notificationCommentDetailCoordinator?.createViewController(with: note) { commentDetailViewController in
+            guard let commentDetailViewController = commentDetailViewController else {
+                // TODO: show error view
+                return
+            }
+
+            weak var navigationController = self.navigationController
+
+            self.dismiss(animated: true, completion: {
+                commentDetailViewController.navigationItem.largeTitleDisplayMode = .never
+                navigationController?.popViewController(animated: false)
+                navigationController?.pushViewController(commentDetailViewController, animated: false)
+            })
+        }
     }
 
     var shouldEnablePreviousButton: Bool {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -475,6 +475,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     fileprivate func configureDetailsViewController(_ detailsViewController: NotificationDetailsViewController, withNote note: Notification) {
         detailsViewController.navigationItem.largeTitleDisplayMode = .never
         detailsViewController.dataSource = self
+        detailsViewController.notificationCommentDetailCoordinator = notificationCommentDetailCoordinator
         detailsViewController.note = note
         detailsViewController.onDeletionRequestCallback = { request in
             self.showUndeleteForNoteWithID(note.objectID, request: request)
@@ -746,6 +747,10 @@ extension NotificationsViewController {
                         return
                     }
 
+                    self.notificationCommentDetailCoordinator.onSelectedNoteChange = { note in
+                        self.selectRow(for: note)
+                    }
+
                     commentDetailViewController.navigationItem.largeTitleDisplayMode = .never
                     self.showDetailViewController(commentDetailViewController, sender: nil)
                     self.view.isUserInteractionEnabled = true
@@ -798,7 +803,7 @@ extension NotificationsViewController {
     }
 
     /// Will display an Undelete button on top of a given notification.
-    /// On timeout, the destructive action (received via parameter) will be exeuted, and the notification
+    /// On timeout, the destructive action (received via parameter) will be executed, and the notification
     /// will (supposedly) get deleted.
     ///
     /// -   Parameters:

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -747,8 +747,8 @@ extension NotificationsViewController {
                         return
                     }
 
-                    self.notificationCommentDetailCoordinator.onSelectedNoteChange = { note in
-                        self.selectRow(for: note)
+                    self.notificationCommentDetailCoordinator.onSelectedNoteChange = { [weak self] note in
+                        self?.selectRow(for: note)
                     }
 
                     commentDetailViewController.navigationItem.largeTitleDisplayMode = .never

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -16,6 +16,10 @@ class NotificationCommentDetailCoordinator: NSObject {
     // Arrow navigation data source
     private weak var notificationsNavigationDataSource: NotificationsNavigationDataSource?
 
+    // Closure to be executed whenever the notification that's being currently displayed, changes.
+    // This happens due to Navigation Events (Next / Previous)
+    var onSelectedNoteChange: ((Notification) -> Void)?
+
     private lazy var commentService: CommentService = {
         return .init(managedObjectContext: managedObjectContext)
     }()
@@ -108,6 +112,7 @@ private extension NotificationCommentDetailCoordinator {
     func updateViewWith(notification: Notification) {
         if notification.kind == .comment {
             trackDetailsOpened(for: notification)
+            onSelectedNoteChange?(notification)
             configure(with: notification)
             refreshViewController()
         } else {


### PR DESCRIPTION
Ref: #17790

When viewing notification details from the `All` filter, show the new comment details view if the previous/next notification is a Comment.

Note: this only addresses going from a non-Comment notification to a Comment notification. It doesn't work (yet) when going from a Comment notification to a non-Comment notification. That is, if you're viewing Comment details and the previous/next notification is not a Comment, the previous/next button won't do anything.

To test:
- Enable `notificationCommentDetails`.
- Go to Notifications > All.
- Select a notification that has a Comment notification before/after it.
- On the notification details, select previous/next on the nav bar.
- Verify the new Comment details is displayed.


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
