### PR TITLE
My Site Dashboard: fix lateral margins for iPad and separator

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -51,7 +51,6 @@ protocol PostsCardViewControllerDelegate: AnyObject {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        hideSeparatorForGhostCells()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -118,11 +117,6 @@ private extension PostsCardViewController {
 
     func removeGhostableTableView() {
         ghostableTableView?.removeFromSuperview()
-    }
-
-    func hideSeparatorForGhostCells() {
-        ghostableTableView?.visibleCells
-            .forEach { ($0 as? PostCompactCell)?.hideSeparator() }
     }
 
     func presentEditor() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -103,10 +103,10 @@ private extension PostsCardViewController {
         ghostableTableView.isScrollEnabled = false
         ghostableTableView.separatorStyle = .none
 
-        let postCompactCellNib = PostCompactCell.defaultNib
-        ghostableTableView.register(postCompactCellNib, forCellReuseIdentifier: PostCompactCell.defaultReuseID)
+        let postCompactCellNib = BlogDashboardPostCardGhostCell.defaultNib
+        ghostableTableView.register(postCompactCellNib, forCellReuseIdentifier: BlogDashboardPostCardGhostCell.defaultReuseID)
 
-        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: PostCompactCell.defaultReuseID, rowsPerSection: [Constants.numberOfPosts])
+        let ghostOptions = GhostOptions(displaysSectionHeader: false, reuseIdentifier: BlogDashboardPostCardGhostCell.defaultReuseID, rowsPerSection: [Constants.numberOfPosts])
         let style = GhostStyle(beatDuration: GhostStyle.Defaults.beatDuration,
                                beatStartColor: .placeholderElement,
                                beatEndColor: .placeholderElementFaded)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+class BlogDashboardPostCardGhostCell: UITableViewCell, NibReusable {
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var timestampLabel: UILabel!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        WPStyleGuide.configureTableViewCell(self)
+        WPStyleGuide.applyPostCardStyle(self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.xib
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" rowHeight="99" id="I5t-CH-v6f" customClass="BlogDashboardPostCardGhostCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="I5t-CH-v6f" id="Q79-tN-qHr">
+                <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4j2-Ve-ekh">
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="99"/>
+                        <subviews>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="kbh-Ck-sE6" userLabel="Inner Stack View">
+                                <rect key="frame" x="16" y="8" width="312" height="83"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yzx-SY-SGf">
+                                        <rect key="frame" x="0.0" y="0.0" width="312" height="83"/>
+                                        <subviews>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Yj1-10-Dz3">
+                                                <rect key="frame" x="0.0" y="24" width="312" height="35"/>
+                                                <subviews>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zJb-yj-c1C">
+                                                        <rect key="frame" x="0.0" y="0.0" width="272" height="13.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text=" " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VgR-q3-yxV">
+                                                        <rect key="frame" x="0.0" y="21.5" width="192" height="13.5"/>
+                                                        <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
+                                                        <nil key="textColor"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                <constraints>
+                                                    <constraint firstItem="VgR-q3-yxV" firstAttribute="top" secondItem="zJb-yj-c1C" secondAttribute="bottom" constant="8" id="1ol-4A-Rfh"/>
+                                                    <constraint firstAttribute="trailing" secondItem="zJb-yj-c1C" secondAttribute="trailing" constant="40" id="49t-Em-RBE"/>
+                                                    <constraint firstItem="zJb-yj-c1C" firstAttribute="top" secondItem="Yj1-10-Dz3" secondAttribute="top" id="6t6-7q-mDD"/>
+                                                    <constraint firstAttribute="bottom" secondItem="VgR-q3-yxV" secondAttribute="bottom" id="760-l2-GmL"/>
+                                                    <constraint firstItem="zJb-yj-c1C" firstAttribute="leading" secondItem="Yj1-10-Dz3" secondAttribute="leading" id="Vqn-8n-spa"/>
+                                                    <constraint firstAttribute="trailing" secondItem="VgR-q3-yxV" secondAttribute="trailing" constant="120" id="Wmz-X5-JO7"/>
+                                                    <constraint firstItem="VgR-q3-yxV" firstAttribute="leading" secondItem="zJb-yj-c1C" secondAttribute="leading" id="fBe-hc-pjp"/>
+                                                </constraints>
+                                            </view>
+                                        </subviews>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="Yj1-10-Dz3" secondAttribute="trailing" id="G43-bO-eNp"/>
+                                            <constraint firstItem="Yj1-10-Dz3" firstAttribute="centerY" secondItem="yzx-SY-SGf" secondAttribute="centerY" id="ZUc-99-5rc"/>
+                                            <constraint firstItem="Yj1-10-Dz3" firstAttribute="leading" secondItem="yzx-SY-SGf" secondAttribute="leading" id="elk-Ee-xOz"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                            </stackView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="bottom" secondItem="kbh-Ck-sE6" secondAttribute="bottom" constant="8" id="EAD-zc-JTh"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="999" constant="60" id="OcJ-tn-E7x"/>
+                            <constraint firstAttribute="trailing" secondItem="kbh-Ck-sE6" secondAttribute="trailing" constant="-8" id="Z3w-wQ-jiF"/>
+                            <constraint firstItem="kbh-Ck-sE6" firstAttribute="top" secondItem="4j2-Ve-ekh" secondAttribute="top" constant="8" id="a1K-da-e78"/>
+                            <constraint firstItem="kbh-Ck-sE6" firstAttribute="leading" secondItem="4j2-Ve-ekh" secondAttribute="leading" constant="16" id="rFw-1c-vxN"/>
+                        </constraints>
+                    </view>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="t9m-fX-UGv">
+                        <rect key="frame" x="0.0" y="98" width="320" height="1"/>
+                        <color key="backgroundColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="1" placeholder="YES" id="Eos-wQ-OaH"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="4j2-Ve-ekh" secondAttribute="bottom" id="TlK-Ne-mgt"/>
+                    <constraint firstAttribute="trailing" secondItem="t9m-fX-UGv" secondAttribute="trailing" id="b6s-os-xxh"/>
+                    <constraint firstItem="4j2-Ve-ekh" firstAttribute="top" secondItem="Q79-tN-qHr" secondAttribute="top" id="bN3-jA-XK5"/>
+                    <constraint firstAttribute="trailing" secondItem="4j2-Ve-ekh" secondAttribute="trailing" priority="999" id="eNp-ns-Wbl"/>
+                    <constraint firstItem="t9m-fX-UGv" firstAttribute="leading" secondItem="Q79-tN-qHr" secondAttribute="leading" id="poK-76-ZcI"/>
+                    <constraint firstItem="4j2-Ve-ekh" firstAttribute="leading" secondItem="Q79-tN-qHr" secondAttribute="leading" priority="999" id="sbb-HI-X9X"/>
+                    <constraint firstItem="t9m-fX-UGv" firstAttribute="bottom" secondItem="4j2-Ve-ekh" secondAttribute="bottom" id="uAQ-QU-sOb"/>
+                </constraints>
+            </tableViewCellContentView>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+            <connections>
+                <outlet property="timestampLabel" destination="VgR-q3-yxV" id="XnM-f2-gcX"/>
+                <outlet property="titleLabel" destination="zJb-yj-c1C" id="pRO-vQ-ymN"/>
+            </connections>
+            <point key="canvasLocation" x="135" y="179.72222222222223"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -151,14 +151,12 @@ class BlogDetailHeaderView: UIView {
     }
 
     private func constraintsForTitleView() -> [NSLayoutConstraint] {
-        var constraints = [
+        return [
             titleView.topAnchor.constraint(equalTo: topAnchor, constant: LayoutSpacing.top),
             titleView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: LayoutSpacing.atSides),
             titleView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -LayoutSpacing.atSides),
             titleView.bottomAnchor.constraint(equalTo: bottomAnchor)
         ]
-
-        return constraints
     }
 
     // MARK: - User Action Handlers

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -17,6 +17,9 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
     @IBOutlet weak var trailingContentConstraint: NSLayoutConstraint!
 
+    private var iPadReadableLeadingAnchor: NSLayoutConstraint?
+    private var iPadReadableTrailingAnchor: NSLayoutConstraint?
+
     private weak var actionSheetDelegate: PostActionSheetDelegate?
 
     lazy var imageLoader: ImageLoader = {
@@ -32,6 +35,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
             viewModel = PostCardStatusViewModel(post: post)
         }
     }
+
     private var viewModel: PostCardStatusViewModel?
 
     func configure(with post: Post) {
@@ -96,8 +100,11 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
     private func setupReadableGuideForiPad() {
         guard WPDeviceIdentification.isiPad() else { return }
 
-        innerView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor).isActive = true
-        innerView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor).isActive = true
+        iPadReadableLeadingAnchor = innerView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor)
+        iPadReadableTrailingAnchor = innerView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor)
+
+        iPadReadableLeadingAnchor?.isActive = true
+        iPadReadableTrailingAnchor?.isActive = true
     }
 
     private func configureFeaturedImage() {
@@ -238,5 +245,10 @@ extension PostCompactCell {
 
     func hideSeparator() {
         separator.isHidden = true
+    }
+
+    func disableiPadReadableMargin() {
+        iPadReadableLeadingAnchor?.isActive = false
+        iPadReadableTrailingAnchor?.isActive = false
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -238,6 +238,8 @@ extension PostCompactCell {
         trailingContentConstraint.constant = Constants.margin
         headerStackView.spacing = Constants.margin
 
+        disableiPadReadableMargin()
+
         if !post.isScheduled() {
             configureExcerpt()
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1514,6 +1514,10 @@
 		8BDA5A75247C63F300AB124C /* ReaderDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDA5A71247C5E5800AB124C /* ReaderDetailCoordinator.swift */; };
 		8BDC4C39249BA5CA00DE0A2D /* ReaderCSS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */; };
 		8BE69512243E674300FF492F /* PrepublishingHeaderViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */; };
+		8BE6F92A27EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BE6F92927EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib */; };
+		8BE6F92C27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE6F92B27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift */; };
+		8BE6F92D27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE6F92B27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift */; };
+		8BE6F92E27EE27E10008BDC7 /* BlogDashboardPostCardGhostCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8BE6F92927EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib */; };
 		8BE7C84123466927006EDE70 /* I18n.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE7C84023466927006EDE70 /* I18n.swift */; };
 		8BE8545D27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */; };
 		8BE8545E27DBAFED00E4C69A /* BlogDashboardAB.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */; };
@@ -6212,6 +6216,8 @@
 		8BDA5A73247C5EAA00AB124C /* ReaderDetailCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderDetailCoordinatorTests.swift; sourceTree = "<group>"; };
 		8BDC4C38249BA5CA00DE0A2D /* ReaderCSS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCSS.swift; sourceTree = "<group>"; };
 		8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PrepublishingHeaderViewTests.swift; path = WordPressTest/PrepublishingHeaderViewTests.swift; sourceTree = SOURCE_ROOT; };
+		8BE6F92927EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BlogDashboardPostCardGhostCell.xib; sourceTree = "<group>"; };
+		8BE6F92B27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPostCardGhostCell.swift; sourceTree = "<group>"; };
 		8BE7C84023466927006EDE70 /* I18n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = I18n.swift; sourceTree = "<group>"; };
 		8BE8545C27DBAFED00E4C69A /* BlogDashboardAB.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAB.swift; sourceTree = "<group>"; };
 		8BE9AB8727B6B5A300708E45 /* BlogDashboardPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersistenceTests.swift; sourceTree = "<group>"; };
@@ -11443,6 +11449,7 @@
 		8B4DDF24278F3AF60022494D /* Posts */ = {
 			isa = PBXGroup;
 			children = (
+				8BE6F92827EE26AF0008BDC7 /* Views */,
 				8B9DFCBA27999EAC00256DA0 /* DashboardPostsCardCell.swift */,
 				8BD66ED0278745EC00CCD95A /* PostsCardViewController.swift */,
 				8BD66ED32787530C00CCD95A /* PostsCardViewModel.swift */,
@@ -11614,6 +11621,15 @@
 				8BE69511243E674300FF492F /* PrepublishingHeaderViewTests.swift */,
 			);
 			name = "Prepublishing Nudges";
+			sourceTree = "<group>";
+		};
+		8BE6F92827EE26AF0008BDC7 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				8BE6F92927EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib */,
+				8BE6F92B27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift */,
+			);
+			path = Views;
 			sourceTree = "<group>";
 		};
 		8BEE845627B1DC5E0001A93C /* Dashboard */ = {
@@ -15872,6 +15888,7 @@
 				E61507E22220A0FE00213D33 /* richEmbedTemplate.html in Resources */,
 				B5C66B7A1ACF074600F68370 /* NoteBlockUserTableViewCell.xib in Resources */,
 				E6D2E1631B8AAA340000ED14 /* ReaderListStreamHeader.xib in Resources */,
+				8BE6F92A27EE26D30008BDC7 /* BlogDashboardPostCardGhostCell.xib in Resources */,
 				CE1CCB2F2050502B000EE3AC /* MyProfileHeaderView.xib in Resources */,
 				FEC3B81926C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */,
 				5D18FEA01AFBB17400EFEED0 /* RestorePageTableViewCell.xib in Resources */,
@@ -16259,6 +16276,7 @@
 				FABB20142602FC2C00C8785C /* CommentsList.storyboard in Resources */,
 				FABB20162602FC2C00C8785C /* TabbedTotalsCell.xib in Resources */,
 				FABB20172602FC2C00C8785C /* PageListTableViewCell.xib in Resources */,
+				8BE6F92E27EE27E10008BDC7 /* BlogDashboardPostCardGhostCell.xib in Resources */,
 				FABB20182602FC2C00C8785C /* NoteBlockImageTableViewCell.xib in Resources */,
 				FABB201B2602FC2C00C8785C /* SignupEpilogue.storyboard in Resources */,
 				FABB201D2602FC2C00C8785C /* PostStatsTitleCell.xib in Resources */,
@@ -18696,6 +18714,7 @@
 				3F3DD0AF26FCDA3100F5F121 /* PresentationButton.swift in Sources */,
 				988AC37522F10DD900BC1433 /* FileDownloadsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
+				8BE6F92C27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */,
 				FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,
 				D8212CC320AA7F57008E8AE8 /* ReaderBlockSiteAction.swift in Sources */,
@@ -21042,6 +21061,7 @@
 				FABB25B02602FC2C00C8785C /* MediaImportService.swift in Sources */,
 				FABB25B12602FC2C00C8785C /* NSAttributedStringKey+Conversion.swift in Sources */,
 				FABB25B22602FC2C00C8785C /* SelectPostViewController.swift in Sources */,
+				8BE6F92D27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */,
 				FABB25B32602FC2C00C8785C /* ReaderVisitSiteAction.swift in Sources */,
 				FABB25B42602FC2C00C8785C /* ReaderCard+CoreDataProperties.swift in Sources */,
 				FABB25B52602FC2C00C8785C /* GutenbergViewController+MoreActions.swift in Sources */,


### PR DESCRIPTION
Fixes #18194
Fixes #18175

Remove borders from the ghost cells:

<img src="https://user-images.githubusercontent.com/7040243/160169651-c70804b4-9068-4e86-85b3-3f6ade33d99c.png" width="400">

Fixes the leading and trailing margins for the posts on the Dashboard Posts Card:

<img src="https://user-images.githubusercontent.com/7040243/160169764-2c4bf166-be93-4a48-868a-3f89e1309ed2.png" width="400">

### To test

1. Run the app on iPad with MSD flag enabled
2. Check that the lateral margin is the same between posts and stats
3. Tap Stats > Home
4. Check that the ghost cells doesn't have a separator

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
