### PR TITLE
Remove `markAllNotificationsAsRead` feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -20,7 +20,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newCommentThread
     case commentThreadModerationMenu
     case mySiteDashboard
-    case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
     case notificationCommentDetails
     case statsPerformanceImprovements
@@ -70,8 +69,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .mySiteDashboard:
             return false
-        case .markAllNotificationsAsRead:
-            return true
         case .mediaPickerPermissionsNotice:
             return true
         case .notificationCommentDetails:
@@ -142,8 +139,6 @@ extension FeatureFlag {
             return "Comment Thread Moderation Menu"
         case .mySiteDashboard:
             return "My Site Dashboard"
-        case .markAllNotificationsAsRead:
-            return "Mark Notifications As Read"
         case .mediaPickerPermissionsNotice:
             return "Media Picker Permissions Notice"
         case .notificationCommentDetails:

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -512,13 +512,12 @@ private extension NotificationsViewController {
 
     func updateNavigationItems() {
         var barItems: [UIBarButtonItem] = []
+
         if shouldDisplaySettingsButton {
             barItems.append(settingsBarButtonItem)
         }
 
-        if FeatureFlag.markAllNotificationsAsRead.enabled {
-            barItems.append(markAllAsReadBarButtonItem)
-        }
+        barItems.append(markAllAsReadBarButtonItem)
 
         navigationItem.setRightBarButtonItems(barItems, animated: false)
     }


### PR DESCRIPTION
Ref: #17135

This removes the `markAllNotificationsAsRead` feature flag.

To test:
- Go to Notifications.
- Verify the checkmark icon appears in the nav bar.

| <img width="449" alt="Screen Shot 2022-03-16 at 1 18 59 PM" src="https://user-images.githubusercontent.com/1816888/158671989-563619cd-e73e-4f87-83be-8c846cf4835f.png"> | <img width="448" alt="Screen Shot 2022-03-16 at 1 18 45 PM" src="https://user-images.githubusercontent.com/1816888/158672002-6bb700d2-6dc9-4a6a-a694-6c4aca863bbf.png"> |
|--------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
