### PR TITLE
My Site Dashboard (Phase 2): Add ability to remove Quick Start from dashboard

### DIFF
--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
@@ -1,0 +1,13 @@
+#import <UIKit/UIKit.h>
+
+@class Blog;
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UIViewController (RemoveQuickStart)
+
+- (void)removeQuickStartFromBlog:(Blog *)blog;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
@@ -1,0 +1,38 @@
+#import "UIViewController+RemoveQuickStart.h"
+
+#import "Blog.h"
+#import "WordPress-Swift.h"
+
+@implementation UIViewController (RemoveQuickStart)
+
+- (void)removeQuickStartFromBlog:(Blog *)blog
+{
+    [NoticesDispatch lock];
+    NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
+    NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
+    NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
+    NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
+
+    UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
+    [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
+        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
+        [NoticesDispatch unlock];
+    }];
+    [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
+        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
+        [[QuickStartTourGuide shared] removeFrom:blog];
+        [NoticesDispatch unlock];
+    }];
+
+    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
+        [self presentViewController:removeConfirmation animated:YES completion:nil];
+    }];
+    [removeSheet addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
+        [NoticesDispatch unlock];
+    }];
+
+    [self presentViewController:removeSheet animated:YES completion:nil];
+}
+
+@end

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -84,6 +84,7 @@
 #import "UIAlertControllerProxy.h"
 #import "UIApplication+Helpers.h"
 #import "UIView+Subviews.h"
+#import "UIViewController+RemoveQuickStart.h"
 
 #import "WPAccount.h"
 #import "WPActivityDefaults.h"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -109,7 +109,7 @@ final class BlogDashboardViewController: UIViewController {
     }
 
     private func addQuickStartObserver() {
-        NotificationCenter.default.addObserver(self, selector: #selector(showQuickStart), name: .QuickStartTourElementChangedNotification, object: nil)    }
+        NotificationCenter.default.addObserver(self, selector: #selector(toggleQuickStart), name: .QuickStartTourElementChangedNotification, object: nil)    }
 
     @objc private func updateCollectionViewHeight(notification: Notification) {
         collectionView.collectionViewLayout.invalidateLayout()
@@ -124,8 +124,8 @@ final class BlogDashboardViewController: UIViewController {
         viewModel.loadCards()
     }
 
-    /// Show Quick Start if needed
-    @objc private func showQuickStart() {
+    /// Show or hide Quick Start if needed
+    @objc private func toggleQuickStart() {
         guard view.superview != nil else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -62,7 +62,9 @@ class BlogDashboardCardFrameView: UIView {
         let button = UIButton(type: .custom)
         button.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
         button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
-        button.isAccessibilityElement = false
+        button.isAccessibilityElement = true
+        button.accessibilityLabel = Strings.ellipsisButtonAccessibilityLabel
+        button.accessibilityTraits = .button
         button.isHidden = true
         button.on(.touchUpInside) { [weak self] _ in
             self?.onEllipsisButtonTap?()
@@ -232,5 +234,9 @@ class BlogDashboardCardFrameView: UIView {
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+    }
+
+    private enum Strings {
+        static let ellipsisButtonAccessibilityLabel = NSLocalizedString("More", comment: "Accessibility label for more button in dashboard quick start card.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -133,7 +133,6 @@ class BlogDashboardCardFrameView: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateColors()
-        setNeedsDisplay()
     }
 
     /// Add a subview inside the card frame

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -128,6 +128,12 @@ class BlogDashboardCardFrameView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        updateColors()
+        setNeedsDisplay()
+    }
+
     /// Add a subview inside the card frame
     func add(subview: UIView) {
         mainStackView.addArrangedSubview(subview)
@@ -156,6 +162,10 @@ class BlogDashboardCardFrameView: UIView {
             chevronImageView,
             ellipsisButton
         ])
+    }
+
+    private func updateColors() {
+        ellipsisButton.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
     }
 
     private func updateChevronImageState() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -61,7 +61,7 @@ class BlogDashboardCardFrameView: UIView {
     private lazy var ellipsisButton: UIButton = {
         let button = UIButton(type: .custom)
         button.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
-        button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        button.contentEdgeInsets = Constants.ellipsisButtonPadding
         button.isAccessibilityElement = true
         button.accessibilityLabel = Strings.ellipsisButtonAccessibilityLabel
         button.accessibilityTraits = .button

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -17,7 +17,7 @@ class BlogDashboardCardFrameView: UIView {
     /// Header in which icon, title and chevron are added
     private lazy var headerStackView: UIStackView = {
         let topStackView = UIStackView()
-        topStackView.layoutMargins = Constants.headerPadding
+        topStackView.layoutMargins = Constants.headerPaddingWithEllipsisButtonHidden
         topStackView.isLayoutMarginsRelativeArrangement = true
         topStackView.spacing = Constants.headerHorizontalSpacing
         topStackView.alignment = .center
@@ -45,7 +45,7 @@ class BlogDashboardCardFrameView: UIView {
         return titleLabel
     }()
 
-    /// Chevron displayed in case there's any action associa
+    /// Chevron displayed in case there's any action associated
     private lazy var chevronImageView: UIImageView = {
         let chevronImageView = UIImageView(image: UIImage.gridicon(.chevronRight, size: Constants.iconSize).withRenderingMode(.alwaysTemplate))
         chevronImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
@@ -54,6 +54,20 @@ class BlogDashboardCardFrameView: UIView {
         chevronImageView.isAccessibilityElement = false
         chevronImageView.isHidden = true
         return chevronImageView
+    }()
+
+    /// Ellipsis Button displayed on the top right corner of the view.
+    /// Displayed only when an associated action is set
+    private lazy var ellipsisButton: UIButton = {
+        let button = UIButton(type: .custom)
+        button.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
+        button.contentEdgeInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        button.isAccessibilityElement = false
+        button.isHidden = true
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.onEllipsisButtonTap?()
+        }
+        return button
     }()
 
     weak var currentView: UIView?
@@ -90,6 +104,14 @@ class BlogDashboardCardFrameView: UIView {
             addHeaderTapGestureIfNeeded()
         }
 
+    }
+
+    /// Closure to be called when the ellipsis button is tapped..
+    /// If set, the ellipsis button image is displayed.
+    var onEllipsisButtonTap: (() -> Void)? {
+        didSet {
+            updateEllipsisButtonState()
+        }
     }
 
     override init(frame: CGRect) {
@@ -131,12 +153,30 @@ class BlogDashboardCardFrameView: UIView {
         headerStackView.addArrangedSubviews([
             iconImageView,
             titleLabel,
-            chevronImageView
+            chevronImageView,
+            ellipsisButton
         ])
     }
 
     private func updateChevronImageState() {
         chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
+        assertOnTapRecognitionCorrectUsage()
+    }
+
+    private func updateEllipsisButtonState() {
+        ellipsisButton.isHidden = onEllipsisButtonTap == nil
+        let headerPadding = ellipsisButton.isHidden ?
+            Constants.headerPaddingWithEllipsisButtonHidden :
+            Constants.headerPaddingWithEllipsisButtonShown
+        headerStackView.layoutMargins = headerPadding
+        assertOnTapRecognitionCorrectUsage()
+    }
+
+    /// Only one of two types of action should be associated with the card.
+    /// Either ellipsis button tap, or view/header tap
+    private func assertOnTapRecognitionCorrectUsage() {
+        let bothTypesUsed = (onViewTap != nil || onHeaderTap != nil) && onEllipsisButtonTap != nil
+        assert(!bothTypesUsed, "Using onViewTap or onHeaderTap alongside onEllipsisButtonTap is not supported and will result in unexpected behavior.")
     }
 
     private func addHeaderTapGestureIfNeeded() {
@@ -172,14 +212,15 @@ class BlogDashboardCardFrameView: UIView {
         else {
             onViewTap?()
         }
-
     }
 
     private enum Constants {
         static let bottomPadding: CGFloat = 8
-        static let headerPadding = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
+        static let headerPaddingWithEllipsisButtonHidden = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
+        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
         static let headerHorizontalSpacing: CGFloat = 5
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
+        static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -2,11 +2,21 @@ import UIKit
 
 final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDashboardCardConfigurable {
 
+    private weak var viewController: BlogDashboardViewController?
+    private var blog: Blog?
+
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.title = Strings.nextSteps
         frameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
         frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.onEllipsisButtonTap = { [weak self] in
+            guard let viewController = self?.viewController,
+                  let blog = self?.blog else {
+                return
+            }
+            viewController.removeQuickStart(from: blog)
+        }
         return frameView
     }()
 
@@ -29,7 +39,8 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         guard let viewController = viewController else {
             return
         }
-
+        self.viewController = viewController
+        self.blog = blog
         tourStateView.configure(blog: blog, sourceController: viewController)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -13,6 +13,7 @@
 #import "WPGUIConstants.h"
 #import "WordPress-Swift.h"
 #import "MenusViewController.h"
+#import "UIViewController+RemoveQuickStart.h"
 #import <Reachability/Reachability.h>
 #import <WordPressShared/WPTableViewCell.h>
 
@@ -1222,41 +1223,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
     [view setTitle:title];
     view.ellipsisButtonDidTouch = ^(BlogDetailsSectionHeaderView *header) {
-        [NoticesDispatch lock];
-        [weakSelf removeQuickStartSection:header];
+        [weakSelf removeQuickStartFromBlog:weakSelf.blog];
     };
     return view;
-}
-
-- (void)removeQuickStartSection:(BlogDetailsSectionHeaderView *)view
-{
-    NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
-    NSString *removeMessage = NSLocalizedString(@"Removing Next Steps will hide all tours on this site. This action cannot be undone.", @"Explanation of what will happen if the user confirms this alert.");
-    NSString *confirmationTitle = NSLocalizedString(@"Remove", @"Title for button that will confirm removing the next steps/quick start menus.");
-    NSString *cancelTitle = NSLocalizedString(@"Cancel", @"Cancel button");
-    
-    UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
-    [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
-        [NoticesDispatch unlock];
-    }];
-    [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
-        [[QuickStartTourGuide shared] removeFrom:self.blog];
-        [NoticesDispatch unlock];
-    }];
-    
-    UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
-    removeSheet.popoverPresentationController.sourceView = view;
-    removeSheet.popoverPresentationController.sourceRect = view.ellipsisButton.frame;
-    [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
-        [self presentViewController:removeConfirmation animated:YES completion:nil];
-    }];
-    [removeSheet addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
-        [NoticesDispatch unlock];
-    }];
-    
-    [self presentViewController:removeSheet animated:YES completion:nil];
 }
 
 - (NSIndexPath *)tableView:(UITableView *)tableView willSelectRowAtIndexPath:(nonnull NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -44,6 +44,7 @@ open class QuickStartTourGuide: NSObject {
 
     @objc func remove(from blog: Blog) {
         blog.removeAllTours()
+        endCurrentTour()
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -44,6 +44,7 @@ open class QuickStartTourGuide: NSObject {
 
     @objc func remove(from blog: Blog) {
         blog.removeAllTours()
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1334,6 +1334,8 @@
 		7EFF208620EAD918009C4699 /* FormattableUserContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208520EAD918009C4699 /* FormattableUserContent.swift */; };
 		7EFF208A20EADCB6009C4699 /* NotificationTextContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */; };
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
+		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
+		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
 		806E53E227E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
 		806E53E427E01CFE0064315E /* DashboardStatsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */; };
@@ -6022,6 +6024,8 @@
 		7EFF208520EAD918009C4699 /* FormattableUserContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableUserContent.swift; sourceTree = "<group>"; };
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
+		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
+		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
 		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
 		806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModelTests.swift; sourceTree = "<group>"; };
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
@@ -13419,6 +13423,8 @@
 				E69BA1971BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m */,
 				31EC15061A5B6675009FC8B3 /* WPStyleGuide+Suggestions.h */,
 				31EC15071A5B6675009FC8B3 /* WPStyleGuide+Suggestions.m */,
+				8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */,
+				8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */,
 			);
 			path = Categories;
 			sourceTree = "<group>";
@@ -17853,6 +17859,7 @@
 				FE3E83E526A58646008CE851 /* ListSimpleOverlayView.swift in Sources */,
 				98B88452261E4E09007ED7F8 /* LikeUserTableViewCell.swift in Sources */,
 				E16FB7E31F8B61040004DD9F /* WebKitViewController.swift in Sources */,
+				8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */,
 				3F8CBE0B24EEB0EA00F71234 /* AnnouncementsDataSource.swift in Sources */,
 				7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */,
 				321955C324BF77E400E3F316 /* ReaderTopicService+FollowedInterests.swift in Sources */,
@@ -19856,6 +19863,7 @@
 				FABB21C02602FC2C00C8785C /* AppRatingUtilityType.swift in Sources */,
 				FABB21C12602FC2C00C8785C /* MenuItemSourceFooterView.m in Sources */,
 				FABB21C22602FC2C00C8785C /* JetpackRestoreFailedViewController.swift in Sources */,
+				8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */,
 				FABB21C32602FC2C00C8785C /* ActionSheetViewController.swift in Sources */,
 				C737553F27C80DD500C6E9A1 /* String+CondenseWhitespace.swift in Sources */,
 				FABB21C42602FC2C00C8785C /* PostService+Revisions.swift in Sources */,


### PR DESCRIPTION
Part of #17877

## Description
- Refactored code related to removing next steps from `BlogDetailsViewController` to a category on `UIViewController` so it can be used in the dashboard as well
- Added an ellipsis button to `BlogDashboardCardFrameView`
- Used newly added button in quick start card to trigger the "remove next steps" action sheet

<img src="https://user-images.githubusercontent.com/25306722/158922572-efbe9829-5302-457c-98ad-64754c2c44a6.png" width=49%> <img src="https://user-images.githubusercontent.com/25306722/158922581-1d0de136-e7df-4406-b542-95e647822b5d.png" width=49%>

https://user-images.githubusercontent.com/25306722/158922347-dd35d1ba-c8be-4e13-b483-7c6b9eef91db.mov

## Testing Instructions
### Remove Next Steps from the dashboard
1. Make sure the MSD feature flag is enabled
2. Go into app settings and set the initial screen to "Home"
3. Enable quick start for your site
4. Observe the quick start card in the dashboard, an ellipsis button should be displayed
5. Make sure the a11y is correctly set for the button
6. Tap the ellipsis button
7. Make sure an action sheet is displayed
8. Go through the alert to remove "Next steps"
9. Make sure the quick start card is removed.

### Regression on removing Next Steps from My Site
1. Make sure the MSD feature flag is enabled
2. Go into app settings and set the initial screen to "Site Menu"
3. Enable quick start for your site
4. Observe the quick start section in My Site
5. Tap the ellipsis button
6. Make sure an action sheet is displayed
7. Go through the alert to remove "Next steps"
8. Make sure the quick start section is removed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
