### PR TITLE
Quick Start for Existing Users: Refactor additionalSafeAreaInsets logic 

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -170,7 +170,6 @@ final class BlogDashboardViewController: UIViewController {
                     } else {
                         self.collectionView.scrollToTop(animated: true)
                     }
-                    self.mySiteViewController?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPaddingForQuickStartNotices, right: 0)
                 default:
                     break
                 }
@@ -294,7 +293,6 @@ extension BlogDashboardViewController {
         static let horizontalSectionInset: CGFloat = 20
         static let verticalSectionInset: CGFloat = 20
         static let cellSpacing: CGFloat = 20
-        static let bottomPaddingForQuickStartNotices: CGFloat = 80
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -5,8 +5,6 @@ private var observer: NSObjectProtocol?
 
 extension BlogDetailsViewController {
 
-    @objc static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
-
     @objc func startObservingQuickStart() {
         observer = NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] (notification) in
             guard self?.blog.managedObjectContext != nil else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -379,14 +379,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     [super viewWillAppear:animated];
     
-    MySiteViewController *parentVC = (MySiteViewController *)self.parentViewController;
-
-    if ([[QuickStartTourGuide shared] currentElementInt] != NSNotFound) {
-        parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
-    } else {
-        parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
-    }
-
     if (self.splitViewControllerIsHorizontallyCompact) {
         self.restorableSelectedIndexPath = nil;
     }
@@ -1400,7 +1392,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         for (BlogDetailsRow *row in section.rows) {
             if (row.quickStartIdentifier == element) {
                 NSIndexPath *path = [NSIndexPath indexPathForRow:rowCount inSection:sectionCount];
-                parentVC.additionalSafeAreaInsets = UIEdgeInsetsMake(0, 0, [BlogDetailsViewController bottomPaddingForQuickStartNotices], 0);
                 UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:path];
                 [parentVC.scrollView scrollVerticallyToView:cell animated:true];
             }
@@ -1638,7 +1629,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [[QuickStartTourGuide shared] completeViewSiteTourForBlog:self.blog];
     }
 
-    parentVC.additionalSafeAreaInsets = UIEdgeInsetsZero;
 }
 
 - (void)showViewAdmin

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -18,7 +18,7 @@ extension MySiteViewController {
 
                 case .siteMenu:
                     self?.siteMenuSpotlightIsShown = true
-                    self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
+                    fallthrough
 
                 case .pages, .editHomepage, .sharing, .stats, .readerTab, .notifications:
                     self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -9,16 +9,20 @@ extension MySiteViewController {
                let element = info[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
 
                 switch element {
-                case .noSuchElement:
+                case .noSuchElement, .newpost:
                     self?.additionalSafeAreaInsets = .zero
+
                 case .siteIcon, .siteTitle, .viewSite:
                     self?.scrollView.scrollToTop(animated: true)
+                    self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
-                    self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPaddingForQuickStartNotices, right: 0)
                 case .siteMenu:
                     self?.siteMenuSpotlightIsShown = true
+                    self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
-                    self?.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPaddingForQuickStartNotices, right: 0)
+                case .pages, .editHomepage, .sharing, .stats, .readerTab, .notifications:
+                    self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
+
                 default:
                     break
                 }
@@ -27,6 +31,6 @@ extension MySiteViewController {
     }
 
     private enum Constants {
-        static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
+        static let quickStartNoticeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 80, right: 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -15,7 +15,6 @@ open class QuickStartTourGuide: NSObject {
     private var currentSuggestion: QuickStartTour?
     private var currentTourState: TourState?
     private var suggestionWorkItem: DispatchWorkItem?
-    private var taskCompleteWorkItem: DispatchWorkItem?
     private weak var recentlyTouredBlog: Blog?
     private let noticeTag: Notice.Tag = "QuickStartTour"
     static let notificationElementKey = "QuickStartElementKey"

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+QuickStart.swift
@@ -47,8 +47,4 @@ extension SitePickerViewController {
             QuickStartTourGuide.shared.suggest(tourToSuggest, for: blog)
         }
     }
-
-    private enum Constants {
-        static let bottomPaddingForQuickStartNotices: CGFloat = 80.0
-    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -252,11 +252,6 @@ extension SitePickerViewController {
             //  currently working on the View Site tour.
             tourGuide.completeViewSiteTour(forBlog: blog)
         }
-
-        guard let parentVC = parent as? MySiteViewController else {
-            return
-        }
-        parentVC.additionalSafeAreaInsets = .zero
     }
 }
 


### PR DESCRIPTION
Part of #18387

Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/18413#discussion_r857541372

## Description
- Consolidated additionalSafeAreaInsets logic inside MySiteViewController+QuickStart
- Added a few missing cases to the additionalSafeAreaInsets logic

## How to test

### New Site tours (i.e. old tours)
1. Enable Quick Start for New Site via the debug menu
2. Go through each tour
3. ✅ Verify: For each tour, the Quick Start notice doesn't obscure the FAB

### Existing Site tours (i.e. new tours)
1. Enable Quick Start for Existing Site via the debug menu
2. Go through each tour
3. ✅ Verify: For each tour, the Quick Start notice doesn't obscure the FAB

## Regression Notes
1. Potential unintended areas of impact
- Quick Start tours

4. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the above steps

5. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
