### PR TITLE
My Site: Tighten spacings in the my site screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -240,7 +240,7 @@ extension BlogDashboardViewController {
         static let estimatedWidth: CGFloat = 100
         static let estimatedHeight: CGFloat = 44
         static let horizontalSectionInset: CGFloat = 20
-        static let verticalSectionInset: CGFloat = 24
+        static let verticalSectionInset: CGFloat = 20
         static let cellSpacing: CGFloat = 24
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -174,9 +174,9 @@ extension BlogDashboardViewController {
         let section = NSCollectionLayoutSection(group: group)
         let isQuickActionSection = viewModel.card(for: sectionIndex) == .quickActions
         let isLastSection = collectionView.numberOfSections == (sectionIndex + 1)
-        let horizontalInset = isQuickActionSection ? 0 : Constants.sectionInset
-        let bottomInset = isLastSection ? Constants.sectionInset : 0
-        section.contentInsets = NSDirectionalEdgeInsets(top: Constants.sectionInset,
+        let horizontalInset = isQuickActionSection ? 0 : Constants.horizontalSectionInset
+        let bottomInset = isLastSection ? Constants.verticalSectionInset : 0
+        section.contentInsets = NSDirectionalEdgeInsets(top: Constants.verticalSectionInset,
                                                         leading: horizontalInset,
                                                         bottom: bottomInset,
                                                         trailing: horizontalInset)
@@ -239,7 +239,8 @@ extension BlogDashboardViewController {
     private enum Constants {
         static let estimatedWidth: CGFloat = 100
         static let estimatedHeight: CGFloat = 44
-        static let sectionInset: CGFloat = 20
-        static let cellSpacing: CGFloat = 20
+        static let horizontalSectionInset: CGFloat = 20
+        static let verticalSectionInset: CGFloat = 24
+        static let cellSpacing: CGFloat = 24
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eUE-Sb-m3L">
-                    <rect key="frame" x="36" y="0.0" width="30.5" height="36"/>
+                    <rect key="frame" x="36" y="11" width="30.5" height="14.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" name="Gray50"/>
@@ -35,11 +35,10 @@
             </subviews>
             <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="eUE-Sb-m3L" firstAttribute="centerY" secondItem="OEo-2z-Cmk" secondAttribute="centerY" id="5cB-Im-fBT"/>
                 <constraint firstAttribute="leadingMargin" secondItem="eUE-Sb-m3L" secondAttribute="leading" constant="-20" id="Bi6-N7-44O"/>
                 <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" id="EWN-SE-Ilb"/>
-                <constraint firstAttribute="bottom" secondItem="eUE-Sb-m3L" secondAttribute="bottom" id="ILT-ul-3i5"/>
                 <constraint firstAttribute="bottom" secondItem="OEo-2z-Cmk" secondAttribute="bottom" id="a35-Lf-TpM"/>
-                <constraint firstItem="eUE-Sb-m3L" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="oHh-OB-AWn"/>
             </constraints>
             <nil key="simulatedStatusBarMetrics"/>
             <nil key="simulatedTopBarMetrics"/>

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -645,8 +645,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 #pragma mark - iOS 10 bottom padding
 
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
-    BOOL isLastSection = section == self.tableSections.count - 1;
+- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)sectionNum {
+    BlogDetailsSection *section = self.tableSections[sectionNum];
+    BOOL isLastSection = sectionNum == self.tableSections.count - 1;
+    BOOL hasTitle = section.footerTitle != nil && ![section.footerTitle isEmpty];
+    if (hasTitle) {
+        return UITableViewAutomaticDimension;
+    }
     if (isLastSection) {
         return BlogDetailSectionsSpacing;
     }
@@ -655,10 +660,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = self.tableSections[sectionNum];
+    BOOL hasTitle = section.title != nil && ![section.title isEmpty];
 
     if (section.showQuickStartMenu == true) {
         return BlogDetailQuickStartSectionHeaderHeight;
-    } else if (section.title != nil && ![section.title isEmpty]) {
+    } else if (hasTitle) {
         return BlogDetailSectionTitleHeaderHeight;
     }
     return BlogDetailSectionsSpacing;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -36,7 +36,7 @@ NSString * const WPBlogDetailsSelectedIndexPathKey = @"WPBlogDetailsSelectedInde
 CGFloat const BlogDetailGridiconAccessorySize = 17.0;
 CGFloat const BlogDetailQuickStartSectionHeaderHeight = 48.0;
 CGFloat const BlogDetailSectionTitleHeaderHeight = 40.0;
-CGFloat const BlogDetailSectionsSpacing = 24.0;
+CGFloat const BlogDetailSectionsSpacing = 20.0;
 NSTimeInterval const PreloadingCacheTimeout = 60.0 * 5; // 5 minutes
 NSString * const HideWPAdminDate = @"2015-09-07T00:00:00Z";
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -34,7 +34,9 @@ NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 NSString * const WPBlogDetailsSelectedIndexPathKey = @"WPBlogDetailsSelectedIndexPathKey";
 
 CGFloat const BlogDetailGridiconAccessorySize = 17.0;
-CGFloat const BlogDetailQuickStartSectionHeight = 35.0;
+CGFloat const BlogDetailQuickStartSectionHeaderHeight = 48.0;
+CGFloat const BlogDetailSectionTitleHeaderHeight = 40.0;
+CGFloat const BlogDetailSectionsSpacing = 24.0;
 NSTimeInterval const PreloadingCacheTimeout = 60.0 * 5; // 5 minutes
 NSString * const HideWPAdminDate = @"2015-09-07T00:00:00Z";
 
@@ -644,19 +646,22 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 #pragma mark - iOS 10 bottom padding
 
 - (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section {
-    return UITableViewAutomaticDimension;
+    BOOL isLastSection = section == self.tableSections.count - 1;
+    if (isLastSection) {
+        return BlogDetailSectionsSpacing;
+    }
+    return 0;
 }
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = self.tableSections[sectionNum];
 
-    if (section.showQuickStartMenu == true || sectionNum == 0) {
-        return BlogDetailQuickStartSectionHeight;
-    } else if (([section.title isEmpty] || section.title == nil) && sectionNum == 0) {
-        // because tableView:viewForHeaderInSection: is implemented, this must explicitly be 0
-        return 0.0;
+    if (section.showQuickStartMenu == true) {
+        return BlogDetailQuickStartSectionHeaderHeight;
+    } else if (section.title != nil && ![section.title isEmpty]) {
+        return BlogDetailSectionTitleHeaderHeight;
     }
-    return UITableViewAutomaticDimension;
+    return BlogDetailSectionsSpacing;
 }
 
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section {
@@ -1218,10 +1223,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDetailsSection *section = [self.tableSections objectAtIndex:sectionNum];
     if (section.showQuickStartMenu) {
         return [self quickStartHeaderWithTitle:section.title];
-    } else if (sectionNum == 0) {
-        return nil;
     }
-
     return nil;
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -83,7 +83,7 @@ class BlogDetailHeaderView: UIView {
 
     private enum LayoutSpacing {
         static let atSides: CGFloat = 20
-        static let top: CGFloat = 16
+        static let top: CGFloat = 10
         static let bottom: CGFloat = 16
         static let belowActionRow: CGFloat = 24
         static func betweenTitleViewAndActionRow(_ showsActionRow: Bool) -> CGFloat {


### PR DESCRIPTION
Fixes #18268

## Description
Tightens some spacings on the My Site screen.

/ | Before | After | After with Dimenions
-|-|-|-
Top | ![Before-Top](https://user-images.githubusercontent.com/25306722/161670205-19014169-35d8-4e69-8358-bc80e1af335e.png) | ![After-Top](https://user-images.githubusercontent.com/25306722/161670227-60791963-7a0b-42e0-a178-74d54758a2a5.png) | ![After-Top-Dimensions](https://user-images.githubusercontent.com/25306722/161672481-5083de04-cf70-49aa-88fd-d9b8cbf86017.png)
Bottom | ![Before-Bottom](https://user-images.githubusercontent.com/25306722/161670215-9598b126-6d41-4e88-af44-7958946cbd9f.png) | ![After-Bottom](https://user-images.githubusercontent.com/25306722/161670231-ccefbf3b-4e4a-4aa4-8f88-b067f8b1c48e.png) | ![After-Bottom-Dimensions](https://user-images.githubusercontent.com/25306722/161672489-ae2d4457-89e8-4c1e-af1b-76c3924c5053.png)
Top With QuickStart | ![Before-Top-QuickStart](https://user-images.githubusercontent.com/25306722/161670152-d173bf75-eb94-45b5-8aed-34aef5eb37b8.png) | ![After-Top-QuickStart](https://user-images.githubusercontent.com/25306722/161671581-f996ef22-0177-4af6-ab2d-ed0331bc29d6.png) | ![After-Top-QuickStart-Dimensions](https://user-images.githubusercontent.com/25306722/161672526-e3e008b3-a6bd-4d65-bde1-8ddc494f8954.png)
Top With Section Footer | ![Before-Top-Footer-title](https://user-images.githubusercontent.com/25306722/161670219-3cdc0295-d014-409e-9cdf-b85670b00c66.png) | ![After-Top-Footer-title](https://user-images.githubusercontent.com/25306722/161670256-20a31bdc-0f11-4865-9fa7-9656ca2b3a44.png) | Same dimensions for the footer

## Testing Instructions

1. Run the app
2. Open the site menu
3. Check that the spacings match the new specs

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
