### PR TITLE
Blogging Prompts Feature Introduction: add shadow to prompt card view.

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -32,7 +32,7 @@ private extension BloggingPromptsFeatureDescriptionView {
 
         promptCard.layer.borderWidth = Style.borderWidth
         promptCard.layer.cornerRadius = Style.cardCornerRadius
-        promptCard.layer.borderColor = Style.borderColor
+        promptCard.layer.borderColor = Style.cardBorderColor
 
         promptCard.layer.shadowOffset = Style.cardShadowOffset
         promptCard.layer.shadowOpacity = Style.cardShadowOpacity
@@ -51,7 +51,7 @@ private extension BloggingPromptsFeatureDescriptionView {
     func configureNote() {
         noteTextView.layer.borderWidth = Style.borderWidth
         noteTextView.layer.cornerRadius = Style.noteCornerRadius
-        noteTextView.layer.borderColor = Style.borderColor
+        noteTextView.layer.borderColor = Style.noteBorderColor
         noteTextView.textContainerInset = Style.noteInsets
         configureNoteText()
     }
@@ -88,7 +88,8 @@ private extension BloggingPromptsFeatureDescriptionView {
         static let cardShadowRadius: CGFloat = 14
         static let cardShadowOpacity: Float = 0.15
         static let cardShadowOffset = CGSize(width: 0, height: 10.0)
+        static let cardBorderColor = UIColor(red: 0.882, green: 0.886, blue: 0.886, alpha: 1).cgColor
         static let borderWidth: CGFloat = 1
-        static let borderColor = UIColor.textQuaternary.cgColor
+        static let noteBorderColor = UIColor.textQuaternary.cgColor
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -20,20 +20,35 @@ class BloggingPromptsFeatureDescriptionView: UIView, NibLoadable {
 private extension BloggingPromptsFeatureDescriptionView {
 
     func configureView() {
-        promptCardView.layer.borderWidth = Style.borderWidth
-        promptCardView.layer.cornerRadius = Style.cardCornerRadius
-        promptCardView.layer.borderColor = Style.borderColor
+        configurePromptCard()
+        configureDescription()
+        configureNote()
+    }
 
+    func configurePromptCard() {
         let promptCard = DashboardPromptsCardCell()
         promptCard.configureForExampleDisplay()
         promptCard.translatesAutoresizingMaskIntoConstraints = false
+
+        promptCard.layer.borderWidth = Style.borderWidth
+        promptCard.layer.cornerRadius = Style.cardCornerRadius
+        promptCard.layer.borderColor = Style.borderColor
+
+        promptCard.layer.shadowOffset = Style.cardShadowOffset
+        promptCard.layer.shadowOpacity = Style.cardShadowOpacity
+        promptCard.layer.shadowRadius = Style.cardShadowRadius
+
         promptCardView.addSubview(promptCard)
         promptCardView.pinSubviewToSafeArea(promptCard)
+    }
 
+    func configureDescription() {
         descriptionLabel.font = Style.labelFont
         descriptionLabel.textColor = Style.textColor
         descriptionLabel.text = Strings.featureDescription
+    }
 
+    func configureNote() {
         noteTextView.layer.borderWidth = Style.borderWidth
         noteTextView.layer.cornerRadius = Style.noteCornerRadius
         noteTextView.layer.borderColor = Style.borderColor
@@ -69,7 +84,10 @@ private extension BloggingPromptsFeatureDescriptionView {
         static let textColor: UIColor = .textSubtle
         static let noteInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
         static let noteCornerRadius: CGFloat = 6
-        static let cardCornerRadius: CGFloat = 16
+        static let cardCornerRadius: CGFloat = 10
+        static let cardShadowRadius: CGFloat = 14
+        static let cardShadowOpacity: Float = 0.15
+        static let cardShadowOffset = CGSize(width: 0, height: 10.0)
         static let borderWidth: CGFloat = 1
         static let borderColor = UIColor.textQuaternary.cgColor
     }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -86,7 +86,7 @@ private extension BloggingPromptsFeatureDescriptionView {
         static let noteCornerRadius: CGFloat = 6
         static let cardCornerRadius: CGFloat = 10
         static let cardShadowRadius: CGFloat = 14
-        static let cardShadowOpacity: Float = 0.15
+        static let cardShadowOpacity: Float = 0.1
         static let cardShadowOffset = CGSize(width: 0, height: 10.0)
         static let cardBorderColor = UIColor(red: 0.882, green: 0.886, blue: 0.886, alpha: 1).cgColor
         static let borderWidth: CGFloat = 1


### PR DESCRIPTION
Ref: #18176

This adds a shadow to the prompt card view.

After some discussion in Slack, @iamthomasbishop  created a simplified design for the shadow:

<img width="500" alt="simplified_shadow" src="https://user-images.githubusercontent.com/1816888/163287194-8a025af7-2a7d-4f7b-8dc3-77d641cde94e.png">

To test:
- Enable `bloggingPrompts` and `mySiteDashboard` feature flags.
- Run the app.
- When the app launches, the Feature Introduction will appear.
- Verify the prompt card bordered view now has a shadow.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/163289842-13e69a03-f7c0-494c-be69-fe63162135af.png) | ![after](https://user-images.githubusercontent.com/1816888/163289838-ebcbf5b5-fd3a-4589-8318-54fc3ee2c347.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.