### PR TITLE
[Tooling] Additional cleanup of Fastfile lanes (DRYing + QR code support for Installable Builds)

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -103,15 +103,15 @@ platform :ios do
       scheme: 'WordPress',
       workspace: WORKSPACE_PATH,
       clean: true,
-      export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       output_directory: BUILD_PRODUCTS_PATH,
       derived_data_path: DERIVED_DATA_PATH,
+      export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       export_options: { method: 'app-store' }
     )
 
     testflight(
       skip_waiting_for_build_processing: true,
-      team_id: '299112',
+      team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
       api_key_path: APP_STORE_CONNECT_KEY_PATH
     )
 
@@ -192,17 +192,17 @@ platform :ios do
     gym(
       scheme: 'WordPress Internal',
       workspace: WORKSPACE_PATH,
-      export_method: 'enterprise',
       clean: true,
       output_directory: BUILD_PRODUCTS_PATH,
       output_name: 'WordPress Internal',
       derived_data_path: DERIVED_DATA_PATH,
       export_team_id: get_required_env('INT_EXPORT_TEAM_ID'),
+      export_method: 'enterprise',
       export_options: { method: 'enterprise' }
     )
 
     appcenter_upload(
-      api_token: ENV['APPCENTER_API_TOKEN'],
+      api_token: get_required_env('APPCENTER_API_TOKEN'),
       owner_name: APPCENTER_OWNER_NAME,
       owner_type: APPCENTER_OWNER_TYPE,
       app_name: 'WP-Internal',

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -359,14 +359,16 @@ platform :ios do
   #
   def post_installable_build_pr_comment(app_name:, build_number:, url_slug:)    
     download_url = Actions.lane_context[SharedValues::APPCENTER_DOWNLOAD_LINK]
-    UI.message("Successfully built and uploaded installable build here: #{download_url}")
+    UI.message("Successfully built and uploaded installable build `#{build_number}` here: #{download_url}")
 
     return if ENV['BUILDKITE_PULL_REQUEST'].nil?
 
     install_url = "https://install.appcenter.ms/orgs/automattic/apps/#{url_slug}/"
+    qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{URI::encode(install_url)}&choe=UTF-8"
     comment_body = <<~COMMENT_BODY
-      You can test the changes in <strong>#{app_name}</strong> from this Pull Request by downloading it from App Center <a href='#{install_url}'>here</a> with build number: <code>#{build_number}</code>.
-      IPA is available <a href='#{download_url}'>here</a>.
+      You can test the changes in <strong>#{app_name}</strong> from this Pull Request by <a href='#{install_url}'>installing it from App Center here</a> (build number: <code>#{build_number}</code>),
+      or by scanning the QR code below:<br /><img src='#{qr_code_url}' width='250' height='250' /> 
+      The <code>.ipa</code> file can also be <a href='#{download_url}'>downloaded directly here</a>.
       If you need access to this, you can ask a maintainer to add you.
     COMMENT_BODY
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 SENTRY_ORG_SLUG = 'a8c'
+SENTRY_PROJECT_SLUG_WORDPRESS = 'wordpress-ios'
+SENTRY_PROJECT_SLUG_JETPACK = 'jetpack-ios'
 APPCENTER_OWNER_NAME = 'automattic'
 APPCENTER_OWNER_TYPE = 'organization'      
 
@@ -116,7 +118,7 @@ platform :ios do
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
-      project_slug: 'wordpress-ios',
+      project_slug: SENTRY_PROJECT_SLUG_WORDPRESS,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
@@ -166,7 +168,7 @@ platform :ios do
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
-      project_slug: 'jetpack-ios',
+      project_slug: SENTRY_PROJECT_SLUG_JETPACK,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
   end
@@ -212,7 +214,7 @@ platform :ios do
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
-      project_slug: 'wordpress-ios',
+      project_slug: SENTRY_PROJECT_SLUG_WORDPRESS,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
   end
@@ -262,7 +264,7 @@ platform :ios do
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
-      project_slug: 'wordpress-ios',
+      project_slug: SENTRY_PROJECT_SLUG_WORDPRESS,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
@@ -315,7 +317,7 @@ platform :ios do
     sentry_upload_dsym(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
-      project_slug: 'jetpack-ios',
+      project_slug: SENTRY_PROJECT_SLUG_JETPACK,
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -368,10 +368,13 @@ platform :ios do
     install_url = "https://install.appcenter.ms/orgs/automattic/apps/#{url_slug}/"
     qr_code_url = "https://chart.googleapis.com/chart?chs=500x500&cht=qr&chl=#{URI::encode(install_url)}&choe=UTF-8"
     comment_body = <<~COMMENT_BODY
-      You can test the changes in <strong>#{app_name}</strong> from this Pull Request by <a href='#{install_url}'>installing it from App Center here</a> (build number: <code>#{build_number}</code>),
-      or by scanning the QR code below:<br /><img src='#{qr_code_url}' width='250' height='250' /> 
-      The <code>.ipa</code> file can also be <a href='#{download_url}'>downloaded directly here</a>.
-      If you need access to this, you can ask a maintainer to add you.
+      You can test the changes in <strong>#{app_name}</strong> from this Pull Request by:<ul>
+        <li><a href='#{install_url}'>Clicking here</a> or scanning the QR code below</li>
+        <li>Then installing the build number <code>#{build_number}</code> from App Center on your iPhone</li>
+      </ul>
+      <img src='#{qr_code_url}' width='150' height='150' /> 
+      The <code>.ipa</code> file can also be <a href='#{download_url}'>downloaded directly here</a>.<br />
+      If you need access to App Center, please ask a maintainer to add you.
     COMMENT_BODY
 
     comment_on_pr(

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -120,21 +120,21 @@ platform :ios do
       dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
-    if options[:create_release]
-      archive_zip_path = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xarchive.zip')
-      zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
+    next unless options[:create_release]
 
-      version = options[:beta_release] ? ios_get_build_version : ios_get_app_version
-      create_release(
-        repository: GHHELPER_REPO,
-        version: version,
-        release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
-        release_assets: archive_zip_path.to_s,
-        prerelease: options[:beta_release]
-      )
+    archive_zip_path = File.join(PROJECT_ROOT_FOLDER, 'WordPress.xarchive.zip')
+    zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
-      FileUtils.rm_rf(archive_zip_path)
-    end
+    version = options[:beta_release] ? ios_get_build_version : ios_get_app_version
+    create_release(
+      repository: GHHELPER_REPO,
+      version: version,
+      release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
+      release_assets: archive_zip_path.to_s,
+      prerelease: options[:beta_release]
+    )
+
+    FileUtils.rm_rf(archive_zip_path)
   end
 
   # Builds the Jetpack app and uploads it to TestFlight, for beta-testing or final release


### PR DESCRIPTION
ℹ️  This PR builds on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/18140 and targets its `tooling/fastfile-split-refactor` branch (which is itself targeting `release/19.5` since that's the next place where we plan to use those actions).

⚠️  To avoid making the review and diff of #18140 too hard to read, I'd recommend merging #18140 first, and only then merging this #18192 PR in `release/19.5` afterwards (GitHub should automatically update the target branch for this PR accordingly)

## Context

This is a follow up to address the remaining comments and good suggestions from @mokagio in https://github.com/wordpress-mobile/WordPress-iOS/pull/18140

 - b6c8445: Remove the `build_and_upload_itc` lane to only keep `build_and_upload_app_store` — see [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18140#discussion_r832562218)
 - 8fb43f6: Remove the `build_and_upload_internal` lane to only keep `build_and_upload_app_center` — see [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18140#discussion_r832563139)
 - 8d76b3e: Replace the `if` block with an early exit — see [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18140#discussion_r832803743)
 - d633124: DRY the copy used for the Installable Build comment on PRs — see [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18140#discussion_r832802075)
 - 2986339 + e42262e: Took the occasion to add QR code for easier install (modelled after [how it's done on WCAndroid](https://github.com/woocommerce/woocommerce-android/blob/trunk/fastlane/Fastfile#L651-L652))
 - 0dc35af: DRY some additional constant values