### PR TITLE
Quick Start: track tap under "Menu"

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -337,6 +337,7 @@ import Foundation
 
     // Quick Start
     case quickStartStarted
+    case quickStartTapped
 
     /// A String that represents the event
     var value: String {
@@ -878,6 +879,8 @@ import Foundation
         // Quick Start
         case .quickStartStarted:
             return "quick_start_started"
+        case .quickStartTapped:
+            return "quick_start_tapped"
 
         // Site Intent Question
         case .enhancedSiteCreationIntentQuestionCanceled:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -14,7 +14,10 @@ import UIKit
 
         selectionStyle = .none
 
-        tourStateView.configure(blog: blog, sourceController: viewController)
+        let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .quickStartTapped, properties: [:])
+
+        tourStateView.configure(blog: blog, sourceController: viewController,
+                                checklistTappedTracker: checklistTappedTracker)
     }
 
     private enum Metrics {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -16,7 +16,8 @@ import UIKit
 
         let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .quickStartTapped, properties: [:])
 
-        tourStateView.configure(blog: blog, sourceController: viewController,
+        tourStateView.configure(blog: blog,
+                                sourceController: viewController,
                                 checklistTappedTracker: checklistTappedTracker)
     }
 


### PR DESCRIPTION
This PR tracks when a user taps the Quick Start under "Menu".

### To test

1. Open the app
2. Start Quick Start for any site under "Menu"
3. Tap on the Quick Start cell
4. ✅ Make sure `quick_start_tapped` is fired

Please validate the event if everything looks fine.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
