### PR TITLE
Fixes some issues in Domains dashboard

### DIFF
--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -11,14 +11,14 @@ extension BlogService {
     /// Convenience method to be able to refresh the blogs from ObjC.
     ///
     @objc
-    func refreshDomains(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Error) -> Void) {
+    func refreshDomains(for blog: Blog, success: (() -> Void)?, failure: ((Error) -> Void)?) {
         guard let account = blog.account else {
-            failure(BlogServiceDomainError.noAccountForSpecifiedBlog(blog: blog))
+            failure?(BlogServiceDomainError.noAccountForSpecifiedBlog(blog: blog))
             return
         }
 
         guard let siteID = blog.dotComID?.intValue else {
-            failure(BlogServiceDomainError.noSiteIDForSpecifiedBlog(blog: blog))
+            failure?(BlogServiceDomainError.noSiteIDForSpecifiedBlog(blog: blog))
             return
         }
 
@@ -27,9 +27,9 @@ extension BlogService {
         service.refreshDomains(siteID: siteID) { result in
             switch result {
             case .success:
-                success()
+                success?()
             case .failure(let error):
-                failure(error)
+                failure?(error)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1302,6 +1302,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self preloadPages];
         [self preloadComments];
         [self preloadMetadata];
+        [self preloadDomains];
     }
 }
 
@@ -1382,6 +1383,17 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                [weakSelf configureTableViewData];
                                [weakSelf reloadTableViewPreservingSelection];
                            }];
+}
+
+- (void)preloadDomains
+{
+    if (![Feature enabled:FeatureFlagDomains]) {
+        return;
+    }
+
+    [self.blogService refreshDomainsFor:self.blog
+                                success:nil
+                                failure:nil];
 }
 
 - (void)scrollToElement:(QuickStartTourElement) element

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -125,6 +125,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     }
 
     private func hideButton() {
+        buttonViewContainer.layoutIfNeeded()
         buttonContainerBottomConstraint.constant = buttonViewContainer.frame.height
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
@@ -6,7 +6,7 @@ struct DomainsDashboardView: View {
     @ObservedObject var blog: Blog
     @State var isShowingDomainRegistrationFlow = false
     @State var blogService = BlogService.withMainContext()
-    
+
     // Property observer
     private func showingDomainRegistrationFlow(to value: Bool) {
         if value {

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
@@ -5,7 +5,8 @@ import WordPressKit
 struct DomainsDashboardView: View {
     @ObservedObject var blog: Blog
     @State var isShowingDomainRegistrationFlow = false
-
+    @State var blogService = BlogService.withMainContext()
+    
     // Property observer
     private func showingDomainRegistrationFlow(to value: Bool) {
         if value {
@@ -22,6 +23,9 @@ struct DomainsDashboardView: View {
         .padding(.top, Metrics.topPadding)
         .buttonStyle(PlainButtonStyle())
         .onTapGesture(perform: { })
+        .onAppear {
+            blogService.refreshDomains(for: blog, success: nil, failure: nil)
+        }
         .navigationBarTitle(TextContent.navigationTitle)
         .sheet(isPresented: $isShowingDomainRegistrationFlow, content: {
             makeDomainSearch(for: blog, onDismiss: {

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardView.swift
@@ -16,11 +16,13 @@ struct DomainsDashboardView: View {
 
     var body: some View {
         List {
-            makeSiteAddressSection(blog: blog)
+            if blog.supports(.domains) {
+                makeSiteAddressSection(blog: blog)
+            }
             makeDomainsSection(blog: blog)
         }
         .listStyle(GroupedListStyle())
-        .padding(.top, Metrics.topPadding)
+        .padding(.top, blog.supports(.domains) ? Metrics.topPadding : 0)
         .buttonStyle(PlainButtonStyle())
         .onTapGesture(perform: { })
         .onAppear {
@@ -77,17 +79,19 @@ struct DomainsDashboardView: View {
             ForEach(blog.domainsList) {
                 makeDomainCell(domain: $0)
             }
-            PresentationButton(
-                isShowingDestination: $isShowingDomainRegistrationFlow.onChange(showingDomainRegistrationFlow),
-                appearance: {
-                    HStack {
-                        Text(TextContent.additionalDomainTitle(blog.canRegisterDomainWithPaidPlan))
-                            .foregroundColor(Color(UIColor.primary))
-                            .bold()
-                        Spacer()
+            if blog.supports(.domains) {
+                PresentationButton(
+                    isShowingDestination: $isShowingDomainRegistrationFlow.onChange(showingDomainRegistrationFlow),
+                    appearance: {
+                        HStack {
+                            Text(TextContent.additionalDomainTitle(blog.canRegisterDomainWithPaidPlan))
+                                .foregroundColor(Color(UIColor.primary))
+                                .bold()
+                            Spacer()
+                        }
                     }
-                }
-            )
+                )
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes a number of issues that were occurring in the Domains dashboard, when enabled:

* Existing domains weren't being displayed in the domains dashboard due to removed calls to refresh domains
* We were attempting to show existing wpcom domains and a purchase button for Jetpack sites, which currently aren't able to make purchases, so I've hidden these in this situation

**Known issues**

* There's no loading indicator displayed while the Domains Dashboard refreshes data. This is something we could add later.
* For self-hosted sites, domains currently display an expiry date of "Never expires"

**To test**

* Enable the `domains` feature flag
* I tested with the Jetpack app, but it shouldn't make a difference in practice
* From My Site, navigate to Domains
* For a WordPress.com site with a paid plan and an unused domain token, you should see the free wpcom domain listed, and a button to claim your free domain:

<img src="https://user-images.githubusercontent.com/4780/157907646-b2fadeb7-1faf-469d-8d29-3fd746d005a1.png" width=300>

* For a WordPress.com site without a paid plan, you should see the free domain listed at the top of the screen and a big call to action to purchase a new domain:

<img src="https://user-images.githubusercontent.com/4780/157907990-e5385131-e213-4d16-a59a-647aa9fc5a62.png" width=300>

* For a WordPress.com site with an existing custom domain, you should see any existing domains listed with a link to add a new one:

<img src="https://user-images.githubusercontent.com/4780/157908107-cb391ae9-bbf8-4b29-89ed-510f913b2c63.png" width=300>

* For a self-hosted or Jetpack site, you should just see your current domain listed with no call to action and no header at the top:

<img src="https://user-images.githubusercontent.com/4780/157908232-d40aa2b2-2e3f-46e5-9fe6-0083775bcadd.png" width=300>

* Finally, for a site that has the 'add domain' button, tap it and ensure the button at the bottom of the search screen is initially hidden until you select a domain.

## Regression Notes
1. Potential unintended areas of impact

None, these changes should be limited to the Domains section, which is currently disabled.
 
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
