### PR TITLE
My Site Dashboard: Update dashboard layout when trait collection changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -438,6 +438,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
     [super traitCollectionDidChange:previousTraitCollection];
+    
+    // Required to add / remove "Home" section when switching between regular and compact width
+    [self configureTableViewData];
 
     // Required to update disclosure indicators depending on split view status
     [self reloadTableViewPreservingSelection];

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -209,15 +209,28 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        // When switching from compact width to regular width, if the dashboard tab is selected
-        // we must switch to the site menu tab.
+        // When switching between compact and regular width, we need to make sure to select the
+        // appropriate tab. This ensures the following:
         //
-        // This ensures that the site menu is shown in the left pane of the split vc.
+        // 1. Compact -> Regular: If the dashboard tab is selected, switch to the site menu tab
+        // so that the site menu is shown in the left pane of the split vc
         //
-        if previousTraitCollection.horizontalSizeClass == .compact,
-           traitCollection.horizontalSizeClass == .regular,
-           isShowingDashboard {
+        // 2. Regular -> Compact: Switch to the default tab
+        //
+
+        let isCompactToRegularWidth =
+            previousTraitCollection.horizontalSizeClass == .compact &&
+            traitCollection.horizontalSizeClass == .regular
+
+        let isRegularToCompactWidth =
+            previousTraitCollection.horizontalSizeClass == .regular &&
+            traitCollection.horizontalSizeClass == .compact
+
+        if isCompactToRegularWidth, isShowingDashboard {
             segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
+            segmentedControlValueChanged()
+        } else if isRegularToCompactWidth {
+            segmentedControl.selectedSegmentIndex = mySiteSettings.defaultSection.rawValue
             segmentedControlValueChanged()
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -199,12 +199,26 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         createButtonCoordinator?.presentingTraitCollectionWillChange(traitCollection, newTraitCollection: newCollection)
+    }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard let blog = blog else {
+        guard let previousTraitCollection = previousTraitCollection,
+            let blog = blog else {
             return
+        }
+
+        // When switching from compact width to regular width, if the dashboard tab is selected
+        // we must switch to the site menu tab.
+        //
+        // This ensures that the site menu is shown in the left pane of the split vc.
+        //
+        if previousTraitCollection.horizontalSizeClass == .compact,
+           traitCollection.horizontalSizeClass == .regular,
+           isShowingDashboard {
+            segmentedControl.selectedSegmentIndex = Section.siteMenu.rawValue
+            segmentedControlValueChanged()
         }
 
         updateSegmentedControl(for: blog)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -199,6 +199,15 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
         createButtonCoordinator?.presentingTraitCollectionWillChange(traitCollection, newTraitCollection: newCollection)
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard let blog = blog else {
+            return
+        }
+
+        updateSegmentedControl(for: blog)
     }
 
     private func subscribeToContentSizeCategory() {
@@ -214,8 +223,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func updateSegmentedControl(for blog: Blog, switchTabsIfNeeded: Bool = false) {
-        // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device is an iPad
-        let hideSegmentedControl = !FeatureFlag.mySiteDashboard.enabled || !blog.isAccessibleThroughWPCom() || !splitViewControllerIsHorizontallyCompact
+        // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device doesn't have a horizontally compact view
+        let hideSegmentedControl =
+            !FeatureFlag.mySiteDashboard.enabled ||
+            !blog.isAccessibleThroughWPCom() ||
+            !splitViewControllerIsHorizontallyCompact
 
         segmentedControlContainerView.isHidden = hideSegmentedControl
 


### PR DESCRIPTION
Fixes #18288

## Description

Handled updating the dashboard layout when switching between compact width and regular width. 

This fixes issues for rotating between portrait / landscape on larger iPhones ([iPhones that have regular width in landscape orientation](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/)), as well as multitasking on iPad.

## How to test

<img width="716" alt="Screen Shot 2022-04-07 at 17 55 31" src="https://user-images.githubusercontent.com/6711616/162256701-3253bedf-bf73-4410-88bb-78a5534db75d.png">

### Larger iPhones

Use an iPhone that has regular width size class in landscape orientation (e.g. iPhone 11, iPhone 13 Pro Max)

1. Launch in portrait, select the Site Menu tab
2. ✅ Make sure the **compact width requirements** are satisfied (see chart at top of this section)
3. Rotate to landscape
4. ✅ Make sure the **regular width requirements** are satisfied
5. Rotate back to portrait
6. Select the Home tab
7. Rotate to landscape
8. ✅ Make sure the **regular width requirements** are satisfied


https://user-images.githubusercontent.com/6711616/162257471-04c09231-63da-47e0-9ff6-b737dd7cf4af.mp4


### Multitasking on iPad

1. Add another window of any other app. You should have WordPress and another app running side by side
2. ✅ Make sure the **compact width requirements** are satisfied if the WordPress window is compact width (see chart at top of this section)
3. ✅ Make sure the **regular width requirements** are satisfied if the WordPress window is regular width

_Note: the window size class depends on the iPad model. See Figure 2-1 in this [guide on multitasking](https://developer.apple.com/library/archive/documentation/WindowsViews/Conceptual/AdoptingMultitaskingOniPad/QuickStartForSlideOverAndSplitView.html#//apple_ref/doc/uid/TP40015145-CH13) from Apple._

Multitasking compact | Multitasking regular | No multitasking
-- | -- | --
![Simulator Screen Shot - iPad Air (4th generation) - 2022-04-07 at 18 08 20](https://user-images.githubusercontent.com/6711616/162258860-a60b07ed-6985-4ae5-bc0a-e2b703abd2dd.png) | ![Simulator Screen Shot - iPad Air (4th generation) - 2022-04-07 at 17 38 09](https://user-images.githubusercontent.com/6711616/162258603-15684587-1034-4600-b5f3-ab717e4da167.png) | ![Simulator Screen Shot - iPad Air (4th generation) - 2022-04-07 at 17 37 39](https://user-images.githubusercontent.com/6711616/162258643-12a6243b-8a41-4b05-9cd3-917176e52877.png)




## Regression Notes
1. Potential unintended areas of impact
n/a

9. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

10. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
