### PR TITLE
My Site Dashboard: Custom feature announcement

### DIFF
--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsDataSource.swift
@@ -7,19 +7,15 @@ protocol AnnouncementsDataSource: UITableViewDataSource {
 
 class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
 
-    private let store: AnnouncementsStore
-
+    private let features: [WordPressKit.Feature]
+    private let detailsUrl: String
     private let cellTypes: [String: UITableViewCell.Type]
-    private var features: [WordPressKit.Feature] {
-        store.announcements.reduce(into: [WordPressKit.Feature](), {
-            $0.append(contentsOf: $1.features)
-        })
-    }
 
     var dataDidChange: (() -> Void)?
 
-    init(store: AnnouncementsStore, cellTypes: [String: UITableViewCell.Type]) {
-        self.store = store
+    init(features: [WordPressKit.Feature], detailsUrl: String, cellTypes: [String: UITableViewCell.Type]) {
+        self.features = features
+        self.detailsUrl = detailsUrl
         self.cellTypes = cellTypes
         super.init()
     }
@@ -42,7 +38,7 @@ class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
 
         guard indexPath.row <= features.count - 1 else {
             let cell = tableView.dequeueReusableCell(withIdentifier: "findOutMoreCell", for: indexPath) as? FindOutMoreCell ?? FindOutMoreCell()
-            cell.configure(with: URL(string: store.announcements.first?.detailsUrl ?? ""))
+            cell.configure(with: URL(string: detailsUrl))
             return cell
         }
 

--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsDataSource.swift
@@ -4,26 +4,30 @@ protocol AnnouncementsDataSource: UITableViewDataSource {
     var dataDidChange: (() -> Void)? { get set }
 }
 
+typealias AnnouncementTableViewCell = UITableViewCell & Reusable & AnnouncementCellConfigurable
+
+protocol AnnouncementCellConfigurable {
+    func configure(feature: WordPressKit.Feature)
+}
 
 class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
 
     private let features: [WordPressKit.Feature]
     private let detailsUrl: String
-    private let cellTypes: [String: UITableViewCell.Type]
+    private let announcementCellType: AnnouncementTableViewCell.Type
 
     var dataDidChange: (() -> Void)?
 
-    init(features: [WordPressKit.Feature], detailsUrl: String, cellTypes: [String: UITableViewCell.Type]) {
+    init(features: [WordPressKit.Feature], detailsUrl: String, announcementCellType: AnnouncementTableViewCell.Type) {
         self.features = features
         self.detailsUrl = detailsUrl
-        self.cellTypes = cellTypes
+        self.announcementCellType = announcementCellType
         super.init()
     }
 
     func registerCells(for tableView: UITableView) {
-        cellTypes.forEach {
-            tableView.register($0.value, forCellReuseIdentifier: $0.key)
-        }
+        tableView.register(FindOutMoreCell.self, forCellReuseIdentifier: FindOutMoreCell.defaultReuseID)
+        tableView.register(announcementCellType, forCellReuseIdentifier: announcementCellType.defaultReuseID)
     }
 
     func numberOfSections(in: UITableView) -> Int {
@@ -37,12 +41,14 @@ class FeatureAnnouncementsDataSource: NSObject, AnnouncementsDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
 
         guard indexPath.row <= features.count - 1 else {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "findOutMoreCell", for: indexPath) as? FindOutMoreCell ?? FindOutMoreCell()
+            let cell = tableView.dequeueReusableCell(withIdentifier: FindOutMoreCell.defaultReuseID, for: indexPath) as? FindOutMoreCell ?? FindOutMoreCell()
             cell.configure(with: URL(string: detailsUrl))
             return cell
         }
 
-        let cell = tableView.dequeueReusableCell(withIdentifier: "announcementCell", for: indexPath) as? AnnouncementCell ?? AnnouncementCell()
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: announcementCellType.defaultReuseID, for: indexPath) as? AnnouncementTableViewCell else {
+            return UITableViewCell()
+        }
         cell.configure(feature: features[indexPath.row])
         return cell
     }

--- a/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/AnnouncementsStore.swift
@@ -4,6 +4,7 @@ import WordPressKit
 /// Genric type that renders announcements upon requesting them by calling `getAnnouncements()`
 protocol AnnouncementsStore: Observable {
     var announcements: [WordPressKit.Announcement] { get }
+    var appVersionName: String { get }
     var versionHasAnnouncements: Bool { get }
     func getAnnouncements()
 }
@@ -61,6 +62,15 @@ class CachedAnnouncementsStore: AnnouncementsStore {
             return []
         case .ready(let announcements):
             return announcements
+        }
+    }
+
+    var appVersionName: String {
+        switch state {
+        case .loading, .error:
+            return ""
+        case .ready(let announcements):
+            return announcements.first?.appVersionName ?? ""
         }
     }
 

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -111,8 +111,11 @@ private extension WhatIsNewScenePresenter {
         return FeatureAnnouncementsDataSource(features: features, detailsUrl: detailsUrl, announcementCellType: AnnouncementCell.self)
     }
 
+
+    /// Creates a WhatIsNewView using custom layout for dashboard announcement
+    /// Treats feature titles and subtitles of value "." as empty strings.
     private func makeCustomWhatIsNewView() -> WhatIsNewView {
-        let title = features.first(where: {!$0.title.isEmpty})?.title ?? WhatIsNewStrings.title // Extract title from features
+        let title = features.first(where: {!$0.title.isFeatureStringEmpty()})?.title ?? WhatIsNewStrings.title // Extract title from features
         let viewTitles = WhatIsNewViewTitles(header: title,
                                              version: "",
                                              continueButtonTitle: WhatIsNewStrings.gotItButtonTitle,
@@ -122,7 +125,7 @@ private extension WhatIsNewScenePresenter {
     }
 
     private func makeCustomDataSource() -> AnnouncementsDataSource {
-        let adjustedFeatures = features.filter {$0.title.isEmpty && !$0.subtitle.isEmpty}
+        let adjustedFeatures = features.filter {$0.title.isFeatureStringEmpty() && !$0.subtitle.isFeatureStringEmpty()}
         let detailsUrl = self.store.announcements.first?.detailsUrl ?? ""
         return FeatureAnnouncementsDataSource(features: adjustedFeatures, detailsUrl: detailsUrl, announcementCellType: DashboardCustomAnnouncementCell.self)
     }
@@ -155,5 +158,11 @@ private extension UserDefaults {
         set {
             set(newValue, forKey: UserDefaults.announcementsVersionDisplayedKey)
         }
+    }
+}
+
+fileprivate extension String {
+    func isFeatureStringEmpty() -> Bool {
+        return self.isEmpty || self == "."
     }
 }

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -107,8 +107,7 @@ private extension WhatIsNewScenePresenter {
 
     private func makeStandardDataSource() -> AnnouncementsDataSource {
         let detailsUrl = self.store.announcements.first?.detailsUrl ?? ""
-        let cellTypes = ["announcementCell": AnnouncementCell.self, "findOutMoreCell": FindOutMoreCell.self]
-        return FeatureAnnouncementsDataSource(features: features, detailsUrl: detailsUrl, cellTypes: cellTypes)
+        return FeatureAnnouncementsDataSource(features: features, detailsUrl: detailsUrl, announcementCellType: AnnouncementCell.self)
     }
 
     private func makeCustomWhatIsNewView() -> WhatIsNewView {
@@ -123,8 +122,7 @@ private extension WhatIsNewScenePresenter {
     private func makeCustomDataSource() -> AnnouncementsDataSource {
         let adjustedFeatures = features.filter {$0.title.isEmpty && !$0.subtitle.isEmpty}
         let detailsUrl = self.store.announcements.first?.detailsUrl ?? ""
-        let cellTypes = ["announcementCell": AnnouncementCell.self, "findOutMoreCell": FindOutMoreCell.self]
-        return FeatureAnnouncementsDataSource(features: adjustedFeatures, detailsUrl: detailsUrl, cellTypes: cellTypes)
+        return FeatureAnnouncementsDataSource(features: adjustedFeatures, detailsUrl: detailsUrl, announcementCellType: DashboardCustomAnnouncementCell.self)
     }
 
     private func shouldUseDashboardCustomView() -> Bool {

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -79,7 +79,7 @@ private extension WhatIsNewScenePresenter {
                                              version: WhatIsNewStrings.version,
                                              continueButtonTitle: WhatIsNewStrings.continueButtonTitle)
 
-        return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource())
+        return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource(), appearance: .standard)
     }
 
     func makeDataSource() -> AnnouncementsDataSource {

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -112,17 +112,19 @@ private extension WhatIsNewScenePresenter {
     }
 
     private func makeCustomWhatIsNewView() -> WhatIsNewView {
-        let viewTitles = WhatIsNewViewTitles(header: WhatIsNewStrings.title,
+        let title = features.first(where: {!$0.title.isEmpty})?.title ?? WhatIsNewStrings.title // Extract title from features
+        let viewTitles = WhatIsNewViewTitles(header: title,
                                              version: "",
-                                             continueButtonTitle: WhatIsNewStrings.continueButtonTitle)
+                                             continueButtonTitle: WhatIsNewStrings.gotItButtonTitle)
 
         return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource(), appearance: .dashboardCustom)
     }
 
     private func makeCustomDataSource() -> AnnouncementsDataSource {
+        let adjustedFeatures = features.filter {$0.title.isEmpty && !$0.subtitle.isEmpty}
         let detailsUrl = self.store.announcements.first?.detailsUrl ?? ""
         let cellTypes = ["announcementCell": AnnouncementCell.self, "findOutMoreCell": FindOutMoreCell.self]
-        return FeatureAnnouncementsDataSource(features: features, detailsUrl: detailsUrl, cellTypes: cellTypes)
+        return FeatureAnnouncementsDataSource(features: adjustedFeatures, detailsUrl: detailsUrl, cellTypes: cellTypes)
     }
 
     private func shouldUseDashboardCustomView() -> Bool {
@@ -133,6 +135,7 @@ private extension WhatIsNewScenePresenter {
         static let title = NSLocalizedString("What's New in WordPress", comment: "Title of the What's new page.")
         static let versionPrefix = NSLocalizedString("Version ", comment: "Description for the version label in the What's new page.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title for the continue button in the What's New page.")
+        static let gotItButtonTitle = NSLocalizedString("Got it", comment: "Title for the continue button in the dashboard's custom What's New page.")
         static var version: String {
             Bundle.main.shortVersionString() != nil ? versionPrefix + Bundle.main.shortVersionString() : ""
         }

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -100,7 +100,8 @@ private extension WhatIsNewScenePresenter {
     private func makeStandardWhatIsNewView() -> WhatIsNewView {
         let viewTitles = WhatIsNewViewTitles(header: WhatIsNewStrings.title,
                                              version: WhatIsNewStrings.version,
-                                             continueButtonTitle: WhatIsNewStrings.continueButtonTitle)
+                                             continueButtonTitle: WhatIsNewStrings.continueButtonTitle,
+                                             disclaimerTitle: "")
 
         return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource(), appearance: .standard)
     }
@@ -114,7 +115,8 @@ private extension WhatIsNewScenePresenter {
         let title = features.first(where: {!$0.title.isEmpty})?.title ?? WhatIsNewStrings.title // Extract title from features
         let viewTitles = WhatIsNewViewTitles(header: title,
                                              version: "",
-                                             continueButtonTitle: WhatIsNewStrings.gotItButtonTitle)
+                                             continueButtonTitle: WhatIsNewStrings.gotItButtonTitle,
+                                             disclaimerTitle: WhatIsNewStrings.disclaimerTitle)
 
         return WhatIsNewView(viewTitles: viewTitles, dataSource: makeDataSource(), appearance: .dashboardCustom)
     }
@@ -137,6 +139,7 @@ private extension WhatIsNewScenePresenter {
         static var version: String {
             Bundle.main.shortVersionString() != nil ? versionPrefix + Bundle.main.shortVersionString() : ""
         }
+        static let disclaimerTitle = NSLocalizedString("NEW!", comment: "Title for disclaimer in the dashboard's custom What's New page.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/AnnouncementCell.swift
@@ -1,5 +1,5 @@
 
-class AnnouncementCell: UITableViewCell {
+class AnnouncementCell: AnnouncementTableViewCell {
 
     // MARK: - View elements
     private lazy var headingLabel: UILabel = {

--- a/WordPress/Classes/ViewRelated/What's New/Views/DashboardCustomAnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/DashboardCustomAnnouncementCell.swift
@@ -1,0 +1,98 @@
+import UIKit
+
+class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
+
+    // MARK: - View elements
+    private lazy var headingLabel: UILabel = {
+        return makeLabel(font: Appearance.headingFont, color: .secondaryLabel)
+    }()
+
+    private lazy var imageBackgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .quaternarySystemFill
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.masksToBounds = true
+        view.layer.cornerRadius = 10
+        view.addSubview(announcementImageView)
+        return view
+    }()
+
+    private lazy var announcementImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.contentMode = .scaleAspectFit
+        return imageView
+    }()
+
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [headingLabel, imageBackgroundView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .center
+        stackView.spacing = Appearance.imageTextSpacing
+        return stackView
+    }()
+
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        contentView.addSubview(mainStackView)
+        contentView.pinSubviewToSafeArea(mainStackView, insets: Appearance.mainStackViewInsets)
+
+
+        NSLayoutConstraint.activate([
+            imageBackgroundView.heightAnchor.constraint(equalToConstant: Appearance.announcementImageHeight),
+            imageBackgroundView.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
+            announcementImageView.heightAnchor.constraint(equalTo: imageBackgroundView.heightAnchor),
+            announcementImageView.centerXAnchor.constraint(equalTo: imageBackgroundView.centerXAnchor)
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Configures the labels and image views using the data from a `WordPressKit.Feature` object.
+    /// - Parameter feature: The `feature` containing the information to fill the cell with.
+    func configure(feature: WordPressKit.Feature) {
+
+        if let url = URL(string: feature.iconUrl) {
+            announcementImageView.af_setImage(withURL: url)
+        }
+        headingLabel.text = feature.subtitle
+    }
+}
+
+
+// MARK: Helpers
+private extension DashboardCustomAnnouncementCell {
+
+    func makeLabel(font: UIFont, color: UIColor? = nil) -> UILabel {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.numberOfLines = 0
+        label.font = font
+        label.textAlignment = .center
+        if let color = color {
+            label.textColor = color
+        }
+        return label
+    }
+}
+
+
+// MARK: - Appearance
+private extension DashboardCustomAnnouncementCell {
+    enum Appearance {
+        // heading
+        static let headingFont = UIFont(descriptor: UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body), size: 17)
+
+        // announcement image
+        static let announcementImageHeight: CGFloat = 155
+
+        // main stack view
+        static let imageTextSpacing: CGFloat = 12
+        static let mainStackViewInsets = UIEdgeInsets(top: 0, left: 0, bottom: 32, right: 0)
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/Views/DashboardCustomAnnouncementCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/DashboardCustomAnnouncementCell.swift
@@ -7,6 +7,14 @@ class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
         return makeLabel(font: Appearance.headingFont, color: .secondaryLabel)
     }()
 
+    private lazy var headingLabelView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        view.addSubview(headingLabel)
+        view.pinSubviewToAllEdges(headingLabel, insets: Appearance.headingLabelInsets)
+        return view
+    }()
+
     private lazy var imageBackgroundView: UIView = {
         let view = UIView()
         view.backgroundColor = .quaternarySystemFill
@@ -25,7 +33,7 @@ class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
     }()
 
     private lazy var mainStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [headingLabel, imageBackgroundView])
+        let stackView = UIStackView(arrangedSubviews: [headingLabelView, imageBackgroundView])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
         stackView.alignment = .center
@@ -45,7 +53,8 @@ class DashboardCustomAnnouncementCell: AnnouncementTableViewCell {
             imageBackgroundView.heightAnchor.constraint(equalToConstant: Appearance.announcementImageHeight),
             imageBackgroundView.widthAnchor.constraint(equalTo: mainStackView.widthAnchor),
             announcementImageView.heightAnchor.constraint(equalTo: imageBackgroundView.heightAnchor),
-            announcementImageView.centerXAnchor.constraint(equalTo: imageBackgroundView.centerXAnchor)
+            announcementImageView.centerXAnchor.constraint(equalTo: imageBackgroundView.centerXAnchor),
+            announcementImageView.centerYAnchor.constraint(equalTo: imageBackgroundView.centerYAnchor)
         ])
     }
 
@@ -87,6 +96,7 @@ private extension DashboardCustomAnnouncementCell {
     enum Appearance {
         // heading
         static let headingFont = UIFont(descriptor: UIFontDescriptor.preferredFontDescriptor(withTextStyle: .body), size: 17)
+        static let headingLabelInsets = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
 
         // announcement image
         static let announcementImageHeight: CGFloat = 155

--- a/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/FindOutMoreCell.swift
@@ -1,5 +1,5 @@
 
-class FindOutMoreCell: UITableViewCell {
+class FindOutMoreCell: UITableViewCell, Reusable {
 
     private lazy var findOutMoreButton: UIButton = {
         let button = UIButton()

--- a/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
@@ -52,7 +52,7 @@ class StoriesIntroViewController: WhatIsNewViewController {
         ])
 
         super.init(whatIsNewViewFactory: {
-            return WhatIsNewView(viewTitles: titles, dataSource: dataSource, showsBackButton: true)
+            return WhatIsNewView(viewTitles: titles, dataSource: dataSource, appearance: .standard, showsBackButton: true)
         }, onContinue: {
             StoriesIntroViewController.trackContinue()
             continueTapped()

--- a/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
@@ -24,8 +24,9 @@ class StoriesIntroViewController: WhatIsNewViewController {
 
     init(continueTapped: @escaping () -> Void, openURL: @escaping (URL) -> Void) {
         let titles = WhatIsNewViewTitles(header: Constants.headerTitle,
-                                       version: "",
-                                       continueButtonTitle: Constants.continueButtonTitle)
+                                         version: "",
+                                         continueButtonTitle: Constants.continueButtonTitle,
+                                         disclaimerTitle: "")
 
         let storyQueryItems = [URLQueryItem.WPStory.fullscreen, URLQueryItem.WPStory.playOnLoad]
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -13,7 +13,7 @@ class WhatIsNewView: UIView {
     // MARK: - View elements
     private lazy var titleLabel: UILabel = {
         let label = makeLabel(viewTitles.header)
-        label.font = Appearance.headlineFont
+        label.font = self.appearance.headlineFont
         label.numberOfLines = 0
         return label
     }()
@@ -27,7 +27,7 @@ class WhatIsNewView: UIView {
             return label
         }
 
-        label.font = Appearance.subHeadlineFont
+        label.font = self.appearance.subHeadlineFont
         label.textColor = .textSubtle
         return label
     }()
@@ -35,18 +35,18 @@ class WhatIsNewView: UIView {
     private lazy var backButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentEdgeInsets = UIEdgeInsets(top: Appearance.backButtonInset, left: Appearance.backButtonInset, bottom: 0, right: 0)
+        button.contentEdgeInsets = UIEdgeInsets(top: self.appearance.backButtonInset, left: self.appearance.backButtonInset, bottom: 0, right: 0)
         button.setImage(UIImage.gridicon(.arrowLeft), for: .normal)
         button.addTarget(self, action: #selector(backButtonTapped), for: .touchUpInside)
         button.accessibilityLabel = NSLocalizedString("Back", comment: "Dismiss view")
-        button.tintColor = Appearance.backButtonTintColor
+        button.tintColor = self.appearance.backButtonTintColor
         return button
     }()
 
     private lazy var continueButton: UIButton = {
         let button = FancyButton()
         button.isPrimary = true
-        button.titleFont = Appearance.continueButtonFont
+        button.titleFont = self.appearance.continueButtonFont
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(viewTitles.continueButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(continueButtonTapped), for: .touchUpInside)
@@ -76,10 +76,10 @@ class WhatIsNewView: UIView {
     }()
 
     private lazy var systemMaterialView: UIVisualEffectView = {
-        let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: Appearance.material))
+        let visualEffectView = UIVisualEffectView(effect: UIBlurEffect(style: self.appearance.material))
         visualEffectView.translatesAutoresizingMaskIntoConstraints = false
         visualEffectView.contentView.addSubview(continueButton)
-        visualEffectView.contentView.pinSubviewToSafeArea(continueButton, insets: Appearance.continueButtonInsets)
+        visualEffectView.contentView.pinSubviewToSafeArea(continueButton, insets: self.appearance.continueButtonInsets)
         return visualEffectView
     }()
 
@@ -91,14 +91,14 @@ class WhatIsNewView: UIView {
         tableView.allowsSelection = false
         tableView.rowHeight = UITableView.automaticDimension
         tableView.showsVerticalScrollIndicator = false
-        tableView.contentInset = Appearance.tableViewContentInsets
-        tableView.estimatedRowHeight = Appearance.estimatedRowHeight
+        tableView.contentInset = self.appearance.tableViewContentInsets
+        tableView.estimatedRowHeight = self.appearance.estimatedRowHeight
         return tableView
     }()
 
     private lazy var headerStackView: UIStackView = {
         let stackView = makeVerticalStackView(arrangedSubviews: [titleLabel, versionLabel])
-        stackView.setCustomSpacing(Appearance.titleVersionSpacing, after: titleLabel)
+        stackView.setCustomSpacing(self.appearance.titleVersionSpacing, after: titleLabel)
         return stackView
     }()
 
@@ -106,7 +106,7 @@ class WhatIsNewView: UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(headerStackView)
-        view.pinSubviewToAllEdges(headerStackView, insets: Appearance.headerViewInsets)
+        view.pinSubviewToAllEdges(headerStackView, insets: self.appearance.headerViewInsets)
         return view
     }()
 
@@ -114,20 +114,22 @@ class WhatIsNewView: UIView {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(announcementsTableView)
-        view.pinSubviewToSafeArea(announcementsTableView, insets: Appearance.mainContentInsets)
+        view.pinSubviewToSafeArea(announcementsTableView, insets: self.appearance.mainContentInsets)
         return view
     }()
 
     // MARK: - Properties
     private let viewTitles: WhatIsNewViewTitles
     private let dataSource: AnnouncementsDataSource
+    private let appearance: WhatIsNewViewAppearance
 
     var continueAction: (() -> Void)?
     var dismissAction: (() -> Void)?
 
-    init(viewTitles: WhatIsNewViewTitles, dataSource: AnnouncementsDataSource, showsBackButton: Bool = false) {
+    init(viewTitles: WhatIsNewViewTitles, dataSource: AnnouncementsDataSource, appearance: WhatIsNewViewAppearance, showsBackButton: Bool = false) {
         self.viewTitles = viewTitles
         self.dataSource = dataSource
+        self.appearance = appearance
 
         super.init(frame: .zero)
 
@@ -138,7 +140,7 @@ class WhatIsNewView: UIView {
         announcementsTableView.tableHeaderView = headerView
 
         NSLayoutConstraint.activate([
-            continueButton.heightAnchor.constraint(equalToConstant: Appearance.continueButtonHeight),
+            continueButton.heightAnchor.constraint(equalToConstant: self.appearance.continueButtonHeight),
             divider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             continueButtonStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             continueButtonStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
@@ -222,52 +224,6 @@ extension WhatIsNewView {
         }
     }
 }
-
-
-// MARK: - Appearance
-private extension WhatIsNewView {
-
-    enum Appearance {
-        // main view
-        static let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
-
-        // title
-        static var headlineFont: UIFont {
-            if let serifHeadlineDescriptor = UIFontDescriptor
-                    .preferredFontDescriptor(withTextStyle: .headline)
-                    .withDesign(.serif) {
-
-                return UIFont(descriptor: serifHeadlineDescriptor, size: 34)
-            }
-            return UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .headline), size: 34)
-        }
-        static let titleVersionSpacing: CGFloat = 16
-
-        // version label
-        static let subHeadlineFont = UIFont(descriptor: UIFontDescriptor
-                .preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
-        static let versionTableviewSpacing: CGFloat = 32
-
-        // table view
-        static let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
-        static let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
-        // bottom spacing is button height (48) + vertical button insets ( 2 * 16) + vertical spacing before "Find out more" (32)
-        static let tableViewContentInsets = UIEdgeInsets(top: 0, left: 0, bottom: 112, right: 0)
-
-        // continue button
-        static let continueButtonHeight: CGFloat = 48
-        static let continueButtonFont = UIFont.systemFont(ofSize: 22, weight: .medium)
-        static let continueButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        static var material: UIBlurEffect.Style {
-            return .systemChromeMaterial
-        }
-
-        // back button
-        static let backButtonTintColor = UIColor.darkGray
-        static let backButtonInset: CGFloat = 16
-    }
-}
-
 
 // MARK: - Accessibility
 private extension WhatIsNewView {

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -15,6 +15,7 @@ class WhatIsNewView: UIView {
         let label = makeLabel(viewTitles.header)
         label.font = self.appearance.headlineFont
         label.numberOfLines = 0
+        label.textAlignment = self.appearance.headlineAlignment
         return label
     }()
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewView.swift
@@ -4,6 +4,7 @@ struct WhatIsNewViewTitles {
     let header: String
     let version: String
     let continueButtonTitle: String
+    let disclaimerTitle: String
 }
 
 
@@ -31,6 +32,30 @@ class WhatIsNewView: UIView {
         label.font = self.appearance.subHeadlineFont
         label.textColor = .textSubtle
         return label
+    }()
+
+    private lazy var disclaimerLabel: UILabel = {
+        let label = makeLabel(viewTitles.disclaimerTitle)
+        label.font = self.appearance.disclaimerFont
+        label.textColor = .white
+        return label
+    }()
+
+    private lazy var disclaimerLabelView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        // if there's no disclaimer, just hide the label
+        guard !viewTitles.disclaimerTitle.isEmpty else {
+            view.isHidden = true
+            return view
+        }
+        view.backgroundColor = self.appearance.disclaimerBackgroundColor
+        view.layer.cornerRadius = self.appearance.disclaimerViewCornerRadius
+        view.layer.masksToBounds = true
+        view.addSubview(disclaimerLabel)
+        view.pinSubviewToAllEdges(disclaimerLabel, insets: self.appearance.disclaimerLabelInsets)
+        return view
     }()
 
     private lazy var backButton: UIButton = {
@@ -106,8 +131,10 @@ class WhatIsNewView: UIView {
     private lazy var headerView: UIView = {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(headerStackView)
+        view.addSubviews([headerStackView, disclaimerLabelView])
         view.pinSubviewToAllEdges(headerStackView, insets: self.appearance.headerViewInsets)
+        headerStackView.topAnchor.constraint(equalTo: disclaimerLabelView.bottomAnchor, constant: self.appearance.disclaimerTitleSpacing).isActive = true
+        disclaimerLabelView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         return view
     }()
 
@@ -146,7 +173,8 @@ class WhatIsNewView: UIView {
             continueButtonStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
             continueButtonStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             continueButtonStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            headerView.widthAnchor.constraint(equalTo: announcementsTableView.widthAnchor)
+            headerView.widthAnchor.constraint(equalTo: announcementsTableView.widthAnchor),
+            disclaimerLabelView.heightAnchor.constraint(equalToConstant: self.appearance.disclaimerViewHeight)
         ])
 
         if showsBackButton {

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -27,6 +27,14 @@ struct WhatIsNewViewAppearance {
     let backButtonTintColor: UIColor
     let backButtonInset: CGFloat
 
+    // disclaimer label
+    let disclaimerBackgroundColor: UIColor
+    let disclaimerLabelInsets: UIEdgeInsets
+    let disclaimerFont: UIFont
+    let disclaimerViewHeight: CGFloat
+    let disclaimerViewCornerRadius: CGFloat
+    let disclaimerTitleSpacing: CGFloat
+
     static var standard: WhatIsNewViewAppearance {
         // main view
         let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
@@ -63,6 +71,14 @@ struct WhatIsNewViewAppearance {
         // back button
         let backButtonTintColor = UIColor.darkGray
         let backButtonInset: CGFloat = 16
+        // disclaimer label
+        let disclaimerBackgroundColor = UIColor(light: .muriel(name: .pink, .shade40),
+                                                dark: .muriel(name: .pink, .shade50))
+        let disclaimerLabelInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        let disclaimerFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
+        let disclaimerViewHeight: CGFloat = 24
+        let disclaimerViewCornerRadius: CGFloat = 4
+        let disclaimerTitleSpacing: CGFloat = 16
         return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
                                        headlineFont: headlineFont,
                                        headlineAlignment: headlineAlignment,
@@ -76,7 +92,13 @@ struct WhatIsNewViewAppearance {
                                        continueButtonInsets: continueButtonInsets,
                                        material: material,
                                        backButtonTintColor: backButtonTintColor,
-                                       backButtonInset: backButtonInset)
+                                       backButtonInset: backButtonInset,
+                                       disclaimerBackgroundColor: disclaimerBackgroundColor,
+                                       disclaimerLabelInsets: disclaimerLabelInsets,
+                                       disclaimerFont: disclaimerFont,
+                                       disclaimerViewHeight: disclaimerViewHeight,
+                                       disclaimerViewCornerRadius: disclaimerViewCornerRadius,
+                                       disclaimerTitleSpacing: disclaimerTitleSpacing)
     }
 
     static var dashboardCustom: Self {
@@ -107,6 +129,15 @@ struct WhatIsNewViewAppearance {
         // back button
         let backButtonTintColor = UIColor.darkGray
         let backButtonInset: CGFloat = 16
+
+        // disclaimer label
+        let disclaimerBackgroundColor = UIColor(light: .muriel(name: .pink, .shade40),
+                                                dark: .muriel(name: .pink, .shade50))
+        let disclaimerLabelInsets = UIEdgeInsets(top: 0, left: 12, bottom: 0, right: 12)
+        let disclaimerFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
+        let disclaimerViewHeight: CGFloat = 24
+        let disclaimerViewCornerRadius: CGFloat = 4
+        let disclaimerTitleSpacing: CGFloat = 16
         return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
                                        headlineFont: headlineFont,
                                        headlineAlignment: headlineAlignment,
@@ -120,6 +151,12 @@ struct WhatIsNewViewAppearance {
                                        continueButtonInsets: continueButtonInsets,
                                        material: material,
                                        backButtonTintColor: backButtonTintColor,
-                                       backButtonInset: backButtonInset)
+                                       backButtonInset: backButtonInset,
+                                       disclaimerBackgroundColor: disclaimerBackgroundColor,
+                                       disclaimerLabelInsets: disclaimerLabelInsets,
+                                       disclaimerFont: disclaimerFont,
+                                       disclaimerViewHeight: disclaimerViewHeight,
+                                       disclaimerViewCornerRadius: disclaimerViewCornerRadius,
+                                       disclaimerTitleSpacing: disclaimerTitleSpacing)
     }
 }

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -77,4 +77,56 @@ struct WhatIsNewViewAppearance {
                                        backButtonTintColor: backButtonTintColor,
                                        backButtonInset: backButtonInset)
     }
+
+    static var dashboardCustom: Self {
+        // main view
+        let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
+
+        // title
+        var headlineFont: UIFont
+        if let serifHeadlineDescriptor = UIFontDescriptor
+                .preferredFontDescriptor(withTextStyle: .headline)
+                .withDesign(.serif) {
+
+            headlineFont = UIFont(descriptor: serifHeadlineDescriptor, size: 34)
+        }
+        headlineFont = UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .headline), size: 34)
+
+        let titleVersionSpacing: CGFloat = 16
+
+        // version label
+        let subHeadlineFont = UIFont(descriptor: UIFontDescriptor
+                .preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
+        let versionTableviewSpacing: CGFloat = 32
+
+        // table view
+        let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
+        let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
+        // bottom spacing is button height (48) + vertical button insets ( 2 * 16) + vertical spacing before "Find out more" (32)
+        let tableViewContentInsets = UIEdgeInsets(top: 0, left: 0, bottom: 112, right: 0)
+
+        // continue button
+        let continueButtonHeight: CGFloat = 48
+        let continueButtonFont = UIFont.systemFont(ofSize: 22, weight: .medium)
+        let continueButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        let material: UIBlurEffect.Style = .systemChromeMaterial
+
+        // back button
+        let backButtonTintColor = UIColor.darkGray
+        let backButtonInset: CGFloat = 16
+        return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
+                                       headlineFont: headlineFont,
+                                       titleVersionSpacing: titleVersionSpacing,
+                                       subHeadlineFont: subHeadlineFont,
+                                       versionTableviewSpacing: versionTableviewSpacing,
+                                       headerViewInsets: headerViewInsets,
+                                       estimatedRowHeight: estimatedRowHeight,
+                                       tableViewContentInsets: tableViewContentInsets,
+                                       continueButtonHeight: continueButtonHeight,
+                                       continueButtonFont: continueButtonFont,
+                                       continueButtonInsets: continueButtonInsets,
+                                       material: material,
+                                       backButtonTintColor: backButtonTintColor,
+                                       backButtonInset: backButtonInset)
+    }
 }

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -1,3 +1,4 @@
+import UIKit
 
 struct WhatIsNewViewAppearance {
     // main view
@@ -5,11 +6,11 @@ struct WhatIsNewViewAppearance {
 
     // title
     let headlineFont: UIFont
+    let headlineAlignment: NSTextAlignment
     let titleVersionSpacing: CGFloat
 
     // version label
     let subHeadlineFont: UIFont
-    let versionTableviewSpacing: CGFloat
 
     // table view
     let headerViewInsets: UIEdgeInsets
@@ -40,12 +41,12 @@ struct WhatIsNewViewAppearance {
         }
         headlineFont = UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .headline), size: 34)
 
+        let headlineAlignment = NSTextAlignment.left
         let titleVersionSpacing: CGFloat = 16
 
         // version label
         let subHeadlineFont = UIFont(descriptor: UIFontDescriptor
                 .preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
-        let versionTableviewSpacing: CGFloat = 32
 
         // table view
         let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
@@ -64,9 +65,9 @@ struct WhatIsNewViewAppearance {
         let backButtonInset: CGFloat = 16
         return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
                                        headlineFont: headlineFont,
+                                       headlineAlignment: headlineAlignment,
                                        titleVersionSpacing: titleVersionSpacing,
                                        subHeadlineFont: subHeadlineFont,
-                                       versionTableviewSpacing: versionTableviewSpacing,
                                        headerViewInsets: headerViewInsets,
                                        estimatedRowHeight: estimatedRowHeight,
                                        tableViewContentInsets: tableViewContentInsets,
@@ -83,24 +84,16 @@ struct WhatIsNewViewAppearance {
         let mainContentInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
 
         // title
-        var headlineFont: UIFont
-        if let serifHeadlineDescriptor = UIFontDescriptor
-                .preferredFontDescriptor(withTextStyle: .headline)
-                .withDesign(.serif) {
-
-            headlineFont = UIFont(descriptor: serifHeadlineDescriptor, size: 34)
-        }
-        headlineFont = UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .headline), size: 34)
-
+        let headlineFont = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .bold)
+        let headlineAlignment = NSTextAlignment.center
         let titleVersionSpacing: CGFloat = 16
 
         // version label
         let subHeadlineFont = UIFont(descriptor: UIFontDescriptor
                 .preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
-        let versionTableviewSpacing: CGFloat = 32
 
         // table view
-        let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
+        let headerViewInsets = UIEdgeInsets(top: 88, left: 0, bottom: 24, right: 0)
         let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
         // bottom spacing is button height (48) + vertical button insets ( 2 * 16) + vertical spacing before "Find out more" (32)
         let tableViewContentInsets = UIEdgeInsets(top: 0, left: 0, bottom: 112, right: 0)
@@ -109,16 +102,16 @@ struct WhatIsNewViewAppearance {
         let continueButtonHeight: CGFloat = 48
         let continueButtonFont = UIFont.systemFont(ofSize: 22, weight: .medium)
         let continueButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        let material: UIBlurEffect.Style = .systemChromeMaterial
+        let material: UIBlurEffect.Style = .regular
 
         // back button
         let backButtonTintColor = UIColor.darkGray
         let backButtonInset: CGFloat = 16
         return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
                                        headlineFont: headlineFont,
+                                       headlineAlignment: headlineAlignment,
                                        titleVersionSpacing: titleVersionSpacing,
                                        subHeadlineFont: subHeadlineFont,
-                                       versionTableviewSpacing: versionTableviewSpacing,
                                        headerViewInsets: headerViewInsets,
                                        estimatedRowHeight: estimatedRowHeight,
                                        tableViewContentInsets: tableViewContentInsets,

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -80,7 +80,7 @@ struct WhatIsNewViewAppearance {
 
     static var dashboardCustom: Self {
         // main view
-        let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
+        let mainContentInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
 
         // title
         var headlineFont: UIFont

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -116,7 +116,7 @@ struct WhatIsNewViewAppearance {
 
         // table view
         let headerViewInsets = UIEdgeInsets(top: 88, left: 0, bottom: 24, right: 0)
-        let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
+        let estimatedRowHeight: CGFloat = 195 // image height + vertical spacing + bottom inset
         // bottom spacing is button height (48) + vertical button insets ( 2 * 16) + vertical spacing before "Find out more" (32)
         let tableViewContentInsets = UIEdgeInsets(top: 0, left: 0, bottom: 112, right: 0)
 

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewAppearance.swift
@@ -1,0 +1,80 @@
+
+struct WhatIsNewViewAppearance {
+    // main view
+    let mainContentInsets: UIEdgeInsets
+
+    // title
+    let headlineFont: UIFont
+    let titleVersionSpacing: CGFloat
+
+    // version label
+    let subHeadlineFont: UIFont
+    let versionTableviewSpacing: CGFloat
+
+    // table view
+    let headerViewInsets: UIEdgeInsets
+    let estimatedRowHeight: CGFloat
+    let tableViewContentInsets: UIEdgeInsets
+
+    // continue button
+    let continueButtonHeight: CGFloat
+    let continueButtonFont: UIFont
+    let continueButtonInsets: UIEdgeInsets
+    let material: UIBlurEffect.Style
+
+    // back button
+    let backButtonTintColor: UIColor
+    let backButtonInset: CGFloat
+
+    static var standard: WhatIsNewViewAppearance {
+        // main view
+        let mainContentInsets = UIEdgeInsets(top: 0, left: 48, bottom: 0, right: 48)
+
+        // title
+        var headlineFont: UIFont
+        if let serifHeadlineDescriptor = UIFontDescriptor
+                .preferredFontDescriptor(withTextStyle: .headline)
+                .withDesign(.serif) {
+
+            headlineFont = UIFont(descriptor: serifHeadlineDescriptor, size: 34)
+        }
+        headlineFont = UIFont(descriptor: .preferredFontDescriptor(withTextStyle: .headline), size: 34)
+
+        let titleVersionSpacing: CGFloat = 16
+
+        // version label
+        let subHeadlineFont = UIFont(descriptor: UIFontDescriptor
+                .preferredFontDescriptor(withTextStyle: .subheadline), size: 15)
+        let versionTableviewSpacing: CGFloat = 32
+
+        // table view
+        let headerViewInsets = UIEdgeInsets(top: 80, left: 0, bottom: 32, right: 0)
+        let estimatedRowHeight: CGFloat = 72 // image height + vertical spacing
+        // bottom spacing is button height (48) + vertical button insets ( 2 * 16) + vertical spacing before "Find out more" (32)
+        let tableViewContentInsets = UIEdgeInsets(top: 0, left: 0, bottom: 112, right: 0)
+
+        // continue button
+        let continueButtonHeight: CGFloat = 48
+        let continueButtonFont = UIFont.systemFont(ofSize: 22, weight: .medium)
+        let continueButtonInsets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        let material: UIBlurEffect.Style = .systemChromeMaterial
+
+        // back button
+        let backButtonTintColor = UIColor.darkGray
+        let backButtonInset: CGFloat = 16
+        return WhatIsNewViewAppearance(mainContentInsets: mainContentInsets,
+                                       headlineFont: headlineFont,
+                                       titleVersionSpacing: titleVersionSpacing,
+                                       subHeadlineFont: subHeadlineFont,
+                                       versionTableviewSpacing: versionTableviewSpacing,
+                                       headerViewInsets: headerViewInsets,
+                                       estimatedRowHeight: estimatedRowHeight,
+                                       tableViewContentInsets: tableViewContentInsets,
+                                       continueButtonHeight: continueButtonHeight,
+                                       continueButtonFont: continueButtonFont,
+                                       continueButtonInsets: continueButtonInsets,
+                                       material: material,
+                                       backButtonTintColor: backButtonTintColor,
+                                       backButtonInset: backButtonInset)
+    }
+}

--- a/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/WhatIsNewViewController.swift
@@ -27,6 +27,7 @@ class WhatIsNewViewController: UIViewController {
         self.onContinue = onContinue
         self.onDismiss = onDismiss
         super.init(nibName: nil, bundle: nil)
+        self.modalPresentationStyle = .formSheet
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1340,6 +1340,8 @@
 		8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
+		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
+		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -6035,6 +6037,7 @@
 		806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModelTests.swift; sourceTree = "<group>"; };
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
 		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
+		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -9292,6 +9295,7 @@
 				3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */,
 				F5B390E92537E30B0097049E /* GridCell.swift */,
 				F5E1BA9A253A0A5E0091E9A6 /* StoriesIntroViewController.swift */,
+				80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -17425,6 +17429,7 @@
 				433432521E9ED18900915988 /* LoginEpilogueViewController.swift in Sources */,
 				4395A1592106389800844E8E /* QuickStartTours.swift in Sources */,
 				9A2B28EE2191B50500458F2A /* RevisionsTableViewFooter.swift in Sources */,
+				80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */,
 				F5A34BCB25DF244F00C9654B /* KanvasCameraAnalyticsHandler.swift in Sources */,
 				8BD36E022395CAEA00EFFF1C /* MediaEditorOperation+Description.swift in Sources */,
 				839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */,
@@ -19683,6 +19688,7 @@
 				FABB21112602FC2C00C8785C /* BaseRestoreOptionsViewController.swift in Sources */,
 				8B4DDF25278F44CC0022494D /* BlogDashboardViewController.swift in Sources */,
 				FABB21122602FC2C00C8785C /* AddSiteAlertFactory.swift in Sources */,
+				80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */,
 				FABB21132602FC2C00C8785C /* AuthenticationService.swift in Sources */,
 				FABB21142602FC2C00C8785C /* JetpackSiteRef.swift in Sources */,
 				FABB21152602FC2C00C8785C /* WPStyleGuide+Reply.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1342,6 +1342,8 @@
 		808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
+		80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
+		80EF672327F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -6038,6 +6040,7 @@
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
 		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
+		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -9290,6 +9293,7 @@
 			isa = PBXGroup;
 			children = (
 				3F3087C324EDB7040087B548 /* AnnouncementCell.swift */,
+				80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */,
 				3F8CBE0C24EED2CB00F71234 /* FindOutMoreCell.swift */,
 				3F73BE5E24EB3B4400BE99FF /* WhatIsNewView.swift */,
 				3F662C4924DC9FAC00CAEA95 /* WhatIsNewViewController.swift */,
@@ -18624,6 +18628,7 @@
 				17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */,
 				98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				F5E1577F25DE04E200EEEDFB /* GutenbergMediaFilesUploadProcessor.swift in Sources */,
+				80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
 				5DF7F7741B22337C003A05C8 /* WordPress-30-31.xcmappingmodel in Sources */,
 				436D562C2117312700CEAA33 /* RegisterDomainDetailsFooterView.swift in Sources */,
 				73F76E1E222851E300FDDAD2 /* Charts+AxisFormatters.swift in Sources */,
@@ -20198,6 +20203,7 @@
 				FABB22C62602FC2C00C8785C /* NSAttributedString+WPRichText.swift in Sources */,
 				FABB22C72602FC2C00C8785C /* StatsTotalRow.swift in Sources */,
 				C79C308226EA99D500E88514 /* ReferrerDetailsSpamActionCell.swift in Sources */,
+				80EF672327F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
 				FABB22C82602FC2C00C8785C /* SiteCreationAnalyticsHelper.swift in Sources */,
 				FABB22C92602FC2C00C8785C /* NSAttributedString+Helpers.swift in Sources */,
 				FABB22CA2602FC2C00C8785C /* TenorService.swift in Sources */,


### PR DESCRIPTION
Closes #18209

## Description
- Refactored `WhatIsNewView` to depend on an appearance object that gets injected when creating the view.
- Created a new announcement cell to match the new design
- Used `appVersionName` to determine if the announcement is for the dashboard
- Extracted the view's title from the returned features. 
- Injected custom appearance and new custom cell when showing announcement for dashboard  

/ | Light | Dark
-- | -- | --
Dashboard | <img src="https://user-images.githubusercontent.com/25306722/160506159-924b1970-052b-4eed-806f-e41c7158d926.png"> | <img src="https://user-images.githubusercontent.com/25306722/160506175-e651abcd-e88e-41e2-8b64-85c3ad0dd567.png">
Default | <img src="https://user-images.githubusercontent.com/25306722/160507808-a950b9ee-6d26-41c5-beb2-b0d39b40d38c.png"> | <img src="https://user-images.githubusercontent.com/25306722/160507787-5e3e5900-69e4-4d1c-84e3-0df534578168.png">

## Testing Instructions
First you need to modify the response of the feature announcement API to return custom response for testing. This can be achieved in multiple ways. Here are two options:

<details>
  <summary><strong>Hardcoding response in code (Easier)</strong></summary>
  <br>

  - Replace `AnnouncementServiceRemote.swift` in WordPressKit with this [version](https://drive.google.com/file/d/1HUtBzTB7vdDjNhwXaAMPZERBD9JX0rZ9/view?usp=sharing) (This file is in an external pod. Make sure to revert the changes after you're done by removing the pod from Pods folder and running `bundle exec pod install`)
  - Replace `AnnouncementsStore.swift` by this [version](https://drive.google.com/file/d/1RZ4xae57r3XFnHo-kd5ciaX9PO_l1ehj/view?usp=sharing)
  ---
</details>
<details>
  <summary><strong>Using Proxy Apps</strong></summary>
  <br>

  - Install [ProxyMan](https://proxyman.io)
  - Configure ProxyMan to [capture simulator traffic](https://docs.proxyman.io/debug-devices/ios-simulator)   
  - Make sure the app's network traffic shows up in ProxyMan
  - Add a local map for the targetted API
      - Go to Tools -> Map Local...
      - Add new mapping
      - Set URL to `https://public-api.wordpress.com/wpcom/v2/mobile/feature-announcements`
      - Make sure to check "Include all subpaths of this URL"
      - Under "Map to" choose Local Directory and use this [file](https://drive.google.com/file/d/1McI4p5Gl-Ew59Ql7mngpwSPoLVp9PRyh/view?usp=sharing)
  ---
</details>

_PS: Once I have access to the Mobile Announce mc tool, I will create an announcement targeting this PR, which should remove the need for the above requirement._

1. Make sure to follow one of the above options
2. To ease the testing modify `WhatIsNewScenePresenter.shouldPresentWhatIsNew` to always return true
3. Run the app
4. The announcement should be displayed and should match the design
5. Change the `appVersionName` in the response to anything that's not "19.6"
6. Rerun the app
7. The announcement should be displayed and should match the original design
8. Go to My Site
9. Tap the FAB then tap Story Post
10. Make sure Stories intro is displayed correctly
11. Please test light and dark mode

## Regression Notes
1. Potential unintended areas of impact
Normal feature announcement view and stories intro

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually the showing of normal announcements

12. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
