### PR TITLE
Remove `postDetailsComments` feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -18,7 +18,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case timeZoneSuggester
     case aboutScreen
     case newCommentThread
-    case postDetailsComments
     case commentThreadModerationMenu
     case mySiteDashboard
     case followConversationPostDetails
@@ -67,8 +66,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .aboutScreen:
             return true
         case .newCommentThread:
-            return true
-        case .postDetailsComments:
             return true
         case .commentThreadModerationMenu:
             return true
@@ -144,8 +141,6 @@ extension FeatureFlag {
             return "New Unified About Screen"
         case .newCommentThread:
             return "New Comment Thread"
-        case .postDetailsComments:
-            return "Post Details Comments"
         case .commentThreadModerationMenu:
             return "Comment Thread Moderation Menu"
         case .mySiteDashboard:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -160,10 +160,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         configureNoResultsViewController()
         observeWebViewHeight()
         configureNotifications()
-
-        if FeatureFlag.postDetailsComments.enabled {
-            configureCommentsTable()
-        }
+        configureCommentsTable()
 
         coordinator?.start()
 
@@ -533,10 +530,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     @objc private func fetchComments() {
-        guard FeatureFlag.postDetailsComments.enabled,
-              let post = post else {
-                  return
-              }
+        guard let post = post else {
+            return
+        }
 
         coordinator?.fetchComments(for: post)
     }


### PR DESCRIPTION
Ref: #17511 

This removes the `postDetailsComments` feature flag.

To test:
- Go to Reader > post > details.
- Verify the Comments snippet appears.

<kbd><img width="438" alt="Screen Shot 2022-03-15 at 3 35 50 PM" src="https://user-images.githubusercontent.com/1816888/158476750-af9f8231-a890-4cbd-b51c-d38ec7e2bc66.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
