### PR TITLE
Notification Comment Details: post comment functionality

### DIFF
--- a/WordPress/Classes/Services/CommentService+Replies.swift
+++ b/WordPress/Classes/Services/CommentService+Replies.swift
@@ -27,10 +27,13 @@ extension CommentService {
             return
         }
 
-        // also fill in the `author` parameter, so the remote only returns comments authored by the current user.
-        remote.getCommentsV2(for: siteID, parameters: [.parent: parentID, .author: userID]) { remoteComments in
-            // return the most recent commentID (if any).
-            success(remoteComments.sorted { $0.date > $1.date }.first?.commentID ?? 0)
+        // If the current user does not have permission to the site, the `author` endpoint parameter is not permitted.
+        // Therefore, fetch all replies and filter for the current user here.
+        remote.getCommentsV2(for: siteID, parameters: [.parent: parentID]) { remoteComments in
+            // Filter for comments authored by the current user, and return the most recent commentID (if any).
+            success(remoteComments
+                        .filter { $0.authorID == userID }
+                        .sorted { $0.date > $1.date }.first?.commentID ?? 0)
         } failure: { error in
             failure(error)
         }

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -43,7 +43,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
     }
 
     private var siteID: NSNumber? {
-        return comment.blog?.dotComID
+        return comment.blog?.dotComID ?? notification?.metaSiteID
     }
 
     private var replyID: Int32 {
@@ -128,13 +128,20 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
     }
 
     private var parentComment: Comment? {
-        guard comment.hasParentComment(),
-              let blog = comment.blog,
-              let parentComment = commentService.findComment(withID: NSNumber(value: comment.parentID), in: blog) else {
-                  return nil
-              }
+        guard comment.hasParentComment() else {
+            return nil
+        }
 
-        return parentComment
+        if let blog = comment.blog {
+            return commentService.findComment(withID: NSNumber(value: comment.parentID), in: blog)
+
+        }
+
+        if let post = comment.post as? ReaderPost {
+            return commentService.findComment(withID: NSNumber(value: comment.parentID), from: post)
+        }
+
+        return nil
     }
 
     // transparent navigation bar style with visual blur effect.
@@ -537,12 +544,15 @@ private extension CommentDetailViewController {
 
     // Shows the comment thread with the Notification comment highlighted.
     func navigateToNotificationComment() {
-        guard let siteID = siteID,
-              let blog = comment.blog,
-              blog.supports(.wpComRESTAPI) else {
-                  openWebView(for: comment.commentURL())
-                  return
-              }
+        if let blog = comment.blog,
+           !blog.supports(.wpComRESTAPI) {
+            openWebView(for: comment.commentURL())
+            return
+        }
+
+        guard let siteID = siteID else {
+            return
+        }
 
         // Empty Back Button
         navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1004,7 +1004,7 @@ private extension CommentDetailViewController {
 
         // If there is no Blog, try with the Post.
         guard comment.blog != nil else {
-            // TODO: create comment on post.
+            createPostCommentReply(content: content)
             return
         }
 
@@ -1019,6 +1019,24 @@ private extension CommentDetailViewController {
             self?.displayReplyNotice(success: true)
             self?.refreshCommentReplyIfNeeded()
         }, failure: { [weak self] error in
+            DDLogError("Failed uploading comment reply: \(String(describing: error))")
+            self?.displayReplyNotice(success: false)
+        })
+    }
+
+    func createPostCommentReply(content: String) {
+        guard let post = comment.post as? ReaderPost else {
+            return
+        }
+
+        commentService.replyToHierarchicalComment(withID: NSNumber(value: comment.commentID),
+                                                  post: post,
+                                                  content: content,
+                                                  success: { [weak self] in
+            self?.displayReplyNotice(success: true)
+            self?.refreshCommentReplyIfNeeded()
+        }, failure: { [weak self] error in
+            DDLogError("Failed creating post comment reply: \(String(describing: error))")
             self?.displayReplyNotice(success: false)
         })
     }

--- a/WordPress/WordPressTest/CommentService+RepliesTests.swift
+++ b/WordPress/WordPressTest/CommentService+RepliesTests.swift
@@ -105,22 +105,6 @@ final class CommentService_RepliesTests: XCTestCase {
         expect { parameters = mockApi.parametersPassedIn! as! [String: Any] }.toNot(throwError())
         expect(parameters[parentKey] as? Int).to(equal(commentID))
     }
-
-    func test_getReplies_givenValidAuthorId_shouldAddAuthorIdInParameter() {
-        let (mockService, mockApi) = makeMockService()
-        let authorKey = CommentServiceRemoteREST.RequestKeys.author.rawValue
-
-        mockService.getLatestReplyID(for: commentID,
-                                     siteID: siteID,
-                                     accountService: accountService,
-                                     success: { _ in },
-                                     failure: { _ in })
-
-        var parameters = [String: Any]()
-        expect(mockApi.parametersPassedIn).toNot(beNil())
-        expect { parameters = mockApi.parametersPassedIn! as! [String: Any] }.toNot(throwError())
-        expect(parameters[authorKey] as? Int).to(equal(authorID))
-    }
 }
 
 // MARK: - Test Helpers

--- a/WordPress/WordPressTest/Test Data/comments-v2-success.json
+++ b/WordPress/WordPressTest/Test Data/comments-v2-success.json
@@ -24,7 +24,7 @@
     "id": 54,
     "post": 49,
     "parent": 1,
-    "author": 202,
+    "author": 99,
     "author_name": "Mary Sue",
     "author_url": "https://example.com/mary-sue",
     "date": "2021-07-02T17:50:20",


### PR DESCRIPTION
Ref: #17790 
Depends on: #18129

When using the `ReaderPost` to display the comment details, the following functionality is now supported:
- Comment detail header text shows the correct text.
- Tapping the comment detail header shows the threaded comments.
- Replying to a comment.
- `You replied...` is displayed.
- Liking a comment.

To test:
- With a second account, create a comment on a publicly accessible WP.com site (preferably owned by your primary account).
- Switch to your primary account, and reply to your second account's comment. This should trigger a reply notification on the second account.
- Switch back to your second account in your WordPress app, and go to Notifications.
- Tap on the reply notification.
- Verify:
  - The comment header text is `Reply to`.
  - Tapping the header shows the threaded comments.
  - Replying to the comment is successful.
  - The `You replied...` message is displayed.
  - Toggling Like is successful.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
