### PR TITLE
Fix: Crash when displaying remove quickstart action sheet on iPad

### DIFF
--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.h
@@ -6,7 +6,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface UIViewController (RemoveQuickStart)
 
-- (void)removeQuickStartFromBlog:(Blog *)blog;
+
+/// Displays an action sheet with an option to remove current quickstart tours from the provided blog.
+/// Displayed as an action sheet on iPhone and as a popover on iPad
+/// @param blog Blog to remove quickstart from
+/// @param sourceView View used as sourceView for the sheet's popoverPresentationController
+/// @param sourceRect rect used as sourceRect for the sheet's popoverPresentationController
+- (void)removeQuickStartFromBlog:(Blog *)blog sourceView:(UIView *)sourceView sourceRect:(CGRect)sourceRect;
 
 @end
 

--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
@@ -5,7 +5,7 @@
 
 @implementation UIViewController (RemoveQuickStart)
 
-- (void)removeQuickStartFromBlog:(Blog *)blog
+- (void)removeQuickStartFromBlog:(Blog *)blog sourceView:(UIView *)sourceView sourceRect:(CGRect)sourceRect
 {
     [NoticesDispatch lock];
     NSString *removeTitle = NSLocalizedString(@"Remove Next Steps", @"Title for action that will remove the next steps/quick start menus.");
@@ -25,6 +25,8 @@
     }];
 
     UIAlertController *removeSheet = [UIAlertController alertControllerWithTitle:nil message:nil preferredStyle:UIAlertControllerStyleActionSheet];
+    removeSheet.popoverPresentationController.sourceView = sourceView;
+    removeSheet.popoverPresentationController.sourceRect = sourceRect;
     [removeSheet addDestructiveActionWithTitle:removeTitle handler:^(UIAlertAction * _Nonnull action) {
         [self presentViewController:removeConfirmation animated:YES completion:nil];
     }];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -74,6 +74,11 @@ class BlogDashboardCardFrameView: UIView {
 
     weak var currentView: UIView?
 
+    /// Current frame of the ellipsis button. Used when displaying an action sheet as a popover.
+    var ellipsisButtonFrame: CGRect {
+        return ellipsisButton.frame
+    }
+
     /// The title at the header
     var title: String? {
         didSet {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -15,7 +15,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                   let blog = self?.blog else {
                 return
             }
-            viewController.removeQuickStart(from: blog)
+            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButtonRect)
         }
         return frameView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -15,7 +15,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                   let blog = self?.blog else {
                 return
             }
-            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButtonRect)
+            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButtonFrame)
         }
         return frameView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1231,7 +1231,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsSectionHeaderView *view = [self.tableView dequeueReusableHeaderFooterViewWithIdentifier:BlogDetailsSectionHeaderViewIdentifier];
     [view setTitle:title];
     view.ellipsisButtonDidTouch = ^(BlogDetailsSectionHeaderView *header) {
-        [weakSelf removeQuickStartFromBlog:weakSelf.blog];
+        [weakSelf removeQuickStartFromBlog:weakSelf.blog
+                                sourceView:header
+                                sourceRect:header.ellipsisButton.frame];
     };
     return view;
 }


### PR DESCRIPTION
Fixes #18190

## Testing Instructions
Make sure MSD is enabled
1. Set Initial screen from app settings to Dashboard
2. Enable quick start for a site
3. Navigate to dashboard
4. Press ellipsis buttona and remove quick start
5. Set Initial screen from app settings to Site Menu
6. Enable quick start for a site
7. Navigate to Site Menu
8. Press ellipsis buttona and remove quick start

The app shouldn't crash. Please test on iPhone and iPad 🙏 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
