### PR TITLE
My Site Dashboard: Fix RtL for quick start and dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -47,7 +47,8 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Chevron displayed in case there's any action associated
     private lazy var chevronImageView: UIImageView = {
-        let chevronImageView = UIImageView(image: UIImage.gridicon(.chevronRight, size: Constants.iconSize).withRenderingMode(.alwaysTemplate))
+        let chevronImage = UIImage.gridicon(.chevronRight, size: Constants.iconSize).withRenderingMode(.alwaysTemplate)
+        let chevronImageView = UIImageView(image: chevronImage.imageFlippedForRightToLeftLayoutDirection())
         chevronImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
         chevronImageView.tintColor = .listIcon
         chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -127,6 +127,11 @@ extension DashboardQuickActionsCardCell {
             stackView.topAnchor.constraint(equalTo: scrollView.topAnchor),
             stackView.bottomAnchor.constraint(equalTo: scrollView.bottomAnchor)
         ])
+
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            scrollView.transform = CGAffineTransform(scaleX: -1, y: 1)
+            stackView.transform = CGAffineTransform(scaleX: -1, y: 1)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes p5T066-37N-p2#comment-11900

## Description

This PR fixes two RtL issues on the dashboard:
- The quick actions scrollview start position
- The chevron image in dashboard cards

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/162416688-7dcdd6c4-339b-4d4c-bc74-2b164cdc733f.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/162416706-a165116b-1ef3-46eb-b979-619390f8b805.png" width=200>

## How to test

1. Edit the WordPress scheme and select a RtL language (Edit Scheme > Run > Options > App Language)
2. Run the app
3. On My Site, select the Home tab
4. ✅ Check that the Quick Actions scrollview is scrolled all the way to the right (i.e. The posts quick action is completely visible)
5. ✅ Check that the chevron on the dashboard cards points to the left

## Regression Notes
1. Potential unintended areas of impact
- LtR languages

6. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested manually, verified that the above changes don't affect LtR languages

7. What automated tests I added (or what prevented me from doing so)
- n/a, just visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.