### PR TITLE
Blogging Prompts: initial Feature Introduction view

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/BloggingPromptsFeatureIntroduction.swift
@@ -1,0 +1,54 @@
+import UIKit
+
+// TODO: add description
+
+class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
+
+    class func navigationController() -> UINavigationController {
+        let controller = BloggingPromptsFeatureIntroduction()
+        let navController = UINavigationController(rootViewController: controller)
+        return navController
+    }
+
+    init() {
+        super.init(headerTitle: Strings.headerTitle,
+                   headerSubtitle: Strings.headerSubtitle,
+                   // TODO: provide lightbulb image
+                   headerImage: nil,
+                   // TODO: provide feature description view
+                   featureDescriptionView: UIView(),
+                   primaryButtonTitle: Strings.primaryButtonTitle,
+                   secondaryButtonTitle: Strings.secondaryButtonTitle)
+
+        featureIntroductionDelegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}
+
+extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
+
+    func primaryActionSelected() {
+        // TODO: show site selector/draft post
+    }
+
+    func secondaryActionSelected() {
+        // TODO: show site selector/Blogging Reminders
+    }
+
+}
+
+
+private extension BloggingPromptsFeatureIntroduction {
+
+    enum Strings {
+        static let headerTitle: String = NSLocalizedString("Introducing Prompts", comment: "Title displayed on the feature introduction view.")
+        static let headerSubtitle: String = NSLocalizedString("The best way to become a better writer is to build a writing habit and share with others - that’s where Prompts come in!", comment: "Subtitle displayed on the feature introduction view.")
+        static let primaryButtonTitle: String = NSLocalizedString("Try it now", comment: "Primary button title on the feature introduction view.")
+        static let secondaryButtonTitle: String = NSLocalizedString("Remind me", comment: "Secondary button title on the feature introduction view.")
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+@objc protocol FeatureIntroductionDelegate: AnyObject {
+    func primaryActionSelected()
+    @objc optional func secondaryActionSelected()
+}
+
 // TODO: add description
 
 class FeatureIntroductionViewController: CollapsableHeaderViewController {
@@ -7,17 +12,29 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
     // MARK: - Properties
 
     private let scrollView: UIScrollView
+    private let featureDescriptionView: UIView
 
     // View added to scrollView that contains specific Feature Introduction content.
     private lazy var contentView: UIView = {
         let contentView = UIView()
         contentView.translatesAutoresizingMaskIntoConstraints = false
+        // TODO: add featureDescriptionView subview
         return contentView
     }()
 
+    weak var featureIntroductionDelegate: FeatureIntroductionDelegate?
+
     // MARK: - Init
 
-    init() {
+    init(headerTitle: String,
+         headerSubtitle: String,
+         headerImage: UIImage? = nil,
+         featureDescriptionView: UIView,
+         primaryButtonTitle: String,
+         secondaryButtonTitle: String? = nil) {
+
+        self.featureDescriptionView = featureDescriptionView
+
         scrollView = {
             let scrollView = UIScrollView()
             scrollView.showsVerticalScrollIndicator = false
@@ -27,20 +44,16 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
 
         super.init(
             scrollableView: scrollView,
-            mainTitle: Strings.headerTitle,
-            prompt: Strings.headerSubtitle,
-            primaryActionTitle: Strings.primaryActionTitle,
-            secondaryActionTitle: Strings.secondaryActionTitle)
+            mainTitle: headerTitle,
+            prompt: headerSubtitle,
+            // TODO: pass headerImage
+            primaryActionTitle: primaryButtonTitle,
+            // TODO: don't show secondary action button if there is no title
+            secondaryActionTitle: secondaryButtonTitle)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    class func navigationController() -> UINavigationController {
-        let controller = FeatureIntroductionViewController()
-        let navController = UINavigationController(rootViewController: controller)
-        return navController
     }
 
     // MARK: - View
@@ -54,11 +67,11 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
     // MARK: - Button Actions
 
     override func primaryActionSelected(_ sender: Any) {
-        // TODO: call feature specific primary action
+        featureIntroductionDelegate?.primaryActionSelected()
     }
 
     override func secondaryActionSelected(_ sender: Any) {
-        // TODO: call feature specific secondary action
+        featureIntroductionDelegate?.secondaryActionSelected?()
     }
 
 }
@@ -73,14 +86,6 @@ private extension FeatureIntroductionViewController {
 
     @IBAction func closeButtonTapped() {
         dismiss(animated: true)
-    }
-
-    // TODO: move to feature specific implementation.
-    enum Strings {
-        static let headerTitle: String = NSLocalizedString("Introducing Prompts", comment: "Title displayed on the feature introduction view.")
-        static let headerSubtitle: String = NSLocalizedString("The best way to become a better writer is to build a writing habit and share with others - that’s where Prompts come in!", comment: "Subtitle displayed on the feature introduction view.")
-        static let primaryActionTitle: String = NSLocalizedString("Try it now", comment: "Primary button title on the feature introduction view.")
-        static let secondaryActionTitle: String = NSLocalizedString("Remind me", comment: "Secondary button title on the feature introduction view.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -97,7 +97,7 @@ extension WPTabBarController {
     // TODO: remove before merging. For testing only.
     @objc func showFeatureIntroduction() {
         if FeatureFlag.bloggingPrompts.enabled {
-            present(FeatureIntroductionViewController.navigationController(), animated: true)
+            present(BloggingPromptsFeatureIntroduction.navigationController(), animated: true)
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1839,6 +1839,8 @@
 		98BFF57C2398406A008A1DCB /* CocoaLumberjack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 938CF3DB1EF1BE6800AF838E /* CocoaLumberjack.swift */; };
 		98BFF57E23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
 		98BFF57F23984345008A1DCB /* AllTimeWidgetStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */; };
+		98C05B6827F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C05B6727F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift */; };
+		98C05B6927F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98C05B6727F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift */; };
 		98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		98C0CE9C23C559C800D0F27C /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		98CAD296221B4ED2003E8F45 /* StatSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98CAD295221B4ED1003E8F45 /* StatSection.swift */; };
@@ -6525,6 +6527,7 @@
 		98BBB642258047DD0084FF72 /* WordPress 107.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 107.xcdatamodel"; sourceTree = "<group>"; };
 		98BDFF6A20D0732900C72C58 /* SupportTableViewController+Activity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SupportTableViewController+Activity.swift"; sourceTree = "<group>"; };
 		98BFF57D23984344008A1DCB /* AllTimeWidgetStats.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AllTimeWidgetStats.swift; sourceTree = "<group>"; };
+		98C05B6727F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsFeatureIntroduction.swift; sourceTree = "<group>"; };
 		98CAD295221B4ED1003E8F45 /* StatSection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatSection.swift; sourceTree = "<group>"; };
 		98D31B8E2396ED7E009CFF43 /* WordPressAllTimeWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = WordPressAllTimeWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		98D31B962396ED7F009CFF43 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -12195,6 +12198,7 @@
 			isa = PBXGroup;
 			children = (
 				98AA9F2027EA890800B3A98C /* FeatureIntroductionViewController.swift */,
+				98C05B6727F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift */,
 			);
 			path = "Feature Introduction";
 			sourceTree = "<group>";
@@ -18605,6 +18609,7 @@
 				4666534A2501552A00165DD4 /* LayoutPreviewViewController.swift in Sources */,
 				7326A4A8221C8F4100B4EB8C /* UIStackView+Subviews.swift in Sources */,
 				4349B0AC218A45270034118A /* RevisionsTableViewController.swift in Sources */,
+				98C05B6827F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift in Sources */,
 				8BF1C81A27BC00AF00F1C203 /* BlogDashboardCardFrameView.swift in Sources */,
 				E1209FA41BB4978B00D69778 /* PeopleService.swift in Sources */,
 				984B139421F66B2D0004B6A2 /* StatsPeriodStore.swift in Sources */,
@@ -20390,6 +20395,7 @@
 				8B55FAAD2614FC87007D618E /* Text+BoldSubString.swift in Sources */,
 				FABB23382602FC2C00C8785C /* WordPress-22-23.xcmappingmodel in Sources */,
 				FABB23392602FC2C00C8785C /* CountriesMap.swift in Sources */,
+				98C05B6927F4F4130001A01B /* BloggingPromptsFeatureIntroduction.swift in Sources */,
 				FABB233A2602FC2C00C8785C /* RevisionsNavigationController.swift in Sources */,
 				FE3D058426C419C7002A51B0 /* ShareAppContentPresenter+TableView.swift in Sources */,
 				FABB233B2602FC2C00C8785C /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataClass.swift in Sources */,


### PR DESCRIPTION
Ref: #18176
Depends on: #18246

This adds a new view controller, `BloggingPromptsFeatureIntroduction`, that uses `FeatureIntroductionViewController` to display a feature introduction specifically for Blogging Prompts. 

This still applies (since it's branched):
Because we don't have any official way of showing the feature introduction just yet, I have set it to show in `applicationDidBecomeActive` to facilitate easily accessing it (by minimizing and relaunching the app). This is temporary and will be removed before merging. 

---
To test:

There should be no visible difference from before, so verify the view is same as on #18246. That is:

- Enable `bloggingPrompts` feature flag.
- Run the app.
- When the app launches, the Feature Introduction should appear. 
- Verify:
  - Two buttons are shown at the bottom.
  - They are stacked vertically.
  - The primary (blue) button is on top.

<kbd>![fi_buttons](https://user-images.githubusercontent.com/1816888/160907828-cb9d7d11-0fe6-4cb2-8daa-c941fab5088c.png)</kbd>

---
## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
