### PR TITLE
Stats Insights: Align Tracks events with Android

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -108,8 +108,10 @@ import Foundation
     case statsReaderDiscoverNudgeDismissed
     case statsReaderDiscoverNudgeCompleted
 
-    // Stats - Customize card
+    // Stats - Insights
     case statsCustomizeInsightsShown
+    case statsInsightsManagementSaved
+    case statsInsightsManagementDismissed
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -497,9 +499,13 @@ import Foundation
         case .statsReaderDiscoverNudgeCompleted:
             return "stats_reader_discover_nudge_completed"
 
-        // Stats - Customize card
+        // Stats - Insights
         case .statsCustomizeInsightsShown:
             return "stats_customize_insights_shown"
+        case .statsInsightsManagementSaved:
+            return "stats_insights_management_saved"
+        case .statsInsightsManagementDismissed:
+            return "stats_insights_management_dismissed"
 
         // What's New - Feature announcements
         case .featureAnnouncementShown:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -61,6 +61,7 @@ class AddInsightTableViewController: UITableViewController {
     }
 
     @objc private func doneTapped() {
+        WPAnalytics.trackEvent(.statsInsightsManagementDismissed)
         dismiss(animated: true, completion: nil)
     }
 }
@@ -97,6 +98,8 @@ private extension AddInsightTableViewController {
         return { [unowned self] row in
             self.selectedStat = statSection
             self.insightsDelegate?.addInsightSelected?(statSection)
+
+            WPAnalytics.track(.statsInsightsManagementSaved, properties: ["types": [statSection.title]])
             self.dismiss(animated: true, completion: nil)
         }
     }


### PR DESCRIPTION
This PR adds functionality to align some iOS stats insight management flows with Android

Fixes #18077

To test adding a card:
1. Go to Stats screen and then click Insights tab
2. Tap the cog (gear) icon and add a new stats card
3. Track event should show in Xcode console like below with the insight type title:

```
Tracked: stats_insights_management_saved <types: (
    "All-Time"
)>

```
To test clicking the Cog + add and dismissing with no changes:
1. Go to Stats screen and then click Insights tab
2. Tap the cog (gear) icon
3. Dismiss the Add new stats card screen
4. Track event should show in Xcode console like below with the following:

`Tracked: stats_insights_management_dismissed`

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
