### PR TITLE
Notification Comment details: show loading and error views

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -11,7 +11,7 @@ let userInfoCommentIdKey = "commentID"
     func nextCommentSelected()
 }
 
-class CommentDetailViewController: UIViewController {
+class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // MARK: Properties
 
@@ -247,8 +247,18 @@ class CommentDetailViewController: UIViewController {
 
     // Update the Notification Comment being displayed.
     func refreshView(comment: Comment, notification: Notification) {
+        hideNoResults()
         self.notification = notification
         displayComment(comment)
+    }
+
+    // Show an empty view with the given values.
+    func showNoResultsView(title: String, subtitle: String? = nil, accessoryView: UIView? = nil) {
+        hideNoResults()
+        configureAndDisplayNoResults(on: tableView,
+                                     title: title,
+                                     subtitle: subtitle,
+                                     accessoryView: accessoryView)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -253,11 +253,12 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
     }
 
     // Show an empty view with the given values.
-    func showNoResultsView(title: String, subtitle: String? = nil, accessoryView: UIView? = nil) {
+    func showNoResultsView(title: String, subtitle: String? = nil, imageName: String? = nil, accessoryView: UIView? = nil) {
         hideNoResults()
         configureAndDisplayNoResults(on: tableView,
                                      title: title,
                                      subtitle: subtitle,
+                                     image: imageName,
                                      accessoryView: accessoryView)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -229,30 +229,37 @@ private extension NotificationCommentDetailViewController {
 
     func showLoadingView() {
         if let commentDetailViewController = commentDetailViewController {
-            commentDetailViewController.showNoResultsView(title: NoResultsText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
+            commentDetailViewController.showNoResultsView(title: NoResults.loadingTitle,
+                                                          accessoryView: NoResultsViewController.loadingAccessoryView())
         } else {
             hideNoResults()
             configureAndDisplayNoResults(on: view,
-                                         title: NoResultsText.loadingTitle,
+                                         title: NoResults.loadingTitle,
                                          accessoryView: NoResultsViewController.loadingAccessoryView())
         }
     }
 
     func showErrorView() {
         if let commentDetailViewController = commentDetailViewController {
-            commentDetailViewController.showNoResultsView(title: NoResultsText.errorTitle, subtitle: NoResultsText.errorSubtitle)
+            commentDetailViewController.showNoResultsView(title: NoResults.errorTitle,
+                                                          subtitle: NoResults.errorSubtitle,
+                                                          imageName: NoResults.imageName)
         } else {
             hideNoResults()
             configureAndDisplayNoResults(on: view,
-                                         title: NoResultsText.errorTitle,
-                                         subtitle: NoResultsText.errorSubtitle)
+                                         title: NoResults.errorTitle,
+                                         subtitle: NoResults.errorSubtitle,
+                                         image: NoResults.imageName)
+
+
         }
     }
 
-    struct NoResultsText {
+    struct NoResults {
         static let loadingTitle = NSLocalizedString("Loading comment...", comment: "Displayed while a comment is being loaded.")
         static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading a comment.")
         static let errorSubtitle = NSLocalizedString("There was an error loading the comment.", comment: "Text displayed when there is a failure loading a comment.")
+        static let imageName = "wp-illustration-notifications"
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class NotificationCommentDetailViewController: UIViewController {
+class NotificationCommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Properties
 
@@ -159,6 +159,8 @@ private extension NotificationCommentDetailViewController {
     }
 
     func loadComment() {
+        showLoadingView()
+
         fetchParentCommentIfNeeded(completion: { [weak self] in
             guard let self = self else {
                 return
@@ -169,13 +171,13 @@ private extension NotificationCommentDetailViewController {
                 return
             }
 
-            self.fetchComment(self.commentID, completion: { comment in
+            self.fetchComment(self.commentID, completion: { [weak self] comment in
                 guard let comment = comment else {
-                    // TODO: show error view
+                    self?.showErrorView()
                     return
                 }
 
-                self.comment = comment
+                self?.comment = comment
             })
         })
     }
@@ -184,7 +186,6 @@ private extension NotificationCommentDetailViewController {
         guard let commentID = commentID,
               let blog = blog else {
                   DDLogError("Notification Comment: unable to load comment due to missing information.")
-                  // TODO: show error view
                   return nil
               }
 
@@ -195,7 +196,6 @@ private extension NotificationCommentDetailViewController {
         guard let commentID = commentID,
               let blog = blog else {
                   DDLogError("Notification Comment: unable to fetch comment due to missing information.")
-                  // TODO: show error view
                   completion(nil)
                   return
               }
@@ -203,7 +203,6 @@ private extension NotificationCommentDetailViewController {
         commentService.loadComment(withID: commentID, for: blog, success: { comment in
             completion(comment)
         }, failure: { error in
-            // TODO: show error view
             completion(nil)
         })
     }
@@ -224,6 +223,36 @@ private extension NotificationCommentDetailViewController {
     struct Constants {
         static let arrowButtonSize: CGFloat = 24
         static let arrowButtonSpacing: CGFloat = 12
+    }
+
+    // MARK: - No Results Views
+
+    func showLoadingView() {
+        if let commentDetailViewController = commentDetailViewController {
+            commentDetailViewController.showNoResultsView(title: NoResultsText.loadingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
+        } else {
+            hideNoResults()
+            configureAndDisplayNoResults(on: view,
+                                         title: NoResultsText.loadingTitle,
+                                         accessoryView: NoResultsViewController.loadingAccessoryView())
+        }
+    }
+
+    func showErrorView() {
+        if let commentDetailViewController = commentDetailViewController {
+            commentDetailViewController.showNoResultsView(title: NoResultsText.errorTitle, subtitle: NoResultsText.errorSubtitle)
+        } else {
+            hideNoResults()
+            configureAndDisplayNoResults(on: view,
+                                         title: NoResultsText.errorTitle,
+                                         subtitle: NoResultsText.errorSubtitle)
+        }
+    }
+
+    struct NoResultsText {
+        static let loadingTitle = NSLocalizedString("Loading comment...", comment: "Displayed while a comment is being loaded.")
+        static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading a comment.")
+        static let errorSubtitle = NSLocalizedString("There was an error loading the comment.", comment: "Text displayed when there is a failure loading a comment.")
     }
 
 }


### PR DESCRIPTION
Ref: #17790 

When a comment is being loaded, a loading view is displayed. When loading a comment fails, an error view is displayed.

To test:
- Start with a fresh install so no comments are cached.
- Slow down your network connection.
- Go to Notifications.
- Select a Comment notification.
- Verify:
  - The loading view appears.
  - The loading view is removed when the comment is loaded.
  - NOTE: the gap at the top of the view as noted on [this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18049) is still present. This will be addressed later.
- Navigate to other notifications via the buttons on the nav bar.
- Verify:
  - The loading view appears.
  - The loading view is removed when the comment is loaded.
- Implement the hack below to show the error view.
- Select a Comment notification.
- Verify the error view appears.

Hack to test the error view. In `NotificationCommentDetailViewController`:
- Immediately `return nil` from `loadCommentFromCache`.
- `fetchComment` - call `completion(nil)` in the `success` block instead of `completion(comment)`.


| ![loading](https://user-images.githubusercontent.com/1816888/156253225-513e907d-f043-4a18-b138-4a68fdfb88ef.png) | ![error](https://user-images.githubusercontent.com/1816888/156254385-637c43ad-57c2-4919-87d5-fddc630345f5.png) |
|--------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
