### PR TITLE
Cherry-pick #18162 into 19.4.1 hotfix branch

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/BackgroundTasksCoordinator.swift
@@ -78,6 +78,20 @@ class BackgroundTasksCoordinator {
         self.registeredTasks = tasks
 
         for task in tasks {
+            if FeatureFlag.weeklyRoundupBGProcessingTask.enabled {
+                // https://github.com/wordpress-mobile/WordPress-iOS/issues/18156
+                // we still need to register to handle the old identifier = "org.wordpress.bgtask.weeklyroundup"
+                // in order to handle previously scheduled app refresh tasks before this enhancement.
+                //
+                // When the old identifier AppRefreshTask is triggered this will re-schedule using the new identifier going forward
+                // at some point in future when this FeatureFlag is removed and most users are on new version of app this can be removed
+                scheduler.register(forTaskWithIdentifier: WeeklyRoundupBackgroundTask.Constants.taskIdentifier, using: nil) { osTask in
+                    self.schedule(task) { [weak self] result in
+                        self?.taskScheduledCompleted(osTask, identifier: type(of: task).identifier, result: result, cancelled: false)
+                    }
+                }
+            }
+
             scheduler.register(forTaskWithIdentifier: type(of: task).identifier, using: nil) { osTask in
                 guard Feature.enabled(.weeklyRoundup) else {
                     osTask.setTaskCompleted(success: false)
@@ -97,19 +111,37 @@ class BackgroundTasksCoordinator {
                 }) { cancelled in
                     eventHandler.handle(.taskCompleted(identifier: type(of: task).identifier, cancelled: cancelled))
 
-                    self.schedule(task) { result in
-                        switch result {
-                        case .success:
-                            eventHandler.handle(.rescheduled(identifier: type(of: task).identifier))
-                        case .failure(let error):
-                            eventHandler.handle(.error(identifier: type(of: task).identifier, error: error))
+                    if FeatureFlag.weeklyRoundupBGProcessingTask.enabled {
+                        self.schedule(task) { [weak self] result in
+                            self?.taskScheduledCompleted(osTask, identifier: type(of: task).identifier, result: result, cancelled: cancelled)
                         }
+                    } else {
+                        //TODO - remove after removing feature flag
+                        self.schedule(task) { result in
+                            switch result {
+                            case .success:
+                                eventHandler.handle(.rescheduled(identifier: type(of: task).identifier))
+                            case .failure(let error):
+                                eventHandler.handle(.error(identifier: type(of: task).identifier, error: error))
+                            }
 
-                        osTask.setTaskCompleted(success: !cancelled)
+                            osTask.setTaskCompleted(success: !cancelled)
+                        }
                     }
                 }
             }
         }
+    }
+
+    func taskScheduledCompleted(_ osTask: BGTask, identifier: String, result: Result<Void, Error>, cancelled: Bool) {
+        switch result {
+        case .success:
+            eventHandler.handle(.rescheduled(identifier: identifier))
+        case .failure(let error):
+            eventHandler.handle(.error(identifier: identifier, error: error))
+        }
+
+        osTask.setTaskCompleted(success: !cancelled)
     }
 
     /// Schedules the registered tasks.  The reason this step is separated from the registration of the tasks, is that we need


### PR DESCRIPTION
The PR originally targeted 19.4, but was not merged in time. The crash it addresses is one that would potentially affect many users, as we saw with just 1% rollout on Monday 3/21. So let's cherry-pick and ship an hotfix ASAP. 🙂

See also https://github.com/wordpress-mobile/WordPress-iOS/pull/18162#issuecomment-1074670698.

@sla8c , @frosty , @momo-ozawa (authors and reviewers of the original PR):  The cherry-pick was effortless and diff here is the same as #18162. Still, I'd appreciate if you could take a look before I merge it and move on with the hotfix deployment. Thanks!