### PR TITLE
My Site Dashboard: Multiple UI issues fixes for iOS 13

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -53,6 +53,7 @@ class BlogDashboardCardFrameView: UIView {
         chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         chevronImageView.isAccessibilityElement = false
         chevronImageView.isHidden = true
+        chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return chevronImageView
     }()
 
@@ -66,6 +67,7 @@ class BlogDashboardCardFrameView: UIView {
         button.accessibilityLabel = Strings.ellipsisButtonAccessibilityLabel
         button.accessibilityTraits = .button
         button.isHidden = true
+        button.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         button.on(.touchUpInside) { [weak self] _ in
             self?.onEllipsisButtonTap?()
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartChecklistView.swift
@@ -109,7 +109,7 @@ extension QuickStartChecklistView {
             titleLabel.attributedText = NSAttributedString(string: title, attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.single.rawValue])
             titleLabel.textColor = .textSubtle
         } else {
-            titleLabel.attributedText = NSAttributedString(string: title, attributes: [NSAttributedString.Key.strikethroughStyle: []])
+            titleLabel.attributedText = NSAttributedString(string: title, attributes: [:])
             titleLabel.textColor = .text
         }
 


### PR DESCRIPTION
Fixes #18302

## Description
This PR fixes two issues:
1. Fixes an issue found by @dvdchr and mentioned in #18290, where the ellipsis button is misplaced on iOS 13. Issue only happens with the new blogging prompt card, however, I decided to include the fix now just to be safe.
2. Fixes #18302

## Compiling

Use a simulator with iOS 13. If you have an M1 MacBook, you have to do a few extra steps:

1. Under Build Settings > Excluded Architectures > add `arm64`
2. Product > Clean Build Folder
3. Run on a iOS 13 device

## Testing Instructions

1. Run the app on iOS 13 simulator
2. Enable Quick Start
3. Make sure the tour titles are displayed correctly
4. Make sure the ellipsis button is displayed correctly

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.