### PR TITLE
Re-enable Stats UI Tests

### DIFF
--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -24,6 +24,13 @@ public func navigateBack() {
     }
 }
 
+public func pullToRefresh(app: XCUIApplication = XCUIApplication()) {
+    let top = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+    let bottom = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.8))
+
+    top.press(forDuration: 0.01, thenDragTo: bottom)
+}
+
 extension ScreenObject {
 
     // TODO: This was implemented on the original `BaseScreen` and is here just as a copy-paste for the transition.

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -72,4 +72,12 @@ public class StatsScreen: ScreenObject {
         app.buttons[mode.rawValue].tap()
         return self
     }
+
+    public func refreshStatsIfNeeded() -> StatsScreen {
+        let errorMessage = NSPredicate(format: "label == 'An error occurred.'");
+        let isErrorMessagePresent = app.staticTexts.element(matching: errorMessage).exists
+
+        if isErrorMessagePresent { pullToRefresh() }
+        return self
+    }
 }

--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -74,7 +74,7 @@ public class StatsScreen: ScreenObject {
     }
 
     public func refreshStatsIfNeeded() -> StatsScreen {
-        let errorMessage = NSPredicate(format: "label == 'An error occurred.'");
+        let errorMessage = NSPredicate(format: "label == 'An error occurred.'")
         let isErrorMessagePresent = app.staticTexts.element(matching: errorMessage).exists
 
         if isErrorMessagePresent { pullToRefresh() }

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -10,6 +10,7 @@ class StatsTests: XCTestCase {
         statsScreen = try MySiteScreen()
             .goToStatsScreen()
             .switchTo(mode: .insights)
+            .refreshStatsIfNeeded()
             .dismissCustomizeInsightsNotice()
     }
 

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -29,7 +29,6 @@
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
         "SignupTests\/testEmailSignup()",
-        "StatsTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {


### PR DESCRIPTION
The Stats Tests started failing consistently recently only on iPad. Checking logs from failed runs, [like this one](https://buildkite.com/automattic/wordpress-ios/builds/5215#7f5d1318-5f11-4b9e-bbae-ac20e6f970a7/1553-2163), it was noticed that the app did open properly and `Insights` tab is loaded, however when the `Stats` button is tapped in `setUpWithError()` by `goToStatsScreen()` there is an attempt to reload `Insights` data that actually fails and no stats are displayed. It was possible to reproduce the issue locally and the data is back after a pull to refresh gesture. It was NOT possible to reproduce the issue on a real device, it is likely that the problem is related to Simulator+Mocks combo. 

![image](https://user-images.githubusercontent.com/42008628/155232892-5526fbc1-0e6f-44b7-9489-277bcbdb8b91.png)

As a **real problem was discarded**, the objective of this PR is to allow the tests to deal with the issue and have Stats tests running on CI again.

Test PR with multiple runs : #18009 
iPhone tests after 43 runs ([CI server timed out](https://github.com/wordpress-mobile/WordPress-iOS/pull/18009#issuecomment-1049112704)): Passed 43 out of 43.
iPad tests: Passed 49 out of 49*.

*_One of the 50 runs for iPad did timeout even before start running the tests_
```
[!] [31mxcodebuild -showBuildSettings timed out after 4 retries with a base timeout of 3. You can override the base timeout value with the environment variable FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT, and the number of retries with the environment variable FASTLANE_XCODEBUILD_SETTINGS_RETRIES [0m


--- 📦 Zipping test results Run: 8 Status: 1
```

![image](https://user-images.githubusercontent.com/42008628/155410723-a66db0f5-e506-4df2-9e71-a03021937c27.png)
