### PR TITLE
Merge release/19.5 — iOS Widget translator comments

### DIFF
--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -9473,16 +9473,21 @@
 
 /* MARK: - Sites.strings */
 
+/* This text is used when the user is configuring the iOS widget and selecting which WordPress site they want the widget to be for */
 "ios-widget.BOl9KQ" = "There are ${count} options matching ‘${site}’.";
 
+/* This text is used when the user is configuring the iOS widget, as a label for the dropdown to select the site to configure it for */
 "ios-widget.ILcGmf" = "Site";
 
+/* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "ios-widget.cyajMn" = "Site";
 
+/* This text is used when the user is configuring the iOS widget */
 "ios-widget.gpCwrM" = "Select Site";
 
+/* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "ios-widget.s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
 
+/* This text is used when the user is configuring the iOS widget */
 "ios-widget.tVvJ9c" = "Select Site Intent";
-
 

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -9482,12 +9482,9 @@
 /* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "ios-widget.cyajMn" = "Site";
 
-/* This text is used when the user is configuring the iOS widget */
+/* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "ios-widget.gpCwrM" = "Select Site";
 
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "ios-widget.s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
-
-/* This text is used when the user is configuring the iOS widget */
-"ios-widget.tVvJ9c" = "Select Site Intent";
 

--- a/WordPress/WordPressIntents/en.lproj/Sites.strings
+++ b/WordPress/WordPressIntents/en.lproj/Sites.strings
@@ -1,12 +1,17 @@
+/* This text is used when the user is configuring the iOS widget and selecting which WordPress site they want the widget to be for */
 "BOl9KQ" = "There are ${count} options matching ‘${site}’.";
 
+/* This text is used when the user is configuring the iOS widget, as a label for the dropdown to select the site to configure it for */
 "ILcGmf" = "Site";
 
+/* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "cyajMn" = "Site";
 
+/* This text is used when the user is configuring the iOS widget */
 "gpCwrM" = "Select Site";
 
+/* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
 
+/* This text is used when the user is configuring the iOS widget */
 "tVvJ9c" = "Select Site Intent";
-

--- a/WordPress/WordPressIntents/en.lproj/Sites.strings
+++ b/WordPress/WordPressIntents/en.lproj/Sites.strings
@@ -7,11 +7,8 @@
 /* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
 "cyajMn" = "Site";
 
-/* This text is used when the user is configuring the iOS widget */
+/* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "gpCwrM" = "Select Site";
 
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
-
-/* This text is used when the user is configuring the iOS widget */
-"tVvJ9c" = "Select Site Intent";


### PR DESCRIPTION
Making this in order to land the new translator hints for `Sites.strings` (aka iOS widget copies, see https://github.com/wordpress-mobile/WordPress-iOS/pull/18203 for details) in `trunk` before the WeeklyKit get sent out to translator vendor.