### PR TITLE
My Site Dashboard: Show site name in My Site nav title

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] a11y: VoiceOver has been improved on the Menus view and now announces changes to ordering. [#18155]
 * [*] Notifications list: remove comment Trash swipe action. [#18349]
 * [*] Reader: Fixed a bug that caused cut off content in reader web view [#16106]
+* [*] My Site: display site name in My Site screen nav title [#18373]
 
 19.6
 -----

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -125,6 +125,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
             showSitePicker(for: newBlog)
             showBlogDetails(for: newBlog)
+            updateNavigationTitle(for: newBlog)
             updateSegmentedControl(for: newBlog, switchTabsIfNeeded: true)
             createFABIfNeeded()
         }
@@ -249,6 +250,14 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         NotificationCenter.default.addObserver(self, selector: #selector(showAddSelfHostedSite), name: .addSelfHosted, object: nil)
     }
 
+    func updateNavigationTitle(for blog: Blog) {
+        let blogName = blog.settings?.name
+        let title = blogName != nil && blogName?.isEmpty == false
+            ? blogName
+            : Strings.mySite
+        navigationItem.title = title
+    }
+
     private func updateSegmentedControl(for blog: Blog, switchTabsIfNeeded: Bool = false) {
         // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device doesn't have a horizontally compact view
         let hideSegmentedControl =
@@ -327,7 +336,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func setupNavigationItem() {
         navigationItem.largeTitleDisplayMode = FeatureFlag.mySiteDashboard.enabled ? .never : .always
-        navigationItem.title = NSLocalizedString("My Site", comment: "Title of My Site tab")
+        navigationItem.title = Strings.mySite
 
         // Workaround:
         //
@@ -394,6 +403,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         showSitePicker(for: mainBlog)
         showBlogDetails(for: mainBlog)
+        updateNavigationTitle(for: mainBlog)
         updateSegmentedControl(for: mainBlog, switchTabsIfNeeded: true)
     }
 
@@ -753,6 +763,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self.segmentedControlValueChanged()
             }
 
+            self.updateNavigationTitle(for: blog)
             self.updateSegmentedControl(for: blog)
             self.updateChildViewController(for: blog)
             self.createFABIfNeeded()
@@ -882,6 +893,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         static let segmentedControlYOffset: CGFloat = 24
         static let segmentedControlHeight: CGFloat = 32
         static let siteMenuSpotlightOffset: CGFloat = 8
+    }
+
+    private enum Strings {
+        static let mySite = NSLocalizedString("My Site", comment: "Title of My Site tab")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -337,6 +337,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func setupNavigationItem() {
         navigationItem.largeTitleDisplayMode = FeatureFlag.mySiteDashboard.enabled ? .never : .always
         navigationItem.title = Strings.mySite
+        navigationItem.backButtonTitle = Strings.mySite
 
         // Workaround:
         //

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -200,6 +200,13 @@ extension SitePickerViewController {
 
             self?.blogDetailHeaderView.setTitleLoading(false)
             self?.blogDetailHeaderView.refreshSiteTitle()
+
+            guard let parent = self?.parent as? MySiteViewController else {
+                return
+            }
+
+            parent.updateNavigationTitle(for: blog)
+
         }, failure: { [weak self] error in
             self?.blog.settings?.name = existingBlogTitle
             self?.blogDetailHeaderView.setTitleLoading(false)


### PR DESCRIPTION
Fixes #18289 

## Description
- Displays site name in My Site nav title if site name exists. Otherwise, displays "My Site"

<img src="https://user-images.githubusercontent.com/6711616/163363654-b869f08e-93c1-436d-afd6-3b8b410bf13a.png" width=200>


## How to test

1. Go to My Site
2. Scroll up so that the nav title appears
3. ✅ Verify that the nav title displays the site name for the current site
4. Switch sites by tapping on the down chevron at the top of the My Site screen
5. ✅ Verify that the nav title displays the site name for the current site
6. Tap on the site title
7. Update the site title and tap save
8. ✅ Verify that the nav title displays the updated site name
9. Tap on any item in the Menu or the Home tab that pushes a view controller onto the nav stack (i.e. Stats)
10. ✅ Verify that the back button item title is `My Site`



https://user-images.githubusercontent.com/6711616/163363622-d865859a-530b-432b-bbe3-ff9ac6a63343.mp4



## Regression Notes
1. Potential unintended areas of impact
n/a

11. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

12. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
