### PR TITLE
Blogging Prompts: Add creating a new post with a blogging prompt

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -1,0 +1,72 @@
+
+extension Post {
+
+    func prepareForPrompt(_ prompt: Prompt?) {
+        guard let prompt = prompt else { return }
+        postTitle = prompt.postTitle
+        let pullquoteBlock = getPullquoteBlock(title: prompt.promptText,
+                                               promptUrl: prompt.promptUrl?.absoluteString,
+                                               answerUrl: prompt.answerUrl?.absoluteString,
+                                               answerCount: prompt.answerCount)
+        content = pullquoteBlock + Strings.emptyParagraph
+    }
+
+}
+
+// MARK: - Private methods
+
+private extension Post {
+
+    func getPullquoteBlock(title: String,
+                           promptUrl: String?,
+                           answerUrl: String?,
+                           answerCount: Int) -> String {
+        let answerFormat = answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat
+        let answerText = String(format: answerFormat, answerCount)
+        let promptUrlHtml = getUrlHtml(url: promptUrl, urlText: Strings.prompt)
+        let answerUrlHtml = getUrlHtml(url: answerUrl, urlText: answerText)
+        let separatorText = promptUrlHtml.isEmpty || answerUrlHtml.isEmpty ? "" : " — "
+        let subtitleHtml = promptUrlHtml.isEmpty && answerUrlHtml.isEmpty ? "" :  "<cite>\(promptUrlHtml)\(separatorText)\(answerUrlHtml)</cite>"
+        return """
+            <!-- wp:pullquote -->
+            <figure class="wp-block-pullquote"><blockquote><p>\(title)</p>\(subtitleHtml)</blockquote></figure>
+            <!-- /wp:pullquote -->
+            """
+    }
+
+    func getUrlHtml(url: String?, urlText: String) -> String {
+        guard let url = url else { return "" }
+        return "<a href=\"\(url)\">\(urlText)</a>"
+    }
+
+    // MARK: - Strings
+
+    struct Strings {
+        static let prompt = NSLocalizedString("Prompt", comment: "Prompt link text in a new blogging prompts post")
+        static let answerInfoSingularFormat = NSLocalizedString("%1$d answer", comment: "Singular format string for displaying the number of users that answered the blogging prompt.")
+        static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users that answered the blogging prompt.")
+        static let emptyParagraph = """
+            <!-- wp:paragraph -->
+            <p></p>
+            <!-- /wp:paragraph -->
+            """
+    }
+
+}
+
+// MARK: - Temporary prompt object
+
+// TODO: Remove after prompt object is created and use that
+struct Prompt {
+    let postTitle: String
+    let promptText: String
+    let promptUrl: URL?
+    let answerUrl: URL?
+    let answerCount: Int
+
+    static let examplePrompt = Prompt(postTitle: "Cast the movie of my life",
+                                      promptText: "Cast the movie of your life.",
+                                      promptUrl: URL(string: "https://wordpress.com"),
+                                      answerUrl: URL(string: "https://wordpress.com"),
+                                      answerCount: 19)
+}

--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -2,7 +2,9 @@
 extension Post {
 
     func prepareForPrompt(_ prompt: Prompt?) {
-        guard let prompt = prompt else { return }
+        guard let prompt = prompt else {
+            return
+        }
         postTitle = prompt.postTitle
         let pullquoteBlock = getPullquoteBlock(title: prompt.promptText,
                                                promptUrl: prompt.promptUrl?.absoluteString,
@@ -35,7 +37,9 @@ private extension Post {
     }
 
     func getUrlHtml(url: String?, urlText: String) -> String {
-        guard let url = url else { return "" }
+        guard let url = url else {
+            return ""
+        }
         return "<a href=\"\(url)\">\(urlText)</a>"
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -23,6 +23,7 @@ class EditPostViewController: UIViewController {
     private let loadAutosaveRevision: Bool
 
     @objc fileprivate(set) var post: Post?
+    let prompt: Prompt?
     fileprivate var hasShownEditor = false
     fileprivate var editingExistingPost = false
     fileprivate let blog: Blog
@@ -60,13 +61,21 @@ class EditPostViewController: UIViewController {
         self.init(post: nil, blog: blog)
     }
 
+    /// Initialize as an editor to create a new post for the provided blog and prompt
+    ///
+    /// - Parameter blog: blog to create a new post for
+    /// - Parameter prompt: blogging prompt to configure the new post for
+    convenience init(blog: Blog, prompt: Prompt) {
+        self.init(post: nil, blog: blog, prompt: prompt)
+    }
+
     /// Initialize as an editor with a specified post to edit and blog to post too.
     ///
     /// - Parameters:
     ///   - post: the post to edit
     ///   - blog: the blog to create a post for, if post is nil
     /// - Note: it's preferable to use one of the convenience initializers
-    fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false) {
+    fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: Prompt? = nil) {
         self.post = post
         self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {
@@ -77,6 +86,7 @@ class EditPostViewController: UIViewController {
             post.fixLocalMediaURLs()
         }
         self.blog = blog
+        self.prompt = prompt
         super.init(nibName: nil, bundle: nil)
         modalPresentationStyle = .fullScreen
         modalTransitionStyle = .coverVertical
@@ -126,6 +136,7 @@ class EditPostViewController: UIViewController {
             let context = ContextManager.sharedInstance().mainContext
             let postService = PostService(managedObjectContext: context)
             let newPost = postService.createDraftPost(for: blog)
+            newPost.prepareForPrompt(prompt)
             post = newPost
             return newPost
         }

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -23,7 +23,7 @@ class EditPostViewController: UIViewController {
     private let loadAutosaveRevision: Bool
 
     @objc fileprivate(set) var post: Post?
-    let prompt: Prompt?
+    private let prompt: Prompt?
     fileprivate var hasShownEditor = false
     fileprivate var editingExistingPost = false
     fileprivate let blog: Blog

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1403,6 +1403,8 @@
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
 		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
+		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
+		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
@@ -6167,6 +6169,7 @@
 		8370D10811FA499A009D650F /* WPTableViewActivityCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableViewActivityCell.h; sourceTree = "<group>"; };
 		8370D10911FA499A009D650F /* WPTableViewActivityCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableViewActivityCell.m; sourceTree = "<group>"; };
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
+		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
@@ -13101,6 +13104,7 @@
 				B5BE31C31CB825A100BDF770 /* NSURLCache+Helpers.swift */,
 				E1CFC1561E0AC8FF001DF9E9 /* Pattern.swift */,
 				FF70A3201FD5840500BC270D /* PHAsset+Metadata.swift */,
+				83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */,
 				FFD12D5D1FE1998D00F20A00 /* Progress+Helpers.swift */,
 				AE2F3124270B6DA000B2A9C2 /* Scanner+QuotedText.swift */,
 				E177807F1C97FA9500FA7E14 /* StoreKit+Debug.swift */,
@@ -17928,6 +17932,7 @@
 				E66969DC1B9E55C300EC9C00 /* ReaderTopicToReaderListTopic37to38.swift in Sources */,
 				9A2D0B23225CB92B009E585F /* BlogService+JetpackConvenience.swift in Sources */,
 				C856748F243EF177001A995E /* GutenbergTenorMediaPicker.swift in Sources */,
+				83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */,
 				B50C0C5F1EF42A4A00372C65 /* AztecPostViewController.swift in Sources */,
 				086E1FE01BBB35D2002D86CA /* MenusViewController.m in Sources */,
 				FAFC064B27D22E4C002F0483 /* QuickStartTourStateView.swift in Sources */,
@@ -20268,6 +20273,7 @@
 				FABB21872602FC2C00C8785C /* NavBarTitleDropdownButton.m in Sources */,
 				FABB21882602FC2C00C8785C /* ReaderTopicsCardCell.swift in Sources */,
 				FA25FA342609AAAA0005E08F /* AppConfiguration.swift in Sources */,
+				83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */,
 				3FE3D1FC26A6F2AC00F3CD10 /* ListTableViewCell.swift in Sources */,
 				FABB21892602FC2C00C8785C /* PostService+RefreshStatus.swift in Sources */,
 				F1585405267D3B5000A2E966 /* BloggingRemindersFlowIntroViewController.swift in Sources */,


### PR DESCRIPTION
See: #18473

## Description

Adds the following:

- Allows a `Post` to be configured with a blogging prompt
- Adds an initializer for `EditPostViewController` to start a new post with a prompt

## Testing

There is no entry points using the initializer yet so manual changes will be necessary to test.

To test:
- Search for an instance of the edit post initializer `EditPostViewController(blog:`
- Use the example prompt (or create your own) and edit it to the new initializer `EditPostViewController(blog: blog, prompt: .examplePrompt)`
- Navigate to the entry point for that edit
- Start a new post and verify:
  - Visually:
    - Title matches prompt post title
    - Title of pullquote block matches the prompt text
    - Prompt URL matches URL used with creation of prompt object
    - Answer URL matches URL used with creation of prompt object
  - Post can be saved as a draft
  - Post can be posted and viewed


## Regression Notes

1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
