### PR TITLE
Notification Comment details: set background color to fix transition oddity

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -83,6 +83,7 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
     override func viewDidLoad() {
         super.viewDidLoad()
         title = notification.title
+        view.backgroundColor = .basicBackground
         loadComment()
     }
 


### PR DESCRIPTION
Ref: #17790, https://github.com/wordpress-mobile/WordPress-iOS/pull/18064#pullrequestreview-898691061

This sets a background color on `NotificationCommentDetailViewController` to fix the issue where the Notifications list could be seen as the Comment loading view was transitioning in.

⚠️ Auto merge is enabled. ⚠️ 

To test:
- Go to Notifications.
- Select a Comment notification where the comment is not cached.
- Verify, as the loading view is transitioning in, the Notifications list cannot be seen underneath.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
