### PR TITLE
Use feature flag instead of ExPlat for land in the editor

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -2,7 +2,6 @@ import AutomatticTracks
 
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
-    case landInTheEditorPhase1 = "wpios_land_in_the_editor_phase1_v3"
 
     /// Returns a variation for the given experiment
     var variation: Variation {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -23,6 +23,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case notificationCommentDetails
     case statsPerformanceImprovements
     case siteIntentQuestion
+    case landInTheEditor
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -73,6 +74,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .statsPerformanceImprovements:
             return true
         case .siteIntentQuestion:
+            return false
+        case .landInTheEditor:
             return false
         }
     }
@@ -142,6 +145,8 @@ extension FeatureFlag {
             return "Stats Performance Improvements"
         case .siteIntentQuestion:
             return "Site Intent Question"
+        case .landInTheEditor:
+            return "Land In The Editor"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/LandInTheEditorHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/FinalAssembly/LandInTheEditorHelper.swift
@@ -1,16 +1,16 @@
 typealias HomepageEditorCompletion = () -> Void
 
 class LandInTheEditorHelper {
-    /// Land in the editor, or continue as usual for the control group -  Used to branch on the ExPlat experiment for landing in the editor from the site creation flow
+    /// Land in the editor, or continue as usual -  Used to branch on the feature flag for landing in the editor from the site creation flow
     /// - Parameter blog: Blog (which was just created) for which to show the home page editor
     /// - Parameter navigationController: UINavigationController used to present the home page editor
-    /// - Parameter completion: HomepageEditorCompletion callback to be invoked after the user finishes editing the home page, or immediately in the control group case
+    /// - Parameter completion: HomepageEditorCompletion callback to be invoked after the user finishes editing the home page, or immediately iwhen the feature flag is disabled
     static func landInTheEditorOrContinue(for blog: Blog, navigationController: UINavigationController, completion: @escaping HomepageEditorCompletion) {
-        // branch here for explat variation
-        if ABTest.landInTheEditorPhase1.variation == .control {
-            completion()
-        } else {
+        // branch here for feature flag
+        if FeatureFlag.landInTheEditor.enabled {
             landInTheEditor(for: blog, navigationController: navigationController, completion: completion)
+        } else {
+            completion()
         }
     }
 


### PR DESCRIPTION
## Description
This PR replaces the [Land on the editor ExPlat experiment ](https://github.com/wordpress-mobile/WordPress-Android/pull/15627)with a development feature flag. This is needed to avoid pinging the ExPlat server now that the experiment is finished

## To test:
Use the test cases of the [A/B test landing in the editor](https://github.com/wordpress-mobile/WordPress-iOS/pull/17429) PR verifying that:
* when the `landInTheEditor` flag is **disabled** the **control** flow applies
* when the `landInTheEditor` flag is **enabled** the **treatment** flow applies

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
