### PR TITLE
Add spaces around placeholder in Site Name vertical title localized string

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -144,14 +144,14 @@ private extension SiteNameView {
     func setupTitleColors() {
         // enclose the vertical name between two characters that are not in the title
         // (and reasonably never will..) to distinguish it from any substring in the title
-        let selectedVerticalName = "😎" + siteVerticalName + "🙃"
+        let selectedVerticalName = "😎" + siteVerticalName.dropFirst().dropLast() + "🙃"
         let fullTitle = String(format: TextContent.title, selectedVerticalName)
         var attributedTitle = NSMutableAttributedString(string: fullTitle)
         guard let range = fullTitle.nsRange(of: selectedVerticalName), !siteVerticalName.isEmpty else {
             titleLabel.setText(TextContent.defaultTitle)
             return
         }
-        let polishedFullTitle = String(format: TextContent.title, " " + siteVerticalName + " ")
+        let polishedFullTitle = String(format: TextContent.title, siteVerticalName)
         attributedTitle = NSMutableAttributedString(string: polishedFullTitle)
         attributedTitle.addAttributes([
             .foregroundColor: UIColor.primary,
@@ -244,7 +244,7 @@ private extension SiteNameView {
 private extension SiteNameView {
 
     enum TextContent {
-        static let title = NSLocalizedString("Give your%@website a name",
+        static let title = NSLocalizedString("Give your %@ website a name",
                                              comment: "Title of the Site Name screen. Takes the vertical name as a parameter.")
         static let defaultTitle = NSLocalizedString("Give your website a name",
                                                     comment: "Default title of the Site Name screen.")

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -132,9 +132,9 @@ class SiteNameView: UIView {
     }
 
     override func becomeFirstResponder() -> Bool {
-         super.becomeFirstResponder()
-         return searchBar.becomeFirstResponder()
-     }
+        super.becomeFirstResponder()
+        return searchBar.becomeFirstResponder()
+    }
 }
 
 // MARK: setup
@@ -142,20 +142,22 @@ private extension SiteNameView {
 
     /// Highlghts the site name in blue
     func setupTitleColors() {
-        // enclose the vertical name between two characters that are not in the title
-        // (and reasonably never will..) to distinguish it from any substring in the title
-        let selectedVerticalName = "😎" + siteVerticalName.dropFirst().dropLast() + "🙃"
-        let fullTitle = String(format: TextContent.title, selectedVerticalName)
-        var attributedTitle = NSMutableAttributedString(string: fullTitle)
-        guard let range = fullTitle.nsRange(of: selectedVerticalName), !siteVerticalName.isEmpty else {
+        // find the index where the vertical name goes, so that it won't be confused
+        // with any word in the title
+        let replacementIndex = NSString(string: TextContent.title).range(of: "%@")
+
+        guard !siteVerticalName.isEmpty, replacementIndex.length > 0 else {
             titleLabel.setText(TextContent.defaultTitle)
             return
         }
-        let polishedFullTitle = String(format: TextContent.title, siteVerticalName)
-        attributedTitle = NSMutableAttributedString(string: polishedFullTitle)
+
+        let fullTitle = String(format: TextContent.title, siteVerticalName)
+        let attributedTitle = NSMutableAttributedString(string: fullTitle)
+        let replacementRange = NSRange(location: replacementIndex.location, length: siteVerticalName.utf16.count)
+
         attributedTitle.addAttributes([
             .foregroundColor: UIColor.primary,
-        ], range: range)
+        ], range: replacementRange)
         titleLabel.attributedText = attributedTitle
     }
 


### PR DESCRIPTION
This PR addresses an issue with certain languages that require the vertical name not to include spaces before and after, in the localizable string
Fixes #NA

To test:
- Enable site name in the site creation flow (e.g. by setting `shouldShowSiteName` temporarily to `true` in `SiteCreationWizardLauncher`
- start the site creation flow
- Enter any vertical name (custom or from the list) and verify that it shows correctly (see screenshots)
- Go back and enter a custom vertical name that matches one of the words in the default title (e.g. "Give")
- Make sure that the highlight in blue still occurs where the vertical name is
- Go back and skip the step
- Make sure that the default title "Give your website a name" is displayed correctly

default or custom name | name matches a word in the title | skip vertical selection
-- | -- | --
<img height=500 src=https://user-images.githubusercontent.com/34376330/164298123-997b62cd-5711-4d9b-b00c-b59c71bd488d.PNG> | <img height=500 src=https://user-images.githubusercontent.com/34376330/164298151-19586f77-dad7-4ba4-a07e-6f2e34fcbbb1.PNG> | <img height=500 src=https://user-images.githubusercontent.com/34376330/164298188-c56269f6-30c1-4ff1-b1a8-a076b91aa17b.PNG>



## Regression Notes
1. Potential unintended areas of impact
None, this PR just changed the way a string title is generated

2. What I did to test those areas of impact (or what existing automated tests I relied on)
na

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
