### PR TITLE
Blogging Prompts Feature Introduction: show example prompt card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -12,6 +12,18 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         }
     }
 
+    /// When set to true, a "default" version of the card is displayed. That is:
+    /// - `maxAvatarCount` number of avatars.
+    /// - `maxAvatarCount` answer count.
+    /// - `examplePrompt` prompt label.
+    /// - disabled user interaction.
+    private var forExampleDisplay: Bool = false {
+        didSet {
+            isUserInteractionEnabled = false
+            isAnswered = false
+        }
+    }
+
     // MARK: - Private Properties
 
     // Used to present the menu sheet for contextual menu.
@@ -73,8 +85,13 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     // MARK: Middle row views
 
-    // TODO: For testing purposes. Remove once we actually have real avatar URLs.
-    private var answerCount = 3
+    private lazy var answerCount: Int = {
+        if forExampleDisplay {
+            return Constants.maxAvatarCount
+        }
+        // TODO: For testing purposes. Remove once we actually have real avatar URLs.
+        return 3
+    }()
 
     private var answerInfoText: String {
         let stringFormat = (answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat)
@@ -82,8 +99,14 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     }
 
     private var avatarTrainContainerView: UIView {
-        // TODO: Refactor this once we have real avatar URLs.
-        let avatarURLs: [URL?] = (0..<min(answerCount, Constants.maxAvatarCount)).map { _ in nil }
+        let avatarURLs: [URL?] = {
+            if forExampleDisplay {
+                return (0..<Constants.maxAvatarCount).map { _ in nil }
+            }
+            // TODO: Refactor this once we have real avatar URLs.
+            return (0..<min(answerCount, Constants.maxAvatarCount)).map { _ in nil }
+        }()
+
         let avatarTrainView = AvatarTrainView(avatarURLs: avatarURLs)
         avatarTrainView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -134,6 +157,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         button.titleLabel?.font = Style.buttonTitleFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
+
+        // TODO: Implement button tap action
 
         return button
     }()
@@ -209,6 +234,13 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     required init?(coder: NSCoder) {
         super.init(coder: coder)
     }
+
+    // MARK: - Public Methods
+
+    func configureForExampleDisplay() {
+        forExampleDisplay = true
+    }
+
 }
 
 // MARK: - BlogDashboardCardConfigurable
@@ -234,8 +266,8 @@ private extension DashboardPromptsCardCell {
         // clear existing views.
         containerStackView.removeAllSubviews()
 
-        // TODO: For testing purposes. Remove once we can pull content from remote.
-        promptLabel.text = "Cast the movie of your life."
+        // TODO: Remove the hard coded string once we can pull content from remote.
+        promptLabel.text = forExampleDisplay ? Strings.examplePrompt : "Cast the movie of your life."
 
         containerStackView.addArrangedSubview(promptTitleView)
 
@@ -283,6 +315,7 @@ private extension DashboardPromptsCardCell {
     // MARK: Constants
 
     struct Strings {
+        static let examplePrompt = NSLocalizedString("Cast the movie of your life.", comment: "Example prompt for the Prompts card in Feature Introduction.")
         static let cardFrameTitle = NSLocalizedString("Prompts", comment: "Title label for the Prompts card in My Sites tab.")
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button on the prompts card.")
         static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -24,6 +24,12 @@ private extension BloggingPromptsFeatureDescriptionView {
         promptCardView.layer.cornerRadius = Style.cardCornerRadius
         promptCardView.layer.borderColor = Style.borderColor
 
+        let promptCard = DashboardPromptsCardCell()
+        promptCard.configureForExampleDisplay()
+        promptCard.translatesAutoresizingMaskIntoConstraints = false
+        promptCardView.addSubview(promptCard)
+        promptCardView.pinSubviewToSafeArea(promptCard)
+
         descriptionLabel.font = Style.labelFont
         descriptionLabel.textColor = Style.textColor
         descriptionLabel.text = Strings.featureDescription


### PR DESCRIPTION
Ref: #18176

An example version of the My Site Dashboard prompt card is now displayed in the Blogging Prompts Feature Introduction.

To test:
- Enable `bloggingPrompts` and `mySiteDashboard` feature flags.
- Run the app.
- When the app launches, the Feature Introduction will appear.
- Verify the prompt card is displayed in the top bordered view. The card is the same as the My Site card except:
  - The button row only shows the `Answer Prompt` button.
  - The card is non-interactive. i.e. tapping the ellipsis button does nothing.
- Close the Feature Introduction and go to My Site Dashboard > Home tab.
- Verify the prompt card appears as before.
  - The button row shows both buttons.
  - Tapping the ellipsis button shows the menu.

NOTE: The bordered card view doesn't scale with text size changes. I'll address that in a follow-up.

| Feature Introduction | My Site Dashboard |
|--------|-------|
| <img width="374" alt="fi_card" src="https://user-images.githubusercontent.com/1816888/163075502-57b12deb-67d0-4194-98e2-69852bdf1945.png"> | <img width="407" alt="my_site_card" src="https://user-images.githubusercontent.com/1816888/163075497-ef1b8f9c-bd71-444f-92b3-6a382e694111.png"> |


![fi_with_card](https://user-images.githubusercontent.com/1816888/163075448-d83d99c1-b405-499d-ac8b-c18c169f635f.png)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
