### PR TITLE
Notification Comment details: enable feature for release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,8 +1,9 @@
 19.4
 -----
+* [**] Comment Notifications: updated UI and functionality to match My Site Comments. [#18071]
 * [*] Site Creation: Fixed layout of domain input field for RTL languages. [#18006]
 * [*] [internal] The FAB (blue button to create posts/stories/pages) creation/life cycle was changed [#18026]
-8 [*] Stats: we fixed a variety of performance issues in the Insight screen. [#17926, #17936, #18017]
+* [*] Stats: we fixed a variety of performance issues in the Insight screen. [#17926, #17936, #18017]
 
 19.3
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -80,7 +80,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mediaPickerPermissionsNotice:
             return true
         case .notificationCommentDetails:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+            return true
         case .statsPerformanceImprovements:
             return true
         }


### PR DESCRIPTION
Ref: #17790 

This enables the new Comment details view for Comment Notifications.

To test:

TLDR - verify everything works as expected.
- Go to Notifications > comment notification.
- Verify the new details view is displayed.
- Verify Spam, Trash, and deleted comments are removed from the notifications list.
- Verify the ⬆️ and ⬇️ nav bar buttons display the previous and next notification.
- Verify Edit, Reply, and Like work as expected.

<kbd>![comment_details](https://user-images.githubusercontent.com/1816888/156462807-c6550566-38a3-409e-8567-c40ebf8e4d87.png)</kbd>

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Notification Comments and My Site Comments to be sure both work as expected.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
