### PR TITLE
Re-introduce `tVvJ9c` (intent description) key in `Sites.strings`

### DIFF
--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -9485,6 +9485,8 @@
 /* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "ios-widget.gpCwrM" = "Select Site";
 
+/* This text is required by Apple to be part of the tranlsations but is not shown to the users. You can ignore translating this. */
+"ios-widget.tVvJ9c" = "Select Site Intent";
+
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "ios-widget.s4dJhx" = "Just to confirm, you wanted ‘${site}’?";
-

--- a/WordPress/WordPressIntents/en.lproj/Sites.strings
+++ b/WordPress/WordPressIntents/en.lproj/Sites.strings
@@ -10,5 +10,8 @@
 /* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "gpCwrM" = "Select Site";
 
+/* This text is required by Apple to be part of the tranlsations but is not shown to the users. You can ignore translating this. */
+"tVvJ9c" = "Select Site Intent";
+
 /* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
 "s4dJhx" = "Just to confirm, you wanted ‘${site}’?";


### PR DESCRIPTION
This was removed in 909570f8251b1265d2a5cccb6cc271284e28d8af (#18203) and for good reason: it's most likely not shown to the users.

But, App Store Connect gave us warnings upon submission that the localized version of that string is missing.

> ITMS-90626: Invalid Siri Support - Localized description for custom intent: 'SelectSite' not found for locale: ar
> ITMS-90626: Invalid Siri Support - Localized description for custom intent: 'SelectSite' not found for locale: bg
> ITMS-90626: Invalid Siri Support - Localized description for custom intent: 'SelectSite' not found for locale: cs
>
> ... and so on for all locales other than en, en-AU, en-CA, and en-GB, even though those files don't have the key either (en-AU, en-CA, and en-GB are in fact empty)

This commit reintroduces the string with a message for the translators to ignore it.

**Note:** I decided to open it against `trunk` instead of `release/19.5` because any change in the localization won't be ready in time for the release finalization anyways. I considered amending the `.strings` ~~manually~~ with a script in the release branch but decided not to pursue that avenue because the issue is non-blocking for the release submission (the ASC email says "Your delivery was successful, but you may wish to correct the following issues in your next delivery") and the missing strings is not something the user would (as far as we understand) see (or listen to, being for the Siri intent?).

## Regression Notes

1. Potential unintended areas of impact N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) N.A.
3. What automated tests I added (or what prevented me from doing so) N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**