### PR TITLE
Blogging Prompts: Move shared blogging prompt styles into an extension

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -67,7 +67,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     private lazy var promptLabel: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = Style.promptContentFont
+        label.font = WPStyleGuide.BloggingPrompts.promptContentFont
         label.textAlignment = .center
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
@@ -129,8 +129,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.text = answerInfoText
-        label.font = Style.answerInfoLabelFont
-        label.textColor = Style.answerInfoLabelColor
+        label.font = WPStyleGuide.BloggingPrompts.answerInfoLabelFont
+        label.textColor = WPStyleGuide.BloggingPrompts.answerInfoLabelColor
         label.textAlignment = (effectiveUserInterfaceLayoutDirection == .leftToRight ? .left : .right)
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
@@ -166,8 +166,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Strings.answerButtonTitle, for: .normal)
-        button.setTitleColor(Style.buttonTitleColor, for: .normal)
-        button.titleLabel?.font = Style.buttonTitleFont
+        button.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+        button.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
 
@@ -178,8 +178,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     private lazy var answeredLabel: UILabel = {
         let label = UILabel()
-        label.font = Style.buttonTitleFont
-        label.textColor = Style.answeredLabelColor
+        label.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
+        label.textColor = WPStyleGuide.BloggingPrompts.answeredLabelColor
         label.text = Strings.answeredLabelTitle
 
         // The 'answered' label needs to be close to the Share button.
@@ -195,8 +195,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setTitle(Strings.shareButtonTitle, for: .normal)
-        button.setTitleColor(Style.buttonTitleColor, for: .normal)
-        button.titleLabel?.font = Style.buttonTitleFont
+        button.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+        button.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
         button.contentHorizontalAlignment = .leading
@@ -353,12 +353,6 @@ private extension DashboardPromptsCardCell {
     struct Style {
         static let frameIconImage = UIImage(named: "icon-lightbulb-outline")?.resizedImage(Constants.cardIconSize, interpolationQuality: .default)
         static let avatarPlaceholderImage = UIImage(color: .quaternarySystemFill)
-        static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
-        static let answerInfoLabelFont = WPStyleGuide.fontForTextStyle(.caption1)
-        static let answerInfoLabelColor = UIColor.primary
-        static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
-        static let buttonTitleColor = UIColor.primary
-        static let answeredLabelColor = UIColor.muriel(name: .green, .shade50)
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+BloggingPrompts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+BloggingPrompts.swift
@@ -1,0 +1,12 @@
+/// This class groups styles used by blogging prompts
+///
+extension WPStyleGuide {
+    public struct BloggingPrompts {
+        static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
+        static let answerInfoLabelFont = WPStyleGuide.fontForTextStyle(.caption1)
+        static let answerInfoLabelColor = UIColor.primary
+        static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
+        static let buttonTitleColor = UIColor.primary
+        static let answeredLabelColor = UIColor.muriel(name: .green, .shade50)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1393,6 +1393,8 @@
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
+		836498C828172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
+		836498C928172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
 		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
@@ -6141,6 +6143,7 @@
 		8355D67D11D13EAD00A61362 /* MobileCoreServices.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
 		8355D7D811D260AA00A61362 /* CoreData.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		835E2402126E66E50085940B /* AssetsLibrary.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
+		836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		8370D10811FA499A009D650F /* WPTableViewActivityCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableViewActivityCell.h; sourceTree = "<group>"; };
 		8370D10911FA499A009D650F /* WPTableViewActivityCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableViewActivityCell.m; sourceTree = "<group>"; };
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
@@ -13464,6 +13467,7 @@
 			isa = PBXGroup;
 			children = (
 				BE1071FB1BC75E7400906AFF /* WPStyleGuide+Blog.swift */,
+				836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */,
 			);
 			name = Style;
 			sourceTree = "<group>";
@@ -17839,6 +17843,7 @@
 				D853723C21952DC90076F461 /* SiteSegmentsStep.swift in Sources */,
 				32E1BFDA24A66F2A007A08F0 /* ReaderInterestsCollectionViewFlowLayout.swift in Sources */,
 				FEC3B81726C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */,
+				836498C828172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */,
 				FF70A3221FD5840500BC270D /* PHAsset+Metadata.swift in Sources */,
 				5DA5BF4418E32DCF005F11F9 /* Theme.m in Sources */,
 				D8A3A5B1206A49A100992576 /* StockPhotosMediaGroup.swift in Sources */,
@@ -20390,6 +20395,7 @@
 				FABB22C52602FC2C00C8785C /* ActivityStore.swift in Sources */,
 				FABB22C62602FC2C00C8785C /* NSAttributedString+WPRichText.swift in Sources */,
 				FABB22C72602FC2C00C8785C /* StatsTotalRow.swift in Sources */,
+				836498C928172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */,
 				C79C308226EA99D500E88514 /* ReferrerDetailsSpamActionCell.swift in Sources */,
 				80EF672327F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
 				FABB22C82602FC2C00C8785C /* SiteCreationAnalyticsHelper.swift in Sources */,


### PR DESCRIPTION
Ref #18402

## Description

Moves some styling out of the dashboard prompt cell into a `WPStyleGuide` extension. These will be used by another view with similar UI.

## Testing

To test:
- Enable blogging prompts feature flag
- Navigate to my site tab
- Verify blogging prompts card displays the same as previously

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
