### PR TITLE
My Site Dashboard: improve how `invalidateLayout` is called

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -269,6 +269,8 @@ extension NSNotification.Name {
 }
 
 private class PostCardTableView: UITableView {
+    private var previousHeight: CGFloat = 0
+
     override var contentSize: CGSize {
         didSet {
             self.invalidateIntrinsicContentSize()
@@ -279,7 +281,10 @@ private class PostCardTableView: UITableView {
     /// This allows subscribers to update their layouts (ie.: UICollectionViews)
     override var intrinsicContentSize: CGSize {
         layoutIfNeeded()
-        NotificationCenter.default.post(name: .postCardTableViewSizeChanged, object: nil)
+        if contentSize.height != previousHeight {
+            previousHeight = contentSize.height
+            NotificationCenter.default.post(name: .postCardTableViewSizeChanged, object: nil)
+        }
         return CGSize(width: UIView.noIntrinsicMetric, height: contentSize.height)
     }
 }


### PR DESCRIPTION
Part of #17873

Whenever the list of posts changes, we fire a notification so the `UICollectionView` can `invalidateLayout`.

The way this was done, it was causing this notification to be fired over and over again, even if the height didn't change at all.

This PR checks if the height indeed changed before firing the notification.

Although this might be not the final solution yet, it's one big step ahead.

### To test

On `BlogDashboardViewController.updateCollectionViewHeight` add a `print` statement, such as:

```swift
    @objc private func updateCollectionViewHeight(notification: Notification) {
        print("$$ invalidateLayout")
        collectionView.collectionViewLayout.invalidateLayout()
    }
```

I recommend keeping two instances of Xcode so you can compare the number of calls. Then:

1. Run the app
2. Tap Home
3. Add/remove posts and make sure the card update its height
4. Switch blogs

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
