### PR TITLE
My Site Dashboard: Fix stats and quickstart `card_shown` events firing multiple times

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -45,10 +45,6 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .dashboardCardItemTapped, properties:["type": DashboardCard.quickStart.rawValue])
 
         tourStateView.configure(blog: blog, sourceController: viewController, checklistTappedTracker: checklistTappedTracker)
-
-        WPAnalytics.track(.dashboardCardShown,
-                          properties: ["type": DashboardCard.quickStart.rawValue],
-                          blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -90,10 +90,6 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         }
 
         nudgeButton?.isHidden = !(viewModel?.shouldDisplayNudge ?? false)
-
-        WPAnalytics.track(.dashboardCardShown,
-                          properties: ["type": DashboardCard.todaysStats.rawValue],
-                          blog: blog)
     }
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {


### PR DESCRIPTION
Fixes #18228

## Root Cause
The issue is caused by the data source closure being called multiple times for the same card. (`BlogDashboardViewModel.swift line 30`)

## Solution
The workaround I implemented fixes this issue by depending on the data we know while applying the new snapshot instead of relying on how the OS will apply the snapshot.

I compared the items in the current snapshot and the new snapshot and from that we can tell if a new stats card was shown.

I applied this workaround for stats and quick start.

## Testing Instructions

N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
