### PR TITLE
My Site: scroll My Site screen to top when My Site tab is tapped

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+Helpers.swift
@@ -15,21 +15,16 @@ extension UINavigationController {
     @objc func scrollContentToTopAnimated(_ animated: Bool) {
         guard viewControllers.count == 1 else { return }
 
-        let scrollToTop = { (scrollView: UIScrollView) in
-            let offset = CGPoint(x: 0, y: -scrollView.contentInset.top)
-            scrollView.setContentOffset(offset, animated: animated)
-        }
-
         if let topViewController = topViewController as? WPScrollableViewController {
             topViewController.scrollViewToTop()
         } else if let scrollView = topViewController?.view as? UIScrollView {
             // If the view controller's view is a scrollview
-            scrollToTop(scrollView)
+            scrollView.scrollToTop(animated: animated)
         } else if let scrollViews = topViewController?.view.subviews.filter({ $0 is UIScrollView }) as? [UIScrollView] {
             // If one of the top level views of the view controller's view
             // is a scrollview
             if let scrollView = scrollViews.first {
-                scrollToTop(scrollView)
+                scrollView.scrollToTop(animated: animated)
             }
         }
     }


### PR DESCRIPTION
Fixes #18089

## Description
- Fixes an issue where tapping on the My Site tab wasn't scrolling the My Site view up to the very top, when you're already on the My Site tab with the view scrolled down

## How to test

Test on both iPhone and iPad

1. Scroll down a bit on My Site
2. Tap again on the My Site tab
3. The view scrolls all the way to the top, and the site switcher is visible


https://user-images.githubusercontent.com/6711616/156794175-928cbec9-84f8-4a28-bc06-e09090dc4842.mp4


https://user-images.githubusercontent.com/6711616/156794005-10e5e09e-ef68-41c5-bd64-9652a4721362.mp4


## Regression Notes
1. Potential unintended areas of impact
Notifications tab (conforms to WPScrollableViewController)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested the above manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
