### PR TITLE
My Site Dashboard: track posts card shown

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -304,6 +304,7 @@ import Foundation
     case changeUsernameDismissed
 
     // My Site Dashboard
+    case dashboardCardShown
     case dashboardCardItemTapped
 
     /// A String that represents the event
@@ -815,6 +816,8 @@ import Foundation
             return "change_username_dismissed"
 
         // My Site Dashboard
+        case .dashboardCardShown:
+            return "my_site_dashboard_card_shown"
         case .dashboardCardItemTapped:
             return "my_site_dashboard_card_item_tapped"
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -124,6 +124,10 @@ private extension PostsCardViewController {
         _ = tableView.intrinsicContentSize
     }
 
+    func trackPostsDisplayed() {
+        WPAnalytics.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue])
+    }
+
     enum Constants {
         static let numberOfPosts = 3
     }
@@ -149,8 +153,16 @@ extension PostsCardViewController: PostsCardView {
     }
 
     func hideLoading() {
+        guard ghostableTableView?.superview != nil else {
+            return
+        }
+
         errorView?.removeFromSuperview()
         removeGhostableTableView()
+
+        if nextPostView == nil && errorView == nil {
+            trackPostsDisplayed()
+        }
     }
 
     func showError(message: String, retry: Bool) {
@@ -168,6 +180,8 @@ extension PostsCardViewController: PostsCardView {
 
         // Force the table view to recalculate its height
         _ = tableView.intrinsicContentSize
+
+        WPAnalytics.track(.dashboardCardShown, properties: ["type": "post", "sub_type": "error"])
     }
 
     func showNextPostPrompt() {
@@ -190,12 +204,20 @@ extension PostsCardViewController: PostsCardView {
         forceTableViewToRecalculateHeight()
 
         delegate?.didShowNextPostPrompt()
+
+        WPAnalytics.track(.dashboardCardShown, properties: ["type": "post", "sub_type": hasPublishedPosts ? "create_next" : "create_first"])
     }
 
     func hideNextPrompt() {
+        guard nextPostView != nil else {
+            return
+        }
+
         nextPostView?.removeFromSuperview()
         nextPostView = nil
         delegate?.didHideNextPostPrompt()
+
+        trackPostsDisplayed()
     }
 
     func firstPostPublished() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -203,13 +203,13 @@ private extension PostsCardViewModel {
     }
 
     func showNextPostPrompt() {
-        viewController?.hideLoading()
         viewController?.showNextPostPrompt()
+        viewController?.hideLoading()
     }
 
     func showLoadingFailureError() {
-        viewController?.hideLoading()
         viewController?.showError(message: Strings.loadingFailure, retry: true)
+        viewController?.hideLoading()
     }
 
     func hideLoading() {


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/17875

Add tracks for which post card is being displayed. The track is in the form of `my_site_dashboard_card_shown` with `type=post` and the `subtype` depends on the presented content. As it follows:

1. `draft`: showing drafts
2. `future`: showing scheduled
3. `create_next`: create next post
4. `create_first`: create your first post
5. `error`: when an error happened when fetching posts and we have no data to present

### To test

1. Open the app
2. Tap Dashboard
3. Choose a site with drafts and scheduled
4. Check that `draft` and `future` are tracked as subtype
5. Choose a site with no posts published at all
6. Check that `create_first` is the subtype
7. Choose a site with posts published but no drafts and no scheduled
8. Check that `create_next` is the subtype

To test the error, you can change the `PostsCardViewModel.sync` success callback to call `self?.showLoadingFailureError()` then check that subtype is `error`.

**Important**: you will notice that sometimes these events are triggered twice, that's because the collection view is always updating itself. It fires the events once it presents the card the first time, then it reloads and fires again. This should be fixed in a subsequent task.

Anyway, is not a problem to fire the events twice. What is important is to not fire misleading events.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
