### PR TITLE
Add header view to `ActionSheetViewController`

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -45,11 +45,13 @@ class ActionSheetViewController: UIViewController {
         }
     }
 
+    let headerView: UIView?
     let buttons: [ActionSheetButton]
-    let headerTitle: String
+    let buttonHeaderTitle: String
 
-    init(headerTitle: String, buttons: [ActionSheetButton]) {
-        self.headerTitle = headerTitle
+    init(headerView: UIView? = nil, buttonHeaderTitle: String, buttons: [ActionSheetButton]) {
+        self.headerView = headerView
+        self.buttonHeaderTitle = buttonHeaderTitle
         self.buttons = buttons
         super.init(nibName: nil, bundle: nil)
     }
@@ -83,7 +85,7 @@ class ActionSheetViewController: UIViewController {
         headerLabelView.pinSubviewToAllEdges(headerLabel, insets: Constants.Header.insets)
 
         headerLabel.font = WPStyleGuide.fontForTextStyle(.headline)
-        headerLabel.text = headerTitle
+        headerLabel.text = buttonHeaderTitle
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let buttonViews = buttons.map({ (buttonInfo) -> UIButton in
@@ -100,10 +102,13 @@ class ActionSheetViewController: UIViewController {
 
         NSLayoutConstraint.activate(buttonConstraints)
 
-        let stackView = UIStackView(arrangedSubviews: [
-            gripButton,
-            headerLabelView
-        ] + buttonViews)
+        let stackView = UIStackView(arrangedSubviews: [gripButton])
+
+        if let headerView = headerView {
+            stackView.addArrangedSubview(headerView)
+        }
+
+        stackView.addArrangedSubviews([headerLabelView] + buttonViews)
 
         stackView.setCustomSpacing(Constants.Header.spacing, after: gripButton)
         stackView.setCustomSpacing(Constants.Header.spacing, after: headerLabelView)

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -47,11 +47,11 @@ class ActionSheetViewController: UIViewController {
 
     let headerView: UIView?
     let buttons: [ActionSheetButton]
-    let buttonHeaderTitle: String
+    let headerTitle: String
 
-    init(headerView: UIView? = nil, buttonHeaderTitle: String, buttons: [ActionSheetButton]) {
+    init(headerView: UIView? = nil, headerTitle: String, buttons: [ActionSheetButton]) {
         self.headerView = headerView
-        self.buttonHeaderTitle = buttonHeaderTitle
+        self.headerTitle = headerTitle
         self.buttons = buttons
         super.init(nibName: nil, bundle: nil)
     }
@@ -85,7 +85,7 @@ class ActionSheetViewController: UIViewController {
         headerLabelView.pinSubviewToAllEdges(headerLabel, insets: Constants.Header.insets)
 
         headerLabel.font = WPStyleGuide.fontForTextStyle(.headline)
-        headerLabel.text = buttonHeaderTitle
+        headerLabel.text = headerTitle
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
 
         let buttonViews = buttons.map({ (buttonInfo) -> UIButton in

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -12,7 +12,7 @@ class CreateButtonActionSheet: ActionSheetViewController {
 
     init(actions: [ActionSheetItem]) {
         let buttons = actions.map { $0.makeButton() }
-        super.init(headerTitle: Constants.title, buttons: buttons)
+        super.init(buttonHeaderTitle: Constants.title, buttons: buttons)
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -12,7 +12,7 @@ class CreateButtonActionSheet: ActionSheetViewController {
 
     init(actions: [ActionSheetItem]) {
         let buttons = actions.map { $0.makeButton() }
-        super.init(buttonHeaderTitle: Constants.title, buttons: buttons)
+        super.init(headerTitle: Constants.title, buttons: buttons)
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
Ref: #18402

## Description

Allows for a header view to be added to the action sheet view controller. This will be used in a future PR for the blogging prompts header view.

## Testing

To test:
- Sign into the app and navigate to the 'My Site' tab
- Tap on the floating create new action button
- Verify it functions as it previously did

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.