### PR TITLE
Feature Introduction: show header titles in compact height

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-// TODO: add description
+/// This displays a Feature Introduction specifically for Blogging Prompts.
 
 class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -25,6 +25,20 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
 
     weak var featureIntroductionDelegate: FeatureIntroductionDelegate?
 
+    // MARK: - Header View Configuration
+
+    override var separatorStyle: SeparatorStyle {
+        return .hidden
+    }
+
+    override var alwaysResetHeaderOnRotation: Bool {
+        WPDeviceIdentification.isiPhone()
+    }
+
+    override var alwaysShowHeaderTitles: Bool {
+        true
+    }
+
     // MARK: - Init
 
     init(headerTitle: String,

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -5,7 +5,11 @@ import UIKit
     @objc optional func secondaryActionSelected()
 }
 
-// TODO: add description
+/// This is used to display a modal with information about a new feature.
+/// The feature description is displayed via the provided featureDescriptionView,
+/// which is presented in the scrollable area of the view.
+/// A primary action button is always displayed.
+/// A secondary action button is displayed if a secondaryButtonTitle is provided.
 
 class FeatureIntroductionViewController: CollapsableHeaderViewController {
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -126,7 +126,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     }
 
     private var shouldUseCompactLayout: Bool {
-        return alwaysShowHeaderTitles ? false : (traitCollection.verticalSizeClass == .compact)
+        return !alwaysShowHeaderTitles && traitCollection.verticalSizeClass == .compact
     }
 
     private var topInset: CGFloat = 0

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -30,6 +30,13 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         false
     }
 
+    // If set to true, all header titles will always be shown.
+    // If set to false, largeTitleView and promptView labels are hidden in compact height (default behavior).
+    //
+    var alwaysShowHeaderTitles: Bool {
+        false
+    }
+
     private let hasDefaultAction: Bool
     private var notificationObservers: [NSObjectProtocol] = []
     @IBOutlet weak var containerView: UIView!
@@ -55,6 +62,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     @IBOutlet weak var promptView: UILabel!
     @IBOutlet weak var accessoryBar: UIView!
     @IBOutlet weak var accessoryBarHeightConstraint: NSLayoutConstraint!
+    @IBOutlet weak var accessoryBarTopCompactConstraint: NSLayoutConstraint!
     @IBOutlet weak var footerView: UIView!
     @IBOutlet weak var footerHeightContraint: NSLayoutConstraint!
     @IBOutlet weak var defaultActionButton: UIButton!
@@ -118,7 +126,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     }
 
     private var shouldUseCompactLayout: Bool {
-        return traitCollection.verticalSizeClass == .compact
+        return alwaysShowHeaderTitles ? false : (traitCollection.verticalSizeClass == .compact)
     }
 
     private var topInset: CGFloat = 0
@@ -241,6 +249,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             layoutHeader()
         }
 
+        configureHeaderTitleVisibility()
         startObservingKeyboardChanges()
         super.viewWillAppear(animated)
     }
@@ -257,9 +266,12 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
 
-        guard isShowingNoResults || alwaysResetHeaderOnRotation else { return }
+        guard isShowingNoResults || alwaysResetHeaderOnRotation else {
+            return
+        }
 
         coordinator.animate(alongsideTransition: nil) { (_) in
+            self.accessoryBarTopCompactConstraint.isActive = self.shouldUseCompactLayout
             self.updateHeaderDisplay()
             // we're keeping this only for no results,
             // as originally intended before introducing the flag alwaysResetHeaderOnRotation
@@ -279,6 +291,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
         if let previousTraitCollection = previousTraitCollection, traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass {
             isUserInitiatedScroll = false
+            configureHeaderTitleVisibility()
             layoutHeaderInsets()
 
             // This helps reset the header changes after a rotation.
@@ -370,6 +383,11 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     private func configureHeaderImageView() {
         headerImageView.isHidden = (headerImage == nil)
         headerImageView.image = headerImage
+    }
+
+    func configureHeaderTitleVisibility() {
+        largeTitleView.isHidden = shouldUseCompactLayout
+        promptView.isHidden = shouldUseCompactLayout
     }
 
     private func styleButtons() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
@@ -14,6 +14,7 @@
             <connections>
                 <outlet property="accessoryBar" destination="DE5-R9-8tB" id="IAj-gK-2g6"/>
                 <outlet property="accessoryBarHeightConstraint" destination="Eej-Tm-ddy" id="xGU-f0-4kH"/>
+                <outlet property="accessoryBarTopCompactConstraint" destination="uVe-Ze-eIF" id="VXw-pp-QBH"/>
                 <outlet property="containerView" destination="WmP-bw-ceT" id="lul-gs-fMI"/>
                 <outlet property="defaultActionButton" destination="dmc-kV-0d8" id="NfO-bU-Zl7"/>
                 <outlet property="footerHeightContraint" destination="lle-48-IUZ" id="CV2-G2-ryj"/>
@@ -84,7 +85,6 @@
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
-                                    <variation key="heightClass=compact" hidden="YES"/>
                                 </label>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -100,7 +100,6 @@
                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                             <color key="textColor" systemColor="secondaryLabelColor"/>
                             <nil key="highlightedColor"/>
-                            <variation key="heightClass=compact" hidden="YES"/>
                         </label>
                         <view clipsSubviews="YES" contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="DE5-R9-8tB" userLabel="Accessory Bar">
                             <rect key="frame" x="0.0" y="163" width="414" height="44"/>


### PR DESCRIPTION
Ref: #18176

When in compact height, the header titles now show on the Feature Introduction. For all other views using `CollapsableHeaderViewController`, the header titles are still hidden.

To test:

---
Feature Introduction:
- Run on an iPhone.
- Enable `bloggingPrompts` feature flag.
- When the app launches, the Feature Introduction appears.
- Verify all header titles appear.
- Rotate to landscape.
- Verify all header titles appear.
- Scroll down.
- Verify the main title collapses into the nav bar.

| Portrait | Landscape | Landscape Scrolled |
|--------|-------|-------|
| ![fi_port](https://user-images.githubusercontent.com/1816888/166326791-ae15aa0c-10e0-4c1c-b008-76c96e9df185.png) | ![fi_land](https://user-images.githubusercontent.com/1816888/166326783-473dde6f-1420-4ba9-9b6b-cbf0126ce475.png) | ![fi_land_scrolled](https://user-images.githubusercontent.com/1816888/166326778-d2e54283-6c72-4818-b366-2db5ffb0c191.png) |

---
Other `CollapsableHeaderViewController`:
- Go to another view that uses `CollapsableHeaderViewController`.
  - FAB > Site page.
  - My Sites > + > Create WordPress.com site.
- Verify:
  - The header titles appear in portrait.
  - The header titles do not appear in landscape.

| Portrait | Landscape |
|--------|-------|
| ![new_page_port](https://user-images.githubusercontent.com/1816888/166327077-d45537ac-0e52-45c7-adf8-69572f30ddac.png) | ![new_page_land](https://user-images.githubusercontent.com/1816888/166327063-152f83fd-bf17-47f0-8047-3843a21802c2.png) |

## Regression Notes
1. Potential unintended areas of impact
Header titles in these views could appear incorrectly.
- FAB > Site page.
- My Sites > + > Create WordPress.com site.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified they appeared as before.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
