### PR TITLE
My Site Dashboard: fix experiment assignment and tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -315,6 +315,7 @@ import Foundation
     case mySiteTabTapped
     case mySiteSiteMenuShown
     case mySiteDashboardShown
+    case mySiteDefaultTabExperimentVariantAssigned
 
     // Site Intent Question
     case enhancedSiteCreationIntentQuestionCanceled
@@ -857,6 +858,8 @@ import Foundation
             return "my_site_site_menu_shown"
         case .mySiteDashboardShown:
             return "my_site_dashboard_shown"
+        case .mySiteDefaultTabExperimentVariantAssigned:
+            return "my_site_default_tab_experiment_variant_assigned"
 
         // Quick Start
         case .quickStartStarted:

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// A helper class for My Site that manages the default section to display
 ///
@@ -27,6 +28,7 @@ import Foundation
 
     func setDefaultSection(_ tab: MySiteViewController.Section) {
         userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)
+        WPAnalytics.track(.mySiteDefaultTabExperimentVariantAssigned, properties: ["default_tab_experiment": experimentAssignment])
     }
 
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -4,7 +4,9 @@ import Foundation
 ///
 @objc final class MySiteSettings: NSObject {
 
-    private let userDefaults: UserDefaults
+    private var userDefaults: UserDefaults {
+        UserDefaults.standard
+    }
 
     var defaultSection: MySiteViewController.Section {
         let defaultSection: MySiteViewController.Section = .siteMenu
@@ -13,16 +15,15 @@ import Foundation
     }
 
     @objc var experimentAssignment: String {
-        let defaultSection: MySiteViewController.Section = .siteMenu
-        let rawValue = userDefaults.object(forKey: Constants.defaultSectionKey) as? Int ?? defaultSection.rawValue
-        return MySiteViewController.Section(rawValue: rawValue)?.analyticsDescription ?? "nonexistent"
+        if let rawValue = userDefaults.object(forKey: Constants.defaultSectionKey) as? Int,
+            let defaultSection = MySiteViewController.Section(rawValue: rawValue)?.analyticsDescription {
+            return defaultSection
+        }
+
+        return "nonexistent"
     }
 
     // MARK: - Init
-
-    init(userDefaults: UserDefaults = .standard) {
-        self.userDefaults = userDefaults
-    }
 
     func setDefaultSection(_ tab: MySiteViewController.Section) {
         userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -24,8 +24,6 @@ import WordPressShared
         return "nonexistent"
     }
 
-    // MARK: - Init
-
     func setDefaultSection(_ tab: MySiteViewController.Section) {
         userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)
         WPAnalytics.track(.mySiteDefaultTabExperimentVariantAssigned, properties: ["default_tab_experiment": experimentAssignment])


### PR DESCRIPTION
While reviewing our events I noticed that:

1. With a clean install, MySiteSettings was always returning `siteMenu` as the default
2. The assigned tab was not being persisted

This PR fixes these two issues. Also, in order to [keep consistency](https://github.com/wordpress-mobile/WordPress-Android/pull/16187#event-6326341843) with Android I implemented the `my_site_default_tab_experiment_variant_assigned` event.

### To test

I recommend [applying this diff](https://gist.github.com/leandroalonso/5dbcbd0fc3dd407e4ee7b78ac746cb76).

1. Remove the app from your device
2. Run it again
3. ✅ On the log you should see `$$ default_tab_experiment: nonexistent`
4. Login to an account
4. ✅ You should see `$$ assigning: X` where X is `dashboard` OR `siteMenu`
5. ✅ Then you should see `$$ default_tab_experiment: X` where X is `dashboard` or `site_menu`
6. Stop the app
7. Run it again
8. ✅ Then you should see `$$ default_tab_experiment: X` where X is `dashboard` or `site_menu`

#### Event

1. Remove the app from your device
2. Run it again
3. Login to your account
4. ✅ Make sure `🔵 Tracked: my_site_default_tab_experiment_variant_assigned <default_tab_experiment: X>` is fired, where X can be `site_menu` or `dashboard`

**Important:**: this is a temporary event. No need to validate it.

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
