### PR TITLE
Notifications split view: set selected Notification after removing moderated

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -2,11 +2,11 @@ import UIKit
 import CoreData
 
 
-@objc protocol CommentDetailsModerationDelegate: AnyObject {
+@objc protocol CommentDetailsDelegate: AnyObject {
     func nextCommentSelected()
 }
 
-protocol CommentDetailsNotificationNavigationDelegate: AnyObject {
+protocol CommentDetailsNotificationDelegate: AnyObject {
     func previousNotificationTapped(current: Notification?)
     func nextNotificationTapped(current: Notification?)
     func commentWasModerated(for notification: Notification?)
@@ -25,15 +25,15 @@ class CommentDetailViewController: UIViewController {
     private var keyboardManager: KeyboardDismissHelper?
     private var dismissKeyboardTapGesture = UITapGestureRecognizer()
 
-    @objc weak var moderationDelegate: CommentDetailsModerationDelegate?
+    @objc weak var commentDelegate: CommentDetailsDelegate?
+    private weak var notificationDelegate: CommentDetailsNotificationDelegate?
+
     private var comment: Comment
     private var isLastInList = true
     private var managedObjectContext: NSManagedObjectContext
     private var rows = [RowType]()
     private var moderationBar: CommentModerationBar?
     private var notification: Notification?
-
-    private weak var notificationNavigationDelegate: CommentDetailsNotificationNavigationDelegate?
 
     private var isNotificationComment: Bool {
         notification != nil
@@ -220,11 +220,11 @@ class CommentDetailViewController: UIViewController {
 
     init(comment: Comment,
          notification: Notification?,
-         notificationNavigationDelegate: CommentDetailsNotificationNavigationDelegate?,
+         notificationDelegate: CommentDetailsNotificationDelegate?,
          managedObjectContext: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
         self.comment = comment
         self.notification = notification
-        self.notificationNavigationDelegate = notificationNavigationDelegate
+        self.notificationDelegate = notificationDelegate
         self.managedObjectContext = managedObjectContext
         super.init(nibName: nil, bundle: nil)
     }
@@ -675,11 +675,11 @@ private extension CommentDetailViewController {
     }
 
     @objc func previousButtonTapped() {
-        notificationNavigationDelegate?.previousNotificationTapped(current: notification)
+        notificationDelegate?.previousNotificationTapped(current: notification)
     }
 
     @objc func nextButtonTapped() {
-        notificationNavigationDelegate?.nextNotificationTapped(current: notification)
+        notificationDelegate?.nextNotificationTapped(current: notification)
     }
 
     func deleteButtonTapped() {
@@ -858,7 +858,7 @@ private extension CommentDetailViewController {
             return
         }
 
-        notificationNavigationDelegate?.commentWasModerated(for: notification)
+        notificationDelegate?.commentWasModerated(for: notification)
     }
 
     func showActionableNotice(title: String) {
@@ -888,7 +888,7 @@ private extension CommentDetailViewController {
         }
 
         WPAnalytics.track(.commentSnackbarNext)
-        moderationDelegate?.nextCommentSelected()
+        commentDelegate?.nextCommentSelected()
     }
 
     struct ModerationMessages {

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -14,7 +14,7 @@ static NSInteger const CommentsFetchBatchSize                   = 10;
 static NSString *RestorableBlogIdKey = @"restorableBlogIdKey";
 static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 
-@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate, UIViewControllerRestoration, NoResultsViewControllerDelegate, CommentDetailsModerationDelegate>
+@interface CommentsViewController () <WPTableViewHandlerDelegate, WPContentSyncHelperDelegate, UIViewControllerRestoration, NoResultsViewControllerDelegate, CommentDetailsDelegate>
 @property (nonatomic, strong) WPTableViewHandler        *tableViewHandler;
 @property (nonatomic, strong) WPContentSyncHelper       *syncHelper;
 @property (nonatomic, strong) NoResultsViewController   *noResultsViewController;
@@ -233,7 +233,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     self.commentDetailViewController = [[CommentDetailViewController alloc] initWithComment:comment
                                                                                isLastInList:[self isLastRow:indexPath]
                                                                        managedObjectContext:[ContextManager sharedInstance].mainContext];
-    self.commentDetailViewController.moderationDelegate = self;
+    self.commentDetailViewController.commentDelegate = self;
     [self.navigationController pushViewController:self.commentDetailViewController animated:YES];
     [CommentAnalytics trackCommentViewedWithComment:comment];
 }
@@ -752,7 +752,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [self refreshNoConnectionView];
 }
 
-#pragma mark - CommentDetailsModerationDelegate
+#pragma mark - CommentDetailsDelegate
 
 - (void)nextCommentSelected
 {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -728,10 +728,10 @@ extension NotificationsViewController {
             return
         }
 
-        presentCommentDetail(for: note)
+        presentDetails(for: note)
     }
 
-    private func presentCommentDetail(for note: Notification) {
+    private func presentDetails(for note: Notification) {
         // This dispatch avoids a bug that was occurring occasionally where navigation (nav bar and tab bar)
         // would be missing entirely when launching the app from the background and presenting a notification.
         // The issue seems tied to performing a `pop` in `prepareToShowDetails` and presenting

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -149,7 +149,7 @@ private extension NotificationCommentDetailCoordinator {
 
             self.viewController = CommentDetailViewController(comment: comment,
                                                               notification: self.notification,
-                                                              notificationNavigationDelegate: self,
+                                                              notificationDelegate: self,
                                                               managedObjectContext: self.managedObjectContext)
 
             self.updateNavigationButtonStates()
@@ -248,9 +248,9 @@ private extension NotificationCommentDetailCoordinator {
 
 }
 
-// MARK: - CommentDetailsNotificationNavigationDelegate
+// MARK: - CommentDetailsNotificationDelegate
 
-extension NotificationCommentDetailCoordinator: CommentDetailsNotificationNavigationDelegate {
+extension NotificationCommentDetailCoordinator: CommentDetailsNotificationDelegate {
 
     func previousNotificationTapped(current: Notification?) {
         guard let current = current,


### PR DESCRIPTION
Ref: #17790

This fixes an issue where, in split view, the Notification details could still be shown after the first Notification is removed from the list. 

The problem was that `selectFirstNotificationIfAppropriate` was selecting the notification before it was updated. Now, instead of just clearing `selectedNotification`, `syncNotificationsWithModeratedComments` finds the next available notification and sets it as the `selectedNotification`.

Also, there is some code cleanup - the `CommentDetailViewController` protocols have been renamed to be more accurate.

To test:
- In split view, go to Notifications.
- Trash/spam the first comment in the list.
- While still viewing the comment, navigate away from Notifications (ex: tap `My Site` or `Reader` tab).
- Come back to Notifications. 
- Verify the Notification is removed from the list, the next Notification is selected, and the details updates accordingly.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
