### PR TITLE
My Site: Fix navbar back transition animation

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -43,6 +43,8 @@ class BackupListViewController: BaseActivityListViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        extendedLayoutIncludesOpaqueBars = true
+
         tableView.accessibilityIdentifier = "jetpack-backup-table"
 
         WPAnalytics.track(.backupListOpened)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -156,6 +156,7 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
 
         WPStyleGuide.configureColors(view: view, tableView: tableView)
+        self.extendedLayoutIncludesOpaqueBars = true
 
         let nib = UINib(nibName: ActivityListSectionHeaderView.identifier, bundle: nil)
         tableView.register(nib, forHeaderFooterViewReuseIdentifier: ActivityListSectionHeaderView.identifier)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -156,7 +156,6 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
 
         WPStyleGuide.configureColors(view: view, tableView: tableView)
-        extendedLayoutIncludesOpaqueBars = true
 
         let nib = UINib(nibName: ActivityListSectionHeaderView.identifier, bundle: nil)
         tableView.register(nib, forHeaderFooterViewReuseIdentifier: ActivityListSectionHeaderView.identifier)

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -156,7 +156,7 @@ class BaseActivityListViewController: UIViewController, TableViewContainer, Immu
         tableView.estimatedRowHeight = Constants.estimatedRowHeight
 
         WPStyleGuide.configureColors(view: view, tableView: tableView)
-        self.extendedLayoutIncludesOpaqueBars = true
+        extendedLayoutIncludesOpaqueBars = true
 
         let nib = UINib(nibName: ActivityListSectionHeaderView.identifier, bundle: nil)
         tableView.register(nib, forHeaderFooterViewReuseIdentifier: ActivityListSectionHeaderView.identifier)

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -28,6 +28,8 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        extendedLayoutIncludesOpaqueBars = true
+
         WPAnalytics.track(.activityLogViewed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -71,6 +71,8 @@ extension BlogDetailsViewController: DomainCreditRedemptionSuccessViewController
 extension BlogDetailsViewController {
 
     @objc func makeDomainsDashboardViewController() -> UIViewController {
-        UIHostingController(rootView: DomainsDashboardView(blog: self.blog))
+        let viewController = UIHostingController(rootView: DomainsDashboardView(blog: self.blog))
+        viewController.extendedLayoutIncludesOpaqueBars = true
+        return viewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1520,6 +1520,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    controller.extendedLayoutIncludesOpaqueBars = YES;
     [self showDetailViewController:controller sender:self];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -70,6 +70,8 @@ import WordPressShared
 
         navigationItem.title = NSLocalizedString("Manage", comment: "Verb. Title of the screen for managing sharing buttons and settings related to sharing.")
 
+        extendedLayoutIncludesOpaqueBars = true
+
         if isModal() {
             navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done,
                                                                 target: self,

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -46,6 +46,8 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
     self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
     
+    self.extendedLayoutIncludesOpaqueBars = YES;
+    
     if (self.isModal) {
         self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                                target:self

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -122,6 +122,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     [self.tableView registerNib:MediaQuotaCell.nib forCellReuseIdentifier:MediaQuotaCell.defaultReuseIdentifier];
 
     self.navigationItem.title = NSLocalizedString(@"Settings", @"Title for screen that allows configuration of your blog/site settings.");
+    
+    self.extendedLayoutIncludesOpaqueBars = YES;
 
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleDataModelChange:)

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -88,6 +88,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)configureNavBar
 {
     self.title = NSLocalizedString(@"Comments", @"Title for the Blog's Comments Section View");
+
     self.extendedLayoutIncludesOpaqueBars = YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -88,6 +88,7 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)configureNavBar
 {
     self.title = NSLocalizedString(@"Comments", @"Title for the Blog's Comments Section View");
+    self.extendedLayoutIncludesOpaqueBars = YES;
 }
 
 - (void)configureLoadMoreSpinner

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -31,6 +31,8 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
 
         self.title = NSLocalizedString("Scan", comment: "Title of the view")
 
+        extendedLayoutIncludesOpaqueBars = true
+
         configureTableView()
         coordinator.viewDidLoad()
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -41,6 +41,7 @@ open class JetpackSettingsViewController: UITableViewController {
         super.viewDidLoad()
         WPAnalytics.trackEvent(.jetpackSettingsViewed)
         title = NSLocalizedString("Settings", comment: "Title for the Jetpack Security Settings Screen")
+        extendedLayoutIncludesOpaqueBars = true
         ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
         ImmuTable.registerRows([NavigationItemRow.self], tableView: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -90,6 +90,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         super.viewDidLoad()
 
         title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
+
         extendedLayoutIncludesOpaqueBars = true
 
         registerChangeObserver()

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -90,6 +90,7 @@ class MediaLibraryViewController: WPMediaPickerViewController {
         super.viewDidLoad()
 
         title = NSLocalizedString("Media", comment: "Title for Media Library section of the app.")
+        extendedLayoutIncludesOpaqueBars = true
 
         registerChangeObserver()
         registerUploadCoordinatorObserver()

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -83,6 +83,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
     self.navigationItem.title = NSLocalizedString(@"Menus", @"Title for screen that allows configuration of your site's menus");
     self.view.backgroundColor = [UIColor murielListBackground];
+
     self.extendedLayoutIncludesOpaqueBars = YES;
 
     self.scrollView.backgroundColor = self.view.backgroundColor;

--- a/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/MenusViewController.m
@@ -83,6 +83,7 @@ static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;
 
     self.navigationItem.title = NSLocalizedString(@"Menus", @"Title for screen that allows configuration of your site's menus");
     self.view.backgroundColor = [UIColor murielListBackground];
+    self.extendedLayoutIncludesOpaqueBars = YES;
 
     self.scrollView.backgroundColor = self.view.backgroundColor;
     self.scrollView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -550,6 +550,8 @@ private extension PeopleViewController {
     func setupView() {
         title = NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
 
+        extendedLayoutIncludesOpaqueBars = true
+
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))

--- a/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/PlanListViewController.swift
@@ -33,7 +33,7 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        WPStyleGuide.configureColors(view: view, tableView: tableView)
+        configureAppearance()
         ImmuTable.registerRows([PlanListRow.self], tableView: tableView)
         handler.viewModel = viewModel.tableViewModelWithPresenter(self)
         updateNoResults()
@@ -68,6 +68,11 @@ final class PlanListViewController: UITableViewController, ImmuTablePresenter {
         viewModel = .ready(allPlans, service.allPlanFeatures())
     }
 
+    func configureAppearance() {
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
+
+        extendedLayoutIncludesOpaqueBars = true
+    }
 
     // MARK: - ImmuTablePresenter
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -51,6 +51,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
     self.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
     self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+    self.extendedLayoutIncludesOpaqueBars = YES;
     
     UINavigationController *statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:nil] instantiateInitialViewController];
     self.siteStatsDashboardVC = statsNavVC.viewControllers.firstObject;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -51,6 +51,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
     self.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
     self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+
     self.extendedLayoutIncludesOpaqueBars = YES;
     
     UINavigationController *statsNavVC = [[UIStoryboard storyboardWithName:@"SiteStatsDashboard" bundle:nil] instantiateInitialViewController];


### PR DESCRIPTION
Fixes #18039

## Description

The navigation bar is distorted during the animation back to MySite from Stats, Activity Log, and many other screens. This is because the space behind an opaque navbar is empty so when the navbar disappears during the transition, the view behind it becomes visible.

## Solution

Setting `extendedLayoutIncludesOpaqueBars` to true means now the view of the view controller extends behind the navbar filling behind it. So when the navbar disappears the view is still showing behind it.  

## Testing Instructions
1. Go to MySIte 
2. Scroll down a bit
3. Go to Stats
4. Navigate back slowly by swiping left to right
5. ✅ Observe that the transition animation within the navbar is now smooth.
6. Repeat the above steps for all possible segues inside My Site.

Please test this in light and dark modes.

https://user-images.githubusercontent.com/25306722/155916141-106faf1f-5371-4c8b-a1fa-aefc0624da29.MP4

https://user-images.githubusercontent.com/25306722/155916167-4bcf6f93-c432-447f-895b-0daefe0db06c.MP4

## Regression Notes
1. Potential unintended areas of impact
The appearance of all the VCs affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested all VCs in light and dark mode.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
