### PR TITLE
[Site Name] Add back navigation text to Site Name

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameViewController.swift
@@ -40,6 +40,8 @@ private extension SiteNameViewController {
 
     func configureNavigationBar() {
         removeNavigationBarBorder()
+        // Title
+        navigationItem.backButtonTitle = TextContent.backButtonTitle
         // Add skip button
         navigationItem.rightBarButtonItem = UIBarButtonItem(title: TextContent.skipButtonTitle,
                                                             style: .done,
@@ -85,5 +87,7 @@ private extension SiteNameViewController {
                                                                         comment: "Title for Site Name screen in iPhone landscape.")
         static let skipButtonTitle = NSLocalizedString("Skip",
                                                        comment: "Title for the Skip button in the Site Name Screen.")
+        static let backButtonTitle = NSLocalizedString("Name",
+                                                       comment: "Shortened version of the main title to be used in back navigation.")
     }
 }


### PR DESCRIPTION
This PR is a UI tweak to add the back navigation text to Site Name to match the designs.

## To test:

**Prerequisites**: Site Intent and Site Name both should be enabled. [See this PR for more information](https://github.com/wordpress-mobile/WordPress-iOS/pull/18298).

| Before | After |
| -------| ----- |
| ![No Site Name text](https://user-images.githubusercontent.com/2092798/163276178-9786e85f-727e-4ae0-8e24-69504df5772e.png) | ![Site Name back text](https://user-images.githubusercontent.com/2092798/163276273-579eeae8-b62f-4ac5-85c8-6a3cda1634d8.png) |

1. Start the Site Creation flow
2. Skip the Site Intent screen
3. Skip the Site Name screen
4. On the Site Design screen, observe the navigation's "Back" button text - expect it to read "Name"

## Regression Notes
1. Potential unintended areas of impact
- None

5. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual UI testing

6. What automated tests I added (or what prevented me from doing so)
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
