### PR TITLE
Stats Revamp: Updated Most Popular Time card

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -25,6 +25,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case siteIntentQuestion
     case landInTheEditor
     case statsNewAppearance
+    case statsNewInsights
     case siteName
 
     /// Returns a boolean indicating if the feature is enabled
@@ -80,6 +81,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .landInTheEditor:
             return false
         case .statsNewAppearance:
+            return false
+        case .statsNewInsights:
             return false
         case .siteName:
             return true
@@ -159,6 +162,8 @@ extension FeatureFlag {
             return "Land In The Editor"
         case .statsNewAppearance:
             return "New Appearance for Stats"
+        case .statsNewInsights:
+            return "New Cards for Stats Insights"
         case .siteName:
             return "Site Name"
         }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -307,7 +307,13 @@
     struct InsightsHeaders {
         static let latestPostSummary = NSLocalizedString("Latest Post Summary", comment: "Insights latest post summary header")
         static let allTimeStats = NSLocalizedString("All-Time", comment: "Insights 'All-Time' header")
-        static let mostPopularTime = NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
+        static var mostPopularTime: String {
+            if FeatureFlag.statsNewAppearance.enabled {
+                return NSLocalizedString("stats.insights.mostPopularCard.title", value: "🔥 Most Popular Time", comment: "Insights 'Most Popular Time' header. Fire emoji should remain part of the string.")
+            } else {
+                return NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
+            }
+        }
         static let followerTotals = NSLocalizedString("Follower Totals", comment: "Insights 'Follower Totals' header")
         static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
         static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -176,6 +176,7 @@ private extension SiteStatsInsightsTableViewController {
                 PostingActivityRow.self,
                 TabbedTotalsStatsRow.self,
                 TopTotalsInsightStatsRow.self,
+                MostPopularTimeInsightStatsRow.self,
                 TableFooterRow.self,
                 StatsErrorRow.self,
                 StatsGhostGrowAudienceImmutableRow.self,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -5,7 +5,7 @@ class StatsBaseCell: UITableViewCell {
 
     @IBOutlet var topConstraint: NSLayoutConstraint!
 
-    private var headingBottomConstraint: NSLayoutConstraint!
+    private var headingBottomConstraint: NSLayoutConstraint?
 
     /// Finds the item from the top constraint that's not the content view itself.
     /// - Returns: `topConstraint`'s `firstItem` or `secondItem`, whichever is not this cell's content view.
@@ -23,12 +23,6 @@ class StatsBaseCell: UITableViewCell {
             let title = statSection?.title ?? ""
             updateHeadingLabel(with: title)
         }
-    }
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-
-        configureHeadingLabel(with: topConstraint)
     }
 
     func configureHeadingLabel(with topConstraint: NSLayoutConstraint) {
@@ -53,7 +47,7 @@ class StatsBaseCell: UITableViewCell {
 
             // Create a new constraint between the heading label and the first item of the existing top constraint
             headingBottomConstraint = headingLabel.bottomAnchor.constraint(equalTo: anchor, constant: -(Metrics.padding + constant))
-            headingBottomConstraint.isActive = true
+            headingBottomConstraint?.isActive = true
         }
     }
 
@@ -62,15 +56,19 @@ class StatsBaseCell: UITableViewCell {
             return
         }
 
+        if headingBottomConstraint == nil {
+            configureHeadingLabel(with: topConstraint)
+        }
+
         headingLabel.text = title
 
         let hasTitle = !title.isEmpty
 
-        headingBottomConstraint.isActive = hasTitle
+        headingBottomConstraint?.isActive = hasTitle
         topConstraint.isActive = !hasTitle
     }
 
-    private enum Metrics {
+    enum Metrics {
         static let padding: CGFloat = 16.0
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -1,0 +1,158 @@
+import UIKit
+
+struct StatsMostPopularTimeData {
+    var mostPopularDayTitle: String
+    var mostPopularTimeTitle: String
+    var mostPopularDay: String
+    var mostPopularTime: String
+    var dayPercentage: String
+    var timePercentage: String
+}
+
+class StatsMostPopularTimeInsightsCell: StatsBaseCell {
+    private var data: StatsMostPopularTimeData? = nil
+    private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+
+    // MARK: - Subviews
+
+    private var topLeftLabel: UILabel!
+    private var middleLeftLabel: UILabel!
+    private var bottomLeftLabel: UILabel!
+
+    private var topRightLabel: UILabel!
+    private var middleRightLabel: UILabel!
+    private var bottomRightLabel: UILabel!
+
+    // MARK: - Initialization
+
+    required override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        configureView()
+    }
+
+    required init(coder: NSCoder) {
+        fatalError()
+    }
+
+    // MARK: - View Configuration
+
+    private func configureView() {
+        let stackView = makeOuterStackView()
+        contentView.addSubview(stackView)
+
+        topConstraint = stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: StatsBaseCell.Metrics.padding)
+
+        NSLayoutConstraint.activate([
+            topConstraint,
+            stackView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor, constant: -StatsBaseCell.Metrics.padding),
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: StatsBaseCell.Metrics.padding),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -StatsBaseCell.Metrics.padding),
+        ])
+    }
+
+    private func makeOuterStackView() -> UIStackView {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = Metrics.horizontalStackViewSpacing
+
+        let leftStackView = makeLeftStackView()
+        let rightStackView = makeRightStackView()
+        let divider = makeVerticalDivider()
+
+        stackView.addArrangedSubviews([leftStackView, divider, rightStackView])
+
+        configureInnerStackViews(leftStackView: leftStackView,
+                                 rightStackView: rightStackView)
+
+        NSLayoutConstraint.activate([
+            leftStackView.widthAnchor.constraint(equalTo: rightStackView.widthAnchor),
+            divider.widthAnchor.constraint(equalToConstant: Metrics.dividerWidth)
+        ])
+
+        return stackView
+    }
+
+    private func makeLeftStackView() -> UIStackView {
+        let leftStackView = UIStackView()
+        leftStackView.translatesAutoresizingMaskIntoConstraints = false
+        leftStackView.axis = .vertical
+
+        return leftStackView
+    }
+
+    private func makeRightStackView() -> UIStackView {
+        let rightStackView = UIStackView()
+        rightStackView.translatesAutoresizingMaskIntoConstraints = false
+        rightStackView.axis = .vertical
+
+        return rightStackView
+    }
+
+    private func makeVerticalDivider() -> UIView {
+        let divider = UIView()
+        divider.translatesAutoresizingMaskIntoConstraints = false
+        WPStyleGuide.Stats.configureViewAsVerticalSeparator(divider)
+
+        return divider
+    }
+
+    private func configureInnerStackViews(leftStackView: UIStackView,
+                                          rightStackView: UIStackView) {
+        let leftLabels = configure(verticalStackView: leftStackView)
+        let rightLabels = configure(verticalStackView: rightStackView)
+
+        topLeftLabel = leftLabels.topLabel
+        middleLeftLabel = leftLabels.middleLabel
+        bottomLeftLabel = leftLabels.bottomLabel
+
+        topRightLabel = rightLabels.topLabel
+        middleRightLabel = rightLabels.middleLabel
+        bottomRightLabel = rightLabels.bottomLabel
+    }
+
+    private func configure(verticalStackView: UIStackView) -> (topLabel: UILabel, middleLabel: UILabel, bottomLabel: UILabel) {
+        let topLabel = UILabel()
+        topLabel.textColor = .text
+        topLabel.font = .preferredFont(forTextStyle: .body)
+
+        let middleLabel = UILabel()
+        middleLabel.textColor = .text
+        middleLabel.font = .preferredFont(forTextStyle: .title1).bold()
+
+        let bottomLabel = UILabel()
+        bottomLabel.textColor = .textSubtle
+        bottomLabel.font = .preferredFont(forTextStyle: .body)
+
+        verticalStackView.spacing = Metrics.verticalStackViewSpacing
+        verticalStackView.addArrangedSubviews([topLabel, middleLabel, bottomLabel])
+
+        return (topLabel: topLabel, middleLabel: middleLabel, bottomLabel: bottomLabel)
+    }
+
+    // MARK: Public configuration
+
+    func configure(data: StatsMostPopularTimeData?, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+        self.data = data
+        self.statSection = .insightsMostPopularTime
+        self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
+
+        if let data = data {
+            topLeftLabel.text = data.mostPopularDayTitle
+            middleLeftLabel.text = data.mostPopularDay
+            bottomLeftLabel.text = data.dayPercentage
+
+            topRightLabel.text = data.mostPopularTimeTitle
+            middleRightLabel.text = data.mostPopularTime
+            bottomRightLabel.text = data.timePercentage
+        }
+    }
+
+    private enum Metrics {
+        static let horizontalStackViewSpacing: CGFloat = 32.0
+        static let verticalStackViewSpacing: CGFloat = 8.0
+        static let dividerWidth: CGFloat = 1.0
+    }
+}
+

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -1,13 +1,5 @@
 import UIKit
 
-struct StatsMostPopularTimeData {
-    var mostPopularDayTitle: String
-    var mostPopularTimeTitle: String
-    var mostPopularDay: String
-    var mostPopularTime: String
-    var dayPercentage: String
-    var timePercentage: String
-}
 
 class StatsMostPopularTimeInsightsCell: StatsBaseCell {
     private var data: StatsMostPopularTimeData? = nil
@@ -156,3 +148,45 @@ class StatsMostPopularTimeInsightsCell: StatsBaseCell {
     }
 }
 
+// MARK: - Data / View Model
+
+struct StatsMostPopularTimeData {
+    var mostPopularDayTitle: String
+    var mostPopularTimeTitle: String
+    var mostPopularDay: String
+    var mostPopularTime: String
+    var dayPercentage: String
+    var timePercentage: String
+}
+
+// MARK: - Model Formatting Helpers
+
+extension StatsAnnualAndMostPopularTimeInsight {
+    func formattedMostPopularDay() -> String? {
+        guard var mostPopularWeekday = mostPopularDayOfWeek.weekday else {
+            return nil
+        }
+
+        var calendar = Calendar.init(identifier: .gregorian)
+        calendar.locale = Locale.autoupdatingCurrent
+
+        // Back up mostPopularWeekday by 1 to get correct index for standaloneWeekdaySymbols.
+        mostPopularWeekday = mostPopularWeekday == 0 ? calendar.standaloneWeekdaySymbols.count - 1 : mostPopularWeekday - 1
+        return calendar.standaloneWeekdaySymbols[mostPopularWeekday]
+    }
+
+    func formattedMostPopularTime() -> String? {
+        var calendar = Calendar.init(identifier: .gregorian)
+        calendar.locale = Locale.autoupdatingCurrent
+
+        guard let hour = mostPopularHour.hour,
+              let timeModifiedDate = calendar.date(bySettingHour: hour, minute: 0, second: 0, of: Date()) else {
+            return nil
+        }
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.setLocalizedDateFormatFromTemplate("h a")
+
+        return timeFormatter.string(from: timeModifiedDate).uppercased()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -264,6 +264,28 @@ struct TwoColumnStatsRow: ImmuTableRow {
     }
 }
 
+struct MostPopularTimeInsightStatsRow: ImmuTableRow {
+
+    typealias CellType = StatsMostPopularTimeInsightsCell
+
+    static let cell: ImmuTableCell = {
+        return ImmuTableCell.class(CellType.self)
+    }()
+
+    let data: StatsMostPopularTimeData?
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    let action: ImmuTableAction? = nil
+
+    func configureCell(_ cell: UITableViewCell) {
+        guard let cell = cell as? CellType else {
+            return
+        }
+
+        cell.configure(data: data, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+    }
+}
+
+
 // MARK: - Insights Management
 
 struct AddInsightRow: ImmuTableRow {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -337,6 +337,8 @@
 		17A4B6A324F911D5002DFB8E /* KeyValueDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1751E5901CE0E552000CA08D /* KeyValueDatabase.swift */; };
 		17A8858D2757B97F0071FCA3 /* AutomatticAbout in Frameworks */ = {isa = PBXBuildFile; productRef = 17A8858C2757B97F0071FCA3 /* AutomatticAbout */; };
 		17A8858F2757BEC00071FCA3 /* AutomatticAbout in Frameworks */ = {isa = PBXBuildFile; productRef = 17A8858E2757BEC00071FCA3 /* AutomatticAbout */; };
+		17ABD3522811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */; };
+		17ABD3532811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */; };
 		17AD36D51D36C1A60044B10D /* WPStyleGuide+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */; };
 		17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */; };
 		17B7C89E20EC1D0D0042E260 /* UniversalLinkRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */; };
@@ -5117,6 +5119,7 @@
 		17A28DCA2052FB5D00EA6D9E /* AuthorFilterViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorFilterViewController.swift; sourceTree = "<group>"; };
 		17A4A36820EE51870071C2CA /* Routes+Reader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Routes+Reader.swift"; sourceTree = "<group>"; };
 		17A4A36B20EE55320071C2CA /* ReaderCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCoordinator.swift; sourceTree = "<group>"; };
+		17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsMostPopularTimeInsightsCell.swift; sourceTree = "<group>"; };
 		17AD36D41D36C1A60044B10D /* WPStyleGuide+Search.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+Search.swift"; sourceTree = "<group>"; };
 		17AF92241C46634000A99CFB /* BlogSiteVisibilityHelperTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BlogSiteVisibilityHelperTest.m; sourceTree = "<group>"; };
 		17B7C89D20EC1D0D0042E260 /* UniversalLinkRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniversalLinkRouter.swift; sourceTree = "<group>"; };
@@ -12136,6 +12139,7 @@
 				98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */,
 				98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */,
 				176CE91527FB44C100F1E32B /* StatsBaseCell.swift */,
+				17ABD3512811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift */,
 			);
 			path = Insights;
 			sourceTree = "<group>";
@@ -17521,6 +17525,7 @@
 				F16C35D623F33DE400C81331 /* PageAutoUploadMessageProvider.swift in Sources */,
 				8BDA5A6B247C2EAF00AB124C /* ReaderDetailViewController.swift in Sources */,
 				3F8B313025D1D652005A2903 /* HomeWidgetThisWeekData.swift in Sources */,
+				17ABD3522811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */,
 				7E7B4CF820459E21001463D6 /* PersonHeaderCell.swift in Sources */,
 				B03B9234250BC593000A40AF /* SuggestionService.swift in Sources */,
 				B555E1151C04A68D00CEC81B /* WordPress-41-42.xcmappingmodel in Sources */,
@@ -21033,6 +21038,7 @@
 				FAFC064C27D22E4C002F0483 /* QuickStartTourStateView.swift in Sources */,
 				C72A52CF2649B158009CA633 /* JetpackWindowManager.swift in Sources */,
 				FABB25062602FC2C00C8785C /* ReaderTagsTableViewModel.swift in Sources */,
+				17ABD3532811A48900B1E9CB /* StatsMostPopularTimeInsightsCell.swift in Sources */,
 				FABB25072602FC2C00C8785C /* SiteAssemblyService.swift in Sources */,
 				FABB25082602FC2C00C8785C /* ManagedPerson.swift in Sources */,
 				FABB25092602FC2C00C8785C /* ChosenValueRow.swift in Sources */,


### PR DESCRIPTION
Implements #18422. This PR updates the appearance of the Most Popular Time card and adds additional information.

| Before | New Design | After |
|---|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-22 at 00 31 52](https://user-images.githubusercontent.com/4780/164567800-071403c9-f3be-4cc4-a004-1ab52fda2661.png) | ![](https://user-images.githubusercontent.com/4780/164567856-7b2a5018-fd98-4057-9c74-e292ca6c40b8.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-04-21 at 19 01 37](https://user-images.githubusercontent.com/4780/164567836-094881f0-6219-489e-91ad-e8d71f1b5270.png) |

Dark mode:

<img width="338" alt="Screenshot 2022-04-22 at 00 39 36" src="https://user-images.githubusercontent.com/4780/164568233-6d9dbdbe-ea90-41d7-a651-f96d9971671f.png">


**Known issues**

- This currently doesn't cover the 'no data' case – this will come in a future PR:

<img width="336" alt="Screenshot 2022-04-22 at 00 37 25" src="https://user-images.githubusercontent.com/4780/164567989-296a98da-d7f9-4021-ae35-5c2c832d3fad.png">

- Dynamic type support can be improved, as some of the labels get truncated at larger sizes

**To test**

* Ensure that both the `statsNewAppearance` and `statsNewInsights` feature flags are enabled.
* Build and run.
* Navigate to Stats for a site with a lot of views. Check that the new Most Popular Time card is visible and matches the designs above.
* Also build and run with the feature flags disabled and ensure that the old cell appearance remains.

## Regression Notes
1. Potential unintended areas of impact

The existing Most Popular Time cell could be affected.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing to verify that it still appears as expected.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
