### PR TITLE
My Site Dashboard (Phase 2): Fix segmented control alignment in landscape mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -74,6 +74,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     required init?(coder: NSCoder) {
         fatalError("Initializer not implemented!")
     }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
 
     // MARK: - Blog
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -74,7 +74,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     required init?(coder: NSCoder) {
         fatalError("Initializer not implemented!")
     }
-    
+
     deinit {
         NotificationCenter.default.removeObserver(self)
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -115,6 +115,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         setupNavigationItem()
         subscribeToPostSignupNotifications()
         subscribeToModelChanges()
+        subscribeToContentSizeCategory()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -149,6 +150,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         setupTransparentNavBar()
     }
 
+    private func subscribeToContentSizeCategory() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(didChangeDynamicType),
+                                               name: UIContentSizeCategory.didChangeNotification,
+                                               object: nil)
+    }
+
     private func subscribeToPostSignupNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(launchSiteCreationFromNotification), name: .createSite, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
@@ -161,6 +169,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func setupView() {
         view.backgroundColor = .listBackground
+        configureSegmentedControlFont()
     }
 
     /// This method builds a layout with the following view hierarchy:
@@ -460,6 +469,16 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         present(addSiteAlert, animated: true)
+    }
+
+    @objc
+    func didChangeDynamicType() {
+        configureSegmentedControlFont()
+    }
+
+    private func configureSegmentedControlFont() {
+        let font = WPStyleGuide.fontForTextStyle(.subheadline)
+        segmentedControl.setTitleTextAttributes([NSAttributedString.Key.font: font], for: .normal)
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -181,7 +181,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         NSLayoutConstraint.activate([
             stackView.widthAnchor.constraint(equalTo: view.widthAnchor),
-            segmentedControl.leadingAnchor.constraint(equalTo: segmentedControlContainerView.leadingAnchor,
+            segmentedControl.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor,
                                                       constant: Constants.segmentedControlXOffset),
             segmentedControl.centerXAnchor.constraint(equalTo: segmentedControlContainerView.centerXAnchor),
             segmentedControl.topAnchor.constraint(equalTo: segmentedControlContainerView.topAnchor,


### PR DESCRIPTION
## Description
- Fixes constraints for the segmented control so that it displays with the correct alignment in landscape mode
- Handles dynamic type for segmented control

Before | After
-- | --
![Simulator Screen Shot - iPhone 13 - 2022-02-16 at 16 10 54](https://user-images.githubusercontent.com/6711616/154307604-c494ae98-5212-45b3-a259-5c1588380336.png)  | ![Simulator Screen Shot - iPhone 13 - 2022-02-16 at 16 07 15](https://user-images.githubusercontent.com/6711616/154307380-fcc1234c-d5d5-4ec6-bdf2-859192157e47.png)

Dynamic Type (Normal) | Dynamic Type (Large)
-- | --
<img src="https://user-images.githubusercontent.com/6711616/154329055-27b4ef56-ed08-43f9-8c20-e74db76e1e7e.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/154329066-f81d2fa4-d845-4716-8d93-9fce44df138d.png" width=200>


<details>
 <summary>Screen recording below</summary>

https://user-images.githubusercontent.com/6711616/154309128-2f5c0800-d655-4cc8-8bf8-4654d3d1633f.mp4

</details>

## How to test

**Make sure to run your sandbox with the 1.1 API diff applied and to have the My Site Dashboard flag enabled:**

1. Open the app
2. Go to My Site
3. Change your device orientation to landscape
4. ✅ The segmented control should be aligned with the rest of the elements displayed on My Site (i.e. Site icon, Quick Actions cell)
5. Change the system font size (via the Environment Overrrides menu in Xcode, for example)
6. ✅ The font size for the segmented control should change

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
