### PR TITLE
Blogging Prompts: Update prompt card lightbulb icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -226,7 +226,7 @@ private extension DashboardPromptsCardCell {
     }
 
     struct Style {
-        static let frameIconImage = UIImage(systemName: "lightbulb")
+        static let frameIconImage = UIImage(named: "icon-lightbulb-outline")?.resizedImage(Constants.cardIconSize, interpolationQuality: .default)
         static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
         static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
         static let buttonTitleColor = UIColor.primary
@@ -236,6 +236,7 @@ private extension DashboardPromptsCardCell {
     struct Constants {
         static let spacing: CGFloat = 12
         static let answeredButtonsSpacing: CGFloat = 16
+        static let cardIconSize = CGSize(width: 18, height: 18)
         static let cardFrameConstraintPriority = UILayoutPriority(999)
     }
 


### PR DESCRIPTION
Refs #18250 
Depends on #18320

As titled, this updates the lightbulb icon from SFSymbols to `icon-lightbulb-outline`.

Before | After
-|-
![lightbulb_before](https://user-images.githubusercontent.com/1299411/162482446-8c46bf77-1734-45f9-b1ec-cfe8e7f6717c.png) | ![lightbulb_after](https://user-images.githubusercontent.com/1299411/162482439-5ee3ea1a-f776-43be-8423-408900a3b9b0.png)

## To test

- Turn on Blogging Prompts and My Site Dashboard feature flags.
- Go to My Site Dashboard, Home tab.
- Verify that the prompt card is displayed with the new lightbulb icon.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is under development.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
