### PR TITLE
Bump Buildkite `bash-cache` plugin to version `2.2.0`

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.2.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.6.0
+    - automattic/bash-cache#2.2.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#v1.5.0
+    - automattic/bash-cache#2.2.0
     - automattic/git-s3-cache#v1.1.0:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"


### PR DESCRIPTION
This version:

- Updates the logic that installs the CocoaPods libraries to make sure the `Podfile.lock` wasn't changed in CI. If that happens, then the commit author committed an incorrect `Podfile.lock` and they should fix the issues ASAP.
- Has a working version of the `hash_file` internal utility, which was failing on masOS images.

More at https://github.com/Automattic/bash-cache-buildkite-plugin/releases/tag/2.2.0

## To test

Refer to https://github.com/wordpress-mobile/WordPress-iOS/pull/18212, which I used to test the changes as I was making them in the plugin.

In particular:

- [This build](https://buildkite.com/automattic/wordpress-ios/builds/6532) "successfully fails" because of an incorrect `Podfile.lock`
- [This build](https://buildkite.com/automattic/wordpress-ios/builds/6533), from a commit that reverts the change `Podfile.lock` failure, passes

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**