### PR TITLE
My Site Dashboard: Display Stats Insight tab from Today's Stats dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -90,7 +90,7 @@ extension DashboardQuickActionsCardCell {
 
     private func showStats(for blog: Blog, from sourceController: UIViewController) {
         trackQuickActionsEvent(.statsAccessed, blog: blog)
-        StatsViewController.show(for: blog, from: sourceController, showTodayStats: false)
+        StatsViewController.show(for: blog, from: sourceController)
     }
 
     private func showPostList(for blog: Blog, from sourceController: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -97,7 +97,7 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
         WPAnalytics.track(.dashboardCardItemTapped,
                           properties: ["type": DashboardCard.todaysStats.rawValue],
                           blog: blog)
-        StatsViewController.show(for: blog, from: sourceController, showTodayStats: true)
+        StatsViewController.show(for: blog, from: sourceController)
         WPAppAnalytics.track(.statsAccessed, withProperties: [WPAppAnalyticsKeyTabSource: "dashboard", WPAppAnalyticsKeyTapSource: "todays_stats_card"], with: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -79,13 +79,6 @@ class SiteStatsDashboardViewController: UIViewController {
         return button
     }()
 
-    // MARK: Public Functions
-
-    /// When called, the initial selected `StatsPeriodType` is set to days instead of insights.
-    @objc public func forceShowStatsForTodayPeriod() {
-        self.currentSelectedPeriod = .days
-    }
-
     // MARK: - View
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
@@ -6,8 +6,6 @@
 @property (nonatomic, weak) Blog *blog;
 @property (nonatomic, copy) void (^dismissBlock)(void);
 
-+ (void)showForBlog:(nonnull Blog *)blog
-               from:(nonnull UIViewController *)controller
-     showTodayStats:(BOOL)showTodayStats;
++ (void)showForBlog:(nonnull Blog *)blog from:(nonnull UIViewController *)controller;
 
 @end

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -17,7 +17,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 
 @property (nonatomic, assign) BOOL showingJetpackLogin;
 @property (nonatomic, assign) BOOL isActivatingStatsModule;
-@property (nonatomic, assign) BOOL shouldForceShowTodayStats;
 @property (nonatomic, strong) SiteStatsDashboardViewController *siteStatsDashboardVC;
 @property (nonatomic, weak) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIActivityIndicatorView *loadingIndicator;
@@ -36,14 +35,11 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     return self;
 }
 
-+ (void)showForBlog:(nonnull Blog *)blog
-               from:(nonnull UIViewController *)controller
-     showTodayStats:(BOOL)showTodayStats
++ (void)showForBlog:(Blog *)blog from:(UIViewController *)controller
 {
     StatsViewController *statsController = [StatsViewController new];
     statsController.blog = blog;
     statsController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    statsController.shouldForceShowTodayStats = showTodayStats;
     [controller.navigationController pushViewController:statsController animated:YES];
     
     [[QuickStartTourGuide shared] visited:QuickStartTourElementStats];
@@ -105,9 +101,6 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
     [self addChildViewController:self.siteStatsDashboardVC];
     [self.view addSubview:self.siteStatsDashboardVC.view];
     [self.siteStatsDashboardVC didMoveToParentViewController:self];
-    if (self.shouldForceShowTodayStats) {
-        [self.siteStatsDashboardVC forceShowStatsForTodayPeriod];
-    }
 }
 
 - (void) installWidgetsButton


### PR DESCRIPTION
Part of #17876

## Description

- Updated the Today's Stats dashboard card to open the Stats Insights tab instead of the Stats Days tab (Reverted 540a10c)

Ref: p1649694944738209-slack-C0290FLA0RM

## How to test

1. Go to My Site and select the Home tab
2. Tap the Today's Stats dashboard card
3. ✅ The Stats Insights tab should be displayed (not the Days tab)


https://user-images.githubusercontent.com/6711616/162791800-9eb59e65-b8bc-48ab-a137-a9959d7b7f8a.mp4



## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.