### PR TITLE
Blogging Prompts: Present example prompt in prompts feature intro on 'Try it now' tap

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -103,9 +103,9 @@ private extension BloggingPromptsIntroductionPresenter {
             return
         }
 
-        // TODO: pre-populate post content with prompt content.
-        // Do something similar to `ReaderReblogPresenter:prepareForReblog`?
-        let editor = EditPostViewController(blog: blog)
+        // TODO: pre-populate post content with prompt from backend instead
+        // of example prompt
+        let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
         editor.modalPresentationStyle = .fullScreen
         editor.entryPoint = .bloggingPromptsFeatureIntroduction
 


### PR DESCRIPTION
See: #18473 

## Description

Presents the example prompt from the blogging prompts feature introduction view.

## Testing

To test:
- Enabled `bloggingPrompts` feature flag
- Launch the app
- On the blogging prompts feature introduction view, tap on 'Try it now'
- Verify new post is presented with the example prompt details

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
