### PR TITLE
Blogging Prompts Feature Introduction: customize action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
@@ -4,28 +4,57 @@ import UIKit
 
 class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
 
-    class func navigationController() -> UINavigationController {
-        let controller = BloggingPromptsFeatureIntroduction()
+    private var interactionType: BloggingPromptsFeatureIntroduction.InteractionType
+
+    enum InteractionType {
+        // Two buttons are displayed, both perform an action.
+        case actionable
+        // One button is displayed, which only dismisses the view.
+        case informational
+
+        var primaryButtonTitle: String {
+            switch self {
+            case .actionable:
+                return ButtonStrings.tryIt
+            case .informational:
+                return ButtonStrings.gotIt
+            }
+        }
+
+        var secondaryButtonTitle: String? {
+            switch self {
+            case .actionable:
+                return ButtonStrings.remindMe
+            default:
+                return nil
+            }
+        }
+    }
+
+    class func navigationController(interactionType: BloggingPromptsFeatureIntroduction.InteractionType) -> UINavigationController {
+        let controller = BloggingPromptsFeatureIntroduction(interactionType: interactionType)
         let navController = UINavigationController(rootViewController: controller)
         return navController
     }
 
-    init() {
+    init(interactionType: BloggingPromptsFeatureIntroduction.InteractionType) {
+
         let featureDescriptionView: BloggingPromptsFeatureDescriptionView = {
             let featureDescriptionView = BloggingPromptsFeatureDescriptionView.loadFromNib()
              featureDescriptionView.translatesAutoresizingMaskIntoConstraints = false
             return featureDescriptionView
         }()
 
-        let headerImage = UIImage(named: HeaderStyle.imageName)?
-            .withTintColor(.clear)
+        let headerImage = UIImage(named: HeaderStyle.imageName)?.withTintColor(.clear)
 
-        super.init(headerTitle: Strings.headerTitle,
-                   headerSubtitle: Strings.headerSubtitle,
+        self.interactionType = interactionType
+
+        super.init(headerTitle: HeaderStrings.title,
+                   headerSubtitle: HeaderStrings.subtitle,
                    headerImage: headerImage,
                    featureDescriptionView: featureDescriptionView,
-                   primaryButtonTitle: Strings.primaryButtonTitle,
-                   secondaryButtonTitle: Strings.secondaryButtonTitle)
+                   primaryButtonTitle: interactionType.primaryButtonTitle,
+                   secondaryButtonTitle: interactionType.secondaryButtonTitle)
 
         featureIntroductionDelegate = self
     }
@@ -46,10 +75,19 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
 extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
 
     func primaryActionSelected() {
+        guard interactionType == .actionable else {
+            super.closeButtonTapped()
+            return
+        }
+
         // TODO: show site selector/draft post
     }
 
     func secondaryActionSelected() {
+        guard interactionType == .actionable else {
+            return
+        }
+
         // TODO: show site selector/Blogging Reminders
     }
 
@@ -81,11 +119,15 @@ private extension BloggingPromptsFeatureIntroduction {
         headerImageView.layer.addSublayer(gradient)
     }
 
-    enum Strings {
-        static let headerTitle: String = NSLocalizedString("Introducing Prompts", comment: "Title displayed on the feature introduction view.")
-        static let headerSubtitle: String = NSLocalizedString("The best way to become a better writer is to build a writing habit and share with others - that’s where Prompts come in!", comment: "Subtitle displayed on the feature introduction view.")
-        static let primaryButtonTitle: String = NSLocalizedString("Try it now", comment: "Primary button title on the feature introduction view.")
-        static let secondaryButtonTitle: String = NSLocalizedString("Remind me", comment: "Secondary button title on the feature introduction view.")
+    enum ButtonStrings {
+        static let tryIt = NSLocalizedString("Try it now", comment: "Button title on the blogging prompt's feature introduction view to answer a prompt.")
+        static let gotIt = NSLocalizedString("Got it", comment: "Button title on the blogging prompt's feature introduction view to dismiss the view.")
+        static let remindMe = NSLocalizedString("Remind me", comment: "Button title on the blogging prompt's feature introduction view to set a reminder.")
+    }
+
+    enum HeaderStrings {
+        static let title: String = NSLocalizedString("Introducing Prompts", comment: "Title displayed on the feature introduction view.")
+        static let subtitle: String = NSLocalizedString("The best way to become a better writer is to build a writing habit and share with others - that’s where Prompts come in!", comment: "Subtitle displayed on the feature introduction view.")
     }
 
     enum HeaderStyle {

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -74,6 +74,10 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
         featureIntroductionDelegate?.secondaryActionSelected?()
     }
 
+    @IBAction func closeButtonTapped() {
+        dismiss(animated: true)
+    }
+
 }
 
 private extension FeatureIntroductionViewController {
@@ -89,10 +93,6 @@ private extension FeatureIntroductionViewController {
             contentView.leftAnchor.constraint(equalTo: scrollView.leftAnchor),
             contentView.widthAnchor.constraint(equalTo: scrollView.widthAnchor),
         ])
-    }
-
-    @IBAction func closeButtonTapped() {
-        dismiss(animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -97,7 +97,7 @@ extension WPTabBarController {
     // TODO: remove when final launching source determine.
     func showBloggingPromptsFeatureIntroduction() {
         if FeatureFlag.bloggingPrompts.enabled {
-            present(BloggingPromptsFeatureIntroduction.navigationController(), animated: true)
+            present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .actionable), animated: true)
         }
     }
 


### PR DESCRIPTION
Ref: #18176

When the Blogging Prompts feature introduction is displayed, the new `interactionType` parameter indicates how many action (bottom) buttons are displayed and what they do.

- `.actionable`:
  - Primary and secondary buttons are shown as before.
  - In the future they will perform their respective actions. For now, they still do nothing.
  - Is intended to be displayed from notifications.
- `.informational`: 
  - Only the primary button is displayed, with the `Got it` title.
  - Tapping it dismisses the view.
  - Is intended to be displayed from the Help button in the scheduling view. (ref #18316)

To test:
- Enable `bloggingPrompts` feature flag.
- Run the app.
- When the app launches, the Feature Introduction will appear.
- Verify:
  - Both buttons are displayed.
  - Tapping them does nothing.
- In `WPTabBarController+Swift.swift:showBloggingPromptsFeatureIntroduction`, change the `interactionType` to `.informational`.
- Run the app. When the Feature Introduction appears, verify:
  - Only a `Got it` button is displayed.
  - Tapping it dismisses the view.

| Actionable | Informational |
|--------|-------|
| ![actionable](https://user-images.githubusercontent.com/1816888/163296693-11397afd-72be-4e7d-8c20-ddbd0cba786b.png) | ![informational](https://user-images.githubusercontent.com/1816888/163296704-d097d4fd-7db0-418f-b8b5-1624513d8bee.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
