### PR TITLE
Reader Comments: Fix obstructed reply text view when NRV is shown

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -935,7 +935,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         self.noResultsViewController.view.frame = self.tableView.frame;
     }
 
-    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.suggestionsTableView];
+    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.replyTextView];
     [self.noResultsViewController didMoveToParentViewController:self];
 }
 


### PR DESCRIPTION
Fixes #17964

This fixes an issue where after pasting some text, the Reply text view gets partially obstructed when the `NoResultsViewController` (NRV) is displayed in Reader Comments.

<img width="710" alt="Screen Shot 2022-02-16 at 19 07 09" src="https://user-images.githubusercontent.com/1299411/154261506-b9f70fcf-4fde-4bd1-bb49-a38c9ff45328.png">

The fix simply moves the NRV behind, so it no longer obstructs the text view. Here's a before/after comparison:

Before | After
-|-
![17964_before](https://user-images.githubusercontent.com/1299411/154261849-d2773813-f270-4d35-a78b-e187e8e382aa.png) | ![17964_after](https://user-images.githubusercontent.com/1299411/154261835-ee272b9e-0164-4ecd-aba2-61a71eb3b3d0.png)

The only downside to this fix is that the NRV's image is no longer visually vertically centered because it ignores the reply text view's height changes. However, I think this is still very acceptable considering the problem is fixed with very minimal side effects.

The ideal solution would be to fix this with auto layout since the NRV is displayed with frame-based layout, which does not account for dynamic height updates from Reply text view. However, since we're aiming for this to be included in 19.2, I've decided to move forward with a solution that has minimal side effects.

## To test:

⚠️ To save time: prepare a text beforehand, and copy it into your Pasteboard. Here's an example: "Lorem Ipsum is simply a dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s".

### 1️⃣ Verify that the Reply text view works in posts with zero comments

- Go to Reader, and select a Post that has **no comments.**
- Tap on the comment button to enter the comment threads.
- Paste the text into the reply text field.
- Observe that the pasted content and the Reply button are visible.

### 2️⃣ Ensure that the suggestions table view is not obstructed

- Go to Reader, and select a Post that has **one or more comments.**
- Tap on the comment button to enter the comment threads.
- Type "@" in the text field.
- Verify that the suggestions table is shown and not obstructed by the No Results View.

### 3️⃣  Ensure that the Reply text view works fine in a post with existing comments

- Go to Reader, and select a Post that has **no comments.**
- Tap on the comment button to enter the comment threads.
- Paste the text into the reply text field.
- Observe that the pasted content and the Reply button are visible.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing, plus the changes only impact the Reader Comments screen.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
