### PR TITLE
FAB: fix floating notice when switching sites

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -183,6 +183,7 @@ import WordPressFlux
 
     func removeCreateButton() {
         button.removeFromSuperview()
+        noticeContainerView?.removeFromSuperview()
     }
 
     @objc func showCreateButton(for blog: Blog) {


### PR DESCRIPTION
When switching between different sites, the FAB notice was still being displayed as shown below:

https://user-images.githubusercontent.com/7040243/156216157-dfb59985-fb5f-4dc8-9f8e-9e9c89bfd60f.mp4

### To test

1. Remove the app from your device/simulator
2. Install again
3. Login
4. Make sure the "Create a post, page, or story" notice is appearing
5. Switch to another site
6. The notice will still be there but it won't appear on the top blocking the site switcher
 
## Regression Notes
1. Potential unintended areas of impact
-

3. What I did to test those areas of impact (or what existing automated tests I relied on)
-

4. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
