### PR TITLE
Quick Start for Existing Users: Delete "Edit your homepage" tour

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 * [*] [internal] My Site Dashboard: Made some changes to the code architecture of the dashboard. The majority of the changes are related to the posts cards. It should have no visible changes but could cause regressions. Please test it by creating/trashing drafts and scheduled posts and testing that they appear correctly on the dashboard. [#18405]
 * [*] Quick Start: Updated the Stats tour. The tour can now be accessed from either the dashboard or the menu tab. [#18413]
 * [*] Quick Start: Updated the Reader tour. The tour now highlights the Discover tab and guides users to follow topics via the Settings screen. [#18450]
-* [*] Quick Start: Deleted the Edit your homepage tour. [#18469]
+* [*] [internal] Quick Start: Deleted the Edit your homepage tour. [#18469]
 * [*] [internal] Quick Start: Refactored some code related to the tasks displayed in the Quick Start Card and the Quick Start modal. It should have no visible changes but could cause regressions. [#18395]
 
 19.7

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] [internal] My Site Dashboard: Made some changes to the code architecture of the dashboard. The majority of the changes are related to the posts cards. It should have no visible changes but could cause regressions. Please test it by creating/trashing drafts and scheduled posts and testing that they appear correctly on the dashboard. [#18405]
 * [*] Quick Start: Updated the Stats tour. The tour can now be accessed from either the dashboard or the menu tab. [#18413]
 * [*] Quick Start: Updated the Reader tour. The tour now highlights the Discover tab and guides users to follow topics via the Settings screen. [#18450]
+* [*] Quick Start: Deleted the Edit your homepage tour. [#18469]
 * [*] [internal] Quick Start: Refactored some code related to the tasks displayed in the Quick Start Card and the Quick Start modal. It should have no visible changes but could cause regressions. [#18395]
 
 19.7

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+FancyAlerts.swift
@@ -20,7 +20,7 @@ extension BlogDetailsViewController {
                         return
                     }
                     fallthrough
-                case .pages, .editHomepage, .sharing:
+                case .pages, .sharing:
                     self?.scroll(to: info)
                 default:
                     break
@@ -114,13 +114,6 @@ extension BlogDetailsViewController {
         QuickStartTourGuide.shared.visited(.checklist)
 
         createButtonCoordinator?.hideCreateButtonTooltip()
-    }
-
-    @objc func cancelCompletedToursIfNeeded() {
-        if shouldShowQuickStartChecklist() && blog.homepagePageID == nil {
-            // Ends the tour Edit Homepage if the site doesn't have a homepage set or uses the blog.
-            QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), for: blog, postNotification: false)
-        }
     }
 
     @objc func quickStartSectionViewModel() -> BlogDetailsSection {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -69,11 +69,10 @@ typedef NS_ENUM(NSInteger, QuickStartTourElement) {
     QuickStartTourElementStats = 18,
     QuickStartTourElementPlans = 19,
     QuickStartTourElementSiteTitle = 20,
-    QuickStartTourElementEditHomepage = 21,
-    QuickStartTourElementSiteMenu = 22,
-    QuickStartTourElementNotifications = 23,
-    QuickStartTourElementSetupQuickStart = 24,
-    QuickStartTourElementRemoveQuickStart = 25,
+    QuickStartTourElementSiteMenu = 21,
+    QuickStartTourElementNotifications = 22,
+    QuickStartTourElementSetupQuickStart = 23,
+    QuickStartTourElementRemoveQuickStart = 24,
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -395,7 +395,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)viewDidAppear:(BOOL)animated
 {
     [super viewDidAppear:animated];
-    [self cancelCompletedToursIfNeeded];
     [self createUserActivity];
     [self startAlertTimer];
     

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -20,7 +20,7 @@ extension MySiteViewController {
                     self?.siteMenuSpotlightIsShown = true
                     self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
-                case .pages, .editHomepage, .sharing, .stats, .readerTab, .notifications:
+                case .pages, .sharing, .stats, .readerTab, .notifications:
                     self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
                 default:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTours.swift
@@ -299,31 +299,6 @@ struct QuickStartReviewPagesTour: QuickStartTour {
     let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")
 }
 
-struct QuickStartEditHomepageTour: QuickStartTour {
-    let key = "quick-start-edit-homepage-tour"
-    let analyticsKey = "edit_homepage"
-    let title = NSLocalizedString("Edit your homepage", comment: "Title of a Quick Start Tour")
-    let titleMarkedCompleted = NSLocalizedString("Completed: Edit your homepage", comment: "The Quick Start Tour title after the user finished the step.")
-    let description = NSLocalizedString("Change, add, or remove content from your site's homepage.", comment: "Description of a Quick Start Tour")
-    let icon = UIImage.gridicon(.house)
-    let suggestionNoText = Strings.notNow
-    let suggestionYesText = Strings.yesShowMe
-    let possibleEntryPoints: Set<QuickStartTourEntryPoint> = [.blogDetails]
-
-    var waypoints: [WayPoint] = {
-        let descriptionBase = NSLocalizedString("Select %@ to see your page list.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let descriptionTarget = NSLocalizedString("Pages", comment: "The item to select during a guided tour.")
-        let descriptionHomepage = NSLocalizedString("Select %@ to edit your Homepage.", comment: "A step in a guided tour for quick start. %@ will be the name of the item to select.")
-        let homepageTarget = NSLocalizedString("Homepage", comment: "The item to select during a guided tour.")
-        return [
-            (element: .pages, description: descriptionBase.highlighting(phrase: descriptionTarget, icon: .gridicon(.pages))),
-            (element: .editHomepage, description: descriptionHomepage.highlighting(phrase: homepageTarget, icon: .gridicon(.house)))
-        ]
-    }()
-
-    let accessibilityHintText = NSLocalizedString("Guides you through the process of creating a new page for your site.", comment: "This value is used to set the accessibility hint text for creating a new page for the user's site.")
-}
-
 struct QuickStartCheckStatsTour: QuickStartTour {
     let key = "quick-start-check-stats-tour"
     let analyticsKey = "check_stats"

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartToursCollection.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartToursCollection.swift
@@ -28,7 +28,6 @@ struct QuickStartCustomizeToursCollection: QuickStartToursCollection {
             QuickStartCreateTour(),
             QuickStartSiteTitleTour(blog: blog),
             QuickStartSiteIconTour(),
-            QuickStartEditHomepageTour(),
             QuickStartReviewPagesTour(),
             QuickStartViewTour(blog: blog)
         ]

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -420,13 +420,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let page = pageAtIndexPath(indexPath)
         if page.isSiteHomepage {
-            let guide = QuickStartTourGuide.shared
-            if guide.isCurrentElement(.editHomepage) {
-                QuickStartTourGuide.shared.visited(.editHomepage)
-            } else {
-                QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), silentlyForBlog: blog)
-            }
-
             tableView.reloadRows(at: [indexPath], with: .automatic)
         } else if page.isSitePostsPage {
             showSitePostPageUneditableNotice()
@@ -460,12 +453,6 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath)
 
         configureCell(cell, at: indexPath)
-
-        if page.isSiteHomepage && QuickStartTourGuide.shared.isCurrentElement(.editHomepage) {
-            cell.accessoryView = QuickStartSpotlightView()
-        } else {
-            cell.accessoryView = nil
-        }
 
         return cell
     }
@@ -771,19 +758,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     override func deletePost(_ apost: AbstractPost) {
-        completeQuickStartStepIfNeeded(apost)
         super.deletePost(apost)
-    }
-
-    private func completeQuickStartStepIfNeeded(_ page: AbstractPost) {
-        guard let page = page as? Page else { return }
-        guard page.isSiteHomepage else { return }
-
-        if QuickStartTourGuide.shared.isCurrentElement(.editHomepage) {
-            QuickStartTourGuide.shared.visited(.editHomepage)
-        } else {
-            QuickStartTourGuide.shared.complete(tour: QuickStartEditHomepageTour(), for: blog, postNotification: false)
-        }
     }
 
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {

--- a/WordPress/WordPressTest/QuickStartFactoryTests.swift
+++ b/WordPress/WordPressTest/QuickStartFactoryTests.swift
@@ -99,17 +99,16 @@ class QuickStartFactoryTests: XCTestCase {
         let tours = QuickStartFactory.allTours(for: blog)
 
         // Then
-        XCTAssertEqual(tours.count, 10)
+        XCTAssertEqual(tours.count, 9)
         XCTAssertTrue(tours[0] is QuickStartCreateTour)
         XCTAssertTrue(tours[1] is QuickStartSiteTitleTour)
         XCTAssertTrue(tours[2] is QuickStartSiteIconTour)
-        XCTAssertTrue(tours[3] is QuickStartEditHomepageTour)
-        XCTAssertTrue(tours[4] is QuickStartReviewPagesTour)
-        XCTAssertTrue(tours[5] is QuickStartViewTour)
-        XCTAssertTrue(tours[6] is QuickStartShareTour)
-        XCTAssertTrue(tours[7] is QuickStartPublishTour)
-        XCTAssertTrue(tours[8] is QuickStartFollowTour)
-        XCTAssertTrue(tours[9] is QuickStartCheckStatsTour)
+        XCTAssertTrue(tours[3] is QuickStartReviewPagesTour)
+        XCTAssertTrue(tours[4] is QuickStartViewTour)
+        XCTAssertTrue(tours[5] is QuickStartShareTour)
+        XCTAssertTrue(tours[6] is QuickStartPublishTour)
+        XCTAssertTrue(tours[7] is QuickStartFollowTour)
+        XCTAssertTrue(tours[8] is QuickStartCheckStatsTour)
     }
 
     private func newTestBlog(id: Int) -> Blog {


### PR DESCRIPTION
Part of #18387
Fixes #18066

## Description
- Deleted "Edit your homepage" tour 

## Notes
- Ref: p1650465006026059/1650367281.046699-slack-C027K4MNPGQ
- We realized that the "Edit your homepage" tour and the "Review site pages" tour were very similar -- we opted to delete "Edit your homepage" over "Review site pages" since it would resolve #18066


Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/165773747-77f0457e-3cf7-4a6f-8ed8-7c34b08c32aa.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/165772981-1f5f2510-d643-4d06-a926-843b3bbb56fe.png" width=200>

## How to test

1. Enable Quick Start for New Users via the debug menu
2. Open the Customize Your Site checklist
3. ✅ Verify: The "Edit your homepage" tour is not included
4. Go through all the tours
5. ✅ Verify: All tours behave as expected

## Regression Notes
1. Potential unintended areas of impact
- Quick Start for New Users

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the steps above

6. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.