### PR TITLE
Don't let `complete_code_freeze` continue if user asked not to

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -63,9 +63,16 @@ platform :ios do
     ios_completecodefreeze_prechecks(options)
     generate_strings_file_for_glotpress
 
-    UI.confirm('Ready to push changes to remote and trigger the beta build?') unless ENV['RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM']
-    push_to_git_remote(tags: false)
-    trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+    if prompt_for_confirmation(
+      message: 'Ready to push changes to remote and trigger the beta build?',
+      bypass: ENV['RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM']
+    )
+      push_to_git_remote(tags: false)
+      trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+    else
+      UI.message('Aborting code freeze completion. See you later.')
+    end
+
   end
 
   # Creates a new beta by bumping the app version appropriately then triggering a beta build on CI
@@ -233,4 +240,15 @@ def print_release_notes_reminder
   MSG
 
   message.lines.each { |l| UI.important(l.chomp) }
+end
+
+# Wrapper around Fastlane `UI.confirm` that adds the option to bypass the
+# prompt if a given flag is true
+#
+# @param [String] message The text to pass to `UI.confirm` to show the user
+# @param [Boolean] bypass A flag that allows bypassing the `UI.confirm` promt, i.e. acting as if the prompt returned `true`
+def prompt_for_confirmation(message:, bypass:)
+  return true if bypass
+
+  UI.confirm(message)
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -246,7 +246,7 @@ end
 # prompt if a given flag is true
 #
 # @param [String] message The text to pass to `UI.confirm` to show the user
-# @param [Boolean] bypass A flag that allows bypassing the `UI.confirm` promt, i.e. acting as if the prompt returned `true`
+# @param [Boolean] bypass A flag that allows bypassing the `UI.confirm` prompt, i.e. acting as if the prompt returned `true`
 def prompt_for_confirmation(message:, bypass:)
   return true if bypass
 


### PR DESCRIPTION
When I run `complete_code_freeze` today, I was thankful to see the push confirmation prompt because it gave time to realize I hadn't [ported the `Sites.string` fix from #18254](https://github.com/wordpress-mobile/WordPress-iOS/pull/18254#issuecomment-1086990571).

I was then startled when, despite replying `n`, the automation proceeded to push my changes 😅.

This PR addresses the issue. To test the fix, I first applied this diff:

```diff
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -60,15 +60,11 @@ platform :ios do
   #
   desc 'Completes the final steps for the code freeze'
   lane :complete_code_freeze do |options|
-    ios_completecodefreeze_prechecks(options)
-    generate_strings_file_for_glotpress
-
     if prompt_for_confirmation(
       message: 'Ready to push changes to remote and trigger the beta build?',
       bypass: ENV['RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM']
     )
-      push_to_git_remote(tags: false)
-      trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+      UI.message('Placeholder for code freeze completion')
     else
       UI.message('Aborting code freeze completion. See you later.')
     end
```

Then, I run the lane with the different env var and prompt answer permutations:

No env var, reply `y`:

<img width="1082" alt="image" src="https://user-images.githubusercontent.com/1218433/161477334-71d9982a-9f83-4fbb-be55-979c409b9a08.png">

No env var, reply `n`:

<img width="1081" alt="image" src="https://user-images.githubusercontent.com/1218433/161477294-ce9c5876-780b-4f9a-b9df-d1f1c6577fb8.png">


With env var (`RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM=1 bf complete_code_freeze`):

<img width="749" alt="image" src="https://user-images.githubusercontent.com/1218433/161477375-0c418e94-4e0a-4b87-b3d7-c670903770a0.png">

One thing worth noting is that, the behavior is the same whether `RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM` is `1`, `0`, or `false`. I think that's acceptable and consistent with what I've seen in other tools.

**Note**: As far as I can see, WordPress iOS is the only app that has this flag to skip the confirmation. If you know of one that has it too, I'll happily open a PR there as well, once this has been merged. Although, I wonder if it would be more useful to move the logic into our toolkit (although I don't think we have a neat way to expose it to consumers other than by making it an action?), or, even better, open a PR in Fastlane to implement the behavior. (I [checked](https://github.com/fastlane/fastlane/blob/b55f81155c0ba349ea29b17a4c77ee1cba5e6b1d/fastlane_core/lib/fastlane_core/ui/implementations/shell.rb#L133-L136), it doesn't not support a bypass flag at the moment).

**Note:** Recently, we've been opening Fastlane PRs against the release branch. In this case, though, it would only make the release management more noisy, because I won't be running the `complete_code_freeze` lane again on an already completed release branch 😅 

## Regression Notes

1. Potential unintended areas of impact – Only the `complete_code_freeze` lane
2. What I did to test those areas of impact (or what existing automated tests I relied on) – See above
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**