### PR TITLE
Remove `followConversationPostDetails` feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,7 +21,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case postDetailsComments
     case commentThreadModerationMenu
     case mySiteDashboard
-    case followConversationPostDetails
     case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
     case notificationCommentDetails
@@ -75,8 +74,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .mySiteDashboard:
             return false
         case .markAllNotificationsAsRead:
-            return true
-        case .followConversationPostDetails:
             return true
         case .mediaPickerPermissionsNotice:
             return true
@@ -150,8 +147,6 @@ extension FeatureFlag {
             return "Comment Thread Moderation Menu"
         case .mySiteDashboard:
             return "My Site Dashboard"
-        case .followConversationPostDetails:
-            return "Follow Conversation from Post Details"
         case .markAllNotificationsAsRead:
             return "Mark Notifications As Read"
         case .mediaPickerPermissionsNotice:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -19,7 +19,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 
     private var followConversationEnabled = false {
         didSet {
-            followButton.isHidden = !FeatureFlag.followConversationPostDetails.enabled || !followConversationEnabled
+            followButton.isHidden = !followConversationEnabled
         }
     }
 


### PR DESCRIPTION
Ref: #17632
This removes the `followConversationPostDetails` feature flag.

To test:
- Go to Reader > post > details.
- Verify the `Follow Conversation` button appears on the Comments snippet on posts that can be followed.

<kbd><img width="437" alt="Screen Shot 2022-03-15 at 3 47 10 PM" src="https://user-images.githubusercontent.com/1816888/158479163-eb8930fe-7796-4647-8167-da9c925aa0e4.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
