### PR TITLE
Jetpack App: update Post Signup Interstitial welcome text

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -34,6 +34,10 @@ import WordPressAuthenticator
 // MARK: - Localized Strings
 extension AppConstants {
 
+    struct PostSignUpInterstitial {
+        static let welcomeTitleText = NSLocalizedString("Welcome to WordPress", comment: "Post Signup Interstitial Title Text for WordPress iOS")
+    }
+
     struct Settings {
         static let aboutTitle: String = {
             if FeatureFlag.aboutScreen.enabled {

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -13,11 +13,6 @@ extension NSNotification.Name {
 
 private struct Constants {
     // I18N Strings
-    static let welcomeTitleText = NSLocalizedString(
-        "Welcome to WordPress",
-        comment: "Post Signup Interstitial Title Text"
-    )
-
     static let subTitleText = NSLocalizedString(
         "Whatever you want to create or share, we'll help you do it right here.",
         comment: "Post Signup Interstitial Subtitle Text"
@@ -116,7 +111,7 @@ class PostSignUpInterstitialViewController: UIViewController {
 
     // MARK: - Private
     private func configureI18N() {
-        welcomeLabel.text = Constants.welcomeTitleText
+        welcomeLabel.text = AppConstants.PostSignUpInterstitial.welcomeTitleText
         subTitleLabel.text = Constants.subTitleText
         createSiteButton.setTitle(Constants.createSiteButtonTitleText, for: .normal)
         addSelfHostedButton.setTitle(Constants.addSelfHostedButtonTitleText, for: .normal)

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -34,6 +34,10 @@ import WordPressKit
 // MARK: - Localized Strings
 extension AppConstants {
 
+    struct PostSignUpInterstitial {
+        static let welcomeTitleText = NSLocalizedString("Welcome to Jetpack", comment: "Post Signup Interstitial Title Text for Jetpack iOS")
+    }
+
     struct Settings {
         static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
     }


### PR DESCRIPTION
Fixes #18078 

## Description
- Updates the welcome text to "Welcome to Jetpack" for Jetpack app

## How to test

### Jetpack
1. Sign up for a new account on the Jetpack iOS app
2. ✅ Notice that the welcome text is "Welcome to Jetpack"

### WordPress
1. Sign up for a new account on the WordPress iOS app
2. ✅ Notice that the welcome text is "Welcome to WordPress"

![IMG_1501](https://user-images.githubusercontent.com/6711616/156569467-ece9d129-f0c4-409f-950e-260b4dc9db71.PNG) | ![IMG_CE352CD430C0-1](https://user-images.githubusercontent.com/6711616/156569334-4f06d60f-1e0c-4626-bd2b-925aed6067c3.jpeg)
-- | --


## Regression Notes
1. Potential unintended areas of impact
WordPress PSI welcome text

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
