### PR TITLE
Notifications > Comments: fix notification selection issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -10,8 +10,10 @@ class NotificationCommentDetailCoordinator: NSObject {
     private var comment: Comment?
     private let managedObjectContext = ContextManager.shared.mainContext
     private var viewController: CommentDetailViewController?
-    private var commentID: NSNumber?
     private var blog: Blog?
+    private var commentID: NSNumber? {
+        notification?.metaCommentID
+    }
 
     // Arrow navigation data source
     private weak var notificationsNavigationDataSource: NotificationsNavigationDataSource?
@@ -64,8 +66,11 @@ class NotificationCommentDetailCoordinator: NSObject {
 private extension NotificationCommentDetailCoordinator {
 
     func configure(with notification: Notification) {
+        // Clear previous notification's properties.
+        blog = nil
+        comment = nil
+
         self.notification = notification
-        commentID = notification.metaCommentID
 
         if let siteID = notification.metaSiteID {
             blog = Blog.lookup(withID: siteID, in: managedObjectContext)
@@ -106,7 +111,6 @@ private extension NotificationCommentDetailCoordinator {
         // If the comment has a parent and it is not cached, fetch it so the details header is correct.
         guard let notification = notification,
               let parentID = notification.metaParentID,
-              let blog = blog,
               loadCommentFromCache(parentID) == nil else {
                   completion()
                   return
@@ -176,6 +180,7 @@ private extension NotificationCommentDetailCoordinator {
 
     func refreshViewController() {
         if let comment = loadCommentFromCache(commentID) {
+            self.comment = comment
             viewController?.refreshView(comment: comment, notification: notification)
             updateNavigationButtonStates()
             return
@@ -187,6 +192,7 @@ private extension NotificationCommentDetailCoordinator {
                 return
             }
 
+            self.comment = comment
             self.viewController?.refreshView(comment: comment, notification: self.notification)
             self.updateNavigationButtonStates()
         })

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -38,8 +38,9 @@ class NotificationCommentDetailCoordinator: NSObject {
         configure(with: notification)
 
         if let comment = loadCommentFromCache(commentID) {
-            createViewController(comment: comment)
-            completion(viewController)
+            createViewController(comment: comment, completion: {
+                completion(self.viewController)
+            })
             return
         }
 
@@ -50,8 +51,9 @@ class NotificationCommentDetailCoordinator: NSObject {
                 return
             }
 
-            self.createViewController(comment: comment)
-            completion(self.viewController)
+            self.createViewController(comment: comment, completion: {
+                completion(self.viewController)
+            })
         })
     }
 
@@ -115,7 +117,7 @@ private extension NotificationCommentDetailCoordinator {
         })
     }
 
-    func createViewController(comment: Comment) {
+    func createViewController(comment: Comment, completion: @escaping () -> Void) {
         self.comment = comment
 
         fetchParentCommentIfNeeded(completion: { [weak self] in
@@ -129,6 +131,7 @@ private extension NotificationCommentDetailCoordinator {
                                                               managedObjectContext: self.managedObjectContext)
 
             self.updateNavigationButtonStates()
+            completion()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -40,9 +40,9 @@ class NotificationCommentDetailCoordinator: NSObject {
         configure(with: notification)
 
         if let comment = loadCommentFromCache(commentID) {
-            createViewController(comment: comment, completion: {
+            createViewController(comment: comment) {
                 completion(self.viewController)
-            })
+            }
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -53,9 +53,9 @@ class NotificationCommentDetailCoordinator: NSObject {
                 return
             }
 
-            self.createViewController(comment: comment, completion: {
+            self.createViewController(comment: comment) {
                 completion(self.viewController)
-            })
+            }
         })
     }
 


### PR DESCRIPTION
Ref: #17790 

This fixes two issues when selecting a Comment notification:
1. On a fresh install, the app would do nothing and become unresponsive. This was due to  `createViewController:comment` sometimes returning before `fetchParentCommentIfNeeded` was complete. This resulted in `CommentDetailViewController` being `nil`.

To resolve this, a `completion` block has been added to `createViewController:comment` so it doesn't return until the view controller is initialized.

2. Comment details would be from the previously selected comment notification.

This has been resolved by clearing the previous notification's properties when a new notification is displayed.

To test:
- Enable `notificationCommentDetails`.
- Start with a fresh install to ensure no Comments are cached.
- Go to Notifications > Comments.
- Select a notification.
- Verify the comment details view is displayed (and the app doesn't hang).
- Go back to the Notifications list and select other comment notifications.
- Verify the comment details are for the notification selected.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
