### PR TITLE
[Site Name] Adjusts design picker buttons for treatment variation

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
@@ -11,7 +11,7 @@ class SiteDesignPreviewViewController: TemplatePreviewViewController {
         self.createsSite = createsSite
         super.init(demoURL: siteDesign.demoURL, selectedPreviewDevice: selectedPreviewDevice, onDismissWithDeviceSelected: onDismissWithDeviceSelected)
         delegate = self
-        title = NSLocalizedString("Preview", comment: "Title for screen to preview a selected homepage design")
+        title = TextContent.previewTitle
     }
 
     required init?(coder: NSCoder) {
@@ -25,13 +25,13 @@ class SiteDesignPreviewViewController: TemplatePreviewViewController {
     }
 
     private func setPrimaryActionButtonTitle() {
-        let title: String
-        if createsSite {
-            title = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
-        } else {
-            title = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
-        }
-        primaryActionButton.setTitle(title, for: .normal)
+        primaryActionButton.setTitle(createsSite ? TextContent.createSiteButton : TextContent.chooseButton, for: .normal)
+    }
+
+    private enum TextContent {
+        static let previewTitle = NSLocalizedString("Preview", comment: "Title for screen to preview a selected homepage design.")
+        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
+        static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
@@ -30,7 +30,7 @@ class SiteDesignPreviewViewController: TemplatePreviewViewController {
 
     private enum TextContent {
         static let previewTitle = NSLocalizedString("Preview", comment: "Title for screen to preview a selected homepage design.")
-        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
+        static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/SiteDesignPreviewViewController.swift
@@ -1,12 +1,14 @@
 import UIKit
 
 class SiteDesignPreviewViewController: TemplatePreviewViewController {
+    private let createsSite: Bool
     let completion: SiteDesignStep.SiteDesignSelection
     let siteDesign: RemoteSiteDesign
 
-    init(siteDesign: RemoteSiteDesign, selectedPreviewDevice: PreviewDevice?, onDismissWithDeviceSelected: ((PreviewDevice) -> ())?, completion: @escaping SiteDesignStep.SiteDesignSelection) {
+    init(siteDesign: RemoteSiteDesign, selectedPreviewDevice: PreviewDevice?, createsSite: Bool, onDismissWithDeviceSelected: ((PreviewDevice) -> ())?, completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
         self.siteDesign = siteDesign
+        self.createsSite = createsSite
         super.init(demoURL: siteDesign.demoURL, selectedPreviewDevice: selectedPreviewDevice, onDismissWithDeviceSelected: onDismissWithDeviceSelected)
         delegate = self
         title = NSLocalizedString("Preview", comment: "Title for screen to preview a selected homepage design")
@@ -19,6 +21,17 @@ class SiteDesignPreviewViewController: TemplatePreviewViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationItem.leftBarButtonItem = CollapsableHeaderViewController.closeButton(target: self, action: #selector(closeButtonTapped))
+        setPrimaryActionButtonTitle()
+    }
+
+    private func setPrimaryActionButtonTitle() {
+        let title: String
+        if createsSite {
+            title = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
+        } else {
+            title = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
+        }
+        primaryActionButton.setTitle(title, for: .normal)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
@@ -100,13 +100,10 @@ class TemplatePreviewViewController: UIViewController, NoResultsViewHost, UIPopo
     }
 
     private func styleButtons() {
-        let isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
-        let mainButtonTitle = isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
-            : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
         primaryActionButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
         primaryActionButton.backgroundColor = accentColor
         primaryActionButton.layer.cornerRadius = 8
-        primaryActionButton.setTitle(mainButtonTitle, for: .normal)
+        primaryActionButton.setTitle(NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design"), for: .normal)
     }
 
     private func configurePreviewDeviceButton() {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Preview/TemplatePreviewViewController.swift
@@ -100,10 +100,13 @@ class TemplatePreviewViewController: UIViewController, NoResultsViewHost, UIPopo
     }
 
     private func styleButtons() {
+        let isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
+        let mainButtonTitle = isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
+            : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
         primaryActionButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
         primaryActionButton.backgroundColor = accentColor
         primaryActionButton.layer.cornerRadius = 8
-        primaryActionButton.setTitle(NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design"), for: .normal)
+        primaryActionButton.setTitle(mainButtonTitle, for: .normal)
     }
 
     private func configurePreviewDeviceButton() {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -172,7 +172,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     private enum TextContent {
         static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
         static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
-        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
+        static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
         static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")
         static let backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation.")

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -69,21 +69,13 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         )
     }
 
-    private enum TextContent {
-        static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
-        static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
-        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
-        static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
-        static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")
-    }
-
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation")
+        navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()
         configureSkipButton()
@@ -110,7 +102,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private func configureSkipButton() {
-        let skip = UIBarButtonItem(title: NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
+        let skip = UIBarButtonItem(title: TextContent.skipButtonTitle, style: .done, target: self, action: #selector(skipButtonTapped))
         navigationItem.rightBarButtonItem = skip
     }
 
@@ -125,7 +117,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
             return
         }
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", comment: "Cancel site creation"), style: .done, target: self, action: #selector(closeButtonTapped))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: TextContent.cancelButtonTitle, style: .done, target: self, action: #selector(closeButtonTapped))
     }
 
     @objc func skipButtonTapped(_ sender: Any) {
@@ -172,9 +164,22 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     private func handleError(_ error: Error) {
         SiteCreationAnalyticsHelper.trackError(error)
-        let titleText = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
-        let subtitleText = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection.")
+        let titleText = TextContent.errorTitle
+        let subtitleText = TextContent.errorSubtitle
         displayNoResultsController(title: titleText, subtitle: subtitleText, resultsDelegate: self)
+    }
+
+    private enum TextContent {
+        static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
+        static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
+        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
+        static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
+        static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")
+        static let backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation.")
+        static let skipButtonTitle = NSLocalizedString("Skip", comment: "Continue without making a selection.")
+        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel site creation.")
+        static let errorTitle = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
+        static let errorSubtitle = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -28,6 +28,7 @@ class SiteDesignSection: CategorySection {
 class SiteDesignContentCollectionViewController: FilterableCategoriesViewController, UIPopoverPresentationControllerDelegate {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
     private let templateGroups: [TemplateGroup] = [.stable, .singlePage]
+    private let isLastSiteCreationStep: Bool
 
     let completion: SiteDesignStep.SiteDesignSelection
     let restAPI = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
@@ -57,12 +58,15 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     init(_ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
-
+        self.isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
+        let primaryButtonTitle = self.isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
+            : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
+        
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site."),
             prompt: NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site."),
-            primaryActionTitle: NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design"),
+            primaryActionTitle: primaryButtonTitle,
             secondaryActionTitle: NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design")
         )
     }
@@ -100,7 +104,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private func configureSkipButton() {
-        let skip = UIBarButtonItem(title: NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
+        let skip = UIBarButtonItem(title: self.isLastSiteCreationStep ? NSLocalizedString("Skip and create", comment: "Continue without making a selection") : NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
         navigationItem.rightBarButtonItem = skip
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -27,6 +27,7 @@ class SiteDesignSection: CategorySection {
 
 class SiteDesignContentCollectionViewController: FilterableCategoriesViewController, UIPopoverPresentationControllerDelegate {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
+    private let createsSite: Bool
     private let templateGroups: [TemplateGroup] = [.stable, .singlePage]
 
     let completion: SiteDesignStep.SiteDesignSelection
@@ -55,17 +56,22 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         return sections[sectionIndex].designs[position]
     }
 
-    init(_ completion: @escaping SiteDesignStep.SiteDesignSelection) {
+    init(createsSite: Bool, _ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
-        let isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
-        let primaryButtonTitle = isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
-            : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
+        self.createsSite = createsSite
+
+        let primaryActionTitle: String
+        if createsSite {
+            primaryActionTitle = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
+        } else {
+            primaryActionTitle = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
+        }
 
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site."),
             prompt: NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site."),
-            primaryActionTitle: primaryButtonTitle,
+            primaryActionTitle: primaryActionTitle,
             secondaryActionTitle: NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design")
         )
     }
@@ -154,7 +160,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     override func secondaryActionSelected(_ sender: Any) {
         guard let design = selectedDesign else { return }
 
-        let previewVC = SiteDesignPreviewViewController(siteDesign: design, selectedPreviewDevice: selectedPreviewDevice, onDismissWithDeviceSelected: { [weak self] device in
+        let previewVC = SiteDesignPreviewViewController(siteDesign: design, selectedPreviewDevice: selectedPreviewDevice, createsSite: createsSite, onDismissWithDeviceSelected: { [weak self] device in
             self?.selectedPreviewDevice = device
         }, completion: completion)
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -60,20 +60,21 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         self.completion = completion
         self.createsSite = createsSite
 
-        let primaryActionTitle: String
-        if createsSite {
-            primaryActionTitle = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
-        } else {
-            primaryActionTitle = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
-        }
-
         super.init(
             analyticsLocation: "site_creation",
-            mainTitle: NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site."),
-            prompt: NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site."),
-            primaryActionTitle: primaryActionTitle,
-            secondaryActionTitle: NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design")
+            mainTitle: TextContent.mainTitle,
+            prompt: TextContent.subtitle,
+            primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
+            secondaryActionTitle: TextContent.previewButton
         )
+    }
+
+    private enum TextContent {
+        static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
+        static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
+        static let createSiteButton = NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design.")
+        static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
+        static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -61,7 +61,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         self.isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
         let primaryButtonTitle = self.isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
             : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
-        
+
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site."),

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -28,7 +28,6 @@ class SiteDesignSection: CategorySection {
 class SiteDesignContentCollectionViewController: FilterableCategoriesViewController, UIPopoverPresentationControllerDelegate {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
     private let templateGroups: [TemplateGroup] = [.stable, .singlePage]
-    private let isLastSiteCreationStep: Bool
 
     let completion: SiteDesignStep.SiteDesignSelection
     let restAPI = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
@@ -58,8 +57,8 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     init(_ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
-        self.isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
-        let primaryButtonTitle = self.isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
+        let isLastSiteCreationStep = ABTest.siteNameV1.variation == .treatment(nil) && FeatureFlag.siteName.enabled
+        let primaryButtonTitle = isLastSiteCreationStep ? NSLocalizedString("Create site", comment: "Title for the button to progress with creating the site with the selected design")
             : NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design")
 
         super.init(
@@ -104,7 +103,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private func configureSkipButton() {
-        let skip = UIBarButtonItem(title: self.isLastSiteCreationStep ? NSLocalizedString("Skip and create", comment: "Continue without making a selection") : NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
+        let skip = UIBarButtonItem(title: NSLocalizedString("Skip", comment: "Continue without making a selection"), style: .done, target: self, action: #selector(skipButtonTapped))
         navigationItem.rightBarButtonItem = skip
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignStep.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignStep.swift
@@ -5,15 +5,17 @@ final class SiteDesignStep: WizardStep {
     typealias SiteDesignSelection = (_ design: RemoteSiteDesign?) -> Void
     weak var delegate: WizardDelegate?
     private let creator: SiteCreator
+    private let isLastStep: Bool
 
     private(set) lazy var content: UIViewController = {
-        return SiteDesignContentCollectionViewController { [weak self] (design) in
+        return SiteDesignContentCollectionViewController(createsSite: isLastStep) { [weak self] (design) in
             self?.didSelect(design)
         }
     }()
 
-    init(creator: SiteCreator) {
+    init(creator: SiteCreator, isLastStep: Bool) {
         self.creator = creator
+        self.isLastStep = isLastStep
     }
 
     private func didSelect(_ design: RemoteSiteDesign?) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -84,7 +84,9 @@ final class SiteCreationWizardLauncher {
             let addressService = DomainsServiceAdapter(managedObjectContext: ContextManager.sharedInstance().mainContext)
             return WebAddressStep(creator: self.creator, service: addressService)
         case .design:
-            return SiteDesignStep(creator: self.creator)
+            // we call dropLast to remove .siteAssembly
+            let isLastStep = steps.dropLast().last == .design
+            return SiteDesignStep(creator: self.creator, isLastStep: isLastStep)
         case .intent:
             return SiteIntentStep(creator: self.creator)
         case .name:

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2169,6 +2169,7 @@
 		C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */; };
 		C387B7A22638D66F00BDEF86 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38C5D8027F61D2C002F517E /* MenuItemTests.swift */; };
+		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3DA0EE02807062600DA3250 /* SiteCreationNameTracksEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */; };
@@ -6913,6 +6914,7 @@
 		C373D6E628045281008F8C26 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
 		C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentDataTests.swift; sourceTree = "<group>"; };
 		C38C5D8027F61D2C002F517E /* MenuItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MenuItemTests.swift; path = Menus/MenuItemTests.swift; sourceTree = "<group>"; };
+		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
 		C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationNameTracksEventTests.swift; sourceTree = "<group>"; };
@@ -10531,6 +10533,7 @@
 				73178C2221BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift */,
 				73178C2621BEE09300E37C9A /* SiteCreationHeaderDataTests.swift */,
 				730354B921C867E500CD18C2 /* SiteCreatorTests.swift */,
+				C396C80A280F2401006FE7AC /* SiteDesignTests.swift */,
 				73178C2421BEE09300E37C9A /* SiteSegmentsCellTests.swift */,
 				73178C2321BEE09300E37C9A /* SiteSegmentsStepTests.swift */,
 				73178C3421BEE9AC00E37C9A /* TitleSubtitleHeaderTests.swift */,
@@ -19460,6 +19463,7 @@
 				748437EE1F1D4A7300E8DDAF /* RichContentFormatterTests.swift in Sources */,
 				C81CCD6A243AEE1100A83E27 /* TenorAPIResponseTests.swift in Sources */,
 				8BE7C84123466927006EDE70 /* I18n.swift in Sources */,
+				C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */,
 				806E53E427E01CFE0064315E /* DashboardStatsViewModelTests.swift in Sources */,
 				D88A649E208D82D2008AE9BC /* XCTestCase+Wait.swift in Sources */,
 				C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -30,7 +30,7 @@ class SiteDesignTests: XCTestCase {
         // given
         let creator = SiteCreator()
         let siteDesignStep = SiteDesignStep(creator: creator, isLastStep: true)
-        let expectedPrimaryTitle = "Create site"
+        let expectedPrimaryTitle = "Create Site"
 
         // when
         let siteDesignVC = try XCTUnwrap(siteDesignStep.content as? SiteDesignContentCollectionViewController)
@@ -63,7 +63,7 @@ class SiteDesignTests: XCTestCase {
         // given
         let siteDesignPreviewVC = SiteDesignPreviewViewController(
             siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: true, onDismissWithDeviceSelected: nil, completion: {design in })
-        let expectedPrimaryTitle = "Create site"
+        let expectedPrimaryTitle = "Create Site"
 
         // when
         siteDesignPreviewVC.loadViewIfNeeded()

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -1,0 +1,76 @@
+
+import XCTest
+@testable import WordPress
+
+class SiteDesignTests: XCTestCase {
+    private var remoteDesign: RemoteSiteDesign {
+        let siteDesignPayload = "{\"slug\":\"alves\",\"title\":\"Alves\",\"segment_id\":1,\"categories\":[{\"slug\":\"business\",\"title\":\"Business\",\"description\":\"Business\",\"emoji\":\"💼\"}],\"demo_url\":\"https://public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/?language=en\",\"theme\":\"alves\",\"preview\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=1200&vph=1600&w=800&h=1067\",\"preview_tablet\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=800&vph=1066&w=800&h=1067\",\"preview_mobile\":\"https://s0.wp.com/mshots/v1/public-api.wordpress.com/rest/v1/template/demo/alves/alvesstartermobile.wordpress.com/%3Flanguage%3Den?vpw=400&vph=533&w=400&h=534\"}"
+        return try! JSONDecoder().decode(RemoteSiteDesign.self, from: siteDesignPayload.data(using: .utf8)!)
+    }
+
+    func testSiteDesignPrimaryButtonTextNotLastStep() throws {
+
+        // given
+        let creator = SiteCreator()
+        let siteDesignStep = SiteDesignStep(creator: creator, isLastStep: false)
+        let expectedPrimaryTitle = "Choose"
+
+        // when
+        let siteDesignVC = try XCTUnwrap(siteDesignStep.content as? SiteDesignContentCollectionViewController)
+        siteDesignVC.loadViewIfNeeded()
+        siteDesignVC.viewDidLoad()
+
+        // then
+        let currentTitle = siteDesignVC.primaryActionButton.currentTitle
+        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
+    }
+
+    func testSiteDesignPrimaryButtonTextLastStep() throws {
+
+        // given
+        let creator = SiteCreator()
+        let siteDesignStep = SiteDesignStep(creator: creator, isLastStep: true)
+        let expectedPrimaryTitle = "Create site"
+
+        // when
+        let siteDesignVC = try XCTUnwrap(siteDesignStep.content as? SiteDesignContentCollectionViewController)
+        siteDesignVC.loadViewIfNeeded()
+        siteDesignVC.viewDidLoad()
+
+        // then
+        let currentTitle = siteDesignVC.primaryActionButton.currentTitle
+        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
+    }
+
+    func testSiteDesignPreviewButtonTextNotLastStep() throws {
+
+        // given
+        let siteDesignPreviewVC = SiteDesignPreviewViewController(
+            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: false, onDismissWithDeviceSelected: nil, completion: {design in })
+        let expectedPrimaryTitle = "Choose"
+
+        // when
+        siteDesignPreviewVC.loadViewIfNeeded()
+        siteDesignPreviewVC.viewDidLoad()
+
+        // then
+        let currentTitle = siteDesignPreviewVC.primaryActionButton.currentTitle
+        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
+    }
+
+    func testSiteDesignPreviewButtonTextLastStep() throws {
+
+        // given
+        let siteDesignPreviewVC = SiteDesignPreviewViewController(
+            siteDesign: remoteDesign, selectedPreviewDevice: nil, createsSite: true, onDismissWithDeviceSelected: nil, completion: {design in })
+        let expectedPrimaryTitle = "Create site"
+
+        // when
+        siteDesignPreviewVC.loadViewIfNeeded()
+        siteDesignPreviewVC.viewDidLoad()
+
+        // then
+        let currentTitle = siteDesignPreviewVC.primaryActionButton.currentTitle
+        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
+    }
+}


### PR DESCRIPTION
## Description
This PR adjusts the design picker `Choose` buttons to communicate to the user that their action will create the site.

|Design Chooser(Control)|Design Chooser(Treatment)|
|---|---|
|![IMG_0188](https://user-images.githubusercontent.com/304044/163976382-7187bd90-f38b-48d7-a988-da937a36a7bc.PNG)|![IMG_EB02383F75C5-1](https://user-images.githubusercontent.com/304044/164234307-1e7f9369-9c5a-457e-b396-4faeeec0769d.jpeg)|

|Design Preview(Control)|Design Preview(Treatment)|
|---|---|
|![IMG_0189](https://user-images.githubusercontent.com/304044/163976346-88d88c12-bbfe-4c2e-b98f-f959312a0d37.PNG)|![IMG_0187](https://user-images.githubusercontent.com/304044/163976364-f843343f-8993-48f9-af23-92446d390eac.PNG)|

## To test
### Treatment variation
1. Toggle ON the Site Name feature
2. Start the Site Creation flow
3. Choose an intent for your site or skip
4. Enter a site name or skip
5. Select a design
6. Verify that the `choose` button is changed to `create site`
7. Preview a design and verify that the `choose` button is changed to `create site`

### Control variation
1. Toggle OFF the Site Name feature
2. On steps 6 and 7 above verify that the buttons are not changed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
