### PR TITLE
[Site Intent] Trim whitespace and newlines from search input

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -197,13 +197,14 @@ extension SiteIntentViewController: UISearchBarDelegate {
 
     func searchBar(_ searchBar: UISearchBar, textDidChange searchText: String) {
 
-        if searchText.isEmpty {
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmedSearch.isEmpty {
             SiteIntentData.clearCustomVerticals()
         } else {
-            SiteIntentData.insertCustomVertical(searchText)
+            SiteIntentData.insertCustomVertical(trimmedSearch)
         }
 
-        availableVerticals = SiteIntentData.getVerticals(searchText)
+        availableVerticals = SiteIntentData.getVerticals(trimmedSearch)
         tableView.reloadData()
     }
 }


### PR DESCRIPTION
Fixes an issue where:
- Whitespace could be input into the search bar, creating a blank custom vertical
- Existing verticals with spaces would show as search results

| Before | After |
| ------ | ----- |
| ![Simulator Screen Shot - iPhone 13 - 2022-04-07 at 11 38 19](https://user-images.githubusercontent.com/2092798/162238130-e1502ca9-dc3d-49c3-a40d-b4668dca52bc.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-07 at 11 37 26](https://user-images.githubusercontent.com/2092798/162238083-abf5c043-fa1e-4d99-9fe0-ae9170522170.png) |

## To test:

Prerequisites: The user must be in the treatment group for Site Intent and the feature flag must be enabled. https://github.com/wordpress-mobile/WordPress-iOS/pull/18083. To programmatically control the group, return .treatment [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/bug/clear-custom-vertical/WordPress/Classes/ViewRelated/Site%20Creation/Wizard/SiteIntentAB.swift#L26).

1. Start the site creation flow by creating a new site
2. On the Site Intent view, type a space (" ") into the input
3. Observe that no custom vertical is created
4. Observe that the vertical results aren't filtered by names with spaces

## Regression Notes
1. Potential unintended areas of impact
Searching for verticals

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual steps above

6. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
