### PR TITLE
Feature Introduction: set button view height based on buttons displayed 

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -49,7 +49,6 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
             prompt: headerSubtitle,
             // TODO: pass headerImage
             primaryActionTitle: primaryButtonTitle,
-            // TODO: don't show secondary action button if there is no title
             secondaryActionTitle: secondaryButtonTitle)
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -86,7 +86,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
         var height = verticalMargins + buttonHeight + verticalMargins + safeArea
 
-        if usesVerticalActionButtons {
+        if usesVerticalActionButtons && !secondaryActionButton.isHidden {
             height += (buttonHeight + selectedStateButtonsContainer.spacing)
         }
 


### PR DESCRIPTION
Ref: #18176, #18246

This fixes the spacing when only the primary action button is displayed in Feature Introduction.

To test:
- To hide the secondary action button, in `FeatureIntroductionViewController`'s call to `super.init`, set the `secondaryActionTitle` parameter to `nil`.

<img width="472" alt="hack" src="https://user-images.githubusercontent.com/1816888/161633891-ec46dd7a-2c53-4013-82e1-5e11874bc298.png">

- Enable `bloggingPrompts` feature flag.
- Run the app.
- When the app launches, the Feature Introduction appears.
- Verify the `Remind me` button is not shown and the vertical spacing is correct for one button.

| <img width="440" alt="two_buttons" src="https://user-images.githubusercontent.com/1816888/161633969-a29d3cae-ebb1-4350-a9b1-414036a48e01.png"> | <img width="440" alt="one_button" src="https://user-images.githubusercontent.com/1816888/161633968-d6a55bba-411c-4bbe-add5-7b92178b72c6.png"> |
|--------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A. WIP.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. WIP.

3. What automated tests I added (or what prevented me from doing so)
N/A. WIP.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
