### PR TITLE
My Site: track pull to refresh

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -215,6 +215,9 @@ import Foundation
     case domainsRegistrationFormSubmitted
     case domainsPurchaseWebviewViewed
 
+    // My Site
+    case mySitePullToRefresh
+
     // My Site: No sites view displayed
     case mySiteNoSitesViewDisplayed
     case mySiteNoSitesViewActionTapped
@@ -681,6 +684,10 @@ import Foundation
             return "domains_registration_form_submitted"
         case .domainsPurchaseWebviewViewed:
             return "domains_purchase_webview_viewed"
+
+        // My Site
+        case .mySitePullToRefresh:
+            return "my_site_pull_to_refresh"
 
         // My Site No Sites View
         case .mySiteNoSitesViewDisplayed:

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -331,6 +331,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
+        var pulledFrom: String
+
         switch section {
         case .siteMenu:
             blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
@@ -340,12 +342,17 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
                 self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
             }
+
+            pulledFrom = "site_menu"
         case .dashboard:
             blogDashboardViewController?.pulledToRefresh { [weak self] in
                 self?.refreshControl.endRefreshing()
             }
+
+            pulledFrom = "dashboard"
         }
 
+        WPAnalytics.track(.mySitePullToRefresh, properties: ["source": pulledFrom])
     }
 
     // MARK: - Segmented Control

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -16,6 +16,15 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 return NSLocalizedString("Home", comment: "Title for dashboard view on the My Site screen")
             }
         }
+
+        var analyticsDescription: String {
+            switch self {
+            case .siteMenu:
+                return "site_menu"
+            case .dashboard:
+                return "dashboard"
+            }
+        }
     }
 
     private var isShowingDashboard: Bool {
@@ -331,8 +340,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        var pulledFrom: String
-
         switch section {
         case .siteMenu:
             blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
@@ -343,16 +350,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
             }
 
-            pulledFrom = "site_menu"
         case .dashboard:
             blogDashboardViewController?.pulledToRefresh { [weak self] in
                 self?.refreshControl.endRefreshing()
             }
-
-            pulledFrom = "dashboard"
         }
 
-        WPAnalytics.track(.mySitePullToRefresh, properties: ["source": pulledFrom])
+        WPAnalytics.track(.mySitePullToRefresh, properties: ["source": section.analyticsDescription])
     }
 
     // MARK: - Segmented Control


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/17873

### To test

1. Open the app
3. On My Site, pull to refresh
4. Check that `my_site_pull_to_refresh <source: site_menu>` is fired
5. Tap "Home"
6. Pull to refresh
7. Check that `my_site_pull_to_refresh <source: dashboard>` is fired

If this works well, please validate this event on Tracks.

## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
