### PR TITLE
[Site Intent] Fix title not showing on rotation in Site Intent screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -24,6 +24,12 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         return self.hasAccessoryBar ? .visibile : .automatic
     }
 
+    // If set to true, the header will always be pushed down after rotating from compact to regular
+    // If set to false, this will only happen for no results views (default behavior).
+    var alwaysResetHeaderOnRotation: Bool {
+        false
+    }
+
     private let hasDefaultAction: Bool
     private var notificationObservers: [NSObjectProtocol] = []
     @IBOutlet weak var containerView: UIView!
@@ -241,10 +247,12 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        guard isShowingNoResults else { return }
+        guard isShowingNoResults || alwaysResetHeaderOnRotation else { return }
         coordinator.animate(alongsideTransition: nil) { (_) in
             self.updateHeaderDisplay()
-            if self.shouldHideAccessoryBar {
+            // we're keeping this only for no results,
+            // as originally intended before introducing the flag alwaysResetHeaderOnRotation
+            if self.shouldHideAccessoryBar, self.isShowingNoResults {
                 self.disableInitialLayoutHelpers()
                 self.snapToHeight(self.scrollableView, height: self.minHeaderHeight, animated: false)
             }

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -31,7 +31,8 @@ class SiteIntentViewController: CollapsableHeaderViewController {
     }
 
     override var alwaysResetHeaderOnRotation: Bool {
-        true
+        // the default behavior works on iPad, so let's not override it
+        WPDeviceIdentification.isiPhone()
     }
 
     init(_ selection: @escaping SiteIntentStep.SiteIntentSelection) {

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -30,6 +30,10 @@ class SiteIntentViewController: CollapsableHeaderViewController {
         return .hidden
     }
 
+    override var alwaysResetHeaderOnRotation: Bool {
+        true
+    }
+
     init(_ selection: @escaping SiteIntentStep.SiteIntentSelection) {
         self.selection = selection
         tableView = UITableView(frame: .zero, style: .plain)


### PR DESCRIPTION
Fixes #NA

This PR fixes an issue that prevented the large title to properly show on iPhone, when rotating from landscape to portrait (see animations below)

To test:

- Enable the `siteIntentQuestion` feature flag, and, for convenience, bypass the AB test. This can be done in one single place, by temporarily disabling the following code, around line 18 in `SiteIntentStep`:

 
`guard FeatureFlag.siteIntentQuestion.enabled && variant == .treatment else {
            return nil
        }`

- checkout/build/run this branch on an iPhone or iPhone simulator
- go to My Site and rotate to landscape
- Start the site creation flow
- Notice the site intent step appearing
- Rotate to portrait, and make sure that the large title is properly displayed

before | after
-- | --
![Title-rotation-issue](https://user-images.githubusercontent.com/34376330/162370137-a7274109-fae1-449a-92c3-7584f2062ccc.gif) | ![Title-rotation-ok](https://user-images.githubusercontent.com/34376330/162370162-2fb82f44-be2f-4400-ac91-4efdf24ebb45.gif)



## Regression Notes
1. Potential unintended areas of impact
None, this only changes a layout behavior in site intent

2. What I did to test those areas of impact (or what existing automated tests I relied on)
na

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
