### PR TITLE
My Site Dashboard: add wpComID to DashboardCardModel

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -14,19 +14,19 @@ class BlogDashboardService {
     /// Fetch cards from remote
     func fetch(blog: Blog, completion: @escaping (DashboardSnapshot) -> Void, failure: (() -> Void)? = nil) {
 
-        guard let dotComID = blog.dotComID?.intValue else {
+        guard let wpComID = blog.dotComID?.intValue else {
             return
         }
 
         let cardsToFetch: [String] = DashboardCard.remoteCases.map { $0.rawValue }
 
-        remoteService.fetch(cards: cardsToFetch, forBlogID: dotComID, success: { [weak self] cardsDictionary in
+        remoteService.fetch(cards: cardsToFetch, forBlogID: wpComID, success: { [weak self] cardsDictionary in
 
             if let cards = self?.decode(cardsDictionary) {
 
-                self?.persistence.persist(cards: cardsDictionary, for: dotComID)
+                self?.persistence.persist(cards: cardsDictionary, for: wpComID)
 
-                guard let snapshot = self?.parse(cardsDictionary, cards: cards, blog: blog) else {
+                guard let snapshot = self?.parse(cardsDictionary, cards: cards, blog: blog, wpComID: wpComID) else {
                     return
                 }
 
@@ -42,14 +42,18 @@ class BlogDashboardService {
 
     /// Fetch cards from local
     func fetchLocal(blog: Blog) -> DashboardSnapshot {
-        if let dotComID = blog.dotComID?.intValue,
-            let cardsDictionary = persistence.getCards(for: dotComID),
+
+        guard let wpComID = blog.dotComID?.intValue else {
+            return DashboardSnapshot()
+        }
+
+        if let cardsDictionary = persistence.getCards(for: wpComID),
             let cards = decode(cardsDictionary) {
 
-            let snapshot = parse(cardsDictionary, cards: cards, blog: blog)
+            let snapshot = parse(cardsDictionary, cards: cards, blog: blog, wpComID: wpComID)
             return snapshot
         } else {
-            return localCardsAndGhostCards(blog: blog)
+            return localCardsAndGhostCards(blog: blog, wpComID: wpComID)
         }
     }
 }
@@ -57,7 +61,7 @@ class BlogDashboardService {
 private extension BlogDashboardService {
     /// We use the `BlogDashboardRemoteEntity` to inject it into cells
     /// The `NSDictionary` is used for `Hashable` purposes
-    func parse(_ cardsDictionary: NSDictionary, cards: BlogDashboardRemoteEntity, blog: Blog) -> DashboardSnapshot {
+    func parse(_ cardsDictionary: NSDictionary, cards: BlogDashboardRemoteEntity, blog: Blog, wpComID: Int) -> DashboardSnapshot {
         var snapshot = DashboardSnapshot()
 
         DashboardCard.allCases
@@ -67,7 +71,10 @@ private extension BlogDashboardService {
             if card.isRemote {
                 if let viewModel = cardsDictionary[card.rawValue] {
                     let section = DashboardCardSection(id: card)
-                    let item = DashboardCardModel(id: card, hashableDictionary: viewModel as? NSDictionary, entity: cards)
+                    let item = DashboardCardModel(id: card,
+                                                  wpComID: wpComID,
+                                                  hashableDictionary: viewModel as? NSDictionary,
+                                                  entity: cards)
 
                     snapshot.appendSections([section])
                     snapshot.appendItems([item], toSection: section)
@@ -79,7 +86,7 @@ private extension BlogDashboardService {
                 }
 
                 let section = DashboardCardSection(id: card)
-                let item = DashboardCardModel(id: card)
+                let item = DashboardCardModel(id: card, wpComID: wpComID)
 
                 snapshot.appendSections([section])
                 snapshot.appendItems([item], toSection: section)
@@ -100,21 +107,22 @@ private extension BlogDashboardService {
         return try? decoder.decode(BlogDashboardRemoteEntity.self, from: data)
     }
 
-    func localCardsAndGhostCards(blog: Blog) -> DashboardSnapshot {
-        var snapshot = localCards(blog: blog)
+    func localCardsAndGhostCards(blog: Blog, wpComID: Int) -> DashboardSnapshot {
+        var snapshot = localCards(blog: blog, wpComID: wpComID)
 
         let section = DashboardCardSection(id: .ghost)
 
         snapshot.appendSections([section])
         Array(0...4).forEach {
             snapshot.appendItems([DashboardCardModel(id: .ghost,
+                                                     wpComID: wpComID,
                                                      hashableDictionary: ["diff": $0])], toSection: section)
         }
 
         return snapshot
     }
 
-    func localCards(blog: Blog) -> DashboardSnapshot {
-        parse([:], cards: BlogDashboardRemoteEntity(), blog: blog)
+    func localCards(blog: Blog, wpComID: Int) -> DashboardSnapshot {
+        parse([:], cards: BlogDashboardRemoteEntity(), blog: blog, wpComID: wpComID)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Represents a card in the dashboard collection view
 struct DashboardCardModel: Hashable {
     let id: DashboardCard
-    let wpComID: Int
+    let dotComID: Int
     let apiResponse: BlogDashboardRemoteEntity?
 
     /// Used as the `Hashable` to compare this `struct` to others
@@ -21,22 +21,22 @@ struct DashboardCardModel: Hashable {
                 view. The `hashableDictionary` and the `id` is used to differentiate one
                 card from the other.
     */
-    init(id: DashboardCard, wpComID: Int, hashableDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
+    init(id: DashboardCard, dotComID: Int, hashableDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
         self.id = id
-        self.wpComID = wpComID
+        self.dotComID = dotComID
         self.hashableDictionary = hashableDictionary
         self.apiResponse = entity
     }
 
     static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {
         lhs.id == rhs.id &&
-        lhs.wpComID == rhs.wpComID &&
+        lhs.dotComID == rhs.dotComID &&
         lhs.hashableDictionary == rhs.hashableDictionary
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
-        hasher.combine(wpComID)
+        hasher.combine(dotComID)
         hasher.combine(hashableDictionary)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -3,6 +3,7 @@ import Foundation
 /// Represents a card in the dashboard collection view
 struct DashboardCardModel: Hashable {
     let id: DashboardCard
+    let wpComID: Int
     let apiResponse: BlogDashboardRemoteEntity?
 
     /// Used as the `Hashable` to compare this `struct` to others
@@ -20,19 +21,22 @@ struct DashboardCardModel: Hashable {
                 view. The `hashableDictionary` and the `id` is used to differentiate one
                 card from the other.
     */
-    init(id: DashboardCard, hashableDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
+    init(id: DashboardCard, wpComID: Int, hashableDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {
         self.id = id
+        self.wpComID = wpComID
         self.hashableDictionary = hashableDictionary
         self.apiResponse = entity
     }
 
     static func == (lhs: DashboardCardModel, rhs: DashboardCardModel) -> Bool {
         lhs.id == rhs.id &&
+        lhs.wpComID == rhs.wpComID &&
         lhs.hashableDictionary == rhs.hashableDictionary
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+        hasher.combine(wpComID)
         hasher.combine(hashableDictionary)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardCardModel.swift
@@ -14,11 +14,12 @@ struct DashboardCardModel: Hashable {
 
      - Parameters:
      - id: The `DashboardCard` id of this card
+     - dotComID: The blog id for the blog associated with this card
      - hashableDictionary: A `NSDictionary?` that is used to compare this model to others
      - entity: A `BlogDashboardRemoteEntity?` property
 
      - Returns: A `DashboardCardModel` that is used by the dashboard diffable collection
-                view. The `hashableDictionary` and the `id` is used to differentiate one
+                view. The `hashableDictionary`, `id`, and the `dotComID` is used to differentiate one
                 card from the other.
     */
     init(id: DashboardCard, dotComID: Int, hashableDictionary: NSDictionary? = nil, entity: BlogDashboardRemoteEntity? = nil) {


### PR DESCRIPTION
Part of #17873 

## Description
This fixes an issue where the Quick Actions buttons weren’t being udpated when switching blogs.

Adding `wpComID` to the `DashboardCardModel` lets diffable data source know that the Quick Action buttons for site A are different from the buttons for site B.

## How to test

Make sure the MSD feature flag is enabled 

1. On site A, go to the "Home" tab
2. Tap the Quick Action buttons and take note of what's displayed when you tap through each button
3. ✅ The Stats, Posts, Media, and Pages buttons should reflect the stats, posts, media, pages data for site A
4. Switch to site B
5. Tap the Quick Action buttons and take note of what's displayed when you tap through each button
6. ✅ The Stats, Posts, Media, and Pages buttons should reflect the stats, posts, media, pages data for site B


https://user-images.githubusercontent.com/6711616/156751017-d16ca3d0-8f61-440a-8085-77a7cf7884d4.mp4


## Regression Notes
1. Potential unintended areas of impact
n/a

7. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

8. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
