### PR TITLE
Blogging Prompts: Show contextual menu UI when ellipsis button is tapped

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -243,3 +243,17 @@ extension BlogDashboardViewController {
         static let cellSpacing: CGFloat = 20
     }
 }
+
+// MARK: - UI Popover Delegate
+
+/// This view controller may host a `DashboardPromptsCardCell` that requires presenting a `MenuSheetViewController`,
+/// a fallback implementation of `UIMenu` for iOS 13. For more details, see the docs on `MenuSheetViewController`.
+///
+/// NOTE: This should be removed once we drop support for iOS 13.
+///
+extension BlogDashboardViewController: UIPopoverPresentationControllerDelegate {
+    // Force popover views to be presented as a popover (instead of being presented as a form sheet on iPhones).
+    public func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
+        return .none
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -74,11 +74,6 @@ class BlogDashboardCardFrameView: UIView {
 
     weak var currentView: UIView?
 
-    /// Current frame of the ellipsis button. Used when displaying an action sheet as a popover.
-    var ellipsisButtonFrame: CGRect {
-        return ellipsisButton.frame
-    }
-
     /// The title at the header
     var title: String? {
         didSet {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -58,7 +58,7 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Ellipsis Button displayed on the top right corner of the view.
     /// Displayed only when an associated action is set
-    private lazy var ellipsisButton: UIButton = {
+    private(set) lazy var ellipsisButton: UIButton = {
         let button = UIButton(type: .custom)
         button.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
         button.contentEdgeInsets = Constants.ellipsisButtonPadding

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -15,7 +15,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                   let blog = self?.blog else {
                 return
             }
-            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButtonFrame)
+            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButton.frame)
         }
         return frameView
     }()


### PR DESCRIPTION
Refs #18250

As titled, this shows the contextual menu UI when the ellipsis button is tapped, along with the fallback implementation for iOS 13 (i.e., `MenuSheetViewController`). There are some visual issues with the iOS 13 menu – that is, truncated text and the "Remove from dashboard" menu option not tinted red. I'll address these in the next PR.

Here are some screenshots:

iOS 13 | iOS 14+
-|-
![context_ios13](https://user-images.githubusercontent.com/1299411/161824340-4d45e9f1-5901-4c48-9d1a-465521a40157.png) | ![context_ios14](https://user-images.githubusercontent.com/1299411/161824359-b61849fd-8ce4-4595-b2c1-24ec53e32567.png)

Additionally, I'm requesting @hassaanelgarem for review since I made some minor changes to the dashboard code. Feel free to add additional reviewers that you think are relevant for these! Here are some notes:
-  In order to show a `UIMenu` from the ellipsis button (and have it set as the source view for the popover), I needed `ellipsisButton` from `BlogDashboardFrameView` to be public. Therefore, I've set the button to be public & read-only. Let me know if you have an issue with this. 🙇 
- `BlogDashboardViewController` now conforms to `UIPopoverPresentationControllerDelegate`. This is part of a fallback implementation of `UIMenu` for iOS 13 – where we try to present a `UIMenu` clone with no modal presentation style. To prevent iPhone models from presenting the menu with `.formSheet` style, we need to override it to `.none` through this delegate.
- As you can see in the screenshot, the ellipsis button seems to be consistently misplaced on iOS 13. This looks like a bug in `BlogDashboardCardFrameView`. After taking a quick look, this seems to be a content hugging issue (and a different era of autolayout engine 🙃 ). It's fixed if I set `ellipsisButton`'s priority to 251. Let me know if you want to fix this separately, or otherwise, I can address this along in my next PR!

## To test

- Ensure that `Blogging Prompts` and `My Site Dashboard` feature flags are turned on.
- Select the 'Home' dashboard.
- Tap on the ellipsis button.
- Verify that the contextual menu appears.
- Verify that the contextual menu appears on iOS 13.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is under development.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
