### PR TITLE
My Site Dashboard (Phase 2): Add bottom padding to the dashboard collection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -162,10 +162,12 @@ extension BlogDashboardViewController {
 
         let section = NSCollectionLayoutSection(group: group)
         let isQuickActionSection = viewModel.card(for: sectionIndex) == .quickActions
+        let isLastSection = collectionView.numberOfSections == (sectionIndex + 1)
         let horizontalInset = isQuickActionSection ? 0 : Constants.sectionInset
+        let bottomInset = isLastSection ? Constants.sectionInset : 0
         section.contentInsets = NSDirectionalEdgeInsets(top: Constants.sectionInset,
                                                         leading: horizontalInset,
-                                                        bottom: 0,
+                                                        bottom: bottomInset,
                                                         trailing: horizontalInset)
 
         section.interGroupSpacing = Constants.cellSpacing


### PR DESCRIPTION
Fixes #18151

## Description
Adds bottom padding to the last section of the collection view

_P.s: Using `UICollectionView.contentInset` directly would've been simpler but sadly that didn't work. My guess is that it has to do with what we override in `IntrinsicCollectionView`._ 

<img src="https://user-images.githubusercontent.com/25306722/159949903-133c9cb7-0bf4-4b62-b9a4-533f8b250ae4.png" width=200>

## Testing Instructions

1. Make sure MSD is enabled
2. Navigate to the dashboard 
3. Make sure enough cards are showing to fill more than the whole screen
4. Scroll to the bottom of the dashboard
5. Make sure padding exists at the bottom.  

## Regression Notes
1. Potential unintended areas of impact
N/A

6. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.