### PR TITLE
Notification Comment details: remove gap at the top

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -149,7 +149,7 @@ private extension NotificationCommentDetailViewController {
                                                                       notificationDelegate: notificationDelegate,
                                                                       managedObjectContext: managedObjectContext)
 
-            commentDetailViewController.view.frame = view.frame
+            commentDetailViewController.view.translatesAutoresizingMaskIntoConstraints = false
             add(commentDetailViewController)
             view.pinSubviewToAllEdges(commentDetailViewController.view)
             self.commentDetailViewController = commentDetailViewController


### PR DESCRIPTION
Ref: #17790 , https://github.com/wordpress-mobile/WordPress-iOS/pull/18049#pullrequestreview-896464645
Depends on: #18062

This removes the gap that would sometimes appear at the top of the comment details view. It was most reproducable:
- In regular view - when navigating via the nav bar from a non-comment notification to a comment notification.
- In split view - when selecting a comment notification where the comment had to be fetched.

To test:
- Start with a fresh install.
- In regular view:
  - Go to Notifications. Select any notification.
  - Navigate through notifications via the nav bar buttons.
  - Verify comments notifications (cached and fetched) are displayed correctly.
- In split view:
  - Go to Notifications. Select comment notifications.
  - Verify cached and fetched are displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
