### PR TITLE
Quick Start: update release notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 19.5
 -----
 * [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-iOS/pull/17985]
+* [*] Quick Start: updated the design for the Quick Start cell on My Site [#18095]
 
 19.4
 -----


### PR DESCRIPTION
Part of #17877 

## Description
- Updated release notes to include design update for Quick Start cell

## Notes
- I realized I forgot to update the release notes in https://github.com/wordpress-mobile/WordPress-iOS/pull/18095

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
