### PR TITLE
[Tooling] Add Ruby version warning to installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Please refer to the sections below for more detailed information. The instructio
 
 #### Configure Your WordPress App Development Environment
 
+1. Check that your local version of Ruby matches the one in [.ruby-version](./.ruby-version). We recommend installing a tool like [rbenv](https://github.com/rbenv/rbenv) so your system will always use the version defined in that file.
 1. Return to the command line and run `rake init:oss` to configure your computer and WordPress app to be able to run and login to WordPress.com
 1. Once completed, run `rake xcode` to open the project in Xcode.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Please refer to the sections below for more detailed information. The instructio
 
 #### Configure Your WordPress App Development Environment
 
-1. Check that your local version of Ruby matches the one in [.ruby-version](./.ruby-version). We recommend installing a tool like [rbenv](https://github.com/rbenv/rbenv) so your system will always use the version defined in that file.
+1. Check that your local version of Ruby matches the one in [.ruby-version](./.ruby-version). We recommend installing a tool like [rbenv](https://github.com/rbenv/rbenv) so your system will always use the version defined in that file. Once installed, simply run `rbenv install` in the repo to match the version.
 1. Return to the command line and run `rake init:oss` to configure your computer and WordPress app to be able to run and login to WordPress.com
 1. Once completed, run `rake xcode` to open the project in Xcode.
 

--- a/Rakefile
+++ b/Rakefile
@@ -323,7 +323,7 @@ namespace :install do
           puts 'Xcode installed'
         end
 
-        puts 'Checking CI recommendded installed Xcode version'
+        puts 'Checking CI recommended installed Xcode version'
 
         unless xcode_version_is_correct?
           #if xcode is the wrong version, prompt user to install the correct version and terminate rake

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,36 @@ desc 'Install required dependencies'
 task :dependencies => %w[dependencies:check assets:check]
 
 namespace :dependencies do
-  task :check => %w[bundler:check bundle:check credentials:apply pod:check lint:check]
+  task :check => %w[ruby:check bundler:check bundle:check credentials:apply pod:check lint:check]
+
+  namespace :ruby do
+    task :check do
+      unless ruby_version_is_match?
+        #show a warning that Ruby doesn't match .ruby-version
+        puts '====================================================================================='
+        puts 'Warning: Your local Ruby version doesn\'t match .ruby-version'
+        puts ''
+        puts ".ruby-version:\t#{get_ruby_repo_version}"
+        puts "Your Ruby:\t#{RUBY_VERSION}"
+        puts ''
+        puts 'Refer to the WPiOS docs on setting the exact version with rbenv.'
+        puts ''
+        puts 'Press enter to continue anyway'
+        puts '====================================================================================='
+        STDIN.gets.strip
+      end
+    end
+
+    #compare repo Ruby version to local
+    def ruby_version_is_match?
+      get_ruby_repo_version == RUBY_VERSION
+    end
+
+    #get Ruby version defined in the repo
+    def get_ruby_repo_version
+      repo_version = File.read('./.ruby-version').strip
+    end
+  end
 
   namespace :bundler do
     task :check do

--- a/Rakefile
+++ b/Rakefile
@@ -278,7 +278,7 @@ task :xcode => [:dependencies] do
   sh "open #{XCODE_WORKSPACE}"
 end
 
-desc "Install and configure WordPress iOS and it's dependencies - External Contributors"
+desc "Install and configure WordPress iOS and its dependencies - External Contributors"
 namespace :init do
 task :oss => %w[
   install:xcode:check
@@ -288,7 +288,7 @@ task :oss => %w[
   credentials:setup
 ]
 
-desc "Install and configure WordPress iOS and it's dependencies - Automattic Developers"
+desc "Install and configure WordPress iOS and its dependencies - Automattic Developers"
 task :developer => %w[
   install:xcode:check
   dependencies


### PR DESCRIPTION
Fixes #18261

### To test:

#### Test 1: Ruby version doesn't match `.ruby-version`
1. Switch to a version of Ruby that doesn't match [.ruby-version](./ruby-version)
2. Run `rake dependencies` or any of its callers (`rake init:oss`, `rake init:developer`)
3. Expect to see a message similar to:

```
=====================================================================================
Warning: Your local Ruby version doesn't match .ruby-version

.ruby-version:	2.7.4
Your Ruby:	2.6.8

Refer to the WPiOS docs on setting the exact version with rbenv.

Press enter to continue anyway
=====================================================================================
```

4. Expect to be able to continue with the installation if pressing enter

#### Test 2: Ruby version matches `.ruby-version`
1. Switch to a version of Ruby that matches [.ruby-version](./ruby-version)
2. Run `rake dependencies` or any of its callers (`rake init:oss`, `rake init:developer`)
3. Expect no changes to the installer script's behavior

## Regression Notes
1. Potential unintended areas of impact
- The entire `Rakefile` as I've never written Ruby.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manually

6. What automated tests I added (or what prevented me from doing so)
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
