### PR TITLE
Add tracks events to site intent question screen

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -316,6 +316,15 @@ import Foundation
     case mySiteSiteMenuShown
     case mySiteDashboardShown
 
+    // Site Intent Question
+    case enhancedSiteCreationIntentQuestionCanceled
+    case enhancedSiteCreationIntentQuestionSkipped
+    case enhancedSiteCreationIntentQuestionVerticalSelected
+    case enhancedSiteCreationIntentQuestionContinuePressed
+    case enhancedSiteCreationIntentQuestionSearchFocused
+    case enhancedSiteCreationIntentQuestionViewed
+    case enhancedSiteCreationIntentQuestionExperiment
+
     // Quick Start
     case quickStartStarted
 
@@ -852,6 +861,22 @@ import Foundation
         // Quick Start
         case .quickStartStarted:
             return "quick_start_started"
+
+        // Site Intent Question
+        case .enhancedSiteCreationIntentQuestionCanceled:
+            return "enhanced_site_creation_intent_question_canceled"
+        case .enhancedSiteCreationIntentQuestionSkipped:
+            return "enhanced_site_creation_intent_question_skipped"
+        case .enhancedSiteCreationIntentQuestionVerticalSelected:
+            return "enhanced_site_creation_intent_question_vertical_selected"
+        case .enhancedSiteCreationIntentQuestionContinuePressed:
+            return "enhanced_site_creation_intent_question_continue_pressed"
+        case .enhancedSiteCreationIntentQuestionSearchFocused:
+            return "enhanced_site_creation_intent_question_search_focused"
+        case .enhancedSiteCreationIntentQuestionViewed:
+            return "enhanced_site_creation_intent_question_viewed"
+        case .enhancedSiteCreationIntentQuestionExperiment:
+            return "enhanced_site_creation_intent_question_experiment"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -1,35 +1,54 @@
 import Foundation
 import WordPressKit
 
+extension SiteIntentAB.Variant {
+    var tracksProperty: String {
+        switch self {
+        case .treatment: return "treatment"
+        case .control: return "control"
+        }
+    }
+}
+
 class SiteCreationAnalyticsHelper {
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
 
     private static let siteDesignKey = "template"
     private static let previewModeKey = "preview_mode"
+    private static let verticalSlugKey = "vertical_slug"
+    private static let verticalSearchTerm = "search_term"
+    private static let variation = "variation"
 
     // MARK: - Site Intent
     static func trackSiteIntentViewed() {
-        // TODO - enhanced_site_creation_intent_question_viewed
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionViewed)
     }
 
     static func trackSiteIntentSelected(_ vertical: SiteVertical) {
-        // TODO - enhanced_site_creation_intent_question_vertical_selected
+        let properties = [verticalSlugKey: vertical.identifier]
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionVerticalSelected, properties: properties)
     }
 
     static func trackSiteIntentContinuePressed(_ term: String) {
-        // TODO - enhanced_site_creation_intent_question_continue_pressed
+        let properties = [verticalSearchTerm: term]
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionContinuePressed, properties: properties)
     }
 
     static func trackSiteIntentSearchFocused() {
-        // TODO - enhanced_site_creation_intent_question_search_focused
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionSearchFocused)
     }
 
     static func trackSiteIntentSkipped() {
-        // TODO - enhanced_site_creation_intent_question_skipped
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionSkipped)
     }
 
     static func trackSiteIntentCanceled() {
-        // TODO - enhanced_site_creation_intent_question_canceled
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionCanceled)
+    }
+
+    static func trackSiteIntentExperiment(_ variant: SiteIntentAB.Variant) {
+        let properties = [variation: variant.tracksProperty]
+        WPAnalytics.track(.enhancedSiteCreationIntentQuestionExperiment, properties: properties)
     }
 
     // MARK: - Site Design

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
@@ -13,7 +13,9 @@ final class SiteIntentStep: WizardStep {
     }()
 
     init?(siteIntentAB: SiteIntentABTestable = SiteIntentAB.shared, creator: SiteCreator) {
-        guard FeatureFlag.siteIntentQuestion.enabled && siteIntentAB.variant == .treatment else {
+        let variant = siteIntentAB.variant
+        SiteCreationAnalyticsHelper.trackSiteIntentExperiment(variant)
+        guard FeatureFlag.siteIntentQuestion.enabled && variant == .treatment else {
             return nil
         }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -62,10 +62,6 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     }
 
     private func configureCloseButton() {
-        guard navigationController?.viewControllers.first == self else {
-            return
-        }
-
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", comment: "Cancel site creation"), style: .done, target: self, action: #selector(closeButtonTapped))
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1960,6 +1960,7 @@
 		AE2F3129270B6DE200B2A9C2 /* NSMutableAttributedString+ApplyAttributesToQuotes.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2F3127270B6DE200B2A9C2 /* NSMutableAttributedString+ApplyAttributesToQuotes.swift */; };
 		AE3047AA270B66D300FE9266 /* Scanner+QuotedTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3047A9270B66D300FE9266 /* Scanner+QuotedTextTests.swift */; };
 		AEE0828A2681C23C00DCF54B /* GutenbergRefactoredGalleryUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE082892681C23C00DCF54B /* GutenbergRefactoredGalleryUploadProcessorTests.swift */; };
+		B030FE0A27EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B030FE0927EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift */; };
 		B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B9233250BC593000A40AF /* SuggestionService.swift */; };
 		B03B9236250BC5FD000A40AF /* Suggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03B9235250BC5FD000A40AF /* Suggestion.swift */; };
 		B0637527253E7CEC00FD45D2 /* SuggestionsTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0637526253E7CEB00FD45D2 /* SuggestionsTableView.swift */; };
@@ -6635,6 +6636,7 @@
 		AE2F3127270B6DE200B2A9C2 /* NSMutableAttributedString+ApplyAttributesToQuotes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSMutableAttributedString+ApplyAttributesToQuotes.swift"; sourceTree = "<group>"; };
 		AE3047A9270B66D300FE9266 /* Scanner+QuotedTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Scanner+QuotedTextTests.swift"; sourceTree = "<group>"; };
 		AEE082892681C23C00DCF54B /* GutenbergRefactoredGalleryUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergRefactoredGalleryUploadProcessorTests.swift; sourceTree = "<group>"; };
+		B030FE0927EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationIntentTracksEventTests.swift; sourceTree = "<group>"; };
 		B03B9233250BC593000A40AF /* SuggestionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionService.swift; sourceTree = "<group>"; };
 		B03B9235250BC5FD000A40AF /* Suggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Suggestion.swift; sourceTree = "<group>"; };
 		B0637526253E7CEB00FD45D2 /* SuggestionsTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SuggestionsTableView.swift; path = Suggestions/SuggestionsTableView.swift; sourceTree = "<group>"; };
@@ -10447,6 +10449,7 @@
 				73178C3421BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift */,
 				32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */,
 				B089140E27E1352B00CF468B /* SiteCreationIntentTests.swift */,
+				B030FE0927EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift */,
 			);
 			path = SiteCreation;
 			sourceTree = "<group>";
@@ -19497,6 +19500,7 @@
 				E6843840221F5A2200752258 /* PostListExcessiveLoadMoreTests.swift in Sources */,
 				325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */,
 				57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */,
+				B030FE0A27EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift in Sources */,
 				D81C2F5C20F872C2002AE1F1 /* ReplyToCommentActionTests.swift in Sources */,
 				D848CC1720FF38EA00A9038F /* FormattableCommentRangeTests.swift in Sources */,
 				246D0A0325E97D5D0028B83F /* Blog+ObjcTests.m in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteCreationIntentTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreationIntentTests.swift
@@ -7,10 +7,11 @@ class SiteCreationIntentTests: XCTestCase {
         let variant: SiteIntentAB.Variant
     }
 
+    let featureFlags = FeatureFlagOverrideStore()
+
     func testSiteIntentNotAvailableWhenFeatureFlagOff() throws {
 
         // Given
-        let featureFlags = FeatureFlagOverrideStore()
         try featureFlags.override(FeatureFlag.siteIntentQuestion, withValue: false)
         let mockVariant = SiteIntentABMock(variant: .treatment)
         let mockSiteCreator = SiteCreator()
@@ -25,7 +26,6 @@ class SiteCreationIntentTests: XCTestCase {
     func testSiteIntentAvailableForTreatmentGroup() throws {
 
         // Given
-        let featureFlags = FeatureFlagOverrideStore()
         try featureFlags.override(FeatureFlag.siteIntentQuestion, withValue: true)
         let mockVariant = SiteIntentABMock(variant: .treatment)
         let mockSiteCreator = SiteCreator()
@@ -40,7 +40,6 @@ class SiteCreationIntentTests: XCTestCase {
     func testSiteIntentNotAvailableForControlGroup() throws {
 
         // Given
-        let featureFlags = FeatureFlagOverrideStore()
         try featureFlags.override(FeatureFlag.siteIntentQuestion, withValue: true)
         let mockVariant = SiteIntentABMock(variant: .control)
         let mockSiteCreator = SiteCreator()

--- a/WordPress/WordPressTest/SiteCreation/SiteCreationIntentTracksEventTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreationIntentTracksEventTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+@testable import WordPress
+
+class SiteCreationIntentTracksEventTests: XCTestCase {
+
+    let featureFlags = FeatureFlagOverrideStore()
+    let treatmentVariant = SiteIntentAB.Variant.treatment
+
+    let controlVariant = SiteIntentAB.Variant.control
+    let variationEventPropertyKey = "variation"
+
+    override func setUpWithError() throws {
+        TestAnalyticsTracker.setup()
+        try featureFlags.override(FeatureFlag.siteIntentQuestion, withValue: true)
+    }
+
+    override func tearDownWithError() throws {
+        TestAnalyticsTracker.tearDown()
+        try featureFlags.override(FeatureFlag.siteIntentQuestion, withValue: false)
+    }
+
+    func siteIntentViewControllerMaker() throws -> SiteIntentViewController {
+        let mockABTestForTreatment = SiteCreationIntentTests.SiteIntentABMock(variant: treatmentVariant)
+        let mockSiteCreator = SiteCreator()
+        let siteIntentStep = SiteIntentStep(siteIntentAB: mockABTestForTreatment, creator: mockSiteCreator)
+        let siteIntentViewController = try XCTUnwrap(siteIntentStep?.content as? SiteIntentViewController)
+        return siteIntentViewController
+    }
+
+    func load(_ siteIntentViewController: SiteIntentViewController) {
+        siteIntentViewController.loadViewIfNeeded()
+        siteIntentViewController.viewDidLoad()
+    }
+
+    func tap(_ barButtonItem: UIBarButtonItem?) throws {
+        let action = try XCTUnwrap(barButtonItem?.action)
+        UIApplication.shared.sendAction(action, to: barButtonItem?.target, from: nil, for: nil)
+    }
+
+    func testSiteIntentTracksEventFiresForTreatmentGroup() throws {
+
+        // Given
+        let mockABTestForTreatment = SiteCreationIntentTests.SiteIntentABMock(variant: treatmentVariant)
+        let mockSiteCreator = SiteCreator()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationIntentQuestionExperiment.value
+        let expectedProperty = treatmentVariant.tracksProperty
+
+        // When
+        let _ = SiteIntentStep(siteIntentAB: mockABTestForTreatment, creator: mockSiteCreator)
+
+        // Then
+        let firstTracked = try XCTUnwrap(TestAnalyticsTracker.tracked.first)
+        XCTAssertEqual(firstTracked.event, expectedEvent)
+        let variation = try XCTUnwrap(firstTracked.properties[variationEventPropertyKey] as? String)
+        XCTAssertEqual(variation, expectedProperty)
+    }
+
+    func testSiteIntentTracksEventFiresForControlGroup() throws {
+
+        // Given
+        let mockABTestForControl = SiteCreationIntentTests.SiteIntentABMock(variant: controlVariant)
+        let mockSiteCreator = SiteCreator()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationIntentQuestionExperiment.value
+        let expectedProperty = controlVariant.tracksProperty
+
+        // When
+        let _ = SiteIntentStep(siteIntentAB: mockABTestForControl, creator: mockSiteCreator)
+
+        // Then
+        let firstTracked = try XCTUnwrap(TestAnalyticsTracker.tracked.first)
+        XCTAssertEqual(firstTracked.event, expectedEvent)
+        let variation = try XCTUnwrap(firstTracked.properties[variationEventPropertyKey] as? String)
+        XCTAssertEqual(variation, expectedProperty)
+    }
+
+    func testSiteIntentTracksEventFiresWhenViewed() throws {
+
+        // Given
+        let siteIntentViewController = try siteIntentViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationIntentQuestionViewed.value
+
+        // When
+        load(siteIntentViewController)
+
+        // Then
+        let lastTrackedEvent = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(lastTrackedEvent, expectedEvent)
+    }
+
+    func testSiteIntentTracksEventFiresWhenCancelled() throws {
+
+        // Given
+        let siteIntentViewController = try siteIntentViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationIntentQuestionCanceled.value
+
+        // When
+        load(siteIntentViewController)
+        try tap(siteIntentViewController.navigationItem.leftBarButtonItem)
+
+        // Then
+        let lastTrackedEvent = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(lastTrackedEvent, expectedEvent)
+    }
+
+    func testSiteIntentTracksEventFiresWhenSkipped() throws {
+
+        // Given
+        let siteIntentViewController = try siteIntentViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationIntentQuestionSkipped.value
+
+        // When
+        load(siteIntentViewController)
+        try tap(siteIntentViewController.navigationItem.rightBarButtonItem)
+
+        // Then
+        let lastEventTracked = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(lastEventTracked, expectedEvent)
+    }
+}


### PR DESCRIPTION
This implements the functions created in earlier PRs to log tracks events that relate to the site intent question screen.
It also adds a new function for the event, `enhanced_site_creation_intent_question_experiment`, to track which A/B test variant the user is assigned when starting a site creation flow.

I added the events to [`WPAnalyticsEvent.swift`](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift) instead of WordPress-iOS-Shared's [`WPAnalytics.h`](https://github.com/wordpress-mobile/WordPress-iOS-Shared/blob/trunk/WordPressShared/Core/Analytics/WPAnalytics.h) because my understanding is that the former corresponds to events that aren't used by other pods, so it made sense to add them here. If these events were used by [`WordPressAuthenticator-iOS`](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS) for example, I would have added them to `WPAnalytics.h` instead.

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/18086

## To test

The prerequisites to test this PR are:
- Turn ON the feature flag added in https://github.com/wordpress-mobile/WordPress-iOS/pull/18063 (found in the app under Me > App Settings > Debug). I don't know of a way to turn the flag on before logging in, so the workaround is to log in using any user, turn flag ON, and log in with the account you want to test. The flag's state will be persisted.
- Use a WP.com account that falls into the Treatment group (details on this below). There's no way to identify this upfront, so instead you must keep trying different accounts until the new screen (currently blank as of time of writing) appears at the start of the site creation process. You can then use that account for testing, knowing that it is in the Treatment group. Any account that is not in the Treatment group is said to be in the Control group. Reinstalling the app may change the token, thus changing the user's group.

_Please note: If testing this PR via Xcode, you can verify Tracks events via the Xcode log. If you're testing this on a PR build or a beta build of the app, you can either use the Tracks dashboard or the in-app logs (tap profile pic → "Help and Support" → "Activity Logs")._

```
### Treatment group tests
- [ ] Start the "Site Creation" flow, expect the "What's your website about?" screen to be shown and tap "Cancel". Check for events:
  - `enhanced_site_creation_intent_question_experiment` (properties: `variation: treatment`)
  - `enhanced_site_creation_intent_question_viewed` (no properties)
  - `enhanced_site_creation_intent_question_canceled` (no properties)
- [ ] Start the "Site Creation" flow, expect the "What's your website about?" screen to be shown and tap "Skip". Check for event:
  - `enhanced_site_creation_intent_question_skipped` (no properties)

### Control group tests
- [ ] Find a user who is **in the Control group** (keep the feature flag ON), start the "Site Creation" flow, expect the "Choose a design" screen to be shown. Check for event:
  - `enhanced_site_creation_intent_question_experiment` (properties: `variation: control`)
```

## Regression Notes
1. Potential unintended areas of impact

This PR is mostly just adding Tracks, with a very minor refactor within the Site Intent logic application logic. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

No regression testing should be needed here; however, the existing tests in [SiteCreationIntentTests.swift](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/WordPressTest/SiteCreation/SiteCreationIntentTests.swift) should help catch any issues with the aforementioned "very minor refactor".

3. What automated tests I added (or what prevented me from doing so)

Tests were added (see `SiteCreationIntentTracksEventTests.swift`) to verify that Tracks events are fired for buttons and interactions which are implemented thus far (as of time of writing).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
