### PR TITLE
My Site Dashboard: remove provisional loading indicator

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -52,8 +52,15 @@ final class BlogDashboardViewController: UIViewController {
         QuickStartTourGuide.shared.currentTourOrigin = .blogDashboard
     }
 
+    /// If you want to give any feedback when the dashboard
+    /// started loading just change this method.
+    /// For not, it will be transparent
+    ///
     func showLoading() { }
 
+    /// If you want to give any feedback when the dashboard
+    /// stops loading just change this method.
+    ///
     func stopLoading() { }
 
     func update(blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -20,10 +20,6 @@ final class BlogDashboardViewController: UIViewController {
         return collectionView
     }()
 
-    lazy var activityIndicatorView: UIActivityIndicatorView = {
-        UIActivityIndicatorView()
-    }()
-
     @objc init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)
@@ -56,16 +52,9 @@ final class BlogDashboardViewController: UIViewController {
         QuickStartTourGuide.shared.currentTourOrigin = .blogDashboard
     }
 
-    func showLoading() {
-        view.addSubview(activityIndicatorView)
-        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewAtCenter(activityIndicatorView)
-        activityIndicatorView.startAnimating()
-    }
+    func showLoading() { }
 
-    func stopLoading() {
-        activityIndicatorView.stopAnimating()
-    }
+    func stopLoading() { }
 
     func update(blog: Blog) {
         self.blog = blog


### PR DESCRIPTION
Part of #17873

Removes the provisional loading indicator that appears over the dashboard content.

As [per this comment](https://github.com/wordpress-mobile/WordPress-iOS/issues/17873#issuecomment-1058306079), we decided to not show feedback to the user when the dashboard is automatically updating.

_Important: I kept the methods in case we want to iterate over that in the future, then it will be easier._

### To test

1. Run the app
2. Tap Home
3. Notice that there's no loading indicator on the top of the dashboard content
4. Switch blogs
5. Notice that there's no loading indicator
6. Pull to refresh
7. You should see the loading indicator feedback at the top

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
