### PR TITLE
My Site Dashboard: open the editor without delay

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewController.swift
@@ -120,8 +120,8 @@ private extension PostsCardViewController {
     }
 
     func presentEditor() {
-        let editor = EditPostViewController(blog: blog)
-        present(editor, animated: true)
+        let controller = tabBarController as? WPTabBarController
+        controller?.showPostTab()
     }
 
     func notifyOfHeightChange() {


### PR DESCRIPTION
Fixes #18331

This PR changes how the editor is presented to be quicker.

### To test

1. Open the app
2. Open the dashboard for a blog without drafts or scheduled
3. Tap the "write your first post" or "write your next post" prompt
4. ✅ Check that the editor opens right away, without delay5. 

### Additional info

I'm really not 100% sure why we had this delay before but I believe it's because of the Core Data context shared between the blog and the fetched results controller. By initializing this way, we give enough time for the editor to open before the core data operations start on the table view.

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
