### PR TITLE
Notification Comment details: add tracks for actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -660,9 +660,11 @@ private extension CommentDetailViewController {
         }
 
         if comment.isLiked {
-            CommentAnalytics.trackCommentUnLiked(comment: comment)
+            isNotificationComment ? WPAppAnalytics.track(.notificationsCommentUnliked, withBlogID: notification?.metaSiteID) :
+                                    CommentAnalytics.trackCommentUnLiked(comment: comment)
         } else {
-            CommentAnalytics.trackCommentLiked(comment: comment)
+            isNotificationComment ? WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: notification?.metaSiteID) :
+                                    CommentAnalytics.trackCommentLiked(comment: comment)
         }
 
         commentService.toggleLikeStatus(for: comment, siteID: siteID, success: {}, failure: { _ in
@@ -739,7 +741,8 @@ extension CommentDetailViewController: CommentModerationBarDelegate {
 private extension CommentDetailViewController {
 
     func unapproveComment() {
-        CommentAnalytics.trackCommentUnApproved(comment: comment)
+        isNotificationComment ? WPAppAnalytics.track(.notificationsCommentUnapproved, withBlogID: notification?.metaSiteID) :
+                                CommentAnalytics.trackCommentUnApproved(comment: comment)
 
         commentService.unapproveComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.pendingSuccess)
@@ -751,7 +754,8 @@ private extension CommentDetailViewController {
     }
 
     func approveComment() {
-        CommentAnalytics.trackCommentApproved(comment: comment)
+        isNotificationComment ? WPAppAnalytics.track(.notificationsCommentApproved, withBlogID: notification?.metaSiteID) :
+                                CommentAnalytics.trackCommentApproved(comment: comment)
 
         commentService.approve(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.approveSuccess)
@@ -763,7 +767,8 @@ private extension CommentDetailViewController {
     }
 
     func spamComment() {
-        CommentAnalytics.trackCommentSpammed(comment: comment)
+        isNotificationComment ? WPAppAnalytics.track(.notificationsCommentFlaggedAsSpam, withBlogID: notification?.metaSiteID) :
+                                CommentAnalytics.trackCommentSpammed(comment: comment)
 
         commentService.spamComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.spamSuccess)
@@ -775,7 +780,8 @@ private extension CommentDetailViewController {
     }
 
     func trashComment() {
-        CommentAnalytics.trackCommentTrashed(comment: comment)
+        isNotificationComment ? WPAppAnalytics.track(.notificationsCommentTrashed, withBlogID: notification?.metaSiteID) :
+                                CommentAnalytics.trackCommentTrashed(comment: comment)
 
         commentService.trashComment(comment, success: { [weak self] in
             self?.showActionableNotice(title: ModerationMessages.trashSuccess)
@@ -993,7 +999,8 @@ private extension CommentDetailViewController {
     }
 
     @objc func createReply(content: String) {
-        CommentAnalytics.trackCommentRepliedTo(comment: comment)
+        isNotificationComment ? WPAppAnalytics.track(.notificationsCommentRepliedTo) :
+                                CommentAnalytics.trackCommentRepliedTo(comment: comment)
 
         guard let reply = commentService.createReply(for: comment) else {
             DDLogError("Failed creating comment reply.")


### PR DESCRIPTION
Ref: #17790 
Depends on: #18064

This adds event tracking specific to notification comments, replicated from `NotificationDetailsViewController`.

To test:
Perform the following actions. Verify the events logged.

Notification Comments:
- Like - `🔵 Tracked: notifications_comment_liked <blog_id: xxx, site_type: blog>`
- Unlike - `🔵 Tracked: notifications_comment_unliked <blog_id: xxx, site_type: blog>`
- Pending - `🔵 Tracked: notifications_comment_unapproved <blog_id: xxx, site_type: blog>`
- Approve - `🔵 Tracked: notifications_approved <blog_id: xxx, site_type: blog>`
- Spam - `🔵 Tracked: notifications_flagged_as_spam <blog_id: xxx, site_type: blog>`
- Trash - `🔵 Tracked: notifications_comment_trashed <blog_id: xxx, site_type: blog>`
- Reply - `🔵 Tracked: notifications_replied_to <>`

My Site Comments:

- Like - `🔵 Tracked: comment_liked <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Unlike - `🔵 Tracked: comment_unliked <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Pending - `🔵 Tracked: comment_unapproved <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Approve - `🔵 Tracked: comment_approved <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Spam - `🔵 Tracked: comment_spammed <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Trash - `🔵 Tracked: comment_trashed <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`
- Reply - `🔵 Tracked: comment_replied_to <blog_id: xxx, comment_id: yyy, context: sites, post_id: zzz, site_type: blog>`



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
