### PR TITLE
Quick Start for Existing Users: Update Reader task

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [**] Self hosted sites are not restricted by video length during media uploads [https://github.com/wordpress-mobile/WordPress-iOS/pull/18414]
 * [*] [internal] My Site Dashboard: Made some changes to the code architecture of the dashboard. The majority of the changes are related to the posts cards. It should have no visible changes but could cause regressions. Please test it by creating/trashing drafts and scheduled posts and testing that they appear correctly on the dashboard. [#18405]
 * [*] Quick Start: Updated the Stats tour. The tour can now be accessed from either the dashboard or the menu tab. [#18413]
+* [*] Quick Start: Updated the Reader tour. The tour now highlights the Discover tab and guides users to follow topics via the Settings screen. [#18450]
 * [*] [internal] Quick Start: Refactored some code related to the tasks displayed in the Quick Start Card and the Quick Start modal. It should have no visible changes but could cause regressions. [#18395]
 
 19.7

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementSharing = 8,
     QuickStartTourElementConnections = 9,
     QuickStartTourElementReaderTab = 10,
-    QuickStartTourElementReaderSearch = 12,
+    QuickStartTourElementReaderDiscoverSettings = 12,
     QuickStartTourElementTourCompleted = 13,
     QuickStartTourElementCongratulations = 14,
     QuickStartTourElementSiteIcon = 15,

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -253,7 +253,7 @@ open class QuickStartTourGuide: NSObject {
         }
         if element != currentElement {
             let blogDetailEvents: [QuickStartTourElement] = [.blogDetailNavigation, .checklist, .themes, .viewSite, .sharing, .siteMenu]
-            let readerElements: [QuickStartTourElement] = [.readerTab, .readerSearch]
+            let readerElements: [QuickStartTourElement] = [.readerTab, .readerDiscoverSettings]
 
             if blogDetailEvents.contains(element) {
                 endCurrentTour()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -191,22 +191,22 @@ struct QuickStartPublishTour: QuickStartTour {
 struct QuickStartFollowTour: QuickStartTour {
     let key = "quick-start-follow-tour"
     let analyticsKey = "follow_site"
-    let title = NSLocalizedString("Follow other sites", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Follow other sites", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Find sites that speak to you, and follow them to get updates when they publish.", comment: "Description of a Quick Start Tour")
+    let title = NSLocalizedString("Connect with other sites", comment: "Title of a Quick Start Tour")
+    let titleMarkedCompleted = NSLocalizedString("Completed: Connect with other sites", comment: "The Quick Start Tour title after the user finished the step.")
+    let description = NSLocalizedString("Discover and follow sites that inspire you.", comment: "Description of a Quick Start Tour")
     let icon = UIImage.gridicon(.readerFollow)
     let suggestionNoText = Strings.notNow
     let suggestionYesText = Strings.yesShowMe
     let possibleEntryPoints: Set<QuickStartTourEntryPoint> = [.blogDetails, .blogDashboard]
 
     var waypoints: [WayPoint] = {
-        let step1DescriptionBase = NSLocalizedString("Select %@ to continue", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step1DescriptionBase = NSLocalizedString("Select %@ to find other sites.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2DescriptionBase = NSLocalizedString("Select %@ to look for sites with similar interests", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step2DescriptionTarget = NSLocalizedString("Search", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.search)))
+        let step2DescriptionBase = NSLocalizedString("Select %@ to add topics you like.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DescriptionTarget = NSLocalizedString("Settings", comment: "The menu item to select during a guided tour.")
+        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.cog)))
 
         return [step1, step2]
     }()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -206,7 +206,7 @@ struct QuickStartFollowTour: QuickStartTour {
 
         let step2DescriptionBase = NSLocalizedString("Select %@ to add topics you like.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
         let step2DescriptionTarget = NSLocalizedString("Settings", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .readerSearch, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.cog)))
+        let step2: WayPoint = (element: .readerDiscoverSettings, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.cog)))
 
         return [step1, step2]
     }()

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -204,9 +204,19 @@ struct QuickStartFollowTour: QuickStartTour {
         let step1DescriptionTarget = NSLocalizedString("Reader", comment: "The menu item to select during a guided tour.")
         let step1: WayPoint = (element: .readerTab, description: step1DescriptionBase.highlighting(phrase: step1DescriptionTarget, icon: .gridicon(.reader)))
 
-        let step2DescriptionBase = NSLocalizedString("Select %@ to add topics you like.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let step2DescriptionTarget = NSLocalizedString("Settings", comment: "The menu item to select during a guided tour.")
-        let step2: WayPoint = (element: .readerDiscoverSettings, description: step2DescriptionBase.highlighting(phrase: step2DescriptionTarget, icon: .gridicon(.cog)))
+        let step2DiscoverDescriptionBase = NSLocalizedString("Use %@ to find sites and tags.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2DiscoverDescriptionTarget = NSLocalizedString("Discover", comment: "The menu item to select during a guided tour.")
+        let step2DiscoverDescription = step2DiscoverDescriptionBase.highlighting(phrase: step2DiscoverDescriptionTarget, icon: nil)
+
+        let step2SettingsDescriptionBase = NSLocalizedString("Try selecting %@ to add topics you like.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
+        let step2SettingsDescriptionTarget = NSLocalizedString("Settings", comment: "The menu item to select during a guided tour.")
+        let step2SettingsDescription = step2SettingsDescriptionBase.highlighting(phrase: step2SettingsDescriptionTarget, icon: .gridicon(.cog))
+
+        /// Combined description for step 2
+        let step2Format = NSAttributedString(string: "%@ %@")
+        let step2Description = NSAttributedString(format: step2Format, args: step2DiscoverDescription, step2SettingsDescription)
+
+        let step2: WayPoint = (element: .readerDiscoverSettings, description: step2Description)
 
         return [step1, step2]
     }()
@@ -428,5 +438,17 @@ private extension String {
         static var highlightColor: UIColor {
             .invertedLabel
         }
+    }
+}
+
+private extension NSAttributedString {
+    convenience init(format: NSAttributedString, args: NSAttributedString...) {
+        let mutableNSAttributedString = NSMutableAttributedString(attributedString: format)
+
+        args.forEach { (attributedString) in
+            let range = NSString(string: mutableNSAttributedString.string).range(of: "%@")
+            mutableNSAttributedString.replaceCharacters(in: range, with: attributedString)
+        }
+        self.init(attributedString: mutableNSAttributedString)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -53,7 +53,7 @@ class ReaderManageScenePresenter: ScenePresenter {
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
 
-        QuickStartTourGuide.shared.visited(.readerSearch)
+        QuickStartTourGuide.shared.visited(.readerDiscoverSettings)
         WPAnalytics.track(.readerManageViewDisplayed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderManageScenePresenter.swift
@@ -53,6 +53,7 @@ class ReaderManageScenePresenter: ScenePresenter {
         presentedViewController = navigationController
         viewController.present(navigationController, animated: true, completion: nil)
 
+        QuickStartTourGuide.shared.visited(.readerSearch)
         WPAnalytics.track(.readerManageViewDisplayed)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -64,7 +64,7 @@ class ReaderTabViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        if QuickStartTourGuide.shared.isCurrentElement(.readerSearch) {
+        if QuickStartTourGuide.shared.isCurrentElement(.readerDiscoverSettings) {
 
             if viewModel.selectedIndex != ReaderTabConstants.discoverIndex {
                 viewModel.showTab(at: ReaderTabConstants.discoverIndex)

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -12,7 +12,6 @@ class ReaderTabViewController: UIViewController {
     }()
 
     private let settingsButton: SpotlightableButton = SpotlightableButton(type: .custom)
-    private let searchButton: SpotlightableButton = SpotlightableButton(type: .custom)
 
     init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> ReaderTabView) {
         self.viewModel = viewModel
@@ -81,22 +80,21 @@ class ReaderTabViewController: UIViewController {
     }
 
     func setupNavigationButtons() {
+        // Search Button
+        let searchButton = UIBarButtonItem(image: UIImage.gridicon(.search),
+                                           style: .plain,
+                                           target: self,
+                                           action: #selector(didTapSearchButton))
+        searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
+
         // Settings Button
         settingsButton.spotlightOffset = ReaderTabConstants.spotlightOffset
         settingsButton.setImage(.gridicon(.cog), for: .normal)
         settingsButton.addTarget(self, action: #selector(didTapSettingsButton), for: .touchUpInside)
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
-
-        // Search Button
-        searchButton.spotlightOffset = ReaderTabConstants.spotlightOffset
-        searchButton.setImage(.gridicon(.search), for: .normal)
-        searchButton.addTarget(self, action: #selector(didTapSearchButton), for: .touchUpInside)
-        searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
-
         let settingsButton = UIBarButtonItem(customView: settingsButton)
-        let searchBarButton = UIBarButtonItem(customView: searchButton)
 
-        navigationItem.rightBarButtonItems = [searchBarButton, settingsButton]
+        navigationItem.rightBarButtonItems = [searchButton, settingsButton]
     }
 
     override func loadView() {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -62,7 +62,16 @@ class ReaderTabViewController: UIViewController {
     }
 
     override func viewWillAppear(_ animated: Bool) {
-        searchButton.shouldShowSpotlight = QuickStartTourGuide.shared.isCurrentElement(.readerSearch)
+        super.viewWillAppear(animated)
+
+        if QuickStartTourGuide.shared.isCurrentElement(.readerSearch) {
+
+            if viewModel.selectedIndex != ReaderTabConstants.discoverIndex {
+                viewModel.showTab(at: ReaderTabConstants.discoverIndex)
+            }
+
+            settingsButton.shouldShowSpotlight = true
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
@@ -116,6 +125,7 @@ class ReaderTabViewController: UIViewController {
 // MARK: - Navigation Buttons
 extension ReaderTabViewController {
     @objc private func didTapSettingsButton() {
+        settingsButton.shouldShowSpotlight = false
         viewModel.presentManage(from: self)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -11,6 +11,7 @@ class ReaderTabViewController: UIViewController {
         return makeReaderTabView(viewModel)
     }()
 
+    private let settingsButton: SpotlightableButton = SpotlightableButton(type: .custom)
     private let searchButton: SpotlightableButton = SpotlightableButton(type: .custom)
 
     init(viewModel: ReaderTabViewModel, readerTabViewFactory: @escaping (ReaderTabViewModel) -> ReaderTabView) {
@@ -72,18 +73,18 @@ class ReaderTabViewController: UIViewController {
 
     func setupNavigationButtons() {
         // Settings Button
-        let settingsButton = UIBarButtonItem(image: UIImage.gridicon(.cog),
-                                             style: .plain,
-                                             target: self,
-                                             action: #selector(didTapSettingsButton))
+        settingsButton.spotlightOffset = ReaderTabConstants.spotlightOffset
+        settingsButton.setImage(.gridicon(.cog), for: .normal)
+        settingsButton.addTarget(self, action: #selector(didTapSettingsButton), for: .touchUpInside)
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
 
         // Search Button
-        searchButton.spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
+        searchButton.spotlightOffset = ReaderTabConstants.spotlightOffset
         searchButton.setImage(.gridicon(.search), for: .normal)
         searchButton.addTarget(self, action: #selector(didTapSearchButton), for: .touchUpInside)
         searchButton.accessibilityIdentifier = ReaderTabConstants.searchButtonAccessibilityIdentifier
 
+        let settingsButton = UIBarButtonItem(customView: settingsButton)
         let searchBarButton = UIBarButtonItem(customView: searchButton)
 
         navigationItem.rightBarButtonItems = [searchBarButton, settingsButton]
@@ -172,5 +173,6 @@ extension ReaderTabViewController {
         static let restorationIdentifier = "WPReaderTabControllerRestorationID"
         static let encodedIndexKey = "WPReaderTabControllerIndexRestorationKey"
         static let discoverIndex = 1
+        static let spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/WPTabBarController+ReaderTabNavigation.swift
@@ -64,7 +64,6 @@ extension WPTabBarController {
     func navigateToReaderSearch() {
         let searchController = ReaderSearchViewController.controller()
         navigateToReader(searchController)
-        QuickStartTourGuide.shared.visited(.readerSearch)
     }
 
     func navigateToReaderSite(_ topic: ReaderSiteTopic) {


### PR DESCRIPTION
Part of #18387

Slack ref: p1650979195578659/1650977534.552379-slack-C027K4MNPGQ

## Description
- Updated the Reader tour
    - Modified the tour to automatically switch to the Discover tab 
    - Modified the second step to point to the settings instead of search 
    
<img src="https://user-images.githubusercontent.com/6711616/165329976-6eacada1-67e3-47cb-b96c-623b80fd8f0a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/165329986-ac26b776-3bf7-4965-a131-ed76caf130fe.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/165329998-fd2ef155-72a5-42b6-bb36-1b7e633bb8ac.png" width=200>
-- | -- | --


## How to test

### Discover tab already selected

1. Go to Reader
2. Select the Discover tab
3. Go back to My Site
4. Enable Quick Start for Existing Users via the debug menu
5. Start the **Connect with other sites** tour
6. Switch to the Reader tab when prompted
7. ✅ Verify: Reader stays on the Discover tab
8. ✅ Verify: A waypoint is displayed on top of the Settings button
9. Tap on the Settings button
10. Dismiss the Settings screen
11. ✅ Verify: No waypoint is displayed on top of the Settings button

https://user-images.githubusercontent.com/6711616/165332623-77e65216-b5ef-4beb-9a91-fd1f711a9c01.mp4


### Discover tab not selected

1. Go to Reader
2. Select the Following tab
3. Go back to My Site
4. Enable Quick Start for Existing Users via the debug menu
5. Start the **Connect with other sites** tour
6. Switch to the Reader tab when prompted
7. ✅ Verify: Reader automatically switches to the Discover tab
8. ✅ Verify: A waypoint is displayed on top of the Settings button
9. Tap on the Settings button
10. Dismiss the Settings screen
11. ✅ Verify: No waypoint is displayed on top of the Settings button

https://user-images.githubusercontent.com/6711616/165332658-65efe403-d44c-4e35-bd29-ad912abdf0cd.mp4


## Regression Notes
1. Potential unintended areas of impact
n/a

12. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

13. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.