### PR TITLE
Add comments to Sites.strings for translators

### DIFF
--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -9473,16 +9473,21 @@
 
 /* MARK: - Sites.strings */
 
+/* This text is used when the user is configuring the iOS widget and selecting which WordPress site they want the widget to be for */
 "ios-widget.BOl9KQ" = "There are ${count} options matching ‘${site}’.";
 
+/* This text is used when the user is configuring the iOS widget, as a label for the dropdown to select the site to configure it for */
 "ios-widget.ILcGmf" = "Site";
 
+/* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "ios-widget.cyajMn" = "Site";
 
+/* This text is used when the user is configuring the iOS widget */
 "ios-widget.gpCwrM" = "Select Site";
 
+/* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "ios-widget.s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
 
+/* This text is used when the user is configuring the iOS widget */
 "ios-widget.tVvJ9c" = "Select Site Intent";
-
 

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -9482,12 +9482,9 @@
 /* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "ios-widget.cyajMn" = "Site";
 
-/* This text is used when the user is configuring the iOS widget */
+/* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "ios-widget.gpCwrM" = "Select Site";
 
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "ios-widget.s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
-
-/* This text is used when the user is configuring the iOS widget */
-"ios-widget.tVvJ9c" = "Select Site Intent";
 

--- a/WordPress/WordPressIntents/en.lproj/Sites.strings
+++ b/WordPress/WordPressIntents/en.lproj/Sites.strings
@@ -1,12 +1,17 @@
+/* This text is used when the user is configuring the iOS widget and selecting which WordPress site they want the widget to be for */
 "BOl9KQ" = "There are ${count} options matching ‘${site}’.";
 
+/* This text is used when the user is configuring the iOS widget, as a label for the dropdown to select the site to configure it for */
 "ILcGmf" = "Site";
 
+/* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "cyajMn" = "Site";
 
+/* This text is used when the user is configuring the iOS widget */
 "gpCwrM" = "Select Site";
 
+/* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
 
+/* This text is used when the user is configuring the iOS widget */
 "tVvJ9c" = "Select Site Intent";
-

--- a/WordPress/WordPressIntents/en.lproj/Sites.strings
+++ b/WordPress/WordPressIntents/en.lproj/Sites.strings
@@ -7,11 +7,8 @@
 /* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "cyajMn" = "Site";
 
-/* This text is used when the user is configuring the iOS widget */
+/* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "gpCwrM" = "Select Site";
 
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
-
-/* This text is used when the user is configuring the iOS widget */
-"tVvJ9c" = "Select Site Intent";


### PR DESCRIPTION
## Why?

While working on #18061 and making the `Sites.strings` strings used in `WordPressIntents` being part of the translation pipeline again, I forgot to add comments for translators for those strings like I did for the `InfoPlist.strings`.

This led to the strings not having any hint in GlotPress for translators to understand the context of what they were supposed to translate. (or worse, the first string picking up the `/* MARK: Sites.strings */` comment before it instead 😅 

<table><tr>
<td><img width="320" alt="image" src="https://user-images.githubusercontent.com/216089/159907908-83db846f-1e65-402c-8aa2-b376be76816e.png"></td>
<td><img width="320" alt="image" src="https://user-images.githubusercontent.com/216089/159908028-51b8c8e2-4509-4db8-a2e1-f1d14bfeddd7.png"></td>
</tr></table>

## How?

- This PR simply adds `/* comments */` in front of each of those strings in the source `Sites.strings` file to help translators.
- I've also updated the `Localizable.strings` file (which merged the content of `Sites.strings` with key prefixes during code freeze, see #18061) with the exact same comments, so that those make it to GlotPress as soon as this lands in `trunk` (instead of waiting for the next code freeze and thus new merge of `Sites.strings` into `Localizable.strings` for them to be imported)

Since `git blame` tells me that @diegoreymendez is the original author of the `Sites.intentdefinition` files (in which those `Sites.strings` are used), I've also added him as reviewer so he can confirm the context provided by my comments are appropriate and give the right context to translators.

## Targeting 19.5

This PR is targeting the `release/19.5` branch and `19.5` milestone since those strings have been re-introduced in the `Localizable.strings` imported by GlotPress during 19.5 code freeze and we want those translations to ideally be part of 19.5