### PR TITLE
My Site Dashboard: change Quick Actions order

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -13,10 +13,10 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, BlogD
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
-            statsButton,
+            pagesButton,
             postsButton,
             mediaButton,
-            pagesButton
+            statsButton
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal


### PR DESCRIPTION
Based on this comment, we've decided to change the order of Quick Actions buttons. It should be: Pages, Posts, Media, Stats.

This PR address this change.

<img width="300" alt="Screen Shot 2022-03-28 at 13 46 10" src="https://user-images.githubusercontent.com/7040243/160447169-efa45252-e87b-4e28-b889-c2a6ce49ec9b.png">

### To test

1. Run the app
2. Tap Home
3. Make sure the Quick Actions order is: Pages, Posts, Media, Stats.

## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
