### PR TITLE
Notification Comment Details: get comment from post if blog is unavailable

### DIFF
--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -32,9 +32,12 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 // Restore draft reply
 - (Comment *)restoreReplyForComment:(Comment *)comment;
 
+// Find cached comments
 - (NSSet *)findCommentsWithPostID:(NSNumber *)postID inBlog:(Blog *)blog;
 
 - (Comment *)findCommentWithID:(NSNumber *)commentID inBlog:(Blog *)blog;
+
+- (Comment *)findCommentWithID:(NSNumber *)commentID fromPost:(ReaderPost *)post;
 
 // Sync comments
 - (void)syncCommentsForBlog:(Blog *)blog
@@ -68,6 +71,11 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 // Load a single comment
 - (void)loadCommentWithID:(NSNumber *_Nonnull)commentID
                   forBlog:(Blog *_Nonnull)blog
+                  success:(void (^_Nullable)(Comment *_Nullable))success
+                  failure:(void (^_Nullable)(NSError *_Nullable))failure;
+
+- (void)loadCommentWithID:(NSNumber *_Nonnull)commentID
+                  forPost:(ReaderPost *_Nonnull)post
                   success:(void (^_Nullable)(Comment *_Nullable))success
                   failure:(void (^_Nullable)(NSError *_Nullable))failure;
 

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -237,4 +237,14 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
    deletingEarlier:(BOOL)deleteEarlier
     callingSuccess:(void (^)(NSInteger count, BOOL hasMore))success;
 
+
+/**
+ Get a cached site's ReaderPost with the specified ID.
+ 
+ @param postID ID of the post.
+ @param siteID ID of th site the post belongs to.
+ @return the matching ReaderPost.
+ */
+- (ReaderPost *)findPostWithID:(NSNumber *)postID forSite:(NSNumber *)siteID;
+
 @end

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -158,6 +158,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
     } failure:^(NSError *error) {
         if (failure) {
+            DDLogError(@"Error fetching post with id %@ and site %@. %@", postID, siteID, error);
             failure(error);
         }
     }];
@@ -187,6 +188,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
     } failure:^(NSError *error) {
         if (failure) {
+            DDLogError(@"Error fetching post with url %@. %@", postURL, error);
             failure(error);
         }
     }];
@@ -206,6 +208,19 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     }];
 }
 
+- (ReaderPost *)findPostWithID:(NSNumber *)postID forSite:(NSNumber *)siteID
+{
+    NSError *error;
+    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:NSStringFromClass([ReaderPost class])];
+    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"postID = %@ AND siteID = %@", postID, siteID];
+    NSArray *results = [self.managedObjectContext executeFetchRequest:fetchRequest error:&error];
+    if (error) {
+        DDLogError(@"Error loading cached post with id %@ and site %@. %@", postID, siteID, error);
+        return nil;
+    }
+    
+    return results.firstObject;
+}
 
 #pragma mark - Update Methods
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1002,6 +1002,12 @@ private extension CommentDetailViewController {
         isNotificationComment ? WPAppAnalytics.track(.notificationsCommentRepliedTo) :
                                 CommentAnalytics.trackCommentRepliedTo(comment: comment)
 
+        // If there is no Blog, try with the Post.
+        guard comment.blog != nil else {
+            // TODO: create comment on post.
+            return
+        }
+
         guard let reply = commentService.createReply(for: comment) else {
             DDLogError("Failed creating comment reply.")
             return

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -27,11 +27,19 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
         return Blog.lookup(withID: siteID, in: managedObjectContext)
     }
 
+    // If the user does not have permission to the Blog, it will be nil.
+    // In this case, use the Post to obtain Comment information.
+    private var post: ReaderPost?
+
     private var commentDetailViewController: CommentDetailViewController?
     private weak var notificationDelegate: CommentDetailsNotificationDelegate?
     private let managedObjectContext = ContextManager.shared.mainContext
 
     private lazy var commentService: CommentService = {
+        return .init(managedObjectContext: managedObjectContext)
+    }()
+
+    private lazy var postService: ReaderPostService = {
         return .init(managedObjectContext: managedObjectContext)
     }()
 
@@ -162,50 +170,101 @@ private extension NotificationCommentDetailViewController {
     func loadComment() {
         showLoadingView()
 
-        fetchParentCommentIfNeeded(completion: { [weak self] in
-            guard let self = self else {
-                return
-            }
+        loadPostIfNeeded(completion: { [weak self] in
 
-            if let comment = self.loadCommentFromCache(self.commentID) {
-                self.comment = comment
-                return
-            }
-
-            self.fetchComment(self.commentID, completion: { [weak self] comment in
-                guard let comment = comment else {
-                    self?.showErrorView()
+            self?.fetchParentCommentIfNeeded(completion: { [weak self] in
+                guard let self = self else {
                     return
                 }
 
-                self?.comment = comment
+                if let comment = self.loadCommentFromCache(self.commentID) {
+                    self.comment = comment
+                    return
+                }
+
+                self.fetchComment(self.commentID, completion: { [weak self] comment in
+                    guard let comment = comment else {
+                        self?.showErrorView()
+                        return
+                    }
+
+                    self?.comment = comment
+                })
             })
         })
     }
 
-    func loadCommentFromCache(_ commentID: NSNumber?) -> Comment? {
-        guard let commentID = commentID,
-              let blog = blog else {
-                  DDLogError("Notification Comment: unable to load comment due to missing information.")
-                  return nil
-              }
+    func loadPostIfNeeded(completion: @escaping () -> Void) {
 
-        return commentService.findComment(withID: commentID, in: blog)
-    }
-
-    func fetchComment(_ commentID: NSNumber?, completion: @escaping (Comment?) -> Void) {
-        guard let commentID = commentID,
-              let blog = blog else {
-                  DDLogError("Notification Comment: unable to fetch comment due to missing information.")
-                  completion(nil)
+        // The post is only needed if there is no Blog.
+        guard blog == nil,
+              let postID = notification.metaPostID,
+              let siteID = notification.metaSiteID else {
+                  completion()
                   return
               }
 
-        commentService.loadComment(withID: commentID, for: blog, success: { comment in
-            completion(comment)
-        }, failure: { error in
-            completion(nil)
+        if let post = postService.findPost(withID: postID, forSite: siteID) {
+            self.post = post
+            completion()
+            return
+        }
+
+        postService.fetchPost(postID.uintValue,
+                              forSite: siteID.uintValue,
+                              isFeed: false,
+                              success: { [weak self] post in
+            self?.post = post
+            completion()
+        }, failure: { [weak self] _ in
+            self?.post = nil
+            completion()
         })
+    }
+
+    func loadCommentFromCache(_ commentID: NSNumber?) -> Comment? {
+        guard let commentID = commentID else {
+            DDLogError("Notification Comment: unable to load comment due to missing commentID.")
+            return nil
+        }
+
+        if let blog = blog {
+            return commentService.findComment(withID: commentID, in: blog)
+        }
+
+        if let post = post {
+            return commentService.findComment(withID: commentID, from: post)
+        }
+
+        return nil
+    }
+
+    func fetchComment(_ commentID: NSNumber?, completion: @escaping (Comment?) -> Void) {
+        guard let commentID = commentID else {
+            DDLogError("Notification Comment: unable to fetch comment due to missing commentID.")
+            completion(nil)
+            return
+        }
+
+        if let blog = blog {
+            commentService.loadComment(withID: commentID, for: blog, success: { comment in
+                completion(comment)
+            }, failure: { error in
+                completion(nil)
+            })
+            return
+        }
+
+        if let post = post {
+            commentService.loadComment(withID: commentID, for: post, success: { comment in
+                completion(comment)
+            }, failure: { error in
+                completion(nil)
+            })
+            return
+        }
+
+        completion(nil)
     }
 
     func fetchParentCommentIfNeeded(completion: @escaping () -> Void) {
@@ -251,8 +310,6 @@ private extension NotificationCommentDetailViewController {
                                          title: NoResults.errorTitle,
                                          subtitle: NoResults.errorSubtitle,
                                          image: NoResults.imageName)
-
-
         }
     }
 


### PR DESCRIPTION
Ref: #17790 

When the `Blog` is unavailable for a `Comment`, the `ReaderPost` is now used to obtain the comment information.

Known issues:
- The header text is not correct. It says `Comment on` instead of `Reply to`.
- Tapping the header does not show the threaded comments.
- Reply does not work.
- `You replied...` is not displayed.
- Like does not work.

To test:
Repro steps from [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/18062#pullrequestreview-898656276) comment.

- With a second account, create a comment on a publicly accessible WP.com site (preferably owned by your primary account).
- Switch to your primary account, and reply to your second account's comment. This should trigger a reply notification on the second account.
- Switch back to your second account in your WordPress app, and go to Notifications.
- Tap on the reply notification.
- Verify:
  - The comment content is displayed.
  - The moderation bar is not displayed.
  - `Edit` is not displayed on the nav bar.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
