### PR TITLE
Blogging Prompts Feature Introduction: show post creation

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -88,7 +88,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     private lazy var answerCount: Int = {
         if forExampleDisplay {
-            return Constants.maxAvatarCount
+            return Constants.exampleAnswerCount
         }
         // TODO: For testing purposes. Remove once we actually have real avatar URLs.
         return 3
@@ -366,6 +366,7 @@ private extension DashboardPromptsCardCell {
         static let answeredButtonsSpacing: CGFloat = 16
         static let answerInfoViewSpacing: CGFloat = 6
         static let maxAvatarCount = 3
+        static let exampleAnswerCount = 19
         static let cardIconSize = CGSize(width: 18, height: 18)
         static let cardFrameConstraintPriority = UILayoutPriority(999)
     }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -66,8 +66,22 @@ private extension BloggingPromptsIntroductionPresenter {
     }
 
     func showPostCreation() {
-        // TODO: show post creation
-        navigationController.dismiss(animated: true, completion: nil)
+        guard let blog = accountSites?.first,
+              let presentingViewController = presentingViewController else {
+            navigationController.dismiss(animated: true)
+            return
+        }
+
+        // TODO: pre-populate post content with prompt content.
+        // Do something similar to `ReaderReblogPresenter:prepareForReblog`?
+        let editor = EditPostViewController(blog: blog)
+        editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = .bloggingPromptsFeatureIntroduction
+
+        navigationController.dismiss(animated: true, completion: { [weak self] in
+            presentingViewController.present(editor, animated: false)
+            self?.trackPostEditorShown(blog)
+        })
     }
 
     func showRemindersScheduling() {
@@ -82,6 +96,12 @@ private extension BloggingPromptsIntroductionPresenter {
                                           for: blog,
                                           source: .bloggingPromptsFeatureIntroduction)
         })
+    }
+
+    func trackPostEditorShown(_ blog: Blog) {
+        WPAppAnalytics.track(.editorCreatedPost,
+                             withProperties: [WPAppAnalyticsKeyTapSource: "blogging_prompts_feature_introduction", WPAppAnalyticsKeyPostType: "post"],
+                             with: blog)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -5,7 +5,7 @@ import UIKit
 /// and directs the flow according to which action button is tapped.
 /// - Try it: the answer prompt flow.
 /// - Remind me: the blogging reminders flow.
-/// - If the account has multiple sites, a site picker is displayed before either of the above.
+/// - If the account has multiple sites, a site selector is displayed before either of the above.
 
 class BloggingPromptsIntroductionPresenter: NSObject {
 
@@ -62,7 +62,7 @@ private extension BloggingPromptsIntroductionPresenter {
 
     func showSiteSelector() {
         // TODO: show site selector
-        navigationController.dismiss(animated: true, completion: nil)
+        navigationController.dismiss(animated: true)
     }
 
     func showPostCreation() {
@@ -87,7 +87,7 @@ private extension BloggingPromptsIntroductionPresenter {
     func showRemindersScheduling() {
         guard let blog = accountSites?.first,
         let presentingViewController = presentingViewController else {
-            navigationController.dismiss(animated: true, completion: nil)
+            navigationController.dismiss(animated: true)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -154,4 +154,5 @@ enum PostEditorEntryPoint: String {
     case unknown
     case postsList
     case dashboard
+    case bloggingPromptsFeatureIntroduction
 }


### PR DESCRIPTION
Ref: #18176

The default post creation view is now displayed when selecting `Try it now` on an account with one site. Support for multiple sites coming soon. 

Random bonus: the answer count on the example card is now 19 to match the design.

To test:
- Enable the `bloggingPrompts` feature.
- Log into the app with an account that has one site.
- On the Feature Introduction, tap `Try it now`.
  - Note: you may need to minimize/maximize the app after immediately logging in to get the FI to show.
- Verify:
  - The Feature Introduction is dismissed.
  - The new post view is shown.
- Log into the app with an account that has multiple sites.
  - On the FI, verify tapping both buttons simply dismisses the view (for now).

| FI | New Post |
|--------|-------|
| ![fi](https://user-images.githubusercontent.com/1816888/164798631-31a9dc48-d6da-410e-aeb1-5f23b57683a3.png) | ![new_post](https://user-images.githubusercontent.com/1816888/164798630-1dd95240-dec4-4f11-a4f4-56ccc72e6ff8.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
