### PR TITLE
Split VC: Show correct vc when collapsing split view controllers

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1093,7 +1093,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
 
     self.restorableSelectedIndexPath = nil;
-
+    
+    WPSplitViewController *splitViewController = (WPSplitViewController *)self.splitViewController;
+    splitViewController.isShowingInitialDetail = YES;
+    
     if ([self shouldShowDashboard]) {
         [self showDetailViewForSubsection:BlogDetailsSubsectionHome];
     } else {
@@ -1179,6 +1182,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
 {
+    WPSplitViewController *splitViewController = (WPSplitViewController *)self.splitViewController;
+    splitViewController.isShowingInitialDetail = NO;
+    
     BlogDetailsSection *section = [self.tableSections objectAtIndex:indexPath.section];
     BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];
     row.callback();

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -230,6 +230,11 @@ class WPSplitViewController: UISplitViewController {
         }
     }
 
+    /// A flag that indicates whether the split view controller is showing the
+    /// initial (i.e. default) view controller or not.
+    ///
+    @objc var isShowingInitialDetail = false
+
     fileprivate let dimmingViewAlpha: CGFloat = 0.5
     fileprivate let dimmingViewAnimationDuration: TimeInterval = 0.3
 
@@ -507,7 +512,7 @@ extension WPSplitViewController: UISplitViewControllerDelegate {
                 let forceKeepDetail = (collapseMode == .AlwaysKeepDetail &&
                                        primaryViewController.viewControllers.last is WPSplitViewControllerDetailProvider)
 
-                if detailNavigationStackHasBeenModified || forceKeepDetail {
+                if (!isShowingInitialDetail && detailNavigationStackHasBeenModified) || forceKeepDetail {
                     primaryViewController.viewControllers.append(contentsOf: secondaryViewController.viewControllers)
                 }
             }


### PR DESCRIPTION
Fixes [#18021](https://github.com/wordpress-mobile/WordPress-iOS/issues/18021#issuecomment-1067536071)

## Description

This fixes an issue where the split view controller was incorrectly collapsing to the detail vc if the app was launched in landscape orientation then rotated to portrait.

## Context

Currently My Site is configured to display in split view mode if the landscape [size class](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/) is regular width (as opposed to compact width). All iPad models have a regular width regardless of portrait vs landscape orientation. Some iPhone models have a regular width in landscape orientation. For example:
 
- [iPhone 11 is regular width in landscape](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/) -> displayed in split view
- [iPhone 13 is compact width in landscape](https://useyourloaf.com/blog/iphone-13-screen-sizes/) -> not displayed in split view

On iPhones that display My Site in a split vc in landscape mode, the detail pane will be pushed onto the primary navigation stack if the user has manually changed the selection in the primary pane. Otherwise, if the detail pane is still showing its default content, it will be discarded. 

https://github.com/wordpress-mobile/WordPress-iOS/blob/a08cc72e4bfb15d4fa88c06c549c16941fb2a64a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift#L22-L28

## How to test

### No user input on primary vc

0. Build and run the app on an iPhone that has a regular width in landscape (i.e. iPhone 11)
1. Launch app in landscape
2. Rotate device to portrait
3. ✅ The My Site screen should be displayed when the split vc collapses

https://user-images.githubusercontent.com/6711616/158527529-18fda08c-1451-438a-806f-d2bc8f213ad9.mp4

### User input on primary vc

0. Build and run the app on an iPhone that has a regular width in landscape (i.e. iPhone 11)
1. Launch app in landscape
2. Select a different item than the currently selected item on the primary vc pane
3. Rotate device to portrait
4. ✅ The detail VC screen you selected in step 2 should be displayed when the split vc collapses

https://user-images.githubusercontent.com/6711616/158528378-84cf44c1-fc3d-4d7e-8a95-6d5c43252c99.mp4


## Regression Notes
1. Potential unintended areas of impact
The above cases launched in portrait mode

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
