### PR TITLE
Enable Insights Performance Improvements Feature Flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Site Creation: Fixed layout of domain input field for RTL languages. [#18006]
 * [*] [internal] The FAB (blue button to create posts/stories/pages) creation/life cycle was changed [#18026]
+8 [*] Stats: we fixed a variety of performance issues in the Insight screen. [#17926, #17936, #18017]
 
 19.3
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -82,7 +82,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .notificationCommentDetails:
             return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
         case .statsPerformanceImprovements:
-            return BuildConfiguration.current == .localDeveloper
+            return true
         }
     }
 


### PR DESCRIPTION
Fixes NA

This PR Enables the feature flag for the performance improvements we introduced in Insights

To test:

- Build/run this branch with any configuration and make sure the Insights performance improvements implemented in the following PRs are properly functioning.

Here's the list of PRs:

- #17926 
- #17936 
- #18017

## Regression Notes
1. Potential unintended areas of impact
none, just enabling a feature flag

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. - Updated
