### PR TITLE
My Site: fix iPad default selected row

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Improves the error message shown when trying to create a new site with non-English characters in the domain name [https://github.com/wordpress-mobile/WordPress-iOS/pull/17985]
 * [*] Quick Start: updated the design for the Quick Start cell on My Site [#18095]
 * [*] Reader: Fixed a bug where comment replies are misplaced after its parent comment is moderated [#18094]
+* [*] iPad: Fixed a bug where the current displayed section wasn't selected on the menu [#18118]
 
 19.4
 -----

--- a/WordPress/Classes/Models/Blog+MySite.swift
+++ b/WordPress/Classes/Models/Blog+MySite.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension Blog {
+    /// If the blog should show the "Jetpack" or the "General" section
+    @objc var shouldShowJetpackSection: Bool {
+        (supports(.activity) && !isWPForTeams()) || supports(.jetpackSettings)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -5,14 +5,18 @@ extension Array where Element: BlogDetailsSection {
 }
 
 extension BlogDetailsSubsection {
-    fileprivate var sectionCategory: BlogDetailsSectionCategory {
+    func sectionCategory(for blog: Blog) -> BlogDetailsSectionCategory {
         switch self {
         case .domainCredit:
             return .domainCredit
         case .quickStart:
             return .quickStart
-        case .stats, .activity, .jetpackSettings:
+        case .activity, .jetpackSettings:
             return .jetpack
+        case .stats where blog.shouldShowJetpackSection:
+            return .jetpack
+        case .stats where !blog.shouldShowJetpackSection:
+            return .general
         case .pages, .posts, .media, .comments:
             return .publish
         case .themes, .customize:
@@ -32,7 +36,7 @@ extension BlogDetailsViewController {
         return sections.findSectionIndex(of: category) ?? NSNotFound
     }
 
-    @objc func sectionCategory(subsection: BlogDetailsSubsection) -> BlogDetailsSectionCategory {
-        return subsection.sectionCategory
+    @objc func sectionCategory(subsection: BlogDetailsSubsection, blog: Blog) -> BlogDetailsSectionCategory {
+        return subsection.sectionCategory(for: blog)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -25,7 +25,7 @@ extension BlogDetailsSubsection {
             return .configure
         case .home:
             return .home
-        @unknown default:
+        default:
             fatalError()
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -11,16 +11,14 @@ extension BlogDetailsSubsection {
             return .domainCredit
         case .quickStart:
             return .quickStart
-        case .stats, .activity:
-            return .general
+        case .stats, .activity, .jetpackSettings:
+            return .jetpack
         case .pages, .posts, .media, .comments:
             return .publish
         case .themes, .customize:
             return .personalize
         case .sharing, .people, .plugins:
             return .configure
-        case .jetpackSettings:
-            return .jetpack
         case .home:
             return .home
         @unknown default:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -567,7 +567,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         case BlogDetailsSubsectionQuickStart:
             return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionStats:
-            return [self shouldShowQuickStartChecklist] ? [NSIndexPath indexPathForRow:1 inSection:section] : [NSIndexPath indexPathForRow:0 inSection:section];
+            return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionActivity:
             return [NSIndexPath indexPathForRow:0 inSection:section];
         case BlogDetailsSubsectionJetpackSettings:
@@ -598,7 +598,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     if (!_restorableSelectedIndexPath) {
         // If nil, default to stats subsection.
-        BlogDetailsSubsection subsection = BlogDetailsSubsectionStats;
+        BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
         self.selectedSectionCategory = [self sectionCategoryWithSubsection:subsection];
         NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
         _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
@@ -612,6 +612,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (restorableSelectedIndexPath != nil && restorableSelectedIndexPath.section < [self.tableSections count]) {
         BlogDetailsSection *section = [self.tableSections objectAtIndex:restorableSelectedIndexPath.section];
         switch (section.category) {
+            case BlogDetailsSectionCategoryQuickAction:
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
                 _restorableSelectedIndexPath = nil;
@@ -687,9 +688,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
         // For QuickStart and Use Domain cases we want to select the first row on the next available section
         switch (section.category) {
+            case BlogDetailsSectionCategoryQuickAction:
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
-                BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:BlogDetailsSubsectionStats];
+                BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
+                BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:subsection];
                 sectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
                 break;
@@ -705,10 +708,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                             self.restorableSelectedIndexPath.row < [self.tableView numberOfRowsInSection:self.restorableSelectedIndexPath.section];
     if (isValidIndexPath && ![self splitViewControllerIsHorizontallyCompact]) {
         // And finally we'll reselect the selected row, if there is one
+        NSLog(@"$$ index path row %d %d", self.restorableSelectedIndexPath.row, self.restorableSelectedIndexPath.section);
 
         [self.tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
                                     animated:NO
                               scrollPosition:[self optimumScrollPositionForIndexPath:self.restorableSelectedIndexPath]];
+    } else {
+        NSLog(@"$$ NSNotFound %d", self.selectedSectionCategory);
     }
 }
 
@@ -1087,6 +1093,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self splitViewControllerIsHorizontallyCompact]) {
         return;
     }
+
+    self.restorableSelectedIndexPath = nil;
 
     if ([self shouldShowDashboard]) {
         [self showDetailViewForSubsection:BlogDetailsSubsectionHome];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -708,8 +708,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                             self.restorableSelectedIndexPath.row < [self.tableView numberOfRowsInSection:self.restorableSelectedIndexPath.section];
     if (isValidIndexPath && ![self splitViewControllerIsHorizontallyCompact]) {
         // And finally we'll reselect the selected row, if there is one
-        NSLog(@"$$ index path row %d %d", self.restorableSelectedIndexPath.row, self.restorableSelectedIndexPath.section);
-
         [self.tableView selectRowAtIndexPath:self.restorableSelectedIndexPath
                                     animated:NO
                               scrollPosition:[self optimumScrollPositionForIndexPath:self.restorableSelectedIndexPath]];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -556,7 +556,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 // MARK: Todo: this needs to adjust based on the existence of the QSv2 section
 - (NSIndexPath *)indexPathForSubsection:(BlogDetailsSubsection)subsection
 {
-    BlogDetailsSectionCategory sectionCategory = [self sectionCategoryWithSubsection:subsection];
+    BlogDetailsSectionCategory sectionCategory = [self sectionCategoryWithSubsection:subsection blog: self.blog];
     NSInteger section = [self findSectionIndexWithSections:self.tableSections category:sectionCategory];
     switch (subsection) {
         case BlogDetailsSubsectionReminders:
@@ -599,7 +599,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (!_restorableSelectedIndexPath) {
         // If nil, default to stats subsection.
         BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
-        self.selectedSectionCategory = [self sectionCategoryWithSubsection:subsection];
+        self.selectedSectionCategory = [self sectionCategoryWithSubsection:subsection blog: self.blog];
         NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
         _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
     }
@@ -692,7 +692,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryDomainCredit: {
                 BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
-                BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:subsection];
+                BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:subsection blog: self.blog];
                 sectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
                 break;
@@ -746,7 +746,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact]) {
         [marr addObject:[self homeSectionViewModel]];
     }
-    if (([self.blog supports:BlogFeatureActivity] && ![self.blog isWPForTeams]) || [self.blog supports:BlogFeatureJetpackSettings]) {
+    if (self.blog.shouldShowJetpackSection) {
         [marr addObject:[self jetpackSectionViewModel]];
     } else {
         [marr addObject:[self generalSectionViewModel]];

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -721,9 +721,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         switch section {
         case .siteMenu:
             blogDetailsViewController?.blog = blog
-            blogDetailsViewController?.showInitialDetailsForBlog()
             blogDetailsViewController?.tableView.reloadData()
             blogDetailsViewController?.preloadMetadata()
+            blogDetailsViewController?.showInitialDetailsForBlog()
         case .dashboard:
             blogDashboardViewController?.update(blog: blog)
         }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -721,6 +721,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         switch section {
         case .siteMenu:
             blogDetailsViewController?.blog = blog
+            blogDetailsViewController?.configureTableViewData()
             blogDetailsViewController?.tableView.reloadData()
             blogDetailsViewController?.preloadMetadata()
             blogDetailsViewController?.showInitialDetailsForBlog()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1412,6 +1412,8 @@
 		8B45C12727B2B08900EA3257 /* DashboardStatsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */; };
 		8B45C12827B2B0D500EA3257 /* BlogDashboardService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */; };
 		8B4DDF25278F44CC0022494D /* BlogDashboardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73D7D5278D9E5D00DF24B3 /* BlogDashboardViewController.swift */; };
+		8B4EDADD27DF9D5E004073B6 /* Blog+MySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */; };
+		8B4EDADE27DF9D5E004073B6 /* Blog+MySite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */; };
 		8B51844525893F140085488D /* FilterBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B51844425893F140085488D /* FilterBarView.swift */; };
 		8B55F9B82614D819007D618E /* UnifiedPrologueEditorContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F851414260D0A3300A4B938 /* UnifiedPrologueEditorContentView.swift */; };
 		8B55F9CA2614D8BC007D618E /* RoundRectangleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8513DE260D091500A4B938 /* RoundRectangleView.swift */; };
@@ -6115,6 +6117,7 @@
 		8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+mainWindow.swift"; sourceTree = "<group>"; };
 		8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryStartupEvent.swift; sourceTree = "<group>"; };
 		8B45C12527B2A27400EA3257 /* dashboard-200-with-drafts-only.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-drafts-only.json"; sourceTree = "<group>"; };
+		8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+MySite.swift"; sourceTree = "<group>"; };
 		8B51844425893F140085488D /* FilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBarView.swift; sourceTree = "<group>"; };
 		8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsCardCell.swift; sourceTree = "<group>"; };
 		8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardService.swift; sourceTree = "<group>"; };
@@ -12626,6 +12629,7 @@
 				401AC82622DD2387006D78D4 /* Blog+Plans.swift */,
 				2420BEF025D8DAB300966129 /* Blog+Lookup.swift */,
 				F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */,
+				8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -17557,6 +17561,7 @@
 				D88106FA20C0CFEE001D2F00 /* ReaderSaveForLaterRemovedPosts.swift in Sources */,
 				1751E5931CE23801000CA08D /* NSAttributedString+StyledHTML.swift in Sources */,
 				3F8513DF260D091500A4B938 /* RoundRectangleView.swift in Sources */,
+				8B4EDADD27DF9D5E004073B6 /* Blog+MySite.swift in Sources */,
 				D8071631203DA23700B32FD9 /* Accessible.swift in Sources */,
 				9826AE9021B5D3CD00C851FA /* PostingActivityCell.swift in Sources */,
 				934098C02719577D00B3E77E /* InsightType.swift in Sources */,
@@ -20480,6 +20485,7 @@
 				3F2ABE1D277118CC005D8916 /* WPMediaAsset+VideoLimits.swift in Sources */,
 				FABB23FB2602FC2C00C8785C /* WPTabBarController+MeNavigation.swift in Sources */,
 				FABB23FC2602FC2C00C8785C /* SitePromptView.swift in Sources */,
+				8B4EDADE27DF9D5E004073B6 /* Blog+MySite.swift in Sources */,
 				FABB23FD2602FC2C00C8785C /* BaseRestoreCompleteViewController.swift in Sources */,
 				FAA4012E27B405DB009E1137 /* DashboardQuickActionsCardCell.swift in Sources */,
 				FABB23FE2602FC2C00C8785C /* SharingService.swift in Sources */,

--- a/WordPress/WordPressTest/BlogDetailsSubsectionToSectionCategoryTests.swift
+++ b/WordPress/WordPressTest/BlogDetailsSubsectionToSectionCategoryTests.swift
@@ -2,20 +2,37 @@ import XCTest
 @testable import WordPress
 
 class BlogDetailsSubsectionToSectionCategoryTests: XCTestCase {
+    var blog: Blog!
+
+    override func setUp() {
+        blog = BlogBuilder(TestContextManager().mainContext).build()
+    }
+
     func testEachSubsectionToSectionCategory() {
         let blogDetailsViewController = BlogDetailsViewController()
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .domainCredit), .domainCredit)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .quickStart), .quickStart)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .stats), .general)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .activity), .general)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .pages), .publish)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .posts), .publish)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .media), .publish)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .comments), .publish)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .themes), .personalize)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .customize), .personalize)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .sharing), .configure)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .people), .configure)
-        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .plugins), .configure)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .domainCredit, blog: blog), .domainCredit)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .quickStart, blog: blog), .quickStart)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .stats, blog: blog), .general)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .activity, blog: blog), .jetpack)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .pages, blog: blog), .publish)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .posts, blog: blog), .publish)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .media, blog: blog), .publish)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .comments, blog: blog), .publish)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .themes, blog: blog), .personalize)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .customize, blog: blog), .personalize)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .sharing, blog: blog), .configure)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .people, blog: blog), .configure)
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .plugins, blog: blog), .configure)
+    }
+
+    func testEachSubsectionToSectionCategoryForJetpack() {
+        let blogDetailsViewController = BlogDetailsViewController()
+        let blog = BlogBuilder(TestContextManager().mainContext)
+            .set(blogOption: "is_wpforteams_site", value: false)
+            .withAnAccount()
+            .with(isAdmin: true)
+            .build()
+
+        XCTAssertEqual(blogDetailsViewController.sectionCategory(subsection: .stats, blog: blog), .jetpack)
     }
 }


### PR DESCRIPTION
Part of #17873 
Fixes #17958

This PR fixes a bug that has been there for quite some time: the default selected row when using iPad.

### To test

#### With My Site Dashboard flag disabled:

1. Do a clean install of the app on an iPad
2. Login with an account with multiple sites
3. Accept the help when prompted
4. ✅ "Stats" should be the selected row
5. Tap any other section
6. Switch to another site
7. ✅ "Stats" should be the selected row

#### With My Site Dashboard flag enabled

1. Enable My Site Dashboard feature flag
2. Close and reopen the app
3. ✅ "Stats" should be the selected row
4. Tap "Home"
5. Switch to another site
3. ✅ "Stats" should be the selected row

Make sure to check the site that has Quick Start enabled too, "Stats" should be the selected row there.

#### My Site Dashboard flag enabled and dashboard as the default

1. Create a new site (this will make the Dashboard the default)
2. ✅ "Home" should be the selected row
3. Switch to another site
2. ✅ "Home" should be the selected row

## Regression Notes
1. Potential unintended areas of impact
iPhone

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested on iPhone

5. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
