### PR TITLE
My Site Dashboard: keep collection view position after an update

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -21,6 +21,11 @@ final class BlogDashboardViewController: UIViewController {
         return collectionView
     }()
 
+    /// The "My Site" main scroll view
+    var mySiteScrollView: UIScrollView? {
+        return view.superview?.superview as? UIScrollView
+    }
+
     @objc init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -81,7 +81,22 @@ class BlogDashboardViewModel {
 private extension BlogDashboardViewModel {
 
     func apply(snapshot: DashboardSnapshot) {
-        dataSource?.apply(snapshot, animatingDifferences: false)
+        let scrollView = viewController?.mySiteScrollView
+        let position = scrollView?.contentOffset
+
+        dataSource?.apply(snapshot, animatingDifferences: false) { [weak self] in
+            guard let scrollView = scrollView, let position = position else {
+                return
+            }
+
+            self?.scroll(scrollView, to: position)
+        }
+    }
+
+    func scroll(_ scrollView: UIScrollView, to position: CGPoint) {
+        if position.y > 0 {
+            scrollView.setContentOffset(position, animated: false)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #18195

This PR is somewhat a workaround around the collection view scrolling to the top after an update. In order to properly fix we'll need to review the way we display posts cards.

However, it does offer a better experience. :)

https://user-images.githubusercontent.com/7040243/160898509-9f49cdac-c787-4c8c-aed9-8008d63eb4b3.mp4

### To test

1. Run the app
2. Go to a site with Quick Start enabled and a few draft posts (enough content to scroll down as the video above)
3. Create a scheduled post
4. Check that the dashboard update but the position is the same

## Regression Notes
1. Potential unintended areas of impact
iPad

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I manually tested on iPad.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
