### PR TITLE
[Tooling/CI] Print more helpful message when UI Tests failures are reported after zip step

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -24,7 +24,7 @@ install_gems
 echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
-echo "--- 🧪 Testing"
+echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
@@ -36,4 +36,8 @@ echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
 
 echo "--- 🚦 Report Tests Exit Status"
+if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
+  echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
+  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
+fi
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -33,6 +33,7 @@ TESTS_EXIT_STATUS=$?
 set -e
 
 if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
+  # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
   echo "^^^ +++"
   echo "UI Tests failed!"
 fi

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -39,5 +39,7 @@ echo "--- 🚦 Report Tests Exit Status"
 if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
   echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
+else
+  echo "UI Tests seems to have passed (exit code 0). All good 👍"
 fi
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -32,14 +32,19 @@ bundle exec fastlane test_without_building name:"$TEST_NAME" try_count:3 device:
 TESTS_EXIT_STATUS=$?
 set -e
 
+if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
+  echo "^^^ +++"
+  echo "UI Tests failed!"
+fi
+
 echo "--- 📦 Zipping test results"
 cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
 
 echo "--- 🚦 Report Tests Exit Status"
-if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
+if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
+  echo "UI Tests seems to have passed (exit code 0). All good 👍"
+else
   echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
   echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
-else
-  echo "UI Tests seems to have passed (exit code 0). All good 👍"
 fi
 exit $TESTS_EXIT_STATUS

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -22,18 +22,13 @@
     {
       "skippedTests" : [
         "EditorAztecTests",
-        "EditorGutenbergTests",
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "LoginTests\/testEmailPasswordLoginLogout()",
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
-        "MainNavigationTests",
-        "ReaderTests",
         "SignupTests\/testEmailSignup()",
-        "StatsTests",
-        "SupportScreenTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -22,13 +22,18 @@
     {
       "skippedTests" : [
         "EditorAztecTests",
+        "EditorGutenbergTests",
         "EditorTests\/testPlayground()",
         "LoginTests\/testEmailMagicLinkLogin()",
         "LoginTests\/testEmailPasswordLoginLogout()",
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
+        "MainNavigationTests",
+        "ReaderTests",
         "SignupTests\/testEmailSignup()",
+        "StatsTests",
+        "SupportScreenTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {


### PR DESCRIPTION
### Why?

Currently when the UI Tests fail, because of the dance we've had to implement in #17884, the logs in Buildkite might end up being confusing:
 - They are looking like the `--- Testing` section passed, then the `--- Zipping test results` also pass… and only the very last (and seemingly empty with no log content) step failing. Making it look like it was a glitch only on the closing step
 - While in practice, what happens is that, [following the recommendation from Buildkite](https://buildkite.com/docs/pipelines/writing-build-scripts#capturing-exit-status), we kinda "absorb" any error (non-zero exit code) from the `--- Testing` section, only to report it back later. Which makes it not super clear that the real failure to look for logs happened on the `--- Testing` step, not the last closing step.

### How?

This PR simply prints some additional message to help reduce the confusion when such a failure happened during the UI Tests being run, giving better guidance at where to look for details.