### PR TITLE
[Site Design Revamp] Update title text and remove subtext

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -12,7 +12,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     let accessoryView: UIView?
     let mainTitle: String
     let navigationBarTitle: String?
-    let prompt: String
+    let prompt: String?
     let primaryActionTitle: String
     let secondaryActionTitle: String?
     let defaultActionTitle: String?
@@ -189,7 +189,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
          mainTitle: String,
          navigationBarTitle: String? = nil,
          headerImage: UIImage? = nil,
-         prompt: String,
+         prompt: String? = nil,
          primaryActionTitle: String,
          secondaryActionTitle: String? = nil,
          defaultActionTitle: String? = nil,
@@ -323,6 +323,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         titleView.text = navigationBarTitle ?? mainTitle
         titleView.sizeToFit()
         largeTitleView.text = mainTitle
+        promptView.isHidden = prompt == nil
         promptView.text = prompt
         primaryActionButton.setTitle(primaryActionTitle, for: .normal)
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -54,7 +54,7 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     init(
         analyticsLocation: String,
         mainTitle: String,
-        prompt: String,
+        prompt: String? = nil,
         primaryActionTitle: String,
         secondaryActionTitle: String? = nil,
         defaultActionTitle: String? = nil

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -70,7 +70,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: TextContent.mainTitle,
-            prompt: TextContent.subtitle,
+            prompt: "",
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
@@ -82,6 +82,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        promptView.isHidden = true
         navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()
@@ -162,7 +163,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     private enum TextContent {
         static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
-        static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
         static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
         static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -70,7 +70,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         super.init(
             analyticsLocation: "site_creation",
             mainTitle: TextContent.mainTitle,
-            prompt: "",
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
             secondaryActionTitle: TextContent.previewButton
         )
@@ -82,7 +81,6 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        promptView.isHidden = true
         navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -161,7 +161,7 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
     }
 
     private enum TextContent {
-        static let mainTitle = NSLocalizedString("Choose a design", comment: "Title for the screen to pick a design and homepage for a site.")
+        static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
         static let subtitle = NSLocalizedString("Pick your favorite homepage layout. You can edit and customize it later.", comment: "Prompt for the screen to pick a design and homepage for a site.")
         static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
         static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")


### PR DESCRIPTION
Fixes items **B and C** in https://github.com/wordpress-mobile/WordPress-iOS/issues/18433.

This PR:
- Renames the title from "Choose a design" to "Choose a theme"
- Removes the subtext from the view (it was decided to not repurpose this text for a11y)

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-04-28 at 15 47 24](https://user-images.githubusercontent.com/2092798/165833779-9b66787f-8f4e-49df-a28a-0a647746b7bb.png) | ![image](https://user-images.githubusercontent.com/2092798/165834015-ad11853b-667f-412f-989c-d2ead039d6b7.png) |

## To test:

1. Start the Site Creation flow and navigate to the Site Design screen
2. Expect that the title is "Choose a theme"
3. Expect there to be no subtext (e.g. "Pick your favorite homepage layout...")

⚠️ On screen rotation there is a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/18475) that wasn't introduced with this PR.

## Regression Notes
1. Potential unintended areas of impact
    - Visual impacts of views that rely on the Collapsable Header View
        - Page layout view (when creating a new page)
        - Site Intent view (when creating a site)
        - Domain selection view (when creating a site, if not prompted to enter the site name)
        - Blogging prompts feature introduction view (this appears to be disabled behind a Feature Flag)

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Visiting the views above and testing scrolling + orientation changes.

3. What automated tests I added (or what prevented me from doing so)
    - These changes are primarily visual

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
