### PR TITLE
Suggestion: Spell out "one" instead of using numeric placeholder in Reader likes singular string

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailLikesView.swift
@@ -98,11 +98,11 @@ private extension ReaderDetailLikesView {
         case (true, 0):
             summaryLabel.attributedText = highlightedText(SummaryLabelFormats.onlySelf)
         case (true, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf, totalLikes))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singularWithSelf))
         case (true, _) where totalLikes > 1:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.pluralWithSelf, totalLikes))
         case (false, 1):
-            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular, totalLikes))
+            summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.singular))
         default:
             summaryLabel.attributedText = highlightedText(String(format: SummaryLabelFormats.plural, totalLikes))
         }
@@ -160,17 +160,16 @@ private extension ReaderDetailLikesView {
         static let onlySelf = NSLocalizedString("_You_ like this.",
                                                 comment: "Describes that the current user is the only one liking a post."
                                                     + " The underscores denote underline and is not displayed.")
-        static let singularWithSelf = NSLocalizedString("_You and %1$d blogger_ like this.",
+        static let singularWithSelf = NSLocalizedString("_You and another blogger_ like this.",
                                                         comment: "Describes that the current user and one other user like a post."
-                                                            + " %1$d is the number of likes, excluding the like by current user."
                                                             + " The underscores denote underline and is not displayed.")
         static let pluralWithSelf = NSLocalizedString("_You and %1$d bloggers_ like this.",
                                                       comment: "Plural format string for displaying the number of post likes, including the like from the current user."
                                                         + " %1$d is the number of likes, excluding the like by current user."
                                                         + " The underscores denote underline and is not displayed.")
-        static let singular = NSLocalizedString("_%1$d blogger_ likes this.",
+        static let singular = NSLocalizedString("_One blogger_ likes this.",
                                                 comment: "Describes that only one user likes a post. "
-                                                    + " %1$d is the number of likes. The underscores denote underline and is not displayed.")
+                                                    + " The underscores denote underline and is not displayed.")
         static let plural = NSLocalizedString("_%1$d bloggers_ like this.",
                                               comment: "Plural format string for displaying the number of post likes."
                                                 + " %1$d is the number of likes. The underscores denote underline and is not displayed.")


### PR DESCRIPTION
Note: This is _a suggestion_. The rationale is to make the copy more straightforward so to avoid possible back and forth with translators. Take it or leave it 😄 .

I decided to open against `trunk` even though this addresses a localization issue from 19.7 to avoid additional localization work there. I'm hopeful that we can collaborate with the `.org` polyglots to address the issue (see below) in GlotPress for 19.7, then use this update (if the PR is approved) in 19.8.

---

This essentially reverts the change made in 8881d237ede89288f27d1f219bf177b36e1403fc.

While the version of the code from that commit, namely to have a numeric placeholder two localized strings in `ReaderDetailLikesView` for a number that would always result a "1" at runtime was technically correct
and in line with the String File Format references (see links below), in practice some translators replaced it with a spelled out version.

Links:

- https://github.com/wordpress-mobile/WordPress-iOS/pull/16965#discussion_r682979305
-https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/StringsdictFileFormat/StringsdictFileFormat.html

For example, "%1$d Like" got [translated to "O apreciere" in Romanian](https://translate.wordpress.org/projects/apps/ios/dev/ro/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=11994998&sort%5Bby%5D=translation_date_added&sort%5Bhow%5D=asc
). 

As [suggested](https://github.com/wordpress-mobile/WordPress-iOS/pull/16965#discussion_r683345920) by @AliSoftware, we could "spell out" the numeral 1 to bypass confusion during translation.

As a matter of fact, that's what the Romanian translator did.

Unfortunately, that's not okay in the codebase because the runtime requires the placeholder to be there. (I looked for crashes due to this in Sentry but couldn't find any. That's either due to insufficient Sentry searching skills on my end, or the possibility that there are relatively few users with the app in the `ro` locale that the code path never run.)

---

To test:

- Open a post where only you and one other person liked the post, and verify that the likes summary is displayed correctly.
- Open a post where only one person liked the post, and verify that the likes summary text is displayed correctly.

**On `trunk`**

<table>
<tr>
	<td>
     <img alt="IMG_1753" src="https://user-images.githubusercontent.com/1218433/164597559-bd2658ff-4cd8-41ed-aa3e-dd767bcbaa74.PNG" />
	</td>
	<td>
<img alt="IMG_1752" src="https://user-images.githubusercontent.com/1218433/164597526-40036308-a5fb-4b68-81b8-9ba8c32ce005.PNG" />
	</td>
</tr>
</table>

**This branch**

<table>
<tr>
	<td>
<img width="452" alt="Screen Shot 2022-04-22 at 2 03 48 pm" src="https://user-images.githubusercontent.com/1218433/164597175-7d8a978a-2561-4ef1-9c92-3483c5723fe2.png">
	</td>
	<td>
<img width="452" alt="Screen Shot 2022-04-22 at 2 06 42 pm" src="https://user-images.githubusercontent.com/1218433/164597224-a07709b2-0f6a-4de3-9b85-660979a1d1f8.png"></td>
</tr>
</table>

## Regression Notes
1. Potential unintended areas of impact — None
2. What I did to test those areas of impact (or what existing automated tests I relied on) – See above
3. What automated tests I added (or what prevented me from doing so) – N.A.

PR submission checklist:

- [x] I have completed the Regression Notes. – N.A.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
