### PR TITLE
[Site Intent] UI Tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/IntentCell.xib
@@ -11,15 +11,15 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <tableViewCell contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="IntentCell" customModule="WordPress" customModuleProvider="target">
+        <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" rowHeight="62" id="KGk-i7-Jjw" customClass="IntentCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="337.5" height="62"/>
+                <rect key="frame" x="0.0" y="0.0" width="362" height="62"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oUW-7f-3I7">
-                        <rect key="frame" x="20" y="12" width="297.5" height="40"/>
+                        <rect key="frame" x="20" y="12" width="322" height="40"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A5Z-4z-ewC" userLabel="Emoji Container">
                                 <rect key="frame" x="0.0" y="0.0" width="40" height="40"/>
@@ -44,7 +44,7 @@
                                 </constraints>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Intent Topic" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQm-TV-IDW">
-                                <rect key="frame" x="60" y="10.5" width="237.5" height="19.5"/>
+                                <rect key="frame" x="60" y="10.5" width="262" height="19.5"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="16"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -128,7 +128,7 @@ extension SiteIntentViewController {
                                                  comment: "Select the site's intent. Title")
         static let navigationBarTitle = NSLocalizedString("Site Topic",
                                                           comment: "Title of the navigation bar, shown when the large title is hidden.")
-        static let prompt = NSLocalizedString("Choose a topic from the list below or type your own",
+        static let prompt = NSLocalizedString("Choose a topic from the list below or type your own.",
                                               comment: "Select the site's intent. Subtitle")
         static let primaryAction = NSLocalizedString("Continue",
                                                      comment: "Button to progress to the next step")

--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentViewController.swift
@@ -138,7 +138,7 @@ extension SiteIntentViewController {
                                                        comment: "Continue without making a selection")
         static let cancelButtonTitle = NSLocalizedString("Cancel",
                                                          comment: "Cancel site creation")
-        static let searchTextFieldPlaceholder = NSLocalizedString("Eg. Fashion, Poetry, Politics", comment: "Placeholder text for the search field int the Site Intent screen.")
+        static let searchTextFieldPlaceholder = NSLocalizedString("E.g. Fashion, Poetry, Politics", comment: "Placeholder text for the search field int the Site Intent screen.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the continue button for the Site Intent screen.")
     }
 


### PR DESCRIPTION
**This PR:**
- Adds a period to the prompt text
- Removes the chevron from the Intent cell
- Updates the search placeholder text

**To test:**
- Observe item A. There should be a period on the end of the sentence.
- Observe item B. There should be no chevron (arrow pointing to the right).
- Observe item C. The placeholder text should read: "E.g."

| Before | After |
| ------ | ----- |
| ![Before](https://user-images.githubusercontent.com/2092798/162815450-3282c889-fa40-42ba-a8e5-22fba485454a.png) | ![After](https://user-images.githubusercontent.com/2092798/162815471-3aa89966-4ef8-4df9-bf5d-993c3defc85a.png) |

## Regression Notes
1. Potential unintended areas of impact
Visual / VoiceOver

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Visually inspected the changes.

3. What automated tests I added (or what prevented me from doing so)
None. These are UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
