### PR TITLE
Reader: Fix unsatisfiable constraints

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.m
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.m
@@ -4,7 +4,6 @@
 
 @interface PostListFooterView()
 
-@property (nonatomic, strong) IBOutlet UIView *bannerView;
 @property (nonatomic, strong) IBOutlet UIActivityIndicatorView *activityView;
 
 @end
@@ -16,8 +15,6 @@
     [super awakeFromNib];
 
     self.backgroundColor = [UIColor clearColor];
-    self.bannerView.backgroundColor = [UIColor murielNeutral0];
-    self.bannerView.hidden = YES;
 }
 
 - (void)showSpinner:(BOOL)show

--- a/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostListFooterView.xib
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,83 +13,21 @@
             <rect key="frame" x="0.0" y="0.0" width="300" height="44"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="F4q-47-pPM">
+                <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" fixedFrame="YES" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="F4q-47-pPM">
                     <rect key="frame" x="140" y="12" width="20" height="20"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                 </activityIndicatorView>
-                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AoX-vc-zrF">
-                    <rect key="frame" x="7" y="11" width="286" height="22"/>
-                    <subviews>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MBZ-lN-HGt">
-                            <rect key="frame" x="0.0" y="11" width="124" height="1"/>
-                            <color key="backgroundColor" red="0.73886972665786743" green="0.8065076470375061" blue="0.85388457775115967" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="1" id="gOn-eC-zhZ"/>
-                            </constraints>
-                        </view>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKm-Mr-TCA">
-                            <rect key="frame" x="162" y="11" width="124" height="1"/>
-                            <color key="backgroundColor" red="0.73886972665786743" green="0.8065076470375061" blue="0.85388457775115967" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="1" id="k2g-PF-m8U"/>
-                            </constraints>
-                        </view>
-                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-post-list-footer" translatesAutoresizingMaskIntoConstraints="NO" id="2lx-TZ-H9w">
-                            <rect key="frame" x="132" y="0.0" width="22" height="22"/>
-                            <constraints>
-                                <constraint firstAttribute="width" constant="22" id="3hc-zb-3fV"/>
-                                <constraint firstAttribute="height" constant="22" id="cJ3-uM-7zP"/>
-                            </constraints>
-                        </imageView>
-                    </subviews>
-                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                    <constraints>
-                        <constraint firstAttribute="centerX" secondItem="2lx-TZ-H9w" secondAttribute="centerX" id="BXl-cW-Ywt"/>
-                        <constraint firstAttribute="centerY" secondItem="MBZ-lN-HGt" secondAttribute="centerY" constant="-0.5" id="SM7-09-i4J"/>
-                        <constraint firstAttribute="centerY" secondItem="wKm-Mr-TCA" secondAttribute="centerY" constant="-0.5" id="X37-jz-nrb"/>
-                        <constraint firstItem="2lx-TZ-H9w" firstAttribute="leading" secondItem="MBZ-lN-HGt" secondAttribute="trailing" constant="8" id="Y0M-I9-BOr"/>
-                        <constraint firstAttribute="trailing" secondItem="wKm-Mr-TCA" secondAttribute="trailing" id="b0b-rA-YhB"/>
-                        <constraint firstItem="MBZ-lN-HGt" firstAttribute="leading" secondItem="AoX-vc-zrF" secondAttribute="leading" id="gr5-vp-wLh"/>
-                        <constraint firstAttribute="height" constant="22" id="jnj-8K-NpN"/>
-                        <constraint firstItem="wKm-Mr-TCA" firstAttribute="leading" secondItem="2lx-TZ-H9w" secondAttribute="trailing" constant="8" id="qGB-cG-EAL"/>
-                        <constraint firstAttribute="centerY" secondItem="2lx-TZ-H9w" secondAttribute="centerY" id="wf6-gD-lPc"/>
-                    </constraints>
-                </view>
             </subviews>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-            <constraints>
-                <constraint firstAttribute="bottom" secondItem="AoX-vc-zrF" secondAttribute="bottom" constant="11" id="CZF-8o-geK"/>
-                <constraint firstAttribute="trailing" secondItem="AoX-vc-zrF" secondAttribute="trailing" constant="7" id="ciu-4z-aHt"/>
-                <constraint firstItem="F4q-47-pPM" firstAttribute="centerX" secondItem="AoX-vc-zrF" secondAttribute="centerX" id="oYN-Kz-3Zu"/>
-                <constraint firstAttribute="trailingMargin" secondItem="AoX-vc-zrF" secondAttribute="trailing" priority="999" id="s16-Gc-tvU"/>
-                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leadingMargin" id="yzD-7E-gw6"/>
-                <constraint firstItem="AoX-vc-zrF" firstAttribute="leading" secondItem="TCZ-n9-coy" secondAttribute="leading" constant="7" id="znD-ba-XuU"/>
-                <constraint firstItem="F4q-47-pPM" firstAttribute="centerY" secondItem="AoX-vc-zrF" secondAttribute="centerY" id="zvW-CV-pmP"/>
-            </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <variation key="default">
-                <mask key="constraints">
-                    <exclude reference="s16-Gc-tvU"/>
-                    <exclude reference="yzD-7E-gw6"/>
-                </mask>
-            </variation>
-            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES">
-                <mask key="constraints">
-                    <exclude reference="ciu-4z-aHt"/>
-                    <include reference="s16-Gc-tvU"/>
-                    <include reference="yzD-7E-gw6"/>
-                    <exclude reference="znD-ba-XuU"/>
-                </mask>
-            </variation>
+            <variation key="widthClass=regular" layoutMarginsFollowReadableWidth="YES" preservesSuperviewLayoutMargins="YES"/>
             <connections>
                 <outlet property="activityView" destination="F4q-47-pPM" id="zVo-Q1-ggr"/>
-                <outlet property="bannerView" destination="AoX-vc-zrF" id="hSc-aF-tjn"/>
             </connections>
+            <point key="canvasLocation" x="139" y="112"/>
         </view>
     </objects>
-    <resources>
-        <image name="icon-post-list-footer" width="22" height="22"/>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -35,11 +35,14 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     @IBOutlet private weak var avatarImageView: UIImageView!
     @IBOutlet private weak var authorAvatarImageView: UIImageView!
     @IBOutlet private weak var headerBlogButton: UIButton!
+    @IBOutlet private weak var labelsStackView: UIStackView!
 
+    @IBOutlet private weak var authorAndBlogNameStackView: UIStackView!
     @IBOutlet private weak var authorNameLabel: UILabel!
     @IBOutlet private weak var arrowImageView: UIImageView!
     @IBOutlet private weak var blogNameLabel: UILabel!
 
+    @IBOutlet private weak var hostAndTimeStackView: UIStackView!
     @IBOutlet private weak var blogHostNameLabel: UILabel!
     @IBOutlet private weak var bylineLabel: UILabel!
     @IBOutlet private weak var bylineSeparatorLabel: UILabel!
@@ -995,7 +998,10 @@ extension ReaderPostCardCell: GhostableView {
         menuButton.layer.opacity = 0
         commentActionButton.setTitle("", for: .normal)
         likeActionButton.setTitle("", for: .normal)
-        headerStackView.heightAnchor.constraint(equalTo: avatarImageView.heightAnchor, multiplier: 1.3).isActive = true
+        authorAndBlogNameStackView.spacing = 0
+        headerBlogButton.isHidden = true
+        labelsStackView.distribution = .fillEqually
+        hostAndTimeStackView.alignment = .fill
         featuredImageView.layer.borderWidth = 0
         ghostPlaceholderView.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -998,7 +998,11 @@ extension ReaderPostCardCell: GhostableView {
         authorAndBlogNameStackView.spacing = 0
         headerBlogButton.isHidden = true
         labelsStackView.distribution = .fillEqually
+        labelsStackView.spacing = 8
         hostAndTimeStackView.alignment = .fill
+        bylineLabel.text = nil
+        bylineLabel.widthAnchor.constraint(equalTo: hostAndTimeStackView.widthAnchor, multiplier: 0.33).isActive = true
+        bylineLabel.isGhostableDisabled = true
         featuredImageView.layer.borderWidth = 0
         ghostPlaceholderView.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.swift
@@ -66,9 +66,6 @@ protocol ReaderTopicsChipsDelegate: AnyObject {
     @IBOutlet private weak var menuButton: UIButton!
     @IBOutlet private weak var reblogActionButton: UIButton!
 
-    // Layout Constraints
-    @IBOutlet private weak var featuredMediaHeightConstraint: NSLayoutConstraint!
-
     // Ghost cells placeholders
     @IBOutlet private weak var ghostPlaceholderView: UIView!
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -361,6 +361,7 @@
                 <outlet property="actionStackView" destination="Wzi-SV-nkT" id="4lH-Qh-6iA"/>
                 <outlet property="arrowImageView" destination="7dJ-PC-Ihr" id="Jxx-N1-CPe"/>
                 <outlet property="attributionView" destination="nU7-76-6MV" id="Pjl-4F-R7r"/>
+                <outlet property="authorAndBlogNameStackView" destination="nmf-Gu-jLG" id="tpk-9U-mBk"/>
                 <outlet property="authorAvatarImageView" destination="X3v-d3-Adn" id="mVo-WI-68y"/>
                 <outlet property="authorNameLabel" destination="2Gk-4n-1vI" id="0GK-nh-b6j"/>
                 <outlet property="avatarImageView" destination="7Qj-iX-iqv" id="sjW-0m-Xxe"/>
@@ -376,7 +377,9 @@
                 <outlet property="ghostPlaceholderView" destination="9Jf-BY-VHz" id="NRJ-D8-aWX"/>
                 <outlet property="headerBlogButton" destination="l5X-fR-34a" id="kYK-6e-pwI"/>
                 <outlet property="headerStackView" destination="xwk-ft-EDo" id="mVV-0H-yAh"/>
+                <outlet property="hostAndTimeStackView" destination="c3n-LO-Igq" id="oq6-NR-Dko"/>
                 <outlet property="interfaceVerticalSizingHelperView" destination="Aav-jm-io6" id="2VW-l9-UiQ"/>
+                <outlet property="labelsStackView" destination="Pv6-I0-BNp" id="L6K-mG-Lpm"/>
                 <outlet property="likeActionButton" destination="z4x-8W-5Dc" id="anJ-1J-8im"/>
                 <outlet property="menuButton" destination="Z6l-P3-Z3i" id="4gf-Ii-bwa"/>
                 <outlet property="reblogActionButton" destination="Mch-Ja-RJu" id="RnC-n2-AhY"/>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -62,7 +62,7 @@
                                 <rect key="frame" x="16" y="16" width="288" height="40"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="-20" translatesAutoresizingMaskIntoConstraints="NO" id="z25-Q5-35K" userLabel="Avatar Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="90.333333333333329" height="40"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
                                         <subviews>
                                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="7Qj-iX-iqv" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -72,20 +72,8 @@
                                                     <constraint firstAttribute="width" secondItem="7Qj-iX-iqv" secondAttribute="height" multiplier="1:1" id="EEk-WN-bIC"/>
                                                 </constraints>
                                             </imageView>
-                                            <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l5X-fR-34a">
-                                                <rect key="frame" x="20" y="0.0" width="70.333333333333329" height="40"/>
-                                                <connections>
-                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchCancel" id="3lc-7d-9nA"/>
-                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragExit" id="Ph0-Z2-0e5"/>
-                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragOutside" id="fUQ-0g-O1I"/>
-                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpOutside" id="rSb-y4-PkS"/>
-                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpInside" id="vgG-Vu-rLZ"/>
-                                                    <action selector="blogButtonTouchesDidHighlight:" destination="IB3-vN-rW4" eventType="touchDown" id="aZQ-Hw-YOa"/>
-                                                    <action selector="didTapHeaderBlogButton:" destination="IB3-vN-rW4" eventType="touchUpInside" id="khN-2b-2n2"/>
-                                                </connections>
-                                            </button>
                                             <imageView hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="X3v-d3-Adn" userLabel="Author Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="90.333333333333329" y="0.0" width="39.999999999999986" height="40"/>
+                                                <rect key="frame" x="40" y="0.0" width="40" height="40"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="X3v-d3-Adn" secondAttribute="height" multiplier="1:1" id="D9D-ol-V5e"/>
@@ -95,10 +83,10 @@
                                         </subviews>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Pv6-I0-BNp" userLabel="Label Stack View">
-                                        <rect key="frame" x="100.33333333333333" y="0.0" width="133.66666666666669" height="40"/>
+                                        <rect key="frame" x="50" y="0.0" width="184" height="40"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="nmf-Gu-jLG" userLabel="Author / Blog Name Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="133.66666666666666" height="39"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="184" height="39"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Gk-4n-1vI" userLabel="Author Name Label">
                                                         <rect key="frame" x="0.0" y="0.0" width="43.333333333333336" height="39"/>
@@ -114,7 +102,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Blog name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wvp-3d-4a9">
-                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="68.333333333333343" height="39"/>
+                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="118.66666666666666" height="39"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" red="0.0" green="0.66666666666666663" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -123,7 +111,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="c3n-LO-Igq" userLabel="Host Name / Time Stack View">
-                                                <rect key="frame" x="0.0" y="40" width="133.66666666666666" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="40" width="184" height="0.0"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="740" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BCZ-4n-fDW" userLabel="Blog Host Name">
                                                         <rect key="frame" x="0.0" y="0.0" width="87.666666666666671" height="0.0"/>
@@ -133,7 +121,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="740" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cyk-BL-kmJ">
-                                                        <rect key="frame" x="87.666666666666671" y="0.0" width="10.666666666666671" height="0.0"/>
+                                                        <rect key="frame" x="87.666666666666657" y="0.0" width="10.666666666666671" height="0.0"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="10.5" id="vYw-c9-BGz"/>
@@ -143,7 +131,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="740" text="Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EQf-tj-ltv">
-                                                        <rect key="frame" x="98.333333333333329" y="0.0" width="35.333333333333329" height="0.0"/>
+                                                        <rect key="frame" x="98.333333333333343" y="0.0" width="85.666666666666657" height="0.0"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -313,6 +301,18 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="6" right="16"/>
                     </stackView>
+                    <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l5X-fR-34a">
+                        <rect key="frame" x="16" y="24" width="234" height="40"/>
+                        <connections>
+                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchCancel" id="3lc-7d-9nA"/>
+                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragExit" id="Ph0-Z2-0e5"/>
+                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragOutside" id="fUQ-0g-O1I"/>
+                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpOutside" id="rSb-y4-PkS"/>
+                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpInside" id="vgG-Vu-rLZ"/>
+                            <action selector="blogButtonTouchesDidHighlight:" destination="IB3-vN-rW4" eventType="touchDown" id="aZQ-Hw-YOa"/>
+                            <action selector="didTapHeaderBlogButton:" destination="IB3-vN-rW4" eventType="touchUpInside" id="khN-2b-2n2"/>
+                        </connections>
+                    </button>
                 </subviews>
                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
@@ -326,6 +326,8 @@
                     <constraint firstItem="74d-A6-ibb" firstAttribute="centerY" secondItem="z4x-8W-5Dc" secondAttribute="centerY" id="9Xj-zo-fVp"/>
                     <constraint firstItem="9Jf-BY-VHz" firstAttribute="centerX" secondItem="519-Nh-f7o" secondAttribute="centerX" id="A5e-rx-Vqc"/>
                     <constraint firstItem="RWd-ZJ-3Hc" firstAttribute="centerX" secondItem="D4Q-6L-ZIL" secondAttribute="centerX" id="A7m-a4-fdG"/>
+                    <constraint firstItem="l5X-fR-34a" firstAttribute="top" secondItem="xwk-ft-EDo" secondAttribute="top" id="BaV-0j-AW4"/>
+                    <constraint firstItem="l5X-fR-34a" firstAttribute="leading" secondItem="xwk-ft-EDo" secondAttribute="leading" id="Bac-xp-pwp"/>
                     <constraint firstItem="kha-YG-ZlO" firstAttribute="bottom" secondItem="k3b-5o-H9u" secondAttribute="bottom" id="DRR-5z-mcq"/>
                     <constraint firstItem="BfA-lS-oeX" firstAttribute="width" secondItem="3W2-KV-isX" secondAttribute="height" id="EMj-4q-PBv"/>
                     <constraint firstAttribute="bottom" secondItem="k3b-5o-H9u" secondAttribute="bottom" id="Ffl-rl-aPr"/>
@@ -334,6 +336,7 @@
                     <constraint firstItem="9Jf-BY-VHz" firstAttribute="centerY" secondItem="519-Nh-f7o" secondAttribute="centerY" id="PSJ-p4-3NZ"/>
                     <constraint firstItem="Vth-Nl-tJe" firstAttribute="height" secondItem="YRe-Q4-Aq4" secondAttribute="height" id="PX5-cS-xoT"/>
                     <constraint firstItem="RWd-ZJ-3Hc" firstAttribute="height" secondItem="D4Q-6L-ZIL" secondAttribute="height" id="QNw-FM-sqv"/>
+                    <constraint firstItem="l5X-fR-34a" firstAttribute="bottom" secondItem="xwk-ft-EDo" secondAttribute="bottom" id="QcW-r1-3Rd"/>
                     <constraint firstItem="kha-YG-ZlO" firstAttribute="top" secondItem="k3b-5o-H9u" secondAttribute="top" id="RwA-AG-OfQ"/>
                     <constraint firstAttribute="trailing" secondItem="k3b-5o-H9u" secondAttribute="trailing" id="SQx-7T-hZ3"/>
                     <constraint firstItem="Vth-Nl-tJe" firstAttribute="centerY" secondItem="YRe-Q4-Aq4" secondAttribute="centerY" id="Vnk-9N-j9w"/>
@@ -345,6 +348,7 @@
                     <constraint firstItem="9Jf-BY-VHz" firstAttribute="height" secondItem="519-Nh-f7o" secondAttribute="height" id="lTf-rN-Pc5"/>
                     <constraint firstItem="kha-YG-ZlO" firstAttribute="leading" secondItem="k3b-5o-H9u" secondAttribute="leading" constant="-1" id="lbK-St-20e"/>
                     <constraint firstItem="RWd-ZJ-3Hc" firstAttribute="centerY" secondItem="D4Q-6L-ZIL" secondAttribute="centerY" id="nef-PY-yZz"/>
+                    <constraint firstItem="l5X-fR-34a" firstAttribute="trailing" secondItem="Pv6-I0-BNp" secondAttribute="trailing" id="nja-w0-Ub1"/>
                     <constraint firstItem="BfA-lS-oeX" firstAttribute="centerY" secondItem="3W2-KV-isX" secondAttribute="centerY" id="vhc-lN-EiN"/>
                     <constraint firstItem="grC-7j-rBx" firstAttribute="centerX" secondItem="Mch-Ja-RJu" secondAttribute="centerX" id="wA6-V8-ITR"/>
                 </constraints>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCardCell.xib
@@ -25,19 +25,19 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="484"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Vth-Nl-tJe">
-                                <rect key="frame" x="16" y="332.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="16" y="331.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="grC-7j-rBx">
-                                <rect key="frame" x="103.33333333333333" y="332.66666666666669" width="31.999999999999986" height="32"/>
+                                <rect key="frame" x="103.33333333333333" y="331.66666666666669" width="31.999999999999986" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BfA-lS-oeX">
-                                <rect key="frame" x="184.66666666666666" y="332.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="184.66666666666666" y="331.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="74d-A6-ibb">
-                                <rect key="frame" x="272" y="332.66666666666669" width="32" height="32"/>
+                                <rect key="frame" x="272" y="331.66666666666669" width="32" height="32"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RWd-ZJ-3Hc">
@@ -61,8 +61,8 @@
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="xwk-ft-EDo" userLabel="Header Stack View">
                                 <rect key="frame" x="16" y="16" width="288" height="40"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="31" translatesAutoresizingMaskIntoConstraints="NO" id="z25-Q5-35K" userLabel="Avatar Stack View">
-                                        <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" spacing="-20" translatesAutoresizingMaskIntoConstraints="NO" id="z25-Q5-35K" userLabel="Avatar Stack View">
+                                        <rect key="frame" x="0.0" y="0.0" width="90.333333333333329" height="40"/>
                                         <subviews>
                                             <imageView contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="post-blavatar-placeholder" translatesAutoresizingMaskIntoConstraints="NO" id="7Qj-iX-iqv" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -72,8 +72,20 @@
                                                     <constraint firstAttribute="width" secondItem="7Qj-iX-iqv" secondAttribute="height" multiplier="1:1" id="EEk-WN-bIC"/>
                                                 </constraints>
                                             </imageView>
+                                            <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l5X-fR-34a">
+                                                <rect key="frame" x="20" y="0.0" width="70.333333333333329" height="40"/>
+                                                <connections>
+                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchCancel" id="3lc-7d-9nA"/>
+                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragExit" id="Ph0-Z2-0e5"/>
+                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragOutside" id="fUQ-0g-O1I"/>
+                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpOutside" id="rSb-y4-PkS"/>
+                                                    <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpInside" id="vgG-Vu-rLZ"/>
+                                                    <action selector="blogButtonTouchesDidHighlight:" destination="IB3-vN-rW4" eventType="touchDown" id="aZQ-Hw-YOa"/>
+                                                    <action selector="didTapHeaderBlogButton:" destination="IB3-vN-rW4" eventType="touchUpInside" id="khN-2b-2n2"/>
+                                                </connections>
+                                            </button>
                                             <imageView hidden="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="X3v-d3-Adn" userLabel="Author Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="20" y="0.0" width="40" height="40"/>
+                                                <rect key="frame" x="90.333333333333329" y="0.0" width="39.999999999999986" height="40"/>
                                                 <gestureRecognizers/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="X3v-d3-Adn" secondAttribute="height" multiplier="1:1" id="D9D-ol-V5e"/>
@@ -81,15 +93,12 @@
                                                 </constraints>
                                             </imageView>
                                         </subviews>
-                                        <constraints>
-                                            <constraint firstItem="X3v-d3-Adn" firstAttribute="leading" secondItem="7Qj-iX-iqv" secondAttribute="centerX" id="ilX-FC-Cqo"/>
-                                        </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="Pv6-I0-BNp" userLabel="Label Stack View">
-                                        <rect key="frame" x="50" y="0.0" width="184" height="40"/>
+                                        <rect key="frame" x="100.33333333333333" y="0.0" width="133.66666666666669" height="40"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" spacing="3" translatesAutoresizingMaskIntoConstraints="NO" id="nmf-Gu-jLG" userLabel="Author / Blog Name Stack View">
-                                                <rect key="frame" x="0.0" y="0.0" width="184" height="39"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="133.66666666666666" height="39"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" verticalHuggingPriority="251" text="Author" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2Gk-4n-1vI" userLabel="Author Name Label">
                                                         <rect key="frame" x="0.0" y="0.0" width="43.333333333333336" height="39"/>
@@ -105,7 +114,7 @@
                                                         </constraints>
                                                     </imageView>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" verticalHuggingPriority="251" horizontalCompressionResistancePriority="749" text="Blog name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wvp-3d-4a9">
-                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="118.66666666666666" height="39"/>
+                                                        <rect key="frame" x="65.333333333333343" y="0.0" width="68.333333333333343" height="39"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                         <color key="textColor" red="0.0" green="0.66666666666666663" blue="0.86274509803921573" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -114,7 +123,7 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" alignment="lastBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="c3n-LO-Igq" userLabel="Host Name / Time Stack View">
-                                                <rect key="frame" x="0.0" y="40" width="184" height="0.0"/>
+                                                <rect key="frame" x="0.0" y="40" width="133.66666666666666" height="0.0"/>
                                                 <subviews>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="750" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="740" text="blog.host.name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BCZ-4n-fDW" userLabel="Blog Host Name">
                                                         <rect key="frame" x="0.0" y="0.0" width="87.666666666666671" height="0.0"/>
@@ -124,7 +133,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="740" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cyk-BL-kmJ">
-                                                        <rect key="frame" x="87.666666666666657" y="0.0" width="10.666666666666671" height="0.0"/>
+                                                        <rect key="frame" x="87.666666666666671" y="0.0" width="10.666666666666671" height="0.0"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="10.5" id="vYw-c9-BGz"/>
@@ -134,7 +143,7 @@
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="749" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="740" text="Time" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EQf-tj-ltv">
-                                                        <rect key="frame" x="98.333333333333343" y="0.0" width="85.666666666666657" height="0.0"/>
+                                                        <rect key="frame" x="98.333333333333329" y="0.0" width="35.333333333333329" height="0.0"/>
                                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -168,10 +177,10 @@
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="0hd-Lx-knp" userLabel="Title / Summary / Attr / Action Stack View">
-                                <rect key="frame" x="16" y="233.99999999999997" width="288" height="122.66666666666666"/>
+                                <rect key="frame" x="16" y="233.99999999999997" width="288" height="121.66666666666666"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="gTo-Tc-GMR">
-                                        <rect key="frame" x="0.0" y="0.0" width="288" height="46.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="288" height="45.333333333333336"/>
                                         <subviews>
                                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Zf5-cD-Pd2" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="288" height="24"/>
@@ -181,7 +190,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Summary" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u1n-gR-1xw" customClass="ReaderPostCardContentLabel" customModule="WordPress" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="31.999999999999996" width="288" height="14.333333333333332"/>
+                                                <rect key="frame" x="0.0" y="31.999999999999996" width="288" height="13.333333333333332"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -190,7 +199,7 @@
                                         </subviews>
                                     </stackView>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nU7-76-6MV" customClass="ReaderCardDiscoverAttributionView" customModule="WordPress">
-                                        <rect key="frame" x="0.0" y="58.333333333333321" width="288" height="20.333333333333336"/>
+                                        <rect key="frame" x="0.0" y="57.333333333333321" width="288" height="20.333333333333336"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="tUL-YG-fIa" customClass="CircularImageView" customModule="WordPress">
                                                 <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
@@ -223,7 +232,7 @@
                                         </connections>
                                     </view>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" translatesAutoresizingMaskIntoConstraints="NO" id="Wzi-SV-nkT">
-                                        <rect key="frame" x="0.0" y="90.666666666666686" width="288" height="32"/>
+                                        <rect key="frame" x="0.0" y="89.666666666666686" width="288" height="32"/>
                                         <subviews>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="YRe-Q4-Aq4" customClass="PostMetaButton">
                                                 <rect key="frame" x="0.0" y="0.0" width="44" height="32"/>
@@ -297,25 +306,13 @@
                                 </subviews>
                             </stackView>
                             <view contentMode="scaleToFill" verticalHuggingPriority="1" verticalCompressionResistancePriority="1" translatesAutoresizingMaskIntoConstraints="NO" id="Aav-jm-io6" userLabel="View (Spacer)">
-                                <rect key="frame" x="16" y="364.66666666666669" width="288" height="100.33333333333331"/>
+                                <rect key="frame" x="16" y="363.66666666666669" width="288" height="101.33333333333331"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                             </view>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="6" right="16"/>
                     </stackView>
-                    <button contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="l5X-fR-34a">
-                        <rect key="frame" x="16" y="24" width="234" height="40"/>
-                        <connections>
-                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchCancel" id="3lc-7d-9nA"/>
-                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragExit" id="Ph0-Z2-0e5"/>
-                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchDragOutside" id="fUQ-0g-O1I"/>
-                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpOutside" id="rSb-y4-PkS"/>
-                            <action selector="blogButtonTouchesDidEnd:" destination="IB3-vN-rW4" eventType="touchUpInside" id="vgG-Vu-rLZ"/>
-                            <action selector="blogButtonTouchesDidHighlight:" destination="IB3-vN-rW4" eventType="touchDown" id="aZQ-Hw-YOa"/>
-                            <action selector="didTapHeaderBlogButton:" destination="IB3-vN-rW4" eventType="touchUpInside" id="khN-2b-2n2"/>
-                        </connections>
-                    </button>
                 </subviews>
                 <color key="backgroundColor" red="0.66666666666666663" green="0.66666666666666663" blue="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 <constraints>
@@ -341,7 +338,6 @@
                     <constraint firstAttribute="trailing" secondItem="k3b-5o-H9u" secondAttribute="trailing" id="SQx-7T-hZ3"/>
                     <constraint firstItem="Vth-Nl-tJe" firstAttribute="centerY" secondItem="YRe-Q4-Aq4" secondAttribute="centerY" id="Vnk-9N-j9w"/>
                     <constraint firstItem="74d-A6-ibb" firstAttribute="width" secondItem="z4x-8W-5Dc" secondAttribute="height" id="VzA-rX-Dd4"/>
-                    <constraint firstItem="l5X-fR-34a" firstAttribute="leading" secondItem="xwk-ft-EDo" secondAttribute="leading" id="Y8E-6u-aiv"/>
                     <constraint firstItem="grC-7j-rBx" firstAttribute="width" secondItem="Mch-Ja-RJu" secondAttribute="height" id="f5N-Cf-Nho"/>
                     <constraint firstItem="grC-7j-rBx" firstAttribute="height" secondItem="Mch-Ja-RJu" secondAttribute="height" id="fDI-az-HWu"/>
                     <constraint firstItem="k3b-5o-H9u" firstAttribute="trailing" secondItem="kha-YG-ZlO" secondAttribute="trailing" constant="-1" id="gD7-ug-WFu"/>
@@ -349,9 +345,6 @@
                     <constraint firstItem="9Jf-BY-VHz" firstAttribute="height" secondItem="519-Nh-f7o" secondAttribute="height" id="lTf-rN-Pc5"/>
                     <constraint firstItem="kha-YG-ZlO" firstAttribute="leading" secondItem="k3b-5o-H9u" secondAttribute="leading" constant="-1" id="lbK-St-20e"/>
                     <constraint firstItem="RWd-ZJ-3Hc" firstAttribute="centerY" secondItem="D4Q-6L-ZIL" secondAttribute="centerY" id="nef-PY-yZz"/>
-                    <constraint firstItem="l5X-fR-34a" firstAttribute="bottom" secondItem="xwk-ft-EDo" secondAttribute="bottom" id="of6-De-80c"/>
-                    <constraint firstItem="l5X-fR-34a" firstAttribute="top" secondItem="xwk-ft-EDo" secondAttribute="top" id="up0-8u-OYB"/>
-                    <constraint firstItem="l5X-fR-34a" firstAttribute="trailing" secondItem="Pv6-I0-BNp" secondAttribute="trailing" id="vVS-qW-Hfu"/>
                     <constraint firstItem="BfA-lS-oeX" firstAttribute="centerY" secondItem="3W2-KV-isX" secondAttribute="centerY" id="vhc-lN-EiN"/>
                     <constraint firstItem="grC-7j-rBx" firstAttribute="centerX" secondItem="Mch-Ja-RJu" secondAttribute="centerX" id="wA6-V8-ITR"/>
                 </constraints>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,10 +20,10 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="30" y="105.5" width="315" height="456.5"/>
+                                        <rect key="frame" x="67.5" y="108.5" width="240.5" height="450"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
-                                                <rect key="frame" x="38" y="0.0" width="239" height="234"/>
+                                                <rect key="frame" x="0.5" y="0.0" width="239" height="234"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="czl-5D-gem" userLabel="Accessory View">
                                                         <rect key="frame" x="69.5" y="0.0" width="100" height="100"/>
@@ -39,19 +39,19 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="37.5" y="254" width="240.5" height="202.5"/>
+                                                <rect key="frame" x="0.0" y="254" width="240.5" height="196"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
-                                                        <rect key="frame" x="26.5" y="0.0" width="187.5" height="74.5"/>
+                                                        <rect key="frame" x="38" y="0.0" width="164.5" height="68"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
-                                                                <rect key="frame" x="2" y="0.0" width="183.5" height="26.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="23"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="This is the subtitle text." textAlignment="center" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pAg-XC-9IM" userLabel="Subtitle Text View">
-                                                                <rect key="frame" x="0.0" y="36.5" width="187.5" height="38"/>
+                                                                <rect key="frame" x="2" y="33" width="160.5" height="35"/>
                                                                 <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -59,13 +59,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3N8-XV-xJk" userLabel="Subtitle Image View">
-                                                        <rect key="frame" x="0.0" y="94.5" width="240.5" height="44"/>
+                                                        <rect key="frame" x="0.0" y="88" width="240.5" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="GdA-7V-dg9"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="FancyButton" customModule="WordPressUI">
-                                                        <rect key="frame" x="78" y="158.5" width="84" height="44"/>
+                                                        <rect key="frame" x="84" y="152" width="72" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
                                                         </constraints>
@@ -90,12 +90,12 @@
                                 </subviews>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" secondItem="0Ae-eX-ae9" secondAttribute="leading" constant="30" id="Gn9-QB-PCu"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerX" secondItem="0Ae-eX-ae9" secondAttribute="centerX" id="NmZ-mA-W4r"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="awy-Qw-qAb"/>
-                                    <constraint firstAttribute="trailing" secondItem="Mkl-mm-wtH" secondAttribute="trailing" constant="30" id="gZv-Ze-rOt"/>
                                 </constraints>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="x31-wL-G0k" firstAttribute="trailing" secondItem="0Ae-eX-ae9" secondAttribute="trailing" id="8y0-se-MDj"/>
@@ -103,7 +103,6 @@
                             <constraint firstItem="x31-wL-G0k" firstAttribute="bottom" secondItem="0Ae-eX-ae9" secondAttribute="bottom" id="H2g-99-0jI"/>
                             <constraint firstItem="0Ae-eX-ae9" firstAttribute="leading" secondItem="x31-wL-G0k" secondAttribute="leading" id="Yvc-NG-l0P"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="x31-wL-G0k"/>
                     </view>
                     <size key="freeformSize" width="375" height="667"/>
                     <connections>


### PR DESCRIPTION
Part of #18098

## Description
This resolves a few unsatisfiable constraints errors related to the reader. Errors fixed are:
- Issue in `NoResultsViewController`
    - This was triggered because the main stack view had leading and trailing constraints to superview. And this was conflicting with the width determined by its content.
    - Fixed by removing leading and trailing constraints and adding a center horizontally constraint instead.
    - This change resulted in no visible change.
- Issue in `ReaderPostCardCell`, related to the two overlapping avatar image views
    - Both image views are inside a stack view. The overlapping was implemented by tying the leading edge of the second avatar to the center of the first avatar. This constraint conflicted with constraints added by the stack view for its subviews.
    - Fixed by removing this constraint and instead, setting the spacing to a negative value equal to half the width of the avatar. This works fine because the avatar width is static and set using a constraint.
    - This change resulted in no visible change.
- Issue in `PostListFooterView`
    - This view had a subview, and the constraints on that subview were conflicting with constraints added by the table view.
    - This was fixed by completely removing the problematic subview as it was always hidden either way.
    - This change resulted in no visible change.
- Issue in `ReaderPostCardCell `, related to ghost view of the cell
    - This was caused by a height constraint between the header stack view and one of its subviews.
    - Because of this issue the header stack view always had a height of `0` and was never visible inside the ghost cell. After looking at how the ghost cell used to look when it was implemented (#14485), this seems like a bug to me.
    - Fixed by removing this constraint and configuring the header stack view.

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/25306722/157365138-8e78e369-c439-432e-a8b1-f0df3b01f756.png" width=200> | <img src="https://user-images.githubusercontent.com/25306722/157365125-adabeed0-9cec-4210-90f6-452948cb4e47.png" width=200>

## Testing Instructions
1. Open the reader on a tab that has no posts to show
2. ✅ Make sure that no results view is displayed correctly
3. Open a tab that has posts
4. While the poss are loading observe the ghost cells
5. ✅ Make sure that ghost cells are displayed correctly.
6. Observe a post cell after it's loaded.
7. ✅ Make sure that in the case where one avatar is shown, it is displayed correctly. 
8. ✅ Make sure that in the case where two avatars are shown, they are displayed correctly.
9. Scroll to the bottom.
8. ✅ Make sure the footer is displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
