### PR TITLE
Fix unsatisfiable constraints in MySite and Notification tabs

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -530,6 +530,7 @@ private extension NotificationsViewController {
     func setupConstraints() {
         // Inline prompt is initially hidden!
         inlinePromptView.translatesAutoresizingMaskIntoConstraints = false
+        filterTabBar.tabBarHeightConstraintPriority = 999
 
         NSLayoutConstraint.activate([
             tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor),

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -33,7 +33,7 @@ static CGFloat const FeaturedImageSize = 120.0;
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-    self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
+    self.contentView.autoresizingMask = UIViewAutoresizingFlexibleHeight;
     [self applyStyles];
     [self setupAccessibility];
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -33,7 +33,7 @@ static CGFloat const FeaturedImageSize = 120.0;
 - (void)awakeFromNib
 {
     [super awakeFromNib];
-
+    self.contentView.translatesAutoresizingMaskIntoConstraints = NO;
     [self applyStyles];
     [self setupAccessibility];
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
+++ b/WordPress/Classes/ViewRelated/Post/PostCardCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -257,7 +257,7 @@
                             <progressView opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="750" progressViewStyle="bar" progress="0.90000000000000002" translatesAutoresizingMaskIntoConstraints="NO" id="33v-Uz-9S6">
                                 <rect key="frame" x="0.0" y="446" width="326" height="5"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="4" id="gFE-it-kOj"/>
+                                    <constraint firstAttribute="height" priority="999" constant="4" id="gFE-it-kOj"/>
                                 </constraints>
                                 <color key="trackTintColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                             </progressView>

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -42,6 +42,7 @@ class LatestPostSummaryCell: UITableViewCell, NibLoadable, Accessible {
         super.awakeFromNib()
         applyStyles()
         prepareForVoiceOver()
+        setupStackViewsMargins()
     }
 
     override func prepareForReuse() {
@@ -97,6 +98,17 @@ private extension LatestPostSummaryCell {
         viewsDataLabel.textColor = Style.defaultTextColor
 
         actionLabel.textColor = Style.actionTextColor
+    }
+    
+    func setupStackViewsMargins() {
+        actionStackView.isLayoutMarginsRelativeArrangement = true
+        actionStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
+        
+        viewsStackView.isLayoutMarginsRelativeArrangement = true
+        viewsStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
+        
+        chartStackView.isLayoutMarginsRelativeArrangement = true
+        chartStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
     }
 
     func configureViewForAction() {
@@ -190,6 +202,10 @@ private extension LatestPostSummaryCell {
         static let dataShown = CGFloat(24)
         static let dataHidden = CGFloat(16)
     }
+    
+    struct StackViewsMargins {
+        static let horizontalPaddingMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
+    }
 
     struct CellStrings {
         static let summaryPostInfo = NSLocalizedString("It's been %@ since %@ was published. ", comment: "Latest post summary text including placeholder for time and the post title.")
@@ -262,12 +278,5 @@ private extension LatestPostSummaryCell {
 
         resetChartContainerView()
         chartStackView.addArrangedSubview(chartView)
-
-        NSLayoutConstraint.activate([
-            chartView.leadingAnchor.constraint(equalTo: chartStackView.leadingAnchor),
-            chartView.trailingAnchor.constraint(equalTo: chartStackView.trailingAnchor),
-            chartView.topAnchor.constraint(equalTo: chartStackView.topAnchor),
-            chartView.bottomAnchor.constraint(equalTo: chartStackView.bottomAnchor)
-        ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.swift
@@ -99,14 +99,14 @@ private extension LatestPostSummaryCell {
 
         actionLabel.textColor = Style.actionTextColor
     }
-    
+
     func setupStackViewsMargins() {
         actionStackView.isLayoutMarginsRelativeArrangement = true
         actionStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
-        
+
         viewsStackView.isLayoutMarginsRelativeArrangement = true
         viewsStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
-        
+
         chartStackView.isLayoutMarginsRelativeArrangement = true
         chartStackView.directionalLayoutMargins = StackViewsMargins.horizontalPaddingMargins
     }
@@ -202,7 +202,7 @@ private extension LatestPostSummaryCell {
         static let dataShown = CGFloat(24)
         static let dataHidden = CGFloat(16)
     }
-    
+
     struct StackViewsMargins {
         static let horizontalPaddingMargins = NSDirectionalEdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Latest Post Summary/LatestPostSummaryCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14854.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14806.4"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,35 +18,35 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="It's been 999 months since Your Post was published. Here's how the post performed so far." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MnQ-57-h8x" userLabel="Summary Label">
-                        <rect key="frame" x="16" y="16" width="343" height="38"/>
+                        <rect key="frame" x="16" y="16" width="343" height="30.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yj9-fI-q4P" userLabel="Summary Button">
-                        <rect key="frame" x="16" y="16" width="343" height="38"/>
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="yj9-fI-q4P" userLabel="Summary Button">
+                        <rect key="frame" x="16" y="16" width="343" height="30.5"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>
                             <action selector="didTapSummaryButton:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="pk5-ep-izU"/>
                         </connections>
                     </button>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="bEY-vj-O3h" userLabel="Content Stack View">
-                        <rect key="frame" x="0.0" y="91" width="375" height="304"/>
+                        <rect key="frame" x="0.0" y="83.5" width="375" height="311.5"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="irr-i0-AM0" userLabel="Views Stack View">
-                                <rect key="frame" x="16" y="0.0" width="343" height="50"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="GRi-20-ac2">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="40,000" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="GLF-sc-SL2" userLabel="Views Data Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="100.5" height="50"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="99.5" height="50"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="30"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Views" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ioe-GD-QRv" userLabel="Views Label">
-                                                <rect key="frame" x="108.5" y="24.5" width="45.5" height="20.5"/>
+                                                <rect key="frame" x="107.5" y="28" width="38.5" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -64,10 +64,10 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="dVi-l5-zbj" userLabel="Chart Stack View">
-                                <rect key="frame" x="16" y="65" width="343" height="130"/>
+                                <rect key="frame" x="0.0" y="65" width="375" height="137.5"/>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="BoB-0m-Daq" userLabel="Bottom Stack View">
-                                <rect key="frame" x="0.0" y="210" width="375" height="94"/>
+                                <rect key="frame" x="0.0" y="217.5" width="375" height="94"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="SgZ-KL-6tA" userLabel="Rows Stack View">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -76,7 +76,7 @@
                                         </constraints>
                                     </stackView>
                                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="dj8-5c-J6O" userLabel="Action Stack View">
-                                        <rect key="frame" x="16" y="50" width="343" height="44"/>
+                                        <rect key="frame" x="0.0" y="50" width="375" height="44"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OZB-d7-5Vo" userLabel="Action Icon Image">
                                                 <rect key="frame" x="0.0" y="10" width="24" height="24"/>
@@ -86,13 +86,13 @@
                                                 </constraints>
                                             </imageView>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Xet-wC-hmj" userLabel="Action Label">
-                                                <rect key="frame" x="40" y="12" width="279" height="20.5"/>
+                                                <rect key="frame" x="40" y="13.5" width="311" height="17"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="NUJ-mV-eYK" userLabel="Disclosure Image">
-                                                <rect key="frame" x="335" y="15.5" width="8" height="13"/>
+                                                <rect key="frame" x="367" y="15.5" width="8" height="13"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="8" id="AYx-EH-X3W"/>
                                                     <constraint firstAttribute="height" constant="13" id="AZH-gy-7Ym"/>
@@ -104,24 +104,14 @@
                                         </constraints>
                                     </stackView>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstItem="SgZ-KL-6tA" firstAttribute="leading" secondItem="BoB-0m-Daq" secondAttribute="leading" id="JPl-Fi-L7M"/>
-                                    <constraint firstItem="dj8-5c-J6O" firstAttribute="leading" secondItem="BoB-0m-Daq" secondAttribute="leading" constant="16" id="NoN-2X-b6R"/>
-                                    <constraint firstAttribute="trailing" secondItem="dj8-5c-J6O" secondAttribute="trailing" constant="16" id="cW9-eg-w99"/>
-                                    <constraint firstAttribute="trailing" secondItem="SgZ-KL-6tA" secondAttribute="trailing" id="kVT-UJ-S0F"/>
-                                </constraints>
                             </stackView>
                         </subviews>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="BoB-0m-Daq" secondAttribute="trailing" id="4YA-iY-eOu"/>
                             <constraint firstItem="BoB-0m-Daq" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" id="Ef2-Bo-VQb"/>
-                            <constraint firstAttribute="trailing" secondItem="irr-i0-AM0" secondAttribute="trailing" constant="16" id="Gyk-oi-Z6b"/>
-                            <constraint firstItem="dVi-l5-zbj" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" constant="16" id="X70-QR-Oxz"/>
-                            <constraint firstAttribute="trailing" secondItem="dVi-l5-zbj" secondAttribute="trailing" constant="16" id="kuA-hL-x7l"/>
-                            <constraint firstItem="irr-i0-AM0" firstAttribute="leading" secondItem="bEY-vj-O3h" secondAttribute="leading" constant="16" id="xpf-9u-a0Z"/>
                         </constraints>
                     </stackView>
-                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
+                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3OP-qA-To0" userLabel="Action Button">
                         <rect key="frame" x="0.0" y="351" width="375" height="44"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <connections>

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -81,6 +81,12 @@ class FilterTabBar: UIControl {
         }
     }
 
+    var tabBarHeightConstraintPriority: Float = UILayoutPriority.required.rawValue {
+        didSet {
+            tabBarHeightConstraint.priority = UILayoutPriority(tabBarHeightConstraintPriority)
+        }
+    }
+
     var equalWidthFill: UIStackView.Distribution = .fillEqually {
         didSet {
             stackView.distribution = equalWidthFill


### PR DESCRIPTION
Part of #18098

## Description
This resolves a few unsatisfiable constraints errors related to the notifications and My Site. Errors fixed are:
- Issue in `NotificationsViewController`
    - This was triggered by a conflict of constraints while laying out the table's header view. 
    - Fixed by setting the filter bar height constraint priority to `999`
- Issue in `LatestPostSummaryCell`
    - This was triggered because the multiple stack views had leading and trailing constraints to superview. And this was conflicting with the width determined by its content.
    - Fixed by removing this constraint and instead, setting leading and trailing margins.
- Issue in `PostCardCell`
    - This was triggered by a conflict of constraints while laying out the cell. 
    - Fixed by setting the progress view height constraint priority to `999`
- Issue in `PageListTableViewCell`
    - This was triggered by a conflict of constraints while laying out the cell. The conflict came from auto resizing constraints on the content view
    - Fixed by setting `translatesAutoresizingMaskIntoConstraints` of the content view to false.
    
All fixes do not introduce any visible changes.

https://user-images.githubusercontent.com/25306722/157586738-065fdef7-6ec6-46ed-a750-24cdbb2df151.mov

## Testing Instructions
1. Open the notifications tab
2. ✅ Make sure that the header and filter bar is displayed correctly.
3. Open stats page and access the insights tab.
4. ✅ Make sure that the latest post summary is displayed correctly.
5. Open the Posts list screen
6. Make sure to enable the progress bar of any post, either normally or by overriding `PostCardStatusViewModel.shouldHideProgressView`
7. ✅ Make sure the cell is displayed correctly.
8. Open Pages list screen.
9. ✅ Make sure cells are displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
UI of the components touched

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Testing manually all affected areas.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
