### PR TITLE
[Site Design Revamp] Remove preview mode selector from nav bar

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -22,7 +22,7 @@ workspace 'WordPress.xcworkspace'
 def wordpress_shared
     #pod 'WordPressShared', '~> 1.17.1'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
-    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/remove-design-thumbnail-button-tapped'
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'feature/site-design-revamp'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
     #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end

--- a/Podfile
+++ b/Podfile
@@ -20,9 +20,9 @@ workspace 'WordPress.xcworkspace'
 ## ===================================
 ##
 def wordpress_shared
-    pod 'WordPressShared', '~> 1.17.1'
+    #pod 'WordPressShared', '~> 1.17.1'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :tag => ''
-    #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => ''
+    pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :branch => 'task/remove-design-thumbnail-button-tapped'
     #pod 'WordPressShared', :git => 'https://github.com/wordpress-mobile/WordPress-iOS-Shared.git', :commit  => ''
     #pod 'WordPressShared', :path => '../WordPress-iOS-Shared'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -593,7 +593,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.50.0)
   - WordPressMocks (~> 0.0.15)
-  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `task/remove-design-thumbnail-button-tapped`)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `feature/site-design-revamp`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.3)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.74.0/third-party-podspecs/Yoga.podspec.json`)
@@ -753,7 +753,7 @@ EXTERNAL SOURCES:
     :submodules: true
     :tag: v1.74.0
   WordPressShared:
-    :branch: task/remove-design-thumbnail-button-tapped
+    :branch: feature/site-design-revamp
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.74.0/third-party-podspecs/Yoga.podspec.json
@@ -771,7 +771,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.74.0
   WordPressShared:
-    :commit: e3ca2763fd28b7f1d326653b58a2ceb111491a10
+    :commit: cd17c7c81d2ad7005a724b580f99e42a50a06bdb
     :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
@@ -874,6 +874,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 0c76b3628a2a62ca073f6c1e4ce934689c2184c3
+PODFILE CHECKSUM: b8a2c329dc0c5787b885a9311d168d112338a918
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -593,7 +593,7 @@ DEPENDENCIES:
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.50.0)
   - WordPressMocks (~> 0.0.15)
-  - WordPressShared (~> 1.17.1)
+  - WordPressShared (from `https://github.com/wordpress-mobile/WordPress-iOS-Shared.git`, branch `task/remove-design-thumbnail-button-tapped`)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.3)
   - Yoga (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.74.0/third-party-podspecs/Yoga.podspec.json`)
@@ -642,7 +642,6 @@ SPEC REPOS:
     - WordPress-Editor-iOS
     - WordPressKit
     - WordPressMocks
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -753,6 +752,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.74.0
+  WordPressShared:
+    :branch: task/remove-design-thumbnail-button-tapped
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.74.0/third-party-podspecs/Yoga.podspec.json
 
@@ -768,6 +770,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.74.0
+  WordPressShared:
+    :commit: e3ca2763fd28b7f1d326653b58a2ceb111491a10
+    :git: https://github.com/wordpress-mobile/WordPress-iOS-Shared.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -869,6 +874,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 4ec8f8e1fe1324b2079ae08999bcc274e8232655
+PODFILE CHECKSUM: 0c76b3628a2a62ca073f6c1e4ce934689c2184c3
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -702,9 +702,6 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
         case WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewLoaded:
             eventName = @"enhanced_site_creation_site_design_preview_loaded";
             break;
-        case     WPAnalyticsStatEnhancedSiteCreationSiteDesignThumbnailModeButtonTapped:
-            eventName = @"enhanced_site_creation_site_design_thumbnail_mode_button_tapped";
-            break;
         case WPAnalyticsStatEnhancedSiteCreationSiteDesignPreviewModeButtonTapped:
             eventName = @"enhanced_site_creation_site_design_preview_mode_button_tapped";
             break;

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -12,7 +12,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     let accessoryView: UIView?
     let mainTitle: String
     let navigationBarTitle: String?
-    let prompt: String
+    let prompt: String?
     let primaryActionTitle: String
     let secondaryActionTitle: String?
     let defaultActionTitle: String?
@@ -189,7 +189,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
          mainTitle: String,
          navigationBarTitle: String? = nil,
          headerImage: UIImage? = nil,
-         prompt: String,
+         prompt: String? = nil,
          primaryActionTitle: String,
          secondaryActionTitle: String? = nil,
          defaultActionTitle: String? = nil,
@@ -323,6 +323,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         titleView.text = navigationBarTitle ?? mainTitle
         titleView.sizeToFit()
         largeTitleView.text = mainTitle
+        promptView.isHidden = prompt == nil
         promptView.text = prompt
         primaryActionButton.setTitle(primaryActionTitle, for: .normal)
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -54,7 +54,7 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     init(
         analyticsLocation: String,
         mainTitle: String,
-        prompt: String,
+        prompt: String? = nil,
         primaryActionTitle: String,
         secondaryActionTitle: String? = nil,
         defaultActionTitle: String? = nil

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -70,7 +70,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: TextContent.mainTitle,
-            prompt: TextContent.subtitle,
+            prompt: "",
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
@@ -82,6 +82,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        promptView.isHidden = true
         navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()
@@ -162,7 +163,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     private enum TextContent {
         static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
-        static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
         static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
         static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -49,7 +49,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
             tableView.reloadData()
         }
     }
-    var previewDeviceButtonItem: UIBarButtonItem?
 
     var selectedDesign: RemoteSiteDesign? {
         guard let sectionIndex = selectedItem?.section, let position = selectedItem?.item else { return nil }
@@ -79,7 +78,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         fetchSiteDesigns()
         configureCloseButton()
         configureSkipButton()
-        configurePreviewDeviceButton()
         SiteCreationAnalyticsHelper.trackSiteDesignViewed(previewMode: selectedPreviewDevice)
     }
 
@@ -106,12 +104,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         navigationItem.rightBarButtonItem = skip
     }
 
-    private func configurePreviewDeviceButton() {
-        let button = UIBarButtonItem(image: UIImage(named: "icon-devices"), style: .plain, target: self, action: #selector(previewDeviceButtonTapped))
-        previewDeviceButtonItem = button
-        navigationItem.rightBarButtonItems?.append(button)
-    }
-
     private func configureCloseButton() {
         guard navigationController?.viewControllers.first == self else {
             return
@@ -124,21 +116,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         presentedViewController?.dismiss(animated: true)
         SiteCreationAnalyticsHelper.trackSiteDesignSkipped()
         completion(nil)
-    }
-
-    @objc private func previewDeviceButtonTapped() {
-        SiteCreationAnalyticsHelper.trackSiteDesignThumbnailModeButtonTapped(selectedPreviewDevice)
-        let popoverContentController = PreviewDeviceSelectionViewController()
-        popoverContentController.selectedOption = selectedPreviewDevice
-        popoverContentController.onDeviceChange = { [weak self] device in
-            guard let self = self else { return }
-            SiteCreationAnalyticsHelper.trackSiteDesignPreviewModeChanged(device)
-            self.selectedPreviewDevice = device
-        }
-
-        popoverContentController.modalPresentationStyle = .popover
-        popoverContentController.popoverPresentationController?.delegate = self
-        self.present(popoverContentController, animated: true, completion: nil)
     }
 
     override func primaryActionSelected(_ sender: Any) {
@@ -187,32 +164,5 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 extension SiteDesignContentCollectionViewController: NoResultsViewControllerDelegate {
     func actionButtonPressed() {
         fetchSiteDesigns()
-    }
-}
-
-// MARK: UIPopoverPresentationDelegate
-extension SiteDesignContentCollectionViewController {
-    func prepareForPopoverPresentation(_ popoverPresentationController: UIPopoverPresentationController) {
-        guard popoverPresentationController.presentedViewController is PreviewDeviceSelectionViewController else {
-            return
-        }
-
-        popoverPresentationController.permittedArrowDirections = .up
-        popoverPresentationController.barButtonItem = previewDeviceButtonItem
-    }
-
-    func adaptivePresentationStyle(for controller: UIPresentationController, traitCollection: UITraitCollection) -> UIModalPresentationStyle {
-        return .none
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        // Reset our source rect and view for a transition to a new size
-        guard let popoverPresentationController = presentedViewController?.presentationController as? UIPopoverPresentationController else {
-                return
-        }
-
-        prepareForPopoverPresentation(popoverPresentationController)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -36,6 +36,11 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     private var sections: [SiteDesignSection] = []
     internal override var categorySections: [CategorySection] { get { sections }}
 
+    override var selectedPreviewDevice: PreviewDevice {
+        get { .mobile }
+        set { /* no op */ }
+    }
+
     var siteDesigns = RemoteSiteDesigns() {
         didSet {
             if oldValue.categories.count == 0 {
@@ -67,9 +72,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
-
-        // show mobile thumbnails for all devices
-        selectedPreviewDevice = .mobile
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -41,6 +41,8 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         set { /* no op */ }
     }
 
+    lazy var previewViewSelectedPreviewDevice = selectedPreviewDevice
+
     var siteDesigns = RemoteSiteDesigns() {
         didSet {
             if oldValue.categories.count == 0 {
@@ -136,7 +138,15 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     override func secondaryActionSelected(_ sender: Any) {
         guard let design = selectedDesign else { return }
 
-        let previewVC = SiteDesignPreviewViewController(siteDesign: design, selectedPreviewDevice: PreviewDevice.default, createsSite: createsSite, onDismissWithDeviceSelected: nil, completion: completion)
+        let previewVC = SiteDesignPreviewViewController(
+            siteDesign: design,
+            selectedPreviewDevice: previewViewSelectedPreviewDevice,
+            createsSite: createsSite,
+            onDismissWithDeviceSelected: { [weak self] device in
+                self?.previewViewSelectedPreviewDevice = device
+            },
+            completion: completion
+        )
 
         let navController = GutenbergLightNavigationController(rootViewController: previewVC)
         navController.modalPresentationStyle = .pageSheet

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -70,7 +70,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: TextContent.mainTitle,
-            prompt: "",
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
@@ -82,7 +81,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        promptView.isHidden = true
         navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -35,6 +35,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     var selectedIndexPath: IndexPath? = nil
     private var sections: [SiteDesignSection] = []
     internal override var categorySections: [CategorySection] { get { sections }}
+
     var siteDesigns = RemoteSiteDesigns() {
         didSet {
             if oldValue.categories.count == 0 {
@@ -66,6 +67,9 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
+
+        // show mobile thumbnails for all devices
+        selectedPreviewDevice = .mobile
     }
 
     required init?(coder: NSCoder) {
@@ -130,9 +134,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     override func secondaryActionSelected(_ sender: Any) {
         guard let design = selectedDesign else { return }
 
-        let previewVC = SiteDesignPreviewViewController(siteDesign: design, selectedPreviewDevice: selectedPreviewDevice, createsSite: createsSite, onDismissWithDeviceSelected: { [weak self] device in
-            self?.selectedPreviewDevice = device
-        }, completion: completion)
+        let previewVC = SiteDesignPreviewViewController(siteDesign: design, selectedPreviewDevice: PreviewDevice.default, createsSite: createsSite, onDismissWithDeviceSelected: nil, completion: completion)
 
         let navController = GutenbergLightNavigationController(rootViewController: previewVC)
         navController.modalPresentationStyle = .pageSheet

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -41,7 +41,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         set { /* no op */ }
     }
 
-    private lazy var previewViewSelectedPreviewDevice = selectedPreviewDevice
+    private lazy var previewViewSelectedPreviewDevice = PreviewDevice.default
 
     var siteDesigns = RemoteSiteDesigns() {
         didSet {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -161,7 +161,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private enum TextContent {
-        static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
+        static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
         static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
         static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -41,7 +41,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         set { /* no op */ }
     }
 
-    lazy var previewViewSelectedPreviewDevice = selectedPreviewDevice
+    private lazy var previewViewSelectedPreviewDevice = selectedPreviewDevice
 
     var siteDesigns = RemoteSiteDesigns() {
         didSet {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -77,10 +77,6 @@ class SiteCreationAnalyticsHelper {
         WPAnalytics.track(.enhancedSiteCreationSiteDesignViewed, withProperties: commonProperties(previewMode))
     }
 
-    static func trackSiteDesignThumbnailModeButtonTapped(_ previewMode: PreviewDevice) {
-        WPAnalytics.track(.enhancedSiteCreationSiteDesignThumbnailModeButtonTapped, withProperties: commonProperties(previewMode))
-    }
-
     static func trackSiteDesignSkipped() {
         WPAnalytics.track(.enhancedSiteCreationSiteDesignSkipped)
     }

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -88,27 +88,4 @@ class SiteDesignTests: XCTestCase {
         // then
         XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
     }
-
-    /// Tests that the preview device on the Preview view can be changed
-    func testSiteDesignPreviewPreviewDeviceCanBeChanged() throws {
-
-        // given
-        let siteDesignPreviewVC = SiteDesignPreviewViewController(
-            siteDesign: remoteDesign,
-            selectedPreviewDevice: PreviewDeviceSelectionViewController.PreviewDevice.mobile,
-            createsSite: true,
-            onDismissWithDeviceSelected: nil,
-            completion: {design in }
-        )
-        let expectedDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
-
-        // when
-        siteDesignPreviewVC.loadViewIfNeeded()
-        siteDesignPreviewVC.viewDidLoad()
-        XCTAssertEqual(siteDesignPreviewVC.selectedPreviewDevice, PreviewDeviceSelectionViewController.PreviewDevice.mobile)
-        siteDesignPreviewVC.selectedPreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
-
-        // then
-        XCTAssertEqual(siteDesignPreviewVC.selectedPreviewDevice, expectedDevice)
-    }
 }

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -73,4 +73,19 @@ class SiteDesignTests: XCTestCase {
         let currentTitle = siteDesignPreviewVC.primaryActionButton.currentTitle
         XCTAssertEqual(expectedPrimaryTitle, currentTitle)
     }
+
+    /// Tests that the selected preview device cannot be changed from mobile
+    func testSiteDesignPreviewDeviceIsAlwaysMobile() throws {
+
+        // given
+        let siteDesignVC = SiteDesignContentCollectionViewController(createsSite: false) { _ in }
+        let expectedDevice = PreviewDeviceSelectionViewController.PreviewDevice.mobile
+        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
+
+        // when
+        siteDesignVC.selectedPreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
+
+        // then
+        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
+    }
 }

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -74,18 +74,41 @@ class SiteDesignTests: XCTestCase {
         XCTAssertEqual(expectedPrimaryTitle, currentTitle)
     }
 
-    /// Tests that the selected preview device cannot be changed from mobile
+    /// Tests that the preview device on the Design view cannot be changed
     func testSiteDesignPreviewDeviceIsAlwaysMobile() throws {
 
         // given
         let siteDesignVC = SiteDesignContentCollectionViewController(createsSite: false) { _ in }
         let expectedDevice = PreviewDeviceSelectionViewController.PreviewDevice.mobile
-        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
 
         // when
+        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
         siteDesignVC.selectedPreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
 
         // then
         XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
+    }
+
+    /// Tests that the preview device on the Preview view can be changed
+    func testSiteDesignPreviewPreviewDeviceCanBeChanged() throws {
+
+        // given
+        let siteDesignPreviewVC = SiteDesignPreviewViewController(
+            siteDesign: remoteDesign,
+            selectedPreviewDevice: PreviewDeviceSelectionViewController.PreviewDevice.mobile,
+            createsSite: true,
+            onDismissWithDeviceSelected: nil,
+            completion: {design in }
+        )
+        let expectedDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
+
+        // when
+        siteDesignPreviewVC.loadViewIfNeeded()
+        siteDesignPreviewVC.viewDidLoad()
+        XCTAssertEqual(siteDesignPreviewVC.selectedPreviewDevice, PreviewDeviceSelectionViewController.PreviewDevice.mobile)
+        siteDesignPreviewVC.selectedPreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
+
+        // then
+        XCTAssertEqual(siteDesignPreviewVC.selectedPreviewDevice, expectedDevice)
     }
 }


### PR DESCRIPTION
- Item **A** Subtask of #18433
- Related PR: https://github.com/wordpress-mobile/WordPress-iOS-Shared/pull/309

**This PR:**
- Removes the mode selector from the nav bar on the Site Design screen
- Enforces mobile-sized thumbnails for all devices

| Before - iPhone | After - iPhone |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-04-27 at 17 49 49](https://user-images.githubusercontent.com/2092798/165637044-a9a9f33e-766c-4c66-a85d-b6e90ba64afa.png) | ![image](https://user-images.githubusercontent.com/2092798/165621913-96c628f7-2641-421f-be5b-c5f8cf58c03f.png) |

| Before - iPad | After - iPad |
| - | - |
| ![Simulator Screen Shot - iPad (9th generation) - 2022-04-27 at 16 02 07](https://user-images.githubusercontent.com/2092798/165621572-be63f504-1390-497b-9299-d88c71fafa00.png) | ![image](https://user-images.githubusercontent.com/2092798/165621956-892d49c6-230c-4d64-8cca-da05021cf2be.png) |

## To test:

### Mobile thumbnails - Phone
1. Using a phone, start the Site Creation Flow and navigate to the Site Design screen
2. Expect thumbnails to be screenshots of the mobile layout
3. Select a design and tap the "Preview" button
4. Expect preview to be in the mobile layout
5. Tap the device mode picker at the top right and confirm that the mode is set to Mobile
6. Tap Tablet to switch to the tablet mode
7. Expect preview to be in the tablet layout
8. Dismiss the preview
9. Expect thumbnails to be screenshots of the mobile layout (they did not switch to tablet layout)
10. Select a design and tap the "Preview" button
11. Expect preview to be in the tablet layout (the Preview view retained the last layout mode)

### Mobile thumbnails - iPad
1. Using an iPad, start the Site Creation Flow and navigate to the Site Design screen
2. Expect thumbnails to be screenshots of the mobile layout (not tablet)
3. Select a design and tap the "Preview" button
4. Expect preview to be in the tablet layout
5. Tap the device mode picker at the top right and confirm that the mode is set to Tablet
6. Tap Mobile to switch to the mobile mode
7. Expect preview to be in the mobile layout
8. Dismiss the preview
9. Expect thumbnails to be screenshots of the mobile layout (they did not switch to tablet layout)
10. Select a design and tap the "Preview" button
11. Expect preview to be in the mobile layout (the Preview view retained the last layout mode)

### Tracks events - Phone
1. Using a phone, start the Site Creation Flow and navigate to the Site Design screen
12. Expect `enhanced_site_creation_site_design_viewed` to be fired with `preview_mode` set to `mobile`
13. Select a design and tap the "Preview" button
14. Expect `enhanced_site_creation_site_design_preview_viewed` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
15. Expect `enhanced_site_creation_site_design_preview_loading` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
16. Expect `enhanced_site_creation_site_design_preview_loaded` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
17. Tap the device mode picker at the top right and switch to Tablet
18. Expect `enhanced_site_creation_site_design_preview_mode_button_tapped` to be fired with `preview_mode` set to `mobile`
19. Expect `enhanced_site_creation_site_design_preview_mode_changed ` to be fired with `preview_mode` set to `tablet`
20. Expect `enhanced_site_creation_site_design_preview_loading` to be fired with `preview_mode` set to `tablet` and `template` set to the corresponding design
21. Expect `enhanced_site_creation_site_design_preview_loaded` to be fired with `preview_mode` set to `tablet` and `template` set to the corresponding design
22. Tap "Create Site" (the button may say "Choose" depending on Site Name treatment)
23. Expect `enhanced_site_creation_site_design_selected` to be fired with `template` set to the corresponding design

### Tracks events - iPad
1. Using an iPad, start the Site Creation Flow and navigate to the Site Design screen
2. Expect `enhanced_site_creation_site_design_viewed` to be fired with `preview_mode` set to `mobile`
3. Select a design and tap the "Preview" button
4. Expect `enhanced_site_creation_site_design_preview_viewed` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
5. Expect `enhanced_site_creation_site_design_preview_loading` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
6. Expect `enhanced_site_creation_site_design_preview_loaded` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
7. Tap the device mode picker at the top right and switch to Mobile
8. Expect `enhanced_site_creation_site_design_preview_mode_button_tapped` to be fired with `preview_mode` set to `tablet`
9. Expect `enhanced_site_creation_site_design_preview_mode_changed ` to be fired with `preview_mode` set to `mobile`
12. Expect `enhanced_site_creation_site_design_preview_loading` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
13. Expect `enhanced_site_creation_site_design_preview_loaded` to be fired with `preview_mode` set to `mobile` and `template` set to the corresponding design
14. Tap "Create Site" (the button may say "Choose" depending on Site Name treatment)
15. Expect `enhanced_site_creation_site_design_selected` to be fired with `template` set to the corresponding design

## Regression Notes
1. Potential unintended areas of impact
    - Site Design thumbnails
    - Tracks event sent related to the Site Design view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual steps above

3. What automated tests I added (or what prevented me from doing so)
    - Added `testSiteDesignPreviewDeviceIsAlwaysMobile`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
