### PR TITLE
My Site Dashboard: Sync blog and update nav title after pull to refresh

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -158,5 +158,5 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)showStatsFromSource:(BlogDetailsNavigationSource)source;
 - (void)updateTableView:(nullable void(^)(void))completion;
 - (void)preloadMetadata;
-- (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl;
+- (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl onCompletion:(nullable void(^)(void))completion;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -158,5 +158,5 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)showStatsFromSource:(BlogDetailsNavigationSource)source;
 - (void)updateTableView:(nullable void(^)(void))completion;
 - (void)preloadMetadata;
-- (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl  onCompletion:(nullable void(^)(void))completion;
+- (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl;
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1757,22 +1757,18 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 }
 
 #pragma mark - Pull To Refresh
-- (void)pulledToRefresh {
-    [self pulledToRefreshWith:self.tableView.refreshControl onCompletion:^{}];
-}
 
-- (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl onCompletion:( void(^)(void))completion {
+- (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl {
+    
+    [self configureTableViewData];
+    [self reloadTableViewPreservingSelection];
 
-    [self updateTableView: ^{
-        // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
-        // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
-        // down to refresh the site.
-        dispatch_async(dispatch_get_main_queue(), ^(void){
-            [refreshControl endRefreshing];
-            
-            completion();
-        });
-    }];
+    // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
+    // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
+    // down to refresh the site.
+    dispatch_async(dispatch_get_main_queue(), ^(void){
+        [refreshControl endRefreshing];
+    });
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1758,17 +1758,18 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 #pragma mark - Pull To Refresh
 
-- (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl {
+- (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl onCompletion:( void(^)(void))completion {
     
-    [self configureTableViewData];
-    [self reloadTableViewPreservingSelection];
+    [self updateTableView: ^{
+        // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
+        // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
+        // down to refresh the site.
+        dispatch_async(dispatch_get_main_queue(), ^(void){
+            [refreshControl endRefreshing];
 
-    // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
-    // To recognize if we can remove this, simply remove the dispatch_async call and test pulling
-    // down to refresh the site.
-    dispatch_async(dispatch_get_main_queue(), ^(void){
-        [refreshControl endRefreshing];
-    });
+            completion();
+        });
+    }];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1759,7 +1759,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 #pragma mark - Pull To Refresh
 
 - (void)pulledToRefreshWith:(UIRefreshControl *)refreshControl onCompletion:( void(^)(void))completion {
-    
+
     [self updateTableView: ^{
         // WORKAROUND: if we don't dispatch this asynchronously, the refresh end animation is clunky.
         // To recognize if we can remove this, simply remove the dispatch_async call and test pulling

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -435,7 +435,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         switch section {
         case .siteMenu:
-            self.blogDetailsViewController?.pulledToRefresh(with: self.refreshControl) { [weak self] in
+            blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
                 guard let self = self else {
                     return
                 }
@@ -447,11 +447,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
             /// The dashboard’s refresh control is intentionally not tied to blog syncing in order to keep
             /// the dashboard updating fast.
-            self.blogDashboardViewController?.pulledToRefresh { [weak self] in
+            blogDashboardViewController?.pulledToRefresh { [weak self] in
                 self?.refreshControl.endRefreshing()
             }
 
-            self.blogService.syncBlogAndAllMetadata(blog) { [weak self] in
+            blogService.syncBlogAndAllMetadata(blog) { [weak self] in
                 guard let self = self else {
                     return
                 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -427,24 +427,30 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     @objc
     private func pulledToRefresh() {
-        guard let section = currentSection else {
-            return
+
+        guard let blog = blog,
+              let section = currentSection else {
+                  return
         }
 
-        switch section {
-        case .siteMenu:
-            blogDetailsViewController?.pulledToRefresh(with: refreshControl) { [weak self] in
-                guard let self = self else {
-                    return
+        blogService.syncBlogAndAllMetadata(blog) { [weak self] in
+
+            guard let self = self else {
+                return
+            }
+
+            self.updateNavigationTitle(for: blog)
+            self.sitePickerViewController?.blogDetailHeaderView.blog = blog
+
+            switch section {
+            case .siteMenu:
+                self.blogDetailsViewController?.pulledToRefresh(with: self.refreshControl)
+            case .dashboard:
+                self.blogDashboardViewController?.pulledToRefresh {
+                    self.refreshControl.endRefreshing()
                 }
-
-                self.sitePickerViewController?.blogDetailHeaderView.blog = self.blog
             }
 
-        case .dashboard:
-            blogDashboardViewController?.pulledToRefresh { [weak self] in
-                self?.refreshControl.endRefreshing()
-            }
         }
 
         WPAnalytics.track(.mySitePullToRefresh, properties: [WPAppAnalyticsKeyTabSource: section.analyticsDescription])


### PR DESCRIPTION
Fixes p5T066-3al-p2#comment-12160


## Description
This fixes two PtR issues.

1. Fixed updating the site picker header title / the nav title after PtR
2. Fixed syncing blog and metadata for the dashboard tab


## How to test

### iPhone: Dashboard tab
1. Switch to the dashboard tab
2. On the web (or another device) update the site title
3. Pull to refresh
4. ✅ Verify: The site picker title matches the new site title
5. Scroll up
6. ✅ Verify: The nav title matches the new site title

https://user-images.githubusercontent.com/6711616/165734209-0b812a5e-28ac-4e5a-9d5d-ab7638b05cdf.mp4


### iPhone: Menu tab
1. Switch to the menu tab
2. On the web (or another device) update the site title
3. Pull to refresh
4. ✅ Verify: The site picker title matches the new site title
5. Scroll up
6. ✅ Verify: The nav title matches the new site title

https://user-images.githubusercontent.com/6711616/165734236-189cbf1d-051e-4ba1-a274-716e8b4e4b4f.mp4

### iPad
1. On the web (or another device) update the site title
2. Pull to refresh the menu on the left hand side
3. ✅ Verify: The site picker title matches the new site title
4. Scroll up
5. ✅ Verify: The nav title matches the new site title


https://user-images.githubusercontent.com/6711616/165734309-d440edbf-6ac8-4d6c-9c5e-e72ce85f95f0.mp4



## Regression Notes
1. Potential unintended areas of impact
- Updating the blog / dashboard

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the steps above

7. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.