### PR TITLE
Issue/18323 Stop grow audience card from being displayed incorrectly

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -210,6 +210,8 @@ private extension SiteStatsInsightsTableViewController {
                 if viewsCount != nil {
                     trackNudgeShown(for: hintType)
                 }
+            case InsightType.customize where !insightsToShow.contains(.customize):
+                insightsToShow = insightsToShow.filter { $0 != .growAudience }
             default:
                 break
             }


### PR DESCRIPTION
Fixes #18323. This PR fixes the issue detailed in #18323, where the Grow Audience empty stats card could be displayed incorrectly after the Customise card was hidden in #18058.

**To test**

* Build and run and navigate to a site with a lot of views (over 3000). In Stats > Insights, ensure you don't see a Grow Your Audience card.
* Navigate to a site with a small number of views (fewer than 3000). In Stats > Insights, you should see a Grow Your Audience card.

cc @leandroalonso 

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
