### PR TITLE
My Site Dashboard: Fix nudge view for Stats card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -7,7 +7,7 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
 
     private var viewModel: DashboardStatsViewModel?
     private var frameView: BlogDashboardCardFrameView?
-    private var nudgeButton: DashboardStatsNudgeButton?
+    private var nudgeView: DashboardStatsNudgeView?
     private var statsStackView: DashboardStatsStackView?
 
     private lazy var stackView: UIStackView = {
@@ -48,18 +48,15 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
         frameView.add(subview: statsStackview)
         self.statsStackView = statsStackview
 
-        let nudgeButton = createNudgeButton()
-        frameView.add(subview: nudgeButton)
-        self.nudgeButton = nudgeButton
+        let nudgeView = createNudgeView()
+        frameView.add(subview: nudgeView)
+        self.nudgeView = nudgeView
 
         stackView.addArrangedSubview(frameView)
     }
 
-    private func createNudgeButton() -> DashboardStatsNudgeButton {
-        let nudgeButton = DashboardStatsNudgeButton(title: Strings.nudgeButtonTitle, hint: Strings.nudgeButtonHint)
-        nudgeButton.contentEdgeInsets = Constants.nudgeButtonMargins
-
-        return nudgeButton
+    private func createNudgeView() -> DashboardStatsNudgeView {
+        DashboardStatsNudgeView(title: Strings.nudgeButtonTitle, hint: Strings.nudgeButtonHint)
     }
 }
 
@@ -85,11 +82,11 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         statsStackView?.visitors = viewModel?.todaysVisitors
         statsStackView?.likes = viewModel?.todaysLikes
 
-        nudgeButton?.onTap = { [weak self] in
+        nudgeView?.onTap = { [weak self] in
             self?.showNudgeHint(for: blog, from: viewController)
         }
 
-        nudgeButton?.isHidden = !(viewModel?.shouldDisplayNudge ?? false)
+        nudgeView?.isHidden = !(viewModel?.shouldDisplayNudge ?? false)
 
         WPAnalytics.track(.dashboardCardShown,
                           properties: ["type": DashboardCard.todaysStats.rawValue],
@@ -135,7 +132,6 @@ private extension DashboardStatsCardCell {
     enum Constants {
         static let spacing: CGFloat = 20
         static let iconSize = CGSize(width: 18, height: 18)
-        static let nudgeButtonMargins = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
 
         static let constraintPriority = UILayoutPriority(999)
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeButton.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-final class DashboardStatsNudgeButton: MultilineButton {
+final class DashboardStatsNudgeButton: UIButton {
 
     var onTap: (() -> Void)?
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeButton.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeButton.swift
@@ -10,6 +10,16 @@ final class DashboardStatsNudgeButton: MultilineButton {
         setTitle(title: title, hint: hint)
     }
 
+    // MARK: - Overrides
+
+    override var intrinsicContentSize: CGSize {
+        if let intrinsicContentSize = titleLabel?.intrinsicContentSize {
+            return CGSize(width: intrinsicContentSize.width, height: intrinsicContentSize.height + contentEdgeInsets.top + contentEdgeInsets.bottom)
+        }
+
+        return .zero
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -22,7 +32,10 @@ final class DashboardStatsNudgeButton: MultilineButton {
     override func layoutSubviews() {
         super.layoutSubviews()
         titleLabel?.preferredMaxLayoutWidth = titleLabel?.frame.size.width ?? 0
+        super.layoutSubviews()
     }
+
+    // MARK: - View setup
 
     private func setup() {
         setTitleColor(.textSubtle, for: .normal)
@@ -45,7 +58,7 @@ final class DashboardStatsNudgeButton: MultilineButton {
 
         let attachmentString = NSAttributedString(attachment: externalAttachment)
 
-        let titleString = NSMutableAttributedString(string: "\(title) ")
+        let titleString = NSMutableAttributedString(string: "\(title) \u{FEFF}")
         if let subStringRange = title.nsRange(of: hint) {
             titleString.addAttributes([
                 .foregroundColor: UIColor.primary,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
@@ -1,23 +1,30 @@
 import UIKit
 
-final class DashboardStatsNudgeButton: UIButton {
+final class DashboardStatsNudgeView: UIView {
 
-    var onTap: (() -> Void)?
+    var onTap: (() -> Void)? {
+        didSet {
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(buttonTapped))
+            addGestureRecognizer(tapGesture)
+        }
+    }
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        label.textColor = .textSubtle
+        label.numberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        return label
+    }()
+
+    // MARK: - Init
 
     convenience init(title: String, hint: String) {
         self.init(frame: .zero)
 
         setTitle(title: title, hint: hint)
-    }
-
-    // MARK: - Overrides
-
-    override var intrinsicContentSize: CGSize {
-        if let intrinsicContentSize = titleLabel?.intrinsicContentSize {
-            return CGSize(width: intrinsicContentSize.width, height: intrinsicContentSize.height + contentEdgeInsets.top + contentEdgeInsets.bottom)
-        }
-
-        return .zero
     }
 
     override init(frame: CGRect) {
@@ -29,23 +36,11 @@ final class DashboardStatsNudgeButton: UIButton {
         fatalError("Not implemented")
     }
 
-    override func layoutSubviews() {
-        super.layoutSubviews()
-        titleLabel?.preferredMaxLayoutWidth = titleLabel?.frame.size.width ?? 0
-        super.layoutSubviews()
-    }
-
     // MARK: - View setup
 
     private func setup() {
-        setTitleColor(.textSubtle, for: .normal)
-        titleLabel?.lineBreakMode = .byWordWrapping
-        titleLabel?.numberOfLines = 0
-        titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        titleLabel?.textColor = .textSubtle
-        contentHorizontalAlignment = .leading
-        contentVerticalAlignment = .top
-        addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
+        addSubview(titleLabel)
+        pinSubviewToAllEdges(titleLabel, insets: Constants.margins)
     }
 
     @objc private func buttonTapped() {
@@ -68,12 +63,13 @@ final class DashboardStatsNudgeButton: UIButton {
 
         titleString.append(attachmentString)
 
-        setAttributedTitle(titleString, for: .normal)
+        titleLabel.attributedText = titleString
     }
 
     private enum Constants {
         static let iconSize = CGSize(width: 16, height: 16)
         static let iconBounds = CGRect(x: 0, y: -2, width: 16, height: 16)
+        static let margins = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
@@ -41,6 +41,8 @@ final class DashboardStatsNudgeView: UIView {
     private func setup() {
         addSubview(titleLabel)
         pinSubviewToAllEdges(titleLabel, insets: Constants.margins)
+
+        prepareForVoiceOver()
     }
 
     @objc private func buttonTapped() {
@@ -72,4 +74,13 @@ final class DashboardStatsNudgeView: UIView {
         static let margins = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 16)
     }
 
+}
+
+extension DashboardStatsNudgeView: Accessible {
+
+    func prepareForVoiceOver() {
+        isAccessibilityElement = false
+        titleLabel.isAccessibilityElement = true
+        titleLabel.accessibilityTraits = .button
+    }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2881,8 +2881,8 @@
 		FAA9084D27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */; };
 		FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE3F02615996E00BF29FE /* AppConstants.swift */; };
 		FAADE43A26159B2800BF29FE /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAADE42726159B1300BF29FE /* AppConstants.swift */; };
-		FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeButton.swift */; };
-		FAB37D4727ED84BC00CA993C /* DashboardStatsNudgeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeButton.swift */; };
+		FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */; };
+		FAB37D4727ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */; };
 		FAB4F32724EDE12A00F259BA /* FollowCommentsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */; };
 		FAB8004925AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB8004825AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift */; };
 		FAB800B225AEE3C600D5D54A /* RestoreCompleteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAB800B125AEE3C600D5D54A /* RestoreCompleteView.swift */; };
@@ -7688,7 +7688,7 @@
 		FAA9084B27BD60710093FFA8 /* MySiteViewController+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySiteViewController+QuickStart.swift"; sourceTree = "<group>"; };
 		FAADE3F02615996E00BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		FAADE42726159B1300BF29FE /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
-		FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsNudgeButton.swift; sourceTree = "<group>"; };
+		FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsNudgeView.swift; sourceTree = "<group>"; };
 		FAB4F32624EDE12A00F259BA /* FollowCommentsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FollowCommentsServiceTests.swift; sourceTree = "<group>"; };
 		FAB8004825AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupCompleteViewController.swift; sourceTree = "<group>"; };
 		FAB800B125AEE3C600D5D54A /* RestoreCompleteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoreCompleteView.swift; sourceTree = "<group>"; };
@@ -11697,7 +11697,7 @@
 			children = (
 				8B6214DF27B1AD9D001DF7B6 /* DashboardStatsCardCell.swift */,
 				8071390627D039E70012DB21 /* DashboardSingleStatView.swift */,
-				FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeButton.swift */,
+				FAB37D4527ED84BC00CA993C /* DashboardStatsNudgeView.swift */,
 				80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */,
 			);
 			path = Stats;
@@ -17418,7 +17418,7 @@
 				8B1E62D625758AAF009A0F80 /* ActivityTypeSelectorViewController.swift in Sources */,
 				7E4123CC20F418A500DF8486 /* ActivityActionsParser.swift in Sources */,
 				40F46B6B22121BA800A2143B /* AnnualAndMostPopularTimeStatsRecordValue+CoreDataProperties.swift in Sources */,
-				FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeButton.swift in Sources */,
+				FAB37D4627ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */,
 				17F0E1DA20EBDC0A001E9514 /* Routes+Me.swift in Sources */,
 				D83CA3AB20842E5F0060E310 /* StockPhotosResultsPage.swift in Sources */,
 				4348C88321002FBD00735DC0 /* QuickStartTourGuide.swift in Sources */,
@@ -19725,7 +19725,7 @@
 				FABB20DF2602FC2C00C8785C /* ContextManager.m in Sources */,
 				FABB20E02602FC2C00C8785C /* CookieJar.swift in Sources */,
 				C7F7BDBD26262A1B00CE547F /* AppDependency.swift in Sources */,
-				FAB37D4727ED84BC00CA993C /* DashboardStatsNudgeButton.swift in Sources */,
+				FAB37D4727ED84BC00CA993C /* DashboardStatsNudgeView.swift in Sources */,
 				FABB20E12602FC2C00C8785C /* WebAddressStep.swift in Sources */,
 				FABB20E22602FC2C00C8785C /* NotificationSyncMediator.swift in Sources */,
 				FABB20E42602FC2C00C8785C /* ThemeBrowserHeaderView.swift in Sources */,


### PR DESCRIPTION
Fixes #18286 

## Description
- Fixed the nudge view overflowing from its container by subclassing `UIButton` and using a `UILabel` instead of using a `MultilineButton`

## How to test
1. Navigate to a WordPress.com site with no recent views or visitors
2. Notice the new "if you want to try get more views..." prompt
3. Switch the device to landscape mode
4. ✅ Make sure that the prompt is properly contained within its container
5. Tap on the prompt
6. ✅ A wp.com support page "Getting More View and Traffic" should open
7. Tap the X button
8. Switch the device to portrait mode
9. ✅ Make sure that the prompt is properly contained within its container
10. Tap on the prompt
11. ✅ A wp.com support page "Getting More View and Traffic" should open


https://user-images.githubusercontent.com/6711616/161952871-838876fe-a8c8-4862-8d72-da778c5bd061.mp4



## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
