### PR TITLE
My Site Dashboard: ensure error is not shown alongside posts or prompt and only sync authors if the user is an administrator

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -162,7 +162,7 @@ extension PostsCardViewController: PostsCardView {
             return
         }
 
-        errorView?.removeFromSuperview()
+        hideError()
         removeGhostableTableView()
 
         if nextPostView == nil && errorView == nil {
@@ -189,12 +189,18 @@ extension PostsCardViewController: PostsCardView {
         WPAnalytics.track(.dashboardCardShown, properties: ["type": "post", "sub_type": "error"])
     }
 
+    func hideError() {
+        errorView?.removeFromSuperview()
+    }
+
     func showNextPostPrompt() {
         guard nextPostView == nil ||
               nextPostView?.hasPublishedPosts != hasPublishedPosts else {
             notifyOfHeightChange()
             return
         }
+
+        hideError()
 
         self.nextPostView?.removeFromSuperview()
         self.nextPostView = nil

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -8,6 +8,7 @@ protocol PostsCardView: AnyObject {
     func showLoading()
     func hideLoading()
     func showError(message: String, retry: Bool)
+    func hideError()
     func showNextPostPrompt()
     func hideNextPrompt()
     func firstPostPublished()
@@ -212,7 +213,7 @@ private extension PostsCardViewModel {
             self?.syncing = nil
             self?.performInitialLoading()
             self?.refresh()
-        }, failure: { [weak self] _ in
+        }, failure: { [weak self] error in
             self?.syncing = nil
             self?.showLoadingFailureError()
         })
@@ -319,6 +320,7 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
                 fatalError("Cell is not a PostCompactCell")
         }
 
+        viewController?.hideError()
         configurablePostView.configureForDashboard(with: post)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -181,7 +181,8 @@ private extension PostsCardViewModel {
         syncing = (blog.dotComID, status)
 
         // If the userID is nil we need to sync authors
-        if blog.userID == nil {
+        // But only if the user is an admin
+        if blog.userID == nil && blog.isAdmin {
             syncAuthors()
             return
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -214,7 +214,7 @@ private extension PostsCardViewModel {
             self?.syncing = nil
             self?.performInitialLoading()
             self?.refresh()
-        }, failure: { [weak self] error in
+        }, failure: { [weak self] _ in
             self?.syncing = nil
             self?.showLoadingFailureError()
         })


### PR DESCRIPTION
Fixes #18287

This PR has two changes:

1. Ensure that the error message is never displayed together with a next post prompt or posts
2. Do not sync authors if the user is not an administrator §

§ We sync authors in some cases because we want to display only the user posts. However, when the user is not an admin, this API returns an error, which was making the error message appear.

### To test

Use a site to which you are a contributor.

### Making sure the error doesn't appear

1. Navigate to the new dashboard.
1. Tap on a post to get to the posts list and navigate back to the new dashboard again.
1. Keep navigating to different areas of the app before navigating back to the new dashboard and eventually seeing the error.

### Checking offline

1. Delete all your posts on your test site until the next prompt appear
1. Go offline
1. Create a new post and save as draft
1. Make sure no errors are displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
