### PR TITLE
Quick Start: Fix issue of displaying wrong data in quick start steps when the user creates a new site

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 * [*] Block Editor: Add GIF badge for animated GIFs uploaded to Image blocks [https://github.com/WordPress/gutenberg/pull/38996]
 * [*] Block Editor: Small refinement to media upload errors, including centering and tweaking copy. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4597]
 * [*] Block Editor: Fix issue with list's starting index and the order [https://github.com/WordPress/gutenberg/pull/39354]
+* [*] Quick Start: Fixed a bug where a user creating a new site is displayed a quick start tour containing data from their presviously active site.
 
 19.4
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -38,7 +38,7 @@ final class QuickStartTourStateView: UIView {
     func configure(blog: Blog, sourceController: UIViewController, checklistTappedTracker: QuickStartChecklistTappedTracker? = nil) {
 
         customizeChecklistView.configure(
-            tours: QuickStartTourGuide.createCustomizeListTours(),
+            tours: QuickStartTourGuide.shared.customizeListTours,
             blog: blog,
             title: Strings.customizeTitle,
             hint: Strings.customizeHint
@@ -49,7 +49,7 @@ final class QuickStartTourStateView: UIView {
         }
 
         growChecklistView.configure(
-            tours: QuickStartTourGuide.createGrowListTours(),
+            tours: QuickStartTourGuide.shared.createGrowListTours,
             blog: blog,
             title: Strings.growTitle,
             hint: Strings.growHint

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -49,7 +49,7 @@ final class QuickStartTourStateView: UIView {
         }
 
         growChecklistView.configure(
-            tours: QuickStartTourGuide.shared.createGrowListTours,
+            tours: QuickStartTourGuide.shared.growListTours,
             blog: blog,
             title: Strings.growTitle,
             hint: Strings.growHint

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -38,7 +38,7 @@ final class QuickStartTourStateView: UIView {
     func configure(blog: Blog, sourceController: UIViewController, checklistTappedTracker: QuickStartChecklistTappedTracker? = nil) {
 
         customizeChecklistView.configure(
-            tours: QuickStartTourGuide.customizeListTours,
+            tours: QuickStartTourGuide.createCustomizeListTours(),
             blog: blog,
             title: Strings.customizeTitle,
             hint: Strings.customizeHint
@@ -49,7 +49,7 @@ final class QuickStartTourStateView: UIView {
         }
 
         growChecklistView.configure(
-            tours: QuickStartTourGuide.growListTours,
+            tours: QuickStartTourGuide.createGrowListTours(),
             blog: blog,
             title: Strings.growTitle,
             hint: Strings.growHint

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -42,10 +42,10 @@ class QuickStartChecklistViewController: UITableViewController {
         switch type {
         case .customize:
             return QuickStartChecklistConfiguration(title: Constants.customizeYourSite,
-                                                    tours: QuickStartTourGuide.createCustomizeListTours())
+                                                    tours: QuickStartTourGuide.shared.customizeListTours)
         case .grow:
             return QuickStartChecklistConfiguration(title: Constants.growYourAudience,
-                                                    tours: QuickStartTourGuide.createGrowListTours())
+                                                    tours: QuickStartTourGuide.shared.createGrowListTours)
         }
     }()
     private lazy var successScreen: NoResultsViewController = {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -42,10 +42,10 @@ class QuickStartChecklistViewController: UITableViewController {
         switch type {
         case .customize:
             return QuickStartChecklistConfiguration(title: Constants.customizeYourSite,
-                                                    tours: QuickStartTourGuide.customizeListTours)
+                                                    tours: QuickStartTourGuide.createCustomizeListTours())
         case .grow:
             return QuickStartChecklistConfiguration(title: Constants.growYourAudience,
-                                                    tours: QuickStartTourGuide.growListTours)
+                                                    tours: QuickStartTourGuide.createGrowListTours())
         }
     }()
     private lazy var successScreen: NoResultsViewController = {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -45,7 +45,7 @@ class QuickStartChecklistViewController: UITableViewController {
                                                     tours: QuickStartTourGuide.shared.customizeListTours)
         case .grow:
             return QuickStartChecklistConfiguration(title: Constants.growYourAudience,
-                                                    tours: QuickStartTourGuide.shared.createGrowListTours)
+                                                    tours: QuickStartTourGuide.shared.growListTours)
         }
     }()
     private lazy var successScreen: NoResultsViewController = {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -56,7 +56,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
+        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.growListTours
         let checklistCompletedCount = countChecklistCompleted(in: list, for: blog)
         return checklistCompletedCount > 0
     }
@@ -69,7 +69,7 @@ open class QuickStartTourGuide: NSObject {
         let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
         let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
         let unavailableTours = Array(Set(completedTours + skippedTours))
-        let allTours = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
+        let allTours = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.growListTours
 
         guard isQuickStartEnabled(for: blog),
             recentlyTouredBlog == blog else {
@@ -332,7 +332,7 @@ open class QuickStartTourGuide: NSObject {
         ]
     }
 
-    var createGrowListTours: [QuickStartTour] {
+    var growListTours: [QuickStartTour] {
         return [
             QuickStartShareTour(),
             QuickStartPublishTour(),
@@ -396,7 +396,7 @@ private extension QuickStartTourGuide {
     /// - Parameter blog: blog to check
     /// - Returns: boolean, true if all tours have been completed
     func allToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
+        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.growListTours
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -56,7 +56,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
+        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
         let checklistCompletedCount = countChecklistCompleted(in: list, for: blog)
         return checklistCompletedCount > 0
     }
@@ -69,7 +69,7 @@ open class QuickStartTourGuide: NSObject {
         let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
         let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
         let unavailableTours = Array(Set(completedTours + skippedTours))
-        let allTours = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
+        let allTours = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
 
         guard isQuickStartEnabled(for: blog),
             recentlyTouredBlog == blog else {
@@ -279,7 +279,7 @@ open class QuickStartTourGuide: NSObject {
             let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
             let completedIDs = completedTours.map { $0.tourID }
 
-            for tour in QuickStartTourGuide.createChecklistListTours() {
+            for tour in QuickStartTourGuide.shared.checklistListTours {
                 if !completedIDs.contains(tour.key) {
                     blog.completeTour(tour.key)
                 }
@@ -310,7 +310,7 @@ open class QuickStartTourGuide: NSObject {
         currentTourState = nil
     }
 
-    static func createChecklistListTours() -> [QuickStartTour] {
+    var checklistListTours: [QuickStartTour] {
         return [
             QuickStartCreateTour(),
             QuickStartViewTour(),
@@ -321,7 +321,7 @@ open class QuickStartTourGuide: NSObject {
         ]
     }
 
-    static func createCustomizeListTours() -> [QuickStartTour] {
+    var customizeListTours: [QuickStartTour] {
         return [
             QuickStartCreateTour(),
             QuickStartSiteTitleTour(),
@@ -332,7 +332,7 @@ open class QuickStartTourGuide: NSObject {
         ]
     }
 
-    static func createGrowListTours() -> [QuickStartTour] {
+    var createGrowListTours: [QuickStartTour] {
         return [
             QuickStartShareTour(),
             QuickStartPublishTour(),
@@ -396,7 +396,7 @@ private extension QuickStartTourGuide {
     /// - Parameter blog: blog to check
     /// - Returns: boolean, true if all tours have been completed
     func allToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
+        let list = QuickStartTourGuide.shared.customizeListTours + QuickStartTourGuide.shared.createGrowListTours
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 
@@ -407,7 +407,7 @@ private extension QuickStartTourGuide {
     /// - Note: This method is needed for upgrade/migration to V2 and should not
     ///         be removed when the V2 feature flag is removed.
     func allOriginalToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.createChecklistListTours()
+        let list = QuickStartTourGuide.shared.checklistListTours
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -56,7 +56,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let list = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
         let checklistCompletedCount = countChecklistCompleted(in: list, for: blog)
         return checklistCompletedCount > 0
     }
@@ -69,7 +69,7 @@ open class QuickStartTourGuide: NSObject {
         let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
         let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
         let unavailableTours = Array(Set(completedTours + skippedTours))
-        let allTours = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let allTours = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
 
         guard isQuickStartEnabled(for: blog),
             recentlyTouredBlog == blog else {
@@ -279,7 +279,7 @@ open class QuickStartTourGuide: NSObject {
             let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
             let completedIDs = completedTours.map { $0.tourID }
 
-            for tour in QuickStartTourGuide.checklistTours {
+            for tour in QuickStartTourGuide.createChecklistListTours() {
                 if !completedIDs.contains(tour.key) {
                     blog.completeTour(tour.key)
                 }
@@ -310,32 +310,38 @@ open class QuickStartTourGuide: NSObject {
         currentTourState = nil
     }
 
-    static let checklistTours: [QuickStartTour] = [
-        QuickStartCreateTour(),
-        QuickStartViewTour(),
-        QuickStartThemeTour(),
-        QuickStartShareTour(),
-        QuickStartPublishTour(),
-        QuickStartFollowTour()
-    ]
+    static func createChecklistListTours() -> [QuickStartTour] {
+        return [
+            QuickStartCreateTour(),
+            QuickStartViewTour(),
+            QuickStartThemeTour(),
+            QuickStartShareTour(),
+            QuickStartPublishTour(),
+            QuickStartFollowTour()
+        ]
+    }
 
-    static let customizeListTours: [QuickStartTour] = [
-        QuickStartCreateTour(),
-        QuickStartSiteTitleTour(),
-        QuickStartSiteIconTour(),
-        QuickStartEditHomepageTour(),
-        QuickStartReviewPagesTour(),
-        QuickStartViewTour()
-    ]
+    static func createCustomizeListTours() -> [QuickStartTour] {
+        return [
+            QuickStartCreateTour(),
+            QuickStartSiteTitleTour(),
+            QuickStartSiteIconTour(),
+            QuickStartEditHomepageTour(),
+            QuickStartReviewPagesTour(),
+            QuickStartViewTour()
+        ]
+    }
 
-    static let growListTours: [QuickStartTour] = [
-        QuickStartShareTour(),
-        QuickStartPublishTour(),
-        QuickStartFollowTour(),
-        QuickStartCheckStatsTour()
-// Temporarily disabled
-//        QuickStartExplorePlansTour()
-    ]
+    static func createGrowListTours() -> [QuickStartTour] {
+        return [
+            QuickStartShareTour(),
+            QuickStartPublishTour(),
+            QuickStartFollowTour(),
+            QuickStartCheckStatsTour()
+    // Temporarily disabled
+    //        QuickStartExplorePlansTour()
+        ]
+    }
 }
 
 private extension QuickStartTourGuide {
@@ -390,7 +396,7 @@ private extension QuickStartTourGuide {
     /// - Parameter blog: blog to check
     /// - Returns: boolean, true if all tours have been completed
     func allToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let list = QuickStartTourGuide.createCustomizeListTours() + QuickStartTourGuide.createGrowListTours()
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 
@@ -401,7 +407,7 @@ private extension QuickStartTourGuide {
     /// - Note: This method is needed for upgrade/migration to V2 and should not
     ///         be removed when the V2 feature flag is removed.
     func allOriginalToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.checklistTours
+        let list = QuickStartTourGuide.createChecklistListTours()
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 


### PR DESCRIPTION
Fixes #18222

## Root Cause
Quick start tours were all created on launch, which meant that the strings used were tailored for the blog at launch only. And not modified when the current blog changes.

https://user-images.githubusercontent.com/25306722/160860594-09b528cf-364f-474c-8ea0-667d2fe72f7c.mov

## Testing Instructions

1. Create a new site
2. When asked for help to manage the new site, press Show me around button
3. In Customize Your Site, tap the option Check your site title
4. Check the title of the site in the message at the bottom of the screen
5. It should be "Site Title" and not the title of the previous site.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
