### PR TITLE
Enable Stats UI Tests to deal with insights cards not being loaded

### DIFF
--- a/WordPress/UITestsFoundation/Screens/StatsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/StatsScreen.swift
@@ -76,8 +76,11 @@ public class StatsScreen: ScreenObject {
     public func refreshStatsIfNeeded() -> StatsScreen {
         let errorMessage = NSPredicate(format: "label == 'An error occurred.'")
         let isErrorMessagePresent = app.staticTexts.element(matching: errorMessage).exists
+        let expectedCardsWithoutData = 3
+        let isDataLoaded = app.staticTexts.matching(identifier: "No data yet").count <= expectedCardsWithoutData
 
-        if isErrorMessagePresent { pullToRefresh() }
+        if isErrorMessagePresent == true || isDataLoaded == false { pullToRefresh() }
+
         return self
     }
 }


### PR DESCRIPTION
This PR replays #18112 on top of `release/19.4` frozen branch.

To test:
Stats UI Tests should pass.

## Regression Notes
1. Potential unintended areas of impact
Stats UI Tests

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test PR #18113 ran the tests 20 times and all passed.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
