### PR TITLE
[Site Intent] Disable emoji description on VoiceOver

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
@@ -26,6 +26,9 @@
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="😎" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h9n-u3-B9Q" userLabel="Emoji">
                                         <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <bool key="isElement" value="NO"/>
+                                        </accessibility>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>


### PR DESCRIPTION
This PR disables emojis from being announced by VoiceOver on the Site Intent screen.

## To test:

| Before (contains audio) 🔈 | After (contains audio) 🔈  |
| ------ | ----- |
| <video src="https://user-images.githubusercontent.com/2092798/162765619-01e6c660-b2c5-4949-85ad-e90557456383.MP4" /> | <video src="https://user-images.githubusercontent.com/2092798/162765675-0ea2691c-fb8e-4ae8-a405-bb1d30729403.MP4" /> |


**Prerequisites:** The user must be in the `treatment` group for Site Intent and the feature flag must be enabled. [More information here](https://github.com/wordpress-mobile/WordPress-iOS/pull/18083). To programmatically control the group, return `.treatment` [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/bug/clear-custom-vertical/WordPress/Classes/ViewRelated/Site%20Creation/Wizard/SiteIntentAB.swift#L26).

VoiceOver should be enabled to test this. [See instructions on how to easily toggle this setting](https://support.apple.com/guide/iphone/accessibility-shortcuts-iph3e2e31a5/15.0/ios/15.0#iph3ce566f26).

1. Start the site creation flow by creating a new site
2. On the Site Intent view with VoiceOver enabled, give verticals focus
3. Expect that VoiceOver doesn't announce the emoji for a focused vertical

## Regression Notes
1. Potential unintended areas of impact
- None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual tests above

3. What automated tests I added (or what prevented me from doing so)
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
