### PR TITLE
Feature Introduction: fix header image layout

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -502,12 +502,13 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     /// - The primary and secondary action buttons are always displayed.
     /// - The defaultActionButton is never displayed.
     /// Therefore:
-    /// - itemSelectionChanged is called to accomplish the two points above.
+    /// - The footerView with the action buttons is shown.
     /// - The selectedStateButtonsContainer axis is set to vertical.
     /// - The primaryActionButton is moved to the top of the stack view.
     func configureVerticalButtonView() {
         usesVerticalActionButtons = true
-        itemSelectionChanged(true)
+
+        footerHeightContraint.constant = footerHeight
         selectedStateButtonsContainer.axis = .vertical
 
         selectedStateButtonsContainer.removeArrangedSubview(primaryActionButton)


### PR DESCRIPTION
Ref: #18176, #18407

This fixes an issue where the top of the header image was cut off.

The change made in #18407 caused the layout to change. Unfortunately, that broke the header. When I initially implemented support for vertically stacked action buttons, I reused the `itemSelectionChanged` method since it layed out the buttons nicely. Uh... not anymore. :smile: 

Now, when `configureVerticalButtonView` is called, the footer is set up directly instead of calling `itemSelectionChanged`.

To test:
- Enable `bloggingPrompts` feature.
- Run the app.
- When the app launches, the Feature Introduction will appear.
- Verify:
  - The header image is whole again.
  - The bottom buttons appear as expected.

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/164562824-78586fb3-17f1-4c42-b137-54a782cd702e.png) | ![after](https://user-images.githubusercontent.com/1816888/164562788-fc47323e-65eb-4701-a650-311c827de934.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
