### PR TITLE
[Site Design Revamp] Main View - remove filtering and action buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
@@ -25,8 +25,7 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
         }
     }
 
-    /// Set to `true` to disable showing visual decorations like a checkmark or border when a cell is selected.
-    var selectionDecorationsHidden = false
+    var showsCheckMarkWhenSelected = true
 
     override func prepareForReuse() {
         super.prepareForReuse()
@@ -95,12 +94,6 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
     }
 
     private func styleSelectedBorder(animated: Bool = false) {
-        guard !selectionDecorationsHidden else {
-            imageView.layer.borderColor = borderColor.cgColor
-            imageView.layer.borderWidth = borderWith
-            return
-        }
-
         let imageBorderColor = isSelected ? accentColor.cgColor : borderColor.cgColor
         let imageBorderWidth = isSelected ? 2 : borderWith
         guard animated else {
@@ -126,7 +119,7 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
     }
 
     private func checkmarkHidden(_ isHidden: Bool, animated: Bool = false) {
-        guard !selectionDecorationsHidden else {
+        guard showsCheckMarkWhenSelected else {
             checkmarkContainerView.isHidden = true
             return
         }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/Collapsable Header Collection View Cell/CollapsableHeaderCollectionViewCell.swift
@@ -25,6 +25,9 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
         }
     }
 
+    /// Set to `true` to disable showing visual decorations like a checkmark or border when a cell is selected.
+    var selectionDecorationsHidden = false
+
     override func prepareForReuse() {
         super.prepareForReuse()
         imageView.cancelImageDownload()
@@ -92,6 +95,12 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
     }
 
     private func styleSelectedBorder(animated: Bool = false) {
+        guard !selectionDecorationsHidden else {
+            imageView.layer.borderColor = borderColor.cgColor
+            imageView.layer.borderWidth = borderWith
+            return
+        }
+
         let imageBorderColor = isSelected ? accentColor.cgColor : borderColor.cgColor
         let imageBorderWidth = isSelected ? 2 : borderWith
         guard animated else {
@@ -117,6 +126,11 @@ class CollapsableHeaderCollectionViewCell: UICollectionViewCell {
     }
 
     private func checkmarkHidden(_ isHidden: Bool, animated: Bool = false) {
+        guard !selectionDecorationsHidden else {
+            checkmarkContainerView.isHidden = true
+            return
+        }
+
         guard animated else {
             checkmarkContainerView.isHidden = isHidden
             return

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -51,8 +51,7 @@ class CategorySectionTableViewCell: UITableViewCell {
     }
 
     var isGhostCell: Bool = false
-    /// Set to `true` to disable showing visual decorations like a checkmark or border when a cell is selected.
-    var selectionDecorationsHidden = false
+    var showsCheckMarkWhenSelected = true
 
     override func prepareForReuse() {
         section?.scrollOffset = collectionView.contentOffset
@@ -92,6 +91,7 @@ extension CategorySectionTableViewCell: UICollectionViewDelegate {
             deselectItem(indexPath)
             return false
         }
+
         return true
     }
 
@@ -128,7 +128,7 @@ extension CategorySectionTableViewCell: UICollectionViewDataSource {
 
         let thumbnail = thumbnails[indexPath.row]
         cell.previewURL = thumbnailUrl(forThumbnail: thumbnail)
-        cell.selectionDecorationsHidden = selectionDecorationsHidden
+        cell.showsCheckMarkWhenSelected = showsCheckMarkWhenSelected
         cell.isAccessibilityElement = true
         cell.accessibilityLabel = thumbnail.slug
         return cell

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -51,6 +51,8 @@ class CategorySectionTableViewCell: UITableViewCell {
     }
 
     var isGhostCell: Bool = false
+    /// Set to `true` to disable showing visual decorations like a checkmark or border when a cell is selected.
+    var selectionDecorationsHidden = false
 
     override func prepareForReuse() {
         section?.scrollOffset = collectionView.contentOffset
@@ -126,6 +128,7 @@ extension CategorySectionTableViewCell: UICollectionViewDataSource {
 
         let thumbnail = thumbnails[indexPath.row]
         cell.previewURL = thumbnailUrl(forThumbnail: thumbnail)
+        cell.selectionDecorationsHidden = selectionDecorationsHidden
         cell.isAccessibilityElement = true
         cell.accessibilityLabel = thumbnail.slug
         return cell

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/RemoteSiteDesign+Thumbnail.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/RemoteSiteDesign+Thumbnail.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+extension RemoteSiteDesign: Thumbnail {
+    var urlDesktop: String? { screenshot }
+    var urlTablet: String? { tabletScreenshot }
+    var urlMobile: String? { mobileScreenshot}
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -39,11 +39,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
             tableView.reloadData()
         }
     }
-
-    var selectedPreviewDevice: PreviewDevice {
-        get { .mobile }
-        set { /* no op */ }
-    }
+    let selectedPreviewDevice = PreviewDevice.mobile
 
     init(createsSite: Bool, _ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -161,7 +161,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         cell.section = isLoading ? nil : sections[indexPath.row]
         cell.isGhostCell = isLoading
-        cell.selectionDecorationsHidden = true
+        cell.showsCheckMarkWhenSelected = false
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
@@ -182,6 +182,7 @@ extension SiteDesignContentCollectionViewController: CategorySectionTableViewCel
             createsSite: createsSite,
             onDismissWithDeviceSelected: { [weak self] device in
                 self?.previewViewSelectedPreviewDevice = device
+                cell.deselectItems()
             },
             completion: completion
         )

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -1,49 +1,32 @@
 import UIKit
 import WordPressKit
 
-extension RemoteSiteDesign: Thumbnail {
-    var urlDesktop: String? { screenshot }
-    var urlTablet: String? { tabletScreenshot }
-    var urlMobile: String? { mobileScreenshot}
-}
-
-class SiteDesignSection: CategorySection {
-    var category: RemoteSiteDesignCategory
-    var designs: [RemoteSiteDesign]
-
-    var categorySlug: String { category.slug }
-    var title: String { category.title }
-    var emoji: String? { category.emoji }
-    var description: String? { category.description }
-    var thumbnails: [Thumbnail] { designs }
-    var scrollOffset: CGPoint
-
-    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign]) {
-        self.category = category
-        self.designs = designs
-        self.scrollOffset = .zero
-    }
-}
-
-class SiteDesignContentCollectionViewController: FilterableCategoriesViewController {
+class SiteDesignContentCollectionViewController: CollapsableHeaderViewController {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
+    typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice
+
     private let createsSite: Bool
     private let templateGroups: [TemplateGroup] = [.stable, .singlePage]
-
-    let completion: SiteDesignStep.SiteDesignSelection
-    let restAPI = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
-    var selectedIndexPath: IndexPath? = nil
+    private let tableView: UITableView
+    private let completion: SiteDesignStep.SiteDesignSelection
+    private let restAPI = WordPressComRestApi.anonymousApi(
+        userAgent: WPUserAgent.wordPress(),
+        localeKey: WordPressComRestApi.LocaleKeyV2
+    )
     private var sections: [SiteDesignSection] = []
-    internal override var categorySections: [CategorySection] { get { sections }}
+    private var isLoading: Bool = true {
+        didSet {
+            if isLoading {
+                tableView.startGhostAnimation(style: GhostCellStyle.muriel)
+            } else {
+                tableView.stopGhostAnimation()
+            }
 
-    override var selectedPreviewDevice: PreviewDevice {
-        get { .mobile }
-        set { /* no op */ }
+            tableView.reloadData()
+        }
     }
-
-    private lazy var previewViewSelectedPreviewDevice = PreviewDevice.default
-
-    var siteDesigns = RemoteSiteDesigns() {
+    private var previewViewSelectedPreviewDevice = PreviewDevice.default
+    private var siteDesigns = RemoteSiteDesigns() {
         didSet {
             if oldValue.categories.count == 0 {
                 scrollableView.setContentOffset(.zero, animated: false)
@@ -52,26 +35,29 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
                 SiteDesignSection(category: category, designs: siteDesigns.designs.filter { design in design.categories.map({$0.slug}).contains(category.slug)
                 })
             }
-            NSLog("sections: %@", String(describing: sections))
             contentSizeWillChange()
             tableView.reloadData()
         }
     }
 
-    var selectedDesign: RemoteSiteDesign? {
-        guard let sectionIndex = selectedItem?.section, let position = selectedItem?.item else { return nil }
-        return sections[sectionIndex].designs[position]
+    var selectedPreviewDevice: PreviewDevice {
+        get { .mobile }
+        set { /* no op */ }
     }
 
     init(createsSite: Bool, _ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
         self.createsSite = createsSite
+        tableView = UITableView(frame: .zero, style: .plain)
+        tableView.separatorStyle = .singleLine
+        tableView.separatorInset = .zero
+        tableView.showsVerticalScrollIndicator = false
 
         super.init(
-            analyticsLocation: "site_creation",
+            scrollableView: tableView,
             mainTitle: TextContent.mainTitle,
-            primaryActionTitle: createsSite ? TextContent.createSiteButton : TextContent.chooseButton,
-            secondaryActionTitle: TextContent.previewButton
+            // the primary action button is never shown
+            primaryActionTitle: ""
         )
     }
 
@@ -81,6 +67,8 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        tableView.register(CategorySectionTableViewCell.nib, forCellReuseIdentifier: CategorySectionTableViewCell.cellReuseIdentifier)
+        tableView.dataSource = self
         navigationItem.backButtonTitle = TextContent.backButtonTitle
         fetchSiteDesigns()
         configureCloseButton()
@@ -119,23 +107,78 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: TextContent.cancelButtonTitle, style: .done, target: self, action: #selector(closeButtonTapped))
     }
 
-    @objc func skipButtonTapped(_ sender: Any) {
+    @objc
+    private func closeButtonTapped(_ sender: Any) {
+        dismiss(animated: true)
+    }
+
+    @objc
+    private func skipButtonTapped(_ sender: Any) {
         presentedViewController?.dismiss(animated: true)
         SiteCreationAnalyticsHelper.trackSiteDesignSkipped()
         completion(nil)
     }
 
-    override func primaryActionSelected(_ sender: Any) {
-        guard let design = selectedDesign else {
-            completion(nil)
-            return
-        }
-        SiteCreationAnalyticsHelper.trackSiteDesignSelected(design)
-        completion(design)
+    private func handleError(_ error: Error) {
+        SiteCreationAnalyticsHelper.trackError(error)
+        let titleText = TextContent.errorTitle
+        let subtitleText = TextContent.errorSubtitle
+        displayNoResultsController(title: titleText, subtitle: subtitleText, resultsDelegate: self)
     }
 
-    override func secondaryActionSelected(_ sender: Any) {
-        guard let design = selectedDesign else { return }
+    private enum TextContent {
+        static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
+        static let backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation.")
+        static let skipButtonTitle = NSLocalizedString("Skip", comment: "Continue without making a selection.")
+        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel site creation.")
+        static let errorTitle = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
+        static let errorSubtitle = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection.")
+    }
+}
+
+// MARK: - NoResultsViewControllerDelegate
+
+extension SiteDesignContentCollectionViewController: NoResultsViewControllerDelegate {
+    func actionButtonPressed() {
+        fetchSiteDesigns()
+    }
+}
+
+// MARK: - UITableViewDataSource
+
+extension SiteDesignContentCollectionViewController: UITableViewDataSource {
+
+    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
+        return CategorySectionTableViewCell.estimatedCellHeight
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return isLoading ? 1 : (sections.count)
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cellReuseIdentifier = CategorySectionTableViewCell.cellReuseIdentifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: cellReuseIdentifier, for: indexPath) as? CategorySectionTableViewCell else {
+            fatalError("Expected the cell with identifier \"\(cellReuseIdentifier)\" to be a \(CategorySectionTableViewCell.self). Please make sure the table view is registering the correct nib before loading the data")
+        }
+        cell.delegate = self
+        cell.selectionStyle = UITableViewCell.SelectionStyle.none
+        cell.section = isLoading ? nil : sections[indexPath.row]
+        cell.isGhostCell = isLoading
+        cell.selectionDecorationsHidden = true
+        cell.layer.masksToBounds = false
+        cell.clipsToBounds = false
+        cell.collectionView.allowsSelection = !isLoading
+        return cell
+    }
+}
+
+// MARK: - CategorySectionTableViewCellDelegate
+
+extension SiteDesignContentCollectionViewController: CategorySectionTableViewCellDelegate {
+    func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String) {
+        guard let sectionIndex = sections.firstIndex(where: { $0.categorySlug == slug }) else { return }
+        let design = sections[sectionIndex].designs[position]
 
         let previewVC = SiteDesignPreviewViewController(
             siteDesign: design,
@@ -152,29 +195,10 @@ class SiteDesignContentCollectionViewController: FilterableCategoriesViewControl
         navigationController?.present(navController, animated: true)
     }
 
-    private func handleError(_ error: Error) {
-        SiteCreationAnalyticsHelper.trackError(error)
-        let titleText = TextContent.errorTitle
-        let subtitleText = TextContent.errorSubtitle
-        displayNoResultsController(title: titleText, subtitle: subtitleText, resultsDelegate: self)
-    }
+    func didDeselectItem(forCell cell: CategorySectionTableViewCell) {}
 
-    private enum TextContent {
-        static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
-        static let createSiteButton = NSLocalizedString("Create Site", comment: "Title for the button to progress with creating the site with the selected design.")
-        static let chooseButton = NSLocalizedString("Choose", comment: "Title for the button to progress with the selected site homepage design.")
-        static let previewButton = NSLocalizedString("Preview", comment: "Title for button to preview a selected homepage design.")
-        static let backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation.")
-        static let skipButtonTitle = NSLocalizedString("Skip", comment: "Continue without making a selection.")
-        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel site creation.")
-        static let errorTitle = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
-        static let errorSubtitle = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection.")
-    }
-}
-
-// MARK: - NoResultsViewControllerDelegate
-extension SiteDesignContentCollectionViewController: NoResultsViewControllerDelegate {
-    func actionButtonPressed() {
-        fetchSiteDesigns()
+    func accessibilityElementDidBecomeFocused(forCell cell: CategorySectionTableViewCell) {
+        guard UIAccessibility.isVoiceOverRunning, let cellIndexPath = tableView.indexPath(for: cell) else { return }
+        tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -25,7 +25,7 @@ class SiteDesignSection: CategorySection {
     }
 }
 
-class SiteDesignContentCollectionViewController: FilterableCategoriesViewController, UIPopoverPresentationControllerDelegate {
+class SiteDesignContentCollectionViewController: FilterableCategoriesViewController {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
     private let createsSite: Bool
     private let templateGroups: [TemplateGroup] = [.stable, .singlePage]

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+class SiteDesignSection: CategorySection {
+    var category: RemoteSiteDesignCategory
+    var designs: [RemoteSiteDesign]
+
+    var categorySlug: String { category.slug }
+    var title: String { category.title }
+    var emoji: String? { category.emoji }
+    var description: String? { category.description }
+    var thumbnails: [Thumbnail] { designs }
+    var scrollOffset: CGPoint
+
+    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign]) {
+        self.category = category
+        self.designs = designs
+        self.scrollOffset = .zero
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2192,6 +2192,7 @@
 		C395FB232821FE4400AE7C11 /* SiteDesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */; };
 		C395FB242821FE4B00AE7C11 /* SiteDesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */; };
 		C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
+		C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
@@ -21673,6 +21674,7 @@
 				FABB26172602FC2C00C8785C /* MediaExternalExporter.swift in Sources */,
 				FABB26182602FC2C00C8785C /* RegisterDomainDetailsViewModel+SectionDefinitions.swift in Sources */,
 				FABB26192602FC2C00C8785C /* ActionRow.swift in Sources */,
+				C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */,
 				9815D0B426B49A0600DF7226 /* Comment+CoreDataProperties.swift in Sources */,
 				FABB261A2602FC2C00C8785C /* AppSettingsViewController.swift in Sources */,
 				FABB261B2602FC2C00C8785C /* ReaderPostService+PostsV2.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2189,6 +2189,9 @@
 		C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */; };
 		C387B7A22638D66F00BDEF86 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38C5D8027F61D2C002F517E /* MenuItemTests.swift */; };
+		C395FB232821FE4400AE7C11 /* SiteDesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */; };
+		C395FB242821FE4B00AE7C11 /* SiteDesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */; };
+		C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
@@ -6958,6 +6961,8 @@
 		C373D6E628045281008F8C26 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
 		C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentDataTests.swift; sourceTree = "<group>"; };
 		C38C5D8027F61D2C002F517E /* MenuItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MenuItemTests.swift; path = Menus/MenuItemTests.swift; sourceTree = "<group>"; };
+		C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSection.swift; sourceTree = "<group>"; };
+		C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSiteDesign+Thumbnail.swift"; sourceTree = "<group>"; };
 		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
@@ -10108,8 +10113,10 @@
 			isa = PBXGroup;
 			children = (
 				464688D5255C719500ECA61C /* Preview */,
+				C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */,
 				46241C0E2540BD01002B8A12 /* SiteDesignStep.swift */,
 				46241C3A2540D483002B8A12 /* SiteDesignContentCollectionViewController.swift */,
+				C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */,
 			);
 			path = "Design Selection";
 			sourceTree = "<group>";
@@ -17731,6 +17738,7 @@
 				7462BFD02028C49800B552D8 /* ShareNoticeViewModel.swift in Sources */,
 				17A4A36920EE51870071C2CA /* Routes+Reader.swift in Sources */,
 				0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */,
+				C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */,
 				9A73B7152362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift in Sources */,
 				74AF4D7C1FE417D200E3EBFE /* PostUploadOperation.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
@@ -19151,6 +19159,7 @@
 				E1A03EE217422DCF0085D192 /* BlogToAccount.m in Sources */,
 				C77FC90928009C7000726F00 /* OnboardingQuestionsPromptViewController.swift in Sources */,
 				8BE6F92C27EE27DB0008BDC7 /* BlogDashboardPostCardGhostCell.swift in Sources */,
+				C395FB232821FE4400AE7C11 /* SiteDesignSection.swift in Sources */,
 				FA4F660525946B5F00EAA9F5 /* JetpackRestoreHeaderView.swift in Sources */,
 				FEA6517B281C491C002EA086 /* BloggingPromptsService.swift in Sources */,
 				436D55DF210F866900CEAA33 /* StoryboardLoadable.swift in Sources */,
@@ -21457,6 +21466,7 @@
 				FABB256B2602FC2C00C8785C /* InteractivePostView.swift in Sources */,
 				FABB256C2602FC2C00C8785C /* LinearGradientView.swift in Sources */,
 				FABB256D2602FC2C00C8785C /* WizardStep.swift in Sources */,
+				C395FB242821FE4B00AE7C11 /* SiteDesignSection.swift in Sources */,
 				FABB256E2602FC2C00C8785C /* PostPostViewController.swift in Sources */,
 				FABB256F2602FC2C00C8785C /* QuickStartSpotlightView.swift in Sources */,
 				FABB25702602FC2C00C8785C /* ReaderReblogAction.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -8,40 +8,6 @@ class SiteDesignTests: XCTestCase {
         return try! JSONDecoder().decode(RemoteSiteDesign.self, from: siteDesignPayload.data(using: .utf8)!)
     }
 
-    func testSiteDesignPrimaryButtonTextNotLastStep() throws {
-
-        // given
-        let creator = SiteCreator()
-        let siteDesignStep = SiteDesignStep(creator: creator, isLastStep: false)
-        let expectedPrimaryTitle = "Choose"
-
-        // when
-        let siteDesignVC = try XCTUnwrap(siteDesignStep.content as? SiteDesignContentCollectionViewController)
-        siteDesignVC.loadViewIfNeeded()
-        siteDesignVC.viewDidLoad()
-
-        // then
-        let currentTitle = siteDesignVC.primaryActionButton.currentTitle
-        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
-    }
-
-    func testSiteDesignPrimaryButtonTextLastStep() throws {
-
-        // given
-        let creator = SiteCreator()
-        let siteDesignStep = SiteDesignStep(creator: creator, isLastStep: true)
-        let expectedPrimaryTitle = "Create Site"
-
-        // when
-        let siteDesignVC = try XCTUnwrap(siteDesignStep.content as? SiteDesignContentCollectionViewController)
-        siteDesignVC.loadViewIfNeeded()
-        siteDesignVC.viewDidLoad()
-
-        // then
-        let currentTitle = siteDesignVC.primaryActionButton.currentTitle
-        XCTAssertEqual(expectedPrimaryTitle, currentTitle)
-    }
-
     func testSiteDesignPreviewButtonTextNotLastStep() throws {
 
         // given

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignTests.swift
@@ -39,19 +39,4 @@ class SiteDesignTests: XCTestCase {
         let currentTitle = siteDesignPreviewVC.primaryActionButton.currentTitle
         XCTAssertEqual(expectedPrimaryTitle, currentTitle)
     }
-
-    /// Tests that the preview device on the Design view cannot be changed
-    func testSiteDesignPreviewDeviceIsAlwaysMobile() throws {
-
-        // given
-        let siteDesignVC = SiteDesignContentCollectionViewController(createsSite: false) { _ in }
-        let expectedDevice = PreviewDeviceSelectionViewController.PreviewDevice.mobile
-
-        // when
-        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
-        siteDesignVC.selectedPreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice.tablet
-
-        // then
-        XCTAssertEqual(siteDesignVC.selectedPreviewDevice, expectedDevice)
-    }
 }


### PR DESCRIPTION
This PR aims to resolve:
- Item **D** subtask of https://github.com/wordpress-mobile/WordPress-iOS/issues/18433 - remove filter pills
- Item **E** subtask of https://github.com/wordpress-mobile/WordPress-iOS/issues/18433 - remove primary and secondary buttons
- Closes #18447
- Doesn't show a checkmark when a design is selected, but shows the border. Removes the border when the preview is dismissed.

**Before**

| Portrait | Landscape |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 35 16](https://user-images.githubusercontent.com/2092798/166521486-abb194d1-89de-49e9-93bd-c5f00ea6af49.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 35 25](https://user-images.githubusercontent.com/2092798/166521521-4ac726d9-0927-444c-8ae2-9d09cc2a9659.png) |

**After**

| Portrait | Landscape |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 32 25](https://user-images.githubusercontent.com/2092798/166521749-46965d45-fcd7-4e58-a233-6f741721b7a5.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-03 at 14 36 26](https://user-images.githubusercontent.com/2092798/166521823-7ebe4308-3960-4af0-9bb2-7a6b8c377838.png) |

| iPad Portrait | iPad Landscape |
| - | - |
| ![Simulator Screen Shot - iPad (9th generation) - 2022-05-03 at 20 43 24](https://user-images.githubusercontent.com/2092798/166611139-c29cab1f-f76e-48fc-9cbf-f5ee3c85bf44.png) | ![Simulator Screen Shot - iPad (9th generation) - 2022-05-03 at 20 43 31](https://user-images.githubusercontent.com/2092798/166611145-c42fb59e-8733-41d1-ada3-322f222a3520.png) |


**Animated Border**

https://user-images.githubusercontent.com/2092798/166810155-8a1c3702-ffb3-456c-b5e2-86abe2c70305.mp4


### Observations:
1. The gray separator no longer appears between the title and the collection. This matches the designs for the project.
2. Extra spacing between the title and the collection. We should consider tightening the design after (or while) implementing https://github.com/wordpress-mobile/WordPress-iOS/issues/18434.
3. In landscape the collapsed title isn't shown in the nav bar. This is a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/18167).

| Change | Design |
| - | - |
| <img src="https://user-images.githubusercontent.com/2092798/166523498-81e6f913-b94f-403f-87c2-ab57df5dd037.png" width="350px" /> | <img src="https://user-images.githubusercontent.com/2092798/166523825-edf7ac87-83c3-462c-9623-f19a1fc6feab.png" width="350px" /> |

### Testing

**No filter bar**
1. Start the Site Creation flow
2. On the Design Screen, expect that there is no filter bar at the top

**No action buttons appear upon design selection**
1. Start the Site Creation flow
2. On the Design Screen, tap a design
3. Expect that the design is shown in a Preview modal view

**Only the border is shown around a selected design thumbnail when tapping**
1. Start the Site Creation flow
2. Tap on a design
3. Expect that a border is shown around the design
4. Expect that no checkmark is shown
5. Expect that when dismissing the preview, the border disappears (the design is no longer selected)

**Page creation isn't affected**
1. From the My Site view, tap the FAB button (blue circle at the bottom right)
6. Tap "Site page"
7. Expect a filter bar
8. Tap one or more categories on the filter bar and expect the page designs to be filtered
9. Expect that the primary action button at the bottom says "Create Blank Page"
10. Tap a design
11. Expect the action buttons at the bottom to now be "Preview" and "Create Page" 
12. Expect that the selected design has a checkmark and border

## Regression Notes
1. Potential unintended areas of impact
    - The tests in https://github.com/wordpress-mobile/WordPress-iOS/pull/18455 should pass
    - The checkmark and border that appears when selecting a Page design
    - Accessibility

5. What I did to test those areas of impact (or what existing automated tests I relied on)
    - I manually test the steps above
    - I manually tested the tests in https://github.com/wordpress-mobile/WordPress-iOS/pull/18455
        - Any steps with "Select a design and tap the "Preview" button" were replaced with just tapping the design
    - I tested the main view with VoiceOver on and found no regressions

6. What automated tests I added (or what prevented me from doing so)
    - None as this altered the view and not much logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
