### PR TITLE
Blogging Prompts: Configure prompt card bottom row for answered state

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -3,6 +3,17 @@ import WordPressShared
 
 class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
+
+    /// Controls available actions on the bottom row.
+    /// TODO: Might need to review this once we have a better picture of what the Prompt model looks like.
+    var isAnswered: Bool = true {
+        didSet {
+            refreshStackView()
+        }
+    }
+
+    // MARK: Private Properties
+
     private lazy var containerStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
@@ -16,8 +27,10 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.title = Strings.cardFrameTitle
         frameView.icon = Style.frameIconImage
-        frameView.onEllipsisButtonTap = {
+        frameView.onEllipsisButtonTap = { [weak self] in
             // TODO: Show contextual menu.
+            // TODO: For testing purposes; added to make it easier to toggle answered state.
+            self?.isAnswered.toggle()
         }
 
         return frameView
@@ -29,6 +42,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         label.font = Style.promptContentFont
         label.textAlignment = .center
         label.numberOfLines = 0
+        label.adjustsFontForContentSizeCategory = true
 
         return label
     }()
@@ -48,7 +62,50 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         button.setTitle(Strings.answerButtonTitle, for: .normal)
         button.setTitleColor(Style.buttonTitleColor, for: .normal)
         button.titleLabel?.font = Style.buttonTitleFont
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
+        button.titleLabel?.adjustsFontSizeToFitWidth = true
+
         return button
+    }()
+
+    private lazy var answeredLabel: UILabel = {
+        let label = UILabel()
+        label.font = Style.buttonTitleFont
+        label.textColor = Style.answeredLabelColor
+        label.text = Strings.answeredLabelTitle
+
+        // The 'answered' label needs to be close to the Share button.
+        // swiftlint:disable:next inverse_text_alignment
+        label.textAlignment = (effectiveUserInterfaceLayoutDirection == .leftToRight ? .right : .left)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+
+        return label
+    }()
+
+    private lazy var shareButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(Strings.shareButtonTitle, for: .normal)
+        button.setTitleColor(Style.buttonTitleColor, for: .normal)
+        button.titleLabel?.font = Style.buttonTitleFont
+        button.contentHorizontalAlignment = .leading
+
+        // TODO: Implement button tap action
+
+        return button
+    }()
+
+    private lazy var answeredStateView: UIView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .fillProportionally
+        stackView.spacing = Constants.answeredButtonsSpacing
+
+        // added some spacer views to make the label and button look more centered together.
+        stackView.addArrangedSubviews([UIView(), answeredLabel, shareButton, UIView()])
+
+        return stackView
     }()
 
     // MARK: Initializers
@@ -67,15 +124,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
 extension DashboardPromptsCardCell: BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
-        // clear existing views.
-        containerStackView.removeAllSubviews()
-
-        // TODO: For testing purposes. Remove once we can pull content from remote.
-        promptLabel.text = "Cast the movie of your life."
-
-        // TODO: Add train of avatars view.
-        // TODO: Add 'answered' state, which shows the "Answered" text and Share button.
-        containerStackView.addArrangedSubviews([promptTitleView, answerButton])
+        refreshStackView()
     }
 }
 
@@ -89,9 +138,22 @@ private extension DashboardPromptsCardCell {
         cardFrameView.add(subview: containerStackView)
     }
 
+    func refreshStackView() {
+        // clear existing views.
+        containerStackView.removeAllSubviews()
+
+        // TODO: For testing purposes. Remove once we can pull content from remote.
+        promptLabel.text = "Cast the movie of your life."
+
+        // TODO: Add train of avatars view.
+        containerStackView.addArrangedSubviews([promptTitleView, (isAnswered ? answeredStateView : answerButton)])
+    }
+
     struct Strings {
         static let cardFrameTitle = NSLocalizedString("Prompts", comment: "Title label for the Prompts card in My Sites tab.")
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button on the prompts card.")
+        static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")
+        static let shareButtonTitle = NSLocalizedString("Share", comment: "Title for a button that allows the user to share their answer to the prompt.")
     }
 
     struct Style {
@@ -99,10 +161,12 @@ private extension DashboardPromptsCardCell {
         static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
         static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
         static let buttonTitleColor = UIColor.primary
+        static let answeredLabelColor = UIColor.muriel(name: .green, .shade50)
     }
 
     struct Constants {
         static let spacing: CGFloat = 12
+        static let answeredButtonsSpacing: CGFloat = 16
         static let cardFrameConstraintPriority = UILayoutPriority(999)
     }
 }


### PR DESCRIPTION
Refs #18250

This adds the UI for the prompt card's bottom row when the prompt has been answered. Some screenshots:

• | Portrait | Landscape
--|--|--
iPhone 11 Pro Max | ![iphone_portrait](https://user-images.githubusercontent.com/1299411/161306135-041e086f-c628-4e87-96af-0fd44060a55f.png) | ![iphone_landscape](https://user-images.githubusercontent.com/1299411/161306152-fcacf839-a17f-499b-9872-02c7e3b3770d.png)
iPad | ![ipad_portrait](https://user-images.githubusercontent.com/1299411/161306143-3a1c0506-163f-4f1c-b33d-cfd1352fc041.png) | ![ipad_landscape](https://user-images.githubusercontent.com/1299411/161306109-87a3809f-9c2a-47d5-ac74-5795f28522c0.png)

Other notes:
- Also added basic accessibility support, but there's still an unhandled case when using the largest accessibility sizes, where the "answered" label and the Share button fight for horizontal space 😅 . I'll note this for the accessibility review round.
- For testing purposes, tapping on the ellipsis menu now toggles between the prompt card's answered state. This will be removed in the next PR.
- The Share button's tap action is not yet implemented.

## To test

- Ensure that the Blogging Prompts and My Site Dashboard feature flags are enabled.
- Tap on the ellipsis menu to toggle the card into an "answered" state.
- Verify that the Answered label and the Share button are displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature under development.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
