### PR TITLE
My Site Dashboard (Phase 2): Implement UI for Stats card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -76,7 +76,8 @@ class BlogDashboardCardFrameView: UIView {
     /// If set, the chevron image is displayed.
     var onViewTap: (() -> Void)? {
         didSet {
-            chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
+            updateChevronImageState()
+            addViewTapGestureIfNeeded()
         }
     }
 
@@ -85,8 +86,10 @@ class BlogDashboardCardFrameView: UIView {
     /// If set, the chevron image is displayed.
     var onHeaderTap: (() -> Void)? {
         didSet {
-            chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
+            updateChevronImageState()
+            addHeaderTapGestureIfNeeded()
         }
+
     }
 
     override init(frame: CGRect) {
@@ -130,14 +133,32 @@ class BlogDashboardCardFrameView: UIView {
             titleLabel,
             chevronImageView
         ])
+    }
 
-        // Add frame tap gesture
-        let frameTapGesture = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
-        self.addGestureRecognizer(frameTapGesture)
+    private func updateChevronImageState() {
+        chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
+    }
 
-        // Add header tap gesture
-        let tap = UITapGestureRecognizer(target: self, action: #selector(headerTapped))
-        headerStackView.addGestureRecognizer(tap)
+    private func addHeaderTapGestureIfNeeded() {
+        // Reset any previously added gesture recognizers
+        headerStackView.gestureRecognizers?.forEach {headerStackView.removeGestureRecognizer($0)}
+
+        // Add gesture recognizer if needed
+        if onHeaderTap != nil {
+            let tap = UITapGestureRecognizer(target: self, action: #selector(headerTapped))
+            headerStackView.addGestureRecognizer(tap)
+        }
+    }
+
+    private func addViewTapGestureIfNeeded() {
+        // Reset any previously added gesture recognizers
+        self.gestureRecognizers?.forEach {self.removeGestureRecognizer($0)}
+
+        // Add gesture recognizer if needed
+        if onViewTap != nil {
+            let frameTapGesture = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+            self.addGestureRecognizer(frameTapGesture)
+        }
     }
 
     @objc private func viewTapped() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -72,9 +72,20 @@ class BlogDashboardCardFrameView: UIView {
         }
     }
 
+    /// Closure to be called when anywhere in the view is tapped.
+    /// If set, the chevron image is displayed.
+    var onViewTap: (() -> Void)? {
+        didSet {
+            chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
+        }
+    }
+
+    /// Closure to be called when the header view is tapped.
+    /// If set, this overrides the `onViewTap` closure if the tap is inside the header.
+    /// If set, the chevron image is displayed.
     var onHeaderTap: (() -> Void)? {
         didSet {
-            chevronImageView.isHidden = onHeaderTap == nil
+            chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
         }
     }
 
@@ -120,13 +131,27 @@ class BlogDashboardCardFrameView: UIView {
             chevronImageView
         ])
 
-        // Add tap gesture
+        // Add frame tap gesture
+        let frameTapGesture = UITapGestureRecognizer(target: self, action: #selector(viewTapped))
+        self.addGestureRecognizer(frameTapGesture)
+
+        // Add header tap gesture
         let tap = UITapGestureRecognizer(target: self, action: #selector(headerTapped))
         headerStackView.addGestureRecognizer(tap)
     }
 
+    @objc private func viewTapped() {
+        onViewTap?()
+    }
+
     @objc private func headerTapped() {
-        onHeaderTap?()
+        if let onHeaderTap = onHeaderTap {
+            onHeaderTap()
+        }
+        else {
+            onViewTap?()
+        }
+
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -90,7 +90,7 @@ extension DashboardQuickActionsCardCell {
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
         trackQuickActionsEvent(.statsAccessed, blog: blog)
-        StatsViewController.show(for: blog, from: sourceController)
+        StatsViewController.show(for: blog, from: sourceController, showTodayStats: false)
     }
 
     private func showPostList(for blog: Blog, from sourceController: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
@@ -1,0 +1,68 @@
+import UIKit
+
+final class DashboardSingleStatView: UIView {
+
+    // MARK: Private Variables
+
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            numberLabel,
+            titleLabel
+        ])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+        stackView.distribution = .fill
+        stackView.spacing = Constants.mainStackViewSpacing
+        return stackView
+    }()
+
+    private lazy var numberLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .bold)
+        label.textColor = .text
+        return label
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        label.textColor = .textSubtle
+        return label
+    }()
+
+    // MARK: Initializers
+
+    convenience init(countString: String, title: String) {
+        self.init()
+        self.numberLabel.text = countString
+        self.titleLabel.text = title
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: Private Helpers
+
+    private func setupViews() {
+        addSubview(mainStackView)
+        pinSubviewToAllEdges(mainStackView)
+    }
+}
+
+// MARK: Constants
+
+private extension DashboardSingleStatView {
+
+    enum Constants {
+        static let mainStackViewSpacing = 2.0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -29,14 +29,14 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
 
 extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
-        guard let _ = viewController, let _ = apiResponse else {
+        guard let viewController = viewController else {
             return
         }
 
         // TODO: Use apiResponse to create a View Model and use it to populate the cell
 
         clearFrames()
-        addTodayStatsCard()
+        addTodayStatsCard(for: blog, in: viewController)
 
         // TODO: Add grow your audience card if needed
     }
@@ -46,14 +46,19 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         stackView.removeAllSubviews()
     }
 
-    private func addTodayStatsCard() {
+    private func addTodayStatsCard(for blog: Blog, in viewController: UIViewController) {
         let frameView = BlogDashboardCardFrameView()
         frameView.title = Strings.statsTitle
         frameView.icon = UIImage.gridicon(.statsAlt, size: Constants.iconSize)
-        stackView.addArrangedSubview(frameView)
+        frameView.onViewTap = { [weak self] in
+            self?.showStats(for: blog, from: viewController)
+        }
+
         let views = statsViews()
         let statsStackview = createStatsStackView(arrangedSubviews: views)
         frameView.add(subview: statsStackview)
+
+        stackView.addArrangedSubview(frameView)
     }
 
     private func createStatsStackView(arrangedSubviews: [UIView]) -> UIStackView {
@@ -73,6 +78,10 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         let visitorsStatsView = DashboardSingleStatView(countString: "885", title: Strings.visitorsTitle)
         let likesStatsView = DashboardSingleStatView(countString: "112", title: Strings.likesTitle)
         return [viewsStatsView, visitorsStatsView, likesStatsView]
+    }
+
+    private func showStats(for blog: Blog, from sourceController: UIViewController) {
+        StatsViewController.show(for: blog, from: sourceController)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -81,7 +81,7 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     }
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
-        StatsViewController.show(for: blog, from: sourceController)
+        StatsViewController.show(for: blog, from: sourceController, showTodayStats: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -37,8 +37,6 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
 
         clearFrames()
         addTodayStatsCard(for: blog, in: viewController)
-
-        // TODO: Add grow your audience card if needed
     }
 
     /// Remove any card frame, if present
@@ -72,7 +70,6 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     }
 
     // TODO: Data is now static. It should be brought in from the view model.
-    // View model should also return data for comments in the case of an iPad.
     private func statsViews() -> [UIView] {
         let viewsStatsView = DashboardSingleStatView(countString: "1,492", title: Strings.viewsTitle)
         let visitorsStatsView = DashboardSingleStatView(countString: "885", title: Strings.visitorsTitle)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -1,7 +1,96 @@
 import UIKit
 
-class DashboardStatsCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+class DashboardStatsCardCell: UICollectionViewCell, Reusable {
 
+    // MARK: Private Variables
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = Constants.spacing
+        return stackView
+    }()
+
+    // MARK: Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        contentView.addSubview(stackView)
+        contentView.pinSubviewToAllEdges(stackView)
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+// MARK: BlogDashboardCardConfigurable
+
+extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        guard let _ = viewController, let _ = apiResponse else {
+            return
+        }
+
+        // TODO: Use apiResponse to create a View Model and use it to populate the cell
+
+        clearFrames()
+        addTodayStatsCard()
+
+        // TODO: Add grow your audience card if needed
+    }
+
+    /// Remove any card frame, if present
+    private func clearFrames() {
+        stackView.removeAllSubviews()
+    }
+
+    private func addTodayStatsCard() {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.title = Strings.statsTitle
+        frameView.icon = UIImage.gridicon(.statsAlt, size: Constants.iconSize)
+        stackView.addArrangedSubview(frameView)
+        let views = statsViews()
+        let statsStackview = createStatsStackView(arrangedSubviews: views)
+        frameView.add(subview: statsStackview)
+    }
+
+    private func createStatsStackView(arrangedSubviews: [UIView]) -> UIStackView {
+        let stackview = UIStackView(arrangedSubviews: arrangedSubviews)
+        stackview.axis = .horizontal
+        stackview.translatesAutoresizingMaskIntoConstraints = false
+        stackview.distribution = .fillEqually
+        stackview.isLayoutMarginsRelativeArrangement = true
+        stackview.directionalLayoutMargins = Constants.statsStackViewMargins
+        return stackview
+    }
+
+    // TODO: Data is now static. It should be brought in from the view model.
+    // View model should also return data for comments in the case of an iPad.
+    private func statsViews() -> [UIView] {
+        let viewsStatsView = DashboardSingleStatView(countString: "1,492", title: Strings.viewsTitle)
+        let visitorsStatsView = DashboardSingleStatView(countString: "885", title: Strings.visitorsTitle)
+        let likesStatsView = DashboardSingleStatView(countString: "112", title: Strings.likesTitle)
+        return [viewsStatsView, visitorsStatsView, likesStatsView]
+    }
+}
+
+// MARK: Constants
+
+private extension DashboardStatsCardCell {
+
+    enum Strings {
+        static let statsTitle = NSLocalizedString("Today's Stats", comment: "Title for the card displaying today's stats.")
+        static let viewsTitle = NSLocalizedString("Views", comment: "Today's Stats 'Views' label")
+        static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
+        static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
+        static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
+    }
+
+    enum Constants {
+        static let spacing: CGFloat = 20
+        static let iconSize = CGSize(width: 18, height: 18)
+        static let statsStackViewMargins = NSDirectionalEdgeInsets(top: 16, leading: 16, bottom: 16, trailing: 16)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -79,6 +79,13 @@ class SiteStatsDashboardViewController: UIViewController {
         return button
     }()
 
+    // MARK: Public Functions
+
+    /// When called, the initial selected `StatsPeriodType` is set to days instead of insights.
+    @objc public func forceShowStatsForTodayPeriod() {
+        self.currentSelectedPeriod = .days
+    }
+
     // MARK: - View
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
@@ -6,6 +6,8 @@
 @property (nonatomic, weak) Blog *blog;
 @property (nonatomic, copy) void (^dismissBlock)(void);
 
-+ (void)showForBlog:(nonnull Blog *)blog from:(nonnull UIViewController *)controller;
++ (void)showForBlog:(nonnull Blog *)blog
+               from:(nonnull UIViewController *)controller
+     showTodayStats:(BOOL)showTodayStats;
 
 @end

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -17,6 +17,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 @property (nonatomic, assign) BOOL showingJetpackLogin;
 @property (nonatomic, assign) BOOL isActivatingStatsModule;
+@property (nonatomic, assign) BOOL shouldForceShowTodayStats;
 @property (nonatomic, strong) SiteStatsDashboardViewController *siteStatsDashboardVC;
 @property (nonatomic, weak) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIActivityIndicatorView *loadingIndicator;
@@ -35,11 +36,14 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     return self;
 }
 
-+ (void)showForBlog:(Blog *)blog from:(UIViewController *)controller
++ (void)showForBlog:(nonnull Blog *)blog
+               from:(nonnull UIViewController *)controller
+     showTodayStats:(BOOL)showTodayStats
 {
     StatsViewController *statsController = [StatsViewController new];
     statsController.blog = blog;
     statsController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    statsController.shouldForceShowTodayStats = showTodayStats;
     [controller.navigationController pushViewController:statsController animated:YES];
     
     [[QuickStartTourGuide shared] visited:QuickStartTourElementStats];
@@ -101,6 +105,9 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     [self addChildViewController:self.siteStatsDashboardVC];
     [self.view addSubview:self.siteStatsDashboardVC.view];
     [self.siteStatsDashboardVC didMoveToParentViewController:self];
+    if (self.shouldForceShowTodayStats) {
+        [self.siteStatsDashboardVC forceShowStatsForTodayPeriod];
+    }
 }
 
 - (void) installWidgetsButton

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1338,6 +1338,8 @@
 		7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208520EAD918009C4699 /* FormattableUserContent.swift */; };
 		7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */; };
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
+		8071390727D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
+		8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
@@ -6006,6 +6008,7 @@
 		7EFF208520EAD918009C4699 /* FormattableUserContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableUserContent.swift; sourceTree = "<group>"; };
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
+		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
 		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
@@ -11574,6 +11577,7 @@
 			isa = PBXGroup;
 			children = (
 				8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */,
+				8071390627D039E70012DB21 /* DashboardSingleStatView.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -17732,6 +17736,7 @@
 				D8A3A5B3206A49BF00992576 /* StockPhotosMedia.swift in Sources */,
 				176BB87F20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift in Sources */,
 				E6805D321DCD399600168E4F /* WPRichTextMediaAttachment.swift in Sources */,
+				8071390727D039E70012DB21 /* DashboardSingleStatView.swift in Sources */,
 				C81CCD64243AECA100A83E27 /* TenorMediaObject.swift in Sources */,
 				B5C0CF3D204DA41000DB0362 /* NotificationReplyStore.swift in Sources */,
 				AE2F3128270B6DE200B2A9C2 /* NSMutableAttributedString+ApplyAttributesToQuotes.swift in Sources */,
@@ -20788,6 +20793,7 @@
 				FABB25182602FC2C00C8785C /* NoticeStyle.swift in Sources */,
 				FABB25192602FC2C00C8785C /* NotificationSettings.swift in Sources */,
 				FABB251A2602FC2C00C8785C /* HeaderContentStyles.swift in Sources */,
+				8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */,
 				FABB251B2602FC2C00C8785C /* Revision.swift in Sources */,
 				FABB251C2602FC2C00C8785C /* PluginDirectoryAccessoryItem.swift in Sources */,
 				FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */,


### PR DESCRIPTION
Part of #17876

## Description
- Adds UI for today's stats card with dummy data.
- Shows Stats VC when the stats card is tapped.

<img src="https://user-images.githubusercontent.com/25306722/156480320-5c9cda33-9568-4db7-afeb-a6c5747ecf8c.png" width=49%> <img src="https://user-images.githubusercontent.com/25306722/156480336-843e2a98-b7c7-4176-9cf8-1048b7f7081b.png" width=49%>

## Testing Instructions

Make sure the MSD feature flag is enabled

1. Tap "Home" on the segmented control to display the dashboard
2. Make sure the UI of the stats card is correct
3. Toggle the device's appearance (Light/Dark)
4. Make sure the UI of the stats card is correct
5. Tap anywhere in the stats card
6. Make sure the stats VC is displayed, with the Today tab selected.

Other areas to test:
- Make sure navigating to stats VC from anywhere else, shows Insights as the initially selected tab
- Make sure that tapping on the header of posts cards is not affected.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
