### PR TITLE
My Site Dashboard (Phase 2): Set default section on My Site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -57,7 +57,7 @@ enum DashboardCard: String, CaseIterable {
         case .quickActions:
             return true
         case .quickStart:
-            return QuickStartTourGuide.shouldShowChecklist(for: blog) && mySiteSettings.defaultSection() == .dashboard
+            return QuickStartTourGuide.shouldShowChecklist(for: blog) && mySiteSettings.defaultSection == .dashboard
         case .posts:
             return true
         case .todaysStats:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -52,12 +52,12 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    func shouldShow(for blog: Blog) -> Bool {
+    func shouldShow(for blog: Blog, mySiteSettings: MySiteSettings = MySiteSettings()) -> Bool {
         switch self {
         case .quickActions:
             return true
         case .quickStart:
-            return QuickStartTourGuide.shouldShowChecklist(for: blog)
+            return QuickStartTourGuide.shouldShowChecklist(for: blog) && mySiteSettings.defaultSection() == .dashboard
         case .posts:
             return true
         case .todaysStats:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension BlogDetailsViewController {
 
-    @objc func dashboardIsEnabled() -> Bool {
+    @objc func isDashboardEnabled() -> Bool {
         return FeatureFlag.mySiteDashboard.enabled && blog.isAccessibleThroughWPCom()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension BlogDetailsViewController {
 
-    @objc func shouldShowDashboard() -> Bool {
+    @objc func dashboardIsEnabled() -> Bool {
         return FeatureFlag.mySiteDashboard.enabled && blog.isAccessibleThroughWPCom()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -81,7 +81,16 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowQuickStartChecklist() -> Bool {
-        return QuickStartTourGuide.shouldShowChecklist(for: blog) && !shouldShowDashboard()
+        if shouldShowDashboard() {
+
+            guard let parentVC = parent as? MySiteViewController else {
+                return false
+            }
+
+            return QuickStartTourGuide.shouldShowChecklist(for: blog) && parentVC.mySiteSettings.defaultSection() == .siteMenu
+        }
+
+        return QuickStartTourGuide.shouldShowChecklist(for: blog)
     }
 
     @objc func showQuickStartCustomize() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -81,7 +81,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowQuickStartChecklist() -> Bool {
-        if shouldShowDashboard() {
+        if dashboardIsEnabled() {
 
             guard let parentVC = parent as? MySiteViewController else {
                 return false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -81,7 +81,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowQuickStartChecklist() -> Bool {
-        if dashboardIsEnabled() {
+        if isDashboardEnabled() {
 
             guard let parentVC = parent as? MySiteViewController else {
                 return false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -80,6 +80,14 @@ extension BlogDetailsViewController {
         }
     }
 
+    @objc func shouldShowDashboard() -> Bool {
+        guard let parentVC = parent as? MySiteViewController, isDashboardEnabled() else {
+            return false
+        }
+
+        return parentVC.mySiteSettings.defaultSection == .dashboard
+    }
+
     @objc func shouldShowQuickStartChecklist() -> Bool {
         if isDashboardEnabled() {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -87,7 +87,7 @@ extension BlogDetailsViewController {
                 return false
             }
 
-            return QuickStartTourGuide.shouldShowChecklist(for: blog) && parentVC.mySiteSettings.defaultSection() == .siteMenu
+            return QuickStartTourGuide.shouldShowChecklist(for: blog) && parentVC.mySiteSettings.defaultSection == .siteMenu
         }
 
         return QuickStartTourGuide.shouldShowChecklist(for: blog)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -21,6 +21,8 @@ extension BlogDetailsSubsection {
             return .configure
         case .jetpackSettings:
             return .jetpack
+        case .home:
+            return .home
         @unknown default:
             fatalError()
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -36,7 +36,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionComments,
     BlogDetailsSubsectionSharing,
     BlogDetailsSubsectionPeople,
-    BlogDetailsSubsectionPlugins
+    BlogDetailsSubsectionPlugins,
+    BlogDetailsSubsectionHome,
 };
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -731,7 +731,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self shouldShowQuickStartChecklist]) {
         [marr addObject:[self quickStartSectionViewModel]];
     }
-    if ([self shouldShowDashboard] && ![self splitViewControllerIsHorizontallyCompact]) {
+    if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact]) {
         [marr addObject:[self homeSectionViewModel]];
     }
     if (([self.blog supports:BlogFeatureActivity] && ![self.blog isWPForTeams]) || [self.blog supports:BlogFeatureJetpackSettings]) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -450,6 +450,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     switch (section) {
         case BlogDetailsSubsectionReminders:
         case BlogDetailsSubsectionDomainCredit:
+        case BlogDetailsSubsectionHome:
+            self.restorableSelectedIndexPath = indexPath;
+            [self.tableView selectRowAtIndexPath:indexPath
+                                        animated:NO
+                                  scrollPosition:[self optimumScrollPositionForIndexPath:indexPath]];
+            [self showDashboard];
+            break;
         case BlogDetailsSubsectionQuickStart:
             self.restorableSelectedIndexPath = indexPath;
             [self.tableView selectRowAtIndexPath:indexPath
@@ -556,6 +563,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     NSInteger section = [self findSectionIndexWithSections:self.tableSections category:sectionCategory];
     switch (subsection) {
         case BlogDetailsSubsectionReminders:
+        case BlogDetailsSubsectionHome:
+            return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionDomainCredit:
             return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionQuickStart:
@@ -1081,8 +1090,12 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self splitViewControllerIsHorizontallyCompact]) {
         return;
     }
-    
-    [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
+
+    if ([self shouldShowDashboard]) {
+        [self showDetailViewForSubsection:BlogDetailsSubsectionHome];
+    } else {
+        [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
+    }
 }
 
 #pragma mark - Table view data source

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// A helper class for My Site that manages the default section to display
+///
+final class MySiteSettings {
+
+    private let userDefaults: UserDefaults
+
+    // MARK: - Init
+
+    init(userDefaults: UserDefaults = .standard) {
+        self.userDefaults = userDefaults
+    }
+
+    func defaultSection() -> MySiteViewController.Section {
+        let rawValue = userDefaults.integer(forKey: Constants.defaultSectionKey)
+        return MySiteViewController.Section(rawValue: rawValue) ?? .siteMenu
+    }
+
+    func setDefaultSection(_ tab: MySiteViewController.Section) {
+        userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)
+    }
+
+    private enum Constants {
+        static let defaultSectionKey = "MySiteDefaultSectionKey"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -6,15 +6,15 @@ final class MySiteSettings {
 
     private let userDefaults: UserDefaults
 
+    var defaultSection: MySiteViewController.Section {
+        let rawValue = userDefaults.integer(forKey: Constants.defaultSectionKey)
+        return MySiteViewController.Section(rawValue: rawValue) ?? .siteMenu
+    }
+
     // MARK: - Init
 
     init(userDefaults: UserDefaults = .standard) {
         self.userDefaults = userDefaults
-    }
-
-    func defaultSection() -> MySiteViewController.Section {
-        let rawValue = userDefaults.integer(forKey: Constants.defaultSectionKey)
-        return MySiteViewController.Section(rawValue: rawValue) ?? .siteMenu
     }
 
     func setDefaultSection(_ tab: MySiteViewController.Section) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -4,25 +4,25 @@ import SwiftUI
 
 class MySiteViewController: UIViewController, NoResultsViewHost {
 
-    private enum Section: Int, CaseIterable {
-        case siteMenu
+    enum Section: Int, CaseIterable {
         case dashboard
+        case siteMenu
 
         var title: String {
             switch self {
-            case .siteMenu:
-                return NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen")
             case .dashboard:
                 return NSLocalizedString("Home", comment: "Title for dashboard view on the My Site screen")
+            case .siteMenu:
+                return NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen")
             }
         }
 
         var analyticsDescription: String {
             switch self {
-            case .siteMenu:
-                return "site_menu"
             case .dashboard:
                 return "dashboard"
+            case .siteMenu:
+                return "site_menu"
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -102,7 +102,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         if FeatureFlag.mySiteDashboard.enabled {
             // TODO: A/B test default section
-            mySiteSettings.setDefaultSection(.dashboard)
+            mySiteSettings.setDefaultSection(.siteMenu)
         }
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -63,7 +63,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         let segmentedControl = UISegmentedControl(items: Section.allCases.map { $0.title })
         segmentedControl.translatesAutoresizingMaskIntoConstraints = false
         segmentedControl.addTarget(self, action: #selector(segmentedControlValueChanged(_:)), for: .valueChanged)
-        segmentedControl.selectedSegmentIndex = 0
+        segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
         return segmentedControl
     }()
 
@@ -219,7 +219,14 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func updateSegmentedControl(for blog: Blog) {
         // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device is an iPad
-        segmentedControlContainerView.isHidden = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || !splitViewControllerIsHorizontallyCompact
+        let hideSegmentedControl = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || !splitViewControllerIsHorizontallyCompact
+
+        segmentedControlContainerView.isHidden = hideSegmentedControl
+
+        if !hideSegmentedControl {
+            segmentedControl.selectedSegmentIndex = mySiteSettings.defaultSection().rawValue
+            segmentedControl.sendActions(for: .valueChanged)
+        }
     }
 
     private func setupView() {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -91,12 +91,19 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private let meScenePresenter: ScenePresenter
     private let blogService: BlogService
+    private(set) var mySiteSettings: MySiteSettings
 
     // MARK: - Initializers
 
-    init(meScenePresenter: ScenePresenter, blogService: BlogService? = nil) {
+    init(meScenePresenter: ScenePresenter, blogService: BlogService? = nil, mySiteSettings: MySiteSettings = MySiteSettings()) {
         self.meScenePresenter = meScenePresenter
         self.blogService = blogService ?? BlogService(managedObjectContext: ContextManager.shared.mainContext)
+        self.mySiteSettings = mySiteSettings
+
+        if FeatureFlag.mySiteDashboard.enabled {
+            // TODO: A/B test default section
+            mySiteSettings.setDefaultSection(.siteMenu)
+        }
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -102,7 +102,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         if FeatureFlag.mySiteDashboard.enabled {
             // TODO: A/B test default section
-            mySiteSettings.setDefaultSection(.siteMenu)
+            mySiteSettings.setDefaultSection(.dashboard)
         }
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -224,7 +224,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         segmentedControlContainerView.isHidden = hideSegmentedControl
 
         if !hideSegmentedControl {
-            segmentedControl.selectedSegmentIndex = mySiteSettings.defaultSection().rawValue
+            segmentedControl.selectedSegmentIndex = mySiteSettings.defaultSection.rawValue
             segmentedControl.sendActions(for: .valueChanged)
         }
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2797,6 +2797,8 @@
 		FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
+		FA4F383627D766020068AAF5 /* MySiteSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F383527D766020068AAF5 /* MySiteSettings.swift */; };
+		FA4F383727D766020068AAF5 /* MySiteSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F383527D766020068AAF5 /* MySiteSettings.swift */; };
 		FA4F65A72594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */; };
 		FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */; };
 		FA4F661425946B8500EAA9F5 /* JetpackRestoreHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */; };
@@ -7587,6 +7589,7 @@
 		FA41070D263957C000E90EBF /* JetpackBackupOptionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsScreen.swift; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
+		FA4F383527D766020068AAF5 /* MySiteSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySiteSettings.swift; sourceTree = "<group>"; };
 		FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreOptionsViewController.swift; sourceTree = "<group>"; };
 		FA4F660425946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreHeaderView.swift; sourceTree = "<group>"; };
 		FA4F661325946B8500EAA9F5 /* JetpackRestoreHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = JetpackRestoreHeaderView.xib; sourceTree = "<group>"; };
@@ -8245,6 +8248,7 @@
 				1716AEFB25F2927600CF49EC /* MySiteViewController.swift */,
 				FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */,
 				F56A33322538C0ED00E2AEF3 /* MySiteViewController+FAB.swift */,
+				FA4F383527D766020068AAF5 /* MySiteSettings.swift */,
 			);
 			path = "My Site";
 			sourceTree = "<group>";
@@ -17709,6 +17713,7 @@
 				FF1FD0242091268900186384 /* URL+LinkNormalization.swift in Sources */,
 				3234BB082530D7DC0068DA40 /* ReaderTopicService+SiteInfo.swift in Sources */,
 				B5326E6F203F554D007392C3 /* WordPressSupportSourceTag+Helpers.swift in Sources */,
+				FA4F383627D766020068AAF5 /* MySiteSettings.swift in Sources */,
 				9AF724EF2146813C00F63A61 /* ParentPageSettingsViewController.swift in Sources */,
 				1759F1701FE017BF0003EC81 /* Queue.swift in Sources */,
 				B56A70181B5040B9001D5815 /* SwitchTableViewCell.swift in Sources */,
@@ -19887,6 +19892,7 @@
 				FABB21F52602FC2C00C8785C /* PostNoticeNavigationCoordinator.swift in Sources */,
 				FABB21F62602FC2C00C8785C /* SearchableActivityConvertable.swift in Sources */,
 				FABB21F72602FC2C00C8785C /* GridCell.swift in Sources */,
+				FA4F383727D766020068AAF5 /* MySiteSettings.swift in Sources */,
 				C72A4F68264088E4009CA633 /* JetpackNotFoundErrorViewModel.swift in Sources */,
 				FABB21F82602FC2C00C8785C /* AdaptiveNavigationController.swift in Sources */,
 				FABB21F92602FC2C00C8785C /* RemotePostCategory+Extensions.swift in Sources */,


### PR DESCRIPTION
Part of #17877 

## Description
- Added a `MySiteSettings` helper class that manages the default section for My Site
- Updated the site menu and the dashboard to show Quick Start based on the default section
- Updated the segmented control order
    1. Dashboard
    2. Site menu

## How to test

⚠️ Please test each scenario on both iPhone and iPad

### MSD disabled
1. Disable MSD feature flag
2. Enable Quick Start via Me > App Settings > Debug > Enable Quick Start for site
3. ✅ Make sure Quick Start is displayed on the site menu

<img src="https://user-images.githubusercontent.com/6711616/157236711-17d17ffc-cf62-4545-ab44-7b3c0497358e.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/157236714-ad4a2927-378c-4476-b656-bd35ca090ee7.png" width=200>
-- | --


### MSD enabled, default section == site menu

1. Enable MSD feature flag
2. Enable Quick Start via Me > App Settings > Debug > Enable Quick Start for site
3. ✅ For iPhone only: Make sure the segmented control order is [Home, Site Menu]
4. ✅ Make sure Quick Start is displayed on the site menu
5. Tap on "Home"
6. ✅ Make sure Quick Start is NOT displayed in the dashboard

<img src="https://user-images.githubusercontent.com/6711616/157236756-5f18e340-9053-4d77-9947-ed50b3c013e4.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/157236760-2a9d827f-6ed1-4465-a6e1-252ae8f8a8c0.png" width=200>
-- | --


### MSD enabled, default section == dashboard

1. Change`MySiteViewController.swift L105` to `mySiteSettings.setDefaultSection(.dashboard)`
2. Enable MSD feature flag
3. Enable Quick Start via Me > App Settings > Debug > Enable Quick Start for site
4. ✅ For iPhone only: Make sure the segmented control order is [Home, Site Menu]
5. ✅ Make sure Quick Start is NOT displayed on the site menu
6. Tap on "Home"
7. ✅ Make sure Quick Start is displayed in the dashboard

<img src="https://user-images.githubusercontent.com/6711616/157237255-1cc35834-32ac-4a58-8870-f6ae71876928.png" width=300> | <img src="https://user-images.githubusercontent.com/6711616/157237373-8c8f40c9-154f-45ca-98d5-e350fa068c1f.png" width=200>
-- | --


## Regression Notes
4. Potential unintended areas of impact
- Switching sites for MSD (https://github.com/wordpress-mobile/WordPress-iOS/pull/17829)

5. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested steps from https://github.com/wordpress-mobile/WordPress-iOS/pull/17829

7. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
