### PR TITLE
Blogging Prompts: Fix centering of prompt card views

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -94,7 +94,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
             trainContainerView.centerYAnchor.constraint(equalTo: avatarTrainView.centerYAnchor),
             trainContainerView.topAnchor.constraint(lessThanOrEqualTo: avatarTrainView.topAnchor),
             trainContainerView.bottomAnchor.constraint(greaterThanOrEqualTo: avatarTrainView.bottomAnchor),
-            trainContainerView.leadingAnchor.constraint(lessThanOrEqualTo: avatarTrainView.leadingAnchor),
+            trainContainerView.leadingAnchor.constraint(equalTo: avatarTrainView.leadingAnchor),
             trainContainerView.trailingAnchor.constraint(equalTo: avatarTrainView.trailingAnchor)
         ])
 
@@ -114,15 +114,26 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         return label
     }
 
-    private var answerInfoStackView: UIStackView {
+    private var answerInfoView: UIView {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.distribution = .fillEqually
         stackView.spacing = Constants.answerInfoViewSpacing
         stackView.addArrangedSubviews([avatarTrainContainerView, answerInfoLabel])
 
-        return stackView
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: stackView.topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+            containerView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
+            containerView.leadingAnchor.constraint(lessThanOrEqualTo: stackView.leadingAnchor),
+            containerView.trailingAnchor.constraint(greaterThanOrEqualTo: stackView.trailingAnchor)
+        ])
+
+        return containerView
     }
 
     // MARK: Bottom row views
@@ -252,7 +263,7 @@ private extension DashboardPromptsCardCell {
         containerStackView.addArrangedSubview(promptTitleView)
 
         if answerCount > 0 {
-            containerStackView.addArrangedSubview(answerInfoStackView)
+            containerStackView.addArrangedSubview(answerInfoView)
         }
 
         containerStackView.addArrangedSubview((isAnswered ? answeredStateView : answerButton))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -170,14 +170,25 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     private lazy var answeredStateView: UIView = {
         let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
-        stackView.distribution = .fillProportionally
         stackView.spacing = Constants.answeredButtonsSpacing
+        stackView.addArrangedSubviews([answeredLabel, shareButton])
 
-        // added some spacer views to make the label and button look more centered together.
-        stackView.addArrangedSubviews([UIView(), answeredLabel, shareButton, UIView()])
+        // center the stack view's contents based on its total intrinsic width (instead of having it stretched edge to edge).
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(stackView)
 
-        return stackView
+        NSLayoutConstraint.activate([
+            containerView.topAnchor.constraint(equalTo: stackView.topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
+            containerView.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
+            containerView.leadingAnchor.constraint(lessThanOrEqualTo: stackView.leadingAnchor),
+            containerView.trailingAnchor.constraint(greaterThanOrEqualTo: stackView.trailingAnchor)
+        ])
+
+        return containerView
     }()
 
     // Defines the structure of the contextual menu items.

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -91,8 +91,9 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         trainContainerView.translatesAutoresizingMaskIntoConstraints = false
         trainContainerView.addSubview(avatarTrainView)
         NSLayoutConstraint.activate([
-            trainContainerView.topAnchor.constraint(equalTo: avatarTrainView.topAnchor),
-            trainContainerView.bottomAnchor.constraint(equalTo: avatarTrainView.bottomAnchor),
+            trainContainerView.centerYAnchor.constraint(equalTo: avatarTrainView.centerYAnchor),
+            trainContainerView.topAnchor.constraint(lessThanOrEqualTo: avatarTrainView.topAnchor),
+            trainContainerView.bottomAnchor.constraint(greaterThanOrEqualTo: avatarTrainView.bottomAnchor),
             trainContainerView.leadingAnchor.constraint(lessThanOrEqualTo: avatarTrainView.leadingAnchor),
             trainContainerView.trailingAnchor.constraint(equalTo: avatarTrainView.trailingAnchor)
         ])


### PR DESCRIPTION
Refs #18250, https://github.com/wordpress-mobile/WordPress-iOS/pull/18329#issuecomment-1093354894

The design centers the "answered" label and the Share button based on their total width (instead of plainly dividing the available space equally). This PR achieves just that: the centering should now be based on the total intrinsic width of the views. Here are some screenshots:

Description | Screenshot
-|-
Normal size | ![centering_normal](https://user-images.githubusercontent.com/1299411/162770685-59140723-832c-4c9d-ac4a-94b8204b5521.png)
Accessibility size | ![centering_a11y](https://user-images.githubusercontent.com/1299411/162770679-6f2ef9b4-3f10-46e5-a3ec-c2d9ecad0ca7.png)
Small size | ![centering_small](https://user-images.githubusercontent.com/1299411/162770665-595bd6fd-8f4c-48fa-88ee-621954acbd57.png)

## To test

- Ensure that the Blogging Prompts and the My Site Dashboard feature flags are enabled.
- Verify that the answered label and Share button are centered correctly in normal, A11y, and small sizes.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is under development.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
