### PR TITLE
[Site Name] Add Tracks events and tests for Site Name

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -333,6 +333,7 @@ import Foundation
     case enhancedSiteCreationSiteNameSkipped
     case enhancedSiteCreationSiteNameEntered
     case enhancedSiteCreationSiteNameViewed
+    case enhancedSiteCreationSiteNameExperiment
 
     // Quick Start
     case quickStartStarted
@@ -903,6 +904,8 @@ import Foundation
             return "enhanced_site_creation_site_name_entered"
         case .enhancedSiteCreationSiteNameViewed:
             return "enhanced_site_creation_site_name_viewed"
+        case .enhancedSiteCreationSiteNameExperiment:
+            return "enhanced_site_creation_site_name_experiment"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -328,6 +328,12 @@ import Foundation
     case enhancedSiteCreationIntentQuestionViewed
     case enhancedSiteCreationIntentQuestionExperiment
 
+    // Site Name
+    case enhancedSiteCreationSiteNameCanceled
+    case enhancedSiteCreationSiteNameSkipped
+    case enhancedSiteCreationSiteNameEntered
+    case enhancedSiteCreationSiteNameViewed
+
     // Quick Start
     case quickStartStarted
 
@@ -887,6 +893,16 @@ import Foundation
             return "enhanced_site_creation_intent_question_viewed"
         case .enhancedSiteCreationIntentQuestionExperiment:
             return "enhanced_site_creation_intent_question_experiment"
+
+        // Site Name
+        case .enhancedSiteCreationSiteNameCanceled:
+            return "enhanced_site_creation_site_name_canceled"
+        case .enhancedSiteCreationSiteNameSkipped:
+            return "enhanced_site_creation_site_name_skipped"
+        case .enhancedSiteCreationSiteNameEntered:
+            return "enhanced_site_creation_site_name_entered"
+        case .enhancedSiteCreationSiteNameViewed:
+            return "enhanced_site_creation_site_name_viewed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -1,11 +1,23 @@
 import Foundation
 import WordPressKit
+import AutomatticTracks
 
 extension SiteIntentAB.Variant {
     var tracksProperty: String {
         switch self {
         case .treatment: return "treatment"
         case .control: return "control"
+        }
+    }
+}
+
+extension Variation {
+    var tracksProperty: String {
+        switch self {
+        case .treatment:
+            return "treatment"
+        case .control:
+            return "control"
         }
     }
 }
@@ -17,7 +29,7 @@ class SiteCreationAnalyticsHelper {
     private static let previewModeKey = "preview_mode"
     private static let verticalSlugKey = "vertical_slug"
     private static let verticalSearchTerm = "search_term"
-    private static let variation = "variation"
+    private static let variationKey = "variation"
     private static let siteNameKey = "site_name"
 
     // MARK: - Site Intent
@@ -47,7 +59,7 @@ class SiteCreationAnalyticsHelper {
     }
 
     static func trackSiteIntentExperiment(_ variant: SiteIntentAB.Variant) {
-        let properties = [variation: variant.tracksProperty]
+        let properties = [variationKey: variant.tracksProperty]
         WPAnalytics.track(.enhancedSiteCreationIntentQuestionExperiment, properties: properties)
     }
 
@@ -67,6 +79,11 @@ class SiteCreationAnalyticsHelper {
 
     static func trackSiteNameCanceled() {
         WPAnalytics.track(.enhancedSiteCreationSiteNameCanceled)
+    }
+
+    static func trackSiteNameExperiment(_ variant: Variation) {
+        let properties = [variationKey: variant.tracksProperty]
+        WPAnalytics.track(.enhancedSiteCreationSiteNameExperiment, properties: properties)
     }
 
     // MARK: - Site Design

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -18,6 +18,7 @@ class SiteCreationAnalyticsHelper {
     private static let verticalSlugKey = "vertical_slug"
     private static let verticalSearchTerm = "search_term"
     private static let variation = "variation"
+    private static let siteNameKey = "site_name"
 
     // MARK: - Site Intent
     static func trackSiteIntentViewed() {
@@ -48,6 +49,24 @@ class SiteCreationAnalyticsHelper {
     static func trackSiteIntentExperiment(_ variant: SiteIntentAB.Variant) {
         let properties = [variation: variant.tracksProperty]
         WPAnalytics.track(.enhancedSiteCreationIntentQuestionExperiment, properties: properties)
+    }
+
+    // MARK: - Site Name
+    static func trackSiteNameViewed() {
+        WPAnalytics.track(.enhancedSiteCreationSiteNameViewed)
+    }
+
+    static func trackSiteNameEntered(_ name: String) {
+        let properties = [siteNameKey: name]
+        WPAnalytics.track(.enhancedSiteCreationSiteNameEntered, properties: properties)
+    }
+
+    static func trackSiteNameSkipped() {
+        WPAnalytics.track(.enhancedSiteCreationSiteNameSkipped)
+    }
+
+    static func trackSiteNameCanceled() {
+        WPAnalytics.track(.enhancedSiteCreationSiteNameCanceled)
     }
 
     // MARK: - Site Design

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameStep.swift
@@ -8,6 +8,7 @@ final class SiteNameStep: WizardStep {
 
     var content: UIViewController {
         SiteNameViewController(siteNameViewFactory: makeSiteNameView) { [weak self] in
+            SiteCreationAnalyticsHelper.trackSiteNameSkipped()
             self?.didSet(siteName: nil)
         }
     }
@@ -17,6 +18,10 @@ final class SiteNameStep: WizardStep {
     }
 
     private func didSet(siteName: String?) {
+        if let siteName = siteName {
+            SiteCreationAnalyticsHelper.trackSiteNameEntered(siteName)
+        }
+
         // if users go back and then skip, the failable initializer of SiteInformation
         // will reset the state, avoiding to retain the previous site name
         creator.information = SiteInformation(title: siteName, tagLine: creator.information?.tagLine)
@@ -29,7 +34,7 @@ extension SiteNameStep {
     /// Builds a the view to be used as main content
     private func makeSiteNameView() -> UIView {
         SiteNameView(siteVerticalName: creator.vertical?.localizedTitle ?? "") { [weak self] siteName in
-            self?.didSet(siteName: siteName)
+            self?.didSet(siteName: siteName?.trimmingCharacters(in: .whitespacesAndNewlines))
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -6,7 +6,7 @@ import WordPressShared
 class SiteNameView: UIView {
 
     private var siteVerticalName: String
-    private let onContinue: (String?) -> Void
+    let onContinue: (String?) -> Void
 
     // Continue button constraints: will always be set in the initialzer, so it's fine to implicitly unwrap
     private var continueButtonTopConstraint: NSLayoutConstraint!
@@ -89,7 +89,7 @@ class SiteNameView: UIView {
     }()
 
     @objc private func navigateToNextScreen() {
-        onContinue(searchBar.text?.trimmingCharacters(in: .whitespacesAndNewlines))
+        onContinue(searchBar.text)
     }
 
     private lazy var continueButtonView: UIView = {

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameViewController.swift
@@ -29,9 +29,27 @@ class SiteNameViewController: UIViewController {
         setTitleForTraitCollection()
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        SiteCreationAnalyticsHelper.trackSiteNameViewed()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         view.becomeFirstResponder()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+
+        if isMovingFromParent {
+            // Called when popping from a nav controller, e.g. hitting "Back"
+            viewMovingFromParent()
+        }
+    }
+
+    func viewMovingFromParent() {
+        SiteCreationAnalyticsHelper.trackSiteNameCanceled()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -79,7 +79,7 @@ final class SiteCreationWizardLauncher {
 
     private func trackVariants() {
         SiteCreationAnalyticsHelper.trackSiteIntentExperiment(intentVariant)
-        // TODO: Track Site Name
+        SiteCreationAnalyticsHelper.trackSiteNameExperiment(nameVariant)
     }
 
     private func initStep(_ step: SiteCreationStep) -> WizardStep {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2173,6 +2173,7 @@
 		C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38C5D8027F61D2C002F517E /* MenuItemTests.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
+		C3DA0EE02807062600DA3250 /* SiteCreationNameTracksEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */; };
 		C3E2462926277B7700B99EA6 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C3E42AB027F4D30E00546706 /* MenuItemsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E42AAF27F4D30E00546706 /* MenuItemsViewControllerTests.swift */; };
 		C533CF350E6D3ADA000C3DE8 /* CommentsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C533CF340E6D3ADA000C3DE8 /* CommentsViewController.m */; };
@@ -6917,6 +6918,7 @@
 		C38C5D8027F61D2C002F517E /* MenuItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MenuItemTests.swift; path = Menus/MenuItemTests.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
+		C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationNameTracksEventTests.swift; sourceTree = "<group>"; };
 		C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostAuthorSelectorViewController.swift; sourceTree = "<group>"; };
 		C3E42AAF27F4D30E00546706 /* MenuItemsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemsViewControllerTests.swift; sourceTree = "<group>"; };
 		C52812131832E071008931FD /* WordPress 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 13.xcdatamodel"; sourceTree = "<group>"; };
@@ -10538,6 +10540,7 @@
 				32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */,
 				C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */,
 				B030FE0927EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift */,
+				C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */,
 				C3439B5E27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift */,
 			);
 			path = SiteCreation;
@@ -19442,6 +19445,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C3DA0EE02807062600DA3250 /* SiteCreationNameTracksEventTests.swift in Sources */,
 				73C8F06621BEF76B00DDDF7E /* SiteAssemblyViewTests.swift in Sources */,
 				73178C2821BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift in Sources */,
 				D81C2F6020F891C4002AE1F1 /* TrashCommentActionTests.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteCreationNameTracksEventTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreationNameTracksEventTests.swift
@@ -4,21 +4,14 @@ import AutomatticTracks
 
 class SiteCreationNameTracksEventTests: XCTestCase {
 
-    let featureFlags = FeatureFlagOverrideStore()
-
-    private let controlVariant = Variation.control
-    private let treatmentVariant = Variation.treatment(nil)
-
     private let siteNameEventPropertyKey = "site_name"
 
     override func setUpWithError() throws {
         TestAnalyticsTracker.setup()
-        try featureFlags.override(FeatureFlag.siteName, withValue: true)
     }
 
     override func tearDownWithError() throws {
         TestAnalyticsTracker.tearDown()
-        try featureFlags.override(FeatureFlag.siteName, withValue: false)
     }
 
     func siteNameViewControllerMaker() throws -> SiteNameViewController {

--- a/WordPress/WordPressTest/SiteCreation/SiteCreationNameTracksEventTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreationNameTracksEventTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+import AutomatticTracks
+@testable import WordPress
+
+class SiteCreationNameTracksEventTests: XCTestCase {
+
+    let featureFlags = FeatureFlagOverrideStore()
+
+    private let controlVariant = Variation.control
+    private let treatmentVariant = Variation.treatment(nil)
+
+    private let siteNameEventPropertyKey = "site_name"
+
+    override func setUpWithError() throws {
+        TestAnalyticsTracker.setup()
+        try featureFlags.override(FeatureFlag.siteName, withValue: true)
+    }
+
+    override func tearDownWithError() throws {
+        TestAnalyticsTracker.tearDown()
+        try featureFlags.override(FeatureFlag.siteName, withValue: false)
+    }
+
+    func siteNameViewControllerMaker() throws -> SiteNameViewController {
+        let mockSiteCreator = SiteCreator()
+        let siteNameStep = SiteNameStep(creator: mockSiteCreator)
+        let siteIntentViewController = try XCTUnwrap(siteNameStep.content as? SiteNameViewController)
+        return siteIntentViewController
+    }
+
+    func load(_ siteNameViewController: SiteNameViewController) {
+        siteNameViewController.loadViewIfNeeded()
+        siteNameViewController.viewDidLoad()
+    }
+
+    func tap(_ barButtonItem: UIBarButtonItem?) throws {
+        let action = try XCTUnwrap(barButtonItem?.action)
+        UIApplication.shared.sendAction(action, to: barButtonItem?.target, from: nil, for: nil)
+    }
+
+    func testSiteNameTracksEventFiresWhenViewed() throws {
+
+        // Given
+        let siteNameViewController = try siteNameViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationSiteNameViewed.value
+
+        // When
+        load(siteNameViewController)
+
+        // Then
+        let lastTrackedEvent = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(lastTrackedEvent, expectedEvent)
+    }
+
+    func testSiteNameTracksEventFiresWhenSkipped() throws {
+
+        // Given
+        let siteNameViewController = try siteNameViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationSiteNameSkipped.value
+
+        // When
+        load(siteNameViewController)
+        try tap(siteNameViewController.navigationItem.rightBarButtonItem)
+
+        // Then
+        let trackedEvent = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(expectedEvent, trackedEvent)
+    }
+
+    func testSiteNameTracksEventFiresWhenCanceled() throws {
+
+        // Given
+        let siteNameViewController = try siteNameViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationSiteNameCanceled.value
+
+        // When
+        siteNameViewController.viewMovingFromParent()
+
+        // Then
+        let trackedEvent = try XCTUnwrap(TestAnalyticsTracker.tracked.last?.event)
+        XCTAssertEqual(expectedEvent, trackedEvent)
+    }
+
+    func testSiteNameTracksEventFiresWhenEntered() throws {
+
+        // Given
+        let siteNameViewController = try siteNameViewControllerMaker()
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationSiteNameEntered.value
+        let expectedProperty = "My Test Site"
+        let siteNameView = try XCTUnwrap(siteNameViewController.view as? SiteNameView)
+
+        // When
+        siteNameView.onContinue(expectedProperty)
+
+        // Then
+        let lastTracked = try XCTUnwrap(TestAnalyticsTracker.tracked.last)
+        XCTAssertEqual(expectedEvent, lastTracked.event)
+        let siteTitle = try XCTUnwrap(lastTracked.properties[siteNameEventPropertyKey] as? String)
+        XCTAssertEqual(siteTitle, expectedProperty)
+    }
+}

--- a/WordPress/WordPressTest/SiteCreation/SiteCreationWizardLauncherTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteCreationWizardLauncherTests.swift
@@ -101,7 +101,35 @@ class SiteCreationWizardLauncherTests: XCTestCase {
         // When
         let _ = SiteCreationWizardLauncher(intentVariant: variant)
 
-        //Then
+        // Then
+        let trackedEvents = try XCTUnwrap(TestAnalyticsTracker.tracked.filter { $0.event == expectedEvent })
+        XCTAssertEqual(trackedEvents.count, 1)
+        let variation = try XCTUnwrap(trackedEvents[0].properties[variationEventPropertyKey] as? String)
+        XCTAssertEqual(variation, expectedProperty)
+
+        TestAnalyticsTracker.tearDown()
+    }
+
+    func testSiteNameVariantTracking() throws {
+
+        /// When the Site Creation Wizard Launcher starts, it should fire an event for the variant being tracked
+
+        try runSiteNameVariantTrackingTest(for: nameTreatment)
+        try runSiteNameVariantTrackingTest(for: nameControl)
+    }
+
+    private func runSiteNameVariantTrackingTest(for variant: Variation) throws {
+        TestAnalyticsTracker.setup()
+
+        // Given
+        let expectedEvent = WPAnalyticsEvent.enhancedSiteCreationSiteNameExperiment.value
+        let expectedProperty = variant.tracksProperty
+        let variationEventPropertyKey = "variation"
+
+        // When
+        let _ = SiteCreationWizardLauncher(nameVariant: variant)
+
+        // Then
         let trackedEvents = try XCTUnwrap(TestAnalyticsTracker.tracked.filter { $0.event == expectedEvent })
         XCTAssertEqual(trackedEvents.count, 1)
         let variation = try XCTUnwrap(trackedEvents[0].properties[variationEventPropertyKey] as? String)


### PR DESCRIPTION
Closes #18337

## To test:

**Prerequisites:** [See this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18298) for instructions on enabling the Site Name feature.

_Please note: If testing this PR via Xcode, you can verify Tracks events via the Xcode log. If you're testing this on a PR build or a beta build of the app, you can either use the Tracks dashboard or the in-app logs (tap profile pic → "Help and Support" → "Activity Logs")._

**Important**: If you're overriding the experiment variants manually, don't be surprised if the event value doesn't match what you'd expect (e.g. it shows `control` though you can see the view). This is dependent on where you overrode the value.

1. Start Site Creation flow
2. Expect three events: `enhanced_site_creation_intent_question_experiment`, `enhanced_site_creation_site_name_experiment`, `enhanced_site_creation_accessed`, `enhanced_site_creation_intent_question_viewed`
3. Tap a vertical
4. Expect two events: `enhanced_site_creation_intent_question_vertical_selected`, `enhanced_site_creation_site_name_viewed`
5. Tap "Skip" at the top right on the Site Name screen
6. Expect two events: `enhanced_site_creation_site_name_skipped`, `enhanced_site_creation_site_design_viewed`
7. Tap the back arrow at the top left on the Design Screen (as of this PR the text for Site Name isn't showing in the nav bar, this will be fixed)
8. Tap the back arrow at the top left on the Site Name screen
9. Expect one event `enhanced_site_creation_site_name_canceled`
10. Tap a vertical (events from step 4 will fire again)
11. Type a site name and tap "Continue"
12. Expect one event `enhanced_site_creation_site_name_entered` with a property `site_name` containing the name that was typed in step 11

## Regression Notes
1. Potential unintended areas of impact
- Sending Tracks events during Site Creation

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested manually with the steps above
- Ran existing automated tests related to Site Creation

3. What automated tests I added (or what prevented me from doing so)
- Added `SiteCreationNameTracksEventTests`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
