### PR TITLE
My Site Dasboard (Phase 2): Add tracking for Quick Start dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -42,6 +42,10 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         self.viewController = viewController
         self.blog = blog
 
+        let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .dashboardCardItemTapped, properties:["type": DashboardCard.quickStart.rawValue])
+
+        tourStateView.configure(blog: blog, sourceController: viewController, checklistTappedTracker: checklistTappedTracker)
+
         WPAnalytics.track(.dashboardCardShown,
                           properties: ["type": DashboardCard.quickStart.rawValue],
                           blog: blog)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -41,7 +41,10 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         }
         self.viewController = viewController
         self.blog = blog
-        tourStateView.configure(blog: blog, sourceController: viewController)
+
+        WPAnalytics.track(.dashboardCardShown,
+                          properties: ["type": DashboardCard.quickStart.rawValue],
+                          blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -20,8 +20,8 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         return frameView
     }()
 
-    private lazy var tourStateView: QuickStarTourStateView = {
-        let view = QuickStarTourStateView()
+    private lazy var tourStateView: QuickStartTourStateView = {
+        let view = QuickStartTourStateView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+typealias QuickStartChecklistTappedTracker = (event: WPAnalyticsEvent, properties: [AnyHashable: Any])
+
 final class QuickStarTourStateView: UIView {
 
     private lazy var stackView: UIStackView = {
@@ -33,7 +35,7 @@ final class QuickStarTourStateView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(blog: Blog, sourceController: UIViewController) {
+    func configure(blog: Blog, sourceController: UIViewController, checklistTappedTracker: QuickStartChecklistTappedTracker? = nil) {
 
         customizeChecklistView.configure(
             tours: QuickStartTourGuide.customizeListTours,
@@ -43,7 +45,7 @@ final class QuickStarTourStateView: UIView {
         )
 
         customizeChecklistView.onTap = { [weak self] in
-            self?.showQuickStart(with: .customize, from: sourceController, for: blog)
+            self?.showQuickStart(with: .customize, from: sourceController, for: blog, tracker: checklistTappedTracker)
         }
 
         growChecklistView.configure(
@@ -54,7 +56,7 @@ final class QuickStarTourStateView: UIView {
         )
 
         growChecklistView.onTap = { [weak self] in
-            self?.showQuickStart(with: .grow, from: sourceController, for: blog)
+            self?.showQuickStart(with: .grow, from: sourceController, for: blog, tracker: checklistTappedTracker)
         }
     }
 
@@ -74,7 +76,14 @@ extension QuickStarTourStateView {
 
 extension QuickStarTourStateView {
 
-    private func showQuickStart(with type: QuickStartType, from sourceController: UIViewController, for blog: Blog) {
+    private func showQuickStart(with type: QuickStartType, from sourceController: UIViewController, for blog: Blog, tracker: QuickStartChecklistTappedTracker? = nil) {
+
+        if let tracker = tracker {
+            WPAnalytics.track(tracker.event,
+                              properties: tracker.properties,
+                              blog: blog)
+        }
+
         let checklist = QuickStartChecklistViewController(blog: blog, type: type)
         let navigationViewController = UINavigationController(rootViewController: checklist)
         sourceController.present(navigationViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -2,7 +2,7 @@ import UIKit
 
 typealias QuickStartChecklistTappedTracker = (event: WPAnalyticsEvent, properties: [AnyHashable: Any])
 
-final class QuickStarTourStateView: UIView {
+final class QuickStartTourStateView: UIView {
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
@@ -64,7 +64,7 @@ final class QuickStarTourStateView: UIView {
 
 // MARK: - Setup
 
-extension QuickStarTourStateView {
+extension QuickStartTourStateView {
 
     private func setupViews() {
         addSubview(stackView)
@@ -74,7 +74,7 @@ extension QuickStarTourStateView {
 
 // MARK: - Actions
 
-extension QuickStarTourStateView {
+extension QuickStartTourStateView {
 
     private func showQuickStart(with type: QuickStartType, from sourceController: UIViewController, for blog: Blog, tracker: QuickStartChecklistTappedTracker? = nil) {
 
@@ -94,7 +94,7 @@ extension QuickStarTourStateView {
 
 // MARK: - Constants
 
-extension QuickStarTourStateView {
+extension QuickStartTourStateView {
 
     private enum Strings {
         static let customizeTitle = NSLocalizedString("Customize Your Site",

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -2,8 +2,8 @@ import UIKit
 
 @objc class QuickStartCell: UITableViewCell {
 
-    private lazy var tourStateView: QuickStarTourStateView = {
-        let view = QuickStarTourStateView()
+    private lazy var tourStateView: QuickStartTourStateView = {
+        let view = QuickStartTourStateView()
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()


### PR DESCRIPTION
Fixes #18173 

## Description
- Added event tracking for Quick Start
  - `my_site_dashboard_card_shown`
  - `my_site_dashboard_card_item_tapped`
    
## How to test
1. Make sure the MSD feature flag is enabled
2. Tap on the "Home" tab
3. ✅ Check that the `my_site_dashboard_card_shown` event is fired with `type: quickStart`
4. Tap on a tour in the Quick Start dashboard card
5. ✅ Check that the `my_site_dashboard_card_item_tapped` event is fired with `type: quickStart`

## Regression Notes
1. Potential unintended areas of impact
n/a

6. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
