### PR TITLE
[19.7] Update release note for #18127

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 -----
 * [*] a11y: VoiceOver has been improved on the Menus view and now announces changes to ordering. [#18155]
 * [*] Notifications list: remove comment Trash swipe action. [#18349]
-* [*] Reader: Fixed a bug that caused cut off content in reader web view [#16106]
+* [*] Web previews now abide by safe areas when a toolbar is shown [#18127]
 * [*] Site creation: Adds a new screen asking the user the intent of the site [#18367]
 * [**] Block Editor: Quote block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/40133]
 * [**] Block Editor: Update "add block" button's style in default editor view [https://github.com/WordPress/gutenberg/pull/39726]


### PR DESCRIPTION
This PR updates the release note for the changes submitted by an external contributor in #18127.

Originally the issue [seemed limited to Reader](https://github.com/wordpress-mobile/WordPress-iOS/issues/16106), but the final fix affected multiple areas of the app that render web previews.