### PR TITLE
Fix Site Name screen layout on smaller iPhones

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -149,7 +149,10 @@ private extension SiteNameView {
         let selectedVerticalName = "😎" + siteVerticalName + "🙃"
         let fullTitle = String(format: TextContent.title, selectedVerticalName)
         var attributedTitle = NSMutableAttributedString(string: fullTitle)
-        guard let range = fullTitle.nsRange(of: selectedVerticalName), !siteVerticalName.isEmpty else {
+        // Use default title if the vertical name is empty or too long
+        guard let range = fullTitle.nsRange(of: selectedVerticalName),
+              !siteVerticalName.isEmpty,
+              siteVerticalName.count <= Metrics.verticalNameDisplayLimit else {
             titleLabel.setText(TextContent.defaultTitle)
             return
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -238,10 +238,22 @@ private extension SiteNameView {
 
     /// hides or shows titles based on the passed boolean parameter
     func hideTitlesIfNeeded() {
-        let isAccessibility = traitCollection.verticalSizeClass == .compact || traitCollection.preferredContentSizeCategory.isAccessibilityCategory
-        let isVerylarge = [UIContentSizeCategory.extraExtraLarge, UIContentSizeCategory.extraExtraExtraLarge].contains(traitCollection.preferredContentSizeCategory)
+        let isAccessibility = traitCollection.verticalSizeClass == .compact ||
+        traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+
+        let isVerylarge = [
+            UIContentSizeCategory.extraExtraLarge,
+            UIContentSizeCategory.extraExtraExtraLarge
+        ].contains(traitCollection.preferredContentSizeCategory)
+
         titleLabelView.isHidden = isAccessibility
-        subtitleLabelView.isHidden = isAccessibility || isVerylarge
+
+        subtitleLabelView.isHidden = isAccessibility || isVerylarge || isIphoneSEorSmaller
+    }
+
+    var isIphoneSEorSmaller: Bool {
+        UIScreen.main.nativeBounds.height <= Metrics.smallerIphonesNativeBoundsHeight &&
+        UIScreen.main.nativeScale <= Metrics.nativeScale
     }
 }
 
@@ -279,8 +291,10 @@ private extension SiteNameView {
         static func continueButtonViewFrame(_ accessoryWidth: CGFloat) -> CGRect {
             CGRect(x: 0, y: 0, width: accessoryWidth, height: 76)
         }
+        // native bounds height and scale of iPhone SE 3rd gen and iPhone 8
+        static let smallerIphonesNativeBoundsHeight: CGFloat = 1334
+        static let nativeScale: CGFloat = 2
     }
-
 }
 
 // MARK: search bar delegate

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Name/SiteNameView.swift
@@ -24,6 +24,8 @@ class SiteNameView: UIView {
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = Metrics.numberOfLinesInTitle
         label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Metrics.titleMinimumScaleFactor
         return label
     }()
 
@@ -132,9 +134,9 @@ class SiteNameView: UIView {
     }
 
     override func becomeFirstResponder() -> Bool {
-         super.becomeFirstResponder()
-         return searchBar.becomeFirstResponder()
-     }
+        super.becomeFirstResponder()
+        return searchBar.becomeFirstResponder()
+    }
 }
 
 // MARK: setup
@@ -262,9 +264,11 @@ private extension SiteNameView {
         // search bar
         static let searchbarHeight: CGFloat = 64
         // title and subtitle
-        static let numberOfLinesInTitle = 0
+        static let numberOfLinesInTitle = 3
         static let numberOfLinesInSubtitle = 0
         static let titlesInsets = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
+        static let verticalNameDisplayLimit = 32
+        static let titleMinimumScaleFactor: CGFloat = 0.75
         //continue button
         static let continueButtonStandardPadding: CGFloat = 16
         static let continueButtonAdditionaliPadPadding: CGFloat = 8


### PR DESCRIPTION
Fixes #18409

This PR applies the following changes to better render the Site Name screen layout, especially on smaller iPhones:
- if the (custom) vertical name is too long, the title will fallback to the default: "Give your website a name". The allowed maximum length for a vertical name is set to `32` characters.
- The maximum number of line in the title is set to 3, and the font will scale down as needed, with a minimum scale factor of `0.75`.
- If the current device is a _supported_ smaller iPhone (iPhone SE 3rd gen or iPhone 8), the subtitle will be hidden.

### To test:
### Test on iPhone SE 3rd Gen / iPhone 8. Also test on any other device to make sure everything still looks fine.
- checkout this branch and ensure that you will see the Site Name screen in the site creation flow. This can be achieved by setting `shouldShowSiteName` temporarily to `true` in `SiteCreationWizardLauncher`
- Build/run and start the site creation flow
- Select an available vertical or input a custom one, with a name shorter or equal to 32 characters.
- Tap "Continue" and make sure that:
    - the title contains the vertical name highlighted in blue
    - the view is laid out correctly and the input text is not hidden behind the continue button
    - if you are testing on a smaller iPhone, the subtitle does not appear
- Go back,  and input a vertical name longer than `32` characrters
- Tap continue and make sure that:
    - the title is the default "Give your website a name"
    -  the view is laid out correctly and the input text is not hidden behind the continue button
    -  if you are testing on a smaller iPhone, the subtitle does not appear

## Regression Notes
1. Potential unintended areas of impact
None, this PR only adjusts font in a label and hide the subtitle for one more category

2. What I did to test those areas of impact (or what existing automated tests I relied on)
na

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
