### PR TITLE
My Site Dashboard: Dashboard data source unit tests

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -42,7 +42,7 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
-    func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil, mySiteSettings: MySiteSettings = MySiteSettings()) -> Bool {
+    func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil, mySiteSettings: DefaultSectionProvider = MySiteSettings()) -> Bool {
         switch self {
         case .quickStart:
             return QuickStartTourGuide.shouldShowChecklist(for: blog) && mySiteSettings.defaultSection == .dashboard

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -1,9 +1,13 @@
 import Foundation
 import WordPressShared
 
+protocol DefaultSectionProvider {
+    var defaultSection: MySiteViewController.Section { get }
+}
+
 /// A helper class for My Site that manages the default section to display
 ///
-@objc final class MySiteSettings: NSObject {
+@objc final class MySiteSettings: NSObject, DefaultSectionProvider {
 
     private var userDefaults: UserDefaults {
         UserDefaults.standard

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1344,6 +1344,7 @@
 		8071390827D039E70012DB21 /* DashboardSingleStatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8071390627D039E70012DB21 /* DashboardSingleStatView.swift */; };
 		808C578F27C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
 		808C579027C7FB1A0099A92C /* ButtonScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */; };
+		80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */; };
 		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
@@ -6067,6 +6068,7 @@
 		806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModelTests.swift; sourceTree = "<group>"; };
 		8071390627D039E70012DB21 /* DashboardSingleStatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSingleStatView.swift; sourceTree = "<group>"; };
 		808C578E27C7FB1A0099A92C /* ButtonScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonScrollView.swift; sourceTree = "<group>"; };
+		80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsStackView.swift; sourceTree = "<group>"; };
@@ -11529,6 +11531,7 @@
 				8B2D4F5427ECE376009B085C /* BlogDashboardPostsParserTests.swift */,
 				8BD34F0827D144FF005E931C /* BlogDashboardStateTests.swift */,
 				806E53E327E01CFE0064315E /* DashboardStatsViewModelTests.swift */,
+				80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -19417,6 +19420,7 @@
 				400A2C8F2217AD7F000A8A59 /* ClicksStatsRecordValueTests.swift in Sources */,
 				7320C8BD2190C9FC0082FED5 /* UITextView+SummaryTests.swift in Sources */,
 				24A2948325D602710000A51E /* BlogTimeZoneTests.m in Sources */,
+				80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */,
 				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,
 				F11023A323186BCA00C4E84A /* MediaBuilder.swift in Sources */,
 				17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -58,27 +58,31 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         let blog = newTestBlog(id: wpComID, context: context)
 
-        service.fetch(blog: blog) { snapshot in
-            let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .posts })
-            let postsCardItem: DashboardCardModel = snapshot.itemIdentifiers(inSection: postsSection!).first!
+        service.fetch(blog: blog) { cards in
+            let draftPostsCardItem = cards.first(where: {$0.cardType == .draftPosts})
+            let scheduledPostsCardItem = cards.first(where: {$0.cardType == .scheduledPosts})
 
             // Posts section exists
-            XCTAssertNotNil(postsSection)
-
-            // Item id is posts
-            XCTAssertEqual(postsCardItem.id, .posts)
+            XCTAssertNotNil(draftPostsCardItem)
+            XCTAssertNotNil(scheduledPostsCardItem)
 
             // Has published is `true`
-            XCTAssertTrue(postsCardItem.apiResponse!.posts!.hasPublished!)
+            XCTAssertTrue(draftPostsCardItem!.apiResponse!.posts!.hasPublished!)
 
             // 3 scheduled item
-            XCTAssertEqual(postsCardItem.apiResponse!.posts!.draft!.count, 3)
+            XCTAssertEqual(draftPostsCardItem!.apiResponse!.posts!.draft!.count, 3)
 
             // 1 scheduled item
-            XCTAssertEqual(postsCardItem.apiResponse!.posts!.scheduled!.count, 1)
+            XCTAssertEqual(draftPostsCardItem!.apiResponse!.posts!.scheduled!.count, 1)
 
-            // cell view model is a `NSDictionary`
-            XCTAssertTrue(postsCardItem.hashableDictionary!["has_published"] as! Bool)
+            // Has published is `true`
+            XCTAssertTrue(scheduledPostsCardItem!.apiResponse!.posts!.hasPublished!)
+
+            // 3 scheduled item
+            XCTAssertEqual(scheduledPostsCardItem!.apiResponse!.posts!.draft!.count, 3)
+
+            // 1 scheduled item
+            XCTAssertEqual(scheduledPostsCardItem!.apiResponse!.posts!.scheduled!.count, 1)
 
             expect.fulfill()
         }
@@ -92,50 +96,17 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         let blog = newTestBlog(id: wpComID, context: context)
 
-        service.fetch(blog: blog) { snapshot in
-            let todaysStatsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .todaysStats })
-            let todaysStatsItem: DashboardCardModel = snapshot.itemIdentifiers(inSection: todaysStatsSection!).first!
+        service.fetch(blog: blog) { cards in
+            let todaysStatsItem = cards.first(where: {$0.cardType == .todaysStats})
 
             // Todays stats section exists
-            XCTAssertNotNil(todaysStatsSection)
-
-            // The item identifier id is todaysStats
-            XCTAssertEqual(todaysStatsItem.id, .todaysStats)
+            XCTAssertNotNil(todaysStatsItem)
 
             // Entity has the correct values
-            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.views, 0)
-            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.visitors, 0)
-            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.likes, 0)
-            XCTAssertEqual(todaysStatsItem.apiResponse!.todaysStats!.comments, 0)
-
-            // Todays Stats has the correct NSDictionary
-            XCTAssertEqual(todaysStatsItem.hashableDictionary, ["views": 0, "visitors": 0, "likes": 0, "comments": 0])
-
-            expect.fulfill()
-        }
-
-        waitForExpectations(timeout: 3, handler: nil)
-    }
-
-    func testLocalCards() {
-        let expect = expectation(description: "Return local cards stats")
-        remoteServiceMock.respondWith = .withDraftAndSchedulePosts
-
-        let blog = newTestBlog(id: wpComID, context: context)
-
-        service.fetch(blog: blog) { snapshot in
-            // Quick Actions exists
-            let quickActionsSection = snapshot.sectionIdentifiers.filter { $0.id == .quickActions }
-            XCTAssertEqual(quickActionsSection.count, 1)
-
-            // The item identifier id is quick actions
-            XCTAssertEqual(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.id, .quickActions)
-
-            // It doesn't have an api response dictionary
-            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.hashableDictionary)
-
-            // It doesn't have an api response entity
-            XCTAssertNil(snapshot.itemIdentifiers(inSection: quickActionsSection.first!).first?.apiResponse)
+            XCTAssertEqual(todaysStatsItem!.apiResponse!.todaysStats!.views, 0)
+            XCTAssertEqual(todaysStatsItem!.apiResponse!.todaysStats!.visitors, 0)
+            XCTAssertEqual(todaysStatsItem!.apiResponse!.todaysStats!.likes, 0)
+            XCTAssertEqual(todaysStatsItem!.apiResponse!.todaysStats!.comments, 0)
 
             expect.fulfill()
         }
@@ -165,10 +136,12 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         let blog = newTestBlog(id: wpComID, context: context)
 
-        let snapshot = service.fetchLocal(blog: blog)
+        let cards = service.fetchLocal(blog: blog)
 
-        let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .posts })
-        XCTAssertNotNil(postsSection)
+        let hasDrafts = cards.contains(where: {$0.cardType == .draftPosts})
+        let hasScheduled = cards.contains(where: {$0.cardType == .scheduledPosts})
+        XCTAssertTrue(hasDrafts)
+        XCTAssertTrue(hasScheduled)
         XCTAssertEqual(persistenceMock.didCallGetCardsWithWpComID, wpComID)
     }
 
@@ -181,9 +154,9 @@ class ZBlogDashboardServiceTests: XCTestCase {
         remoteServiceMock.respondWith = .withDraftAndSchedulePosts
         let blog = newTestBlog(id: 10, context: context)
 
-        service.fetch(blog: blog) { snapshot in
-            let ghostSection = snapshot.sectionIdentifiers.first(where: { $0.id == .ghost })
-            XCTAssertNil(ghostSection)
+        service.fetch(blog: blog) { cards in
+            let hasGhost = cards.contains(where: {$0.cardType == .ghost})
+            XCTAssertFalse(hasGhost)
 
             expect.fulfill()
         }
@@ -197,10 +170,10 @@ class ZBlogDashboardServiceTests: XCTestCase {
         persistenceMock.respondWith = dictionary(from: "dashboard-200-with-drafts-and-scheduled.json")!
         let blog = newTestBlog(id: 11, context: context)
 
-        let snapshot = service.fetchLocal(blog: blog)
+        let cards = service.fetchLocal(blog: blog)
 
-        let ghostSection = snapshot.sectionIdentifiers.first(where: { $0.id == .ghost })
-        XCTAssertNil(ghostSection)
+        let hasGhost = cards.contains(where: {$0.cardType == .ghost})
+        XCTAssertFalse(hasGhost)
     }
 
     /// Ghost cards SHOULD be displayed when there are no cached data
@@ -210,11 +183,10 @@ class ZBlogDashboardServiceTests: XCTestCase {
         persistenceMock.respondWith = nil
         let blog = newTestBlog(id: 12, context: context)
 
-        let snapshot = service.fetchLocal(blog: blog)
+        let cards = service.fetchLocal(blog: blog)
 
-        let ghostSection = snapshot.sectionIdentifiers.first(where: { $0.id == .ghost })
-        XCTAssertNotNil(ghostSection)
-        XCTAssertEqual(snapshot.itemIdentifiers(inSection: ghostSection!).count, 1)
+        let ghostCards = cards.filter({$0.cardType == .ghost})
+        XCTAssertEqual(ghostCards.count, 1)
     }
 
     // MARK: - Error card
@@ -227,9 +199,9 @@ class ZBlogDashboardServiceTests: XCTestCase {
         persistenceMock.respondWith = nil
         let blog = newTestBlog(id: 13, context: context)
 
-        service.fetch(blog: blog) { _ in } failure: { snapshot in
-            let failureSection = snapshot?.sectionIdentifiers.first(where: { $0.id == .failure })
-            XCTAssertNotNil(failureSection)
+        service.fetch(blog: blog) { _ in } failure: { cards in
+            let hasError = cards.contains(where: {$0.cardType == .failure})
+            XCTAssertTrue(hasError)
 
             expect.fulfill()
         }
@@ -247,13 +219,13 @@ class ZBlogDashboardServiceTests: XCTestCase {
         let blog = newTestBlog(id: 14, context: context)
 
         /// Call it once and fails
-        service.fetch(blog: blog) { _ in } failure: { snapshot in
+        service.fetch(blog: blog) { _ in } failure: { cards in
 
             self.remoteServiceMock.respondWith = .withDraftAndSchedulePosts
             /// Call again and succeeds
-            self.service.fetch(blog: blog) { snapshot in
-                let failureSection = snapshot.sectionIdentifiers.first(where: { $0.id == .failure })
-                XCTAssertNil(failureSection)
+            self.service.fetch(blog: blog) { cards in
+                let hasError = cards.contains(where: {$0.cardType == .failure})
+                XCTAssertFalse(hasError)
 
                 expect.fulfill()
             }
@@ -275,15 +247,11 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         let blog = newTestBlog(id: wpComID, context: context)
 
-        service.fetch(blog: blog) { snapshot in
-            let postsSection = snapshot.sectionIdentifiers.first(where: { $0.id == .posts })
-            let postsCardItem: DashboardCardModel = snapshot.itemIdentifiers(inSection: postsSection!).first!
-
-            // It should have 1 draft items
-            XCTAssertEqual(postsCardItem.apiResponse!.posts!.draft!.count, 1)
-
-            // It should have 1 scheduled item
-            XCTAssertEqual(postsCardItem.apiResponse!.posts!.scheduled!.count, 1)
+        service.fetch(blog: blog) { cards in
+            let hasDrafts = cards.contains(where: {$0.cardType == .draftPosts})
+            let hasScheduled = cards.contains(where: {$0.cardType == .scheduledPosts})
+            XCTAssertTrue(hasDrafts)
+            XCTAssertTrue(hasScheduled)
 
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -58,9 +58,10 @@ class DashboardCardTests: XCTestCase {
     func testShouldAlwaysShowStatsCard() {
         // Given
         let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: false, hasScheduled: false, hasPublished: false)
 
         // When
-        let shouldShow = DashboardCard.todaysStats.shouldShow(for: blog)
+        let shouldShow = DashboardCard.todaysStats.shouldShow(for: blog, apiResponse: apiResponse)
 
         // Then
         XCTAssertTrue(shouldShow)

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -249,6 +249,25 @@ class DashboardCardTests: XCTestCase {
 
     // MARK: Remote Cards
 
+    func testNotShowingRemoteCardsIfResponseNotPresent() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: nil)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: nil)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: nil)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: nil)
+        let shouldShowStats = DashboardCard.createPost.shouldShow(for: blog, apiResponse: nil)
+
+        // Then
+        XCTAssertFalse(shouldShowDrafts)
+        XCTAssertFalse(shouldShowScheduled)
+        XCTAssertFalse(shouldShowNextPost)
+        XCTAssertFalse(shouldShowCreatePost)
+        XCTAssertFalse(shouldShowStats)
+    }
+
     func testRemoteCardsIdentifiers() {
         // When
         let identifiers = DashboardCard.RemoteDashboardCard.allCases.map { $0.rawValue }

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -1,0 +1,268 @@
+import XCTest
+@testable import WordPress
+
+class MockDefaultSectionProvider: DefaultSectionProvider {
+    var defaultSection: MySiteViewController.Section
+
+    init(defaultSection: MySiteViewController.Section) {
+        self.defaultSection = defaultSection
+    }
+}
+
+class DashboardCardTests: XCTestCase {
+
+    // MARK: Quick Start
+
+    func testShouldShowQuickStartIfEnabledAndDefaultSectionIsDashboard() {
+        // Given
+        let mySiteSettings = MockDefaultSectionProvider(defaultSection: .dashboard)
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        QuickStartTourGuide.shared.setup(for: blog)
+
+        // When
+        let shouldShow = DashboardCard.quickStart.shouldShow(for: blog, mySiteSettings: mySiteSettings)
+
+        // Then
+        XCTAssertTrue(shouldShow)
+    }
+
+    func testShouldNotShowQuickStartIfDefaultSectionIsSiteMenu() {
+        // Given
+        let mySiteSettings = MockDefaultSectionProvider(defaultSection: .siteMenu)
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        QuickStartTourGuide.shared.setup(for: blog)
+
+        // When
+        let shouldShow = DashboardCard.quickStart.shouldShow(for: blog, mySiteSettings: mySiteSettings)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    func testShouldNotShowQuickStartIfDisabled() {
+        // Given
+        let mySiteSettings = MockDefaultSectionProvider(defaultSection: .dashboard)
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        QuickStartTourGuide.shared.setup(for: blog)
+        QuickStartTourGuide.shared.remove(from: blog)
+
+        // When
+        let shouldShow = DashboardCard.quickStart.shouldShow(for: blog, mySiteSettings: mySiteSettings)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    // MARK: Stats
+
+    func testShouldAlwaysShowStatsCard() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+
+        // When
+        let shouldShow = DashboardCard.todaysStats.shouldShow(for: blog)
+
+        // Then
+        XCTAssertTrue(shouldShow)
+    }
+
+    // MARK: Ghost
+
+    func testShouldShowGhostCardOnFirstLoad() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = false
+        dashboardState.failedToLoad = false
+
+        // When
+        let shouldShow = DashboardCard.ghost.shouldShow(for: blog)
+
+        // Then
+        XCTAssertTrue(shouldShow)
+    }
+
+    func testShouldNotShowGhostCardIfLoaded() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = true
+        dashboardState.failedToLoad = false
+
+        // When
+        let shouldShow = DashboardCard.ghost.shouldShow(for: blog)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    func testShouldNotShowGhostCardIfFailedToLoad() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = false
+        dashboardState.failedToLoad = true
+
+        // When
+        let shouldShow = DashboardCard.ghost.shouldShow(for: blog)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    // MARK: Failure
+
+    func testShouldShowFailureCardOnFirstLoadFailure() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = false
+        dashboardState.failedToLoad = true
+
+        // When
+        let shouldShow = DashboardCard.failure.shouldShow(for: blog)
+
+        // Then
+        XCTAssertTrue(shouldShow)
+    }
+
+    func testShouldNotShowFailureCardIfSecondLoadFailed() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = true
+        dashboardState.failedToLoad = true
+
+        // When
+        let shouldShow = DashboardCard.failure.shouldShow(for: blog)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    func testShouldNotShowFailureCardIfLoaded() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let dashboardState = BlogDashboardState.shared(for: blog)
+        dashboardState.hasCachedData = true
+        dashboardState.failedToLoad = false
+
+        // When
+        let shouldShow = DashboardCard.failure.shouldShow(for: blog)
+
+        // Then
+        XCTAssertFalse(shouldShow)
+    }
+
+    // MARK: Posts
+
+    func testShowingDraftsCardOnly() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: true, hasScheduled: false, hasPublished: false)
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: apiResponse)
+
+        // Then
+        XCTAssertTrue(shouldShowDrafts)
+        XCTAssertFalse(shouldShowScheduled)
+        XCTAssertFalse(shouldShowNextPost)
+        XCTAssertFalse(shouldShowCreatePost)
+    }
+
+    func testShowingScheduledCardOnly() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: false, hasScheduled: true, hasPublished: false)
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: apiResponse)
+
+        // Then
+        XCTAssertFalse(shouldShowDrafts)
+        XCTAssertTrue(shouldShowScheduled)
+        XCTAssertFalse(shouldShowNextPost)
+        XCTAssertFalse(shouldShowCreatePost)
+    }
+
+    func testShowingDraftsAndScheduled() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: true, hasScheduled: true, hasPublished: false)
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: apiResponse)
+
+        // Then
+        XCTAssertTrue(shouldShowDrafts)
+        XCTAssertTrue(shouldShowScheduled)
+        XCTAssertFalse(shouldShowNextPost)
+        XCTAssertFalse(shouldShowCreatePost)
+    }
+
+    func testShowingNextPostCardOnly() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: false, hasScheduled: false, hasPublished: true)
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: apiResponse)
+
+        // Then
+        XCTAssertFalse(shouldShowDrafts)
+        XCTAssertFalse(shouldShowScheduled)
+        XCTAssertTrue(shouldShowNextPost)
+        XCTAssertFalse(shouldShowCreatePost)
+    }
+
+    func testShowingCreatePostCardOnly() {
+        // Given
+        let blog = BlogBuilder(TestContextManager().mainContext).build()
+        let apiResponse = buildEntity(hasDrafts: false, hasScheduled: false, hasPublished: false)
+
+        // When
+        let shouldShowDrafts = DashboardCard.draftPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowScheduled = DashboardCard.scheduledPosts.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowNextPost = DashboardCard.nextPost.shouldShow(for: blog, apiResponse: apiResponse)
+        let shouldShowCreatePost = DashboardCard.createPost.shouldShow(for: blog, apiResponse: apiResponse)
+
+        // Then
+        XCTAssertFalse(shouldShowDrafts)
+        XCTAssertFalse(shouldShowScheduled)
+        XCTAssertFalse(shouldShowNextPost)
+        XCTAssertTrue(shouldShowCreatePost)
+    }
+
+    // MARK: Remote Cards
+
+    func testRemoteCardsIdentifiers() {
+        // When
+        let identifiers = DashboardCard.RemoteDashboardCard.allCases.map { $0.rawValue }
+
+        // Then
+        XCTAssertEqual(identifiers, ["todays_stats", "posts"])
+    }
+
+    // MARK: Helpers
+
+    private func buildEntity(hasDrafts: Bool, hasScheduled: Bool, hasPublished: Bool) -> BlogDashboardRemoteEntity {
+        let drafts = hasDrafts ? [BlogDashboardRemoteEntity.BlogDashboardPosts.BlogDashboardPost()] : []
+        let scheduled = hasScheduled ? [BlogDashboardRemoteEntity.BlogDashboardPosts.BlogDashboardPost()] : []
+        let posts = BlogDashboardRemoteEntity.BlogDashboardPosts(hasPublished: hasPublished, draft: drafts, scheduled: scheduled)
+        return BlogDashboardRemoteEntity(posts: posts, todaysStats: nil)
+    }
+
+}


### PR DESCRIPTION
Part of #18308

## Description
This adds and fixes tests related to #18309 and #18310
- Fixes tests build errors in `BlogDashboardServiceTests`
- Adds `DashboardCardTests` 


## Testing Instructions

N/A

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
