### PR TITLE
My Site Dashboard: hide quick actions from Site Menu for users assigned to the experiment

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -732,7 +732,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     NSMutableArray *marr = [NSMutableArray array];
     
-    if (AppConfiguration.showsQuickActions) {
+    if (AppConfiguration.showsQuickActions && ![[MySiteSettings alloc] isAssignedToExperiment]) {
         [marr addObject:[self quickActionsSectionViewModel]];
     }
     if ([DomainCreditEligibilityChecker canRedeemDomainCreditWithBlog:self.blog]) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -33,6 +33,7 @@ NSString * const WPBlogDetailsRestorationID = @"WPBlogDetailsID";
 NSString * const WPBlogDetailsBlogKey = @"WPBlogDetailsBlogKey";
 NSString * const WPBlogDetailsSelectedIndexPathKey = @"WPBlogDetailsSelectedIndexPathKey";
 
+CGFloat const FirstHeaderSectionHeight = 20.0;
 CGFloat const BlogDetailGridiconAccessorySize = 17.0;
 CGFloat const BlogDetailQuickStartSectionHeight = 35.0;
 NSTimeInterval const PreloadingCacheTimeout = 60.0 * 5; // 5 minutes
@@ -652,6 +653,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)sectionNum {
     BlogDetailsSection *section = self.tableSections[sectionNum];
+
+    if ([[MySiteSettings alloc] isAssignedToExperiment] && sectionNum == 0 && (section.title == nil || section.title.isEmpty)) {
+        return FirstHeaderSectionHeight;
+    }
 
     if (section.showQuickStartMenu == true || sectionNum == 0) {
         return BlogDetailQuickStartSectionHeight;

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -24,6 +24,10 @@ import WordPressShared
         return "nonexistent"
     }
 
+    @objc var isAssignedToExperiment: Bool {
+        experimentAssignment != "nonexistent"
+    }
+
     func setDefaultSection(_ tab: MySiteViewController.Section) {
         userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)
         WPAnalytics.track(.mySiteDefaultTabExperimentVariantAssigned, properties: ["default_tab_experiment": experimentAssignment])

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -25,7 +25,7 @@ import WordPressShared
     }
 
     @objc var isAssignedToExperiment: Bool {
-        experimentAssignment != "nonexistent"
+        FeatureFlag.mySiteDashboard.enabled && experimentAssignment != "nonexistent"
     }
 
     func setDefaultSection(_ tab: MySiteViewController.Section) {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -77,7 +77,8 @@ public class MySiteScreen: ScreenObject {
     }
 
     public func removeSelfHostedSite() {
-        app.cells[ElementStringIDs.removeSiteButton].tap()
+        app.tables[ElementStringIDs.blogTable].swipeUp(velocity: .fast)
+        app.cells[ElementStringIDs.removeSiteButton].doubleTap()
 
         let removeButton: XCUIElement
         if XCUIDevice.isPad {


### PR DESCRIPTION
This PR hides the Quick Actions under Site Menu if 1) my site dashboard feature flag is enabled 2) the user is assigned to a variant (it doesn't matter if it's site menu or dashboard)

https://user-images.githubusercontent.com/7040243/162814546-49c7ad33-434e-48f6-9949-9e7b53eb1a2f.mp4

**Important**: please, also test on iPad an check that the selected cells (Home or Stats) works as expected.

### To test

1. Do a clean install of the app
2. Login
3. ✅ Check that Quick Actions under Site Menu shouldn't appear
4. Set the My Site Dashboard feature flag to `false`
5. Run the app
6. ✅ Check that Quick Actions under Site Menu appear

#### Users out of the experiment

1. Change `WordPressAuthenticationManager.assignMySiteExperimentIfNeeded` remove the call to `MySiteSettings.setDefaultSection`
2. Do a clean install of the app
3. Login
4. ✅ Check that Quick Actions under Site Menu appear

## Regression Notes
1. Potential unintended areas of impact
Current users without the experiment assigned.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual test.

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
