### PR TITLE
Remove tip section from blogging reminders

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -136,66 +136,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return stackView
     }()
 
-    private lazy var trophy: UIView = {
-        let trophy = UIImageView(image: .gridicon(.trophy, size: Metrics.tipsTrophyImageSize))
-        trophy.translatesAutoresizingMaskIntoConstraints = false
-        trophy.tintColor = .secondaryLabel
-        return trophy
-    }()
-
-    private lazy var tipLabel: UILabel = {
-        let tipLabel = UILabel()
-        tipLabel.translatesAutoresizingMaskIntoConstraints = false
-        tipLabel.adjustsFontForContentSizeCategory = true
-        tipLabel.textColor = .secondaryLabel
-        tipLabel.font = WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold)
-        tipLabel.text = TextContent.tipPanelTitle
-        return tipLabel
-    }()
-
-    private lazy var tipDescriptionLabel: UILabel = {
-        let tipDescriptionLabel = UILabel()
-        tipDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
-        tipDescriptionLabel.adjustsFontForContentSizeCategory = true
-        tipDescriptionLabel.textColor = .secondaryLabel
-        tipDescriptionLabel.font = UIFont.preferredFont(forTextStyle: .footnote)
-        tipDescriptionLabel.text = TextContent.tipPanelDescription
-        tipDescriptionLabel.numberOfLines = 0
-        return tipDescriptionLabel
-    }()
-
-    private lazy var bottomTipPanel: UIView = {
-        let view = UIView()
-        view.backgroundColor = .quaternaryBackground
-        view.layer.cornerRadius = Metrics.tipPanelCornerRadius
-        view.addSubview(tipStackView)
-
-        return view
-    }()
-
-    private lazy var tipStackView: UIStackView = {
-        let tipStackView = UIStackView(arrangedSubviews: [trophy, tipLabelsStackView])
-        tipStackView.spacing = Metrics.tipPanelHorizontalStackSpacing
-        tipStackView.translatesAutoresizingMaskIntoConstraints = false
-        tipStackView.axis = .horizontal
-        tipStackView.alignment = .top
-        return tipStackView
-    }()
-
-    private lazy var tipLabelsStackView: UIStackView = {
-        let tipLabelsStackView = UIStackView(arrangedSubviews: [tipLabel, tipDescriptionLabel])
-        tipLabelsStackView.translatesAutoresizingMaskIntoConstraints = false
-        tipLabelsStackView.axis = .vertical
-        tipLabelsStackView.alignment = .leading
-        tipLabelsStackView.addArrangedSubviews([tipLabel, tipDescriptionLabel])
-        return tipLabelsStackView
-    }()
-
-    private lazy var timeSelectionToTipSpacer: UIView = {
-        makeSpacer()
-    }()
-
-    private lazy var tipToConfirmationButtonSpacer: UIView = {
+    private lazy var timeSelectionToConfirmationButtonSpacer: UIView = {
         makeSpacer()
     }()
 
@@ -305,7 +246,6 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        bottomTipPanel.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory || !shouldShowFullUI
         imageView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory || !shouldShowFullUI
     }
 
@@ -415,16 +355,15 @@ private extension BloggingRemindersFlowSettingsViewController {
         return view
     }
 
-    /// Determines if the calendar image and the tip should be displayed, depending on the screen vertical size
+    /// Determines if the calendar image should be displayed, depending on the screen vertical size
     var shouldShowFullUI: Bool {
         (WPDeviceIdentification.isiPhone() && UIScreen.main.bounds.height >= Metrics.minimumHeightForFullUI) ||
             (WPDeviceIdentification.isiPad() && UIDevice.current.orientation.isPortrait)
     }
 
-    /// Hides/shows the optional UI Elements (dismiss button, calendar icon, tip)
+    /// Hides/shows the optional UI Elements (dismiss button & calendar icon)
     /// - Parameter isVisible: true if we need to show the elements (Full UI), false otherwise
     func showFullUI(_ isVisible: Bool) {
-        bottomTipPanel.isHidden = !isVisible
         imageView.isHidden = !isVisible
     }
 
@@ -480,9 +419,7 @@ private extension BloggingRemindersFlowSettingsViewController {
             daysOuterStackView,
             frequencyView,
             timeSelectionView,
-            timeSelectionToTipSpacer,
-            bottomTipPanel,
-            tipToConfirmationButtonSpacer,
+            timeSelectionToConfirmationButtonSpacer,
             button,
             confirmationButtonBottomSpacer
         ])
@@ -494,11 +431,9 @@ private extension BloggingRemindersFlowSettingsViewController {
     func configureConstraints() {
         frequencyView.pinSubviewToAllEdges(frequencyLabel)
         timeSelectionView.pinSubviewToAllEdges(timeSelectionStackView)
-        bottomTipPanel.pinSubviewToAllEdges(tipStackView, insets: Metrics.tipPanelMargins)
 
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        tipDescriptionLabel.setContentCompressionResistancePriority(.required, for: .vertical)
         timeSelectionView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         button.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
@@ -512,17 +447,14 @@ private extension BloggingRemindersFlowSettingsViewController {
 
             button.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             button.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-            bottomTipPanel.widthAnchor.constraint(equalTo: stackView.widthAnchor),
 
             topDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             bottomDivider.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
             timeSelectionView.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             timeSelectionView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             frequencyView.heightAnchor.constraint(equalToConstant: Metrics.frequencyLabelHeight),
-            tipLabel.heightAnchor.constraint(equalTo: trophy.heightAnchor),
-            timeSelectionToTipSpacer.heightAnchor.constraint(equalTo: tipToConfirmationButtonSpacer.heightAnchor),
-            timeSelectionToTipSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor),
-            tipToConfirmationButtonSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor)
+            timeSelectionToConfirmationButtonSpacer.heightAnchor.constraint(greaterThanOrEqualToConstant: 0),
+            timeSelectionToConfirmationButtonSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor)
         ])
     }
 
@@ -613,10 +545,6 @@ private enum TextContent {
     static let nextButtonTitle = NSLocalizedString("Notify me", comment: "Title of button to navigate to the next screen of the blogging reminders flow, setting up push notifications.")
 
     static let updateButtonTitle = NSLocalizedString("Update", comment: "(Verb) Title of button confirming updating settings for blogging reminders.")
-
-    static let tipPanelTitle = NSLocalizedString("Tip", comment: "Title of a panel shown in the Blogging Reminders Settings screen, providing the user with a helpful tip.")
-
-    static let tipPanelDescription = NSLocalizedString("Posting regularly can help keep your readers engaged, and attract new visitors to your site.", comment: "Informative tip shown to user in the Blogging Reminders Settings screen.")
 }
 
 private enum Images {
@@ -625,23 +553,17 @@ private enum Images {
 
 private enum Metrics {
     static let edgeMargins = UIEdgeInsets(top: 46, left: 20, bottom: 56, right: 20)
-    static let tipPanelMargins = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
 
     static let stackSpacing: CGFloat = 24.0
     static let innerStackSpacing: CGFloat = 8.0
     static let afterTitleLabelSpacing: CGFloat = 16.0
     static let afterPromptLabelSpacing: CGFloat = 40.0
-    static let tipPanelHorizontalStackSpacing: CGFloat = 12.0
-    static let tipPanelVerticalStackSpacing: CGFloat = 8.0
 
     static let buttonHeight: CGFloat = 44.0
-    static let tipPanelCornerRadius: CGFloat = 12.0
-    static let tipsTrophyImageSize = CGSize(width: 20, height: 20)
-    static let tipDescriptionHeight: CGFloat = 34.0
     static let frequencyLabelHeight: CGFloat = 30
 
     static let topRowDayCount = 4
 
-    // the smallest logical iPhone height (iPhone 12 mini) to display the full UI, which includes calendar icon and tip.
+    // the smallest logical iPhone height (iPhone 12 mini) to display the full UI, which includes calendar icon.
     static let minimumHeightForFullUI: CGFloat = 812
 }


### PR DESCRIPTION
See discussion: pbArwn-4in-p2#comment-5450
Ref: #18316

Removes the "Tip" section in the blogging reminders screen to make room for the blogging prompts toggle. This is a temporary solution in order to move forward with the prompt toggle. There is a potential future refactor to turn this into a scroll view in order to properly fit all the content and make it more flexible.

To test:
1. Pick a site
2. Go to site menu
3. Open Configure > Site Settings
4. Open Blogging Reminders
5. Verify no layout issues due to removal

## Screenshots
| Before | After |
|-------|------|
| ![Simulator Screen Shot - iPhone 11 - 2022-04-12 at 16 26 57](https://user-images.githubusercontent.com/2454408/163054618-964d986c-e5e0-4cee-a347-10c7ac963a95.png) | ![Simulator Screen Shot - iPhone 11 - 2022-04-12 at 16 30 15](https://user-images.githubusercontent.com/2454408/163054635-7d68fadc-0d24-4f0a-8776-0a9915ffdae8.png) |
| ![Simulator Screen Shot - iPhone 11 - 2022-04-12 at 16 27 05](https://user-images.githubusercontent.com/2454408/163054634-6bbb2300-37bf-42f2-ac13-d8ba9cc02626.png) | ![Simulator Screen Shot - iPhone 11 - 2022-04-12 at 16 30 23](https://user-images.githubusercontent.com/2454408/163054637-5335e820-ee63-4344-9733-f48ebf06ab88.png) |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
