### PR TITLE
Reader Comments: Preventatively cancel ongoing image downloads

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -214,6 +214,15 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         nameLabel?.setText(comment.authorForDisplay())
         dateLabel?.setText(comment.dateForDisplay()?.toMediumString() ?? String())
 
+        // Always cancel ongoing image downloads, just in case. This is to prevent comment cells being displayed with the wrong avatar image,
+        // likely resulting from previous download operation before the cell is reused.
+        //
+        // Note that when downloading an image, any ongoing operation will be cancelled in UIImageView+Networking.
+        // This is more of a preventative step where the cancellation is made to happen as early as possible.
+        //
+        // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17972
+        avatarImageView.cancelImageDownload()
+
         if let avatarURL = URL(string: comment.authorAvatarURL) {
             configureImage(with: avatarURL)
         } else {


### PR DESCRIPTION
Fixes #17972 

This is a preventative measure that cancels any ongoing image download on the content cell. Note that `UIImageView+Networking` already does this every time `downloadImage` is invoked, but this change moves up the cancellation so it happens earlier – hoping that this could reduce the amount of wrong avatar image assignments.

## To test

- Go to Notifications.
- Tap a mention notification.
- Tap on the header to go to the comment threads.
- Verify that the author's avatar image is displayed correctly (not mismatched).

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested to ensure that the change introduced no negative impact.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
