### PR TITLE
My Site Dashboard: Hide navigation title when scrolled to the top edge

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -217,7 +217,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func setupNavigationItem() {
-        navigationItem.largeTitleDisplayMode = .always
+        navigationItem.largeTitleDisplayMode = FeatureFlag.mySiteDashboard.enabled ? .never : .always
         navigationItem.title = NSLocalizedString("My Site", comment: "Title of My Site tab")
 
         // Workaround:
@@ -242,10 +242,18 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func setupTransparentNavBar() {
         navigationController?.navigationBar.scrollEdgeAppearance?.configureWithTransparentBackground()
+        if FeatureFlag.mySiteDashboard.enabled {
+            let transparentTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.clear]
+            navigationController?.navigationBar.scrollEdgeAppearance?.titleTextAttributes = transparentTitleAttributes
+        }
     }
 
     private func setupOpaqueNavBar() {
         navigationController?.navigationBar.scrollEdgeAppearance?.configureWithOpaqueBackground()
+        if FeatureFlag.mySiteDashboard.enabled {
+            let solidTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.appBarText]
+            navigationController?.navigationBar.scrollEdgeAppearance?.titleTextAttributes = solidTitleAttributes
+        }
     }
 
     // MARK: - Account

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -129,13 +129,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             showBlogDetailsForMainBlogOrNoSites()
         }
 
-        setupTransparentNavBar()
+        setupNavBarAppearance()
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        setupOpaqueNavBar()
+        resetNavBarAppearance()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -151,7 +151,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         trackNoSitesVisibleIfNeeded()
 
-        setupTransparentNavBar()
+        setupNavBarAppearance()
     }
 
     private func subscribeToContentSizeCategory() {
@@ -240,7 +240,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         navigationController?.navigationBar.accessibilityIdentifier = "my-site-navigation-bar"
     }
 
-    private func setupTransparentNavBar() {
+    private func setupNavBarAppearance() {
         navigationController?.navigationBar.scrollEdgeAppearance?.configureWithTransparentBackground()
         if FeatureFlag.mySiteDashboard.enabled {
             let transparentTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.clear]
@@ -248,12 +248,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
-    private func setupOpaqueNavBar() {
-        navigationController?.navigationBar.scrollEdgeAppearance?.configureWithOpaqueBackground()
-        if FeatureFlag.mySiteDashboard.enabled {
-            let solidTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.appBarText]
-            navigationController?.navigationBar.scrollEdgeAppearance?.titleTextAttributes = solidTitleAttributes
-        }
+    private func resetNavBarAppearance() {
+        WPStyleGuide.configureNavigationAppearance()
     }
 
     // MARK: - Account


### PR DESCRIPTION
Fixes #17882
Closes #18013 

## Description

Removes the large title for My Site Dashboard. The title now is only displayed if the user scrolls down.
This fixes an [issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/17882) with pull to refresh in landscape mode out of the box. The issue was caused by the large title.

### Note
The pull to refresh issue will still occur until the My Site Dashboard is rolled out. As discussed with @momo-ozawa, due to the low priority of the issue this should not be a concern.

## Testing Instructions

1. Make sure the MSD feature flag is enabled
2. Go to My Site
3. ✅ Notice that the Navigation title is not showing
4. Scroll down a bit
5. ✅ Notice that the Navigation title is now showing same as before
6. Scroll up to the top of the screen
7. ✅ Notice that the Navigation title is once again not showing
8. Switch the orientation to landscape
9. Try to pull down to refresh
10. ✅ Refreshing should work normally

https://user-images.githubusercontent.com/25306722/155447947-c0c83e57-8f46-4586-b9a0-20038d749a0b.MP4

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
