### PR TITLE
Reader Follow Topics: Removes empty space at the bottom of the screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -35,7 +35,7 @@ class ReaderSelectInterestsViewController: UIViewController {
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var buttonContainerView: UIView!
     @IBOutlet weak var nextButton: FancyButton!
-    @IBOutlet weak var contentContainerView: UIView!
+    @IBOutlet weak var contentContainerView: UIStackView!
 
     @IBOutlet weak var activityIndicatorView: UIActivityIndicatorView!
     @IBOutlet weak var loadingLabel: UILabel!
@@ -219,9 +219,9 @@ class ReaderSelectInterestsViewController: UIViewController {
         if let buttonTitle = configuration.buttonTitle {
             nextButton.setTitle(buttonTitle.enabled, for: .normal)
             nextButton.setTitle(buttonTitle.disabled, for: .disabled)
-            nextButton.isHidden = false
+            buttonContainerView.isHidden = false
         } else {
-            nextButton.isHidden = true
+            buttonContainerView.isHidden = true
         }
 
         loadingLabel.text = configuration.loading

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -15,7 +15,7 @@
                 <outlet property="bottomSpaceHeightConstraint" destination="XCs-b1-Ce2" id="Wdz-a3-j40"/>
                 <outlet property="buttonContainerView" destination="X4F-fc-WqY" id="TtA-Ul-l6R"/>
                 <outlet property="collectionView" destination="fUq-vV-Pah" id="ueF-52-q8k"/>
-                <outlet property="contentContainerView" destination="y7t-k2-AgA" id="KvG-Vr-Y5Y"/>
+                <outlet property="contentContainerView" destination="Bt3-aY-FXs" id="byT-7R-pMh"/>
                 <outlet property="loadingLabel" destination="NPa-Pf-eLr" id="Uzi-sA-Nvp"/>
                 <outlet property="loadingView" destination="DIz-pa-QD0" id="NUq-Ic-P2y"/>
                 <outlet property="nextButton" destination="5kh-rf-B5P" id="pMz-bN-ncz"/>
@@ -29,23 +29,23 @@
             <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="y7t-k2-AgA" userLabel="Content Container View">
+                <stackView contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Bt3-aY-FXs" userLabel="Content Container View">
                     <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="2ka-fB-oWM">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="670"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="19" translatesAutoresizingMaskIntoConstraints="NO" id="rOi-KY-muX">
-                                    <rect key="frame" x="20" y="12" width="374" height="121"/>
+                                    <rect key="frame" x="20" y="12" width="374" height="111"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discover and follow blogs you love" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sln-01-DYL" userLabel="Header Label">
-                                            <rect key="frame" x="0.0" y="0.0" width="374" height="81.666666666666671"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="374" height="75"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Choose your topics" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Efr-XO-GjF" userLabel="Subtitle Label">
-                                            <rect key="frame" x="0.0" y="100.66666666666667" width="374" height="20.333333333333329"/>
+                                            <rect key="frame" x="0.0" y="94" width="374" height="17"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -53,7 +53,7 @@
                                     </subviews>
                                 </stackView>
                                 <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="fUq-vV-Pah">
-                                    <rect key="frame" x="20" y="143" width="374" height="527"/>
+                                    <rect key="frame" x="20" y="133" width="374" height="537"/>
                                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="IKi-eM-O1E" customClass="ReaderInterestsCollectionViewFlowLayout" customModule="WordPress" customModuleProvider="target">
                                         <size key="itemSize" width="128" height="128"/>
@@ -69,7 +69,7 @@
                             </subviews>
                             <edgeInsets key="layoutMargins" top="12" left="20" bottom="0.0" right="20"/>
                         </stackView>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
+                        <view tag="7" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
                             <rect key="frame" x="0.0" y="670" width="414" height="66"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5kh-rf-B5P" customClass="FancyButton" customModule="WordPressUI">
@@ -104,19 +104,7 @@
                         </view>
                     </subviews>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                    <constraints>
-                        <constraint firstAttribute="trailing" secondItem="be9-lX-CD7" secondAttribute="trailing" id="0de-fR-YWW"/>
-                        <constraint firstItem="be9-lX-CD7" firstAttribute="top" secondItem="X4F-fc-WqY" secondAttribute="bottom" id="67o-fb-UOy"/>
-                        <constraint firstItem="X4F-fc-WqY" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="9mr-Wg-Hvq"/>
-                        <constraint firstAttribute="trailing" secondItem="X4F-fc-WqY" secondAttribute="trailing" id="AzF-5F-ioe"/>
-                        <constraint firstAttribute="trailing" secondItem="2ka-fB-oWM" secondAttribute="trailing" id="Fnt-G7-QEW"/>
-                        <constraint firstItem="2ka-fB-oWM" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="Mso-AA-bvt"/>
-                        <constraint firstItem="2ka-fB-oWM" firstAttribute="top" secondItem="y7t-k2-AgA" secondAttribute="top" id="NQz-F4-hfI"/>
-                        <constraint firstItem="X4F-fc-WqY" firstAttribute="top" secondItem="2ka-fB-oWM" secondAttribute="bottom" id="PrH-sw-ZRT"/>
-                        <constraint firstItem="be9-lX-CD7" firstAttribute="leading" secondItem="y7t-k2-AgA" secondAttribute="leading" id="ZZq-Y8-qmh"/>
-                        <constraint firstAttribute="bottom" secondItem="be9-lX-CD7" secondAttribute="bottom" id="zzz-rJ-cDv"/>
-                    </constraints>
-                </view>
+                </stackView>
                 <stackView hidden="YES" opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="33" translatesAutoresizingMaskIntoConstraints="NO" id="DIz-pa-QD0" userLabel="Loading Container View">
                     <rect key="frame" x="20" y="331.33333333333331" width="374" height="73.333333333333314"/>
                     <subviews>
@@ -135,14 +123,14 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="y7t-k2-AgA" secondAttribute="bottom" id="1eg-oJ-DKt"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="DIz-pa-QD0" secondAttribute="trailing" constant="20" id="LAe-0c-dgq"/>
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="W40-bk-aVZ"/>
-                <constraint firstItem="y7t-k2-AgA" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="Wnu-bP-bRf"/>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="y7t-k2-AgA" secondAttribute="trailing" id="iN8-nW-KD8"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="Bt3-aY-FXs" secondAttribute="bottom" id="ee4-MG-0Sv"/>
+                <constraint firstItem="Bt3-aY-FXs" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="j7y-Kw-vJ1"/>
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" constant="20" id="nhC-Ak-j1v"/>
+                <constraint firstItem="Bt3-aY-FXs" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="o0Y-HU-o3a"/>
                 <constraint firstItem="DIz-pa-QD0" firstAttribute="centerY" secondItem="i5M-Pr-FkT" secondAttribute="centerY" id="oBH-mC-Zzj"/>
-                <constraint firstItem="y7t-k2-AgA" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="w4M-aZ-bPI"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="Bt3-aY-FXs" secondAttribute="trailing" id="vZ2-gp-0Lf"/>
             </constraints>
             <point key="canvasLocation" x="-794" y="135"/>
         </view>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.xib
@@ -69,7 +69,7 @@
                             </subviews>
                             <edgeInsets key="layoutMargins" top="12" left="20" bottom="0.0" right="20"/>
                         </stackView>
-                        <view tag="7" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="X4F-fc-WqY" userLabel="Button Container View">
                             <rect key="frame" x="0.0" y="670" width="414" height="66"/>
                             <subviews>
                                 <button opaque="NO" contentMode="scaleToFill" layoutMarginsFollowReadableWidth="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="5kh-rf-B5P" customClass="FancyButton" customModule="WordPressUI">


### PR DESCRIPTION
Fixes #17774

## Description
Fixes an issue where the Follow Topics screen displayed a bar of unused space at the bottom of the screen. In Dark mode this bar has different color so is clearly visible.

<p align="center">
  <img width=40%  src="https://user-images.githubusercontent.com/25306722/155309467-518ea90a-dd02-4f1b-8e36-ba593f23d7cb.png">
</p>

## Root Cause
The issue resides in `ReaderSelectInterestsViewController`. This view controller displays a collection of topics. And in some cases a button gets displayed at the bottom of the screen. When not needed the button is hidden. However its container view stays unhidden, causing the issue.

## Solution
The simplified view hierarchy of the screen (omitting some unrelated views):  
Content Container View (UIView) >
…… StackView containing collection view
…… Button Container View >
………… Button

Now we hide the button container view instead of the button, and the “Content Container View” is now a `UIStackView` to handle the hiding of the encapsulated view (Button Container View) gracefully, instead of having to programmatically modify constraints.

<img src="https://user-images.githubusercontent.com/25306722/155308765-5186b02c-b318-4203-84cc-76daf02c994a.png" width=32%> <img src="https://user-images.githubusercontent.com/25306722/155308802-3c077ad6-dd92-4e3a-9a6e-50fee6d25c0d.png" width=32%> <img src="https://user-images.githubusercontent.com/25306722/155308809-818d84d2-b7c6-4074-9ffc-0e524e1cb2dc.png" width=32%>

## Testing Instructions
The affected view is displayed in three separate scenarios:

### Scenario 1 (Managing followed topics):
1. Put the device in dark mode
2. Go to the Reader tab
3. Tap ⚙️
4. Tap Discover more topics
5. There should not be an empty space at the bottom of the screen.

### Scenario 2 (Discover tab when not following any topics):
1. Go to the Reader tab
2. Tap ⚙️
3. Make sure to unfollow all topics
4. Tap Done
5. Tap Discover
6. Collection of topics should be displayed and a button properly displayed at the bottom of the screen above the tab bar.

### Scenario 3 (Grow audience stats card):
1. Before building the app, go to `SiteStatsPinnedItemStore.swift` and make the following adjustments:
    1. Change the value of `lowSiteViewsCountThreshold` to be `Int.max`
    2. Modify the lazy var `items` to return an array of only one item which is `GrowAudienceCell.HintType.readerDiscover`
3. Put the device in dark mode
4. Tap on Stats
5. In the first card, tap on “Discover blogs to follow”
6. There should not be an empty space at the bottom of the screen.

## Regression Notes
1. Potential unintended areas of impact
The Follow Topics screen is displayed in multiple scenarios, not just the one outlined in the issue.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested all scenarios where the screen is displayed (scenarios mentioned in previous section).

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
