### PR TITLE
Notifications: Fix intermittent crash when tapping on a push notification

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1080,8 +1080,7 @@ private extension NotificationsViewController {
         // ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15370
         guard let indexPath = tableViewHandler.resultsController.indexPath(forObject: notification),
               indexPath != tableView.indexPathForSelectedRow,
-              indexPath.row < tableView.numberOfRows(inSection: indexPath.section),
-              indexPath.row >= 0 else {
+              0..<tableView.numberOfRows(inSection: indexPath.section) ~= indexPath.row else {
                   return
               }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1076,7 +1076,7 @@ private extension NotificationsViewController {
                    scrollPosition: UITableView.ScrollPosition = .none) {
         selectedNotification = notification
 
-        // also ensure that the index path returned does not contain negative values.
+        // also ensure that the index path returned from results controller does not have negative row index.
         // ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15370
         guard let indexPath = tableViewHandler.resultsController.indexPath(forObject: notification),
               indexPath != tableView.indexPathForSelectedRow,

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1076,10 +1076,17 @@ private extension NotificationsViewController {
                    scrollPosition: UITableView.ScrollPosition = .none) {
         selectedNotification = notification
 
-        if let indexPath = tableViewHandler.resultsController.indexPath(forObject: notification), indexPath != tableView.indexPathForSelectedRow {
-            DDLogInfo("\(self) \(#function) Selecting row at \(indexPath) for Notification: \(notification.notificationId) (\(notification.type ?? "Unknown type")) - \(notification.title ?? "No title")")
-            tableView.selectRow(at: indexPath, animated: animated, scrollPosition: scrollPosition)
-        }
+        // also ensure that the index path returned does not contain negative values.
+        // ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/15370
+        guard let indexPath = tableViewHandler.resultsController.indexPath(forObject: notification),
+              indexPath != tableView.indexPathForSelectedRow,
+              indexPath.row < tableView.numberOfRows(inSection: indexPath.section),
+              indexPath.row >= 0 else {
+                  return
+              }
+
+        DDLogInfo("\(self) \(#function) Selecting row at \(indexPath) for Notification: \(notification.notificationId) (\(notification.type ?? "Unknown type")) - \(notification.title ?? "No title")")
+        tableView.selectRow(at: indexPath, animated: animated, scrollPosition: scrollPosition)
     }
 
     func reloadTableViewPreservingSelection() {


### PR DESCRIPTION
Refs #15370 

`NotificationsViewController.selectRow` is one of the two causes for the `NSInternalInconsistencyException` crash filed logged in https://sentry.io/share/issue/26030d0c26be4d41b1bad2ce380e8b41/. Based on the stack trace, the crash happened when tapping on a push notification that leads to a Notification Details screen (new comment, likes, mention, etc.).  

Thanks to @AliSoftware 's crash log (`p1644448555670899-slack-C012H19SZQ8?thread_ts=1644448209.220209`), I noticed that the index path from the `NSFetchedResultsController` returned negative values sometimes:

```
<WordPress.NotificationsViewController: 0x10c8ae600> selectRow(for:animated:scrollPosition:) Selecting row at [1, -23] for Notification: xxxxxx (comment) - Mention
```

I then stumbled onto #15368 where a similar crash issue happens in `WPTableViewHandler` and was fixed in #15475. Thus, this PR applies a similar fix: ensure that the index path is valid; within the bounds of the table view's rows.

## To test:

⚠️ Note that I've been unable to reproduce the crash, and these steps are based on ad hoc reports and Sentry breadcrumbs. Also, this needs to be tested on a device since it requires interacting with push notifications.

- Open the WordPress app, and minimize it.
- Perform an action (comment, Like, or mention) that triggers a push notification for the Notifications section of the app.
- Tap the push notification.
- 🔍 Verify that the app doesn't crash, and the notification detail is shown correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I was unable to reproduce the crash before applying the fix. However, the changes were manually tested to ensure no negative impact.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
