### PR TITLE
Quick Start for Existing Users: Respect feature flag when logging into a self-hosted site

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -335,7 +335,8 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         // If adding a self-hosted site, skip the Epilogue
         if let wporg = credentials.wporg,
            let blog = Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: ContextManager.shared.mainContext) {
-            presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissQuickStartPromptForExistingSiteHandler)
+            let onDismissHandler = FeatureFlag.quickStartForExistingUsers.enabled ? onDismissQuickStartPromptForExistingSiteHandler : onDismissQuickStartPromptForNewSiteHandler
+            presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissHandler)
             return
         }
 


### PR DESCRIPTION
Part of #18388

## Description
- We decided to show the new tour after signing into a self-hosted site. (Ref: p1650894845585159/1650522675.714159-slack-C027K4MNPGQ)
- This was added in f1a81addcb6ee3d874e43762308e07d941cc0994 but I forgot to account for the feature flag.
- This PR hides this new logic behind the `quickStartForExistingUsers` feature flag

## Testing Instructions

### Self Hosted with Feature Flag enabled

1. Install the app
2. Logout if needed
3. Login into a self hosted site
4. Tap "Show me around"
5. Make sure that the **new** set of tasks is displayed in the quick start card

### Self Hosted with Feature Flag disabled

1. Manually disable feature flag from code
2. Install the app
3. Logout if needed
4. Login into a self hosted site
5. Tap "Show me around"
6. Make sure that the **old** set of tasks is displayed in the quick start card


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
