### PR TITLE
Add prompt option to blogging reminders settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -136,11 +136,82 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return stackView
     }()
 
-    private lazy var timeSelectionToConfirmationButtonSpacer: UIView = {
-        makeSpacer()
+    private lazy var bloggingPromptsTitle: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.adjustsFontForContentSizeCategory = true
+        label.font = .preferredFont(forTextStyle: .body)
+        label.text = TextContent.bloggingPromptsTitle
+        return label
     }()
 
-    private lazy var confirmationButtonBottomSpacer: UIView = {
+    private lazy var bloggingPromptsInfoButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setImage(.gridicon(.helpOutline), for: .normal)
+        button.tintColor = .listSmallIcon
+        button.accessibilityLabel = TextContent.bloggingPromptsInfoButton
+        button.addTarget(self, action: #selector(bloggingPromptsInfoButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var bloggingPromptsInfoButtonView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bloggingPromptsInfoButton)
+        return view
+    }()
+
+    private lazy var bloggingPromptsTitleStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bloggingPromptsTitle, bloggingPromptsInfoButtonView, makeSpacer()])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = Metrics.BloggingPrompts.titleSpacing
+        stackView.alignment = .center
+        return stackView
+    }()
+
+    private lazy var bloggingPromptsDescription: UILabel = {
+        let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.text = TextContent.bloggingPromptsDescription
+        label.textColor = .textSubtle
+        label.numberOfLines = 0
+        return label
+    }()
+
+    private lazy var bloggingPromptsSwitch: UISwitch = {
+        let bloggingPromptsSwitch = UISwitch()
+        bloggingPromptsSwitch.translatesAutoresizingMaskIntoConstraints = false
+        bloggingPromptsSwitch.isOn = true
+        bloggingPromptsSwitch.addTarget(self, action: #selector(bloggingPromptsSwitchChanged), for: .valueChanged)
+        return bloggingPromptsSwitch
+    }()
+
+    private lazy var bloggingPromptsSwitchView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(bloggingPromptsSwitch)
+        return view
+    }()
+
+    private lazy var bloggingPromptsLabelsStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bloggingPromptsTitleStackView, bloggingPromptsDescription])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.spacing = Metrics.BloggingPrompts.labelsSpacing
+        return stackView
+    }()
+
+    private lazy var bloggingPromptsStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [bloggingPromptsLabelsStackView, bloggingPromptsSwitchView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.alignment = .center
+        stackView.isHidden = !FeatureFlag.bloggingPrompts.enabled
+        return stackView
+    }()
+
+    private lazy var bloggingPromptsToConfirmationButtonSpacer: UIView = {
         makeSpacer()
     }()
 
@@ -261,6 +332,18 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         tracker.buttonPressed(button: .continue, screen: .dayPicker)
 
         scheduleReminders()
+    }
+
+    @objc private func bloggingPromptsInfoButtonTapped() {
+        tracker.buttonPressed(button: .bloggingPromptsInfo, screen: .dayPicker)
+
+        present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
+    }
+
+    @objc private func bloggingPromptsSwitchChanged(_ sender: UISwitch) {
+        tracker.switchPressed(control: .bloggingPrompts,
+                              state: sender.isOn ? .enabled : .disabled,
+                              screen: .dayPicker)
     }
 
     /// Schedules the reminders and shows a VC that requests PN authorization, if necessary.
@@ -419,29 +502,35 @@ private extension BloggingRemindersFlowSettingsViewController {
             daysOuterStackView,
             frequencyView,
             timeSelectionView,
-            timeSelectionToConfirmationButtonSpacer,
+            bloggingPromptsStackView,
+            bloggingPromptsToConfirmationButtonSpacer,
             button,
-            confirmationButtonBottomSpacer
         ])
 
         stackView.setCustomSpacing(Metrics.afterTitleLabelSpacing, after: titleLabel)
         stackView.setCustomSpacing(Metrics.afterPromptLabelSpacing, after: promptLabel)
+        stackView.setCustomSpacing(Metrics.afterTimeSelectionViewSpacing, after: timeSelectionView)
     }
 
     func configureConstraints() {
         frequencyView.pinSubviewToAllEdges(frequencyLabel)
         timeSelectionView.pinSubviewToAllEdges(timeSelectionStackView)
+        bloggingPromptsInfoButtonView.pinSubviewToAllEdges(bloggingPromptsInfoButton)
 
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
         imageView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         timeSelectionView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         button.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
 
+        bloggingPromptsDescription.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        bloggingPromptsDescription.setContentCompressionResistancePriority(.required, for: .vertical)
+
         NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.edgeMargins.left),
             stackView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -Metrics.edgeMargins.right),
             stackView.topAnchor.constraint(equalTo: view.topAnchor, constant: Metrics.edgeMargins.top),
-            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor, constant: WPDeviceIdentification.isiPad() ? .zero : -Metrics.edgeMargins.bottom),
+            stackView.bottomAnchor.constraint(equalTo: view.safeBottomAnchor,
+                                              constant: WPDeviceIdentification.isiPad() ? Metrics.ipadBottomMargin : -Metrics.edgeMargins.bottom),
 
             imageView.heightAnchor.constraint(equalTo: imageView.widthAnchor),
 
@@ -453,8 +542,17 @@ private extension BloggingRemindersFlowSettingsViewController {
             timeSelectionView.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             timeSelectionView.widthAnchor.constraint(equalTo: stackView.widthAnchor),
             frequencyView.heightAnchor.constraint(equalToConstant: Metrics.frequencyLabelHeight),
-            timeSelectionToConfirmationButtonSpacer.heightAnchor.constraint(greaterThanOrEqualToConstant: 0),
-            timeSelectionToConfirmationButtonSpacer.widthAnchor.constraint(equalTo: stackView.widthAnchor)
+
+            bloggingPromptsInfoButton.heightAnchor.constraint(equalToConstant: Metrics.BloggingPrompts.infoButtonHeight),
+            bloggingPromptsInfoButton.widthAnchor.constraint(equalTo: bloggingPromptsInfoButton.heightAnchor),
+            bloggingPromptsSwitch.topAnchor.constraint(greaterThanOrEqualTo: bloggingPromptsSwitchView.topAnchor,
+                                                       constant: Metrics.BloggingPrompts.switchMargins.top),
+            bloggingPromptsSwitch.bottomAnchor.constraint(lessThanOrEqualTo: bloggingPromptsSwitchView.bottomAnchor,
+                                                          constant: Metrics.BloggingPrompts.switchMargins.bottom),
+            bloggingPromptsSwitch.leadingAnchor.constraint(equalTo: bloggingPromptsSwitchView.leadingAnchor,
+                                                           constant: Metrics.BloggingPrompts.switchMargins.left),
+            bloggingPromptsSwitch.trailingAnchor.constraint(equalTo: bloggingPromptsSwitchView.trailingAnchor),
+            bloggingPromptsStackView.widthAnchor.constraint(equalTo: stackView.widthAnchor)
         ])
     }
 
@@ -545,6 +643,9 @@ private enum TextContent {
     static let nextButtonTitle = NSLocalizedString("Notify me", comment: "Title of button to navigate to the next screen of the blogging reminders flow, setting up push notifications.")
 
     static let updateButtonTitle = NSLocalizedString("Update", comment: "(Verb) Title of button confirming updating settings for blogging reminders.")
+    static let bloggingPromptsTitle = NSLocalizedString("Include prompt", comment: "Title of the switch to turn on or off the blogging prompts feature.")
+    static let bloggingPromptsDescription = NSLocalizedString("Notification will include a word or short phrase for inspiration", comment: "Description of the blogging prompts feature on the Blogging Reminders Settings screen.")
+    static let bloggingPromptsInfoButton = NSLocalizedString("Learn more about prompts", comment: "Accessibility label for the blogging prompts info button on the Blogging Reminders Settings screen.")
 }
 
 private enum Images {
@@ -553,11 +654,13 @@ private enum Images {
 
 private enum Metrics {
     static let edgeMargins = UIEdgeInsets(top: 46, left: 20, bottom: 56, right: 20)
+    static let ipadBottomMargin: CGFloat = -20.0
 
     static let stackSpacing: CGFloat = 24.0
     static let innerStackSpacing: CGFloat = 8.0
     static let afterTitleLabelSpacing: CGFloat = 16.0
     static let afterPromptLabelSpacing: CGFloat = 40.0
+    static let afterTimeSelectionViewSpacing: CGFloat = 10.0
 
     static let buttonHeight: CGFloat = 44.0
     static let frequencyLabelHeight: CGFloat = 30
@@ -566,4 +669,11 @@ private enum Metrics {
 
     // the smallest logical iPhone height (iPhone 12 mini) to display the full UI, which includes calendar icon.
     static let minimumHeightForFullUI: CGFloat = 812
+
+    enum BloggingPrompts {
+        static let titleSpacing: CGFloat = 5.0
+        static let labelsSpacing: CGFloat = 2.0
+        static let infoButtonHeight: CGFloat = 16.0
+        static let switchMargins = UIEdgeInsets(top: 6.0, left: 16.0, bottom: -7.0, right: 0.0)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
@@ -25,6 +25,7 @@ class BloggingRemindersTracker {
         // Misc UI events
         case buttonPressed = "blogging_reminders_button_pressed"
         case screenShown = "blogging_reminders_screen_shown"
+        case switchPressed = "blogging_reminders_switch_pressed"
     }
 
     enum FlowStartSource: String {
@@ -52,6 +53,16 @@ class BloggingRemindersTracker {
         case `continue`
         case dismiss
         case notificationSettings
+        case bloggingPromptsInfo
+    }
+
+    enum Switch: String {
+        case bloggingPrompts
+    }
+
+    enum State: String {
+        case disabled
+        case enabled
     }
 
     enum Property: String {
@@ -60,6 +71,8 @@ class BloggingRemindersTracker {
         case source = "source"
         case screen = "screen"
         case selectedTime = "selected_time"
+        case `switch` = "switch"
+        case state = "state"
     }
 
     /// The type of blog.
@@ -85,6 +98,16 @@ class BloggingRemindersTracker {
         ]
 
         track(event(.buttonPressed, properties: properties))
+    }
+
+    func switchPressed(control: Switch, state: State, screen: Screen) {
+        let properties = [
+            Property.switch.rawValue: control.rawValue,
+            Property.state.rawValue: state.rawValue,
+            Property.screen.rawValue: screen.rawValue,
+        ]
+
+        track(event(.switchPressed, properties: properties))
     }
 
     func flowCompleted() {


### PR DESCRIPTION
See: #18316

## Description

Makes the following changes:

- Adds the UI for the blogging prompts title, description, help button,
  and switch to turn the feature on/off
- Removes the spacer view after the next button and uses a constant
  value for spacing on iPad
- Adds tracking to the prompt help button press and to the switch that
  turns the feature on/off

## Testing

To test:

- Enable blogging prompts feature flag
- Select a site
- Go to Configure > Site Settings
- Open Blogging Reminders
- Validate UI is correctly laid out
- Tap the help button
  - Verify screen properly navigates to the blogging prompts info screen
  - Verify help button fires tracking on tap
- Go back to setting screen
- Tap switch and verify tracking on on/off

## Screenshots

| Before | After |
|-------|-------|
| ![Simulator Screen Shot - iPhone 11 - 2022-04-19 at 11 46 33](https://user-images.githubusercontent.com/2454408/164043771-62817e47-ee5b-4fcf-ab12-bcc8760bca09.png) | ![Simulator Screen Shot - iPhone 11 - 2022-04-19 at 11 44 53](https://user-images.githubusercontent.com/2454408/164043838-87053b82-12b4-4dd2-8600-36dca653ea1b.png) |
| ![Simulator Screen Shot - iPhone 11 - 2022-04-19 at 11 46 39](https://user-images.githubusercontent.com/2454408/164043968-7466cdb6-5e72-4772-9437-5cf911441ba5.png) | ![Simulator Screen Shot - iPhone 11 - 2022-04-19 at 11 45 15](https://user-images.githubusercontent.com/2454408/164044030-a84cb0e9-98bf-435f-b18e-7e006a044bc7.png) |

## Regression Notes

1. Potential unintended areas of impact
Blogging reminders settings layout

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Validated the screen in dark mode, different text sizes, and on iPad

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
