### PR TITLE
My Site: Properly reset navigation bar appearance when disappearing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -269,7 +269,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func resetNavBarAppearance() {
-        WPStyleGuide.configureNavigationAppearance()
+        navigationController?.navigationBar.scrollEdgeAppearance = UINavigationBar.appearance().scrollEdgeAppearance
     }
 
     // MARK: - Account


### PR DESCRIPTION
Fixes #18037
This issue is a regression caused by #18018 

## Description
The navigation bar has an incorrect appearance when navigating to screens from MySIte (for example stats screen).

## Testing Instructions
1. Open My Site
2. Navigate to Stats
3. ✅ Observe that the color of the navigation bar is the default navbar color.

https://user-images.githubusercontent.com/25306722/155908213-e00d110f-46e8-495f-b860-ce38f1993a9d.MP4

## Regression Notes
1. Potential unintended areas of impact
Navbar appearance of view controllers being presented by the MySite screen. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually testing all presented views.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
