### PR TITLE
Blogging Prompts: Add destructive menu item style for the iOS 13 fallback

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -293,7 +293,7 @@ private extension DashboardPromptsCardCell {
             case .viewMore(let handler),
                     .skip(let handler),
                     .remove(let handler):
-                return .init(title: title, image: image, handler: handler)
+                return .init(title: title, image: image, destructive: menuAttributes.contains(.destructive), handler: handler)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
@@ -17,6 +17,18 @@ class MenuSheetViewController: UITableViewController {
         let title: String
         let image: UIImage?
         let handler: () -> Void
+        let destructive: Bool
+
+        init(title: String, image: UIImage? = nil, destructive: Bool = false, handler: @escaping () -> Void) {
+            self.title = title
+            self.image = image
+            self.handler = handler
+            self.destructive = destructive
+        }
+
+        var foregroundColor: UIColor {
+            return destructive ? .error : .text
+        }
     }
 
     private let itemSource: [[MenuItem]]
@@ -96,7 +108,8 @@ extension MenuSheetViewController {
               }
 
         let cell = tableView.dequeueReusableCell(withIdentifier: Constants.cellIdentifier, for: indexPath)
-        cell.tintColor = .text
+        cell.tintColor = item.foregroundColor
+        cell.textLabel?.textColor = item.foregroundColor
         cell.textLabel?.setText(item.title)
         cell.accessoryView = UIImageView(image: item.image?.withTintColor(.text))
 

--- a/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
@@ -111,6 +111,7 @@ extension MenuSheetViewController {
         cell.tintColor = item.foregroundColor
         cell.textLabel?.textColor = item.foregroundColor
         cell.textLabel?.setText(item.title)
+        cell.textLabel?.numberOfLines = 0
         cell.accessoryView = UIImageView(image: item.image?.withTintColor(.text))
 
         return cell

--- a/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/MenuSheetViewController.swift
@@ -145,6 +145,7 @@ private extension MenuSheetViewController {
     func configureTable() {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellIdentifier)
         tableView.sectionHeaderHeight = 0
+        tableView.bounces = false
 
         // draw the separators from edge to edge.
         tableView.separatorInset = .zero


### PR DESCRIPTION
Refs #18250 
Depends on #18290 

As titled, this allows the menu item to be displayed with a `destructive` attribute, similar to the actual `UIMenu`. Additionally, long texts are now wrapped properly (instead of truncated), and the table bounce is removed from the menu.

Before | After
-|-
![context_ios13](https://user-images.githubusercontent.com/1299411/161969894-7a23b97b-7808-42aa-8291-51f1351d55b5.png) | ![ios13_destructive](https://user-images.githubusercontent.com/1299411/161969913-f065bf69-7ac7-465b-8bb8-ae2a73cd2114.png)

Note that the change on `MenuSheetViewController` is not feature flagged, as this is quite minor and should be safe (famous last words 😆 ). Currently only Reader Comments uses `MenuSheetViewController`, so I'll provide additional testing steps to ensure that this has no impact on existing usage.

## To test:

### Verifying the destructive styling on the prompt card

- Build the app targeting iOS 13.
- Enable Blogging Prompts and My Site Dashboard feature flags.
- Tap on the prompt card's ellipsis icon.
- Verify that the "Remove from dashboard" menu item is displayed in red.
- Verify that the text wraps properly.

### Verifying impact on existing usage

- Build the app targeting iOS 13.
- Go to comment threads.
- Tap on the contextual menu on any comment.
- Verify that the menu is displayed properly

## Regression Notes
1. Potential unintended areas of impact
Reader Comments uses the same `MenuSheetViewController`. However, the change is made to ensure that it doesn't impact existing usage.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
