### PR TITLE
Blogging Prompts: Initial prompt dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -1,0 +1,108 @@
+import UIKit
+import WordPressShared
+
+class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
+
+    private lazy var containerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = Constants.spacing
+        return stackView
+    }()
+
+    private lazy var cardFrameView: BlogDashboardCardFrameView = {
+        let frameView = BlogDashboardCardFrameView()
+        frameView.translatesAutoresizingMaskIntoConstraints = false
+        frameView.title = Strings.cardFrameTitle
+        frameView.icon = Style.frameIconImage
+        frameView.onEllipsisButtonTap = {
+            // TODO: Show contextual menu.
+        }
+
+        return frameView
+    }()
+
+    private lazy var promptLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = Style.promptContentFont
+        label.textAlignment = .center
+        label.numberOfLines = 0
+
+        return label
+    }()
+
+    private lazy var promptTitleView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(promptLabel)
+        view.pinSubviewToAllEdges(promptLabel, insets: .init(top: Constants.spacing, left: 0, bottom: 0, right: 0))
+
+        return view
+    }()
+
+    private lazy var answerButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(Strings.answerButtonTitle, for: .normal)
+        button.setTitleColor(Style.buttonTitleColor, for: .normal)
+        button.titleLabel?.font = Style.buttonTitleFont
+        return button
+    }()
+
+    // MARK: Initializers
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupViews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}
+
+// MARK: - BlogDashboardCardConfigurable
+
+extension DashboardPromptsCardCell: BlogDashboardCardConfigurable {
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        // clear existing views.
+        containerStackView.removeAllSubviews()
+
+        // TODO: For testing purposes. Remove once we can pull content from remote.
+        promptLabel.text = "Cast the movie of your life."
+
+        // TODO: Add train of avatars view.
+        // TODO: Add 'answered' state, which shows the "Answered" text and Share button.
+        containerStackView.addArrangedSubviews([promptTitleView, answerButton])
+    }
+}
+
+// MARK: - Constants
+
+private extension DashboardPromptsCardCell {
+
+    func setupViews() {
+        contentView.addSubview(cardFrameView)
+        contentView.pinSubviewToAllEdges(cardFrameView, priority: Constants.cardFrameConstraintPriority)
+        cardFrameView.add(subview: containerStackView)
+    }
+
+    struct Strings {
+        static let cardFrameTitle = NSLocalizedString("Prompts", comment: "Title label for the Prompts card in My Sites tab.")
+        static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button on the prompts card.")
+    }
+
+    struct Style {
+        static let frameIconImage = UIImage(systemName: "lightbulb")
+        static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
+        static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
+        static let buttonTitleColor = UIColor.primary
+    }
+
+    struct Constants {
+        static let spacing: CGFloat = 12
+        static let cardFrameConstraintPriority = UILayoutPriority(999)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -10,6 +10,7 @@ import Foundation
 enum DashboardCard: String, CaseIterable {
     case quickActions
     case quickStart
+    case prompts
     case todaysStats = "todays_stats"
     case posts
 
@@ -28,6 +29,8 @@ enum DashboardCard: String, CaseIterable {
             return true
         case .todaysStats:
             return true
+        case .prompts:
+            return false // TODO: Change this to true later.
         case .ghost:
             return false
         case .failure:
@@ -45,6 +48,8 @@ enum DashboardCard: String, CaseIterable {
             return DashboardPostsCardCell.self
         case .todaysStats:
             return DashboardStatsCardCell.self
+        case .prompts:
+            return DashboardPromptsCardCell.self
         case .ghost:
             return DashboardGhostCardCell.self
         case .failure:
@@ -62,6 +67,8 @@ enum DashboardCard: String, CaseIterable {
             return true
         case .todaysStats:
             return true
+        case .prompts:
+            return FeatureFlag.bloggingPrompts.enabled
         case .ghost:
             return blog.dashboardState.isFirstLoad
         case .failure:

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4501,6 +4501,7 @@
 		FE02F95F269DC14A00752A44 /* Comment+Interface.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02F95E269DC14A00752A44 /* Comment+Interface.swift */; };
 		FE06AC8326C3BD0900B69DE4 /* ShareAppContentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8226C3BD0900B69DE4 /* ShareAppContentPresenter.swift */; };
 		FE06AC8526C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE06AC8426C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift */; };
+		FE18495827F5ACBA00D26879 /* DashboardPromptsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */; };
 		FE23EB4926E7C91F005A1698 /* richCommentTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */; };
 		FE23EB4A26E7C91F005A1698 /* richCommentTemplate.html in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */; };
 		FE23EB4B26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
@@ -7731,6 +7732,7 @@
 		FE02F95E269DC14A00752A44 /* Comment+Interface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Comment+Interface.swift"; sourceTree = "<group>"; };
 		FE06AC8226C3BD0900B69DE4 /* ShareAppContentPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppContentPresenter.swift; sourceTree = "<group>"; };
 		FE06AC8426C3C2F800B69DE4 /* ShareAppTextActivityItemSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareAppTextActivityItemSource.swift; sourceTree = "<group>"; };
+		FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPromptsCardCell.swift; sourceTree = "<group>"; };
 		FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = richCommentTemplate.html; path = Resources/HTML/richCommentTemplate.html; sourceTree = "<group>"; };
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
@@ -11460,6 +11462,7 @@
 		8B4DDF23278F3AED0022494D /* Cards */ = {
 			isa = PBXGroup;
 			children = (
+				FE18495627F5ACA400D26879 /* Prompts */,
 				8B92D69427CD51CE001F5371 /* Ghost */,
 				FAA4012F27B405DF009E1137 /* Quick Actions */,
 				FA8E2FE327C6377D00DA0982 /* Quick Start */,
@@ -15023,6 +15026,14 @@
 			path = Sharing;
 			sourceTree = "<group>";
 		};
+		FE18495627F5ACA400D26879 /* Prompts */ = {
+			isa = PBXGroup;
+			children = (
+				FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */,
+			);
+			path = Prompts;
+			sourceTree = "<group>";
+		};
 		FE32F004275F60360040BE67 /* ContentRenderer */ = {
 			isa = PBXGroup;
 			children = (
@@ -18459,6 +18470,7 @@
 				086103961EE09C91004D7C01 /* MediaVideoExporter.swift in Sources */,
 				E126C81F1F95FC1B00A5F464 /* PluginViewController.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
+				FE18495827F5ACBA00D26879 /* DashboardPromptsCardCell.swift in Sources */,
 				FAB8004925AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift in Sources */,
 				9A8ECE0C2254A3260043C8DA /* JetpackLoginViewController.swift in Sources */,
 				46F583A92624CE790010A723 /* BlockEditorSettings+CoreDataClass.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4532,6 +4532,7 @@
 		FE43DAB026DFAD1C00CFF595 /* CommentContentTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE43DAAD26DFAD1C00CFF595 /* CommentContentTableViewCell.swift */; };
 		FE43DAB126DFAD1C00CFF595 /* CommentContentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */; };
 		FE43DAB226DFAD1C00CFF595 /* CommentContentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */; };
+		FE4C46FF27FAE61700285F35 /* DashboardPromptsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */; };
 		FE9CC71A26D7A2A40026AEF3 /* CommentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9CC71926D7A2A40026AEF3 /* CommentDetailViewController.swift */; };
 		FE9CC71B26D7A2A40026AEF3 /* CommentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9CC71926D7A2A40026AEF3 /* CommentDetailViewController.swift */; };
 		FEA088012696E7F600193358 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
@@ -19914,6 +19915,7 @@
 				FABB21932602FC2C00C8785C /* GutenbergTenorMediaPicker.swift in Sources */,
 				FABB21942602FC2C00C8785C /* AztecPostViewController.swift in Sources */,
 				F1585442267D3BF900A2E966 /* CalendarDayToggleButton.swift in Sources */,
+				FE4C46FF27FAE61700285F35 /* DashboardPromptsCardCell.swift in Sources */,
 				FABB21972602FC2C00C8785C /* MenusViewController.m in Sources */,
 				FABB21982602FC2C00C8785C /* UIViewController+Notice.swift in Sources */,
 				FABB21992602FC2C00C8785C /* GutenbergFileUploadProcessor.swift in Sources */,


### PR DESCRIPTION
Refs #18250

<img width="405" alt="Screen Shot 2022-03-31 at 21 04 41" src="https://user-images.githubusercontent.com/1299411/161074170-cee6e61f-0965-4ca9-9cdf-372627a9f178.png">

This adds the initial prompt card for the new dashboard. Please note these are not implemented yet and will be addressed in future PRs:

- Train of avatars & the number of prompt answers  
- Contextual menu
- Buttons for the "answered" state
- Actual button actions
- Prompt card in Blog Detail

To test:

- Turn on `Blogging Prompts` and `My Site Dashboard` feature flags.
- Kill the app, and open it again (so the new dashboard appears).
- 🔍 Verify that the prompt card appears correctly (except those that are noted above).

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is under development.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
