### PR TITLE
AB test: make ExPlat available only for WPiOS

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -1,5 +1,7 @@
 import AutomatticTracks
 
+// Attention: AB test is available only for WPiOS
+// Jetpack is not supported
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
     case siteNameV1 = "wpios_site_name_v1"
@@ -14,7 +16,8 @@ extension ABTest {
     /// Start the AB Testing platform if any experiment exists
     ///
     static func start() {
-        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn else {
+        guard ABTest.allCases.count > 1, AccountHelper.isLoggedIn,
+              AppConfiguration.isWordPress else {
             return
         }
 

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = false
+    @objc static let isWordPress: Bool = true
     @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = true
     @objc static let allowsConnectSite: Bool = true

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -5,6 +5,7 @@ import Foundation
  */
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true
+    @objc static let isWordPress: Bool = false
     @objc static let showJetpackSitesOnly: Bool = false
     @objc static let allowsNewPostShortcut: Bool = true
     @objc static let allowsConnectSite: Bool = true


### PR DESCRIPTION
Jetpack is not available on ExPlat. Thus, we should not request an experiment for it. This PR address:

* Experiment for Jetpack will always return `.control`
* it only refresh experiments if it's WPiOS

### To test

You should be logged in for testing.

1. Add a breakpoint in `ABtest.swift` line `27`
2. Run WPiOS
3. ✅ Make sure the breakpoint is hit
4. Run Jetpack
5. ✅ Make sure the breakpoint is not hit

## Regression Notes
1. Potential unintended areas of impact
WordPress AB testing

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested that is working as expected.

4. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
