### PR TITLE
My Site Dashboard: Add pull to refresh to the dashboard on the iPad 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1536,7 +1536,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showDashboard
 {
-    BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog];
+    BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog embeddedInScrollView:NO];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     controller.extendedLayoutIncludesOpaqueBars = YES;
     [self showDetailViewController:controller sender:self];

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -760,7 +760,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     ///         - blog: The blog to show the details of.
     ///
     private func showDashboard(for blog: Blog) {
-        let blogDashboardViewController = self.blogDashboardViewController ?? BlogDashboardViewController(blog: blog)
+        let blogDashboardViewController = self.blogDashboardViewController ?? BlogDashboardViewController(blog: blog, embeddedInScrollView: true)
         blogDashboardViewController.update(blog: blog)
         embedChildInStackView(blogDashboardViewController)
         self.blogDashboardViewController = blogDashboardViewController


### PR DESCRIPTION
Fixes #18265

## Description

If the dashboard is being embedded inside the My Site scroll view, no changes are applied.
Now a refresh control is added directly to the dashboard's collection view if the dashboard is being displayed as a separate detailed VC.

https://user-images.githubusercontent.com/25306722/161582414-3ccfafa2-bfd8-47e8-9d58-1f97d8fe0afa.mp4

## Testing Instructions

1. Run the app on an iPad
2. Open the dashboard
3. Attempt to scroll down to refresh
4. Observe the refresh control is present
5. Make sure the dashboard actually updates if needed

## Regression Notes
1. Potential unintended areas of impact
Pull to refresh on iPhone

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually on iPhone

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
