### PR TITLE
My Site Dashboard: Fix Quick Actions horizontal scroll

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -3,8 +3,8 @@ import WordPressShared
 
 final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
 
-    private lazy var scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
+    private lazy var scrollView: ButtonScrollView = {
+        let scrollView = ButtonScrollView()
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.alwaysBounceHorizontal = false

--- a/WordPress/Classes/ViewRelated/Views/ButtonScrollView.swift
+++ b/WordPress/Classes/ViewRelated/Views/ButtonScrollView.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+/// Thiis UIScrollView subclass enables scrolling when the initial tap is inisde a UIButton.
+/// By default touches inisde a UIButton cancels the scrolling action. This subclass overrides this behavior.
+/// It's recommeneded to use this subclass when a scroll view is mainly populated by UIButtons.
+class ButtonScrollView: UIScrollView {
+
+    override func touchesShouldCancel(in view: UIView) -> Bool {
+        if view.isKind(of: UIButton.self) {
+          return true
+        }
+
+        return super.touchesShouldCancel(in: view)
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Views/ButtonScrollView.swift
+++ b/WordPress/Classes/ViewRelated/Views/ButtonScrollView.swift
@@ -1,8 +1,8 @@
 import UIKit
 
-/// Thiis UIScrollView subclass enables scrolling when the initial tap is inisde a UIButton.
-/// By default touches inisde a UIButton cancels the scrolling action. This subclass overrides this behavior.
-/// It's recommeneded to use this subclass when a scroll view is mainly populated by UIButtons.
+/// This UIScrollView subclass enables scrolling when the initial tap is inside a UIButton.
+/// By default touches inside a UIButton cancels the scrolling action. This subclass overrides this behavior.
+/// It's recommended to use this subclass when a scroll view is mainly populated by UIButtons.
 class ButtonScrollView: UIScrollView {
 
     override func touchesShouldCancel(in view: UIView) -> Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1338,6 +1338,8 @@
 		7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208520EAD918009C4699 /* FormattableUserContent.swift */; };
 		7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */; };
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
+		808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
+		808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -5995,6 +5997,7 @@
 		7EFF208520EAD918009C4699 /* FormattableUserContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableUserContent.swift; sourceTree = "<group>"; };
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
+		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -8023,6 +8026,7 @@
 				F18CB8952642E58700B90794 /* FixedSizeImageView.swift */,
 				FADFBD25265F580500039C41 /* MultilineButton.swift */,
 				FA1A5FD327A1A91F001A38D8 /* IntrinsicCollectionView.swift */,
+				808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -18233,6 +18237,7 @@
 				7E729C28209A087300F76599 /* ImageLoader.swift in Sources */,
 				3FAF9CC226D01CFE00268EA2 /* DomainsDashboardView.swift in Sources */,
 				73C8F06821BF1A5E00DDDF7E /* SiteAssemblyContentView.swift in Sources */,
+				808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */,
 				178DDD30266D7576006C68C4 /* BloggingRemindersFlowCompletionViewController.swift in Sources */,
 				5D146EBB189857ED0068FDC6 /* FeaturedImageViewController.m in Sources */,
 				98BAA7C326F925F70073A2F9 /* InlineEditableSingleLineCell.swift in Sources */,
@@ -20355,6 +20360,7 @@
 				FABB23BB2602FC2C00C8785C /* TableViewHeaderDetailView.swift in Sources */,
 				FABB23BC2602FC2C00C8785C /* MenuItemAbstractView.m in Sources */,
 				FABB23BD2602FC2C00C8785C /* LocationService.m in Sources */,
+				808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */,
 				FABB23BE2602FC2C00C8785C /* Domain.swift in Sources */,
 				FABB23BF2602FC2C00C8785C /* PostListViewController.swift in Sources */,
 				FABB23C02602FC2C00C8785C /* FeatureItemRow.swift in Sources */,


### PR DESCRIPTION
Part of #17874 
Ref: p1645562101459479-slack-C0290FLA0RM

## Description

Quick Actions section which is a horizontal scrollable view, becomes un-scrollable when tapping and holding one of the options.

## Root Cause

This happens because the touches are being tracked by the `UIButton` and not the `UIScrollView`.

## Solution

The key here is the function `touchesShouldCancel(in:)`. As per apple's documentation:

> Returns whether to cancel touches related to the content subview and start dragging.
> The scroll view calls this method just after it starts sending tracking messages to the content view. If it receives false from this method, it stops dragging and forwards the touch events to the content subview.

If the subview is a `UIControl` object (`UIButton` is a `UIControl` object), then it returns false. Meaning it doesn't cancel touches to UIButtons and never starts dragging.

The fix was to override this function to return true if the subview is a `UIButton`.

## Testing Instructions:

1. Make sure the MSD feature flag is enabled
2. Go to My Site
3. Switch to the dashboard
4. Try pressing and dragging any of the quick action items
5. ✅ The scrolling behavior should work normally.6. 6. 

https://user-images.githubusercontent.com/25306722/155610044-09ae4899-1b81-45b1-a910-ffa16a6a508f.MP4

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
