### PR TITLE
Blogging Prompts: Use plain gray color as default avatar image

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/AvatarTrainView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/AvatarTrainView.swift
@@ -8,6 +8,8 @@ final class AvatarTrainView: UIView {
 
     private var avatarURLs: [URL?]
 
+    private var placeholderImage: UIImage
+
     private lazy var avatarStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -25,8 +27,9 @@ final class AvatarTrainView: UIView {
 
     // MARK: Public Methods
 
-    init(avatarURLs: [URL?]) {
+    init(avatarURLs: [URL?], placeholderImage: UIImage? = nil) {
         self.avatarURLs = avatarURLs
+        self.placeholderImage = placeholderImage ?? Constants.placeholderImage
         super.init(frame: .zero)
 
         setupViews()
@@ -57,7 +60,7 @@ private extension AvatarTrainView {
     }
 
     func makeAvatarImageView(with avatarURL: URL? = nil) -> UIImageView {
-        let imageView = CircularImageView(image: Constants.placeholderImage)
+        let imageView = CircularImageView(image: placeholderImage)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         configureBorder(for: imageView)
 
@@ -67,7 +70,7 @@ private extension AvatarTrainView {
         ])
 
         if let avatarURL = avatarURL {
-            imageView.downloadImage(from: avatarURL, placeholderImage: Constants.placeholderImage)
+            imageView.downloadImage(from: avatarURL, placeholderImage: placeholderImage)
         }
 
         return imageView
@@ -81,7 +84,7 @@ private extension AvatarTrainView {
     // MARK: Constants
 
     struct Constants {
-        static let imageViewSpacing: CGFloat = -4
+        static let imageViewSpacing: CGFloat = -5
         static let avatarDiameter: CGFloat = 20
         static let borderWidth: CGFloat = 2
         static let placeholderImage: UIImage = .gravatarPlaceholderImage

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressShared
+import WordPressUI
 
 class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
@@ -107,7 +108,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
             return (0..<min(answerCount, Constants.maxAvatarCount)).map { _ in nil }
         }()
 
-        let avatarTrainView = AvatarTrainView(avatarURLs: avatarURLs)
+        let avatarTrainView = AvatarTrainView(avatarURLs: avatarURLs, placeholderImage: Style.avatarPlaceholderImage)
         avatarTrainView.translatesAutoresizingMaskIntoConstraints = false
 
         let trainContainerView = UIView()
@@ -351,6 +352,7 @@ private extension DashboardPromptsCardCell {
 
     struct Style {
         static let frameIconImage = UIImage(named: "icon-lightbulb-outline")?.resizedImage(Constants.cardIconSize, interpolationQuality: .default)
+        static let avatarPlaceholderImage = UIImage(color: .init(hexString: "EEEEEE"))
         static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
         static let answerInfoLabelFont = WPStyleGuide.fontForTextStyle(.caption1)
         static let answerInfoLabelColor = UIColor.primary

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -352,7 +352,7 @@ private extension DashboardPromptsCardCell {
 
     struct Style {
         static let frameIconImage = UIImage(named: "icon-lightbulb-outline")?.resizedImage(Constants.cardIconSize, interpolationQuality: .default)
-        static let avatarPlaceholderImage = UIImage(color: .init(hexString: "EEEEEE"))
+        static let avatarPlaceholderImage = UIImage(color: .quaternarySystemFill)
         static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
         static let answerInfoLabelFont = WPStyleGuide.fontForTextStyle(.caption1)
         static let answerInfoLabelColor = UIColor.primary


### PR DESCRIPTION
Refs #18250

As titled, this updates the placeholder for the avatar train on My Sites prompt card. Here are some screenshots:

• | Before | After
-|-|-
Light | ![before_light](https://user-images.githubusercontent.com/1299411/163807091-13f90c83-7627-4696-aed7-dafd88b02013.png) | ![after_qsf_light](https://user-images.githubusercontent.com/1299411/163968227-1b7ddb92-6c5d-426e-93a0-a250f10b81a7.png)
Dark | ![before_dark](https://user-images.githubusercontent.com/1299411/163968398-94ce2cdf-c7a9-4b11-9a30-565277d92be8.png) | ![after_qsf_dark](https://user-images.githubusercontent.com/1299411/163968210-c83369a5-233a-469a-a823-d9009e85baf5.png)

(cc: @iamthomasbishop)

To test:

- Enable Blogging Prompts and My Site Dashboard feature flags.
- Verify that plain gray images are displayed on the avatar train.

## Regression Notes
1. Potential unintended areas of impact
n/a. Feature is under development.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a. Feature is under development.

3. What automated tests I added (or what prevented me from doing so)
n/a. Feature is under development.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
