### PR TITLE
Move creating model instance function out from CoreDataStack mocks

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -980,7 +980,7 @@
 		598DD1711B97985700146967 /* ThemeBrowserCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598DD1701B97985700146967 /* ThemeBrowserCell.swift */; };
 		59A3CADD1CD2FF0C009BFA1B /* BasePageListCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A3CADC1CD2FF0C009BFA1B /* BasePageListCell.m */; };
 		59A9AB351B4C33A500A433DC /* ThemeService.m in Sources */ = {isa = PBXBuildFile; fileRef = 59A9AB341B4C33A500A433DC /* ThemeService.m */; };
-		59B48B621B99E132008EBB84 /* JSONLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B48B611B99E132008EBB84 /* JSONLoader.swift */; };
+		59B48B621B99E132008EBB84 /* JSONObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B48B611B99E132008EBB84 /* JSONObject.swift */; };
 		59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59DCA5201CC68AF3000F245F /* PageListViewController.swift */; };
 		59DD94341AC479ED0032DD6B /* WPLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 59DD94331AC479ED0032DD6B /* WPLogger.m */; };
 		59E1D46E1CEF77B500126697 /* Page.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E1D46C1CEF77B500126697 /* Page.swift */; };
@@ -5752,7 +5752,7 @@
 		59A9AB331B4C33A500A433DC /* ThemeService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ThemeService.h; sourceTree = "<group>"; };
 		59A9AB341B4C33A500A433DC /* ThemeService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ThemeService.m; sourceTree = "<group>"; };
 		59A9AB391B4C3ECD00A433DC /* LocalCoreDataServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LocalCoreDataServiceTests.m; sourceTree = "<group>"; };
-		59B48B611B99E132008EBB84 /* JSONLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONLoader.swift; path = TestUtilities/JSONLoader.swift; sourceTree = "<group>"; };
+		59B48B611B99E132008EBB84 /* JSONObject.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONObject.swift; path = TestUtilities/JSONObject.swift; sourceTree = "<group>"; };
 		59DCA5201CC68AF3000F245F /* PageListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		59DD94321AC479ED0032DD6B /* WPLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPLogger.h; sourceTree = "<group>"; };
 		59DD94331AC479ED0032DD6B /* WPLogger.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPLogger.m; sourceTree = "<group>"; };
@@ -10248,7 +10248,7 @@
 		59B48B601B99E0B0008EBB84 /* TestUtilities */ = {
 			isa = PBXGroup;
 			children = (
-				59B48B611B99E132008EBB84 /* JSONLoader.swift */,
+				59B48B611B99E132008EBB84 /* JSONObject.swift */,
 				E157D5DF1C690A6C00F04FB9 /* ImmuTableTestUtils.swift */,
 				570BFD8F2282418A007859A8 /* PostBuilder.swift */,
 				57B71D4D230DB5F200789A68 /* BlogBuilder.swift */,
@@ -19884,7 +19884,7 @@
 				175CC17527205BFB00622FB4 /* DomainExpiryDateFormatterTests.swift in Sources */,
 				B5416CFE1C1756B900006DD8 /* PushNotificationsManagerTests.m in Sources */,
 				321955C124BE4EBF00E3F316 /* ReaderSelectInterestsCoordinatorTests.swift in Sources */,
-				59B48B621B99E132008EBB84 /* JSONLoader.swift in Sources */,
+				59B48B621B99E132008EBB84 /* JSONObject.swift in Sources */,
 				3F82310F24564A870086E9B8 /* ReaderTabViewTests.swift in Sources */,
 				C3E42AB027F4D30E00546706 /* MenuItemsViewControllerTests.swift in Sources */,
 				D842EA4021FABB1800210E96 /* SiteSegmentTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -920,6 +920,7 @@
 		46F584B82624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F58501262605930010A723 /* BlockEditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */; };
+		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
 		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
@@ -5679,6 +5680,7 @@
 		46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlockEditorSettings+GutenbergEditorSettings.swift"; sourceTree = "<group>"; };
 		46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceTests.swift; sourceTree = "<group>"; };
 		46F84612185A8B7E009D0DA5 /* PostContentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostContentProvider.h; sourceTree = "<group>"; };
+		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		528B9926294302CD0A4EB5C4 /* Pods-WordPressScreenshotGeneration.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -14142,6 +14144,7 @@
 			children = (
 				E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */,
 				E1B642121EFA5113001DC6D7 /* ModelTestHelper.swift */,
+				4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */,
 				93E9050519E6F3D8005513C9 /* ContextManagerMock.h */,
 				93E9050619E6F3D8005513C9 /* ContextManagerMock.m */,
 				8BD6E34B24775164009AE97C /* TestContextManager.h */,
@@ -19995,6 +19998,7 @@
 				8B749E9025AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift in Sources */,
 				F1450CF72437E8F800A28BFE /* MediaHostTests.swift in Sources */,
 				436D55F02115CB6800CEAA33 /* RegisterDomainDetailsSectionTests.swift in Sources */,
+				4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */,
 				E1B921BC1C0ED5A3003EA3CB /* MediaSizeSliderCellTest.swift in Sources */,
 				C314543B262770BE005B216B /* BlogServiceAuthorTests.swift in Sources */,
 				40F50B80221310D400CBBB73 /* FollowersStatsRecordValueTests.swift in Sources */,

--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -15,6 +15,6 @@ final class ActivityContentFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -15,6 +15,6 @@ final class ActivityContentFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 }

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -28,7 +28,7 @@ class ActivityLogTestData {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 
     func getCommentEventDictionary() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -28,7 +28,7 @@ class ActivityLogTestData {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 
     func getCommentEventDictionary() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/ContextManagerMock.h
+++ b/WordPress/WordPressTest/ContextManagerMock.h
@@ -22,17 +22,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @interface ContextManagerMock : ContextManager <ManagerMock, CoreDataStack>
 
-
-/**
- *  @brief      Loads the contents of any given JSON file into a new NSManagedObject instance
- *  @details    This helper method is useful for Unit Testing scenarios.
- *
- *  @param      entityName  The name of the entity to be inserted.
- *  @param      filename    The name of the JSON file to be loaded.
- */
-- (NSManagedObject *)loadEntityNamed:(NSString *)entityName withContentsOfFile:(NSString *)filename;
-- (NSDictionary *)objectWithContentOfFile:(NSString *)filename;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/WordPressTest/ContextManagerMock.m
+++ b/WordPress/WordPressTest/ContextManagerMock.m
@@ -124,39 +124,4 @@
     return [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPressTest.sqlite"]];
 }
 
-- (NSManagedObject *)loadEntityNamed:(NSString *)entityName withContentsOfFile:(NSString *)filename
-{
-    NSParameterAssert(entityName);
-
-    NSDictionary *dict = [self objectWithContentOfFile:filename];
-
-    // Insert + Set Values
-    NSManagedObject *object= [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:self.mainContext];
-
-    for (NSString *key in dict.allKeys) {
-        [object setValue:dict[key] forKey:key];
-    }
-
-    return object;
-}
-
-- (NSDictionary *)objectWithContentOfFile:(NSString *)filename
-{
-    NSParameterAssert(filename);
-
-    // Load the Raw JSON
-    NSString *name      = filename.stringByDeletingPathExtension;
-    NSString *extension = filename.pathExtension;
-    NSString *path      = [[NSBundle bundleForClass:[self class]] pathForResource:name ofType:extension];
-    NSData *contents    = [NSData dataWithContentsOfFile:path];
-    NSAssert(contents, @"Mockup data could not be loaded");
-
-    // Parse
-    NSDictionary *dict  = [NSJSONSerialization JSONObjectWithData:contents
-                                                          options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves
-                                                            error:nil];
-    NSAssert(dict, @"Mockup data could not be parsed");
-    return dict;
-}
-
 @end

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -138,7 +138,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 
     private func loadLikeNotification() -> WordPress.Notification {

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -138,7 +138,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 
     private func loadLikeNotification() -> WordPress.Notification {

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -64,6 +64,6 @@ final class FormattableContentGroupTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 }

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -64,6 +64,6 @@ final class FormattableContentGroupTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -138,7 +138,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
     private func loadMeta() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -134,7 +134,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 
     private func loadLikeNotification() -> WordPress.Notification {

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -134,11 +134,11 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 
     private func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
     }
 
     private func loadMeta() -> [String: AnyObject] {

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -9,9 +9,7 @@ extension NSManagedObject {
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
     static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) -> Self {
-        guard let jsonObject = JSONLoader().loadFile(named: fileName) else {
-            fatalError("Mockup data could not be parsed, the filename is \(fileName)")
-        }
+        let jsonObject = JSONObject.loadFile(named: fileName)
         let model = Self.init(context: context)
         for (key, value) in jsonObject {
             model.setValue(value, forKey: key)

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -1,0 +1,24 @@
+import CoreData
+
+extension NSManagedObject {
+
+    /// Loads the contents of any given JSON file into a new NSManagedObject instance.
+    ///
+    /// This helper method is useful for Unit Testing scenarios.
+    ///
+    /// - Parameters:
+    ///   - filename: The name of the JSON file to be loaded
+    ///   - context: The managed object context to use
+    /// - Returns: A new instance with property values of the given JSON file.
+    static func fixture(fromFile filename: String, context: NSManagedObjectContext) -> Self {
+        guard let jsonObject = JSONLoader().loadFile(named: filename) else {
+            fatalError("Mockup data could not be parsed, the filename is \(filename)")
+        }
+        let model = Self.init(context: context)
+        for (key, value) in jsonObject {
+            model.setValue(value, forKey: key)
+        }
+        return model
+    }
+
+}

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -2,7 +2,7 @@ import CoreData
 
 extension NSManagedObject {
 
-    /// Loads the contents of any given JSON file into a new NSManagedObject instance.
+    /// Loads the contents of any given JSON file into a new `NSManagedObject` instance.
     ///
     /// This helper method is useful for Unit Testing scenarios.
     ///

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -10,7 +10,7 @@ extension NSManagedObject {
     ///   - filename: The name of the JSON file to be loaded
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
-    static func fixture(fromFile filename: String, context: NSManagedObjectContext) -> Self {
+    static func fixture(fromFile fileName: String, context: NSManagedObjectContext) -> Self {
         guard let jsonObject = JSONLoader().loadFile(named: filename) else {
             fatalError("Mockup data could not be parsed, the filename is \(filename)")
         }

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -4,13 +4,11 @@ extension NSManagedObject {
 
     /// Loads the contents of any given JSON file into a new `NSManagedObject` instance.
     ///
-    /// This helper method is useful for Unit Testing scenarios.
-    ///
     /// - Parameters:
     ///   - filename: The name of the JSON file to be loaded
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
-    static func fixture(fromFile fileName: String, context: NSManagedObjectContext) -> Self {
+    static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) -> Self {
         guard let jsonObject = JSONLoader().loadFile(named: fileName) else {
             fatalError("Mockup data could not be parsed, the filename is \(fileName)")
         }

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -11,8 +11,8 @@ extension NSManagedObject {
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
     static func fixture(fromFile fileName: String, context: NSManagedObjectContext) -> Self {
-        guard let jsonObject = JSONLoader().loadFile(named: filename) else {
-            fatalError("Mockup data could not be parsed, the filename is \(filename)")
+        guard let jsonObject = JSONLoader().loadFile(named: fileName) else {
+            fatalError("Mockup data could not be parsed, the filename is \(fileName)")
         }
         let model = Self.init(context: context)
         for (key, value) in jsonObject {

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -65,6 +65,6 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -65,6 +65,6 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 }

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -155,7 +155,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
         // Inject Dummy Note
         let path = "notifications-like.json"
-        let note = WordPress.Notification.fixture(fromFile: path, context: manager.mainContext)
+        let note = WordPress.Notification.fixture(fromFile: path, insertInto: manager.mainContext)
 
         XCTAssertNotNil(note)
         XCTAssertFalse(note.read)
@@ -187,9 +187,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = WordPress.Notification.fixture(fromFile: path1, context: manager.mainContext)
-        let note2 = WordPress.Notification.fixture(fromFile: path2, context: manager.mainContext)
-        let note3 = WordPress.Notification.fixture(fromFile: path3, context: manager.mainContext)
+        let note1 = WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
+        let note2 = WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
+        let note3 = WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)
@@ -225,9 +225,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = WordPress.Notification.fixture(fromFile: path1, context: manager.mainContext)
-        let note2 = WordPress.Notification.fixture(fromFile: path2, context: manager.mainContext)
-        let note3 = WordPress.Notification.fixture(fromFile: path3, context: manager.mainContext)
+        let note1 = WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
+        let note2 = WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
+        let note3 = WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -155,7 +155,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
         // Inject Dummy Note
         let path = "notifications-like.json"
-        let note = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path) as! WordPress.Notification
+        let note = WordPress.Notification.fixture(fromFile: path, context: manager.mainContext)
 
         XCTAssertNotNil(note)
         XCTAssertFalse(note.read)
@@ -187,9 +187,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path1) as! WordPress.Notification
-        let note2 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path2) as! WordPress.Notification
-        let note3 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path3) as! WordPress.Notification
+        let note1 = WordPress.Notification.fixture(fromFile: path1, context: manager.mainContext)
+        let note2 = WordPress.Notification.fixture(fromFile: path2, context: manager.mainContext)
+        let note3 = WordPress.Notification.fixture(fromFile: path3, context: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)
@@ -225,9 +225,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path1) as! WordPress.Notification
-        let note2 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path2) as! WordPress.Notification
-        let note3 = manager.loadEntityNamed(Notification.entityName(), withContentsOfFile: path3) as! WordPress.Notification
+        let note1 = WordPress.Notification.fixture(fromFile: path1, context: manager.mainContext)
+        let note2 = WordPress.Notification.fixture(fromFile: path2, context: manager.mainContext)
+        let note3 = WordPress.Notification.fixture(fromFile: path3, context: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -96,11 +96,11 @@ final class NotificationTextContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 
     private func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -100,7 +100,7 @@ final class NotificationTextContentTests: XCTestCase {
     }
 
     private func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -96,7 +96,7 @@ final class NotificationTextContentTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 
     private func loadLikeNotification() -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -21,27 +21,27 @@ class NotificationUtility {
     }
 
     func loadBadgeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-badge.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-badge.json", insertInto: contextManager.mainContext)
     }
 
     func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
     func loadFollowerNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-new-follower.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-new-follower.json", insertInto: contextManager.mainContext)
     }
 
     func loadCommentNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-replied-comment.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-replied-comment.json", insertInto: contextManager.mainContext)
     }
 
     func loadUnapprovedCommentNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-unapproved-comment.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-unapproved-comment.json", insertInto: contextManager.mainContext)
     }
 
     func loadPingbackNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-pingback.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-pingback.json", insertInto: contextManager.mainContext)
     }
 
     func mockCommentContent() -> FormattableCommentContent {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -21,31 +21,31 @@ class NotificationUtility {
     }
 
     func loadBadgeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-badge.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-badge.json", context: contextManager.mainContext)
     }
 
     func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
     }
 
     func loadFollowerNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-new-follower.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-new-follower.json", context: contextManager.mainContext)
     }
 
     func loadCommentNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-replied-comment.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-replied-comment.json", context: contextManager.mainContext)
     }
 
     func loadUnapprovedCommentNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-unapproved-comment.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-unapproved-comment.json", context: contextManager.mainContext)
     }
 
     func loadPingbackNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-pingback.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-pingback.json", context: contextManager.mainContext)
     }
 
     func mockCommentContent() -> FormattableCommentContent {
-        let dictionary = contextManager.object(withContentOfFile: "notifications-replied-comment.json") as! [String: AnyObject]
+        let dictionary = JSONLoader().loadFile(named: "notifications-replied-comment.json") ?? [:]
         let body = dictionary["body"]
         let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -45,7 +45,7 @@ class NotificationUtility {
     }
 
     func mockCommentContent() -> FormattableCommentContent {
-        let dictionary = JSONLoader().loadFile(named: "notifications-replied-comment.json") ?? [:]
+        let dictionary = JSONObject.loadFile(named: "notifications-replied-comment.json")
         let body = dictionary["body"]
         let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -36,7 +36,7 @@ final class NotificationsContentFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONLoader().loadFile(named: fileName) ?? [:]
+        return JSONObject.loadFile(named: fileName)
     }
 
     func loadLikeNotification() -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -36,10 +36,10 @@ final class NotificationsContentFactoryTests: XCTestCase {
     }
 
     private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return contextManager.object(withContentOfFile: fileName) as! [String: AnyObject]
+        return JSONLoader().loadFile(named: fileName) ?? [:]
     }
 
     func loadLikeNotification() -> WordPress.Notification {
-        return contextManager.loadEntityNamed(entityName, withContentsOfFile: "notifications-like.json") as! WordPress.Notification
+        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
     }
 }

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -40,6 +40,6 @@ final class NotificationsContentFactoryTests: XCTestCase {
     }
 
     func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", context: contextManager.mainContext)
+        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 }

--- a/WordPress/WordPressTest/PinghubTests.swift
+++ b/WordPress/WordPressTest/PinghubTests.swift
@@ -106,7 +106,7 @@ class PingHubTests: XCTestCase {
 
 private extension PingHubTests {
     func loadJSONMessage(name: String) -> [String: AnyObject]? {
-        return JSONLoader().loadFile(name, type: "json")
+        return JSONObject.loadFile(name, type: "json")
     }
 }
 

--- a/WordPress/WordPressTest/TestContextManager.h
+++ b/WordPress/WordPressTest/TestContextManager.h
@@ -23,17 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable,  readwrite, strong) XCTestExpectation   *testExpectation;
 @property (nonatomic, strong, nullable) id<ManagerMock, CoreDataStack>  stack;
 
-
-/**
- *  @brief      Loads the contents of any given JSON file into a new NSManagedObject instance
- *  @details    This helper method is useful for Unit Testing scenarios.
- *
- *  @param      entityName  The name of the entity to be inserted.
- *  @param      filename    The name of the JSON file to be loaded.
- */
-- (NSManagedObject *)loadEntityNamed:(NSString *)entityName withContentsOfFile:(NSString *)filename;
-- (NSDictionary *)objectWithContentOfFile:(NSString *)filename;
-
 + (instancetype)sharedInstance;
 + (void)overrideSharedInstance:(id <CoreDataStack> _Nullable)contextManager;
 

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -109,41 +109,6 @@ static TestContextManager *_instance;
     return [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPressTest.sqlite"]];
 }
 
-- (NSManagedObject *)loadEntityNamed:(NSString *)entityName withContentsOfFile:(NSString *)filename
-{
-    NSParameterAssert(entityName);
-
-    NSDictionary *dict = [self objectWithContentOfFile:filename];
-
-    // Insert + Set Values
-    NSManagedObject *object= [NSEntityDescription insertNewObjectForEntityForName:entityName inManagedObjectContext:self.mainContext];
-
-    for (NSString *key in dict.allKeys) {
-        [object setValue:dict[key] forKey:key];
-    }
-
-    return object;
-}
-
-- (NSDictionary *)objectWithContentOfFile:(NSString *)filename
-{
-    NSParameterAssert(filename);
-
-    // Load the Raw JSON
-    NSString *name      = filename.stringByDeletingPathExtension;
-    NSString *extension = filename.pathExtension;
-    NSString *path      = [[NSBundle bundleForClass:[self class]] pathForResource:name ofType:extension];
-    NSData *contents    = [NSData dataWithContentsOfFile:path];
-    NSAssert(contents, @"Mockup data could not be loaded");
-
-    // Parse
-    NSDictionary *dict  = [NSJSONSerialization JSONObjectWithData:contents
-                                                          options:NSJSONReadingMutableContainers | NSJSONReadingMutableLeaves
-                                                            error:nil];
-    NSAssert(dict, @"Mockup data could not be parsed");
-    return dict;
-}
-
 + (instancetype)sharedInstance
 {
     if (_instance) {

--- a/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
@@ -4,13 +4,12 @@ import Foundation
 @objc open class JSONLoader: NSObject {
     public typealias JSONDictionary = Dictionary<String, AnyObject>
 
-    /**
-    *  @brief      Loads the specified json file name and returns a dictionary representing it.
-    *
-    *  @param      path    The path of the json file to load.
-    *
-    *  @returns    A dictionary representing the contents of the json file.
-    */
+    /// Loads the specified json file and returns a dictionary representing it.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the file
+    ///   - type: The extension of the file
+    /// - Returns: A dictionary representing the contents of the json file.
     open func loadFile(_ name: String, type: String) -> JSONDictionary? {
 
         let path = Bundle(for: Swift.type(of: self)).path(forResource: name, ofType: type)
@@ -22,13 +21,10 @@ import Foundation
         }
     }
 
-    /**
-     *  @brief      Loads the specified json file name and returns a dictionary representing it.
-     *
-     *  @param      path    The path of the json file to load.
-     *
-     *  @returns    A dictionary representing the contents of the json file.
-     */
+    /// Loads the specified json file and returns a dictionary representing it.
+    ///
+    /// - Parameter path: The path of the json file to load.
+    /// - Returns: A dictionary representing the contents of the json file.
     open func loadFile(_ path: String) -> JSONDictionary? {
 
         if let contents = try? Data(contentsOf: URL(fileURLWithPath: path)) {
@@ -36,6 +32,17 @@ import Foundation
         }
 
         return nil
+    }
+
+    /// Loads the specified json file and returns a dictionary representing it.
+    ///
+    /// - Parameter filename: The full name of the json file to load.
+    /// - Returns: A dictionary representing the contents of the json file.
+    open func loadFile(named filename: String) -> JSONDictionary? {
+        return loadFile(
+            (filename as NSString).deletingPathExtension,
+            type: (filename as NSString).pathExtension
+        )
     }
 
     fileprivate func parseData(_ data: Data) -> JSONDictionary? {

--- a/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
@@ -4,12 +4,12 @@ import Foundation
 @objc open class JSONLoader: NSObject {
     public typealias JSONDictionary = Dictionary<String, AnyObject>
 
-    /// Loads the specified json file and returns a dictionary representing it.
+    /// Loads the specified JSON file and returns a dictionary representing it.
     ///
     /// - Parameters:
     ///   - name: The name of the file
     ///   - type: The extension of the file
-    /// - Returns: A dictionary representing the contents of the json file.
+    /// - Returns: A dictionary representing the contents of the JSON file.
     open func loadFile(_ name: String, type: String) -> JSONDictionary? {
 
         let path = Bundle(for: Swift.type(of: self)).path(forResource: name, ofType: type)

--- a/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONLoader.swift
@@ -1,8 +1,20 @@
 
 import Foundation
 
-@objc open class JSONLoader: NSObject {
-    public typealias JSONDictionary = Dictionary<String, AnyObject>
+typealias JSONObject = Dictionary<String, AnyObject>
+
+extension JSONObject {
+
+    /// Loads the specified json file and returns a dictionary representing it.
+    ///
+    /// - Parameter fileName: The full name of the json file to load.
+    /// - Returns: A dictionary representing the contents of the json file.
+    static func loadFile(named fileName: String) -> JSONObject {
+        return loadFile(
+            (fileName as NSString).deletingPathExtension,
+            type: (fileName as NSString).pathExtension
+        )
+    }
 
     /// Loads the specified JSON file and returns a dictionary representing it.
     ///
@@ -10,49 +22,25 @@ import Foundation
     ///   - name: The name of the file
     ///   - type: The extension of the file
     /// - Returns: A dictionary representing the contents of the JSON file.
-    open func loadFile(_ name: String, type: String) -> JSONDictionary? {
-
-        let path = Bundle(for: Swift.type(of: self)).path(forResource: name, ofType: type)
-
-        if let unwrappedPath = path {
-            return loadFile(unwrappedPath)
-        } else {
-            return nil
+    static func loadFile(_ name: String, type: String) -> JSONObject {
+        guard let url = Bundle(for: BundlerFinder.self).url(forResource: name, withExtension: type) else {
+            fatalError("File not found in the test bundle: \(name).\(type)")
         }
-    }
-
-    /// Loads the specified json file and returns a dictionary representing it.
-    ///
-    /// - Parameter path: The path of the json file to load.
-    /// - Returns: A dictionary representing the contents of the json file.
-    open func loadFile(_ path: String) -> JSONDictionary? {
-
-        if let contents = try? Data(contentsOf: URL(fileURLWithPath: path)) {
-            return parseData(contents)
+        guard let data = try? Data(contentsOf: url) else {
+            fatalError("Can't read content of file: \(name).\(type)")
         }
-
-        return nil
-    }
-
-    /// Loads the specified json file and returns a dictionary representing it.
-    ///
-    /// - Parameter filename: The full name of the json file to load.
-    /// - Returns: A dictionary representing the contents of the json file.
-    open func loadFile(named filename: String) -> JSONDictionary? {
-        return loadFile(
-            (filename as NSString).deletingPathExtension,
-            type: (filename as NSString).pathExtension
-        )
-    }
-
-    fileprivate func parseData(_ data: Data) -> JSONDictionary? {
-        let options: JSONSerialization.ReadingOptions = [.mutableContainers, .mutableLeaves]
-
-        do {
-            let parseResult = try JSONSerialization.jsonObject(with: data as Data, options: options)
-            return parseResult as? JSONDictionary
-        } catch {
-            return nil
+        guard let parseResult = try? JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .mutableLeaves]) else {
+            fatalError("Can't parse file as JSON: \(name).\(type)")
         }
+        guard let result = parseResult as? JSONObject else {
+            fatalError("File content isn't a JSON object: \(name).\(type)")
+        }
+        return result
     }
+
+}
+
+/// Class for finding the test bundler
+private class BundlerFinder {
+    // Empty
 }

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -1,4 +1,3 @@
-
 import Foundation
 
 typealias JSONObject = Dictionary<String, AnyObject>


### PR DESCRIPTION
This PR is part of paaHJt-3ky-p2.

## Changes
Two methods are deleted from `TestContextManager` and `ContextManagerMock`:
* `objectWithContentOfFile:`, replaced with new function in [`JSONLoader`](https://github.com/wordpress-mobile/WordPress-iOS/blob/6544502af7e1151e6c28ec768375d52ad3d1e557/WordPress/WordPressTest/TestUtilities/JSONLoader.swift)
* `loadEntityNamed:withContentsOfFile:`, replaced with a new extension function to `NSManagedObject`.

## Test Instructions
Make sure all unit tests pass.

## Regression Notes
N/A. All changes in this PR are in unit test, they don't have any impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
