### PR TITLE
Notification Comment Details: enable feature for release

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Quick Start: updated the design for the Quick Start cell on My Site [#18095]
 * [*] Reader: Fixed a bug where comment replies are misplaced after its parent comment is moderated [#18094]
 * [*] iPad: Fixed a bug where the current displayed section wasn't selected on the menu [#18118]
+* [**] Comment Notifications: updated UI and functionality to match My Site Comments. [#18141]
 
 19.4
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -81,7 +81,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mediaPickerPermissionsNotice:
             return true
         case .notificationCommentDetails:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+            return true
         case .statsPerformanceImprovements:
             return true
         case .siteIntentQuestion:


### PR DESCRIPTION
Ref: #17790

This enables the new Comment details view for Comment Notifications.

To test:

TLDR - verify everything works as expected.


- Go to Notifications > comment notification.
- Verify the new details view is displayed.
- Verify Spam, Trash, and deleted comments are removed from the notifications list.
- Verify the ⬆️ and ⬇️ nav bar buttons display the previous and next notification.
- Verify Edit, Reply, and Like work as expected.
- Verify the `You replied...` message appears if you've replied to a comment.

If you do not have permission to the site the notification is for, verify:
- The comment content appears.
- The moderation bar does not.
- `Edit` nav bar button does not.
- `Email address` and `IP address` do not.

| ![all_the_things](https://user-images.githubusercontent.com/1816888/158470533-2b33eddf-4070-4ca5-b117-85a29a432fa8.png) | ![some_things](https://user-images.githubusercontent.com/1816888/158471309-0b659d08-7c3e-475c-8a79-7dc314899e27.png) |
|--------|-------|

## Regression Notes
1. Potential unintended areas of impact
Should be done.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested Notification Comments and My Site Comments to be sure both work as expected.

3. What automated tests I added (or what prevented me from doing so)
Updated existing WP tests, new tests added to WPKit.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
