### PR TITLE
Posts Card: change the title font

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardEmptyPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardEmptyPostsCardCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// Card cell prompting the user to create their first post
 final class DashboardFirstPostCardCell: DashboardEmptyPostsCardCell, BlogDashboardCardConfigurable {
@@ -48,7 +49,7 @@ class DashboardEmptyPostsCardCell: UICollectionViewCell, Reusable {
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
         titleLabel.text = "Create your first post"
-        titleLabel.font = WPStyleGuide.notoBoldFontForTextStyle(.title3)
+        titleLabel.font = WPStyleGuide.serifFontForTextStyle(.title3, fontWeight: .semibold)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.adjustsFontSizeToFitWidth = true
         titleLabel.minimumScaleFactor = 0.5


### PR DESCRIPTION
This PR changes the next post card prompt font title from "Noto" to "New York".

<img src="https://user-images.githubusercontent.com/7040243/165521735-43d58a7b-9e7a-4828-85d3-c231b40aea65.png" width="300">

### To test

1. Run the app
2. ✅ Check the next post prompt font

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
