### PR TITLE
Update Ruby tooling to expect Bundler 2.3.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -341,4 +341,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.6
+   2.3.7


### PR DESCRIPTION
This version fixes an issue that could have created confusion when running `BUNDLE_WITH=screenshots bundle install` would result in an automated change to `.bundle/config`.

To test:

- Run `gem update bundler` and verify `bundle --version` returns 2.3.7 (the latest at the time of writing)
- Run `bundle install` and verify no file has changed
- Run `BUNDLE_WITH=screenshots bundle install` and verify no file has changed – This is the actual fix. With previous versions of Bundler, .bundle/config would have now had that environment setting, which is not what we wanted.

--- 
## Regression Notes
1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

PR submission checklist:

- [x] I have completed the Regression Notes. N.A.
- [x] I have considered adding unit tests for my changes. N.A.
- [x] I have considered adding accessibility improvements for my changes. N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
