### PR TITLE
Notifications > Comment details header: fix misc issues

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -41,14 +41,15 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     func displayCommentsWithPostId(_ postID: NSNumber?, siteID: NSNumber?, commentID: NSNumber?, source: ReaderCommentsSource) throws {
-        guard let postID = postID, let siteID = siteID else {
-            throw DisplayError.missingParameter
-        }
+        guard let postID = postID,
+              let siteID = siteID,
+              let commentsViewController = ReaderCommentsViewController(postID: postID, siteID: siteID, source: source) else {
+                  throw DisplayError.missingParameter
+              }
 
-        let commentsViewController = ReaderCommentsViewController(postID: postID, siteID: siteID, source: source)
-        commentsViewController?.navigateToCommentID = commentID
-        commentsViewController?.allowsPushingPostDetails = true
-        controller?.navigationController?.pushViewController(commentsViewController!, animated: true)
+        commentsViewController.navigateToCommentID = commentID
+        commentsViewController.allowsPushingPostDetails = true
+        controller?.navigationController?.pushViewController(commentsViewController, animated: true)
     }
 
     func displayStatsWithSiteID(_ siteID: NSNumber?, url: URL? = nil) throws {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -570,6 +570,26 @@ private extension CommentDetailViewController {
 
     // MARK: Actions and navigations
 
+    // Shows the comment thread with the Notification comment highlighted.
+    func navigateToNotificationComment() {
+        guard let siteID = siteID,
+              let blog = comment.blog,
+              blog.supports(.wpComRESTAPI) else {
+                  openWebView(for: comment.commentURL())
+                  return
+              }
+
+        // Empty Back Button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+
+        try? contentCoordinator.displayCommentsWithPostId(NSNumber(value: comment.postID),
+                                                          siteID: siteID,
+                                                          commentID: NSNumber(value: comment.commentID),
+                                                          source: .commentNotification)
+    }
+
+
+
     // Shows the comment thread with the parent comment highlighted.
     func navigateToParentComment() {
         guard let parentComment = parentComment,
@@ -596,7 +616,7 @@ private extension CommentDetailViewController {
         try? contentCoordinator.displayCommentsWithPostId(NSNumber(value: comment.postID),
                                                           siteID: siteID,
                                                           commentID: NSNumber(value: replyID),
-                                                          source: .mySiteComment)
+                                                          source: isNotificationComment ? .commentNotification : .mySiteComment)
     }
 
     func navigateToPost() {
@@ -915,14 +935,15 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
 
         switch rows[indexPath.row] {
         case .header:
-            comment.hasParentComment() ? navigateToParentComment() : navigateToPost()
-
+            if isNotificationComment {
+                navigateToNotificationComment()
+            } else {
+                comment.hasParentComment() ? navigateToParentComment() : navigateToPost()
+            }
         case .replyIndicator:
             navigateToReplyComment()
-
         case .text(let title, _, _) where title == .webAddressLabelText:
             visitAuthorURL()
-
         default:
             break
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -119,7 +119,7 @@ class CommentDetailViewController: UIViewController {
         return DefaultContentCoordinator(controller: self, context: managedObjectContext)
     }()
 
-    private lazy var parentComment: Comment? = {
+    private var parentComment: Comment? {
         guard comment.hasParentComment(),
               let blog = comment.blog,
               let parentComment = commentService.findComment(withID: NSNumber(value: comment.parentID), in: blog) else {
@@ -127,7 +127,7 @@ class CommentDetailViewController: UIViewController {
               }
 
         return parentComment
-    }()
+    }
 
     // transparent navigation bar style with visual blur effect.
     private lazy var blurredBarAppearance: UINavigationBarAppearance = {


### PR DESCRIPTION
Ref: #17790 

This fixes a few issues with the Comment details header when displayed in Notifications:
- Tapping the header now always shows the comment thread with the notification comment highlighted.
- When viewing the threaded comments, the nav back button now has no label. Previously, it would display the previous view's title - Reply, Mention, etc.
- When navigating through the Comment notifications via the previous/next buttons, the header now updates for the displayed comment.

To test:

**Header tapping:**
- Enable `notificationCommentDetails`.
- Go to Notifications > Comments.
- Select any notification.
- Tap the header.
- Verify the threaded comments are displayed, and the notification comment is highlighted.
  - Note: sometimes the comment is not highlighted/scrolled to as it seems that action can happen before the comment is loaded. This is a legacy issue, not introduced here.
- Verify the back nav bar button has no label.

**Header updating:**
- Go to Notifications > Comments > select a notification.
- Tap the previous/next buttons on the nav bar.
- Verify the Comment detail header is updated for the Comment being displayed.
- Note: This is not specific to the new Notification Comments. The same behavior can be seen when moderating comments from My Site > Comments, and selecting `Next` on the confirmation notice.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
