### PR TITLE
My Site Dashboard: handle auto-update

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -42,6 +42,7 @@ final class BlogDashboardViewController: UIViewController {
         setupNavigation()
         setupCollectionView()
         addHeightObservers()
+        addWillEnterForegroundObserver()
         viewModel.viewDidLoad()
 
         // Force the view to update its layout immediately, so the content size is calculated correctly
@@ -91,8 +92,21 @@ final class BlogDashboardViewController: UIViewController {
         NotificationCenter.default.addObserver(self, selector: #selector(self.updateCollectionViewHeight(notification:)), name: .postCardTableViewSizeChanged, object: nil)
     }
 
+    private func addWillEnterForegroundObserver() {
+        NotificationCenter.default.addObserver(self, selector: #selector(loadCards), name: UIApplication.willEnterForegroundNotification, object: nil)
+    }
+
     @objc private func updateCollectionViewHeight(notification: Notification) {
         collectionView.collectionViewLayout.invalidateLayout()
+    }
+
+    /// Load cards if view is appearing
+    @objc private func loadCards() {
+        guard view.superview != nil else {
+            return
+        }
+
+        viewModel.loadCards()
     }
 }
 


### PR DESCRIPTION
Part of #17873

Just like Android, this PR handles auto-updating the dashboard. The update always happens whenever:

* The app comes back from background
* The screen is show

Since no TTL nor specific logic were added in Android I'll keep the same approach here.

### To test

I recommend adding a breakpoint or `print` something on `BlogDashboardService.fetch`

1. Open the app
2. Tap "Home"
3. Check that the fetch happen
4. Tap Posts
5. Tap Back
6. The fetch happen
7. Put the app in the background
8. Bring it back
9. The fetch happen

#### Updating only when the dashboard is visible

1. Open the app
2. Tap "Home"
3. Tap "Site menu"
4. Put the app in the background
5. Bring it back
6. Fetch **should not** happen

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
