### PR TITLE
Enable My Site Dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] Enhances the exit animation of notices. [#18182]
 * [*] Media Permissions: display error message when using camera to capture photos and media permission not given [https://github.com/wordpress-mobile/WordPress-iOS/pull/18139]
-* [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual information in the form of cards. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [#18240]
+* [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [#18240]
 
 19.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Enhances the exit animation of notices. [#18182]
 * [*] Media Permissions: display error message when using camera to capture photos and media permission not given [https://github.com/wordpress-mobile/WordPress-iOS/pull/18139]
+* [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual information in the form of cards. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [#18240]
 
 19.5
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -66,7 +66,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .aboutScreen:
             return true
         case .mySiteDashboard:
-            return false
+            return true
         case .mediaPickerPermissionsNotice:
             return true
         case .notificationCommentDetails:


### PR DESCRIPTION
Enables My Site Dashboard **for WordPress and Jetpack**.

1. All users will see two tabs under My Site: "Site Menu" and "Home"
2. New logins will be assigned to Site Menu **or** Home as default, for AB testing.

[All these PRs](https://github.com/wordpress-mobile/WordPress-iOS/pulls?q=is%3Apr+label%3A%22My+Site+Dashboard%22+is%3Aclosed+milestone%3A19.6) are enabled with this flag. Given they are a lot, I recommend reading p5T066-35l-p2 for more information.

These are what I consider big changes:

1. Tabs on My Site — allowing the user to switch between Site Menu and Home (the dashboard)
2. Quick Start will start based on the screen that is the default for this user
3. The Dashboard has 4 cards: Quick Actions, Quick Start, Stats, and Posts
4. Posts is by far the most complex and the one that deserves more attention. It has 4 variations: draft posts, scheduled posts, write your first post and write the next post. Offline support is implemented. §

§ Posts have an infinite number of different combinations, so we'll have to prioritize the issues. Even the current posts list have a few edge cases that aren't supported.

### To test

For this specific PR:

1. Remove the app from your device
2. Install it again
3. Login
4. Make sure tabs are appearing

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
