### PR TITLE
Quick Start for Existing Users: Update View Site task

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -38,7 +38,7 @@ final class QuickStartTourStateView: UIView {
     func configure(blog: Blog, sourceController: UIViewController, checklistTappedTracker: QuickStartChecklistTappedTracker? = nil) {
 
         customizeChecklistView.configure(
-            tours: QuickStartTourGuide.customizeListTours,
+            tours: QuickStartTourGuide.customizeListTours(for: blog),
             blog: blog,
             title: Strings.customizeTitle,
             hint: Strings.customizeHint

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -19,21 +19,6 @@ extension BlogDetailsViewController {
                 switch info {
                 case .pages, .editHomepage, .sharing, .stats:
                     self?.scroll(to: info)
-                case .viewSite:
-                    self?.scroll(to: info)
-
-                    guard let self = self,
-                        let navigationController = self.navigationController,
-                        navigationController.visibleViewController != self else {
-                        return
-                    }
-
-                    self.dismiss(animated: true) {
-                        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .top, animated: false)
-                        self.shouldScrollToViewSite = true
-
-                        navigationController.popToRootViewController(animated: true)
-                    }
                 default:
                     break
                 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -406,11 +406,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self cancelCompletedToursIfNeeded];
     [self createUserActivity];
     [self startAlertTimer];
-
-    if (self.shouldScrollToViewSite == YES) {
-        [self scrollToElement:QuickStartTourElementViewSite];
-        self.shouldScrollToViewSite = NO;
-    }
     
     QuickStartTourGuide *tourGuide = [QuickStartTourGuide shared];
     
@@ -1026,7 +1021,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                                callback:^{
         [weakSelf showViewSiteFromSource:BlogDetailsNavigationSourceRow];
     }];
-    viewSiteRow.quickStartIdentifier = QuickStartTourElementViewSite;
     viewSiteRow.showsSelectionState = NO;
     [rows addObject:viewSiteRow];
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1618,17 +1618,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                        animated:YES
                      completion:nil];
 
+    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
+    
     QuickStartTourGuide *guide = [QuickStartTourGuide shared];
 
     if ([guide isCurrentElement:QuickStartTourElementViewSite]) {
         [[QuickStartTourGuide shared] visited:QuickStartTourElementViewSite];
+        [parentVC toggleSpotlightOnSitePicker];
     } else {
         // Just mark as completed if we've viewed the site and aren't
         //  currently working on the View Site tour.
         [[QuickStartTourGuide shared] completeViewSiteTourForBlog:self.blog];
     }
 
-    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
     parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -38,6 +38,7 @@ class BlogDetailHeaderView: UIView {
         didSet {
             refreshIconImage()
             toggleSpotlightOnSiteTitle()
+            toggleSpotlightOnSiteUrl()
             refreshSiteTitle()
 
             if let displayURL = blog?.displayURL as String? {
@@ -75,6 +76,10 @@ class BlogDetailHeaderView: UIView {
 
     @objc func toggleSpotlightOnSiteTitle() {
         titleView.titleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.siteTitle)
+    }
+
+    func toggleSpotlightOnSiteUrl() {
+        titleView.subtitleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.viewSite)
     }
 
     @objc func toggleSpotlightOnSiteIcon() {
@@ -240,8 +245,8 @@ fileprivate extension BlogDetailHeaderView {
             return siteIconView
         }()
 
-        let subtitleButton: UIButton = {
-            let button = UIButton()
+        let subtitleButton: SpotlightableButton = {
+            let button = SpotlightableButton(type: .custom)
 
             button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.footnote)
             button.titleLabel?.adjustsFontForContentSizeCategory = true

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -74,7 +74,7 @@ class BlogDetailHeaderView: UIView {
         titleView.titleButton.setTitle(title, for: .normal)
     }
 
-    @objc func toggleSpotlightOnSiteTitle() {
+    func toggleSpotlightOnSiteTitle() {
         titleView.titleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.siteTitle)
     }
 
@@ -82,7 +82,7 @@ class BlogDetailHeaderView: UIView {
         titleView.subtitleButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.viewSite)
     }
 
-    @objc func toggleSpotlightOnSiteIcon() {
+    func toggleSpotlightOnSiteIcon() {
         titleView.siteIconView.spotlightIsShown = QuickStartTourGuide.shared.isCurrentElement(.siteIcon)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -11,7 +11,7 @@ extension MySiteViewController {
                 switch element {
                 case .noSuchElement:
                     self?.additionalSafeAreaInsets = .zero
-                case .siteIcon, .siteTitle:
+                case .siteIcon, .siteTitle, .viewSite:
                     self?.scrollView.scrollToTop(animated: true)
 
                     self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPaddingForQuickStartNotices, right: 0)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -668,6 +668,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         WordPressAuthenticator.showLoginForSelfHostedSite(self)
     }
 
+    @objc
+    func toggleSpotlightOnSitePicker() {
+        sitePickerViewController?.toggleSpotlightOnHeaderView()
+    }
+
     // MARK: - Blog Details UI Logic
 
     private func hideBlogDetails() {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -42,7 +42,7 @@ class QuickStartChecklistViewController: UITableViewController {
         switch type {
         case .customize:
             return QuickStartChecklistConfiguration(title: Constants.customizeYourSite,
-                                                    tours: QuickStartTourGuide.customizeListTours)
+                                                    tours: QuickStartTourGuide.customizeListTours(for: blog))
         case .grow:
             return QuickStartChecklistConfiguration(title: Constants.growYourAudience,
                                                     tours: QuickStartTourGuide.growListTours)

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -56,7 +56,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func shouldShowChecklist(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let list = QuickStartTourGuide.customizeListTours(for: blog) + QuickStartTourGuide.growListTours
         let checklistCompletedCount = countChecklistCompleted(in: list, for: blog)
         return checklistCompletedCount > 0
     }
@@ -69,7 +69,7 @@ open class QuickStartTourGuide: NSObject {
         let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
         let skippedTours: [QuickStartTourState] = blog.skippedQuickStartTours ?? []
         let unavailableTours = Array(Set(completedTours + skippedTours))
-        let allTours = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let allTours = QuickStartTourGuide.customizeListTours(for: blog) + QuickStartTourGuide.growListTours
 
         guard isQuickStartEnabled(for: blog),
             recentlyTouredBlog == blog else {
@@ -183,7 +183,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc func completeViewSiteTour(forBlog blog: Blog) {
-        complete(tour: QuickStartViewTour(), silentlyForBlog: blog)
+        complete(tour: QuickStartViewTour(blog: blog), silentlyForBlog: blog)
     }
 
     @objc func completeSharingTour(forBlog blog: Blog) {
@@ -279,7 +279,7 @@ open class QuickStartTourGuide: NSObject {
             let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
             let completedIDs = completedTours.map { $0.tourID }
 
-            for tour in QuickStartTourGuide.checklistTours {
+            for tour in QuickStartTourGuide.checklistTours(for: blog) {
                 if !completedIDs.contains(tour.key) {
                     blog.completeTour(tour.key)
                 }
@@ -310,10 +310,10 @@ open class QuickStartTourGuide: NSObject {
         currentTourState = nil
     }
 
-    static var checklistTours: [QuickStartTour] {
+    static func checklistTours(for blog: Blog) -> [QuickStartTour] {
         return [
             QuickStartCreateTour(),
-            QuickStartViewTour(),
+            QuickStartViewTour(blog: blog),
             QuickStartThemeTour(),
             QuickStartShareTour(),
             QuickStartPublishTour(),
@@ -321,14 +321,14 @@ open class QuickStartTourGuide: NSObject {
         ]
     }
 
-    static var customizeListTours: [QuickStartTour] {
+    static func customizeListTours(for blog: Blog) -> [QuickStartTour] {
         return [
             QuickStartCreateTour(),
             QuickStartSiteTitleTour(),
             QuickStartSiteIconTour(),
             QuickStartEditHomepageTour(),
             QuickStartReviewPagesTour(),
-            QuickStartViewTour()
+            QuickStartViewTour(blog: blog)
         ]
     }
 
@@ -396,7 +396,7 @@ private extension QuickStartTourGuide {
     /// - Parameter blog: blog to check
     /// - Returns: boolean, true if all tours have been completed
     func allToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.customizeListTours + QuickStartTourGuide.growListTours
+        let list = QuickStartTourGuide.customizeListTours(for: blog) + QuickStartTourGuide.growListTours
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 
@@ -407,7 +407,7 @@ private extension QuickStartTourGuide {
     /// - Note: This method is needed for upgrade/migration to V2 and should not
     ///         be removed when the V2 feature flag is removed.
     func allOriginalToursCompleted(for blog: Blog) -> Bool {
-        let list = QuickStartTourGuide.checklistTours
+        let list = QuickStartTourGuide.checklistTours(for: blog)
         return countChecklistCompleted(in: list, for: blog) >= list.count
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -324,7 +324,7 @@ open class QuickStartTourGuide: NSObject {
     static func customizeListTours(for blog: Blog) -> [QuickStartTour] {
         return [
             QuickStartCreateTour(),
-            QuickStartSiteTitleTour(),
+            QuickStartSiteTitleTour(blog: blog),
             QuickStartSiteIconTour(),
             QuickStartEditHomepageTour(),
             QuickStartReviewPagesTour(),

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -1,4 +1,5 @@
 import Gridicons
+import Foundation
 
 protocol QuickStartTour {
     typealias WayPoint = (element: QuickStartTourElement, description: NSAttributedString)
@@ -92,13 +93,18 @@ struct QuickStartViewTour: QuickStartTour {
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
 
-    var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Select %@ to preview", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let descriptionTarget = NSLocalizedString("View Site", comment: "The menu item to select during a guided tour.")
-        return [(element: .viewSite, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.house)))]
-    }()
+    var waypoints: [WayPoint]
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of previewing your site.", comment: "This value is used to set the accessibility hint text for previewing a user's site.")
+
+    init(blog: Blog) {
+        let descriptionBase = NSLocalizedString("Select %@ to view your site", comment: "A step in a guided tour for quick start. %@ will be the site url.")
+        let descriptionTarget = (blog.displayURL ?? "") as String
+
+        self.waypoints = [
+            (element: .viewSite, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))
+        ]
+    }
 }
 
 struct QuickStartThemeTour: QuickStartTour {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -92,6 +92,7 @@ struct QuickStartViewTour: QuickStartTour {
     let icon = UIImage.gridicon(.external)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
+    let shownInBlogDetails = false
 
     var waypoints: [WayPoint]
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -222,7 +222,7 @@ struct QuickStartSiteTitleTour: QuickStartTour {
     var waypoints: [WayPoint]
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of setting a title for your site.", comment: "This value is used to set the accessibility hint text for setting the site title.")
-    
+
     init(blog: Blog) {
         let descriptionBase = NSLocalizedString("Select %@ to set a new title.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let placeholder = NSLocalizedString("Site Title", comment: "The item to select during a guided tour.")

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -87,7 +87,7 @@ struct QuickStartViewTour: QuickStartTour {
     let analyticsKey = "view_site"
     let title = NSLocalizedString("View your site", comment: "Title of a Quick Start Tour")
     let titleMarkedCompleted = NSLocalizedString("Completed: View your site", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Preview your new site to see what your visitors will see.", comment: "Description of a Quick Start Tour")
+    let description = NSLocalizedString("Preview your site to see what your visitors will see.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.external)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -100,7 +100,8 @@ struct QuickStartViewTour: QuickStartTour {
 
     init(blog: Blog) {
         let descriptionBase = NSLocalizedString("Select %@ to view your site", comment: "A step in a guided tour for quick start. %@ will be the site url.")
-        let descriptionTarget = (blog.displayURL ?? "") as String
+        let placeholder = NSLocalizedString("Site URL", comment: "The item to select during a guided tour.")
+        let descriptionTarget = (blog.displayURL as String?) ?? placeholder
 
         self.waypoints = [
             (element: .viewSite, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))
@@ -218,14 +219,19 @@ struct QuickStartSiteTitleTour: QuickStartTour {
     let suggestionYesText = Strings.yesShowMe
     let shownInBlogDetails = false
 
-    var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Select %@ to set a new title.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let placeholder = NSLocalizedString("Site Title", comment: "The item to select during a guided tour.")
-        let descriptionTarget = WPTabBarController.sharedInstance()?.currentOrLastBlog()?.title ?? placeholder
-        return [(element: .siteTitle, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))]
-    }()
+    var waypoints: [WayPoint]
 
     let accessibilityHintText = NSLocalizedString("Guides you through the process of setting a title for your site.", comment: "This value is used to set the accessibility hint text for setting the site title.")
+    
+    init(blog: Blog) {
+        let descriptionBase = NSLocalizedString("Select %@ to set a new title.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let placeholder = NSLocalizedString("Site Title", comment: "The item to select during a guided tour.")
+        let descriptionTarget = blog.title ?? placeholder
+
+        self.waypoints = [
+            (element: .siteTitle, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: nil))
+        ]
+    }
 }
 
 struct QuickStartSiteIconTour: QuickStartTour {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
@@ -16,6 +16,7 @@ extension SitePickerViewController {
             }
 
             self?.blogDetailHeaderView.toggleSpotlightOnSiteTitle()
+            self?.blogDetailHeaderView.toggleSpotlightOnSiteUrl()
             self?.blogDetailHeaderView.refreshIconImage()
         }
     }
@@ -37,6 +38,7 @@ extension SitePickerViewController {
 
     func toggleSpotlightOnHeaderView() {
         blogDetailHeaderView.toggleSpotlightOnSiteTitle()
+        blogDetailHeaderView.toggleSpotlightOnSiteUrl()
         blogDetailHeaderView.toggleSpotlightOnSiteIcon()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -187,8 +187,8 @@ extension SitePickerViewController {
         blog.settings?.name = title
         blogDetailHeaderView.setTitleLoading(true)
 
-        QuickStartTourGuide.shared.complete(tour: QuickStartSiteTitleTour(),
-                                                    silentlyForBlog: blog)
+        QuickStartTourGuide.shared.complete(tour: QuickStartSiteTitleTour(blog: blog),
+                                            silentlyForBlog: blog)
 
         blogService.updateSettings(for: blog, success: { [weak self] in
             NotificationCenter.default.post(name: NSNotification.Name.WPBlogUpdated, object: nil)


### PR DESCRIPTION
Part of #18387

## Description
- Updated the Preview Site task to point to the url in the site header instead of the item in the site menu 

<img src="https://user-images.githubusercontent.com/6711616/163834831-c06078d6-21eb-48ca-9939-55ad891e483b.png" width=200>

## Note
Historically, the View Site task's waypoint anchor was the site menu's View Site item, but it could be optionally be completed via the site url in the site header.

The updated version of the View Site task flips the old behavior. The waypoint anchor is now the site url in the site header, and the task can be optionally be completed via the site menu's View Site item.

## How to test

### Check updated the View Site tour
1. Trigger Quick Start either through logging in or using the debug menu and enabling Quick Start
2. Go through the Customize tours sequentially
3. ✅ Check that the View Site tour suggestion reads: `Preview your site to see what your visitors will see.`
4. Tap on Yes, show me
5. ✅ Check that the View Site tour scrolls to the very top, displays the site url in the notice, and displays a spotlight on the site header
6. If needed, switch to the site menu
7. Scroll down all the way to the bottom
8. ✅ Check that there's no spotlight on the View Site item
9. Scroll all the way up
10. Tap on the site url with the spotlight
11. Exit the webview
12. ✅ Check that the spotlight on the site header is gone

https://user-images.githubusercontent.com/6711616/163834816-f937b727-36af-44d6-b094-e1f449987fde.mp4

### View site can be completed via site menu
1. Trigger Quick Start either through logging in or using the debug menu and enabling Quick Start
2. Select the View Site tour
3. If needed, switch to the site menu
4. Scroll down all the way to the bottom
5. Tap on the View Site item
6. ✅ Check that the spotlight on the site header is gone


https://user-images.githubusercontent.com/6711616/163841539-c06b172c-dd1a-4f6a-9300-10db27519d14.mp4



## Regression Notes
1. Potential unintended areas of impact
- Completing the View Site tour via the site menu

13. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps

14. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
