### PR TITLE
My Site Dashboard (Phase 2): iPad info architecture

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -24,7 +24,7 @@ final class BlogDashboardViewController: UIViewController {
         UIActivityIndicatorView()
     }()
 
-    init(blog: Blog) {
+    @objc init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)
     }
@@ -39,6 +39,7 @@ final class BlogDashboardViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setupNavigation()
         setupCollectionView()
         addHeightObservers()
         viewModel.viewDidLoad()
@@ -69,6 +70,10 @@ final class BlogDashboardViewController: UIViewController {
         viewModel.blog = blog
         viewModel.loadCardsFromCache()
         viewModel.loadCards()
+    }
+
+    private func setupNavigation() {
+        title = Strings.home
     }
 
     private func setupCollectionView() {
@@ -121,6 +126,11 @@ extension BlogDashboardViewController {
 }
 
 extension BlogDashboardViewController {
+
+    private enum Strings {
+        static let home = NSLocalizedString("Home", comment: "Title for the dashboard screen.")
+    }
+
 
     private enum Constants {
         static let estimatedWidth: CGFloat = 100

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -784,7 +784,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeHouse]
                                                      callback:^{
-                                                         // TODO: show dashboard
+                                                        [weakSelf showDashboard];
                                                      }]];
     }
     
@@ -831,7 +831,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
                                                         image:[UIImage gridiconOfType:GridiconTypeHouse]
                                                      callback:^{
-                                                         // TODO: show dashboard
+                                                        [weakSelf showDashboard];
                                                      }]];
     }
     
@@ -1546,6 +1546,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementStats];
+}
+
+- (void)showDashboard
+{
+    BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog];
+    controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    [self showDetailViewController:controller sender:self];
 }
 
 - (void)showActivity

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -779,7 +779,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-
+    
+    if ([Feature enabled:FeatureFlagMySiteDashboard] && [self.blog isAccessibleThroughWPCom] && ![self splitViewControllerIsHorizontallyCompact]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
+                                                        image:[UIImage gridiconOfType:GridiconTypeHouse]
+                                                     callback:^{
+                                                         // TODO: show dashboard
+                                                     }]];
+    }
+    
     BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                   accessibilityIdentifier:@"Stats Row"
                                                     image:[UIImage gridiconOfType:GridiconTypeStatsAlt]
@@ -818,6 +826,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
+    
+    if ([Feature enabled:FeatureFlagMySiteDashboard] && [self.blog isAccessibleThroughWPCom] && ![self splitViewControllerIsHorizontallyCompact]) {
+        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
+                                                        image:[UIImage gridiconOfType:GridiconTypeHouse]
+                                                     callback:^{
+                                                         // TODO: show dashboard
+                                                     }]];
+    }
     
     BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                   accessibilityIdentifier:@"Stats Row"

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -156,7 +156,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func updateSegmentedControl(for blog: Blog) {
         // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device is an iPad
-        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || UIDevice.isPad()
+        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || !splitViewControllerIsHorizontallyCompact
     }
 
     private func setupView() {


### PR DESCRIPTION
Part of #17878

## Description
- Adds a new "Home" menu item to the site menu, which displays the dashboard when selected

## Note
- The default selected item is still Stats
- There is an issue where the correct item isn't highlighted when switching sites. When switching sites via the site picker, the default menu item (i.e. Stats) is displayed in the details view controller. This issue has been present since at least 19.0, and perhaps longer (https://github.com/wordpress-mobile/WordPress-iOS/issues/17958)
- The design will be refined later (Slack ref: p1644946298432299-slack-C0290FLA0RM)

## How to test

Make sure to run your sandbox with the 1.1 API diff applied and to have the My Site Dashboard flag enabled:

### iPad
1. Run the app on an iPad
2. Go to My Site
3. ✅ The Home menu item should be visible
4. Tap on the Home menu item
5. ✅ The dashboard should be displayed

### iPhone (horizontally compact size class)
1. Run the app on an iPhone
2. Go to My Site
3. ✅ The Home menu item should be hidden
4. ✅ The segmented control should be displayed
5. Switch to the dashboard
5. ✅ The dashboard should be displayed

iPad | iPhone
-- | --
![Simulator Screen Shot - iPad Air (4th generation) - 2022-02-15 at 16 58 36](https://user-images.githubusercontent.com/6711616/154113553-35f9f8cf-cc61-43d5-811d-4c99e49e976d.png) | ![Simulator Screen Shot - iPhone 13 - 2022-02-15 at 17 15 49](https://user-images.githubusercontent.com/6711616/154114074-f2e3f710-bdf2-44fd-bbaa-22b8f91073a8.png)


## Regression Notes
1. Potential unintended areas of impact
- iPhone layout for My Site VC

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps manually

3. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.