### PR TITLE
My Site Dashboard: add card frame

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -21,6 +21,7 @@ class BlogDashboardCardFrameView: UIView {
         topStackView.isLayoutMarginsRelativeArrangement = true
         topStackView.spacing = Constants.headerHorizontalSpacing
         topStackView.alignment = .center
+        topStackView.axis = .horizontal
         return topStackView
     }()
 
@@ -75,24 +76,7 @@ class BlogDashboardCardFrameView: UIView {
 
         layer.cornerRadius = Constants.cornerRadius
 
-        addSubview(mainStackView)
-        pinSubviewToAllEdges(mainStackView, insets: UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPadding, right: 0))
-
-        mainStackView.addArrangedSubview(headerStackView)
-
-        headerStackView.addArrangedSubview(iconImageView)
-
-        headerStackView.addArrangedSubview(titleLabel)
-
-        headerStackView.addArrangedSubview(chevronImageView)
-
-        // Add tap gesture
-        let tap = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
-        headerStackView.addGestureRecognizer(tap)
-    }
-
-    @objc private func buttonTapped() {
-        print("todo: header tapped")
+        configureStackViews()
     }
 
     required init?(coder: NSCoder) {
@@ -102,6 +86,27 @@ class BlogDashboardCardFrameView: UIView {
     /// Add a subview inside the card frame
     func add(subview: UIView) {
         mainStackView.addArrangedSubview(subview)
+    }
+
+    private func configureStackViews() {
+        addSubview(mainStackView)
+        pinSubviewToAllEdges(mainStackView, insets: UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPadding, right: 0))
+
+        mainStackView.addArrangedSubview(headerStackView)
+
+        headerStackView.addArrangedSubviews([
+            iconImageView,
+            titleLabel,
+            chevronImageView
+        ])
+
+        // Add tap gesture
+        let tap = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
+        headerStackView.addGestureRecognizer(tap)
+    }
+
+    @objc private func buttonTapped() {
+        print("todo: header tapped")
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -1,0 +1,115 @@
+import UIKit
+import Gridicons
+
+/// A view that consists of the frame of a Dashboard card
+/// Title, icon and action can be customizable
+class BlogDashboardCardFrameView: UIView {
+
+    /// The main stack view, in which the header and the content
+    /// are appended to.
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    /// Header in which icon, title and chevron are added
+    private lazy var headerStackView: UIStackView = {
+        let topStackView = UIStackView()
+        topStackView.layoutMargins = Constants.headerPadding
+        topStackView.isLayoutMarginsRelativeArrangement = true
+        topStackView.spacing = Constants.headerHorizontalSpacing
+        topStackView.alignment = .center
+        return topStackView
+    }()
+
+    /// Card's icon image view
+    private lazy var iconImageView: UIImageView = {
+        let iconImageView = UIImageView(image: UIImage.gridicon(.posts, size: Constants.iconSize).withRenderingMode(.alwaysTemplate))
+        iconImageView.tintColor = .label
+        iconImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
+        iconImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        iconImageView.isAccessibilityElement = false
+        return iconImageView
+    }()
+
+    /// Card's title
+    private lazy var titleLabel: UILabel = {
+        let titleLabel = UILabel()
+        titleLabel.text = "Card title"
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        titleLabel.accessibilityTraits = .button
+        return titleLabel
+    }()
+
+    /// Chevron displayed in case there's any action associa
+    private lazy var chevronImageView: UIImageView = {
+        let chevronImageView = UIImageView(image: UIImage.gridicon(.chevronRight, size: Constants.iconSize).withRenderingMode(.alwaysTemplate))
+        chevronImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
+        chevronImageView.tintColor = .listIcon
+        chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        chevronImageView.isAccessibilityElement = false
+        return chevronImageView
+    }()
+
+    /// The title at the header
+    var title: String? {
+        didSet {
+            titleLabel.text = title
+        }
+    }
+
+    /// The icon to be displayed at the header
+    var icon: UIImage? {
+        didSet {
+            iconImageView.image = icon?.withRenderingMode(.alwaysTemplate)
+        }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        backgroundColor = .listForeground
+
+        layer.cornerRadius = Constants.cornerRadius
+
+        addSubview(mainStackView)
+        pinSubviewToAllEdges(mainStackView, insets: UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPadding, right: 0))
+
+        mainStackView.addArrangedSubview(headerStackView)
+
+        headerStackView.addArrangedSubview(iconImageView)
+
+        headerStackView.addArrangedSubview(titleLabel)
+
+        headerStackView.addArrangedSubview(chevronImageView)
+
+        // Add tap gesture
+        let tap = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
+        headerStackView.addGestureRecognizer(tap)
+    }
+
+    @objc private func buttonTapped() {
+        print("tapped")
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Add a subview inside the card frame
+    func add(subview: UIView) {
+        mainStackView.addArrangedSubview(subview)
+    }
+
+    private enum Constants {
+        static let bottomPadding: CGFloat = 8
+        static let headerPadding = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
+        static let headerHorizontalSpacing: CGFloat = 5
+        static let iconSize = CGSize(width: 18, height: 18)
+        static let cornerRadius: CGFloat = 10
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -93,7 +93,7 @@ class BlogDashboardCardFrameView: UIView {
     }
 
     @objc private func buttonTapped() {
-        print("tapped")
+        print("todo: header tapped")
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -37,7 +37,6 @@ class BlogDashboardCardFrameView: UIView {
     /// Card's title
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
-        titleLabel.text = "Card title"
         titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -35,24 +35,26 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
         removeAllChildVCs()
 
         if !hasDrafts && !hasScheduled {
+            let hasPublished = apiResponse.posts?.hasPublished ?? true
             // Temporary: it should display "write your next post"
             let postsViewController = PostsCardViewController(blog: blog, status: .draft)
             draftPostsViewController = postsViewController
 
-            embed(child: postsViewController, to: viewController)
+            let cardTitle = hasPublished ? Strings.nextPostTitle : Strings.firstPostTitle
+            embed(child: postsViewController, to: viewController, with: cardTitle)
         } else {
             if hasDrafts {
                 let postsViewController = PostsCardViewController(blog: blog, status: .draft)
                 draftPostsViewController = postsViewController
 
-                embed(child: postsViewController, to: viewController)
+                embed(child: postsViewController, to: viewController, with: Strings.draftsTitle)
             }
 
             if hasScheduled {
                 let postsViewController = PostsCardViewController(blog: blog, status: .scheduled)
                 scheduledPostsViewController = postsViewController
 
-                embed(child: postsViewController, to: viewController)
+                embed(child: postsViewController, to: viewController, with: Strings.scheduledTitle)
             }
         }
     }
@@ -72,9 +74,9 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
         scheduledPostsViewController = nil
     }
 
-    private func embed(child childViewController: UIViewController, to viewController: UIViewController) {
+    private func embed(child childViewController: UIViewController, to viewController: UIViewController, with title: String) {
         let frame = BlogDashboardCardFrameView()
-        frame.title = "Posts"
+        frame.title = title
         frame.icon = UIImage.gridicon(.posts, size: CGSize(width: 18, height: 18))
         frame.add(subview: childViewController.view)
 
@@ -87,5 +89,12 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
         childViewController.willMove(toParent: nil)
         childViewController.view.removeFromSuperview()
         childViewController.removeFromParent()
+    }
+
+    private enum Strings {
+        static let draftsTitle = NSLocalizedString("Work on a draft post", comment: "Title for the card displaying draft posts.")
+        static let scheduledTitle = NSLocalizedString("Upcoming scheduled posts", comment: "Title for the card displaying upcoming scheduled posts.")
+        static let nextPostTitle = NSLocalizedString("Create your next post", comment: "Title for the card prompting the user to create a new post.")
+        static let firstPostTitle = NSLocalizedString("Create your first post", comment: "Title for the card prompting the user to create their first post.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsCardCell.swift
@@ -73,8 +73,13 @@ class DashboardPostsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardC
     }
 
     private func embed(child childViewController: UIViewController, to viewController: UIViewController) {
+        let frame = BlogDashboardCardFrameView()
+        frame.title = "Posts"
+        frame.icon = UIImage.gridicon(.posts, size: CGSize(width: 18, height: 18))
+        frame.add(subview: childViewController.view)
+
         viewController.addChild(childViewController)
-        stackView.addArrangedSubview(childViewController.view)
+        stackView.addArrangedSubview(frame)
         childViewController.didMove(toParent: viewController)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1501,6 +1501,8 @@
 		8BEE846427B1E05B0001A93C /* DashboardCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */; };
 		8BEE846527B1E05C0001A93C /* DashboardCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */; };
 		8BF0B607247D88EB009A7457 /* UITableViewCell+enableDisable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */; };
+		8BF1C81A27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1C81927BC00AF00F1C203 /* BlogDashboardCardFrameView.swift */; };
+		8BF1C81B27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF1C81927BC00AF00F1C203 /* BlogDashboardCardFrameView.swift */; };
 		8BF9E03327B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
 		8BF9E03427B1A8A800915B27 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9E03227B1A8A800915B27 /* DashboardCard.swift */; };
 		8BFE36FD230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */; };
@@ -6161,6 +6163,7 @@
 		8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardSection.swift; sourceTree = "<group>"; };
 		8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardModel.swift; sourceTree = "<group>"; };
 		8BF0B606247D88EB009A7457 /* UITableViewCell+enableDisable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITableViewCell+enableDisable.swift"; sourceTree = "<group>"; };
+		8BF1C81927BC00AF00F1C203 /* BlogDashboardCardFrameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardCardFrameView.swift; sourceTree = "<group>"; };
 		8BF9E03227B1A8A800915B27 /* DashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCard.swift; sourceTree = "<group>"; };
 		8BFE36FC230F16580061EBA8 /* AbstractPost+fixLocalMediaURLs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLs.swift"; sourceTree = "<group>"; };
 		8BFE36FE230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+fixLocalMediaURLsTests.swift"; sourceTree = "<group>"; };
@@ -11374,6 +11377,7 @@
 				8B9DFCBA27999EAC00256DA0 /* DashboardPostsCardCell.swift */,
 				8BD66ED0278745EC00CCD95A /* PostsCardViewController.swift */,
 				8BD66ED32787530C00CCD95A /* PostsCardViewModel.swift */,
+				8BF1C81927BC00AF00F1C203 /* BlogDashboardCardFrameView.swift */,
 			);
 			path = Posts;
 			sourceTree = "<group>";
@@ -18428,6 +18432,7 @@
 				4666534A2501552A00165DD4 /* LayoutPreviewViewController.swift in Sources */,
 				7326A4A8221C8F4100B4EB8C /* UIStackView+Subviews.swift in Sources */,
 				4349B0AC218A45270034118A /* RevisionsTableViewController.swift in Sources */,
+				8BF1C81A27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
 				984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */,
 				E13A8C9B1C3E6EF2005BB1C1 /* ImmuTable+WordPress.swift in Sources */,
@@ -19774,6 +19779,7 @@
 				FABB21D62602FC2C00C8785C /* PlanComparisonViewController.swift in Sources */,
 				FABB21D72602FC2C00C8785C /* Routes+Stats.swift in Sources */,
 				FABB21D82602FC2C00C8785C /* MeViewController+UIViewControllerRestoration.swift in Sources */,
+				8BF1C81B27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				FABB21D92602FC2C00C8785C /* SearchIdentifierGenerator.swift in Sources */,
 				C7124E922638905B00929318 /* StarFieldView.swift in Sources */,
 				FABB21DA2602FC2C00C8785C /* StatsTwoColumnRow.swift in Sources */,


### PR DESCRIPTION
Part of #17873

Adds the card frame to the posts card.

https://user-images.githubusercontent.com/7040243/154149017-aa783ec2-aee6-4465-90ba-9492cc94f4ea.mp4

I created it as a custom view so all other cards might make use of it if needed.

### To test

**Important: make sure to run the API on your sandbox and to have My Site Dashboard flag enabled.**

1. Run the app
2. Tap Dashboard
3. Check that the cards have the frame, including title, icon, and the chevron
4. Tap the header
5. Check that `"todo: header tapped"` is printed
6. Switch sites
7. Make sure the titles are correct and changes based on the content being displayed

Also: test it using dark and light mode

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
Adding views, no unit tests added.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
