### PR TITLE
My Site Dashboard: Rename Site Menu to Menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 -----
 * [*] Enhances the exit animation of notices. [#18182]
 * [*] Media Permissions: display error message when using camera to capture photos and media permission not given [https://github.com/wordpress-mobile/WordPress-iOS/pull/18139]
-* [***] My Site: your My Site screen now has two tabs, "Site Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [#18240]
+* [***] My Site: your My Site screen now has two tabs, "Menu" and "Home". Under "Home", you'll find contextual cards with some highlights of whats going on with your site. Check your drafts or scheduled posts, your today's stats or go directly to another section of the app. [#18240]
 * [*] [internal] Site creation: Adds a new screen asking the user the intent of the site [#18270]
 
 19.5

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -13,7 +13,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             case .dashboard:
                 return NSLocalizedString("Home", comment: "Title for dashboard view on the My Site screen")
             case .siteMenu:
-                return NSLocalizedString("Site Menu", comment: "Title for the site menu view on the My Site screen")
+                return NSLocalizedString("Menu", comment: "Title for the site menu view on the My Site screen")
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -44,7 +44,7 @@ private struct Strings {
 
 struct QuickStartSiteMenu {
     private static let descriptionBase = NSLocalizedString("Select %@ to continue.", comment: "A step in a guided tour for quick start. %@ will be the name of the segmented control item to select on the Site Menu screen.")
-    private static let descriptionTarget = NSLocalizedString("Site Menu", comment: "The segmented control item to select during a guided tour.")
+    private static let descriptionTarget = NSLocalizedString("Menu", comment: "The segmented control item to select during a guided tour.")
     static let waypoint = QuickStartTour.WayPoint(element: .siteMenu, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))
 }
 


### PR DESCRIPTION
## Description
This PR changes the title of the site menu tab to "Menu". It also updates the string used in quick start to point to the tab.
Ref: p1649765158282219/1649675414.317019-slack-C0290FLA0RM

## Testing Instructions

1. Install and run the app
2. Make sure Site Menu tab title is now "Menu"
3. Enable quick start and make sure initial screen is "Home"
4. Start the "Edit Homepage" tour
5. Make sure the notice reads "Select Menu to continue"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
