### PR TITLE
Feature Introduction: fix colors

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -30,10 +30,7 @@ private extension BloggingPromptsFeatureDescriptionView {
         promptCard.configureForExampleDisplay()
         promptCard.translatesAutoresizingMaskIntoConstraints = false
 
-        promptCard.layer.borderWidth = Style.borderWidth
         promptCard.layer.cornerRadius = Style.cardCornerRadius
-        promptCard.layer.borderColor = Style.cardBorderColor
-
         promptCard.layer.shadowOffset = Style.cardShadowOffset
         promptCard.layer.shadowOpacity = Style.cardShadowOpacity
         promptCard.layer.shadowRadius = Style.cardShadowRadius
@@ -49,7 +46,7 @@ private extension BloggingPromptsFeatureDescriptionView {
     }
 
     func configureNote() {
-        noteTextView.layer.borderWidth = Style.borderWidth
+        noteTextView.layer.borderWidth = Style.noteBorderWidth
         noteTextView.layer.cornerRadius = Style.noteCornerRadius
         noteTextView.layer.borderColor = Style.noteBorderColor
         noteTextView.textContainerInset = Style.noteInsets
@@ -84,12 +81,11 @@ private extension BloggingPromptsFeatureDescriptionView {
         static let textColor: UIColor = .textSubtle
         static let noteInsets = UIEdgeInsets(top: 12, left: 12, bottom: 12, right: 12)
         static let noteCornerRadius: CGFloat = 6
+        static let noteBorderWidth: CGFloat = 1
+        static let noteBorderColor = UIColor.textQuaternary.cgColor
         static let cardCornerRadius: CGFloat = 10
         static let cardShadowRadius: CGFloat = 14
         static let cardShadowOpacity: Float = 0.1
         static let cardShadowOffset = CGSize(width: 0, height: 10.0)
-        static let cardBorderColor = UIColor(red: 0.882, green: 0.886, blue: 0.886, alpha: 1).cgColor
-        static let borderWidth: CGFloat = 1
-        static let noteBorderColor = UIColor.textQuaternary.cgColor
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -85,6 +85,7 @@ private extension FeatureIntroductionViewController {
     func configureView() {
         navigationItem.rightBarButtonItem = CollapsableHeaderViewController.closeButton(target: self, action: #selector(closeButtonTapped))
         scrollView.addSubview(contentView)
+        hideHeaderVisualEffects()
 
         NSLayoutConstraint.activate([
             contentView.topAnchor.constraint(equalTo: scrollView.topAnchor),

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -515,6 +515,13 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         selectedStateButtonsContainer.insertArrangedSubview(primaryActionButton, at: 0)
     }
 
+    /// A public interface to hide the header blur.
+    func hideHeaderVisualEffects() {
+        visualEffects.forEach { (visualEffect) in
+            visualEffect.isHidden = true
+        }
+    }
+    
     /// In scenarios where the content offset before content changes doesn't align with the available space after the content changes then the offset can be lost. In
     /// order to preserve the header's collpased state we cache the offset and attempt to reapply it if needed.
     private var stashedOffset: CGPoint? = nil

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -521,7 +521,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             visualEffect.isHidden = true
         }
     }
-    
+
     /// In scenarios where the content offset before content changes doesn't align with the available space after the content changes then the offset can be lost. In
     /// order to preserve the header's collpased state we cache the offset and attempt to reapply it if needed.
     private var stashedOffset: CGPoint? = nil


### PR DESCRIPTION
Ref: #18176

This fixes some colors on the feature introduction view:
- Removed the border around the prompt card to match the latest design.
- Removed the visual effects view covering the header. This was causing the header to be slightly grayer than the rest of the view.

(cc @iamthomasbishop )

To test:
- Enable `bloggingPrompts` feature flag.
- When the app launches, the Feature Introduction appears.
- Verify:
  - There is no border around the prompt card, just the shadow.
  - The header background color is the same as the feature introduction content background.

| Before | After |
|--------|-------|
| ![light_before](https://user-images.githubusercontent.com/1816888/165179420-32879107-d807-45f5-ad1a-738d1e71104b.png) | ![light_after](https://user-images.githubusercontent.com/1816888/165177881-b83bac80-f331-4a78-bef5-7f7ecd7d7222.png) |
| ![dark_before](https://user-images.githubusercontent.com/1816888/165179453-87c6ca38-e02d-445d-b2ac-ca0a00a50d85.png) | ![dark_after](https://user-images.githubusercontent.com/1816888/165177876-39f62649-6777-49eb-add5-0a4d423a1df8.png) |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
