### PR TITLE
Notifications > Comments: show Notification detail from previous/next buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1369,6 +1369,7 @@ extension NotificationDetailsViewController {
 
     private func refreshView(with note: Notification) {
         onSelectedNoteChange?(note)
+        trackDetailsOpened(for: note)
 
         if FeatureFlag.notificationCommentDetails.enabled,
            note.kind == .comment {
@@ -1379,7 +1380,6 @@ extension NotificationDetailsViewController {
         hideNoResults()
         self.note = note
         showConfettiIfNeeded()
-        trackDetailsOpened(for: note)
     }
 
     private func showCommentDetails(with note: Notification) {


### PR DESCRIPTION
Ref: #17790

When viewing Comment notification details from the `All` filter, show Notification details view if the previous/next notification is not a Comment.

To test:
- Enable `notificationCommentDetails`.
- Go to Notifications > All.
- Select a Comment notification that has a non-Comment notification before/after it.
- On the comment details, select previous/next on the nav bar.
- Verify the Notification details is displayed.
  - Note: sometimes a Post notification doesn't render any content. This is an unrelated preexisting issue.


## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is incomplete and disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
