### PR TITLE
My Site Dashboard (Phase 2): Accessibility and track events for Stats card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
@@ -6,8 +6,8 @@ final class DashboardSingleStatView: UIView {
 
     private lazy var mainStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
-            numberLabel,
-            titleLabel
+            titleLabel,
+            numberLabel
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
@@ -22,6 +22,7 @@ final class DashboardSingleStatView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .bold)
         label.textColor = .text
+        label.isAccessibilityElement = false
         return label
     }()
 
@@ -30,6 +31,7 @@ final class DashboardSingleStatView: UIView {
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = WPStyleGuide.fontForTextStyle(.subheadline)
         label.textColor = .textSubtle
+        label.isAccessibilityElement = false
         return label
     }()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -92,6 +92,9 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     }
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
+        WPAnalytics.track(.dashboardCardItemTapped,
+                          properties: ["type": "stats"],
+                          blog: blog)
         StatsViewController.show(for: blog, from: sourceController, showTodayStats: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -59,6 +59,10 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         frameView.add(subview: statsStackview)
 
         stackView.addArrangedSubview(frameView)
+
+        WPAnalytics.track(.dashboardCardShown,
+                          properties: ["type": DashboardCard.todaysStats.rawValue],
+                          blog: blog)
     }
 
     private func createStatsStackView(arrangedSubviews: [UIView]) -> UIStackView {
@@ -93,7 +97,7 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
         WPAnalytics.track(.dashboardCardItemTapped,
-                          properties: ["type": "stats"],
+                          properties: ["type": DashboardCard.todaysStats.rawValue],
                           blog: blog)
         StatsViewController.show(for: blog, from: sourceController, showTodayStats: true)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -109,7 +109,7 @@ private extension DashboardStatsCardCell {
         static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
         static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
         static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
-        static let accessibilityLabelFormat = "%@ \(viewsTitle), %@ \(visitorsTitle), %@ \(likesTitle)."
+        static let accessibilityLabelFormat = "\(viewsTitle) %@, \(visitorsTitle) %@, \(likesTitle) %@."
         static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -68,6 +68,9 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         stackview.distribution = .fillEqually
         stackview.isLayoutMarginsRelativeArrangement = true
         stackview.directionalLayoutMargins = Constants.statsStackViewMargins
+        stackview.isAccessibilityElement = true
+        stackview.accessibilityTraits = .button
+        stackview.accessibilityLabel = statsStackViewAccessibilityLabel()
         return stackview
     }
 
@@ -76,6 +79,16 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         let visitorsStatsView = DashboardSingleStatView(countString: viewModel?.todaysVisitors ?? "0", title: Strings.visitorsTitle)
         let likesStatsView = DashboardSingleStatView(countString: viewModel?.todaysLikes ?? "0", title: Strings.likesTitle)
         return [viewsStatsView, visitorsStatsView, likesStatsView]
+    }
+
+    private func statsStackViewAccessibilityLabel() -> String {
+        guard let viewModel = viewModel else {
+            return Strings.errorTitle
+        }
+        let arguments = [viewModel.todaysViews.accessibilityLabel ?? viewModel.todaysViews,
+                         viewModel.todaysVisitors.accessibilityLabel ?? viewModel.todaysVisitors,
+                         viewModel.todaysLikes.accessibilityLabel ?? viewModel.todaysLikes]
+        return String(format: Strings.accessibilityLabelFormat, arguments: arguments)
     }
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
@@ -93,6 +106,8 @@ private extension DashboardStatsCardCell {
         static let visitorsTitle = NSLocalizedString("Visitors", comment: "Today's Stats 'Visitors' label")
         static let likesTitle = NSLocalizedString("Likes", comment: "Today's Stats 'Likes' label")
         static let commentsTitle = NSLocalizedString("Comments", comment: "Today's Stats 'Comments' label")
+        static let accessibilityLabelFormat = "%@ \(viewsTitle), %@ \(visitorsTitle), %@ \(likesTitle)."
+        static let errorTitle = NSLocalizedString("Stats not loaded", comment: "The loading view title displayed when an error occurred")
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -10,8 +10,8 @@ import Foundation
 enum DashboardCard: String, CaseIterable {
     case quickActions
     case quickStart
-    case posts
     case todaysStats = "todays_stats"
+    case posts
 
     // Card placeholder for when loading data
     case ghost

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -43,7 +43,7 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         service.fetch(blog: blog) { _ in
             XCTAssertEqual(self.remoteServiceMock.didCallWithBlogID, self.wpComID)
-            XCTAssertEqual(self.remoteServiceMock.didRequestCards, ["posts", "todays_stats"])
+            XCTAssertEqual(self.remoteServiceMock.didRequestCards, ["todays_stats", "posts"])
             expect.fulfill()
         }
 


### PR DESCRIPTION
Finishes of #17876

## Description
- Add a11y for Stats card
- Tracks tap event of Stats card

## Testing Instructions

Make sure the MSD feature flag is enabled

### Tracks

1. Tap "Home" on the segmented control to display the dashboard
2. Tap on the stats cell.
3. Validate the event `my_site_dashboard_card_item_tapped` is fired with the type being "stats" (PCYsg-ktp-p2)

> What does it mean for an event to be valid?
> 
> An event can be marked valid when you’ve checked that it:
> 
>     Fires when it’s supposed to.
>     Fires exactly once each time it’s supposed to fire.
>     Has a blogid set if the event takes place in a site context.  If it’s not in a site context (e.g. a landing page or the wpcom homepage), you can omit a blogid.
>     Has the event properties that you intend it to have, and that are being attached to the event by your code.
> 
> Who should review it?
> 
> Similarly to code reviews, someone on your team or working in the same area as you is probably best to review your event.

### A11y
1. Turn on VoiceOver
2. Tap "Home" on the segmented control to display the dashboard
3. Tap on stats cell title.
4. Make sure the title is read out loud
5. Tap on the data displayed.
6. Make sure views, visitors, and likes are read out loud and grouped together.
7. Make sure that abrreviations are read out in full. For example "3.0M" should be read out as "3.0 million" 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
