### PR TITLE
Stats: Scroll to new Insights card when added - update RELEASE-NOTES.txt

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 19.3
 -----
 * [*] Site previews: Reduced visual flickering when previewing sites and templates. [#17861]
-* [*] Stats: fix navigation between Stats tab. [#17894]
+* [*] Stats: Scroll to new Insights card when added. [#17894]
 * [*] Add "Copy Link" functionality to Posts List and Pages List [#17911]
 * [*] [Jetpack-only] Enables the ability to use and create WordPress.com sites, and enables the Reader tab. [#17914, #17948]
 * [*] Block editor: Autocorrected Headings no longer apply bold formatting if they weren't already bold. [#17844]


### PR DESCRIPTION
This PR corrects the ReleaseNotes update as part of PR #17894

To test:
- Confirm ReleaseNotes are meaningful

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
