### PR TITLE
My Site Dashboard: add AB test after site creation and option to change the default in Settings

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -251,6 +251,7 @@ import Foundation
 
     // App Settings
     case settingsDidChange
+    case initialScreenChanged
 
     // Account Close
     case accountCloseTapped
@@ -744,6 +745,8 @@ import Foundation
         // App Settings
         case .settingsDidChange:
             return "settings_did_change"
+        case .initialScreenChanged:
+            return "app_settings_initial_screen_changed"
         case .appSettingsClearMediaCacheTapped:
             return "app_settings_clear_media_cache_tapped"
         case .appSettingsClearSpotlightIndexTapped:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAB.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+class BlogDashboardAB {
+    static let shared = BlogDashboardAB()
+
+    enum Variant {
+        case control
+        case treatment
+    }
+
+    private let accountService: AccountService
+
+    public var variant: Variant {
+        calculateVariant()
+    }
+
+    private init(accountService: AccountService = AccountService(managedObjectContext: ContextManager.sharedInstance().mainContext)) {
+        self.accountService = accountService
+    }
+
+    private func calculateVariant() -> Variant {
+        let defaultAccount = accountService.defaultWordPressComAccount()
+        let token: String? = defaultAccount?.authToken
+
+        if let token = token {
+            return token.hashCode() % 2 == 0 ? .control : .treatment
+        } else {
+            return .control
+        }
+    }
+}
+
+private extension String {
+    var asciiArray: [UInt32] {
+        return unicodeScalars
+            .filter { $0.isASCII }
+            .map { $0.value }
+    }
+
+    func hashCode() -> Int32 {
+        var h: Int32 = 0
+        for i in self.asciiArray {
+            h = 31 &* h &+ Int32(i)
+        }
+        return h
+    }
+}

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -351,6 +351,7 @@ class AppSettingsViewController: UITableViewController {
                         return
                 }
 
+                WPAnalytics.track(.initialScreenChanged, properties: ["selected": defaultSection.analyticsDescription])
                 MySiteSettings().setDefaultSection(defaultSection)
             }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -327,6 +327,36 @@ class AppSettingsViewController: UITableViewController {
             WPTabBarController.sharedInstance().presentWhatIsNew(on: self)
         }
     }
+
+    func pushInitialScreenSettings() -> ImmuTableAction {
+        return { [weak self] row in
+            let values = MySiteViewController.Section.allCases
+
+            let rawValues = values.map({ $0.rawValue })
+            let titles = values.map({ $0.title })
+
+            let currentStyle = MySiteSettings().defaultSection
+
+            let settingsSelectionConfiguration = [SettingsSelectionDefaultValueKey: AppAppearance.default.rawValue,
+                                                  SettingsSelectionCurrentValueKey: currentStyle.rawValue,
+                                                  SettingsSelectionTitleKey: NSLocalizedString("Initial Screen", comment: "The title of the app initial screen settings screen"),
+                                                  SettingsSelectionTitlesKey: titles,
+                                                  SettingsSelectionValuesKey: rawValues] as [String: Any]
+
+            let viewController = SettingsSelectionViewController(dictionary: settingsSelectionConfiguration)
+
+            viewController?.onItemSelected = { (section: Any!) -> () in
+                guard let section = section as? Int,
+                    let defaultSection = MySiteViewController.Section(rawValue: section) else {
+                        return
+                }
+
+                MySiteSettings().setDefaultSection(defaultSection)
+            }
+
+            self?.navigationController?.pushViewController(viewController!, animated: true)
+        }
+    }
 }
 
 // MARK: - SearchableActivity Conformance
@@ -495,6 +525,12 @@ private extension AppSettingsViewController {
         if AppConfiguration.allowsCustomAppIcons && UIApplication.shared.supportsAlternateIcons {
             // We don't show custom icons for Jetpack
             rows.insert(iconRow, at: 0)
+        }
+
+        if FeatureFlag.mySiteDashboard.enabled {
+            let initialScreen = NavigationItemRow(title: NSLocalizedString("Initial Screen", comment: "Title of the option to change the default initial screen"), detail: MySiteSettings().defaultSection.title, action: pushInitialScreenSettings())
+
+            rows.append(initialScreen)
         }
 
         if FeatureFlag.debugMenu.enabled {

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyWizardContent.swift
@@ -128,8 +128,8 @@ final class SiteAssemblyWizardContent: UIViewController {
                         gutenbergSettings.postSettingsToRemote(for: createdBlog)
                     }
 
-                    if FeatureFlag.mySiteDashboard.enabled {
-                        // TODO: A/B test default section
+                    if FeatureFlag.mySiteDashboard.enabled,
+                       BlogDashboardAB.shared.variant == .treatment {
                         MySiteSettings().setDefaultSection(.dashboard)
                     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1505,6 +1505,8 @@
 		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
+		8BE8545D27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */; };
+		8BE8545E27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */; };
 		8BE9AB8827B6B5A300708E45 /* BlogDashboardPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE9AB8727B6B5A300708E45 /* BlogDashboardPersistenceTests.swift */; };
 		8BEE845A27B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json in Resources */ = {isa = PBXBuildFile; fileRef = 8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */; };
 		8BEE846227B1E0540001A93C /* DashboardCardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */; };
@@ -6190,6 +6192,7 @@
 		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
+		8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAB.swift; sourceTree = "<group>"; };
 		8BE9AB8727B6B5A300708E45 /* BlogDashboardPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersistenceTests.swift; sourceTree = "<group>"; };
 		8BEE845927B1DC9D0001A93C /* dashboard-200-with-drafts-and-scheduled.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "dashboard-200-with-drafts-and-scheduled.json"; sourceTree = "<group>"; };
 		8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardSection.swift; sourceTree = "<group>"; };
@@ -11536,6 +11539,7 @@
 			isa = PBXGroup;
 			children = (
 				8BC81D6427CFC0DA0057F790 /* BlogDashboardState.swift */,
+				8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -18668,6 +18672,7 @@
 				822876F11E929CFD00696BF7 /* ReachabilityUtils+OnlineActions.swift in Sources */,
 				E15632CC1EB9ECF40035A099 /* TableViewKeyboardObserver.swift in Sources */,
 				E1A03F48174283E10085D192 /* BlogToJetpackAccount.m in Sources */,
+				8BE8545D27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */,
 				B522C4F81B3DA79B00E47B59 /* NotificationSettingsViewController.swift in Sources */,
 				93E63369272AC532009DACF8 /* LoginEpilogueChooseSiteTableViewCell.swift in Sources */,
 				9A51DA1522E9E8C7005CC335 /* ChangeUsernameViewController.swift in Sources */,
@@ -20604,6 +20609,7 @@
 				8BAC9D9F27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
 				FABB24612602FC2C00C8785C /* KeyringAccountHelper.swift in Sources */,
 				FABB24622602FC2C00C8785C /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
+				8BE8545E27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */,
 				FABB24632602FC2C00C8785C /* PushAuthenticationService.swift in Sources */,
 				FABB24642602FC2C00C8785C /* AlertView.swift in Sources */,
 				FABB24652602FC2C00C8785C /* WPTabBarController.m in Sources */,


### PR DESCRIPTION
Part of #17873

* Add AB test setup after site creation flow to enable Home or Site Menu as the default
* Add an option in Settings to change the initial screen to Home or Site Menu

https://user-images.githubusercontent.com/7040243/157917081-b27c3e37-14d8-4afd-a35e-e1b93fc66b84.mp4

### Additional info

The AB calculation is based on the token and it's the [same used for the Empty Stats project](https://github.com/wordpress-mobile/WordPress-iOS/pull/17328).

### To test

Do a clean install of the app and don't enable the My Site Dashboard feature flag. Then:

1. Login or create a new account
2. Go to Settings
3. ✅ You shouldn't see an "Initial Screen" option

Enable the My Site Dashboard feature flag:

1. Go to Settings
2. ✅ You should see an "Initial Screen" option
3. Change the value
4. Make sure that an event is fired on the console, like: `🔵 Tracked: app_settings_initial_screen_changed <selected: site_menu>`
4. Close and reopen the app
5. ✅ Make sure the option you selected is now the default

For the AB flow, there's no guarantee the Dashboard will be displayed for you. You can create a new account and site and test if it's displayed (or not).

If the `app_settings_initial_screen_changed` event is fired correctly, please validate it on Tracks.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
