### PR TITLE
Docs: add FAB changes to the release-notes as an internal change

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 19.4
 -----
-* [*] [internal] The FAB (blue button to create posts/stories/pages) creation/life cycle was changed
+* [*] [internal] The FAB (blue button to create posts/stories/pages) creation/life cycle was changed [#18026]
 
 19.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 19.4
 -----
-
+* [*] [internal] The FAB (blue button to create posts/stories/pages) creation/life cycle was changed
 
 19.3
 -----


### PR DESCRIPTION
Following an idea to raise awareness on changes on existing features, I'm adding a note on the release notes about changes on the FAB.