### PR TITLE
Blogging Prompts Feature Introduction: VoiceOver improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -37,6 +37,7 @@ private extension BloggingPromptsFeatureDescriptionView {
         promptCard.cardFrameView.layer.shadowOpacity = Style.cardShadowOpacity
         promptCard.cardFrameView.layer.shadowRadius = Style.cardShadowRadius
 
+        promptCardView.accessibilityElementsHidden = true
         promptCardView.addSubview(promptCard.cardFrameView)
         promptCardView.pinSubviewToAllEdges(promptCard.cardFrameView)
     }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -7,6 +7,7 @@ class BloggingPromptsFeatureDescriptionView: UIView, NibLoadable {
     @IBOutlet private weak var promptCardView: UIView!
     @IBOutlet private weak var descriptionLabel: UILabel!
     @IBOutlet private weak var noteTextView: UITextView!
+    @IBOutlet private weak var noteAccessibilityLabel: UILabel!
 
     // MARK: - Init
 
@@ -71,12 +72,16 @@ private extension BloggingPromptsFeatureDescriptionView {
                                                    .font: UIFont.preferredFont(forTextStyle: .caption1)]))
 
         noteTextView.attributedText = attributedString
+
+        noteTextView.accessibilityElementsHidden = true
+        noteAccessibilityLabel.accessibilityLabel = Strings.noteTextAccessibilityLabel
     }
 
     enum Strings {
         static let featureDescription: String = NSLocalizedString("We’ll show you a new prompt each day on your dashboard to help get those creative juices flowing!", comment: "Description of Blogging Prompts displayed in the Feature Introduction view.")
         static let noteLabel: String = NSLocalizedString("Note:", comment: "Label for the note displayed in the Feature Introduction view.")
         static let noteText: String = NSLocalizedString("You can learn more and set up reminders at any time in My Site > Settings > Blogging Reminders.", comment: "Note displayed in the Feature Introduction view.")
+        static let noteTextAccessibilityLabel: String = NSLocalizedString("You can learn more and set up reminders at any time in My Site, Settings, Blogging Reminders.", comment: "Accessibility hint for Note displayed in the Feature Introduction view.")
     }
 
     enum Style {

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.xib
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.xib
@@ -18,6 +18,9 @@
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8JU-nl-SWR" userLabel="Prompt Card">
                     <rect key="frame" x="52" y="0.0" width="310.5" height="200.5"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" notEnabled="YES"/>
+                    </accessibility>
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" id="BfW-eb-ZtV"/>
                     </constraints>
@@ -31,28 +34,44 @@
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" editable="NO" text="Note: You can learn more and set up reminders at any time in My Site &gt; Settings &gt; Blogging Reminders." textAlignment="natural" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="z9E-X2-t3c" userLabel="Note">
                     <rect key="frame" x="16" y="284.5" width="382" height="42.5"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    <accessibility key="accessibilityConfiguration">
+                        <accessibilityTraits key="traits" notEnabled="YES"/>
+                        <bool key="isElement" value="NO"/>
+                    </accessibility>
                     <color key="textColor" systemColor="secondaryLabelColor"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                     <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                 </textView>
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ART-X9-BCw" userLabel="Note Accessibility Label">
+                    <rect key="frame" x="16" y="284.5" width="382" height="42.5"/>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <nil key="textColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="z9E-X2-t3c" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="1K2-WJ-vdn"/>
                 <constraint firstItem="8JU-nl-SWR" firstAttribute="width" secondItem="iN0-l3-epB" secondAttribute="width" multiplier="0.75" id="4C5-B7-SUy"/>
+                <constraint firstItem="ART-X9-BCw" firstAttribute="leading" secondItem="z9E-X2-t3c" secondAttribute="leading" id="8Qb-0Z-rT5"/>
                 <constraint firstItem="8JU-nl-SWR" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="95d-85-VYs"/>
                 <constraint firstAttribute="bottom" secondItem="z9E-X2-t3c" secondAttribute="bottom" id="IUZ-vA-5QN"/>
                 <constraint firstItem="1gW-xt-yLe" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="WJ4-xD-ctR"/>
+                <constraint firstItem="ART-X9-BCw" firstAttribute="trailing" secondItem="z9E-X2-t3c" secondAttribute="trailing" id="lKl-p8-5Ty"/>
                 <constraint firstItem="8JU-nl-SWR" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="sjz-gT-pc8"/>
                 <constraint firstAttribute="trailing" secondItem="1gW-xt-yLe" secondAttribute="trailing" constant="16" id="srn-mJ-gKe"/>
                 <constraint firstAttribute="trailing" secondItem="z9E-X2-t3c" secondAttribute="trailing" constant="16" id="vmH-4q-pbI"/>
+                <constraint firstItem="ART-X9-BCw" firstAttribute="bottom" secondItem="z9E-X2-t3c" secondAttribute="bottom" id="wAs-7B-QAX"/>
                 <constraint firstItem="z9E-X2-t3c" firstAttribute="top" secondItem="1gW-xt-yLe" secondAttribute="bottom" constant="24" id="wED-RV-9Lf"/>
+                <constraint firstItem="ART-X9-BCw" firstAttribute="top" secondItem="z9E-X2-t3c" secondAttribute="top" id="xiL-2a-FCO"/>
                 <constraint firstItem="1gW-xt-yLe" firstAttribute="top" secondItem="8JU-nl-SWR" secondAttribute="bottom" constant="24" id="yAr-WH-wmx"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="descriptionLabel" destination="1gW-xt-yLe" id="rot-qA-zIV"/>
+                <outlet property="noteAccessibilityLabel" destination="ART-X9-BCw" id="cbu-ST-2Qk"/>
                 <outlet property="noteTextView" destination="z9E-X2-t3c" id="GcN-mv-lZH"/>
                 <outlet property="promptCardView" destination="8JU-nl-SWR" id="tY3-0q-Bn3"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
@@ -79,9 +79,6 @@
                                 </imageView>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Choose a Layout" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nio-Wp-Ebw" userLabel="Large Title">
                                     <rect key="frame" x="79" y="48" width="224" height="37"/>
-                                    <accessibility key="accessibilityConfiguration">
-                                        <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                                    </accessibility>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -91,9 +88,6 @@
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="1000" verticalCompressionResistancePriority="1000" text="Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" adjustsLetterSpacingToFitWidth="YES" adjustsFontForContentSizeCategory="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bxz-wi-I73" userLabel="Prompt">
                             <rect key="frame" x="16" y="107" width="382" height="36"/>
-                            <accessibility key="accessibilityConfiguration">
-                                <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
-                            </accessibility>
                             <constraints>
                                 <constraint firstAttribute="width" priority="750" constant="600" id="Wga-Tr-jFk"/>
                             </constraints>


### PR DESCRIPTION
Ref: #18176
Depends on: #18490

This fixes some VoiceOver issues with Feature Introduction.
- The `Introducing Prompts` and `The best way to become...` labels no longer say `dimmed`.
- The example prompt card is no longer enabled.
- The `Note` no longer reads `greater than` for the `>` characters.

To test:
- Enable `bloggingPrompts` feature flag.
- When the app launches, the Feature Introduction appears.
- Enable VoiceOver.
- Swipe through/select the elements.
- Verify what is read makes sense.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
