### PR TITLE
Prevent copy link notifications from piling up

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -557,7 +557,8 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         pasteboard.string = link as String
         let noticeTitle = NSLocalizedString("Link Copied to Clipboard", comment: "Link copied to clipboard notice title")
         let notice = Notice(title: noticeTitle, feedbackType: .success)
-        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
+        ActionDispatcher.dispatch(NoticeAction.dismiss) // Dismiss any old notices
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     fileprivate func retryPage(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AbstractPostListViewController.swift
@@ -1068,7 +1068,8 @@ class AbstractPostListViewController: UIViewController,
         pasteboard.string = link as String
         let noticeTitle = NSLocalizedString("Link Copied to Clipboard", comment: "Link copied to clipboard notice title")
         let notice = Notice(title: noticeTitle, feedbackType: .success)
-        ActionDispatcher.global.dispatch(NoticeAction.post(notice))
+        ActionDispatcher.dispatch(NoticeAction.dismiss) // Dismiss any old notices
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     @objc func promptThatPostRestoredToFilter(_ filter: PostListFilter) {


### PR DESCRIPTION
Fixes #18022

To test:
1. Go to the Pages/Posts screen
2. Tap the more(...) button on a page/post
3. Select copy
4. Quickly repeat from step 2 a few times
5. Verify that the link copied notifications do not pile up

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
The code change involves a minor UI fix that would be hard to unit test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
