### PR TITLE
My Site Dashboard: update next post prompt when switching between sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -191,10 +191,14 @@ extension PostsCardViewController: PostsCardView {
     }
 
     func showNextPostPrompt() {
-        guard nextPostView == nil else {
+        guard nextPostView == nil ||
+              nextPostView?.hasPublishedPosts != hasPublishedPosts else {
             forceTableViewToRecalculateHeight()
             return
         }
+
+        self.nextPostView?.removeFromSuperview()
+        self.nextPostView = nil
 
         let nextPostView = BlogDashboardNextPostView()
         nextPostView.hasPublishedPosts = hasPublishedPosts


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/17875

Update the content of "next post" prompt when switching between sites with published posts and sites without published posts.

https://user-images.githubusercontent.com/7040243/155749100-ce05c664-fe48-4420-8ef8-8aa7e9bec231.mp4

### To test

For this test you'll need two sites:

1. One with a published posts and no drafts/scheduled
2. One without published posts, no drafts and no scheduled

Then:

1. Open the app
2. Tap "Home" to show the dashboard for one site
3. Switch to the other site
4. Make sure the content of the prompt is updated
5. Switch back to the previous site
6. Make sure the content of the prompt is updated

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
