### PR TITLE
My Site Dashboard: change how `default_tab_experiment` is tracked

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -353,10 +353,6 @@ class AppSettingsViewController: UITableViewController {
 
                 WPAnalytics.track(.initialScreenChanged, properties: ["selected": defaultSection.analyticsDescription])
                 MySiteSettings().setDefaultSection(defaultSection)
-
-                /// If an user changes it's default screen we update the user metadata
-                /// to track the correct experiment assignment.
-                WPAnalytics.refreshMetadata()
             }
 
             self?.navigationController?.pushViewController(viewController!, animated: true)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -535,9 +535,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             if FeatureFlag.mySiteDashboard.enabled {
                 let isTreatment = BlogDashboardAB.shared.variant == .treatment
                 MySiteSettings().setDefaultSection(isTreatment ? .dashboard : .siteMenu)
-
-                // Refresh analytics metadata to track the `default_tab_experiment` correctly
-                WPAnalytics.refreshMetadata()
             }
         }
     }


### PR DESCRIPTION
While reviewing the events for My Site Dashboard, I identified a minor issue:

When changing the initial screen the `my_site_default_tab_experiment_variant_assigned` was being triggered with the old screen value. This isn't a big deal because I don't expect many users to change that, but it's better to have everything correct.

Given the `default_tab_experiment` was added in a different way and it was "invisible" I changed how it is added and now it's also displayed on the logs for better visibility.

### To test

1. Remove the app
2. Install it again
3. Check that before you login the `default_tab_experiment` is `nonexistent`
4. After you login it changes to `dashboard` or `site_menu` and it's the same for all the next events
5. Close and reopen the app
6. Make sure `default_tab_experiment` didn't change
7. Go to Me > Settings
8. Change the initial screen
9. Make sure the events are triggered with the new selected value
10. make sure all subsequent events are triggered with this new value

#### Double-check tracks

1. Go to Tracks > Live
2. Filter by your username
3. Make sure the events are there and have the correct properties

## Regression Notes
1. Potential unintended areas of impact
All events of the app

3. What I did to test those areas of impact (or what existing automated tests I relied on)
I manually tested that they are correctly triggered.

4. What automated tests I added (or what prevented me from doing so)


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
