### PR TITLE
Comment Edit: disable author fields for registered users

### DIFF
--- a/WordPress/Classes/Models/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment+CoreDataClass.swift
@@ -62,6 +62,11 @@ public class Comment: NSManagedObject {
         return !author_url.isEmpty
     }
 
+    func canEditAuthorData() -> Bool {
+        // If the authorID is zero, the user is unregistered. Therefore, the data can be edited.
+        return authorID == 0
+    }
+
     func hasParentComment() -> Bool {
         return parentID > 0
     }

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableSingleLineCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableSingleLineCell.swift
@@ -32,10 +32,11 @@ class InlineEditableSingleLineCell: UITableViewCell, NibReusable {
         configureCell()
     }
 
-    func configure(text: String? = nil, style: TextFieldStyle = .text) {
+    func configure(text: String? = nil, style: TextFieldStyle = .text, disabled: Bool = false) {
         textField.text = text
         textFieldStyle = style
         applyTextFieldStyle()
+        configureInteraction(disabled)
     }
 
     func showInvalidState(_ show: Bool = true) {
@@ -101,6 +102,11 @@ private extension InlineEditableSingleLineCell {
         }()
 
         delegate?.textUpdatedForCell(self)
+    }
+
+    func configureInteraction(_ disabled: Bool) {
+        isUserInteractionEnabled = !disabled
+        textField.textColor = disabled ? .neutral(.shade20) : .text
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/EditCommentTableViewController.swift
@@ -83,13 +83,15 @@ class EditCommentTableViewController: UITableViewController {
             return UITableViewCell()
         }
 
+        let editingDisabled = !comment.canEditAuthorData()
+
         switch tableSection {
         case TableSections.name:
-            cell.configure(text: updatedName)
+            cell.configure(text: updatedName, disabled: editingDisabled)
         case TableSections.webAddress:
-            cell.configure(text: updatedWebAddress, style: .url)
+            cell.configure(text: updatedWebAddress, style: .url, disabled: editingDisabled)
         case TableSections.emailAddress:
-            cell.configure(text: updatedEmailAddress, style: .email)
+            cell.configure(text: updatedEmailAddress, style: .email, disabled: editingDisabled)
         default:
             DDLogError("Edit Comment: unsupported table section.")
             break
@@ -100,12 +102,27 @@ class EditCommentTableViewController: UITableViewController {
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        // Make sure no SectionFooter is rendered
+        if needToShowRegisteredUserNotice(for: section) {
+            return UITableView.automaticDimension
+        }
+
         return CGFloat.leastNormalMagnitude
     }
 
+    override func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        if needToShowRegisteredUserNotice(for: section) {
+            return NSLocalizedString("\nThis user is registered. Their name, web address, and email address cannot be edited.",
+                                     comment: "Notice shown on the Edit Comment view when the author is a registered user.")
+        }
+
+        return nil
+    }
+
     override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
-        // Make sure no SectionFooter is rendered
+        if needToShowRegisteredUserNotice(for: section) {
+            return super.tableView(tableView, viewForFooterInSection: section)
+        }
+
         return nil
     }
 
@@ -210,6 +227,11 @@ private extension EditCommentTableViewController {
             comment.author_email != updatedEmailAddress ||
             comment.author_url != updatedWebAddress ||
             comment.contentForEdit() != updatedContent
+    }
+
+    func needToShowRegisteredUserNotice(for section: Int) -> Bool {
+        // The notice is shown in the footer of the Email Address section
+        return !comment.canEditAuthorData() && TableSections(rawValue: section) == .emailAddress
     }
 
     // MARK: - Table sections


### PR DESCRIPTION
Ref: #17000, Slack [conversation](P1645715119522879-slack-hummingbird)

If a comment author is a registered user, the author fields are disabled on the Edit Comment view.

To test:
- On a WP site:
  - Comment while logged out of WP.
  - Comment while being logged in to WP.
- In the app, go to My Site > Comments.
- Select each comment and Edit.
- Logged out comment:
  - Name, web address, email address are editable.
  - Registered user notice is not shown under the email address field. 
- Logged in comment:
  - Name, web address, email address are not editable and greyed out.
  - The registered user notice is shown under the email address field.


| Registered | Unregistered |
|--------|-------|
| ![registered](https://user-images.githubusercontent.com/1816888/156098455-d79b1dee-afa6-464e-8cf9-31dbee1fcb52.png) | ![unregistered](https://user-images.githubusercontent.com/1816888/156098460-455a1c44-1c59-44ea-bf6f-476208e48a73.png) |





## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
