### PR TITLE
Quick Start for Existing Users: Fix Site Title tour

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -248,7 +248,7 @@ extension SiteAssemblyWizardContent: NUXButtonViewControllerDelegate {
                 guard let self = self else {
                     return
                 }
-                let completedSteps: [QuickStartTour] = self.siteCreator.hasSiteTitle ? [QuickStartSiteTitleTour()] : []
+                let completedSteps: [QuickStartTour] = self.siteCreator.hasSiteTitle ? [QuickStartSiteTitleTour(blog: blog)] : []
                 self.showQuickStartPrompt(for: blog, completedSteps: completedSteps)
             }
         }


### PR DESCRIPTION
Ref: p1650365447446809-slack-C5ALGJYEP

## Description

- This fixes a build failure on trunk -- I forgot to update the Site Title tour inside the site assembly wizard in #18393 
 
## How to test

### Site creation without Site Name step
1. On My Site, tap the down arrow in the site header 
2. Tap the + icon and create a WordPress.com site
3. Accept the Quick Start prompt
4. ✅ The Quick Start tour should start

### Site creation with Site Name step
0. Configure `shouldShowSiteName` to always return true 
1. On My Site, tap the down arrow in the site header 
2. Tap the + icon and create a WordPress.com site
3. Accept the Quick Start prompt
4. ✅ The Quick Start tour should start
5. ✅ The Site Title task should be crossed out

## Regression Notes
1. Potential unintended areas of impact
- The new site name feature in the site creation flow

6. What I did to test those areas of impact (or what existing automated tests I relied on)
- I tested the steps outlined above

7. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.