### PR TITLE
Save xcode results from unit tests to buildkite

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -46,6 +46,6 @@ if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
   echo "UI Tests seems to have passed (exit code 0). All good 👍"
 else
   echo "The UI Tests, ran during the '🔬 Testing' step above, have failed."
-  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
+  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -17,7 +17,7 @@ bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
 TESTS_EXIT_STATUS=$?
 set -e
 
-if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
+if [[ $TESTS_EXIT_STATUS -ne 0 ]]; then
   # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
   echo "^^^ +++"
   echo "Unit Tests failed!"
@@ -31,6 +31,6 @@ if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
   echo "Unit Tests seems to have passed (exit code 0). All good 👍"
 else
   echo "The Unit Tests, ran during the '🔬 Testing' step above, have failed."
-  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
+  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artifacts."
 fi
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -11,5 +11,26 @@ gem install bundler
 echo "--- :rubygems: Setting up Gems"
 install_gems
 
-echo "--- 🧪 Testing"
+echo "--- 🔬 Testing"
+set +e
 bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
+TESTS_EXIT_STATUS=$?
+set -e
+
+if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
+  # Keep the (otherwise collapsed) current "Testing" section open in Buildkite logs on error. See https://buildkite.com/docs/pipelines/managing-log-output#collapsing-output
+  echo "^^^ +++"
+  echo "Unit Tests failed!"
+fi
+
+echo "--- 📦 Zipping test results"
+cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult
+
+echo "--- 🚦 Report Tests Exit Status"
+if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then
+  echo "Unit Tests seems to have passed (exit code 0). All good 👍"
+else
+  echo "The Unit Tests, ran during the '🔬 Testing' step above, have failed."
+  echo "For more details about the failed tests, check the logs under the '🔬 Testing' section and the \`.xcresult\` and test reports in Buildkite artefacts."
+fi
+exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -54,6 +54,8 @@ steps:
     depends_on: "build"
     env: *common_env
     plugins: *common_plugins
+    artifact_paths:
+      - "build/results/*"
     notify:
       - github_commit_status:
           context: "Unit Tests"


### PR DESCRIPTION
Saves xcode results from unit tests as artifacts in Buildkite, enabling us to better investigate when tests fail.
