### PR TITLE
[Site Design Revamp] Main View - Remove the filter bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -22,7 +22,7 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
             debounceSelectionChange.call()
         }
     }
-    private let filterBar: CollapsableHeaderFilterBar
+    private let filterBar: CollapsableHeaderFilterBar?
 
     internal var categorySections: [CategorySection] { get {
         fatalError("This should be overridden by the subclass to provide a conforming collection of categories")
@@ -57,14 +57,15 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
         prompt: String? = nil,
         primaryActionTitle: String,
         secondaryActionTitle: String? = nil,
-        defaultActionTitle: String? = nil
+        defaultActionTitle: String? = nil,
+        showsFilterBar: Bool = true
     ) {
         self.analyticsLocation = analyticsLocation
         tableView = UITableView(frame: .zero, style: .plain)
         tableView.separatorStyle = .singleLine
         tableView.separatorInset = .zero
         tableView.showsVerticalScrollIndicator = false
-        filterBar = CollapsableHeaderFilterBar()
+        filterBar = showsFilterBar ? CollapsableHeaderFilterBar() : nil
         super.init(scrollableView: tableView,
                    mainTitle: mainTitle,
                    prompt: prompt,
@@ -81,7 +82,7 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.register(CategorySectionTableViewCell.nib, forCellReuseIdentifier: CategorySectionTableViewCell.cellReuseIdentifier)
-        filterBar.filterDelegate = self
+        filterBar?.filterDelegate = self
         tableView.dataSource = self
         configureCloseButton()
     }
@@ -102,9 +103,9 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     }
 
     public func loadingStateChanged(_ isLoading: Bool) {
-        filterBar.shouldShowGhostContent = isLoading
-        filterBar.allowsMultipleSelection = !isLoading
-        filterBar.reloadData()
+        filterBar?.shouldShowGhostContent = isLoading
+        filterBar?.allowsMultipleSelection = !isLoading
+        filterBar?.reloadData()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -71,7 +71,8 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
             analyticsLocation: "site_creation",
             mainTitle: TextContent.mainTitle,
             primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
-            secondaryActionTitle: TextContent.previewButton
+            secondaryActionTitle: TextContent.previewButton,
+            showsFilterBar: false
         )
     }
 


### PR DESCRIPTION
- Item **D** subtask of https://github.com/wordpress-mobile/WordPress-iOS/issues/18433

For the Site Design Screen Improvements project it's been decided to remove the filter bar from the Site Design screen. Filtering may be reintroduced in the future.

**Before**

| Portrait | Landscape |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 35 16](https://user-images.githubusercontent.com/2092798/166521486-abb194d1-89de-49e9-93bd-c5f00ea6af49.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 35 25](https://user-images.githubusercontent.com/2092798/166521521-4ac726d9-0927-444c-8ae2-9d09cc2a9659.png) |

**After**

| Portrait | Landscape |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 32 25](https://user-images.githubusercontent.com/2092798/166521749-46965d45-fcd7-4e58-a233-6f741721b7a5.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 36 26](https://user-images.githubusercontent.com/2092798/166521823-7ebe4308-3960-4af0-9bb2-7a6b8c377838.png) |

### Observations:
1. The gray separator no longer appears between the title and the collection. This may be OK as it matches the design for this project.
2. Extra spacing between the title and the collection. We should consider tightening the design after or while implementing https://github.com/wordpress-mobile/WordPress-iOS/issues/18434.
3. In landscape the collapsed title isn't shown in the nav bar. This is a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/18167).

| Change | Design |
| - | - |
| <img src="https://user-images.githubusercontent.com/2092798/166523498-81e6f913-b94f-403f-87c2-ab57df5dd037.png" width="350px" /> | <img src="https://user-images.githubusercontent.com/2092798/166523825-edf7ac87-83c3-462c-9623-f19a1fc6feab.png" width="350px" /> |


### Testing

**No filter bar**
1. Start the Site Creation flow
2. On the Design Screen, expect that there is no filter bar at the top
3. Tapping a design allows the user to preview it
4. Choosing a design and finishing the site creation flow succeeds

**Page creation isn't affected**
1. From the My Site view, tap the FAB button (blue circle at the bottom right)
3. Tap "Site page"
4. Observe the filter bar
5. Tap a category on the filter bar and expect the page designs to be filtered

## Regression Notes
1. Potential unintended areas of impact
    - Other views that use the `FilterableCategoriesViewController`
      - Currently just the page design picker
    - Site Design screen functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - The manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None, as this is UI code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
