### PR TITLE
[Site Intent] Sort Verticals alphabetically on the Site Intent screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/SiteIntent/SiteIntentData.swift
@@ -33,7 +33,7 @@ struct SiteIntentData {
         .init("sports", NSLocalizedString("Sports", comment: "Sports site intent topic"), "⚽"),
         .init("technology", NSLocalizedString("Technology", comment: "Technology site intent topic"), "💻"),
         .init("writing_poetry", NSLocalizedString("Writing & Poetry", comment: "Writing & Poetry site intent topic"), "📓")
-    ]
+    ].sorted(by: { $0.localizedTitle < $1.localizedTitle })
 
     static let defaultVerticals: [SiteIntentVertical] = {
         allVerticals.filter { $0.isDefault }

--- a/WordPress/WordPressTest/SiteCreation/SiteIntentDataTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteIntentDataTests.swift
@@ -99,17 +99,16 @@ class SiteIntentDataTests: XCTestCase {
         XCTAssertEqual(whitespaceSearchResult, emptyStringResult)
     }
 
-    /// Tests that default verticals are on top of the non-default verticals as this affects output ordering
-    func testDefaultsOnTop() throws {
+    /// Tests that verticals are in alphabetical order by localized title
+    func testAlphabetizedTitles() throws {
         // Given
-        let defaultVerticals = SiteIntentData.allVerticals.filter { $0.isDefault == true }
-        let nonDefaultVerticals = SiteIntentData.allVerticals.filter { $0.isDefault == false }
+        let allVerticals = SiteIntentData.allVerticals
 
         // When
-        let allVerticals = (defaultVerticals + nonDefaultVerticals)
+        let alphabetizedVerticals = allVerticals.sorted(by: { $0.localizedTitle < $1.localizedTitle })
 
         // Then
-        XCTAssertEqual(allVerticals, SiteIntentData.allVerticals)
+        XCTAssertEqual(alphabetizedVerticals, allVerticals)
     }
 
     /// Tests that the defaultVerticals properties returns default verticals


### PR DESCRIPTION
This PR sorts all verticals on the Site Intent screen in alphabetical order.

### Default Verticals

| Before | After | 
| -------| ----- |
| ![Before - Defaults](https://user-images.githubusercontent.com/2092798/162994955-fabe1c9d-b2e3-4a0b-9241-f1d3eaeaa756.png) | ![After - Defaults](https://user-images.githubusercontent.com/2092798/162994983-a523edbc-4d16-4c0f-884b-e93a850d5fa1.png) |

### All Verticals

| Before | After |
| ------ | ----- |
| ![Before - All](https://user-images.githubusercontent.com/2092798/162995020-bbf35220-cad9-4046-9d94-d114085b08b9.png) | ![After - All](https://user-images.githubusercontent.com/2092798/162995055-26d41702-7476-427c-a816-7f1185087f3d.png) |


## To test:

**Prerequisites**: The user must be in the treatment group for Site Intent and the feature flag must be enabled. (See https://github.com/wordpress-mobile/WordPress-iOS/pull/18083)

To programmatically control the group, return `.treatment` [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/03fc8649cc5c2f573709b26f306dd12d25c4c92c/WordPress/Classes/ViewRelated/Site%20Creation/Wizard/SiteIntentAB.swift#L26).

1. Start the site creation flow by creating a new site
2. Expect the Site Intent screen to be shown
3. Expect that the default verticals are shown in alphabetical order
4. Tap on the search input
5. Expect that all the verticals are shown in alphabetical order

## Regression Notes
1. Potential unintended areas of impact
Ordering of verticals

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Ran our existing automated tests
- Followed the testing steps above

3. What automated tests I added (or what prevented me from doing so)
- Updated `SiteIntentDataTests` to check for the new ordering

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
