### PR TITLE
Enable Stats UI Tests to deal with insights cards not being loaded

### DIFF
--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -76,8 +76,11 @@ public class StatsScreen: ScreenObject {
     public func refreshStatsIfNeeded() -> StatsScreen {
         let errorMessage = NSPredicate(format: "label == 'An error occurred.'")
         let isErrorMessagePresent = app.staticTexts.element(matching: errorMessage).exists
+        let expectedCardsWithoutData = 3
+        let isDataLoaded = app.staticTexts.matching(identifier: "No data yet").count <= expectedCardsWithoutData
 
-        if isErrorMessagePresent { pullToRefresh() }
+        if isErrorMessagePresent == true || isDataLoaded == false { pullToRefresh() }
+
         return self
     }
 }

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -21,7 +21,6 @@ class StatsTests: XCTestCase {
     }
 
     let insightsStats: [String] = [
-        "35",
         "Views",
         "2,243",
         "Posts",


### PR DESCRIPTION
This PR improves Stats UI Tests to deal with insights card not loaded issue as a reflect of recent insights tab caching strategy. The Insights tab will be refreshed when all the cards show up as `No data yet` like the image below.

<img width="631" alt="image" src="https://user-images.githubusercontent.com/42008628/157584724-619192a6-f298-4b7a-b307-a7a85c38fb2d.png">

This change in addition to the work on #18104 should cover all Stats UI Tests issues.

[Test PR running Stats UI Tests 20 times](https://github.com/wordpress-mobile/WordPress-iOS/pull/18113): 100% Passed.