### PR TITLE
My Site Dashboard: Avoid showing recently deleted posts in dashboard

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -604,6 +604,8 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     
     RemotePost *remotePost = [self remotePostWithPost:post];
     id<PostServiceRemote> remote = [self.postServiceRemoteFactory forBlog:post.blog];
+    post.statusAfterSync = PostStatusTrash;
+    post.latest.statusAfterSync = PostStatusTrash;
     [remote trashPost:remotePost success:successBlock failure:failureBlock];
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -30,7 +30,7 @@ class PostsCardViewModel: NSObject {
 
     private let postService: PostService
 
-    private var postListFilter: PostListFilter = PostListFilter.draftFilter()
+    private var postListFilter: PostListFilter = PostListFilter.draftFilter(includeRecentlyTrashed: false)
 
     private var fetchedResultsController: NSFetchedResultsController<Post>!
 
@@ -250,7 +250,7 @@ private extension PostsCardViewModel {
     func updateFilter() {
         switch status {
         case .draft:
-            self.postListFilter = PostListFilter.draftFilter()
+            self.postListFilter = PostListFilter.draftFilter(includeRecentlyTrashed: false)
         case .scheduled:
             self.postListFilter = PostListFilter.scheduledFilter()
         default:

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -108,6 +108,8 @@ import Foundation
     /// - existing draft/pending posts
     /// - existing draft/pending posts transitioned to another status (e.g. published)
     ///   but not uploaded yet
+    /// - recentely trashed posts: posts that have been trashed but the trash API request hasn't finsihed yet.
+    ///   Not included if the corresponding flag is false. Yet the flag defaults to true
     ///
     @objc class func draftFilter(includeRecentlyTrashed: Bool = true) -> PostListFilter {
         let filterType: Status = .draft

--- a/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilter.swift
@@ -109,10 +109,10 @@ import Foundation
     /// - existing draft/pending posts transitioned to another status (e.g. published)
     ///   but not uploaded yet
     ///
-    @objc class func draftFilter() -> PostListFilter {
+    @objc class func draftFilter(includeRecentlyTrashed: Bool = true) -> PostListFilter {
         let filterType: Status = .draft
         let statuses: [BasePost.Status] = [.draft, .pending]
-
+        let statusesAfterSync: [BasePost.Status] = includeRecentlyTrashed ? [.draft, .pending, .trash] : [.draft, .pending]
         let statusesForLocalDrafts: [BasePost.Status] = [.draft, .pending, .publish, .publishPrivate, .scheduled]
 
         let query =
@@ -127,7 +127,7 @@ import Foundation
             + " OR (postID > %i AND statusAfterSync = nil AND status IN (%@))"
         let predicate = NSPredicate(format: query,
                                     statuses.strings,
-                                    statuses.strings,
+                                    statusesAfterSync.strings,
                                     BasePost.defaultPostIDValue,
                                     statusesForLocalDrafts.strings,
                                     BasePost.defaultPostIDValue,

--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -117,6 +117,26 @@ class PostListFilterTests: XCTestCase {
         expect(matchingPosts).to(allPass { predicate.evaluate(with: $0!) == true })
     }
 
+    func testDraftFilterDoesNotincludeRecentlyTrashedPosts() {
+        // Arrange
+        let predicate = PostListFilter.draftFilter(includeRecentlyTrashed: false).predicateForFetchRequest
+        let recentelyDeletedPost = createPost(.draft, hasRemote: true, statusAfterSync: .trash)
+
+        // Assert
+        let postIncluded = predicate.evaluate(with: recentelyDeletedPost)
+        XCTAssertFalse(postIncluded)
+    }
+
+    func testDraftFilterIncludesRecentelyTrashedPostsIfNeeded() {
+        // Arrange
+        let predicate = PostListFilter.draftFilter(includeRecentlyTrashed: true).predicateForFetchRequest
+        let recentelyDeletedPost = createPost(.draft, hasRemote: true, statusAfterSync: .trash)
+
+        // Assert
+        let postIncluded = predicate.evaluate(with: recentelyDeletedPost)
+        XCTAssertTrue(postIncluded)
+    }
+
     func testPublishedFilterIncludesExistingPrivateAndRemotePublishedPosts() {
         // Arrange
         let predicate = PostListFilter.publishedFilter().predicateForFetchRequest


### PR DESCRIPTION
Part of #18308

## Description
This PR fixes an issue where it was possible to edit a post after trashing it.
It was mentioned in https://github.com/wordpress-mobile/WordPress-iOS/pull/18351#issuecomment-1097115823

## Testing Instructions
1. Open a site with draft posts
2. Make sure you're on a slow connection
3. Delete a draft post
4. Go back immediately to the dashboard
5. Make sure the post is not displayed.

## Regression Notes
1. Potential unintended areas of impact
    - Posts dashboard cards
    - Posts list view controller

3. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Tested manually and added relevant unit tests

4. What automated tests I added (or what prevented me from doing so)
    - `testDraftFilterDoesNotincludeRecentlyTrashedPosts`
    - `testTrashingAPostWillUpdateItsRevisionStatusAfterSyncProperty`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
