### PR TITLE
Quick Start: Enhancements to the Reader tour

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -161,7 +161,6 @@ import Gridicons
             return
         }
 
-        QuickStartTourGuide.shared.visited(.readerSearch)
         WPAppAnalytics.track(.readerSearchLoaded)
         didBumpStats = true
     }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -58,7 +58,9 @@ class ReaderTabViewController: UIViewController {
         if AppConfiguration.showsWhatIsNew {
             WPTabBarController.sharedInstance()?.presentWhatIsNew(on: self)
         }
+    }
 
+    override func viewWillAppear(_ animated: Bool) {
         searchButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -64,6 +64,7 @@ extension WPTabBarController {
     func navigateToReaderSearch() {
         let searchController = ReaderSearchViewController.controller()
         navigateToReader(searchController)
+        QuickStartTourGuide.shared.visited(.readerSearch)
     }
 
     func navigateToReaderSite(_ topic: ReaderSiteTopic) {


### PR DESCRIPTION
Fixes #18202

## Description
- Now, the last notice in the Reader's quickstart tour gets dismissed once the user performs the action, not after, to provide a smoother experience.
- Also fixes an issue where the spotlight view over the search button in reader stays visible after the tour is ended for a split second. 
 
https://user-images.githubusercontent.com/25306722/160046104-59bd2c21-4e1d-4c26-9c36-13d91eee400c.mp4

## Testing Instructions

1. Make sure MSD is enabled
2. Enable quick start for your site
3. Tap "Grow Your Audience"
4. Choose "Follow other sites"
5. Tap the reader tab
6. Tap the search button
7. Observe that the notice gets dismissed right away
8. Tap the back button
9. Observe that the spotlight view over the search button is not visible

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
