### PR TITLE
WeeklyRoundupBackgroundTask - no launch handler

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
@@ -78,6 +78,20 @@ class BackgroundTasksCoordinator {
         self.registeredTasks = tasks
 
         for task in tasks {
+            if FeatureFlag.weeklyRoundupBGProcessingTask.enabled {
+                // https://github.com/wordpress-mobile/WordPress-iOS/issues/18156
+                // we still need to register to handle the old identifier = "org.wordpress.bgtask.weeklyroundup"
+                // in order to handle previously scheduled app refresh tasks before this enhancement.
+                //
+                // When the old identifier AppRefreshTask is triggered this will re-schedule using the new identifier going forward
+                // at some point in future when this FeatureFlag is removed and most users are on new version of app this can be removed
+                scheduler.register(forTaskWithIdentifier: WeeklyRoundupBackgroundTask.Constants.taskIdentifier, using: nil) { osTask in
+                    self.schedule(task) { [weak self] result in
+                        self?.taskScheduledCompleted(osTask, identifier: type(of: task).identifier, result: result, cancelled: false)
+                    }
+                }
+            }
+
             scheduler.register(forTaskWithIdentifier: type(of: task).identifier, using: nil) { osTask in
                 guard Feature.enabled(.weeklyRoundup) else {
                     osTask.setTaskCompleted(success: false)
@@ -97,19 +111,37 @@ class BackgroundTasksCoordinator {
                 }) { cancelled in
                     eventHandler.handle(.taskCompleted(identifier: type(of: task).identifier, cancelled: cancelled))
 
-                    self.schedule(task) { result in
-                        switch result {
-                        case .success:
-                            eventHandler.handle(.rescheduled(identifier: type(of: task).identifier))
-                        case .failure(let error):
-                            eventHandler.handle(.error(identifier: type(of: task).identifier, error: error))
+                    if FeatureFlag.weeklyRoundupBGProcessingTask.enabled {
+                        self.schedule(task) { [weak self] result in
+                            self?.taskScheduledCompleted(osTask, identifier: type(of: task).identifier, result: result, cancelled: cancelled)
                         }
+                    } else {
+                        //TODO - remove after removing feature flag
+                        self.schedule(task) { result in
+                            switch result {
+                            case .success:
+                                eventHandler.handle(.rescheduled(identifier: type(of: task).identifier))
+                            case .failure(let error):
+                                eventHandler.handle(.error(identifier: type(of: task).identifier, error: error))
+                            }
 
-                        osTask.setTaskCompleted(success: !cancelled)
+                            osTask.setTaskCompleted(success: !cancelled)
+                        }
                     }
                 }
             }
         }
+    }
+
+    func taskScheduledCompleted(_ osTask: BGTask, identifier: String, result: Result<Void, Error>, cancelled: Bool) {
+        switch result {
+        case .success:
+            eventHandler.handle(.rescheduled(identifier: identifier))
+        case .failure(let error):
+            eventHandler.handle(.error(identifier: identifier, error: error))
+        }
+
+        osTask.setTaskCompleted(success: !cancelled)
     }
 
     /// Schedules the registered tasks.  The reason this step is separated from the registration of the tasks, is that we need


### PR DESCRIPTION
This PR fixes an issue where iOS was throwing the following error NSInternalInconsistencyException: No launch handler registered for task with identifier org.wordpress.bgtask.weeklyroundup

This was caused by when FeatureFlag.weeklyRoundupBGProcessingTask was enabled the launch handler identifier registered changed.  However WeeklyRoundupBackgroundTasks that were pre-scheduled the week before on existing app installs would be still scheduled with the old identifier.

Fixes #18156

To test:
1. Test on device.  Disable FeatureFlag.weeklyRoundupBGProcessingTask so that it uses the old identifier
2. When app launches go to Me -> App Settings -> Debug.  Tap Weekly Roundup
3. If you don't have enough blogs / history also slide to the right to "Include A8c P2s"
4. Tap one of the Schedule in 10 sec options and then minimise the app in background
5. Weekly Round up Notification should eventually appear as normal
6. Re-enable FeatureFlag weeklyRoundupBGProcessingTask 
7. Repeat the same test steps and Weekly Roundup Notification should eventually appear as normal

## Regression Notes
1. Potential unintended areas of impact
WeeklyRoundupNotificationTask

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested on device

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
