### PR TITLE
Reader Comments: Remove moderation menu feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case domains
     case timeZoneSuggester
     case aboutScreen
-    case commentThreadModerationMenu
     case mySiteDashboard
     case markAllNotificationsAsRead
     case mediaPickerPermissionsNotice
@@ -62,8 +61,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .timeZoneSuggester:
             return true
         case .aboutScreen:
-            return true
-        case .commentThreadModerationMenu:
             return true
         case .mySiteDashboard:
             return false
@@ -133,8 +130,6 @@ extension FeatureFlag {
             return "TimeZone Suggester"
         case .aboutScreen:
             return "New Unified About Screen"
-        case .commentThreadModerationMenu:
-            return "Comment Thread Moderation Menu"
         case .mySiteDashboard:
             return "My Site Dashboard"
         case .markAllNotificationsAsRead:

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -114,7 +114,7 @@ extension NSNotification.Name {
     }
 
     func isModerationMenuEnabled(for comment: Comment) -> Bool {
-        return comment.allowsModeration() && Feature.enabled(.commentThreadModerationMenu)
+        return comment.allowsModeration()
     }
 
     // MARK: - Tracking


### PR DESCRIPTION
Depends on #18163

This cleans up the `commentThreadModerationMenu` feature flag.

## To test

- Go to Reader Comments, preferably on a site where you have admin privileges.
- Verify that the contextual menu is shown, and you can moderate comments. 
- Switch to a comment thread where you don't have moderation power.
- Verify that the share button is shown instead.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing to ensure no side effects after the feature flag is removed.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
