### PR TITLE
Configure button targets for BlogDetailHeaderView outside of initialization closure

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -128,6 +128,10 @@ class BlogDetailHeaderView: UIView {
             self?.delegate?.siteIconReceivedDroppedImage(images.first)
         }
 
+        titleView.subtitleButton.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
+        titleView.titleButton.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
+        titleView.siteSwitcherButton.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
+
         titleView.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(titleView)
@@ -264,7 +268,6 @@ fileprivate extension BlogDetailHeaderView {
             }
 
             button.translatesAutoresizingMaskIntoConstraints = false
-            button.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
 
             return button
         }()
@@ -287,7 +290,6 @@ fileprivate extension BlogDetailHeaderView {
 
             button.setTitleColor(.text, for: .normal)
             button.translatesAutoresizingMaskIntoConstraints = false
-            button.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
             return button
         }()
 
@@ -302,8 +304,6 @@ fileprivate extension BlogDetailHeaderView {
             button.accessibilityLabel = NSLocalizedString("Switch Site", comment: "Button used to switch site")
             button.accessibilityHint = NSLocalizedString("Tap to switch to another site, or add a new site", comment: "Accessibility hint for button used to switch site")
             button.accessibilityIdentifier = "SwitchSiteButton"
-
-            button.addTarget(self, action: #selector(siteSwitcherTapped), for: .touchUpInside)
 
             return button
         }()


### PR DESCRIPTION
Fixes #17970

## Description
- Fixes an issue where the button action wasn't being triggered for the site title, site url, and the site switcher buttons in `BlogDetailHeaderView`

## Background context
- The issue being addressed isn't 100% reproducible (So far, only @guarani and @fluiddot have been able to reproduce this issue)
- Investigation ref: p1645102725020009/1645037908.322089-slack-C011BKNU1V5

## How to test
Make sure the MSD feature flag is **disabled**

1. Log into a WP.com account that has multiple sites
2. Tap on the site title
3. ✅ The Site Title screen should appear
4. Tap Cancel, then tap on the site url
5. ✅ A webview of your site should appear
6. Tap X, then tap on the site switcher (🔽 button)
7. ✅ The My Sites screen containing your blogs should appear
8. Switch to a different site
9. ✅ The My Site screen should reflect the newly selected site

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.