### PR TITLE
[Tooling] Add improved zsh fastlane completion script

### DIFF
--- a/fastlane/completion.zsh
+++ b/fastlane/completion.zsh
@@ -1,0 +1,36 @@
+#!/bin/zsh
+
+# This is a revised version of the ZSH completion script for fastlane
+# which adds support for some lanes being defined in `fastlane/lanes/*.rb`
+#
+# Based on https://github.com/fastlane/fastlane/blob/master/fastlane/lib/assets/completions/completion.zsh
+#
+# To install, copy this file to `~/.fastlane/completions/completion.zsh`,
+# then `source` it from your `~/.zshrc`.
+#
+_fastlane_complete() {
+  local word completions file
+  word="$1"
+
+  # look for Fastfile either in this directory or fastlane/ then grab the lane names
+  if [[ -e "Fastfile" ]] then
+    file=("Fastfile")
+  elif [[ -e "fastlane/Fastfile" ]] then
+    file=("fastlane/Fastfile")
+  elif [[ -e ".fastlane/Fastfile" ]] then
+    file=(".fastlane/Fastfile")
+  else
+    return 1
+  fi
+
+  # Add any fastlane/lanes/*.rb file too, if any
+  files=("$file" fastlane/lanes/*.rb(N))
+
+  # parse 'beta' out of 'lane :beta do', etc
+  completions="$(sed -En 's/^[ 	]*lane +:([^ 	]+).*$/\1/p' "${files[@]}")"
+  completions="$completions update_fastlane"
+
+  reply=( "${=completions}" )
+}
+
+compctl -K _fastlane_complete bundle exec fastlane


### PR DESCRIPTION
## Why?

As @mokagio noticed in https://github.com/wordpress-mobile/WordPress-iOS/pull/18140#issuecomment-1078599450, after splitting our big `Fastfile` into smaller `fastlane/lanes/*.rb` files, the ZSH completion script [provided by fastlane](https://github.com/fastlane/fastlane/blob/668d976ec61d74509f3123ea1b7fe1836a1052e4/fastlane/lib/assets/completions/completion.zsh) (and which you can usually install using `fastlane enable_auto_complete`) stopped working, because it only scanned the `Fastfile` for `lane :(.*)…`, but did not scan those new `lanes/*.rb` files.

## How?

I've made a copy of the completion script in this repo, and adapted it for our use case so that it is able to also scan for those additional files.

To install:
 - Replace the `~/.fastlane/completions/completion.zsh` file (which was created by a likely previous run of `fastlane enable_auto_complete`, or create it otherwise) with the file provided in this repo in `fastlane/completion.zsh`.
 - Then `source` that `~/.fastlane/completions/completion.zsh` file in your `~/.zshrc` (if you didn't do it already from a previous installation of the completion script).
 - Finally, restart your terminal session, to make `.zshrc` reload the new script
