### PR TITLE
[Site Creation] [Site Design] Fix animations when showing action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -535,6 +535,8 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             UIView.animate(withDuration: animationSpeed, delay: 0, options: .curveEaseInOut, animations: {
                 self.footerHeightContraint.constant = hasSelectedItem ? self.footerHeight : 0
                 self.footerView.setNeedsLayout()
+                // call layoutIfNeeded on the parent view to smoothly update constraints
+                // more info: https://stackoverflow.com/a/12664093
                 self.view.layoutIfNeeded()
             })
             return

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -535,7 +535,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             UIView.animate(withDuration: animationSpeed, delay: 0, options: .curveEaseInOut, animations: {
                 self.footerHeightContraint.constant = hasSelectedItem ? self.footerHeight : 0
                 self.footerView.setNeedsLayout()
-                self.footerView.layoutIfNeeded()
+                self.view.layoutIfNeeded()
             })
             return
         }


### PR DESCRIPTION
Fixes #18281

| Before | After |
| ------ | ------ |
| ![Simulator Screen Recording - iPhone 13 - 2022-04-19 at 20 50 59](https://user-images.githubusercontent.com/2092798/164125960-894d68bd-c2b6-45cc-bc5a-a42b6a865a63.gif) | ![Simulator Screen Recording - iPhone 13 - 2022-04-19 at 20 48 24](https://user-images.githubusercontent.com/2092798/164126001-1ef2d618-6fb8-4484-86cd-4f49eb1ae125.gif) |


### To test:
1. Start the Site Creation flow by tapping the chevron at the top right of the My Site view and tapping the +
2. Navigate to the "Choose a design" screen
3. Tap on a design so that the action buttons transition from the bottom (tapping on the same design again will hide them)
4. Observe the animation when the buttons come into view
5. **Expect**: Buttons have a solid background as they slide up
6. **Expect**: Transition isn't jerky during the hiding transition

Note: If using Simulator, it may be helpful to enable "Slow Animations" under the Debug menu item.

## Regression Notes
1. Potential unintended areas of impact
- Animations when showing and hiding the action buttons

8. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual visual testing

9. What automated tests I added (or what prevented me from doing so)
- None, as these are visual animations.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
