### PR TITLE
My Site Dashboard: Update empty stats nudge copy

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -125,7 +125,7 @@ private extension DashboardStatsCardCell {
 
     enum Strings {
         static let statsTitle = NSLocalizedString("Today's Stats", comment: "Title for the card displaying today's stats.")
-        static let nudgeButtonTitle = NSLocalizedString("If you want to try get more views and traffic check out our top tips", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
+        static let nudgeButtonTitle = NSLocalizedString("Interested in building your audience? Check out our top tips", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
         static let nudgeButtonHint = NSLocalizedString("top tips", comment: "The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...'")
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-Android/pull/16268#issuecomment-1097775380

Ref: p1649841547734449-slack-C0290FLA0RM

## Description
- Updated nudge copy for Today's Stats card
  - Before: `If you want to try get more views and traffic check out our top tips`
  - After: `Interested in building your audience? Check out our top tips`
  
<img src="https://user-images.githubusercontent.com/6711616/163167379-9f373b72-ed58-4e1b-8929-c3d5e32e4418.png" width=200>


## How to test
1. Go to My Site and select the Home tab
2. ✅ Verify that the nudge text at the bottom of the Today's Stats is: `Interested in building your audience? Check out our top tips`

## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.