### PR TITLE
Fix issue preventing users from change profile picture

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] Weekly Roundup: We made some further changes to try and ensure that Weekly Roundup notifications are showing up for everybody who's enabled them [#18029]
 * [*] Block editor: Autocorrected Headings no longer apply bold formatting if they weren't already bold. [#17844]
 * [***] Block editor: Support for multiple color palettes [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4588]
+* [**] User profiles: Fixed issue where the app wasn't displaying any of the device photos which the user had granted the app access to.
 
 19.3
 -----

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarPickerViewController.swift
@@ -15,16 +15,7 @@ class GravatarPickerViewController: UIViewController, WPMediaPickerViewControlle
 
     fileprivate var mediaPickerViewController: WPNavigationMediaPickerViewController!
 
-    fileprivate lazy var mediaPickerAssetDataSource: WPPHAssetDataSource? = {
-        let collectionsFetchResult = PHAssetCollection.fetchAssetCollections(with: .smartAlbum, subtype: .smartAlbumSelfPortraits, options: nil)
-        guard let assetCollection = collectionsFetchResult.firstObject else {
-            return nil
-        }
-
-        let dataSource = WPPHAssetDataSource()
-        dataSource.setSelectedGroup(PHAssetCollectionForWPMediaGroup(collection: assetCollection, mediaType: .image))
-        return dataSource
-    }()
+    fileprivate lazy var mediaPickerAssetDataSource = WPPHAssetDataSource()
 
     // MARK: - View Lifecycle Methods
 


### PR DESCRIPTION
- Fixes #18126
- Fixes #13453

This PR is a workaround to fix an issue where the app froze and didn't show device photos when the user attempted to set their profile photo.

It also resolves a related issue where the app was opening different albums when the user attempts to change their profile photo (now the "Recents" album will always be opened when editing profile photos).

The app was freezing (and not showing device photos) because in code, we are not requesting permissions before calling into the `PHPhotoLibrary.shared().register()` function. This function call happened when the app filtered only for "selfie" photos, so eliminating that filter worked around the bug.

To fix the root cause involves calling `requestAuthorization(for:handler:)` before [applying the filter](https://github.com/wordpress-mobile/WordPress-iOS/blob/1406b807d3d4c037d35c3b46b6ae263e48db63d0/WordPress/Classes/ViewRelated/Me/My%20Profile/Gravatar/GravatarPickerViewController.swift#L19-L25). (There was recent work, [see PR here](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/376), that appears to be related to this.)

My plan is to create a separate `WPMediaPicker` issue and follow up on that separately, after shipping this workaround.

I have no preference between the app opening the "Selfies" album or the "Recents" album, so I don't think this change has any negative consequences from a user's perspective (let me know if you think otherwise). 

### To test

The app should now always open the "Recents" album when changing the user's profile picture. Test each of the following scenarios and look for any issues.
```
- [ ] Fresh install, change profile photo during account creation (sign-up)
- [ ] Fresh install, change profile photo after login
- [ ] Fresh install, add media via My Site → Media
- [ ] Fresh install, log in, change profile photo, add media via My Site → Media
- [ ] Fresh install, log in, change profile photo, add media via image block within the block editor
- [ ] Fresh install, log in, change profile photo, change site icon (ensure it shows both media library photos **and** device photos) 
- [ ] Without reinstalling, try any combination of the above and look out for any issues
```

## Regression Notes
1. Potential unintended areas of impact

The media picker is used in many places within the app and all . The test cases above include all known scenarios affected by the bug as well as scenarios where I checked for regressions 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I relied on manual tests as specified in the above test plan.

3. What automated tests I added (or what prevented me from doing so)

I don't think adding automated tests here is feasible. Unless we mocked `PHPhotoLibrary`, the test would have a large external dependency. I think there's room for a unit test inside of the WPMediaPicker library, which we might be able to do once we address the root cause of this issue in a separate PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
