### PR TITLE
Revert FBReactNativeSpec hash

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -785,7 +785,7 @@ SPEC CHECKSUMS:
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
   Down: 71bf4af3c04fa093e65dffa25c4b64fa61287373
   FBLazyVector: 2bf7b5e351f8e33867210ff6eb9c5c178a035522
-  FBReactNativeSpec: b4076f780f69b07abd859b279490f401d127c0ec
+  FBReactNativeSpec: 16a9f79d4f7700be883fbed663947595aa6c21c4
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   FormatterKit: 184db51bf120b633693a73624a4cede89ec51a41
   FSInteractiveMap: a396f610f48b76cb540baa87139d056429abda86


### PR DESCRIPTION
This reverts the change to the `FBReactNativeSpec` hash made in 89141cd6, which was most likely caused by local caching issues.

Slack ref: p1648171041292299-slack-CC7L49W13

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.