### PR TITLE
Remove `commentThreadModerationMenu` feature flag.

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -18,7 +18,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case timeZoneSuggester
     case aboutScreen
     case newCommentThread
-    case commentThreadModerationMenu
     case mySiteDashboard
     case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
@@ -65,8 +64,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .aboutScreen:
             return true
         case .newCommentThread:
-            return true
-        case .commentThreadModerationMenu:
             return true
         case .mySiteDashboard:
             return false
@@ -138,8 +135,6 @@ extension FeatureFlag {
             return "New Unified About Screen"
         case .newCommentThread:
             return "New Comment Thread"
-        case .commentThreadModerationMenu:
-            return "Comment Thread Moderation Menu"
         case .mySiteDashboard:
             return "My Site Dashboard"
         case .markAllNotificationsAsRead:

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -114,7 +114,7 @@ extension NSNotification.Name {
     }
 
     func isModerationMenuEnabled(for comment: Comment) -> Bool {
-        return comment.allowsModeration() && Feature.enabled(.commentThreadModerationMenu)
+        return comment.allowsModeration()
     }
 
     // MARK: - Tracking


### PR DESCRIPTION
Ref: #17629 

This removes the `commentThreadModerationMenu` feature flag.

To test:
- Go to the Reader.
- Select a post who's comments you can moderate.
- View post comments.
  - Verify the ellipsis button is shown for each comment, and tapping it displays the moderation menu.
- Select a post who's comments you cannot moderate.
- View post comments.
  - Verify the share button is shown for each comment.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
