### PR TITLE
[Site Intent Question] Display list of default verticals on the Site Intent Question screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -24,8 +24,8 @@ class SiteCreationAnalyticsHelper {
         WPAnalytics.track(.enhancedSiteCreationIntentQuestionViewed)
     }
 
-    static func trackSiteIntentSelected(_ vertical: SiteVertical) {
-        let properties = [verticalSlugKey: vertical.identifier]
+    static func trackSiteIntentSelected(_ vertical: SiteIntentVertical) {
+        let properties = [verticalSlugKey: vertical.slug]
         WPAnalytics.track(.enhancedSiteCreationIntentQuestionVerticalSelected, properties: properties)
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+final class IntentCell: UITableViewCell, ModelSettableCell {
+    var borders = [UIView]()
+    @IBOutlet weak var title: UILabel!
+    @IBOutlet weak var emojiContainer: UIView!
+    @IBOutlet weak var emoji: UILabel!
+
+    var model: SiteIntentVertical? {
+        didSet {
+            title.text = model?.localizedTitle
+            emoji.text = model?.emoji
+        }
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        selectedBackgroundView?.backgroundColor = .clear
+
+        accessibilityTraits = .button
+        accessibilityHint = NSLocalizedString("Selects this topic as the intent for your site.",
+                                              comment: "Accessibility hint for a topic in the Site Creation intents view.")
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        accessoryType = .disclosureIndicator
+        emojiContainer.layer.cornerRadius = emojiContainer.layer.frame.width / 2
+    }
+
+    override func prepareForReuse() {
+        title.text = nil
+        emoji.text = nil
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
@@ -36,6 +36,7 @@ final class IntentCell: UITableViewCell, ModelSettableCell {
 
         accessoryType = .disclosureIndicator
         emojiContainer.layer.cornerRadius = emojiContainer.layer.frame.width / 2
+        title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .bold)
     }
 
     override func prepareForReuse() {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
@@ -1,7 +1,6 @@
 import UIKit
 
 final class IntentCell: UITableViewCell, ModelSettableCell {
-    var borders = [UIView]()
     @IBOutlet weak var title: UILabel!
     @IBOutlet weak var emojiContainer: UIView!
     @IBOutlet weak var emoji: UILabel!

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.swift
@@ -33,7 +33,6 @@ final class IntentCell: UITableViewCell, ModelSettableCell {
     override func awakeFromNib() {
         super.awakeFromNib()
 
-        accessoryType = .disclosureIndicator
         emojiContainer.layer.cornerRadius = emojiContainer.layer.frame.width / 2
         title.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .bold)
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
@@ -11,15 +11,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="IntentCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="IntentCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
+                <rect key="frame" x="0.0" y="0.0" width="337.5" height="62"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oUW-7f-3I7">
-                        <rect key="frame" x="20" y="12" width="322" height="40"/>
+                        <rect key="frame" x="20" y="12" width="297.5" height="40"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A5Z-4z-ewC" userLabel="Emoji Container">
                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -44,7 +44,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Intent Topic" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
-                                <rect key="frame" x="60" y="10.5" width="262" height="19.5"/>
+                                <rect key="frame" x="60" y="10.5" width="237.5" height="19.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="IntentCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oUW-7f-3I7">
+                        <rect key="frame" x="20" y="12" width="322" height="40"/>
+                        <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A5Z-4z-ewC" userLabel="Emoji Container">
+                                <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="😎" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h9n-u3-B9Q" userLabel="Emoji">
+                                        <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <viewLayoutGuide key="safeArea" id="3dF-ts-Z2Q"/>
+                                <color key="backgroundColor" systemColor="quaternarySystemFillColor"/>
+                                <constraints>
+                                    <constraint firstItem="h9n-u3-B9Q" firstAttribute="bottom" secondItem="3dF-ts-Z2Q" secondAttribute="bottom" id="EbC-xh-Dbv"/>
+                                    <constraint firstAttribute="height" constant="40" id="Exz-6o-lHd"/>
+                                    <constraint firstAttribute="width" constant="40" id="bim-xU-4hB"/>
+                                    <constraint firstItem="h9n-u3-B9Q" firstAttribute="trailing" secondItem="3dF-ts-Z2Q" secondAttribute="trailing" id="fLj-qi-J38"/>
+                                    <constraint firstItem="h9n-u3-B9Q" firstAttribute="top" secondItem="3dF-ts-Z2Q" secondAttribute="top" id="qql-r1-3DL"/>
+                                    <constraint firstAttribute="width" secondItem="A5Z-4z-ewC" secondAttribute="height" multiplier="1:1" id="tBu-AH-nVb"/>
+                                    <constraint firstItem="h9n-u3-B9Q" firstAttribute="leading" secondItem="3dF-ts-Z2Q" secondAttribute="leading" id="xz5-qJ-xng"/>
+                                </constraints>
+                            </view>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Intent Topic" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
+                                <rect key="frame" x="60" y="10.5" width="262" height="19.5"/>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="oUW-7f-3I7" secondAttribute="bottom" constant="12" id="JHW-Dl-5di"/>
+                    <constraint firstItem="oUW-7f-3I7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" symbolic="YES" id="KHA-2L-ltX"/>
+                    <constraint firstAttribute="trailing" secondItem="oUW-7f-3I7" secondAttribute="trailing" constant="20" symbolic="YES" id="Thz-gz-jqO"/>
+                    <constraint firstItem="oUW-7f-3I7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="12" id="vF5-Ve-Yi8"/>
+                </constraints>
+            </tableViewCellContentView>
+            <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
+            <connections>
+                <outlet property="emoji" destination="h9n-u3-B9Q" id="gkT-q1-Q4U"/>
+                <outlet property="emojiContainer" destination="A5Z-4z-ewC" id="kPJ-e0-whK"/>
+                <outlet property="title" destination="hQm-TV-IDW" id="Te9-FB-80O"/>
+            </connections>
+            <point key="canvasLocation" x="104" y="158.32083958020991"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="quaternarySystemFillColor">
+            <color red="0.45490196078431372" green="0.45490196078431372" blue="0.50196078431372548" alpha="0.080000000000000002" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
@@ -37,7 +37,7 @@ struct SiteIntentData {
         .init("personal", NSLocalizedString("Personal", comment: "Personal site intent topic"), "✍️"),
         .init("photography", NSLocalizedString("Photography", comment: "Photography site intent topic"), "📷"),
         .init("politics", NSLocalizedString("Politics", comment: "Politics site intent topic"), "🗳️"),
-        .init("real_state", NSLocalizedString("Real Estate", comment: "Real Estate site intent topic"), "🏠"),
+        .init("real_estate", NSLocalizedString("Real Estate", comment: "Real Estate site intent topic"), "🏠"),
         .init("sports", NSLocalizedString("Sports", comment: "Sports site intent topic"), "⚽"),
         .init("technology", NSLocalizedString("Technology", comment: "Technology site intent topic"), "💻"),
         .init("travel", NSLocalizedString("Travel", comment: "Travel site intent topic"), "✈️"),

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
@@ -1,17 +1,13 @@
 import Foundation
 
 struct SiteIntentData {
-    // Ordering of defaults affects ordering in the UI.
-    private static let defaultVerticalSlugs = [
-        "food",
-        "news",
-        "lifestyle",
-        "personal",
-        "photography",
-        "travel"
-    ]
-
-    static let verticals: Set<SiteIntentVertical> = [
+    static let verticals: [SiteIntentVertical] = [
+        .init("food", NSLocalizedString("Food", comment: "Food site intent topic"), "🍔", isDefault: true),
+        .init("news", NSLocalizedString("News", comment: "News site intent topic"), "🗞️", isDefault: true),
+        .init("lifestyle", NSLocalizedString("Lifestyle", comment: "Lifestyle site intent topic"), "☕", isDefault: true),
+        .init("personal", NSLocalizedString("Personal", comment: "Personal site intent topic"), "✍️", isDefault: true),
+        .init("photography", NSLocalizedString("Photography", comment: "Photography site intent topic"), "📷", isDefault: true),
+        .init("travel", NSLocalizedString("Travel", comment: "Travel site intent topic"), "✈️", isDefault: true),
         .init("art", NSLocalizedString("Art", comment: "Art site intent topic"), "🎨"),
         .init("automotive", NSLocalizedString("Automotive", comment: "Automotive site intent topic"), "🚗"),
         .init("beauty", NSLocalizedString("Beauty", comment: "Beauty site intent topic"), "💅"),
@@ -24,37 +20,30 @@ struct SiteIntentData {
         .init("finance", NSLocalizedString("Finance", comment: "Finance site intent topic"), "💰"),
         .init("film_television", NSLocalizedString("Film & Television", comment: "Film & Television site intent topic"), "🎥"),
         .init("fitness_exercise", NSLocalizedString("Fitness & Exercise", comment: "Fitness & Exercise site intent topic"), "💪"),
-        .init("food", NSLocalizedString("Food", comment: "Food site intent topic"), "🍔"),
         .init("gaming", NSLocalizedString("Gaming", comment: "Gaming site intent topic"), "🎮"),
         .init("health", NSLocalizedString("Health", comment: "Health site intent topic"), "❤️"),
         .init("interior_design", NSLocalizedString("Interior Design", comment: "Interior Design site intent topic"), "🛋️"),
-        .init("lifestyle", NSLocalizedString("Lifestyle", comment: "Lifestyle site intent topic"), "☕"),
         .init("local_services", NSLocalizedString("Local Services", comment: "Local Services site intent topic"), "📍"),
         .init("music", NSLocalizedString("Music", comment: "Music site intent topic"), "🎵"),
-        .init("news", NSLocalizedString("News", comment: "News site intent topic"), "🗞️"),
         .init("parenting", NSLocalizedString("Parenting", comment: "Parenting site intent topic"), "👶"),
         .init("people", NSLocalizedString("People", comment: "People site intent topic"), "🧑‍🤝‍🧑"),
-        .init("personal", NSLocalizedString("Personal", comment: "Personal site intent topic"), "✍️"),
-        .init("photography", NSLocalizedString("Photography", comment: "Photography site intent topic"), "📷"),
         .init("politics", NSLocalizedString("Politics", comment: "Politics site intent topic"), "🗳️"),
         .init("real_estate", NSLocalizedString("Real Estate", comment: "Real Estate site intent topic"), "🏠"),
         .init("sports", NSLocalizedString("Sports", comment: "Sports site intent topic"), "⚽"),
         .init("technology", NSLocalizedString("Technology", comment: "Technology site intent topic"), "💻"),
-        .init("travel", NSLocalizedString("Travel", comment: "Travel site intent topic"), "✈️"),
         .init("writing_poetry", NSLocalizedString("Writing & Poetry", comment: "Writing & Poetry site intent topic"), "📓")
     ]
 
     static let defaultVerticals: [SiteIntentVertical] = {
-        return defaultVerticalSlugs.compactMap { slug in
-            verticals.first(where: { $0.slug == slug })
-        }
+        verticals.filter { $0.isDefault }
     }()
 }
 
 fileprivate extension SiteIntentVertical {
-    init(_ slug: String, _ localizedTitle: String, _ emoji: String) {
+    init(_ slug: String, _ localizedTitle: String, _ emoji: String, isDefault: Bool = false) {
         self.slug = slug
         self.localizedTitle = localizedTitle
         self.emoji = emoji
+        self.isDefault = isDefault
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct SiteIntentData {
+    // Ordering of defaults affects ordering in the UI.
+    private static let defaultVerticalSlugs = [
+        "food",
+        "news",
+        "lifestyle",
+        "personal",
+        "photography",
+        "travel"
+    ]
+
+    static let verticals: Set<SiteIntentVertical> = [
+        .init("art", NSLocalizedString("Art", comment: "Art site intent topic"), "🎨"),
+        .init("automotive", NSLocalizedString("Automotive", comment: "Automotive site intent topic"), "🚗"),
+        .init("beauty", NSLocalizedString("Beauty", comment: "Beauty site intent topic"), "💅"),
+        .init("books", NSLocalizedString("Books", comment: "Books site intent topic"), "📚"),
+        .init("business", NSLocalizedString("Business", comment: "Business site intent topic"), "💼"),
+        .init("community_nonprofit", NSLocalizedString("Community & Non-Profit", comment: "Community & Non-Profit site intent topic"), "🤝"),
+        .init("education", NSLocalizedString("Education", comment: "Education site intent topic"), "🏫"),
+        .init("diy", NSLocalizedString("DIY", comment: "DIY site intent topic"), "🔨"),
+        .init("fashion", NSLocalizedString("Fashion", comment: "Fashion site intent topic"), "👠"),
+        .init("finance", NSLocalizedString("Finance", comment: "Finance site intent topic"), "💰"),
+        .init("film_television", NSLocalizedString("Film & Television", comment: "Film & Television site intent topic"), "🎥"),
+        .init("fitness_exercise", NSLocalizedString("Fitness & Exercise", comment: "Fitness & Exercise site intent topic"), "💪"),
+        .init("food", NSLocalizedString("Food", comment: "Food site intent topic"), "🍔"),
+        .init("gaming", NSLocalizedString("Gaming", comment: "Gaming site intent topic"), "🎮"),
+        .init("health", NSLocalizedString("Health", comment: "Health site intent topic"), "❤️"),
+        .init("interior_design", NSLocalizedString("Interior Design", comment: "Interior Design site intent topic"), "🛋️"),
+        .init("lifestyle", NSLocalizedString("Lifestyle", comment: "Lifestyle site intent topic"), "☕"),
+        .init("local_services", NSLocalizedString("Local Services", comment: "Local Services site intent topic"), "📍"),
+        .init("music", NSLocalizedString("Music", comment: "Music site intent topic"), "🎵"),
+        .init("news", NSLocalizedString("News", comment: "News site intent topic"), "🗞️"),
+        .init("parenting", NSLocalizedString("Parenting", comment: "Parenting site intent topic"), "👶"),
+        .init("people", NSLocalizedString("People", comment: "People site intent topic"), "🧑‍🤝‍🧑"),
+        .init("personal", NSLocalizedString("Personal", comment: "Personal site intent topic"), "✍️"),
+        .init("photography", NSLocalizedString("Photography", comment: "Photography site intent topic"), "📷"),
+        .init("politics", NSLocalizedString("Politics", comment: "Politics site intent topic"), "🗳️"),
+        .init("real_state", NSLocalizedString("Real Estate", comment: "Real Estate site intent topic"), "🏠"),
+        .init("sports", NSLocalizedString("Sports", comment: "Sports site intent topic"), "⚽"),
+        .init("technology", NSLocalizedString("Technology", comment: "Technology site intent topic"), "💻"),
+        .init("travel", NSLocalizedString("Travel", comment: "Travel site intent topic"), "✈️"),
+        .init("writing_poetry", NSLocalizedString("Writing & Poetry", comment: "Writing & Poetry site intent topic"), "📓")
+    ]
+
+    static let defaultVerticals: [SiteIntentVertical] = {
+        return defaultVerticalSlugs.compactMap { slug in
+            verticals.first(where: { $0.slug == slug })
+        }
+    }()
+}
+
+fileprivate extension SiteIntentVertical {
+    init(_ slug: String, _ localizedTitle: String, _ emoji: String) {
+        self.slug = slug
+        self.localizedTitle = localizedTitle
+        self.emoji = emoji
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentStep.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Site Creation: Allows selection of the the site's vertical (a.k.a. intent or industry).
 final class SiteIntentStep: WizardStep {
-    typealias SiteIntentSelection = (_ vertical: SiteVertical?) -> Void
+    typealias SiteIntentSelection = (_ vertical: SiteIntentVertical?) -> Void
     weak var delegate: WizardDelegate?
     private let creator: SiteCreator
 
@@ -22,7 +22,7 @@ final class SiteIntentStep: WizardStep {
         self.creator = creator
     }
 
-    private func didSelect(_ vertical: SiteVertical?) {
+    private func didSelect(_ vertical: SiteIntentVertical?) {
         creator.vertical = vertical
         delegate?.nextStep()
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentVertical.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentVertical.swift
@@ -1,7 +1,8 @@
 import Foundation
 
-struct SiteIntentVertical: Hashable {
+struct SiteIntentVertical {
     let slug: String
     let localizedTitle: String
     let emoji: String
+    let isDefault: Bool
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentVertical.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentVertical.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct SiteIntentVertical: Hashable {
+    let slug: String
+    let localizedTitle: String
+    let emoji: String
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -10,7 +10,7 @@ class SiteIntentViewController: CollapsableHeaderViewController {
         }
     }
 
-    private var data: [SiteIntentVertical] {
+    private var availableVerticals: [SiteIntentVertical] {
         return SiteIntentData.defaultVerticals
     }
 
@@ -106,7 +106,7 @@ class SiteIntentViewController: CollapsableHeaderViewController {
 
 extension SiteIntentViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return data.count
+        return availableVerticals.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -119,8 +119,8 @@ extension SiteIntentViewController: UITableViewDataSource {
             return UITableViewCell()
         }
 
-        let intentVertical = data[indexPath.row]
-        cell.model = intentVertical
+        let vertical = availableVerticals[indexPath.row]
+        cell.model = vertical
         return cell
     }
 }
@@ -133,7 +133,7 @@ extension SiteIntentViewController: UITableViewDelegate {
         // TODO - either use or remove after implementing search
         // searchTextField.resignFirstResponder()
 
-        let vertical = data[indexPath.row]
+        let vertical = availableVerticals[indexPath.row]
 
         SiteCreationAnalyticsHelper.trackSiteIntentSelected(vertical)
         selection(vertical)

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -86,10 +86,6 @@ class SiteIntentViewController: CollapsableHeaderViewController {
 
     // MARK: Actions
 
-    override func primaryActionSelected(_ sender: Any) {
-        // TODO - handle string input
-    }
-
     @objc
     private func skipButtonTapped(_ sender: Any) {
         SiteCreationAnalyticsHelper.trackSiteIntentSkipped()
@@ -131,9 +127,6 @@ extension SiteIntentViewController: UITableViewDataSource {
 extension SiteIntentViewController: UITableViewDelegate {
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        // TODO - either use or remove after implementing search
-        // searchTextField.resignFirstResponder()
-
         let vertical = availableVerticals[indexPath.row]
 
         SiteCreationAnalyticsHelper.trackSiteIntentSelected(vertical)

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 class SiteIntentViewController: CollapsableHeaderViewController {
     private let selection: SiteIntentStep.SiteIntentSelection
-    private let table: UITableView
+    private let tableView: UITableView
 
     private var selectedVertical: SiteIntentVertical? {
         didSet {
@@ -17,10 +17,10 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     init(_ selection: @escaping SiteIntentStep.SiteIntentSelection) {
         self.selection = selection
 
-        table = UITableView(frame: .zero, style: .grouped)
+        tableView = UITableView(frame: .zero, style: .grouped)
 
         super.init(
-            scrollableView: table,
+            scrollableView: tableView,
             mainTitle: Strings.mainTitle,
             prompt: Strings.prompt,
             primaryActionTitle: Strings.primaryAction,
@@ -29,7 +29,7 @@ class SiteIntentViewController: CollapsableHeaderViewController {
             accessoryView: nil
         )
 
-        table.dataSource = self
+        tableView.dataSource = self
     }
 
     // MARK: UIViewController
@@ -60,7 +60,7 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     // MARK: UI Setup
 
     private func configureTable() {
-        table.backgroundColor = .basicBackground
+        tableView.backgroundColor = .basicBackground
     }
 
     private func configureSkipButton() {
@@ -79,9 +79,9 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     private func setupCells() {
         let cellName = IntentCell.cellReuseIdentifier()
         let nib = UINib(nibName: cellName, bundle: nil)
-        table.register(nib, forCellReuseIdentifier: cellName)
-        table.register(InlineErrorRetryTableViewCell.self, forCellReuseIdentifier: InlineErrorRetryTableViewCell.cellReuseIdentifier())
-        table.cellLayoutMarginsFollowReadableWidth = true
+        tableView.register(nib, forCellReuseIdentifier: cellName)
+        tableView.register(InlineErrorRetryTableViewCell.self, forCellReuseIdentifier: InlineErrorRetryTableViewCell.cellReuseIdentifier())
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     // MARK: Actions

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -28,6 +28,8 @@ class SiteIntentViewController: CollapsableHeaderViewController {
             defaultActionTitle: nil,
             accessoryView: nil
         )
+
+        table.dataSource = self
     }
 
     // MARK: UIViewController
@@ -71,7 +73,6 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     }
 
     private func setupTable() {
-        table.dataSource = self
         setupCells()
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreator.swift
@@ -28,7 +28,7 @@ final class SiteCreator {
     // MARK: Properties
     var segment: SiteSegment?
     var design: RemoteSiteDesign?
-    var vertical: SiteVertical?
+    var vertical: SiteIntentVertical?
     var information: SiteInformation?
     var address: DomainSuggestion?
 
@@ -37,8 +37,6 @@ final class SiteCreator {
     /// - Returns: an Encodable object
     ///
     func build() throws -> SiteCreationRequest {
-        let verticalIdentifier = vertical?.identifier.description
-
         guard let domainSuggestion = address else {
             throw SiteCreationRequestAssemblyError.invalidDomain
         }
@@ -48,7 +46,7 @@ final class SiteCreator {
         let request = SiteCreationRequest(
             segmentIdentifier: segment?.identifier,
             siteDesign: siteDesign,
-            verticalIdentifier: verticalIdentifier,
+            verticalIdentifier: vertical?.slug,
             title: information?.title ?? NSLocalizedString("Site Title", comment: "Site info. Title"),
             tagline: information?.tagLine ?? "",
             siteURLString: siteName,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2132,6 +2132,14 @@
 		BED4D8301FF11DEF00A11345 /* EditorAztecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4D82F1FF11DEF00A11345 /* EditorAztecTests.swift */; };
 		BED4D8331FF11E3800A11345 /* LoginFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4D8321FF11E3800A11345 /* LoginFlow.swift */; };
 		C314543B262770BE005B216B /* BlogServiceAuthorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C314543A262770BE005B216B /* BlogServiceAuthorTests.swift */; };
+		C3234F4C27EB96A3004ADB29 /* IntentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C3302CC427EB67D0004229D3 /* IntentCell.xib */; };
+		C3234F4D27EB96A5004ADB29 /* IntentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = C3302CC427EB67D0004229D3 /* IntentCell.xib */; };
+		C3234F4E27EB96A9004ADB29 /* IntentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3302CC527EB67D0004229D3 /* IntentCell.swift */; };
+		C3234F4F27EB96AB004ADB29 /* IntentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3302CC527EB67D0004229D3 /* IntentCell.swift */; };
+		C3234F5127EB9925004ADB29 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5027EB9925004ADB29 /* SiteIntentData.swift */; };
+		C3234F5227EB9925004ADB29 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5027EB9925004ADB29 /* SiteIntentData.swift */; };
+		C3234F5427EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */; };
+		C3234F5527EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */; };
 		C387B7A22638D66F00BDEF86 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
@@ -6852,6 +6860,10 @@
 		BED4D83A1FF13B8A00A11345 /* EditorPublishEpilogueScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorPublishEpilogueScreen.swift; sourceTree = "<group>"; };
 		C2988A406A3D5697C2984F3E /* Pods-WordPressStatsWidgets.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.release-internal.xcconfig"; sourceTree = "<group>"; };
 		C314543A262770BE005B216B /* BlogServiceAuthorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceAuthorTests.swift; sourceTree = "<group>"; };
+		C3234F5027EB9925004ADB29 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
+		C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentVertical.swift; sourceTree = "<group>"; };
+		C3302CC427EB67D0004229D3 /* IntentCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IntentCell.xib; sourceTree = "<group>"; };
+		C3302CC527EB67D0004229D3 /* IntentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentCell.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
 		C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostAuthorSelectorViewController.swift; sourceTree = "<group>"; };
@@ -12572,8 +12584,12 @@
 		B0960C8527D14B9200BC9717 /* SiteIntent */ = {
 			isa = PBXGroup;
 			children = (
+				C3302CC527EB67D0004229D3 /* IntentCell.swift */,
+				C3302CC427EB67D0004229D3 /* IntentCell.xib */,
 				B0960C8627D14BD400BC9717 /* SiteIntentStep.swift */,
 				B089140C27E1255D00CF468B /* SiteIntentViewController.swift */,
+				C3234F5027EB9925004ADB29 /* SiteIntentData.swift */,
+				C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */,
 			);
 			path = SiteIntent;
 			sourceTree = "<group>";
@@ -15883,6 +15899,7 @@
 				B5C66B721ACF071100F68370 /* NoteBlockTextTableViewCell.xib in Resources */,
 				98E55019265C977E00B4BE9A /* ReaderDetailLikesView.xib in Resources */,
 				FF37F90922385CA000AFA3DB /* RELEASE-NOTES.txt in Resources */,
+				C3234F4C27EB96A3004ADB29 /* IntentCell.xib in Resources */,
 				9808655A203D075E00D58786 /* EpilogueUserInfoCell.xib in Resources */,
 				C7E5F2552799BD54009BC263 /* cool-blue-icon-app-83.5x83.5@2x.png in Resources */,
 				17222D92261DDDF90047B163 /* blue-classic-icon-app-83.5x83.5@2x.png in Resources */,
@@ -16326,6 +16343,7 @@
 				FE3E427926A868EC00C596CE /* ListTableHeaderView.xib in Resources */,
 				FABB20772602FC2C00C8785C /* world-map.svg in Resources */,
 				FABB20782602FC2C00C8785C /* NoteBlockTextTableViewCell.xib in Resources */,
+				C3234F4D27EB96A5004ADB29 /* IntentCell.xib in Resources */,
 				9822A8562624D01800FD8A03 /* UserProfileSiteCell.xib in Resources */,
 				FABB207D2602FC2C00C8785C /* RELEASE-NOTES.txt in Resources */,
 				FABB207E2602FC2C00C8785C /* EpilogueUserInfoCell.xib in Resources */,
@@ -18108,6 +18126,7 @@
 				E684383E221F535900752258 /* LoadMoreCounter.swift in Sources */,
 				E6158ACA1ECDF518005FA441 /* LoginEpilogueUserInfo.swift in Sources */,
 				E1E4CE0B1773C59B00430844 /* WPAvatarSource.m in Sources */,
+				C3234F5427EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */,
 				983DBBAB22125DD500753988 /* StatsTableFooter.swift in Sources */,
 				85D239AE1AE5A5FC0074768D /* BlogSyncFacade.m in Sources */,
 				8B0732F3242BF99B00E7FBD3 /* PrepublishingNavigationController.swift in Sources */,
@@ -18817,6 +18836,7 @@
 				436D562E2117347C00CEAA33 /* RegisterDomainDetailsViewModel+RowDefinitions.swift in Sources */,
 				E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */,
 				D8212CB720AA7703008E8AE8 /* ReaderShareAction.swift in Sources */,
+				C3234F5127EB9925004ADB29 /* SiteIntentData.swift in Sources */,
 				9826AE8A21B5CC7300C851FA /* PostingActivityMonth.swift in Sources */,
 				4054F4612214F50300D261AB /* StreakStatsRecordValue+CoreDataClass.swift in Sources */,
 				3F09CCAE24292EFD00D00A8C /* ReaderTabItem.swift in Sources */,
@@ -18824,6 +18844,7 @@
 				FAB8FD6E25AEB23600D5D54A /* JetpackBackupService.swift in Sources */,
 				17171374265FAA8A00F3A022 /* BloggingRemindersNavigationController.swift in Sources */,
 				8236EB502024ED8C007C7CF9 /* NotificationsViewController+JetpackPrompt.swift in Sources */,
+				C3234F4E27EB96A9004ADB29 /* IntentCell.swift in Sources */,
 				5D732F971AE84E3C00CD89E7 /* PostListFooterView.m in Sources */,
 				1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */,
 				0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */,
@@ -20065,6 +20086,7 @@
 				FABB225B2602FC2C00C8785C /* CountryStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB225C2602FC2C00C8785C /* MenuHeaderViewController.m in Sources */,
 				FABB225D2602FC2C00C8785C /* NotificationDetailsViewController.swift in Sources */,
+				C3234F5527EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */,
 				FABB225F2602FC2C00C8785C /* MediaURLExporter.swift in Sources */,
 				FABB22602602FC2C00C8785C /* WordPress.xcdatamodeld in Sources */,
 				93CDC72226CD342900C8A3A8 /* DestructiveAlertHelper.swift in Sources */,
@@ -20174,6 +20196,7 @@
 				982DDF97263238A6002B3904 /* LikeUserPreferredBlog+CoreDataProperties.swift in Sources */,
 				FABB22B82602FC2C00C8785C /* QuickStartChecklistManager.swift in Sources */,
 				FABB22B92602FC2C00C8785C /* NoResultsTenorConfiguration.swift in Sources */,
+				C3234F4F27EB96AB004ADB29 /* IntentCell.swift in Sources */,
 				98AA6D1226B8CE7200920C8B /* Comment+CoreDataClass.swift in Sources */,
 				FABB22BA2602FC2C00C8785C /* JetpackRemoteInstallViewController.swift in Sources */,
 				FABB22BB2602FC2C00C8785C /* PlanDetailViewController.swift in Sources */,
@@ -20393,6 +20416,7 @@
 				FABB23772602FC2C00C8785C /* MediaImageExporter.swift in Sources */,
 				FABB23782602FC2C00C8785C /* GutenbergViewController+InformativeDialog.swift in Sources */,
 				8B55F9DC2614D902007D618E /* CircledIcon.swift in Sources */,
+				C3234F5227EB9925004ADB29 /* SiteIntentData.swift in Sources */,
 				FABB23792602FC2C00C8785C /* ChangePasswordViewController.swift in Sources */,
 				3FE3D1FD26A6F34900F3CD10 /* WPStyleGuide+List.swift in Sources */,
 				175CC17D2723103000622FB4 /* WPAnalytics+Domains.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
@@ -17,7 +17,13 @@ class SiteAssemblyServiceTests: XCTestCase {
             iconColor: "#FF0000",
             mobile: true)
 
-        siteCreator.vertical = SiteIntentVertical(slug: "slug", localizedTitle: "A title", emoji: "😎")
+        siteCreator.vertical = SiteIntentVertical(
+            slug: "slug",
+            localizedTitle: "A title",
+            emoji: "😎",
+            isDefault: true
+        )
+
         siteCreator.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [

--- a/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteAssemblyServiceTests.swift
@@ -17,10 +17,7 @@ class SiteAssemblyServiceTests: XCTestCase {
             iconColor: "#FF0000",
             mobile: true)
 
-        siteCreator.vertical = SiteVertical(identifier: "678910",
-            title: "A title",
-            isNew: true)
-
+        siteCreator.vertical = SiteIntentVertical(slug: "slug", localizedTitle: "A title", emoji: "😎")
         siteCreator.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [

--- a/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
@@ -24,10 +24,7 @@ class SiteCreatorTests: XCTestCase {
         let siteDesignPayload = "{\"slug\":\"alves\",\"title\":\"Alves\",\"segment_id\":1,\"categories\":[{\"slug\":\"business\",\"title\":\"Business\",\"description\":\"Business\",\"emoji\":\"💼\"}],\"demo_url\":\"https://public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/?language=en\",\"theme\":\"alves\",\"preview\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=1200&vph=1600&w=800&h=1067\",\"preview_tablet\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=800&vph=1066&w=800&h=1067\",\"preview_mobile\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=400&vph=533&w=400&h=534\"}"
         defaultInput.design = try! JSONDecoder().decode(RemoteSiteDesign.self, from: siteDesignPayload.data(using: .utf8)!)
 
-        defaultInput.vertical = SiteVertical(identifier: "678910",
-            title: "A title",
-            isNew: true)
-
+        defaultInput.vertical = SiteIntentVertical(slug: "slug", localizedTitle: "A title", emoji: "😎")
         defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [

--- a/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreatorTests.swift
@@ -24,7 +24,13 @@ class SiteCreatorTests: XCTestCase {
         let siteDesignPayload = "{\"slug\":\"alves\",\"title\":\"Alves\",\"segment_id\":1,\"categories\":[{\"slug\":\"business\",\"title\":\"Business\",\"description\":\"Business\",\"emoji\":\"💼\"}],\"demo_url\":\"https://public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/?language=en\",\"theme\":\"alves\",\"preview\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=1200&vph=1600&w=800&h=1067\",\"preview_tablet\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=800&vph=1066&w=800&h=1067\",\"preview_mobile\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=400&vph=533&w=400&h=534\"}"
         defaultInput.design = try! JSONDecoder().decode(RemoteSiteDesign.self, from: siteDesignPayload.data(using: .utf8)!)
 
-        defaultInput.vertical = SiteIntentVertical(slug: "slug", localizedTitle: "A title", emoji: "😎")
+        defaultInput.vertical = SiteIntentVertical(
+            slug: "slug",
+            localizedTitle: "A title",
+            emoji: "😎",
+            isDefault: true
+        )
+
         defaultInput.information = SiteInformation(title: "A title", tagLine: "A tagline")
 
         let domainSuggestionPayload: [String: AnyObject] = [


### PR DESCRIPTION
Closes #18107 

### Description

Subpart of:
- https://github.com/wordpress-mobile/WordPress-iOS/issues/18035

A list of clickable verticals with icons is displayed on the [Site Intent Question screen](https://github.com/wordpress-mobile/WordPress-iOS/issues/18106).

### Acceptance Criteria

- [x] Default Verticals are bundled in the app (pbArwn-3Qf-p2#default-verticals)
  - [x] The name of each vertical is localized
- [x] List of verticals is displayed
  - [x] A list item is displayed as such:
    - [x] Emoji icon in a gray circle
    - [x] Name of the item with bold font weight
  - [x] List item tap → Navigates to "Choose a Design" screen
- [ ] The UI scales with dynamic type (font size) changes
- [x] The UI supports Dark Mode 

<img src="https://user-images.githubusercontent.com/2092798/160418570-630be93f-7567-4c29-9e1d-a4246730cf2c.png" width="350px" alt="Default list of verticals" />

#### Other Considerations:

- [x] Unit Tests are added where applicable
- [x] List is scrollable
- [x] Events are tracked (Vertical selected) ⚠️ This may create noise as multiple verticals could be selected in one session. We may consider sending the selection even at the very end of the site creation in a later PR. 

## Regression Notes
1. Potential unintended areas of impact
None currently as this is behind a feature flag.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
