### PR TITLE
Blogging Prompts Feature Introduction: add gradient colors to header image

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
@@ -17,8 +17,8 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
             return featureDescriptionView
         }()
 
-        let headerImage = UIImage(named: Style.headerImageName)?
-            .withTintColor(Style.headerImageTintColor)
+        let headerImage = UIImage(named: HeaderStyle.imageName)?
+            .withTintColor(.clear)
 
         super.init(headerTitle: Strings.headerTitle,
                    headerSubtitle: Strings.headerSubtitle,
@@ -32,6 +32,13 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Add the gradient after the image has been added to the view so the gradient is the correct size.
+        addHeaderImageGradient()
     }
 
 }
@@ -48,8 +55,31 @@ extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
 
 }
 
-
 private extension BloggingPromptsFeatureIntroduction {
+
+    func addHeaderImageGradient() {
+        // Based on https://stackoverflow.com/a/54096829
+        let gradient = CAGradientLayer()
+
+        gradient.colors = [
+            HeaderStyle.startGradientColor.cgColor,
+            HeaderStyle.endGradientColor.cgColor
+        ]
+
+        // Create a gradient from top to bottom.
+        gradient.startPoint = CGPoint(x: 0.5, y: 0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1)
+        gradient.frame = headerImageView.bounds
+
+        // Add a mask to the gradient so the colors only apply to the image (and not the imageView).
+        let mask = CALayer()
+        mask.contents = headerImageView.image?.cgImage
+        mask.frame = gradient.bounds
+        gradient.mask = mask
+
+        // Add the gradient as a sublayer to the imageView's layer.
+        headerImageView.layer.addSublayer(gradient)
+    }
 
     enum Strings {
         static let headerTitle: String = NSLocalizedString("Introducing Prompts", comment: "Title displayed on the feature introduction view.")
@@ -58,9 +88,10 @@ private extension BloggingPromptsFeatureIntroduction {
         static let secondaryButtonTitle: String = NSLocalizedString("Remind me", comment: "Secondary button title on the feature introduction view.")
     }
 
-    enum Style {
-        static let headerImageName = "icon-lightbulb-outline"
-        static let headerImageTintColor: UIColor = .orange // TODO: use gradient colors
+    enum HeaderStyle {
+        static let imageName = "icon-lightbulb-outline"
+        static let startGradientColor: UIColor = .warning(.shade30)
+        static let endGradientColor: UIColor = .accent(.shade40)
     }
 
 }


### PR DESCRIPTION
Ref: #18176

The lightbulb header image now has gradient colors applied.

To test:
- Enable `bloggingPrompts` feature flag.
- Run the app.
- When the app launches, the Feature Introduction will appear. 
- Verify the lightbulb icon is more colorful.

| Before | After |
|--------|-------|
| <img width="446" alt="before" src="https://user-images.githubusercontent.com/1816888/163045588-130e7730-2417-41e8-8e49-bb48ab9011c1.png"> | <img width="439" alt="after" src="https://user-images.githubusercontent.com/1816888/163045595-b16b6dcc-ea7e-4fa1-b5a8-e7617224d4aa.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.