### PR TITLE
Notifications > Comments: remove Notification when Comment is removed

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -77,7 +77,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mediaPickerPermissionsNotice:
             return true
         case .notificationCommentDetails:
-            return false
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .statsPerformanceImprovements:
             return BuildConfiguration.current == .localDeveloper
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -9,6 +9,7 @@ import CoreData
 protocol CommentDetailsNotificationNavigationDelegate: AnyObject {
     func previousNotificationTapped(current: Notification?)
     func nextNotificationTapped(current: Notification?)
+    func commentWasModerated(for notification: Notification?)
 }
 
 class CommentDetailViewController: UIViewController {
@@ -770,6 +771,8 @@ private extension String {
 extension CommentDetailViewController: CommentModerationBarDelegate {
     func statusChangedTo(_ commentStatus: CommentStatusType) {
 
+        notifyDelegateCommentModerated()
+
         switch commentStatus {
         case .pending:
             unapproveComment()
@@ -848,6 +851,14 @@ private extension CommentDetailViewController {
             self?.moderationBar?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
             completion?(false)
         })
+    }
+
+    func notifyDelegateCommentModerated() {
+        guard let notification = notification else {
+            return
+        }
+
+        notificationNavigationDelegate?.commentWasModerated(for: notification)
     }
 
     func showActionableNotice(title: String) {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -862,10 +862,17 @@ private extension CommentDetailViewController {
     }
 
     func showActionableNotice(title: String) {
+        guard !isNotificationComment else {
+            return
+        }
+
         guard viewIsVisible, !isLastInList else {
             displayNotice(title: title)
             return
         }
+
+        // Dismiss any old notices to avoid stacked Next notices.
+        dismissNotice()
 
         displayActionableNotice(title: title,
                                 style: NormalNoticeStyle(showNextArrow: true),

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -156,6 +156,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
+        syncNotificationsWithModeratedComments()
         setupInlinePrompt()
 
         // Manually deselect the selected row.
@@ -869,6 +870,19 @@ private extension NotificationsViewController {
     func deletionRequestForNoteWithID(_ noteObjectID: NSManagedObjectID) -> NotificationDeletionRequest? {
         return notificationDeletionRequests[noteObjectID]
     }
+
+    // With the `notificationCommentDetails` feature, Comment moderation is handled by the view.
+    // To avoid updating the Notifications here prematurely, affecting the previous/next buttons,
+    // the Notifications are tracked in NotificationCommentDetailCoordinator when their comments are moderated.
+    // Those Notifications are updated here when the view is shown to update the list accordingly.
+    func syncNotificationsWithModeratedComments() {
+        notificationCommentDetailCoordinator.notificationsCommentModerated.forEach {
+            syncNotification(with: $0.notificationId, timeout: Syncing.pushMaxWait, success: {_ in })
+        }
+
+        notificationCommentDetailCoordinator.notificationsCommentModerated = []
+    }
+
 }
 
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -242,6 +242,7 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
     override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
         return true
     }
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
@@ -382,6 +383,11 @@ class NotificationsViewController: UITableViewController, UIViewControllerRestor
 
         selectedNotification = note
         showDetails(for: note)
+
+        if !splitViewControllerIsHorizontallyCompact {
+            syncNotificationsWithModeratedComments()
+        }
+
     }
 
     override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
@@ -876,6 +882,11 @@ private extension NotificationsViewController {
     // the Notifications are tracked in NotificationCommentDetailCoordinator when their comments are moderated.
     // Those Notifications are updated here when the view is shown to update the list accordingly.
     func syncNotificationsWithModeratedComments() {
+        if let selectedNotification = selectedNotification,
+           notificationCommentDetailCoordinator.notificationsCommentModerated.contains(selectedNotification) {
+            self.selectedNotification = nil
+        }
+
         notificationCommentDetailCoordinator.notificationsCommentModerated.forEach {
             syncNotification(with: $0.notificationId, timeout: Syncing.pushMaxWait, success: {_ in })
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -22,6 +22,10 @@ class NotificationCommentDetailCoordinator: NSObject {
     // This happens due to Navigation Events (Next / Previous)
     var onSelectedNoteChange: ((Notification) -> Void)?
 
+    // Keep track of Notifications that have moderated Comments so they can be updated
+    // the next time the Notifications list is displayed.
+    var notificationsCommentModerated: [Notification] = []
+
     private lazy var commentService: CommentService = {
         return .init(managedObjectContext: managedObjectContext)
     }()
@@ -253,6 +257,15 @@ extension NotificationCommentDetailCoordinator: CommentDetailsNotificationNaviga
 
         WPAnalytics.track(.notificationsNextTapped)
         updateViewWith(notification: nextNotification)
+    }
+
+    func commentWasModerated(for notification: Notification?) {
+        guard let notification = notification,
+        !notificationsCommentModerated.contains(notification) else {
+            return
+        }
+
+        notificationsCommentModerated.append(notification)
     }
 
 }


### PR DESCRIPTION
Ref: #17790

When comments are moderated from the Notification Comment details view, the affected notifications are updated when the notifications list is re-shown. The effect is if a Comment is trashed, spammed, or deleted, its Notification is removed from the Notifications list.

In addition, comment moderation confirmation notices are no longer displayed for Notification comments.

Implementation notes:

If the Notification in `NotificationsViewController` is updated as soon as its Comment is trashed or spammed, the Notification will be removed from fetched results. This causes a couple of issues:
- In regular view, the nav bar previous/next buttons wouldn't find the previous/next notification. 
- In split view, it would attempt to remove the notification as the user was possibly viewing it.

So the affected Notifications are tracked by `NotificationCommentDetailCoordinator`. `NotificationsViewController` syncs the Notifications when appropriate to update the Notifications list:
- In any view - when the Notifications list is shown (`viewWillAppear`).
- In split view - when another Notification is selected.

To test:

Regular View:
- Select a Comment notification.
  - In the details, select trash or spam.
  - Using previous/next nav bar buttons, trash/spam more Comment notifications.
  - Return to the Notifications list.
  - Verify all the Notifications for the trashed/spammed Comments are removed.
- Select a Comment notification.
  - In the details, select trash or spam, then `Delete Permanently`.
  - Verify the view is dismissed, and the notification is removed from the Notifications list.

Split View:
- Select a Comment notification.
  - In the details, select trash or spam.
  - Select another Notification.
  - Verify the Notification for the trashed/spammed Comment is removed from the list.
  - Note: `Delete Permanently` does not immediately nix the notification as in regular view. If you select another Notification, it will then be removed. I'll address this separately as it is related to the issue I commented on below.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
