### PR TITLE
Video length restrictions are not applicable to self hosted sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 19.8
 -----
+* [**] Self hosted sites are not restricted by video length during media uploads [https://github.com/wordpress-mobile/WordPress-iOS/pull/18414]
 * [*] [internal] My Site Dashboard: Made some changes to the code architecture of the dashboard. The majority of the changes are related to the posts cards. It should have no visible changes but could cause regressions. Please test it by creating/trashing drafts and scheduled posts and testing that they appear correctly on the dashboard. [#18405]
 
 19.7

--- a/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
+++ b/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
@@ -52,7 +52,7 @@ class WPMediaPickerForKanvas: WPNavigationMediaPickerViewController, MediaPicker
 
         let mediaPickerDelegate = MediaPickerDelegate(kanvasDelegate: delegate,
                                                       presenter: tabBar,
-                                                      shouldDisableLongVideos: !blog.hasPaidPlan)
+                                                      blog: blog)
         let options = WPMediaPickerOptions()
         options.allowCaptureOfMedia = false
 
@@ -85,17 +85,15 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
 
     private weak var kanvasDelegate: KanvasMediaPickerViewControllerDelegate?
     private weak var presenter: UIViewController?
-
-    private let shouldDisableLongVideos: Bool
-
+    private let blog: Blog
     private var cancellables = Set<AnyCancellable>()
 
     init(kanvasDelegate: KanvasMediaPickerViewControllerDelegate,
          presenter: UIViewController,
-         shouldDisableLongVideos: Bool = false) {
+         blog: Blog) {
         self.kanvasDelegate = kanvasDelegate
         self.presenter = presenter
-        self.shouldDisableLongVideos = shouldDisableLongVideos
+        self.blog = blog
     }
 
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
@@ -175,7 +173,7 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldShowOverlayViewForCellFor asset: WPMediaAsset) -> Bool {
-        picker != self && asset.exceedsFreeSitesAllowance() && shouldDisableLongVideos
+        picker != self && !blog.canUploadAsset(asset)
     }
 
     func mediaPickerControllerShouldShowCustomHeaderView(_ picker: WPMediaPickerViewController) -> Bool {
@@ -209,7 +207,7 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, shouldSelect asset: WPMediaAsset) -> Bool {
-        if picker != self, asset.exceedsFreeSitesAllowance(), shouldDisableLongVideos {
+        if picker != self, !blog.canUploadAsset(asset) {
             presentVideoLimitExceededFromPicker(on: picker)
             return false
         }

--- a/WordPress/Classes/Utility/Media/Blog+VideoLimits.swift
+++ b/WordPress/Classes/Utility/Media/Blog+VideoLimits.swift
@@ -2,6 +2,10 @@ extension Blog {
 
     /// returns true if the blog is allowed to upload the given asset, true otherwise
     func canUploadAsset(_ asset: WPMediaAsset) -> Bool {
-        hasPaidPlan || !asset.exceedsFreeSitesAllowance()
+        return canUploadAsset(asset.exceedsFreeSitesAllowance())
+    }
+
+    public func canUploadAsset(_ assetExceedsFreeSitesAllowance: Bool) -> Bool {
+        return hasPaidPlan || !isHostedAtWPcom || !assetExceedsFreeSitesAllowance
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2413,6 +2413,7 @@
 		DC8F61F727032B3F0087AC5D /* TimeZoneFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F61F627032B3F0087AC5D /* TimeZoneFormatter.swift */; };
 		DC8F61F827032B3F0087AC5D /* TimeZoneFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F61F627032B3F0087AC5D /* TimeZoneFormatter.swift */; };
 		DC8F61FC2703321F0087AC5D /* TimeZoneFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F61FB2703321F0087AC5D /* TimeZoneFormatterTests.swift */; };
+		DCC662512810915D00962D0C /* BlogVideoLimitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC662502810915D00962D0C /* BlogVideoLimitsTests.swift */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10290741F30615A00DAC588 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10290731F30615A00DAC588 /* Role.swift */; };
 		E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E102B78F1E714F24007928E8 /* RecentSitesService.swift */; };
@@ -7178,6 +7179,7 @@
 		DC76668226FD9AC9009254DD /* TimeZoneTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeZoneTableViewCell.swift; sourceTree = "<group>"; };
 		DC8F61F627032B3F0087AC5D /* TimeZoneFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneFormatter.swift; sourceTree = "<group>"; };
 		DC8F61FB2703321F0087AC5D /* TimeZoneFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneFormatterTests.swift; sourceTree = "<group>"; };
+		DCC662502810915D00962D0C /* BlogVideoLimitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogVideoLimitsTests.swift; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
 		E10290731F30615A00DAC588 /* Role.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
 		E102B78F1E714F24007928E8 /* RecentSitesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentSitesService.swift; sourceTree = "<group>"; };
@@ -8327,6 +8329,7 @@
 				FF8CD624214184EE00A33A8D /* MediaAssetExporterTests.swift */,
 				08F8CD3A1EBD2D020049D0C0 /* MediaURLExporterTests.swift */,
 				08E77F461EE9D72F006F9515 /* MediaThumbnailExporterTests.swift */,
+				DCC662502810915D00962D0C /* BlogVideoLimitsTests.swift */,
 			);
 			name = Media;
 			sourceTree = "<group>";
@@ -19484,6 +19487,7 @@
 				73B6693A21CAD960008456C3 /* ErrorStateViewTests.swift in Sources */,
 				8BD34F0927D144FF005E931C /* BlogDashboardStateTests.swift in Sources */,
 				1759F1721FE017F20003EC81 /* QueueTests.swift in Sources */,
+				DCC662512810915D00962D0C /* BlogVideoLimitsTests.swift in Sources */,
 				3F1AD48123FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift in Sources */,
 				08F8CD3B1EBD2D020049D0C0 /* MediaURLExporterTests.swift in Sources */,
 				D81C2F6220F89632002AE1F1 /* EditCommentActionTests.swift in Sources */,

--- a/WordPress/WordPressTest/BlogVideoLimitsTests.swift
+++ b/WordPress/WordPressTest/BlogVideoLimitsTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+
+class BlogVideoLimitsTests: XCTestCase {
+
+    private var blog: Blog!
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext!
+
+    override func setUpWithError() throws {
+        contextManager = TestContextManager()
+        context = contextManager.newDerivedContext()
+        blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as? Blog
+        blog.url = Constants.blogURL
+        blog.xmlrpc = Constants.blogURL
+    }
+
+    override func tearDownWithError() throws {
+        blog = nil
+    }
+
+    func testCanUploadAssetPaidPlan() throws {
+        // Given a blog
+        // When blog has a paid plan
+        blog.hasPaidPlan = true
+
+        // Then it can upload assets irrespective of allowance
+        XCTAssertTrue(blog.canUploadAsset(true))
+        XCTAssertTrue(blog.canUploadAsset(false))
+    }
+
+    func testCanUploadAssetWPCom() throws {
+        // Given a blog
+        // When blog is on WPCom and not paid
+        blog.isHostedAtWPcom = true
+        blog.hasPaidPlan = false
+
+        // Then it can upload assets when allowance not exceeded
+        XCTAssertTrue(blog.canUploadAsset(false))
+
+        // Then it cannot upload assets when allowance exceeded
+        XCTAssertFalse(blog.canUploadAsset(true))
+    }
+
+    func testCanUploadAssetSelfHosted() throws {
+        // Given a blog
+        // When blog is not on WPCom and not paid
+        blog.isHostedAtWPcom = false
+        blog.hasPaidPlan = false
+
+        // Then it can upload assets irrespective of allowance
+        XCTAssertTrue(blog.canUploadAsset(true))
+        XCTAssertTrue(blog.canUploadAsset(false))
+    }
+}
+
+private extension BlogVideoLimitsTests {
+    enum Constants {
+        static let blogURL: String = "http://wordpress.com"
+    }
+}


### PR DESCRIPTION
This PR adds functionality to remove the video length restrictions on self hosted sites + adds a unit test to test the different canUploadAsset conditions (paid vs self hosted vs wp.com hosted and free) 

Fixes #18277

Pre-requisites:
 * make sure that you have a self hosted site with and without jetpack for testing
 * make sure to have local files both on device / simulator and from other apps (e.g Files) videos that are longer than 5 minutes and < the maximum file size on your self hosted site
 * To find the max upload size of your self hosted site (as in the issue thanks @twstokes)
		a. Log in to the self-hosted site's dashboard
		b. Select "Media"
		c. Select "Add new"
		d. Look at the value under the "Select Files" button
<img width="542" alt="image" src="https://user-images.githubusercontent.com/88816724/164515737-e7bc9d66-1ad2-4dfe-a207-7475ca7233d4.png">


### To test:
Note: I'm not familiar where all the entry points are of video upload so I might have been overzealous in testing or missed some cases

1. Test from Media screen
	A. Connect WPiOS to a self-hosted site with jetpack plugin installed on your WP self-hosted site
	B. Select your self-hosted site with jetpack
	C. Tap "Media"
	D. Tap "Upload Media"
	E. Tap "Choose from My Device"
	F. Select the video longer than five minutes
	G. Video should be able to upload
2. Test from creating a Blog post
	A. On your self-hosted site with jetpack
	B. Tap "Posts"
	C. Click the blue Floating Action Button (FAB)
	D. Create a Blog post
	E. Tap Add Blocks -> Video
	F. Choose from device
	G. Select the video longer than five minutes
	H. Video should be able to upload
3. Test from creating a Story post
	A. On your self-hosted site with jetpack
	B. Tap "Posts"
	C. Click the blue Floating Action Button (FAB)
	D. Create a Story post
	E. Grant permissions to media
	F. Tap lower left image to select a video
	G. Select the video longer than five minutes
	H. Video should be able to upload
4. Repeat all steps above using a self hosted site without jetpack.  All videos should be able to upload but you will not be able to create a Story post
5. Repeat all steps above using a wordpress.com paid plan site.  All videos should be able to upload
6. Repeat all steps above using a wordpress.com free site.  When testing a wordpress.com free site and tapping the video in the MediaPicker, "Selection not allowed" message should be shown


## Regression Notes
1. Potential unintended areas of impact
Video uploads to blogs

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I manually tested and added a unit test

3. What automated tests I added (or what prevented me from doing so)
I added a unit test to handle the conditions of different blog state(s) for above test scenarios

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
