### PR TITLE
[Site Name] Enable Site Name feature

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [**] Block Editor: Update "add block" button's style in default editor view [https://github.com/WordPress/gutenberg/pull/39726]
 * [*] Block Editor: Remove banner error notification on upload failure [https://github.com/WordPress/gutenberg/pull/39694]
 * [*] My Site: display site name in My Site screen nav title [#18373]
+* [*] [internal] Site creation: Adds a new screen asking the user the name of the site [#18280]
 
 19.6
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -79,7 +79,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .landInTheEditor:
             return false
         case .siteName:
-            return false
+            return true
         }
     }
 


### PR DESCRIPTION
Closes #18362

This PR enables the Site Name feature flag by default.

To test:

**Verify that the feature is turned on by default**

**Prerequisites:** Use the bookmarklet in Abacus to manually assign a user to `wpios_site_name_v1`, or manually set to `.treatment` [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/594fe70ade507a524dc73171706195b65ea091e4/WordPress/Classes/ViewRelated/Site%20Creation/Wizard/SiteCreationWizardLauncher.swift#L75).

1. Start with a fresh install of the app
2. Log in with a user account
3. Start the site creation flow to create a WordPress.com site
4. Select or skip a vertical on the Site Intent screen
5. Expect the Site Name screen to appear after the Site Intent screen

## Regression Notes
1. Potential unintended areas of impact
N/A

7. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
