### PR TITLE
Jetpack Scan: add VaultPress message and option to open the dashboard

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -8,6 +8,7 @@ protocol JetpackScanView {
     func showGenericError()
     func showScanStartError()
     func showMultisiteNotSupportedError()
+    func vaultPressActiveOnSite()
 
     func toggleHistoryButton(_ isEnabled: Bool)
 
@@ -257,6 +258,8 @@ class JetpackScanCoordinator {
         switch (scanObj.state, scanObj.reason) {
         case (.unavailable, JetpackScan.Reason.multiSiteNotSupported):
             view.showMultisiteNotSupportedError()
+        case (.unavailable, JetpackScan.Reason.vaultPressActiveOnSite):
+            view.vaultPressActiveOnSite()
         default:
             view.render()
         }
@@ -393,6 +396,7 @@ extension JetpackScan {
 extension JetpackScan {
     struct Reason {
         static let multiSiteNotSupported = "multisite_not_supported"
+        static let vaultPressActiveOnSite = "vp_active_on_site"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -109,6 +109,23 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         refreshControl.endRefreshing()
     }
 
+    func vaultPressActiveOnSite() {
+        let model = NoResultsViewController.Model(title: NoResultsText.vaultPressError.title,
+                                                  subtitle: NoResultsText.vaultPressError.subtitle,
+                                                  buttonText: NoResultsText.vaultPressError.buttonLabel,
+                                                  imageName: NoResultsText.multisiteError.imageName)
+        updateNoResults(model)
+
+        noResultsViewController?.actionButtonHandler = { [weak self] in
+            let dashboardURL = URL(string: "https://dashboard.vaultpress.com/")!
+            let webViewController = WebViewControllerFactory.controller(url: dashboardURL, source: "jetpack_backup")
+            let webViewNavigationController = UINavigationController(rootViewController: webViewController)
+            self?.present(webViewNavigationController, animated: true)
+        }
+
+        refreshControl.endRefreshing()
+    }
+
     func presentAlert(_ alert: UIAlertController) {
         present(alert, animated: true, completion: nil)
     }
@@ -352,6 +369,13 @@ extension JetpackScanViewController: NoResultsViewControllerDelegate {
         struct multisiteError {
             static let title = NSLocalizedString("WordPress multisites are not supported", comment: "Title for label when the user's site is a multisite.")
             static let subtitle = NSLocalizedString("We're sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time.", comment: "Description for label when the user's site is a multisite.")
+            static let imageName = "jetpack-scan-state-error"
+        }
+
+        struct vaultPressError {
+            static let title = NSLocalizedString("Your site has VaultPress", comment: "Title for label when the user has VaultPress enabled.")
+            static let subtitle = NSLocalizedString("Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.", comment: "Description for label when the user has a site with VaultPress.")
+            static let buttonLabel = NSLocalizedString("Visit Dashboard", comment: "Text of a button that links to the VaultPress dashboard.")
             static let imageName = "jetpack-scan-state-error"
         }
 


### PR DESCRIPTION
Fixes #17146

This PR shows an specific error in case an user has VaultPress and try to access Scan:

| Light Mode | Dark Mode |
| ----------- | ----------- |
| ![Simulator Screen Shot - iPhone 13 - 2022-04-25 at 14 55 41](https://user-images.githubusercontent.com/7040243/165146528-985c14eb-10dd-45f7-9dfc-bd9d0ddb7610.png) | ![Simulator Screen Shot - iPhone 13 - 2022-04-25 at 14 55 49](https://user-images.githubusercontent.com/7040243/165146543-d41fd567-3e18-49c4-ab86-f1dbd8d6de6b.png) |

### To test

1. Open a site that has Backup but with VaultPress enabled
2. Open Scan
3. Make sure you see the screen above
4. Tap "View Dashboard"
5. `https://dashboard.vaultpress.com/` should open

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
