### PR TITLE
My Site Dashboard (Phase 2): Revisit quick start notices logic 

### DIFF
--- a/WordPress/Classes/Utility/WebViewControllerFactory.swift
+++ b/WordPress/Classes/Utility/WebViewControllerFactory.swift
@@ -24,10 +24,12 @@ class WebViewControllerFactory: NSObject {
         return controller(configuration: configuration, source: source)
     }
 
-    @objc static func controller(url: URL, blog: Blog, source: String, withDeviceModes: Bool = false) -> UIViewController {
+    @objc static func controller(url: URL, blog: Blog, source: String, withDeviceModes: Bool = false,
+                                 onClose: (() -> Void)? = nil) -> UIViewController {
         let configuration = WebViewControllerConfiguration(url: url)
         configuration.analyticsSource = source
         configuration.authenticate(blog: blog)
+        configuration.onClose = onClose
         return withDeviceModes ? PreviewWebKitViewController(configuration: configuration) : controller(configuration: configuration, source: source)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -51,6 +51,11 @@ final class BlogDashboardViewController: UIViewController {
 
         viewModel.loadCards()
         QuickStartTourGuide.shared.currentTourOrigin = .blogDashboard
+        startAlertTimer()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        stopAlertTimer()
     }
 
     /// If you want to give any feedback when the dashboard
@@ -163,6 +168,46 @@ extension BlogDashboardViewController {
         section.interGroupSpacing = Constants.cellSpacing
 
         return section
+    }
+}
+
+private var alertWorkItem: DispatchWorkItem?
+
+extension BlogDashboardViewController {
+    @objc func startAlertTimer() {
+        let newWorkItem = DispatchWorkItem { [weak self] in
+            self?.showNoticeAsNeeded()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2, execute: newWorkItem)
+        alertWorkItem = newWorkItem
+    }
+
+    @objc func stopAlertTimer() {
+        alertWorkItem?.cancel()
+        alertWorkItem = nil
+    }
+
+    private func showNoticeAsNeeded() {
+        let quickStartGuide = QuickStartTourGuide.shared
+        guard let tourToSuggest = quickStartGuide.tourToSuggest(for: blog) else {
+            return
+        }
+
+        if quickStartGuide.tourInProgress {
+            // If tour is in progress, show notice regardless of quickstart is shown in dashboard or my site
+            quickStartGuide.suggest(tourToSuggest, for: blog)
+        }
+        else {
+            guard shouldShowQuickStartChecklist() else {
+                return
+            }
+            // Show initial notice only if quick start is shown in the dashboard
+            quickStartGuide.suggest(tourToSuggest, for: blog)
+        }
+    }
+
+    private func shouldShowQuickStartChecklist() -> Bool {
+        return DashboardCard.quickStart.shouldShow(for: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -75,8 +75,21 @@ extension BlogDetailsViewController {
     }
 
     private func showNoticeAsNeeded() {
-        if let tourToSuggest = QuickStartTourGuide.shared.tourToSuggest(for: blog) {
-            QuickStartTourGuide.shared.suggest(tourToSuggest, for: blog)
+        let quickStartGuide = QuickStartTourGuide.shared
+        guard let tourToSuggest = quickStartGuide.tourToSuggest(for: blog) else {
+            return
+        }
+
+        if quickStartGuide.tourInProgress {
+            // If tour is in progress, show notice regardless of quickstart is shown in dashboard or my site
+            quickStartGuide.suggest(tourToSuggest, for: blog)
+        }
+        else {
+            guard shouldShowQuickStartChecklist() else {
+                return
+            }
+            // Show initial notice only if quick start is shown in my site
+            quickStartGuide.suggest(tourToSuggest, for: blog)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1574,7 +1574,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     
     NSURL *targetURL = [NSURL URLWithString:self.blog.homeURL];
 
-    UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL blog:self.blog source:@"my_site_view_site" withDeviceModes:true];
+    void (^onWebViewControllerClose)(void) = ^(void) {
+        [self startAlertTimer];
+    };
+    UIViewController *webViewController = [WebViewControllerFactory controllerWithUrl:targetURL
+                                                                                 blog:self.blog
+                                                                               source:@"my_site_view_site"
+                                                                      withDeviceModes:true
+                                                                              onClose:onWebViewControllerClose];
     LightNavigationController *navController = [[LightNavigationController alloc] initWithRootViewController:webViewController];
     if (self.traitCollection.userInterfaceIdiom == UIUserInterfaceIdiomPad) {
         navController.modalPresentationStyle = UIModalPresentationFullScreen;


### PR DESCRIPTION
Part of #17877

## Description
- Added logic for displaying notices in the dashboard
- Modified current logic to respect the following constraints:
    - That initial notice should only be displayed in the screen where quick start is showing (Default section)
    - Subsequent notices should be shown if the user finishes a step regardless of the default section. This is to ensure a smooth tour for the user.
    - Reference: p1647535820818699/1647529185.837619-slack-C0290FLA0RM
- Fixes an issue where performing the "View your site" tour did not trigger the next notice. 

## Testing Instructions
### My Site is the default section
1. Make sure the MSD feature flag is enabled
2. Go into app settings and set the initial screen to "Site Menu"
3. Make sure Site Menu is the active tab
4. Enable quick start for your site
5. Return back to site menu
6. Go to dashboard
7. Make sure notice is not displayed
8. Go to site menu
9. Make sure notice for the next task is displayed
10. Go through the tasks.
11. Make sure that after completing the "View your site" task, the next task is displayed.

### Dashboard is the default section
1. Make sure the MSD feature flag is enabled
2. Go into app settings and set the initial screen to "Dashboard"
3. Make sure the dashboard is the active tab
4. Enable quick start for your site
5. Return back to the dashboard
6. Go to site menu
7. Make sure notice is not displayed
8. Go to the dashboard
9. Make sure notice for the next task is displayed
10. Go through the tasks.
11. Make sure notices keep displaying even after being forced to navigate to the site menu
12. Make sure that after completing the "View your site" task, the next task is displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.