### PR TITLE
My Site Dashboard (Phase 2): Create dedicated section for Home item in site menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -7,9 +7,11 @@
 @protocol BlogDetailHeader;
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
+    BlogDetailsSectionCategoryQuickAction,
     BlogDetailsSectionCategoryReminders,
     BlogDetailsSectionCategoryDomainCredit,
     BlogDetailsSectionCategoryQuickStart,
+    BlogDetailsSectionCategoryHome,
     BlogDetailsSectionCategoryGeneral,
     BlogDetailsSectionCategoryJetpack,
     BlogDetailsSectionCategoryPublish,
@@ -17,7 +19,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
     BlogDetailsSectionCategoryConfigure,
     BlogDetailsSectionCategoryExternal,
     BlogDetailsSectionCategoryRemoveSite,
-    BlogDetailsSectionCategoryQuickAction
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -755,6 +755,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self shouldShowQuickStartChecklist]) {
         [marr addObject:[self quickStartSectionViewModel]];
     }
+    if ([Feature enabled:FeatureFlagMySiteDashboard] && [self.blog isAccessibleThroughWPCom] && ![self splitViewControllerIsHorizontallyCompact]) {
+        [marr addObject:[self homeSectionViewModel]];
+    }
     if (([self.blog supports:BlogFeatureActivity] && ![self.blog isWPForTeams]) || [self.blog supports:BlogFeatureJetpackSettings]) {
         [marr addObject:[self jetpackSectionViewModel]];
     } else {
@@ -775,18 +778,25 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     self.tableSections = [NSArray arrayWithArray:marr];
 }
 
-- (BlogDetailsSection *)generalSectionViewModel
+- (BlogDetailsSection *)homeSectionViewModel
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
     
-    if ([Feature enabled:FeatureFlagMySiteDashboard] && [self.blog isAccessibleThroughWPCom] && ![self splitViewControllerIsHorizontallyCompact]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
-                                                        image:[UIImage gridiconOfType:GridiconTypeHouse]
-                                                     callback:^{
-                                                        [weakSelf showDashboard];
-                                                     }]];
-    }
+    [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
+                                  accessibilityIdentifier:@"Home Row"
+                                                    image:[UIImage gridiconOfType:GridiconTypeHouse]
+                                                 callback:^{
+                                                    [weakSelf showDashboard];
+                                                 }]];
+    
+    return [[BlogDetailsSection alloc] initWithTitle:nil andRows:rows category:BlogDetailsSectionCategoryHome];
+}
+
+- (BlogDetailsSection *)generalSectionViewModel
+{
+    __weak __typeof(self) weakSelf = self;
+    NSMutableArray *rows = [NSMutableArray array];
     
     BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                   accessibilityIdentifier:@"Stats Row"
@@ -826,14 +836,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
-    
-    if ([Feature enabled:FeatureFlagMySiteDashboard] && [self.blog isAccessibleThroughWPCom] && ![self splitViewControllerIsHorizontallyCompact]) {
-        [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Home", @"Noun. Links to a blog's dashboard screen.")
-                                                        image:[UIImage gridiconOfType:GridiconTypeHouse]
-                                                     callback:^{
-                                                        [weakSelf showDashboard];
-                                                     }]];
-    }
     
     BlogDetailsRow *statsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Stats", @"Noun. Abbv. of Statistics. Links to a blog's Stats screen.")
                                   accessibilityIdentifier:@"Stats Row"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1019,7 +1019,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
     BlogDetailsRow *viewSiteRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"View Site", @"Action title. Opens the user's site in an in-app browser")
-                                                                  image:[UIImage gridiconOfType:GridiconTypeHouse]
+                                                                  image:[UIImage gridiconOfType:GridiconTypeGlobe]
                                                                callback:^{
         [weakSelf showViewSiteFromSource:BlogDetailsNavigationSourceRow];
     }];

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -12,7 +12,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             case .siteMenu:
                 return NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen")
             case .dashboard:
-                return NSLocalizedString("Dashboard", comment: "Title for dashboard view on the My Site screen")
+                return NSLocalizedString("Home", comment: "Title for dashboard view on the My Site screen")
             }
         }
     }


### PR DESCRIPTION
Part of #17878 

## Description

- Updates the "View Site" icon to a globe
- Updates the "Home" item to be in it's own section
- Renames dashboard option to "Home" for iPhone

## Note
- The default selected item will still be Stats
- There is an issue where the correct item isn't highlighted when switching sites. When switching sites via the site picker, the default menu item (i.e. Stats) is displayed in the details view controller. This issue has been present since at least 19.0, and perhaps longer (https://github.com/wordpress-mobile/WordPress-iOS/issues/17958)

## How to test

**Make sure the MSD feature flag is enabled**

### iPad
1. Go to My Site
2. ✅  On the sidebar nav, notice that the "Home" item is in it's own section
3. Scroll down to the "View Site" item
4. ✅ The "View Site" icon should be a globe
3. Tap the "Home" item
4. ✅ The dashboard screen should be displayed in the detail view controller

### iPhone
1. Go to My Site
2. ✅ The segmented control should have a "Site Menu" and "Home" section


![Simulator Screen Shot - iPad Air (4th generation) - 2022-02-18 at 15 07 35](https://user-images.githubusercontent.com/6711616/154715903-ef5ee46e-6372-46d5-89ae-68ac49f6c79e.png) | ![Simulator Screen Shot - iPad Air (4th generation) - 2022-02-18 at 15 19 03](https://user-images.githubusercontent.com/6711616/154715909-fdb0a2b5-e863-484f-8638-83e858c0afcf.png) | ![Simulator Screen Shot - iPhone 13 - 2022-02-18 at 15 40 09](https://user-images.githubusercontent.com/6711616/154715947-1dbadb4b-8546-47e3-acf3-fb3cb22058b6.png)
-- | -- | --


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
