### PR TITLE
Blogging Prompts: Create prompts header view for create new action sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -9,6 +9,7 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var answeredStackView: UIStackView!
     @IBOutlet private weak var answeredLabel: UILabel!
     @IBOutlet private weak var shareButton: UIButton!
+    @IBOutlet private weak var dividerView: UIView!
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -34,6 +35,7 @@ private extension BloggingPromptsHeaderView {
         configureSpacing()
         configureStrings()
         configureStyles()
+        configureConstraints()
     }
 
     func configureSpacing() {
@@ -63,6 +65,12 @@ private extension BloggingPromptsHeaderView {
         shareButton.titleLabel?.adjustsFontForContentSizeCategory = true
         shareButton.titleLabel?.adjustsFontSizeToFitWidth = true
         shareButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+    }
+
+    func configureConstraints() {
+        NSLayoutConstraint.activate([
+            dividerView.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth),
+        ])
     }
 
     // MARK: - Constants

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -1,0 +1,84 @@
+import UIKit
+
+class BloggingPromptsHeaderView: UIView, NibLoadable {
+    @IBOutlet private weak var containerStackView: UIStackView!
+    @IBOutlet private weak var titleStackView: UIStackView!
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var promptLabel: UILabel!
+    @IBOutlet private weak var answerPromptButton: UIButton!
+    @IBOutlet private weak var answeredStackView: UIStackView!
+    @IBOutlet private weak var answeredLabel: UILabel!
+    @IBOutlet private weak var shareButton: UIButton!
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureView()
+    }
+
+    @IBAction private func answerPromptTapped(_ sender: Any) {
+        // TODO
+    }
+
+    @IBAction private func shareTapped(_ sender: Any) {
+        // TODO
+    }
+}
+
+// MARK: - Private methods
+
+private extension BloggingPromptsHeaderView {
+
+    func configureView() {
+        // TODO: Hide correct UI based on if prompt is answered
+        answerPromptButton.isHidden = true
+        configureSpacing()
+        configureStrings()
+        configureStyles()
+    }
+
+    func configureSpacing() {
+        containerStackView.setCustomSpacing(Constants.titleSpacing, after: titleStackView)
+        containerStackView.setCustomSpacing(Constants.answeredViewSpacing, after: answeredStackView)
+        containerStackView.setCustomSpacing(Constants.answerPromptButtonSpacing, after: answerPromptButton)
+    }
+
+    func configureStrings() {
+        titleLabel.text = Strings.title
+        // TODO: Use prompt from backend
+        promptLabel.text = Strings.examplePrompt
+        answerPromptButton.titleLabel?.text = Strings.answerButtonTitle
+        answeredLabel.text = Strings.answeredLabelTitle
+        shareButton.titleLabel?.text = Strings.shareButtonTitle
+    }
+
+    func configureStyles() {
+        titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        promptLabel.font = WPStyleGuide.BloggingPrompts.promptContentFont
+        answerPromptButton.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
+        answerPromptButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        answerPromptButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+        answeredLabel.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
+        answeredLabel.textColor = WPStyleGuide.BloggingPrompts.answeredLabelColor
+        shareButton.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
+        shareButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        shareButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        shareButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+    }
+
+    // MARK: - Constants
+
+    struct Constants {
+        static let titleSpacing: CGFloat = 8.0
+        static let answeredViewSpacing: CGFloat = 9.0
+        static let answerPromptButtonSpacing: CGFloat = 9.0
+    }
+
+    struct Strings {
+        static let examplePrompt = NSLocalizedString("Cast the movie of your life.", comment: "Example prompt for blogging prompts in the create new bottom action sheet.")
+        static let title = NSLocalizedString("Prompts", comment: "Title label for blogging prompts in the create new bottom action sheet.")
+        static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button in the create new bottom action sheet.")
+        static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")
+        static let shareButtonTitle = NSLocalizedString("Share", comment: "Title for a button that allows the user to share their answer to the prompt.")
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB" customClass="BloggingPromptsHeaderView" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="349" height="120"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="HBh-15-Hby">
+                    <rect key="frame" x="0.0" y="0.0" width="349" height="92"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="stO-XN-YJp">
+                            <rect key="frame" x="131" y="0.0" width="87.5" height="24"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-lightbulb-outline" translatesAutoresizingMaskIntoConstraints="NO" id="AiS-VC-l3e">
+                                    <rect key="frame" x="0.0" y="3" width="18" height="18"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="18" id="VuP-Sn-J3O"/>
+                                        <constraint firstAttribute="height" constant="18" id="Wgm-8p-3As"/>
+                                    </constraints>
+                                </imageView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Prompts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJN-uB-YYG">
+                                    <rect key="frame" x="23" y="0.0" width="64.5" height="24"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="5Im-WR-keg"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Cast the movie of your life." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rye-vB-0gG">
+                            <rect key="frame" x="73.5" y="24" width="202.5" height="24"/>
+                            <constraints>
+                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="XJS-Qq-aST"/>
+                            </constraints>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqk-gy-gv5">
+                            <rect key="frame" x="125" y="48" width="99" height="22.5"/>
+                            <state key="normal" title="Button"/>
+                            <buttonConfiguration key="configuration" style="plain" title="Answer Prompt">
+                                <directionalEdgeInsets key="contentInsets" top="16" leading="0.0" bottom="16" trailing="0.0"/>
+                            </buttonConfiguration>
+                            <connections>
+                                <action selector="answerPromptTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="maK-JO-Huc"/>
+                            </connections>
+                        </button>
+                        <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="74j-gh-nmq">
+                            <rect key="frame" x="100.5" y="70.5" width="148" height="20.5"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓ Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ttu-81-Rjc">
+                                    <rect key="frame" x="0.0" y="0.0" width="94.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="deu-kl-qJY">
+                                    <rect key="frame" x="110.5" y="0.0" width="37.5" height="20.5"/>
+                                    <state key="normal" title="Button"/>
+                                    <buttonConfiguration key="configuration" style="plain" title="Share">
+                                        <directionalEdgeInsets key="contentInsets" top="16" leading="0.0" bottom="16" trailing="0.0"/>
+                                    </buttonConfiguration>
+                                    <connections>
+                                        <action selector="shareTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="ABZ-P1-FDh"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9KN-UC-IRC">
+                            <rect key="frame" x="0.0" y="91" width="349" height="1"/>
+                            <color key="backgroundColor" systemColor="separatorColor"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="1" id="Fe2-Kr-HkA"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="9KN-UC-IRC" firstAttribute="leading" secondItem="HBh-15-Hby" secondAttribute="leading" id="i3E-vF-ouk"/>
+                        <constraint firstAttribute="trailing" secondItem="9KN-UC-IRC" secondAttribute="trailing" id="j2W-Lj-CP5"/>
+                    </constraints>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="HBh-15-Hby" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="1Us-st-jWK"/>
+                <constraint firstItem="HBh-15-Hby" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="CcK-Dx-5sh"/>
+                <constraint firstAttribute="bottom" secondItem="HBh-15-Hby" secondAttribute="bottom" constant="28" id="a95-RM-xA7"/>
+                <constraint firstAttribute="trailing" secondItem="HBh-15-Hby" secondAttribute="trailing" id="gqq-A6-5fK"/>
+            </constraints>
+            <nil key="simulatedTopBarMetrics"/>
+            <nil key="simulatedBottomBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <connections>
+                <outlet property="answerPromptButton" destination="fqk-gy-gv5" id="g2H-Pl-Cot"/>
+                <outlet property="answeredLabel" destination="ttu-81-Rjc" id="qUD-tY-fry"/>
+                <outlet property="answeredStackView" destination="74j-gh-nmq" id="mWB-ce-YU3"/>
+                <outlet property="containerStackView" destination="HBh-15-Hby" id="ce7-Wx-TUC"/>
+                <outlet property="promptLabel" destination="Rye-vB-0gG" id="VoE-0W-soe"/>
+                <outlet property="shareButton" destination="deu-kl-qJY" id="4ur-ok-U6p"/>
+                <outlet property="titleLabel" destination="BJN-uB-YYG" id="zxX-90-kDD"/>
+                <outlet property="titleStackView" destination="stO-XN-YJp" id="Mjx-Bg-Wpo"/>
+            </connections>
+            <point key="canvasLocation" x="180.43478260869566" y="-91.741071428571431"/>
+        </view>
+    </objects>
+    <resources>
+        <image name="icon-lightbulb-outline" width="24" height="24"/>
+        <systemColor name="separatorColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -48,7 +48,7 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqk-gy-gv5">
-                            <rect key="frame" x="125" y="48" width="99" height="22.5"/>
+                            <rect key="frame" x="125" y="48" width="99" height="23.5"/>
                             <state key="normal" title="Button"/>
                             <buttonConfiguration key="configuration" style="plain" title="Answer Prompt">
                                 <directionalEdgeInsets key="contentInsets" top="16" leading="0.0" bottom="16" trailing="0.0"/>
@@ -58,7 +58,7 @@
                             </connections>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="74j-gh-nmq">
-                            <rect key="frame" x="100.5" y="70.5" width="148" height="20.5"/>
+                            <rect key="frame" x="100.5" y="71.5" width="148" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓ Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ttu-81-Rjc">
                                     <rect key="frame" x="0.0" y="0.0" width="94.5" height="20.5"/>
@@ -79,11 +79,8 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9KN-UC-IRC">
-                            <rect key="frame" x="0.0" y="91" width="349" height="1"/>
+                            <rect key="frame" x="0.0" y="92" width="349" height="0.0"/>
                             <color key="backgroundColor" systemColor="separatorColor"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="1" id="Fe2-Kr-HkA"/>
-                            </constraints>
                         </view>
                     </subviews>
                     <constraints>
@@ -107,6 +104,7 @@
                 <outlet property="answeredLabel" destination="ttu-81-Rjc" id="qUD-tY-fry"/>
                 <outlet property="answeredStackView" destination="74j-gh-nmq" id="mWB-ce-YU3"/>
                 <outlet property="containerStackView" destination="HBh-15-Hby" id="ce7-Wx-TUC"/>
+                <outlet property="dividerView" destination="9KN-UC-IRC" id="Wnd-hZ-yio"/>
                 <outlet property="promptLabel" destination="Rye-vB-0gG" id="VoE-0W-soe"/>
                 <outlet property="shareButton" destination="deu-kl-qJY" id="4ur-ok-U6p"/>
                 <outlet property="titleLabel" destination="BJN-uB-YYG" id="zxX-90-kDD"/>

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -11,8 +11,9 @@ class CreateButtonActionSheet: ActionSheetViewController {
     }
 
     init(actions: [ActionSheetItem]) {
+        let headerView = FeatureFlag.bloggingPrompts.enabled ? BloggingPromptsHeaderView.loadFromNib() : nil
         let buttons = actions.map { $0.makeButton() }
-        super.init(headerTitle: Constants.title, buttons: buttons)
+        super.init(headerView: headerView, headerTitle: Constants.title, buttons: buttons)
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1395,6 +1395,10 @@
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
 		836498C828172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
 		836498C928172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */; };
+		836498CB2817301800A2C170 /* BloggingPromptsHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */; };
+		836498CC2817301800A2C170 /* BloggingPromptsHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */; };
+		836498CE281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498CD281735CC00A2C170 /* BloggingPromptsHeaderView.swift */; };
+		836498CF281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 836498CD281735CC00A2C170 /* BloggingPromptsHeaderView.swift */; };
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
 		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
@@ -6144,6 +6148,8 @@
 		8355D7D811D260AA00A61362 /* CoreData.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		835E2402126E66E50085940B /* AssetsLibrary.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AssetsLibrary.framework; path = System/Library/Frameworks/AssetsLibrary.framework; sourceTree = SDKROOT; };
 		836498C728172C5900A2C170 /* WPStyleGuide+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+BloggingPrompts.swift"; sourceTree = "<group>"; };
+		836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = BloggingPromptsHeaderView.xib; sourceTree = "<group>"; };
+		836498CD281735CC00A2C170 /* BloggingPromptsHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsHeaderView.swift; sourceTree = "<group>"; };
 		8370D10811FA499A009D650F /* WPTableViewActivityCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableViewActivityCell.h; sourceTree = "<group>"; };
 		8370D10911FA499A009D650F /* WPTableViewActivityCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableViewActivityCell.m; sourceTree = "<group>"; };
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
@@ -14820,6 +14826,8 @@
 			children = (
 				F5E032E32408D537003AF350 /* ActionSheetViewController.swift */,
 				F5E032E52408D537003AF350 /* BottomSheetPresentationController.swift */,
+				836498CD281735CC00A2C170 /* BloggingPromptsHeaderView.swift */,
+				836498CA2817301800A2C170 /* BloggingPromptsHeaderView.xib */,
 			);
 			path = "Action Sheet";
 			sourceTree = "<group>";
@@ -16053,6 +16061,7 @@
 				9808655A203D075E00D58786 /* EpilogueUserInfoCell.xib in Resources */,
 				C7E5F2552799BD54009BC263 /* cool-blue-icon-app-83.5x83.5@2x.png in Resources */,
 				17222D92261DDDF90047B163 /* blue-classic-icon-app-83.5x83.5@2x.png in Resources */,
+				836498CB2817301800A2C170 /* BloggingPromptsHeaderView.xib in Resources */,
 				17222D90261DDDF90047B163 /* blue-classic-icon-app-60x60@2x.png in Resources */,
 				E6D2E1611B8AA4410000ED14 /* ReaderTagStreamHeader.xib in Resources */,
 				577C2AB62294401800AD1F03 /* PostCompactCell.xib in Resources */,
@@ -16364,6 +16373,7 @@
 				FABB1FC12602FC2C00C8785C /* defaultPostTemplate.html in Resources */,
 				FABB1FC32602FC2C00C8785C /* defaultPostTemplate_old.html in Resources */,
 				FABB1FC42602FC2C00C8785C /* ReaderInterestsCollectionViewCell.xib in Resources */,
+				836498CC2817301800A2C170 /* BloggingPromptsHeaderView.xib in Resources */,
 				FABB1FC52602FC2C00C8785C /* StatsGhostTopHeaderCell.xib in Resources */,
 				9856A38A261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */,
 				FABB1FC72602FC2C00C8785C /* RegisterDomainDetailsFooterView.xib in Resources */,
@@ -19020,6 +19030,7 @@
 				8B05D29323AA572A0063B9AA /* GutenbergMediaEditorImage.swift in Sources */,
 				B532D4EA199D4357006E4DF6 /* NoteBlockHeaderTableViewCell.swift in Sources */,
 				24ADA24C24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift in Sources */,
+				836498CE281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */,
 				319D6E8519E44F7F0013871C /* SuggestionsTableViewCell.m in Sources */,
 				40A71C69220E1952002E3D25 /* LastPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				98AA6D1126B8CE7200920C8B /* Comment+CoreDataClass.swift in Sources */,
@@ -19885,6 +19896,7 @@
 				FABB21132602FC2C00C8785C /* AuthenticationService.swift in Sources */,
 				FABB21142602FC2C00C8785C /* JetpackSiteRef.swift in Sources */,
 				FABB21152602FC2C00C8785C /* WPStyleGuide+Reply.swift in Sources */,
+				836498CF281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */,
 				FABB21162602FC2C00C8785C /* WPBlogTableViewCell.m in Sources */,
 				FABB21172602FC2C00C8785C /* JetpackBackupOptionsViewController.swift in Sources */,
 				FABB21182602FC2C00C8785C /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
See #18402
Relies on PR #18453

## Description

Adds a blogging prompt header view to the create new action sheet

## Testing

To test:
- Enable blogging prompts feature flag
- Navigate to the 'My Site' tab
- Tap on the 'Create New' floating action button
- Observe prompts header view and verify:
  - Styling and that it matches the dashboard card
  - Text size
  - Dark mode
- Repeat verification with iPad

## Screenshots

### iPhone

| Before | After |
|--------|------|
| ![Simulator Screen Shot - iPhone 11 - 2022-04-26 at 16 59 41](https://user-images.githubusercontent.com/2454408/165395625-1736b246-db88-4b8d-a8d8-504d05c66700.png) | ![Simulator Screen Shot - iPhone 11 - 2022-04-26 at 17 07 16](https://user-images.githubusercontent.com/2454408/165395667-8f0fbfca-f838-433c-a798-9e8ed3f5d55a.png) |

### iPad
| Before | After |
|--------|------|
| ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-04-26 at 17 10 50](https://user-images.githubusercontent.com/2454408/165395782-c05f889f-d105-42c3-9e57-7bf33d398d99.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-04-26 at 17 11 46](https://user-images.githubusercontent.com/2454408/165395800-c73997c3-f658-4dc9-9955-e14856d725ec.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
