### PR TITLE
Add Blogging Prompts Service

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.50.0'
+    # pod 'WordPressKit', '~> 4.50.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'task/18324-site-creation-with-site-name'
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/blogging-prompts-remote'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.50.0'
+    pod 'WordPressKit', '~> 4.51.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/blogging-prompts-remote'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.50.0):
+  - WordPressKit (4.51.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -591,7 +591,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
-  - WordPressKit (~> 4.50.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/blogging-prompts-remote`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.1)
   - WordPressUI (~> 1.12.5)
@@ -640,7 +640,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -753,6 +752,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
+  WordPressKit:
+    :branch: feature/blogging-prompts-remote
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.75.0/third-party-podspecs/Yoga.podspec.json
 
@@ -768,6 +770,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
+  WordPressKit:
+    :commit: e5618661d0b8f3aa5371d340e2ccb31fb6df495c
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -853,7 +858,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: b5d9b13e7e627134c583d7c6736efa720b306615
+  WordPressKit: 516b88d84ea79503435747fd2ad14f9b0aa8c1f4
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -869,6 +874,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: a7ae8e10cd04d593d0975e33ff124062b1306f1c
+PODFILE CHECKSUM: 6c9781cee94ccf722431310c643ad558a12e3d78
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.51.0-beta.1):
+  - WordPressKit (4.51.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -853,7 +853,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: 13d8806fcc505a89144e1e3d240d17f52026d967
+  WordPressKit: 78ef3c3b083ecc933dca771b7db0a4bfb4be6ba3
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -591,7 +591,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/blogging-prompts-remote`)
+  - WordPressKit (~> 4.51.0-beta)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.1)
   - WordPressUI (~> 1.12.5)
@@ -603,6 +603,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -752,9 +753,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
-  WordPressKit:
-    :branch: feature/blogging-prompts-remote
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.75.0/third-party-podspecs/Yoga.podspec.json
 
@@ -770,9 +768,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
-  WordPressKit:
-    :commit: 32b70527fa0c5430598ae0ce3237f43c5967ae07
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -858,7 +853,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: 516b88d84ea79503435747fd2ad14f9b0aa8c1f4
+  WordPressKit: 13d8806fcc505a89144e1e3d240d17f52026d967
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -874,6 +869,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 6c9781cee94ccf722431310c643ad558a12e3d78
+PODFILE CHECKSUM: 3fa477a11aa74117f1a71675a488092c5cd5d560
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -771,7 +771,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.75.0
   WordPressKit:
-    :commit: e5618661d0b8f3aa5371d340e2ccb31fb6df495c
+    :commit: 32b70527fa0c5430598ae0ce3237f43c5967ae07
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -2,7 +2,6 @@ import CoreData
 import WordPressKit
 
 class BloggingPromptsService {
-
     private let context: NSManagedObjectContext
     private let siteID: NSNumber
     private let remote: BloggingPromptsServiceRemote
@@ -36,7 +35,9 @@ class BloggingPromptsService {
         }
     }
 
-    required init?(context: NSManagedObjectContext = ContextManager.shared.mainContext, blog: Blog? = nil) {
+    required init?(context: NSManagedObjectContext = ContextManager.shared.mainContext,
+                   remote: BloggingPromptsServiceRemote? = nil,
+                   blog: Blog? = nil) {
         guard let account = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
               let siteID = blog?.dotComID ?? account.primaryBlogID else {
             return nil
@@ -44,13 +45,13 @@ class BloggingPromptsService {
 
         self.context = context
         self.siteID = siteID
-        self.remote = .init(wordPressComRestApi: account.wordPressComRestV2Api)
+        self.remote = remote ?? .init(wordPressComRestApi: account.wordPressComRestV2Api)
     }
 }
 
 // MARK: - Temporary model object
 
-/// This is a temporary model to be replaced with Core Data model once the fields have all been finalized.
+/// TODO: This is a temporary model to be replaced with Core Data model once the fields have all been finalized.
 struct BloggingPrompt {
     let promptID: Int
     let text: String

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -1,0 +1,74 @@
+import CoreData
+import WordPressKit
+
+class BloggingPromptsService {
+
+    private let context: NSManagedObjectContext
+    private let siteID: NSNumber
+    private let remote: BloggingPromptsServiceRemote
+    private let calendar: Calendar = .autoupdatingCurrent
+
+    private var defaultDate: Date {
+        calendar.date(byAdding: .day, value: -10, to: Date()) ?? Date()
+    }
+
+    /// Fetches a number of blogging prompts starting from the specified date.
+    /// When no parameters are specified, this method will attempt to return prompts from ten days ago and two weeks ahead.
+    ///
+    /// - Parameters:
+    ///   - date: When specified, only prompts from the specified date will be returned. Defaults to 10 days ago.
+    ///   - number: The amount of prompts to return. Defaults to 24 when unspecified.
+    ///   - success: Closure to be called when the fetch process succeeded.
+    ///   - failure: Closure to be called when the fetch process failed.
+    func fetchPrompts(from date: Date? = nil,
+                      number: Int = 24,
+                      success: @escaping ([BloggingPrompt]) -> Void,
+                      failure: @escaping (Error?) -> Void) {
+        let fromDate = date ?? defaultDate
+        remote.fetchPrompts(for: siteID, number: number, fromDate: fromDate) { result in
+            switch result {
+            case .success(let remotePrompts):
+                // TODO: Upsert into CoreData once the CoreData model is available.
+                success(remotePrompts.map { BloggingPrompt(with: $0) })
+            case .failure(let error):
+                failure(error)
+            }
+        }
+    }
+
+    required init?(context: NSManagedObjectContext = ContextManager.shared.mainContext, blog: Blog? = nil) {
+        guard let account = AccountService(managedObjectContext: context).defaultWordPressComAccount(),
+              let siteID = blog?.dotComID ?? account.primaryBlogID else {
+            return nil
+        }
+
+        self.context = context
+        self.siteID = siteID
+        self.remote = .init(wordPressComRestApi: account.wordPressComRestV2Api)
+    }
+}
+
+// MARK: - Temporary model object
+
+/// This is a temporary model to be replaced with Core Data model once the fields have all been finalized.
+struct BloggingPrompt {
+    let promptID: Int
+    let text: String
+    let title: String // for post title
+    let content: String // for post content
+    let date: Date
+    let answered: Bool
+    let answerCount: Int
+    let displayAvatarURLs: [URL]
+
+    init(with remotePrompt: RemoteBloggingPrompt) {
+        promptID = remotePrompt.promptID
+        text = remotePrompt.text
+        title = remotePrompt.title
+        content = remotePrompt.content
+        date = remotePrompt.date
+        answered = remotePrompt.answered
+        answerCount = remotePrompt.answeredUsersCount
+        displayAvatarURLs = remotePrompt.answeredUserAvatarURLs
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4555,6 +4555,7 @@
 		FE23EB4C26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
 		FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
+		FE2E3729281C839C00A1E82A /* BloggingPromptsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */; };
 		FE32EFFF275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
 		FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
 		FE32F002275F602E0040BE67 /* CommentContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */; };
@@ -7816,6 +7817,7 @@
 		FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = richCommentTemplate.html; path = Resources/HTML/richCommentTemplate.html; sourceTree = "<group>"; };
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
+		FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceTests.swift; sourceTree = "<group>"; };
 		FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewController.swift; sourceTree = "<group>"; };
 		FE32F001275F602E0040BE67 /* CommentContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContentRenderer.swift; sourceTree = "<group>"; };
 		FE32F005275F62620040BE67 /* WebCommentContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCommentContentRenderer.swift; sourceTree = "<group>"; };
@@ -13279,6 +13281,7 @@
 				575802122357C41200E4C63C /* MediaCoordinatorTests.swift */,
 				46B30B772582C7DD00A25E66 /* SiteAddressServiceTests.swift */,
 				17FC0031264D728E00FCBD37 /* SharingServiceTests.swift */,
+				FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -19771,6 +19774,7 @@
 				B0A6DEBF2626335F00B5B8EF /* AztecPostViewController+MenuTests.swift in Sources */,
 				4054F43E221357B600D261AB /* TopCommentedPostStatsRecordValueTests.swift in Sources */,
 				93B853231B4416A30064FE72 /* WPAnalyticsTrackerAutomatticTracksTests.m in Sources */,
+				FE2E3729281C839C00A1E82A /* BloggingPromptsServiceTests.swift in Sources */,
 				D848CC0720FF2BE200A9038F /* NotificationContentRangeFactoryTests.swift in Sources */,
 				732A473F21878EB10015DA74 /* WPRichContentViewTests.swift in Sources */,
 				8BDA5A6D247C2F8400AB124C /* ReaderDetailViewControllerTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1354,16 +1354,16 @@
 		80EF672327F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
 		80EF672527F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */; };
 		80EF672627F3D63B0063B138 /* DashboardStatsStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */; };
-		80EF928D280E83110064A971 /* QuickStartToursCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928C280E83110064A971 /* QuickStartToursCollection.swift */; };
-		80EF928E280E83110064A971 /* QuickStartToursCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928C280E83110064A971 /* QuickStartToursCollection.swift */; };
-		80EF929028105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
-		80EF929128105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
-		80EF92932810FA5A0064A971 /* QuickStartFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */; };
 		80EF9284280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF9283280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift */; };
 		80EF9286280D272E0064A971 /* DashboardPostsSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF9285280D272E0064A971 /* DashboardPostsSyncManager.swift */; };
 		80EF9287280D272E0064A971 /* DashboardPostsSyncManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF9285280D272E0064A971 /* DashboardPostsSyncManager.swift */; };
 		80EF928A280D28140064A971 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF9289280D28140064A971 /* Atomic.swift */; };
 		80EF928B280D28140064A971 /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF9289280D28140064A971 /* Atomic.swift */; };
+		80EF928D280E83110064A971 /* QuickStartToursCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928C280E83110064A971 /* QuickStartToursCollection.swift */; };
+		80EF928E280E83110064A971 /* QuickStartToursCollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928C280E83110064A971 /* QuickStartToursCollection.swift */; };
+		80EF929028105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
+		80EF929128105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
+		80EF92932810FA5A0064A971 /* QuickStartFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -4586,6 +4586,8 @@
 		FEA088032696E81F00193358 /* ListTableHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEA088022696E81F00193358 /* ListTableHeaderView.xib */; };
 		FEA088052696F7AA00193358 /* WPStyleGuide+List.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */; };
 		FEA5CE7F2701DC8000B41F2A /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
+		FEA6517B281C491C002EA086 /* BloggingPromptsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */; };
+		FEA6517C281C491C002EA086 /* BloggingPromptsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */; };
 		FEA7948D26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
 		FEA7948E26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */; };
 		FEA7949026DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */; };
@@ -6109,12 +6111,12 @@
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsStackView.swift; sourceTree = "<group>"; };
-		80EF928C280E83110064A971 /* QuickStartToursCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartToursCollection.swift; sourceTree = "<group>"; };
-		80EF928F28105CFA0064A971 /* QuickStartFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactory.swift; sourceTree = "<group>"; };
-		80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactoryTests.swift; sourceTree = "<group>"; };
 		80EF9283280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPostsSyncManagerTests.swift; sourceTree = "<group>"; };
 		80EF9285280D272E0064A971 /* DashboardPostsSyncManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPostsSyncManager.swift; sourceTree = "<group>"; };
 		80EF9289280D28140064A971 /* Atomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		80EF928C280E83110064A971 /* QuickStartToursCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartToursCollection.swift; sourceTree = "<group>"; };
+		80EF928F28105CFA0064A971 /* QuickStartFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactory.swift; sourceTree = "<group>"; };
+		80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactoryTests.swift; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -7833,6 +7835,7 @@
 		FEA088002696E7F600193358 /* ListTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableHeaderView.swift; sourceTree = "<group>"; };
 		FEA088022696E81F00193358 /* ListTableHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ListTableHeaderView.xib; sourceTree = "<group>"; };
 		FEA088042696F7AA00193358 /* WPStyleGuide+List.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+List.swift"; sourceTree = "<group>"; };
+		FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsService.swift; sourceTree = "<group>"; };
 		FEA7948C26DD136700CEC520 /* CommentHeaderTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentHeaderTableViewCell.swift; sourceTree = "<group>"; };
 		FEA7948F26DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPStyleGuide+CommentDetail.swift"; sourceTree = "<group>"; };
 		FEAC916D28001FC4005026E7 /* AvatarTrainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarTrainView.swift; sourceTree = "<group>"; };
@@ -11916,6 +11919,7 @@
 				F1ADCAF6241FEF0C00F150D2 /* AtomicAuthenticationService.swift */,
 				F12FA5D82428FA8F0054DA21 /* AuthenticationService.swift */,
 				46F584812624DCC80010A723 /* BlockEditorSettingsService.swift */,
+				FEA6517A281C491C002EA086 /* BloggingPromptsService.swift */,
 				822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */,
 				93C1148318EDF6E100DAC95C /* BlogService.h */,
 				93C1148418EDF6E100DAC95C /* BlogService.m */,
@@ -19124,6 +19128,7 @@
 				C77FC90928009C7000726F00 /* OnboardingQuestionsPromptViewController.swift in Sources */,
 				8BE6F92C27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */,
 				FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */,
+				FEA6517B281C491C002EA086 /* BloggingPromptsService.swift in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,
 				D8212CC320AA7F57008E8AE8 /* ReaderBlockSiteAction.swift in Sources */,
 				5D44EB381986D8BA008B7175 /* ReaderSiteService.m in Sources */,
@@ -21369,6 +21374,7 @@
 				FABB253A2602FC2C00C8785C /* WordPressAppDelegate.swift in Sources */,
 				098B8577275E9765004D299F /* AppLocalizedString.swift in Sources */,
 				FABB253B2602FC2C00C8785C /* MediaService.m in Sources */,
+				FEA6517C281C491C002EA086 /* BloggingPromptsService.swift in Sources */,
 				FABB253C2602FC2C00C8785C /* FormattableContentAction.swift in Sources */,
 				3F3DD0B326FD176800F5F121 /* PresentationCard.swift in Sources */,
 				FABB253D2602FC2C00C8785C /* SiteVerticalsService.swift in Sources */,

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -1,0 +1,153 @@
+import XCTest
+
+@testable import WordPress
+
+final class BloggingPromptsServiceTests: XCTestCase {
+    private let siteID = 1
+    private let timeout: TimeInterval = 2
+    private var endpoint: String {
+        "sites/\(siteID)/blogging-prompts"
+    }
+
+    private var context: NSManagedObjectContext!
+    private var remote: BloggingPromptsServiceRemoteMock!
+    private var service: BloggingPromptsService!
+    private var blog: Blog!
+    private var accountService: AccountService!
+
+    override func setUp() {
+        super.setUp()
+
+        context = TestContextManager().mainContext
+        remote = BloggingPromptsServiceRemoteMock()
+        blog = makeBlog()
+        accountService = makeAccountService()
+        service = BloggingPromptsService(context: context, remote: remote, blog: blog)
+    }
+
+    override func tearDown() {
+        context.reset()
+        ContextManager.overrideSharedInstance(nil)
+
+        context = nil
+        remote = nil
+        blog = nil
+        accountService = nil
+        service = nil
+        super.tearDown()
+    }
+
+    // MARK: - Tests
+
+    func test_fetchPrompts_givenSuccessfulResult_callsSuccessBlock() {
+        let expectation = expectation(description: "Fetch prompts should succeed")
+
+        service.fetchPrompts { _ in
+            // TODO: Add mapping tests once CoreData model is added.
+            expectation.fulfill()
+        } failure: { _ in
+            XCTFail("This closure shouldn't be called.")
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func test_fetchPrompts_givenFailureResult_callsFailureBlock() {
+        let expectation = expectation(description: "Fetch prompts should fail")
+        remote.shouldReturnSuccess = false
+
+        service.fetchPrompts { _ in
+            XCTFail("This closure shouldn't be called.")
+            expectation.fulfill()
+        } failure: { _ in
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
+    }
+
+    func test_fetchPrompts_givenNoParameters_assignsDefaultValue() {
+        let expectedDifferenceInHours = 10 * 24 // 10 days ago.
+        let expectedNumber = 24
+        remote.shouldReturnSuccess = false
+
+        // call the fetch just to trigger default parameter assignment. the completion blocks can be ignored.
+        service.fetchPrompts(success: { _ in }, failure: { _ in })
+
+        XCTAssertNotNil(remote.passedDateParameter)
+        let passedDate = remote.passedDateParameter!
+        let differenceInHours = Calendar.autoupdatingCurrent.dateComponents([.hour], from: passedDate, to: Date()).hour!
+        XCTAssertEqual(differenceInHours, expectedDifferenceInHours)
+
+        XCTAssertNotNil(remote.passedNumberParameter)
+        XCTAssertEqual(remote.passedNumberParameter!, expectedNumber)
+    }
+
+    func test_fetchPrompts_givenValidParameters_passesThemToRemote() {
+        let expectedDate = BloggingPromptsServiceRemoteMock.dateFormatter.date(from: "2022-01-02")!
+        let expectedNumber = 10
+        remote.shouldReturnSuccess = false
+
+        // call the fetch just to trigger default parameter assignment. the completion blocks can be ignored.
+        service.fetchPrompts(from: expectedDate, number: expectedNumber, success: { _ in }, failure: { _ in })
+
+        XCTAssertNotNil(remote.passedDateParameter)
+        XCTAssertEqual(remote.passedDateParameter!, expectedDate)
+
+        XCTAssertNotNil(remote.passedNumberParameter)
+        XCTAssertEqual(remote.passedNumberParameter!, expectedNumber)
+    }
+}
+
+
+// MARK: - Helpers
+
+private extension BloggingPromptsServiceTests {
+    func makeAccountService() -> AccountService {
+        let service = AccountService(managedObjectContext: context)
+        let account = service.createOrUpdateAccount(withUsername: "testuser", authToken: "authtoken")
+        account.userID = NSNumber(value: 1)
+        service.setDefaultWordPressComAccount(account)
+
+        return service
+    }
+
+    func makeBlog() -> Blog {
+        return BlogBuilder(context).isHostedAtWPcom().build()
+    }
+}
+
+class BloggingPromptsServiceRemoteMock: BloggingPromptsServiceRemote {
+    var passedSiteID: NSNumber? = nil
+    var passedNumberParameter: Int? = nil
+    var passedDateParameter: Date? = nil
+    var shouldReturnSuccess: Bool = true
+
+    override func fetchPrompts(for siteID: NSNumber,
+                               number: Int? = nil,
+                               fromDate: Date? = nil,
+                               completion: @escaping (Result<[RemoteBloggingPrompt], Error>) -> Void) {
+        passedSiteID = siteID
+        passedNumberParameter = number
+        passedDateParameter = fromDate
+
+        if shouldReturnSuccess {
+            completion(.success([]))
+        } else {
+            completion(.failure(Errors.failed))
+        }
+    }
+
+    enum Errors: Error {
+        case failed
+    }
+
+    static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        return formatter
+    }()
+}


### PR DESCRIPTION
Refs #18375 
Depends on https://github.com/wordpress-mobile/WordPressKit-iOS/pull/496

This adds a Service that fetches the blogging prompts from the remote service. Additionally, since the fields for the model aren't finalized yet (there's still the `attribution` field coming), I've temporarily created a `BloggingPrompt` struct for the model so the UI can be wired with the service.

Hopefully, when the Core Data model comes along, there's minimal to no change required for the UI (famous last words 😆 ).

## To Test

Run the unit tests and ensure that they are passing.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
Added tests for `BloggingPromptsService`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] Update the Podfile once https://github.com/wordpress-mobile/WordPressKit-iOS/pull/496 has been merged.
