### PR TITLE
Ensure all downloaded translations and metadata are committed

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -195,13 +195,23 @@ platform :ios do
       locales: GLOTPRESS_TO_LPROJ_APP_LOCALE_CODES,
       download_dir: parent_dir_for_lprojs
     )
+    git_commit(
+      path: File.join(parent_dir_for_lprojs, '*.lproj', 'Localizable.strings'),
+      message: 'Update app translations – `Localizable.strings`',
+      allow_nothing_to_commit: true
+    )
 
-    # Then redispatch the appropriate subset of translations back to the `InfoPlist.strings` and `Sites.strings` files in corresponding `*.lproj` dirs
+    # Redispatch the appropriate subset of translations back to the manually-maintained `.strings`
+    # files that we previously merged via `ios_merge_strings_files` during `complete_code_freeze`
     modified_files = ios_extract_keys_from_strings_files(
       source_parent_dir: parent_dir_for_lprojs,
       target_original_files: MANUALLY_MAINTAINED_STRINGS_FILES
     )
-    git_commit(path: modified_files, message: 'Update app translations', allow_nothing_to_commit: true)
+    git_commit(
+      path: modified_files,
+      message: 'Update app translations – Other `.strings`',
+      allow_nothing_to_commit: true
+    )
 
     # Finally, also download the AppStore metadata (app title, keywords, etc.)
     # @FIXME: Replace this whole lane with a call to the future replacement of `gp_downloadmetadata` once it's implemented in the release-toolkit (see paaHJt-31O-p2).

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -237,7 +237,7 @@ platform :ios do
     FileUtils.cp(release_notes_source, File.join(metadata_directory, 'en-US', 'release_notes.txt'))
 
     git_commit(
-      path: Dir.glob('**/*.txt', base: metadata_directory),
+      path: File.join(metadata_directory, '**', '*.txt'),
       message: 'Update WordPress metadata translations',
       allow_nothing_to_commit: true
     )
@@ -261,7 +261,7 @@ platform :ios do
     FileUtils.cp(release_notes_source, File.join(metadata_directory, 'en-US', 'release_notes.txt'))
 
     git_commit(
-      path: Dir.glob('**/*.txt', base: metadata_directory),
+      path: File.join(metadata_directory, '**', '*.txt'),
       message: 'Update Jetpack metadata translations',
       allow_nothing_to_commit: true
     )


### PR DESCRIPTION
I run the `new_beta_release` lane today and, while all the translations were downloaded correctly, the were not committed.

This PR has just enough code to address the committing issues. I did not track the result running the updated lane, i.e. the translated files, because I thought I'd ship a new beta on purpose for that, so we can see the diff in the usual "merge beta n" context. You can still see the commits either by creating a new branch from this one and running `download_localized_strings_and_metadata`, or by looking at this demo PR.