### PR TITLE
My Site Dashboard: fix crash for iOS 13 and 14

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -304,7 +304,7 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
         }
         snapshot.reloadItems(reloadIdentifiers)
 
-        let shouldAnimate = viewController?.tableView.numberOfSections != 0
+        let shouldAnimate = viewController?.tableView.numberOfRows(inSection: 0) != 0
         dataSource.apply(snapshot as Snapshot,
                          animatingDifferences: shouldAnimate,
                          completion: { [weak self] in

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -304,7 +304,7 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
         }
         snapshot.reloadItems(reloadIdentifiers)
 
-        let shouldAnimate = viewController?.tableView.numberOfRows(inSection: 0) != 0
+        let shouldAnimate = viewController?.tableView.numberOfSections != 0 && viewController?.tableView.numberOfRows(inSection: 0) != 0
         dataSource.apply(snapshot as Snapshot,
                          animatingDifferences: shouldAnimate,
                          completion: { [weak self] in


### PR DESCRIPTION
Fixes #18224

This PR fixes a crash for iOS 13 and 14 when loading the posts.

### Compiling

Use a simulator with iOS 13 or iOS 14. If you have an M1 MacBook, you have to do a few extra steps:

1. Under Build Settings > Excluded Architectures > add `arm64`
2. Product > Clean Build Folder
3. Run on a iOS 13 device

For iOS 14: I wasn't able to build for it on a M1, so I had to test on an Intel mac.

### To test

1. Open the app on a simulator with iOS 13 or 14
2. Tap "Home" for a blog with drafts and/or scheduled post
3. ✅ Check that they show correctly
4. Create posts, delete, etc

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
