### PR TITLE
Blogging Prompts: Present new post from 'Answer Prompt' tap on dashboard prompt card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -47,9 +47,12 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     private var forExampleDisplay: Bool = false {
         didSet {
             isUserInteractionEnabled = false
+            cardFrameView.isUserInteractionEnabled = false
             isAnswered = false
         }
     }
+
+    private var blog: Blog?
 
     // Used to present the menu sheet for contextual menu.
     // NOTE: Remove this once we drop support for iOS 13.
@@ -171,8 +174,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         button.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.titleLabel?.adjustsFontSizeToFitWidth = true
-
-        // TODO: Implement button tap action
+        button.addTarget(self, action: #selector(answerButtonTapped), for: .touchUpInside)
 
         return button
     }()
@@ -280,6 +282,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
 extension DashboardPromptsCardCell: BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        self.blog = blog
         self.presenterViewController = viewController
         refreshStackView()
     }
@@ -309,6 +312,19 @@ private extension DashboardPromptsCardCell {
         }
 
         containerStackView.addArrangedSubview((isAnswered ? answeredStateView : answerButton))
+    }
+
+    // MARK: Button actions
+
+    @objc func answerButtonTapped() {
+        guard let blog = blog else {
+            return
+        }
+
+        let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
+        editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = .dashboard
+        presenterViewController?.present(editor, animated: true)
     }
 
     // MARK: Context menu actions


### PR DESCRIPTION
See: #18473

## Description

Shows the answer prompt flow with an example prompt on 'Answer Prompt' tap for the dashboard prompt card.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Change `isAnswered` to `false` in `DashboardPromptsCardCell.swift`
- Launch the app
- Verify example dashboard card in prompts feature introduction is not interactable
- Close feature introduction and navigate to the 'My Site' dashboard
- Tap on 'Answer Prompt' in the prompt dashboard card
- Verify new post is presented with the example prompt details

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
