### PR TITLE
My Site Dashboard: use fade animation in posts card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -307,6 +307,7 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
         snapshot.reloadItems(reloadIdentifiers)
 
         let shouldAnimate = viewController?.tableView.numberOfSections != 0 && viewController?.tableView.numberOfRows(inSection: 0) != 0
+        dataSource.defaultRowAnimation = .fade
         dataSource.apply(snapshot as Snapshot,
                          animatingDifferences: shouldAnimate,
                          completion: { [weak self] in


### PR DESCRIPTION
This changes the default animation in posts card to fade.

Before: 

https://user-images.githubusercontent.com/7040243/162443140-3c1dc0c3-de8b-4352-8b1a-a992233577ec.mp4

After:

https://user-images.githubusercontent.com/7040243/162443193-8ac85a13-81bd-4937-8449-47638bff1f41.mp4

### To test

1. Run the app
2. Create a new post
3. ✅ Notice how the post doesn't fly into the position

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
