### PR TITLE
Block Editor UI Tests enhancements

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Media/MediaPickerAlbumScreen.swift
@@ -20,6 +20,16 @@ public class MediaPickerAlbumScreen: ScreenObject {
         selectedImage.tap()
     }
 
+    public func selectMultipleImages(_ numberOfImages: Int) {
+        var index = 0
+        while index < numberOfImages {
+            selectImage(atIndex: index)
+            index += 1
+        }
+
+        app.buttons["SelectedActionButton"].tap()
+    }
+
     func insertSelectedImage() {
         app.buttons["SelectedActionButton"].tap()
     }

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -43,7 +43,7 @@ class EditorGutenbergTests: XCTestCase {
             .done()
     }
 
-    func testBasicPostPublish() throws {
+    func testBasicPostPublishWithCategoryAndTag() throws {
 
         let category = getCategory()
         let tag = getTag()

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -36,7 +36,7 @@ class EditorGutenbergTests: XCTestCase {
         try editorScreen
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
-            .verifyContentStructure(blocks: 1, words: 5, characters: 24)
+            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
             .publish()
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
@@ -51,7 +51,7 @@ class EditorGutenbergTests: XCTestCase {
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImage()
-            .verifyContentStructure(blocks: 2, words: 5, characters: 24)
+            .verifyContentStructure(blocks: 2, words: content.components(separatedBy: " ").count, characters: content.count)
             .openPostSettings()
             .selectCategory(name: category)
             .addTag(name: tag)
@@ -67,7 +67,7 @@ class EditorGutenbergTests: XCTestCase {
         try editorScreen
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
-            .verifyContentStructure(blocks: 1, words: 5, characters: 24)
+            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
             .openPostSettings()
             .setFeaturedImage()
             .verifyPostSettings(hasImage: true)
@@ -83,6 +83,6 @@ class EditorGutenbergTests: XCTestCase {
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImageGallery()
-            .verifyContentStructure(blocks: 5, words: 5, characters: 24)
+            .verifyContentStructure(blocks: 5, words: content.components(separatedBy: " ").count, characters: content.count)
     }
 }

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -11,6 +11,7 @@ class EditorGutenbergTests: XCTestCase {
         editorScreen = try EditorFlow
             .goToMySiteScreen()
             .tabBar.gotoBlockEditorScreen()
+            .dismissNotificationAlertIfNeeded(.accept)
     }
 
     override func tearDownWithError() throws {
@@ -27,14 +28,15 @@ class EditorGutenbergTests: XCTestCase {
         try super.tearDownWithError()
     }
 
+    let title = "Rich post title"
+    let content = "Some text, and more text"
+
     func testTextPostPublish() throws {
 
-        let title = "Text post title"
-        let content = "Text post content"
         try editorScreen
-            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
+            .verifyContentStructure(blocks: 1, words: 5, characters: 24)
             .publish()
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
@@ -43,28 +45,44 @@ class EditorGutenbergTests: XCTestCase {
 
     func testBasicPostPublish() throws {
 
-        let title = "Rich post title"
-        let content = "Some text, and more text"
         let category = getCategory()
         let tag = getTag()
         try editorScreen
-            .dismissNotificationAlertIfNeeded(.accept)
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImage()
+            .verifyContentStructure(blocks: 2, words: 5, characters: 24)
             .openPostSettings()
             .selectCategory(name: category)
             .addTag(name: tag)
-            .setFeaturedImage()
-            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: true)
-            .removeFeatureImage()
-            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: false)
-            .setFeaturedImage()
-            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: true)
             .closePostSettings()
         try BlockEditorScreen().publish()
             .viewPublishedPost(withTitle: title)
             .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
             .done()
+    }
+
+    func testAddRemoveFeaturedImage() throws {
+
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .verifyContentStructure(blocks: 1, words: 5, characters: 24)
+            .openPostSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .removeFeatureImage()
+            .verifyPostSettings(hasImage: false)
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+    }
+
+    func testAddGalleryBlock() throws {
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .addImageGallery()
+            .verifyContentStructure(blocks: 5, words: 5, characters: 24)
     }
 }


### PR DESCRIPTION
This PR aims to split the existing Block Editor UI Tests into smaller and more focused ones and adding new checks.

* `testBasicPostPublish()` is now covered by `testBasicPostPublish()` and `testAddRemoveFeaturedImage()`
* `testTextPostPublish()`, `testBasicPostPublish()` and `testAddRemoveFeaturedImage()` now have an additional check for content structure in order to add coverage for [issues like this](https://github.com/WordPress/gutenberg/issues/38287). 
* `testAddGalleryBlock()` was also added to cover the Gallery Block issue.

Test PR with multiple runs: https://github.com/wordpress-mobile/WordPress-iOS/pull/18074
Results: 20 runs, 19 Passed and 1 unrelated crash.