### PR TITLE
Blogging Prompts Feature Introduction: show site selector

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -22,9 +22,6 @@ class BloggingPromptsIntroductionPresenter: NSObject {
 
     private var siteSelectorNavigationController: UINavigationController?
     private var selectedBlog: Blog?
-    private lazy var blogService: BlogService = {
-        return BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-    }()
 
     private lazy var accountSites: [Blog]? = {
         return AccountService(managedObjectContext: ContextManager.shared.mainContext).defaultWordPressComAccount()?.visibleBlogs

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -86,7 +86,7 @@ private extension BloggingPromptsIntroductionPresenter {
             completion()
         }
 
-        let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: blogService.lastUsedOrFirstBlog()?.dotComID,
+        let selectorViewController = BlogSelectorViewController(selectedBlogDotComID: nil,
                                                                 successHandler: successHandler,
                                                                 dismissHandler: dismissHandler)
 


### PR DESCRIPTION
Ref: #18176
Depends on: #18428

When either action button is selected, if the account has multiple sites, the site selector is now shown before the selected flow.

To test:
- Enable the `bloggingPrompts` feature.
- Log into the app with an account that has multiple sites.
- On the Feature Introduction, tap `Try it now` or `Remind me`.
- Verify:
  - The site selector is displayed.
  - Selecting a site:
    - Dismisses the Feature Introduction.
    - Shows the selected flow with the selected blog. How do know you may ask?
      - Post creation shows the site name in the view title.
      - After setting up blogging reminders, go to the site settings for the selected site and verify.
  - Cancelling the site selector dismisses the view, returning to the Feature Introduction.
- Log into the app with an account that has one site.
  - On the Feature Introduction, verify tapping both buttons shows the selected flow directly.

---
![site_selector](https://user-images.githubusercontent.com/1816888/164863702-81237898-fb35-48e3-8473-0907c74f1ead.png)

---
## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
