### PR TITLE
Notifications > Comment details: fix reply headers

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -232,6 +232,12 @@ extension Notification {
         return metaIds?[MetaKeys.Comment] as? NSNumber
     }
 
+    /// Comment Parent ID, if any.
+    ///
+    @objc var metaParentID: NSNumber? {
+        return metaIds?[MetaKeys.Parent] as? NSNumber
+    }
+
     /// Post ID, if any.
     ///
     @objc var metaPostID: NSNumber? {
@@ -386,6 +392,7 @@ extension Notification {
         static let Site     = "site"
         static let Post     = "post"
         static let Comment  = "comment"
+        static let Parent   = "parent_comment"
         static let Reply    = "reply_comment"
         static let Home     = "home"
     }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -461,6 +461,7 @@ private extension CommentDetailViewController {
     // MARK: Cell configuration
 
     func configureHeaderCell() {
+        // if the comment is a reply, show the author of the parent comment.
         if let parentComment = self.parentComment ?? notificationParentComment {
             return headerCell.configure(for: .reply(parentComment.authorForDisplay()),
                                         subtitle: parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines))

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -119,6 +119,18 @@ class CommentDetailViewController: UIViewController {
         return DefaultContentCoordinator(controller: self, context: managedObjectContext)
     }()
 
+    // Sometimes the parent information of a comment reply notification is in the meta block.
+    private var notificationParentComment: Comment? {
+        guard let parentID = notification?.metaParentID,
+              let siteID = notification?.metaSiteID,
+              let blog = Blog.lookup(withID: siteID, in: managedObjectContext),
+              let parentComment = commentService.findComment(withID: parentID, in: blog) else {
+                  return nil
+              }
+
+        return parentComment
+    }
+
     private var parentComment: Comment? {
         guard comment.hasParentComment(),
               let blog = comment.blog,
@@ -449,8 +461,7 @@ private extension CommentDetailViewController {
     // MARK: Cell configuration
 
     func configureHeaderCell() {
-        // if the comment is a reply, show the author of the parent comment.
-        if let parentComment = self.parentComment {
+        if let parentComment = self.parentComment ?? notificationParentComment {
             return headerCell.configure(for: .reply(parentComment.authorForDisplay()),
                                         subtitle: parentComment.contentPreviewForDisplay().trimmingCharacters(in: .whitespacesAndNewlines))
         }


### PR DESCRIPTION
Ref: #17790 
Depends on: #17969

As noted [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/17969#issuecomment-1042336765), sometimes the parent information of a comment reply notification was in a different place, resulting in the Comment detail header not indicating it is a reply. This addresses that by:
- Getting the `parent_comment` ID from `metaIds`.
- If the parent comment is not cached, it is fetched before the comment details is displayed so the details header has the correct information.

To test:
- Enable `notificationCommentDetails`.
- It's best to start with a fresh install to purge any cached comments.
- Go to Notifications > Comments.
- Select a reply notification.
  - Verify the Comment detail header says `Reply to <author>`.
  - I didn't see a consistency with the replies that are this way, so I can't specify which type of replies to check. But several of mine were this way, so 🤞 you can spot some. 😬 
- Tap the previous/next buttons on the nav bar.
  - Verify the header is updated for the Comment being displayed.


| Reply Notification in List | Detail Header Before | Detail Header After |
|--------|-------|-------|
| <img width="447" alt="notif_list" src="https://user-images.githubusercontent.com/1816888/154394903-a199e3ee-c200-4426-b409-39195a2e8b11.png"> | <img width="448" alt="before_comment_details" src="https://user-images.githubusercontent.com/1816888/154394901-99c574a8-c5ab-4497-aca5-02b269043e5d.png"> | <img width="446" alt="after_comment_details" src="https://user-images.githubusercontent.com/1816888/154394898-fd700e89-3a96-4095-b10e-dcd136f0f6ed.png"> |

Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
