### PR TITLE
Add feature flag for Site Name screen

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -24,6 +24,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case statsPerformanceImprovements
     case siteIntentQuestion
     case landInTheEditor
+    case siteName
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -76,6 +77,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .siteIntentQuestion:
             return true
         case .landInTheEditor:
+            return false
+        case .siteName:
             return false
         }
     }
@@ -147,6 +150,8 @@ extension FeatureFlag {
             return "Site Intent Question"
         case .landInTheEditor:
             return "Land In The Editor"
+        case .siteName:
+            return "Site Name"
         }
     }
 


### PR DESCRIPTION
Closes #18271 

## Description

This PR adds the [feature flag](https://github.com/wordpress-mobile/WordPress-iOS/blob/61245ffdb3890f40e92afa8a171e5676653ed617/docs/feature-flags.md) for the "Site Name" screen.

## To Test

Using a local build or one from CI:

1. Launch the app
2. From `My Site` go to `Me` -> `App Settings` -> `Debug`
3. **Verify** that `Site Name` **exists** and is **toggled off** under `Feature Flags`

## Preview

<img src="https://user-images.githubusercontent.com/2092798/161620187-1fb0481e-e0c8-462f-87db-2ac69534474c.png" width="250px" alt="Site Name feature flag" />


## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Loaded the Debug Settings view and toggled the feature.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
