### PR TITLE
Notification Comment Details: hide back button title in threaded comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -82,7 +82,7 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = notification.title
+        configureNavBar()
         view.backgroundColor = .basicBackground
         loadComment()
     }
@@ -100,6 +100,12 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
 }
 
 private extension NotificationCommentDetailViewController {
+
+    func configureNavBar() {
+        title = notification.title
+        // Empty Back Button
+        navigationItem.backBarButtonItem = UIBarButtonItem(title: String(), style: .plain, target: nil, action: nil)
+    }
 
     func configureNavBarButtons() {
         var barButtonItems: [UIBarButtonItem] = []


### PR DESCRIPTION
Ref: #17790 , #18049

This removes the title from the back button in the threaded comments view.

To test:
- Go to Notifications > Comments > comment details.
- Tap the header to display the threaded comments.
- Verify the nav bar back button does not have a title.

| Before | After |
|--------|-------|
| <img width="435" alt="before" src="https://user-images.githubusercontent.com/1816888/157987222-0d2a6d27-cdc8-4660-9d01-1bfa4a4e5c1a.png"> | <img width="429" alt="after" src="https://user-images.githubusercontent.com/1816888/157987226-27ffb838-6551-485a-90fb-e7b52c5b5335.png"> |

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
