### PR TITLE
Add empty Site Intent Question screen in site creation flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignContentCollectionViewController.swift
@@ -111,6 +111,10 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private func configureCloseButton() {
+        guard navigationController?.viewControllers.first == self else {
+            return
+        }
+
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", comment: "Cancel site creation"), style: .done, target: self, action: #selector(closeButtonTapped))
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Site Creation. First screen: Allows selection of the home page which translates to the initial theme as well.
+/// Site Creation. Allows selection of the home page which translates to the initial theme as well.
 final class SiteDesignStep: WizardStep {
     typealias SiteDesignSelection = (_ design: RemoteSiteDesign?) -> Void
     weak var delegate: WizardDelegate?

--- a/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/DesignSelection/SiteDesignStep.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Site Creation. Allows selection of the home page which translates to the initial theme as well.
+/// Site Creation: Allows selection of the home page which translates to the initial theme as well.
 final class SiteDesignStep: WizardStep {
     typealias SiteDesignSelection = (_ design: RemoteSiteDesign?) -> Void
     weak var delegate: WizardDelegate?

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -1,7 +1,7 @@
 
 import UIKit
 
-/// Site Creation, Last screen: Site Assembly.
+/// Site Creation. Site Assembly
 final class SiteAssemblyStep: WizardStep {
 
     // MARK: Properties

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/SiteAssemblyStep.swift
@@ -1,7 +1,7 @@
 
 import UIKit
 
-/// Site Creation. Site Assembly
+/// Site Creation: Site Assembly
 final class SiteAssemblyStep: WizardStep {
 
     // MARK: Properties

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -7,6 +7,31 @@ class SiteCreationAnalyticsHelper {
     private static let siteDesignKey = "template"
     private static let previewModeKey = "preview_mode"
 
+    // MARK: - Site Intent
+    static func trackSiteIntentViewed() {
+        // TODO - enhanced_site_creation_intent_question_viewed
+    }
+
+    static func trackSiteIntentSelected(_ vertical: SiteVertical) {
+        // TODO - enhanced_site_creation_intent_question_vertical_selected
+    }
+
+    static func trackSiteIntentContinuePressed(_ term: String) {
+        // TODO - enhanced_site_creation_intent_question_continue_pressed
+    }
+
+    static func trackSiteIntentSearchFocused() {
+        // TODO - enhanced_site_creation_intent_question_search_focused
+    }
+
+    static func trackSiteIntentSkipped() {
+        // TODO - enhanced_site_creation_intent_question_skipped
+    }
+
+    static func trackSiteIntentCanceled() {
+        // TODO - enhanced_site_creation_intent_question_canceled
+    }
+
     // MARK: - Site Design
     static func trackSiteDesignViewed(previewMode: PreviewDevice) {
         WPAnalytics.track(.enhancedSiteCreationSiteDesignViewed, withProperties: commonProperties(previewMode))

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Site Intent: Allows selection of the the site's vertical (a.k.a. intent or industry).
+/// Site Creation: Allows selection of the the site's vertical (a.k.a. intent or industry).
 final class SiteIntentStep: WizardStep {
     typealias SiteIntentSelection = (_ vertical: SiteVertical?) -> Void
     weak var delegate: WizardDelegate?

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
@@ -1,10 +1,15 @@
+import Foundation
+
 /// Site Intent: Allows selection of the the site's vertical (a.k.a. intent or industry).
 final class SiteIntentStep: WizardStep {
+    typealias SiteIntentSelection = (_ vertical: SiteVertical?) -> Void
     weak var delegate: WizardDelegate?
     private let creator: SiteCreator
 
     private(set) lazy var content: UIViewController = {
-        return SiteIntentViewController()
+        return SiteIntentViewController { [weak self] vertical in
+            self?.didSelect(vertical)
+        }
     }()
 
     init?(siteIntentAB: SiteIntentABTestable = SiteIntentAB.shared, creator: SiteCreator) {
@@ -13,5 +18,10 @@ final class SiteIntentStep: WizardStep {
         }
 
         self.creator = creator
+    }
+
+    private func didSelect(_ vertical: SiteVertical?) {
+        creator.vertical = vertical
+        delegate?.nextStep()
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -45,7 +45,7 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     // MARK: Constants
 
     private enum Strings {
-        static let mainTitle: String = NSLocalizedString("What's your\nwebsite about?", comment: "Select the site's intent. Title")
+        static let mainTitle: String = NSLocalizedString("What's your website about?", comment: "Select the site's intent. Title")
         static let prompt: String = NSLocalizedString("Choose a topic from the list below or type your own", comment: "Select the site's intent. Subtitle")
         static let primaryAction: String = NSLocalizedString("Continue", comment: "Button to progress to the next step")
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -1,10 +1,94 @@
 import UIKit
 
-class SiteIntentViewController: UIViewController {
+class SiteIntentViewController: CollapsableHeaderViewController {
+    private let selection: SiteIntentStep.SiteIntentSelection
+    private let table: UITableView
+
+    private var selectedVertical: SiteVertical? {
+        didSet {
+            itemSelectionChanged(selectedVertical != nil)
+        }
+    }
+
+    init(_ selection: @escaping SiteIntentStep.SiteIntentSelection) {
+        self.selection = selection
+
+        table = UITableView(frame: .zero, style: .grouped)
+
+        super.init(
+            scrollableView: table,
+            mainTitle: Strings.mainTitle,
+            prompt: Strings.prompt,
+            primaryActionTitle: Strings.primaryAction,
+            secondaryActionTitle: nil,
+            defaultActionTitle: nil,
+            accessoryView: nil
+        )
+    }
+
+    // MARK: UIViewController
+
+    required init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationItem.backButtonTitle = NSLocalizedString("Topic", comment: "Shortened version of the main title to be used in back navigation")
+        configureTable()
+        configureSkipButton()
+        configureCloseButton()
+        largeTitleView.numberOfLines = 2
+        SiteCreationAnalyticsHelper.trackSiteIntentViewed()
+    }
 
-        view.backgroundColor = .systemBackground
+    // MARK: Constants
+
+    private enum Strings {
+        static let mainTitle: String = NSLocalizedString("What's your\nwebsite about?", comment: "Select the site's intent. Title")
+        static let prompt: String = NSLocalizedString("Choose a topic from the list below or type your own", comment: "Select the site's intent. Subtitle")
+        static let primaryAction: String = NSLocalizedString("Continue", comment: "Button to progress to the next step")
+    }
+
+    // MARK: UI Setup
+
+    private func configureTable() {
+        table.backgroundColor = .basicBackground
+    }
+
+    private func configureSkipButton() {
+        let skip = UIBarButtonItem(title: NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
+        navigationItem.rightBarButtonItem = skip
+    }
+
+    private func configureCloseButton() {
+        guard navigationController?.viewControllers.first == self else {
+            return
+        }
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", comment: "Cancel site creation"), style: .done, target: self, action: #selector(closeButtonTapped))
+    }
+
+    // MARK: Actions
+
+    override func primaryActionSelected(_ sender: Any) {
+        guard let selectedVertical = selectedVertical else {
+            return
+        }
+
+        SiteCreationAnalyticsHelper.trackSiteIntentSelected(selectedVertical)
+        selection(selectedVertical)
+    }
+
+    @objc
+    private func skipButtonTapped(_ sender: Any) {
+        SiteCreationAnalyticsHelper.trackSiteIntentSkipped()
+        selection(nil)
+    }
+
+    @objc
+    private func closeButtonTapped(_ sender: Any) {
+        SiteCreationAnalyticsHelper.trackSiteIntentCanceled()
+        dismiss(animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsStep.swift
@@ -1,5 +1,5 @@
 
-/// Site Creation. Site Segments
+/// Site Creation: Site Segments
 final class SiteSegmentsStep: WizardStep {
     private let creator: SiteCreator
     private let service: SiteSegmentsService

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteSegments/SiteSegmentsStep.swift
@@ -1,5 +1,5 @@
 
-/// Site Creation. First screen: Site Segments
+/// Site Creation. Site Segments
 final class SiteSegmentsStep: WizardStep {
     private let creator: SiteCreator
     private let service: SiteSegmentsService

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
@@ -1,5 +1,5 @@
 
-/// Site Creation. Third screen: Domains
+/// Site Creation. Domains
 final class WebAddressStep: WizardStep {
     private let creator: SiteCreator
     private let service: SiteAddressService

--- a/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/WebAddress/WebAddressStep.swift
@@ -1,5 +1,5 @@
 
-/// Site Creation. Domains
+/// Site Creation: Domains
 final class WebAddressStep: WizardStep {
     private let creator: SiteCreator
     private let service: SiteAddressService


### PR DESCRIPTION
Closes #18106

## Description

This PR adds a new (currently empty) step to the Site Creation flow, asking the users for their intent before presenting the site design options.

### Progress Status
The following checks from the issue acceptance criteria & other considerations are implemented:

- [x] The screen is displayed **only** when the `SITE_INTENT_QUESTION` development feature flag is enabled **and** the user is part of the [A/B test treatment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18083).
  - [x] The screen is displayed as an new step in Site Creation flow
  - [x] The screen is displayed after tapping on 'CREATE A WORDPRESS.COM SITE' in the "Welcome to WordPress" screen.
- [x] Header (Back button, Skip Button, Title & Subtitle) is displayed
  - [x] Skip Button tap → Navigates forward to "Choose a Design" screen
  - [x] Back Button tap → Navigates back to:
    - [x] "Choose site" screen if logged in
    - [x] "Welcome to WordPress" screen if not
- [ ] Unit Tests are added where applicable - **N/A**
- [ ] Events are tracked (Back button pressed, Skip button pressed, Screen viewed) - **[Stubs have been added](https://github.com/wordpress-mobile/WordPress-iOS/blob/d63ac5a048e6ee973d01265d31f67d8059297261/WordPress/Classes/ViewRelated/Site%20Creation/Shared/SiteCreationAnalyticsHelper.swift#L10-L33) for [analytics tracking](https://github.com/wordpress-mobile/WordPress-iOS/issues/18086)**
- [x] Back button on "Choose a Design" screens navigates back to the "What's your Website about" screen.

## To Test:

### 💡 Testing Information

### 🟠 How to toggle the [feature flag](https://github.com/wordpress-mobile/WordPress-iOS/pull/18063):
1. Launch the app
2. From `My Site` go to `Me` -> `App Settings` -> `Debug`
3. Toggle `Site Intent Question` under `Feature Flags`

### 🔵 A/B testing

[From the A/B testing PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18083) (which is now merged and a part of this PR):

Use a WP.com account that falls into the Treatment group. There's no way to identify this upfront, so instead you must keep trying different accounts until the new screen (currently blank as of time of writing) appears at the start of the site creation process. You can then use that account for testing, knowing that it is in the Treatment group. Any account that is not in the treatment group is said to be in the Control group. Reinstalling the app may change the token, thus changing the user's group.

### 1. Test the existing flow (with the feature flag off)

1. Launch the app
2. From `My Site` screen tap the `⋁` icon next to the site title
3. On the `Choose a site` screen tap the `➕` menu button
5. Select `Create WordPress.com site`
6. **Verify** that you land on the `Choose a design` screen
7. **Verify** that "Cancel" is an option and dismisses the screen when pressed

### 2. Test the new screen

1. Launch the app
2. Toggle the `Site Intent Question` feature flag on (see 🟠 and 🔵 )
3. From `My Site` screen tap the `⋁` icon next to the site title
4. On the `Choose a site` screen tap on `➕` menu button
5. Select `Create WordPress.com site`
8. **Verify** that you land on the `What's your website about?` screen
9. **Verify** that "Cancel" is an option and dismisses the screen when pressed

### 3. Test interactions on the new screen

1. Tap on the `SKIP button`
2. **Verify** that you land on the `Choose a design` screen
3. Tap the `←` button or the device back button
4. **Verify** that you land on the `What's your website about?` screen
5. Tap again the `←` button or the device back button
6. **Verify** that you land on the `Choose a site` screen

### 4. Test the new screen with a new account

**Prerequisites:**
- Feature must have been enabled on the account previously logged in (see 🟠 )
- The new account must fall into the Treatment group (see 🔵 )

1. Launch the app
2. Log out ( From `My Site` Go to `Me` → `Log out of WordPress.com` → `LOG OUT` )
3. Tap 'Log in or sign up with WordPress.com`
4. Enter an e-mail address not registered with WordPress.com ([you can use the `+` sign with for Gmail](https://danq.me/2017/09/26/gmail-plus/))
5. Tap `Check Email` & pick an e-mail app
   1. In the e-mail app open the latest e-mail from WordPress.com
   2. Tap `Sign up to WordPress.com`
   3. Tap `Done` on first screen about your profile
   4. Tap `CREATE A WORDPRESS.COM SITE`
   5. **Verify** that you land on the `What's your website about?` screen
   6. Tap the `←` button or the device back button
   10. **Verify** that you land on the `My Site` screen

## Previews

| Portrait | Landscape |
| ------- | ----------- |
| ![Simulator Screen Shot - iPhone 13 - 2022-03-20 at 09 41 01](https://user-images.githubusercontent.com/2092798/159167798-fa2f70d9-6ba9-4054-9992-7ab24ff1f65e.png) | ![Simulator Screen Shot - iPhone 13 - 2022-03-20 at 09 47 08](https://user-images.githubusercontent.com/2092798/159167802-52e75d90-ec1a-4632-87c0-bc465f5d6da6.png) |

## 🚨 Known issues at the time of this PR
- https://github.com/wordpress-mobile/WordPress-iOS/issues/18167
- https://github.com/wordpress-mobile/WordPress-iOS/issues/18168

## Regression Notes
1. Potential unintended areas of impact
- Existing flow with the feature flag off
- Other steps in the Site Creation flow when the feature is enabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing

3. What automated tests I added (or what prevented me from doing so)
- This PR contains mostly UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
