### PR TITLE
My Site Dashboard (Phase 2): Display correct data for Stats card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -4,6 +4,8 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
 
     // MARK: Private Variables
 
+    private var viewModel: DashboardStatsViewModel?
+
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -29,11 +31,11 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
 
 extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
-        guard let viewController = viewController else {
+        guard let viewController = viewController, let apiResponse = apiResponse else {
             return
         }
 
-        // TODO: Use apiResponse to create a View Model and use it to populate the cell
+        self.viewModel = DashboardStatsViewModel(apiResponse: apiResponse)
 
         clearFrames()
         addTodayStatsCard(for: blog, in: viewController)
@@ -69,11 +71,10 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         return stackview
     }
 
-    // TODO: Data is now static. It should be brought in from the view model.
     private func statsViews() -> [UIView] {
-        let viewsStatsView = DashboardSingleStatView(countString: "1,492", title: Strings.viewsTitle)
-        let visitorsStatsView = DashboardSingleStatView(countString: "885", title: Strings.visitorsTitle)
-        let likesStatsView = DashboardSingleStatView(countString: "112", title: Strings.likesTitle)
+        let viewsStatsView = DashboardSingleStatView(countString: viewModel?.todaysViews ?? "0", title: Strings.viewsTitle)
+        let visitorsStatsView = DashboardSingleStatView(countString: viewModel?.todaysVisitors ?? "0", title: Strings.visitorsTitle)
+        let likesStatsView = DashboardSingleStatView(countString: viewModel?.todaysLikes ?? "0", title: Strings.likesTitle)
         return [viewsStatsView, visitorsStatsView, likesStatsView]
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardStatsViewModel.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+class DashboardStatsViewModel {
+
+    // MARK: Variables
+
+    private var apiResponse: BlogDashboardRemoteEntity
+
+    // MARK: Initializer
+
+    init(apiResponse: BlogDashboardRemoteEntity) {
+        self.apiResponse = apiResponse
+    }
+
+    // MARK: Public Variables
+
+    var todaysViews: String {
+        apiResponse.todaysStats?.views?.abbreviatedString(forHeroNumber: true) ?? "0"
+    }
+
+    var todaysVisitors: String {
+        apiResponse.todaysStats?.visitors?.abbreviatedString(forHeroNumber: true) ?? "0"
+    }
+
+    var todaysLikes: String {
+        apiResponse.todaysStats?.likes?.abbreviatedString(forHeroNumber: true) ?? "0"
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/DashboardStatsViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 class DashboardStatsViewModel {
 
-    // MARK: Variables
+    // MARK: Private Variables
 
     private var apiResponse: BlogDashboardRemoteEntity
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1334,6 +1334,9 @@
 		7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208520EAD918009C4699 /* FormattableUserContent.swift */; };
 		7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */; };
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
+		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
+		806E53E227E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
+		806E53E427E01CFE0064315E /* DashboardStatsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */; };
 		8071390727D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
@@ -6017,6 +6020,8 @@
 		7EFF208520EAD918009C4699 /* FormattableUserContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableUserContent.swift; sourceTree = "<group>"; };
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
+		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
+		806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModelTests.swift; sourceTree = "<group>"; };
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
 		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
@@ -11451,6 +11456,7 @@
 				8B6214E527B1B446001DF7B6 /* BlogDashboardServiceTests.swift */,
 				8BE9AB8727B6B5A300708E45 /* BlogDashboardPersistenceTests.swift */,
 				8BD34F0827D144FF005E931C /* BlogDashboardStateTests.swift */,
+				806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -11611,6 +11617,7 @@
 				8B074A4F27AC3A64003A2EB8 /* BlogDashboardViewModel.swift */,
 				8BEE845E27B1DE040001A93C /* DashboardCardSection.swift */,
 				8BEE846027B1DE0E0001A93C /* DashboardCardModel.swift */,
+				806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -18319,6 +18326,7 @@
 				D8212CC120AA7C58008E8AE8 /* ReaderShowMenuAction.swift in Sources */,
 				B5BE31C41CB825A100BDF770 /* NSURLCache+Helpers.swift in Sources */,
 				B5552D831CD1062400B26DF6 /* String+Extensions.swift in Sources */,
+				806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */,
 				469EB16824D9AD8B00C764CB /* CollapsableHeaderFilterBar.swift in Sources */,
 				40247E022120FE3600AE1C3C /* AutomatedTransferHelper.swift in Sources */,
 				8BF281FC27CEB69C00AF8CF3 /* DashboardFailureCardCell.swift in Sources */,
@@ -19255,6 +19263,7 @@
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				C81CCD6A243AEE1100A83E27 /* TenorAPIResponseTests.swift in Sources */,
 				8BE7C84123466927006EDE70 /* I18n.swift in Sources */,
+				806E53E427E01CFE0064315E /* DashboardStatsViewModelTests.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
 				E18549DB230FBFEF003C620E /* BlogServiceDeduplicationTests.swift in Sources */,
 				400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */,
@@ -19825,6 +19834,7 @@
 				FABB21B22602FC2C00C8785C /* NotificationActionParser.swift in Sources */,
 				FABB21B32602FC2C00C8785C /* SiteTagsViewController.swift in Sources */,
 				FABB21B42602FC2C00C8785C /* GutenbergImageLoader.swift in Sources */,
+				806E53E227E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */,
 				FABB21B52602FC2C00C8785C /* ReaderCrossPostMeta.swift in Sources */,
 				FABB21B62602FC2C00C8785C /* SnippetsContentStyles.swift in Sources */,
 				FABB21B72602FC2C00C8785C /* TopicsCollectionView.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
@@ -1,0 +1,50 @@
+//
+//  DashboardStatsViewModelTests.swift
+//  WordPressTest
+//
+//  Created by Hassaan El-Garem on 15/03/2022.
+//  Copyright © 2022 WordPress. All rights reserved.
+//
+
+import XCTest
+@testable import WordPress
+
+class DashboardStatsViewModelTests: XCTestCase {
+
+    func testReturnCorrectDataFromAPIResponse() {
+        // Given
+        let statsData = BlogDashboardRemoteEntity.BlogDashboardStats(views: 1, visitors: 2, likes: 3, comments: 0)
+        let apiResponse = BlogDashboardRemoteEntity(posts: nil, todaysStats: statsData)
+        let viewModel = DashboardStatsViewModel(apiResponse: apiResponse)
+
+        // When & Then
+        XCTAssertEqual(viewModel.todaysViews, "1")
+        XCTAssertEqual(viewModel.todaysVisitors, "2")
+        XCTAssertEqual(viewModel.todaysLikes, "3")
+    }
+
+    func testReturnedDataIsFormattedCorrectly() {
+        // Given
+        let statsData = BlogDashboardRemoteEntity.BlogDashboardStats(views: 10000, visitors: 200000, likes: 3000000, comments: 0)
+        let apiResponse = BlogDashboardRemoteEntity(posts: nil, todaysStats: statsData)
+        let viewModel = DashboardStatsViewModel(apiResponse: apiResponse)
+
+        // When & Then
+        XCTAssertEqual(viewModel.todaysViews, "10,000")
+        XCTAssertEqual(viewModel.todaysVisitors, "200.0K")
+        XCTAssertEqual(viewModel.todaysLikes, "3.0M")
+    }
+
+    func testReturnZeroIfAPIResponseIsEmpty() {
+        // Given
+        let statsData = BlogDashboardRemoteEntity.BlogDashboardStats(views: nil, visitors: nil, likes: nil, comments: nil)
+        let apiResponse = BlogDashboardRemoteEntity(posts: nil, todaysStats: statsData)
+        let viewModel = DashboardStatsViewModel(apiResponse: apiResponse)
+
+        // When & Then
+        XCTAssertEqual(viewModel.todaysViews, "0")
+        XCTAssertEqual(viewModel.todaysVisitors, "0")
+        XCTAssertEqual(viewModel.todaysLikes, "0")
+    }
+
+}

--- a/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardStatsViewModelTests.swift
@@ -1,11 +1,3 @@
-//
-//  DashboardStatsViewModelTests.swift
-//  WordPressTest
-//
-//  Created by Hassaan El-Garem on 15/03/2022.
-//  Copyright © 2022 WordPress. All rights reserved.
-//
-
 import XCTest
 @testable import WordPress
 


### PR DESCRIPTION
Part of #17876

## Description
- Add a new ViewModel to process stats data from API response.
- Uses new ViewModel to display data in the dashboard stats card.

## Testing Instructions

Make sure the MSD feature flag is enabled

1. Tap "Home" on the segmented control to display the dashboard
2. Make sure the data displayed in the stats card is not static and matches the data in insights.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
