### PR TITLE
Track `FBReactNativeSpec` hash change after fresh `pod install` run

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -785,7 +785,7 @@ SPEC CHECKSUMS:
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 2bf7b5e351f8e33867210ff6eb9c5c178a035522
-  FBReactNativeSpec: 5a1f15997f42c2f266b63a6b9c3e92a9eca049f5
+  FBReactNativeSpec: b4076f780f69b07abd859b279490f401d127c0ec
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86


### PR DESCRIPTION
With "fresh" I mean the following:

```
pod cache clean --all \
  && rm -rf Pods/ \
  && bundle exec pod repo remove trunk \
  && bundle exec pod install
```

This rectifies the change introduced by 437573bdfbaef73d648d8f3604738401504c63dc, of which I was the author.

I didn't notice the change in the diff at the time. The issue was brought to my attention by @ScoutHarris and @guarani. Thanks folks!

Given you both got the change in this PR and that I was able to reproduce the `Podfile.lock` not changing locally, then changing after a fresh install, I think we can file this as an issue with the cache on my
machine.

**To test:** If you have some time to spare, checkout this branch and run the command above. There should be no change in the `Podfile.lock`.

## Regression Notes
1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

PR submission checklist:

- [x] I have completed the Regression Notes. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have considered adding accessibility improvements for my changes. – N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
