### PR TITLE
My Site Dashboard: Update blog for site picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -87,7 +87,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 return
             }
 
-            addSitePickerIfNeeded(for: newBlog)
+            showSitePicker(for: newBlog)
             showBlogDetails(for: newBlog)
             updateSegmentedControl(for: newBlog)
         }
@@ -271,7 +271,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        addSitePickerIfNeeded(for: mainBlog)
+        showSitePicker(for: mainBlog)
         showBlogDetails(for: mainBlog)
         updateSegmentedControl(for: mainBlog)
     }
@@ -534,17 +534,20 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         return blogDetailsViewController
     }
 
-    private func addSitePickerIfNeeded(for blog: Blog) {
-        guard sitePickerViewController == nil else {
+    private func showSitePicker(for blog: Blog) {
+        guard let sitePickerViewController = sitePickerViewController else {
+
+            let sitePickerViewController = makeSitePickerViewController(for: blog)
+            self.sitePickerViewController = sitePickerViewController
+
+            addChild(sitePickerViewController)
+            stackView.insertArrangedSubview(sitePickerViewController.view, at: 0)
+            sitePickerViewController.didMove(toParent: self)
+
             return
         }
 
-        let sitePickerViewController = makeSitePickerViewController(for: blog)
-        self.sitePickerViewController = sitePickerViewController
-
-        addChild(sitePickerViewController)
-        stackView.insertArrangedSubview(sitePickerViewController.view, at: 0)
-        sitePickerViewController.didMove(toParent: self)
+        sitePickerViewController.blog = blog
     }
 
     private func makeSitePickerViewController(for blog: Blog) -> SitePickerViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -6,7 +6,11 @@ import SVProgressHUD
 
 final class SitePickerViewController: UIViewController {
 
-    var blog: Blog
+    var blog: Blog {
+        didSet {
+            blogDetailHeaderView.blog = blog
+        }
+    }
 
     var siteIconPresenter: SiteIconPickerPresenter?
     var siteIconPickerPresenter: SiteIconPickerPresenter?


### PR DESCRIPTION
Fixes #17993 
Fixes #17982

## Description

- Fixes an issue where the blog associated with the SitePickerViewController wasn't being updated to the correct blog for site creation / site deletion

## How to test

### Site creation
1. Have an existing site loaded in the My Site view
2. Create a new WP.com site
3. ✅ Observe that the title and URL reflect the newly created site

https://user-images.githubusercontent.com/6711616/154847950-8dc93260-aa31-4773-ae18-d3d891b2214b.mp4

### Site deletion (account w multiple sites)
1. On a WP.com site that's OK to delete, go to Site Settings from the My Site view
2. Delete Site
3. ✅ Observe that the title and URL have changed to a different, existing site

https://user-images.githubusercontent.com/6711616/154847961-49ca9749-9d91-4149-acec-7136a5d63a4a.mp4

### Site deletion (account w one site)
1. On a WP.com site that's OK to delete, go to Site Settings from the My Site view
2. Delete Site
3. ✅ Observe that "Create a new site for your business, magazine, or personal blog; or connect an existing WordPress installation" is displayed

https://user-images.githubusercontent.com/6711616/154847983-e3c58886-369a-4f2e-b031-ae512674c5b7.mp4

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
