### PR TITLE
Fix unliked posts still in Likes tab

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderPostCellActions.swift
@@ -84,6 +84,15 @@ class ReaderPostCellActions: NSObject, ReaderPostCellDelegate {
 
         ReaderLikeAction().execute(with: post, context: context, completion: {
             cell.refreshLikeButton()
+            guard let origin = self.origin as? ReaderStreamViewController else {
+                return
+            }
+            // since a like status changed, let's refresh other tabs
+            WPTabBarController.sharedInstance().readerTabViewModel.invalidateCache()
+            // if we are in "Likes", let's remove the unliked post
+            if let topic = origin.readerTopic, ReaderHelpers.topicType(topic) == .likes, !post.isLiked {
+                origin.syncIfAppropriate(forceSync: true)
+            }
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -255,4 +255,11 @@ extension ReaderTabViewModel {
         let context = ContextManager.sharedInstance().mainContext
         ReaderSearchSuggestionService(managedObjectContext: context).deleteAllSuggestions()
     }
+
+    /// Resets the `lastSynced` property for all tabs
+    @objc func invalidateCache() {
+        tabItems.forEach {
+            $0.content.topic?.lastSynced = nil
+        }
+    }
 }


### PR DESCRIPTION
Fixes #16179

This PR adds logic to refresh the likes tab when a post is unliked and make sure that the posts are updated when users navigate to another tab, so that the like/unlike status is up to date

To test:
Preferably test on both iPhone and iPad

- Build, run and select the "Reader" tab (if not already there)
- Select Following (if you have an account with followed sites) or Discover (you can select a few tags if you have not done that yet, in order for posts to show)
- like one or more post
- Switch to the "Likes" tab and make sure that those post appear
- Still in "Likes" unlike one or more posts and make sure that those same posts disappear
- Switch back to the tab where you first found those posts, and make sure that their like status matches what you selected (specifically, those that disappeared from the "Likes" tab should not be liked)

**Note: every update will trigger a remote call and then the local storage will be updated. This works, but the UI updates will not be immediate. A better approach would be to update the local data source and then make a network call to update the server accordingly, but this seem to require a much larger refactor than this one. So, as a first step, I think we can do this change and then look into making it better in a future PR**

## Regression Notes
1. Potential unintended areas of impact
Low impact on the reader: we are invalidating caches and forcing a reload, no other logic is affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test the changes on device

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
