### PR TITLE
Change JSONObject.loadFile function to throw errors

### DIFF
--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -4,17 +4,17 @@ import XCTest
 final class ActivityContentFactoryTests: XCTestCase {
     private let contextManager = TestContextManager()
 
-    func testActivityContentFactoryReturnsExpectedImplementationOfFormattableContent() {
-        let subject = ActivityContentFactory.content(from: [mockBlock()], actionsParser: ActivityActionsParser()).first as? FormattableTextContent
+    func testActivityContentFactoryReturnsExpectedImplementationOfFormattableContent() throws {
+        let subject = ActivityContentFactory.content(from: [try mockBlock()], actionsParser: ActivityActionsParser()).first as? FormattableTextContent
 
         XCTAssertNotNil(subject)
     }
 
-    private func mockBlock() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-activity-content.json")
+    private func mockBlock() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-activity-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -10,11 +10,8 @@ final class ActivityContentFactoryTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
-    private func mockBlock() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-activity-content.json")
+    private func mockBlock() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-activity-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
-    }
 }

--- a/WordPress/WordPressTest/ActivityLogFormattableContentTests.swift
+++ b/WordPress/WordPressTest/ActivityLogFormattableContentTests.swift
@@ -6,8 +6,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
     let testData = ActivityLogTestData()
     let actionsParser = ActivityActionsParser()
 
-    func testPingbackContentIsParsedCorrectly() {
-        let dictionary = testData.getPingbackDictionary()
+    func testPingbackContentIsParsedCorrectly() throws {
+        let dictionary = try testData.getPingbackDictionary()
 
         let pingbackContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
@@ -21,8 +21,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(pingback.ranges.last?.kind, .post)
     }
 
-    func testPostContentIsParsedCorrectly() {
-        let dictionary = testData.getPostContentDictionary()
+    func testPostContentIsParsedCorrectly() throws {
+        let dictionary = try testData.getPostContentDictionary()
         let postContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(postContent.count, 1)
@@ -34,8 +34,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(post.ranges.first?.kind, .post)
     }
 
-    func testCommentContentIsParsedCorrectly() {
-        let dictionary = testData.getCommentContentDictionary()
+    func testCommentContentIsParsedCorrectly() throws {
+        let dictionary = try testData.getCommentContentDictionary()
         let commentContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(commentContent.count, 1)
@@ -48,8 +48,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(comment.ranges.last?.kind, .post)
     }
 
-    func testThemeContentIsParsedCorrectly() {
-        let dictionary = testData.getThemeContentDictionary()
+    func testThemeContentIsParsedCorrectly() throws {
+        let dictionary = try testData.getThemeContentDictionary()
         let themeContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(themeContent.count, 1)
@@ -61,8 +61,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(theme.ranges.first?.kind, .theme)
     }
 
-    func testSettingContentIsParsedCorrectly() {
-        let dictionary = testData.getSettingsContentDictionary()
+    func testSettingContentIsParsedCorrectly() throws {
+        let dictionary = try testData.getSettingsContentDictionary()
         let settingsContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(settingsContent.count, 1)
@@ -75,8 +75,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(settings.ranges.last?.kind, .italic)
     }
 
-    func testSiteContentIsParsedCorreclty() {
-        let dictionary = testData.getSiteContentDictionary()
+    func testSiteContentIsParsedCorreclty() throws {
+        let dictionary = try testData.getSiteContentDictionary()
         let siteContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(siteContent.count, 1)
@@ -88,8 +88,8 @@ final class ActivityLogFormattableContentTests: XCTestCase {
         XCTAssertEqual(site.ranges.first?.kind, .site)
     }
 
-    func testPluginContentIsParsedCorreclty() {
-        let dictionary = testData.getPluginContentDictionary()
+    func testPluginContentIsParsedCorreclty() throws {
+        let dictionary = try testData.getPluginContentDictionary()
         let pluginContent = ActivityContentFactory.content(from: [dictionary], actionsParser: actionsParser)
 
         XCTAssertEqual(pluginContent.count, 1)

--- a/WordPress/WordPressTest/ActivityLogRangesTest.swift
+++ b/WordPress/WordPressTest/ActivityLogRangesTest.swift
@@ -46,8 +46,8 @@ final class ActivityLogRangesTests: XCTestCase {
         XCTAssertEqual(defaultRange.range, range)
     }
 
-    func testRangeFactoryCreatesCommentRange() {
-        let commentRangeRaw = testData.getCommentRangeDictionary()
+    func testRangeFactoryCreatesCommentRange() throws {
+        let commentRangeRaw = try testData.getCommentRangeDictionary()
         let range = ActivityRangesFactory.contentRange(from: commentRangeRaw)
 
         XCTAssertNotNil(range)
@@ -59,8 +59,8 @@ final class ActivityLogRangesTests: XCTestCase {
         XCTAssertNotNil(commentRange?.url)
     }
 
-    func testRangeFactoryCreatesThemeRange() {
-        let themeRangeRaw = testData.getThemeRangeDictionary()
+    func testRangeFactoryCreatesThemeRange() throws {
+        let themeRangeRaw = try testData.getThemeRangeDictionary()
         let range = ActivityRangesFactory.contentRange(from: themeRangeRaw)
 
         XCTAssertNotNil(range)
@@ -72,8 +72,8 @@ final class ActivityLogRangesTests: XCTestCase {
         XCTAssertNotNil(themeRange?.url)
     }
 
-    func testRangeFactoryCreatesPostRange() {
-        let postRangeRaw = testData.getPostRangeDictionary()
+    func testRangeFactoryCreatesPostRange() throws {
+        let postRangeRaw = try testData.getPostRangeDictionary()
 
         let range = ActivityRangesFactory.contentRange(from: postRangeRaw)
         XCTAssertNotNil(range)
@@ -85,24 +85,24 @@ final class ActivityLogRangesTests: XCTestCase {
         XCTAssertEqual(postRange?.url?.absoluteString, testData.testPostUrl)
     }
 
-    func testRangeFactoryCreatesItalicRange() {
-        let italicRangeRaw = testData.getItalicRangeDictionary()
+    func testRangeFactoryCreatesItalicRange() throws {
+        let italicRangeRaw = try testData.getItalicRangeDictionary()
 
         let range = ActivityRangesFactory.contentRange(from: italicRangeRaw)
         XCTAssertNotNil(range)
         XCTAssertEqual(range?.kind, .italic)
     }
 
-    func testRangeFactoryCreatesSiteRange() {
-        let siteRangeRaw = testData.getSiteRangeDictionary()
+    func testRangeFactoryCreatesSiteRange() throws {
+        let siteRangeRaw = try testData.getSiteRangeDictionary()
         let range = ActivityRangesFactory.contentRange(from: siteRangeRaw)
 
         XCTAssertNotNil(range)
         XCTAssertEqual(range?.kind, .site)
     }
 
-    func testRangeFactoryCreatesPluginRange() {
-        let pluginRangeRaw = testData.getPluginRangeDictionary()
+    func testRangeFactoryCreatesPluginRange() throws {
+        let pluginRangeRaw = try testData.getPluginRangeDictionary()
         let range = ActivityRangesFactory.contentRange(from: pluginRangeRaw)
 
         XCTAssertNotNil(range)

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -27,73 +27,73 @@ class ActivityLogTestData {
         return "https://wordpress.com/comment/137726971/7"
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 
-    func getCommentEventDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-comment.json")
+    func getCommentEventDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-comment.json")
     }
 
-    func getPostEventDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-post.json")
+    func getPostEventDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-post.json")
     }
 
-    func getPingbackDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-pingback-content.json")
+    func getPingbackDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-pingback-content.json")
     }
 
-    func getPostContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-post-content.json")
+    func getPostContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-post-content.json")
     }
 
-    func getCommentContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-comment-content.json")
+    func getCommentContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-comment-content.json")
     }
 
-    func getThemeContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-theme-content.json")
+    func getThemeContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-theme-content.json")
     }
 
-    func getSettingsContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-settings-content.json")
+    func getSettingsContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-settings-content.json")
     }
 
-    func getSiteContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-site-content.json")
+    func getSiteContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-site-content.json")
     }
 
-    func getPluginContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-plugin-content.json")
+    func getPluginContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-plugin-content.json")
     }
 
-    func getCommentRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getCommentContentDictionary()
+    func getCommentRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getCommentContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getPostRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getPostContentDictionary()
+    func getPostRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getPostContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getThemeRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getThemeContentDictionary()
+    func getThemeRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getThemeContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getItalicRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getSettingsContentDictionary()
+    func getItalicRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getSettingsContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getSiteRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getSiteContentDictionary()
+    func getSiteRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getSiteContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getPluginRangeDictionary() -> [String: AnyObject] {
-        let dictionary = getPluginContentDictionary()
+    func getPluginRangeDictionary() throws -> [String: AnyObject] {
+        let dictionary = try getPluginContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -27,72 +27,68 @@ class ActivityLogTestData {
         return "https://wordpress.com/comment/137726971/7"
     }
 
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
+    func getCommentEventDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-comment.json")
     }
 
-    func getCommentEventDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-comment.json")
+    func getPostEventDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-post.json")
     }
 
-    func getPostEventDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-post.json")
+    func getPingbackDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-pingback-content.json")
     }
 
-    func getPingbackDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-pingback-content.json")
+    func getPostContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-post-content.json")
     }
 
-    func getPostContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-post-content.json")
+    func getCommentContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-comment-content.json")
     }
 
-    func getCommentContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-comment-content.json")
+    func getThemeContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-theme-content.json")
     }
 
-    func getThemeContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-theme-content.json")
+    func getSettingsContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-settings-content.json")
     }
 
-    func getSettingsContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-settings-content.json")
+    func getSiteContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-site-content.json")
     }
 
-    func getSiteContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-site-content.json")
+    func getPluginContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-plugin-content.json")
     }
 
-    func getPluginContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-plugin-content.json")
-    }
-
-    func getCommentRangeDictionary() throws -> [String: AnyObject] {
+    func getCommentRangeDictionary() throws -> JSONObject {
         let dictionary = try getCommentContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getPostRangeDictionary() throws -> [String: AnyObject] {
+    func getPostRangeDictionary() throws -> JSONObject {
         let dictionary = try getPostContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getThemeRangeDictionary() throws -> [String: AnyObject] {
+    func getThemeRangeDictionary() throws -> JSONObject {
         let dictionary = try getThemeContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getItalicRangeDictionary() throws -> [String: AnyObject] {
+    func getItalicRangeDictionary() throws -> JSONObject {
         let dictionary = try getSettingsContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getSiteRangeDictionary() throws -> [String: AnyObject] {
+    func getSiteRangeDictionary() throws -> JSONObject {
         let dictionary = try getSiteContentDictionary()
         return getRange(at: 0, from: dictionary)
     }
 
-    func getPluginRangeDictionary() throws -> [String: AnyObject] {
+    func getPluginRangeDictionary() throws -> JSONObject {
         let dictionary = try getPluginContentDictionary()
         return getRange(at: 0, from: dictionary)
     }

--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -65,10 +65,10 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.approve)
     }
 
-    func testExecuteCallsUnapproveWhenActionIsOn() {
+    func testExecuteCallsUnapproveWhenActionIsOn() throws {
         action?.on = true
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()
@@ -78,17 +78,17 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.unapproveWasCalled)
     }
 
-    func testExecuteUpdatesActionTitleWhenActionIsOn() {
+    func testExecuteUpdatesActionTitleWhenActionIsOn() throws {
         action?.on = true
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
         XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.approve)
     }
 
-    func testExecuteCallsApproveWhenActionIsOff() {
+    func testExecuteCallsApproveWhenActionIsOff() throws {
         action?.on = false
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()
@@ -98,10 +98,10 @@ final class ApproveCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.approveWasCalled)
     }
 
-    func testExecuteUpdatesActionTitleWhenActionIsOff() {
+    func testExecuteUpdatesActionTitleWhenActionIsOff() throws {
         action?.on = false
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
         XCTAssertEqual(action?.actionTitle, ApproveComment.TitleStrings.unapprove)
     }
 }

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -41,8 +41,8 @@ final class EditCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, EditComment.title)
     }
 
-    func testExecuteCallsEdit() {
-        action?.execute(context: utility.mockCommentContext())
+    func testExecuteCallsEdit() throws {
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -17,10 +17,10 @@ final class FormattableCommentContentTests: XCTestCase {
         static let metaSiteId = NSNumber(integerLiteral: 142010142)
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         utility.setUp()
-        subject = FormattableCommentContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
+        subject = try FormattableCommentContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
     }
 
     override func tearDown() {
@@ -54,13 +54,13 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertEqual(value?.count, mockActionsCount)
     }
 
-    func testMetaReturnsExpectation() {
+    func testMetaReturnsExpectation() throws {
         let value = subject!.meta!
         let ids = value["ids"] as? [String: AnyObject]
         let commentId = ids?["comment"] as? String
         let postId = ids?["post"] as? String
 
-        let mockMeta = loadMeta()
+        let mockMeta = try loadMeta()
         let mockIds = mockMeta["ids"] as? [String: AnyObject]
         let mockMetaCommentId = mockIds?["comment"] as? String
         let mockMetaPostId = mockIds?["post"] as? String
@@ -69,8 +69,8 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertEqual(postId, mockMetaPostId)
     }
 
-    func testParentReturnsValuePassedAsParameter() {
-        let injectedParent = loadLikeNotification()
+    func testParentReturnsValuePassedAsParameter() throws {
+        let injectedParent = try loadLikeNotification()
 
         let parent = subject?.parent
 
@@ -115,8 +115,8 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertEqual(id, Expectations.metaSiteId)
     }
 
-    func testCommentNotificationHasActions() {
-        let commentNotification = utility.loadCommentNotification()
+    func testCommentNotificationHasActions() throws {
+        let commentNotification = try utility.loadCommentNotification()
         let commentContent: FormattableCommentContent? = commentNotification.contentGroup(ofKind: .comment)?.blockOfKind(.comment)
         XCTAssertNotNil(commentContent)
 
@@ -133,20 +133,20 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertNotNil(markAsSpam)
     }
 
-    private func mockDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-comment-content.json")
+    private func mockDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-comment-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 
-    private func loadLikeNotification() -> WordPress.Notification {
-        return utility.loadLikeNotification()
+    private func loadLikeNotification() throws -> WordPress.Notification {
+        return try utility.loadLikeNotification()
     }
 
-    private func loadMeta() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-comment-meta.json")
+    private func loadMeta() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-comment-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -133,20 +133,16 @@ final class FormattableCommentContentTests: XCTestCase {
         XCTAssertNotNil(markAsSpam)
     }
 
-    private func mockDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-comment-content.json")
-    }
-
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
+    private func mockDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-comment-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
         return try utility.loadLikeNotification()
     }
 
-    private func loadMeta() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-comment-meta.json")
+    private func loadMeta() throws -> JSONObject {
+        return try .loadFile(named: "notifications-comment-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -10,11 +10,11 @@ final class FormattableContentGroupTests: XCTestCase {
         static let kind: FormattableContentGroup.Kind = .activity
     }
 
-    override func setUp() {
-        super.setUp()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
         utility.setUp()
         ContextManager.overrideSharedInstance(nil)
-        subject = FormattableContentGroup(blocks: [mockContent()], kind: Constants.kind)
+        subject = FormattableContentGroup(blocks: [try mockContent()], kind: Constants.kind)
     }
 
     override func tearDown() {
@@ -28,9 +28,9 @@ final class FormattableContentGroupTests: XCTestCase {
         XCTAssertEqual(subject?.kind, Constants.kind)
     }
 
-    func testBlocksRemainAsInitialised() {
+    func testBlocksRemainAsInitialised() throws {
         let groupBlocks = subject?.blocks as? [FormattableTextContent]
-        let mockBlocks = [mockContent()]
+        let mockBlocks = [try mockContent()]
 
         /// Compare by the blocks' text
         let groupBlocksText = groupBlocks!.map { $0.text }
@@ -39,11 +39,11 @@ final class FormattableContentGroupTests: XCTestCase {
         XCTAssertEqual(groupBlocksText, mockBlocksText)
     }
 
-    func testBlockOfKindReturnsExpectation() {
+    func testBlockOfKindReturnsExpectation() throws {
         let obtainedBlock: FormattableTextContent? = subject?.blockOfKind(.text)
         let obtainedBlockText = obtainedBlock?.text
 
-        let mockText = mockContent().text
+        let mockText = try mockContent().text
 
         XCTAssertEqual(obtainedBlockText, mockText)
     }
@@ -54,16 +54,16 @@ final class FormattableContentGroupTests: XCTestCase {
         XCTAssertNil(obtainedBlock)
     }
 
-    private func mockContent() -> FormattableTextContent {
-        let text = mockActivity()["text"] as? String ?? ""
+    private func mockContent() throws -> FormattableTextContent {
+        let text = try mockActivity()["text"] as? String ?? ""
         return FormattableTextContent(text: text, ranges: [], actions: [])
     }
 
-    private func mockActivity() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "activity-log-activity-content.json")
+    private func mockActivity() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "activity-log-activity-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -59,11 +59,8 @@ final class FormattableContentGroupTests: XCTestCase {
         return FormattableTextContent(text: text, ranges: [], actions: [])
     }
 
-    private func mockActivity() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "activity-log-activity-content.json")
+    private func mockActivity() throws -> JSONObject {
+        return try .loadFile(named: "activity-log-activity-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
-    }
 }

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -129,20 +129,16 @@ final class FormattableUserContentTests: XCTestCase {
         XCTAssertEqual(id, Expectations.metaSiteId)
     }
 
-    private func mockDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-user-content.json")
-    }
-
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
+    private func mockDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-user-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
         return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
-    private func loadMeta() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-user-content-meta.json")
+    private func loadMeta() throws -> JSONObject {
+        return try .loadFile(named: "notifications-user-content-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -22,9 +22,9 @@ final class FormattableUserContentTests: XCTestCase {
         static let mappedMediaRanges = [NSValue(range: imageRange): testImage]
     }
 
-    override func setUp() {
-        super.setUp()
-        subject = FormattableUserContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        subject = try FormattableUserContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
     }
 
     override func tearDown() {
@@ -68,13 +68,13 @@ final class FormattableUserContentTests: XCTestCase {
         XCTAssertEqual(subject?.imageUrls, [Expectations.imageURL])
     }
 
-    func testMetaReturnsExpectation() {
+    func testMetaReturnsExpectation() throws {
         let value = subject!.meta!
         let ids = value["ids"] as? [String: AnyObject]
         let userId = ids?["user"] as? String
         let siteId = ids?["site"] as? String
 
-        let mockMeta = loadMeta()
+        let mockMeta = try loadMeta()
         let mockIds = mockMeta["ids"] as? [String: AnyObject]
         let mockMetaUserId = mockIds?["user"] as? String
         let mockMetaSiteId = mockIds?["site"] as? String
@@ -83,8 +83,8 @@ final class FormattableUserContentTests: XCTestCase {
         XCTAssertEqual(siteId, mockMetaSiteId)
     }
 
-    func testParentReturnsValuePassedAsParameter() {
-        let injectedParent = loadLikeNotification()
+    func testParentReturnsValuePassedAsParameter() throws {
+        let injectedParent = try loadLikeNotification()
 
         let parent = subject?.parent
 
@@ -129,20 +129,20 @@ final class FormattableUserContentTests: XCTestCase {
         XCTAssertEqual(id, Expectations.metaSiteId)
     }
 
-    private func mockDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-user-content.json")
+    private func mockDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-user-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 
-    private func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
+    private func loadLikeNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
-    private func loadMeta() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-user-content-meta.json")
+    private func loadMeta() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-user-content-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -61,10 +61,10 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.unlike)
     }
 
-    func testExecuteCallsUnlikeWhenActionIsOn() {
+    func testExecuteCallsUnlikeWhenActionIsOn() throws {
         action?.on = true
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()
@@ -74,18 +74,18 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.unlikeWasCalled)
     }
 
-    func testExecuteUpdatesActionTitleWhenActionIsOn() {
+    func testExecuteUpdatesActionTitleWhenActionIsOn() throws {
         action?.on = true
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.like)
     }
 
-    func testExecuteCallsLikeWhenActionIsOff() {
+    func testExecuteCallsLikeWhenActionIsOff() throws {
         action?.on = false
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()
@@ -95,10 +95,10 @@ final class LikeCommentActionTests: XCTestCase {
         XCTAssertTrue(mockService.likeWasCalled)
     }
 
-    func testExecuteUpdatesActionTitleWhenActionIsOff() {
+    func testExecuteUpdatesActionTitleWhenActionIsOff() throws {
         action?.on = false
 
-        action?.execute(context: utility.mockCommentContext())
+        action?.execute(context: try utility.mockCommentContext())
 
         XCTAssertEqual(action?.actionTitle, LikeComment.TitleStrings.unlike)
     }

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -44,12 +44,12 @@ final class MarkAsSpamActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, MarkAsSpam.title)
     }
 
-    func testExecuteCallsSpam() {
+    func testExecuteCallsSpam() throws {
         action?.on = false
 
         var executionCompleted = false
 
-        let context = ActionContext(block: utility.mockCommentContent(), content: "content") { (request, success) in
+        let context = ActionContext(block: try utility.mockCommentContent(), content: "content") { (request, success) in
             executionCompleted = true
         }
 

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -8,8 +8,8 @@ extension NSManagedObject {
     ///   - filename: The name of the JSON file to be loaded
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
-    static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) -> Self {
-        let jsonObject = JSONObject.loadFile(named: fileName)
+    static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) throws -> Self {
+        let jsonObject = try JSONObject.loadFile(named: fileName)
         let model = Self.init(context: context)
         for (key, value) in jsonObject {
             model.setValue(value, forKey: key)

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -4,67 +4,67 @@ import XCTest
 final class NotificationContentRangeFactoryTests: XCTestCase {
     private let contextManager = TestContextManager()
 
-    func testCommentRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockCommentRange()) as? NotificationCommentRange
+    func testCommentRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockCommentRange()) as? NotificationCommentRange
 
         XCTAssertNotNil(subject)
     }
 
-    func testIconRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockIconRange()) as? FormattableNoticonRange
+    func testIconRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockIconRange()) as? FormattableNoticonRange
 
         XCTAssertNotNil(subject)
     }
 
-    func testPostRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockPostRange()) as? NotificationContentRange
+    func testPostRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockPostRange()) as? NotificationContentRange
 
         XCTAssertNotNil(subject)
     }
 
-    func testSiteRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockSiteRange()) as? NotificationContentRange
+    func testSiteRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockSiteRange()) as? NotificationContentRange
 
         XCTAssertNotNil(subject)
     }
 
-    func testUserRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockUserRange()) as? NotificationContentRange
+    func testUserRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockUserRange()) as? NotificationContentRange
 
         XCTAssertNotNil(subject)
     }
 
-    func testDefaultRangeReturnsExpectedImplementationOfFormattableContentRange() {
-        let subject = NotificationContentRangeFactory.contentRange(from: mockBlockQuoteRange()) as? NotificationContentRange
+    func testDefaultRangeReturnsExpectedImplementationOfFormattableContentRange() throws {
+        let subject = NotificationContentRangeFactory.contentRange(from: try mockBlockQuoteRange()) as? NotificationContentRange
 
         XCTAssertNotNil(subject)
     }
 
-    private func mockCommentRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-comment-range.json")
+    private func mockCommentRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-comment-range.json")
     }
 
-    private func mockIconRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-icon-range.json")
+    private func mockIconRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-icon-range.json")
     }
 
-    private func mockPostRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-post-range.json")
+    private func mockPostRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-post-range.json")
     }
 
-    private func mockSiteRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-site-range.json")
+    private func mockSiteRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-site-range.json")
     }
 
-    private func mockUserRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-user-range.json")
+    private func mockUserRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-user-range.json")
     }
 
-    private func mockBlockQuoteRange() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-blockquote-range.json")
+    private func mockBlockQuoteRange() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-blockquote-range.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 }

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -40,31 +40,28 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
-    private func mockCommentRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-comment-range.json")
+    private func mockCommentRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-comment-range.json")
     }
 
-    private func mockIconRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-icon-range.json")
+    private func mockIconRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-icon-range.json")
     }
 
-    private func mockPostRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-post-range.json")
+    private func mockPostRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-post-range.json")
     }
 
-    private func mockSiteRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-site-range.json")
+    private func mockSiteRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-site-range.json")
     }
 
-    private func mockUserRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-user-range.json")
+    private func mockUserRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-user-range.json")
     }
 
-    private func mockBlockQuoteRange() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-blockquote-range.json")
+    private func mockBlockQuoteRange() throws -> JSONObject {
+        return try .loadFile(named: "notifications-blockquote-range.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
-    }
 }

--- a/WordPress/WordPressTest/NotificationContentRouterTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRouterTests.swift
@@ -19,8 +19,8 @@ class NotificationContentRouterTests: XCTestCase {
         super.tearDown()
     }
 
-    func testFollowNotificationSourceRoutesToStream() {
-        let notification = utility.loadFollowerNotification()
+    func testFollowNotificationSourceRoutesToStream() throws {
+        let notification = try utility.loadFollowerNotification()
         sut = NotificationContentRouter(activity: notification, coordinator: coordinator)
         try! sut.routeToNotificationSource()
 

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -146,7 +146,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
     /// Verifies that Mark as Read effectively toggles a Notification's read flag
     ///
-    func testMarkAsReadEffectivelyTogglesNotificationReadStatus() {
+    func testMarkAsReadEffectivelyTogglesNotificationReadStatus() throws {
         // Stub Endpoint
         let endpoint = "notifications/read"
         let stubPath = OHPathForFile("notifications-mark-as-read.json", type(of: self))!
@@ -154,7 +154,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
         // Inject Dummy Note
         let path = "notifications-like.json"
-        let note = WordPress.Notification.fixture(fromFile: path, insertInto: manager.mainContext)
+        let note = try WordPress.Notification.fixture(fromFile: path, insertInto: manager.mainContext)
 
         XCTAssertNotNil(note)
         XCTAssertFalse(note.read)
@@ -176,7 +176,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
     /// Verifies that Mark Notifications as Read effectively toggles a Notifications' read flag
     ///
-    func testMarkNotificationsAsReadEffectivelyTogglesNotificationsReadStatus() {
+    func testMarkNotificationsAsReadEffectivelyTogglesNotificationsReadStatus() throws {
         // Stub Endpoint
         let endpoint = "notifications/read"
         let stubPath = OHPathForFile("notifications-mark-as-read.json", type(of: self))!
@@ -186,9 +186,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
-        let note2 = WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
-        let note3 = WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
+        let note1 = try WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
+        let note2 = try WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
+        let note3 = try WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)
@@ -214,7 +214,7 @@ class NotificationSyncMediatorTests: XCTestCase {
 
     /// Verifies that Mark Notifications as Read modifies only the specified notifications' read status
     ///
-    func testMarkNotificationsAsReadTogglesOnlyTheReadStatusOfPassedInNotifications() {
+    func testMarkNotificationsAsReadTogglesOnlyTheReadStatusOfPassedInNotifications() throws {
         // Stub Endpoint
         let endpoint = "notifications/read"
         let stubPath = OHPathForFile("notifications-mark-as-read.json", type(of: self))!
@@ -224,9 +224,9 @@ class NotificationSyncMediatorTests: XCTestCase {
         let path1 = "notifications-like.json"
         let path2 = "notifications-new-follower.json"
         let path3 = "notifications-unapproved-comment.json"
-        let note1 = WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
-        let note2 = WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
-        let note3 = WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
+        let note1 = try WordPress.Notification.fixture(fromFile: path1, insertInto: manager.mainContext)
+        let note2 = try WordPress.Notification.fixture(fromFile: path2, insertInto: manager.mainContext)
+        let note3 = try WordPress.Notification.fixture(fromFile: path3, insertInto: manager.mainContext)
 
         XCTAssertFalse(note1.read)
         XCTAssertFalse(note3.read)

--- a/WordPress/WordPressTest/NotificationTests.swift
+++ b/WordPress/WordPressTest/NotificationTests.swift
@@ -20,13 +20,13 @@ class NotificationTests: XCTestCase {
         super.tearDown()
     }
 
-    func testBadgeNotificationHasBadgeFlagSetToTrue() {
-        let note = loadBadgeNotification()
+    func testBadgeNotificationHasBadgeFlagSetToTrue() throws {
+        let note = try loadBadgeNotification()
         XCTAssertTrue(note.isBadge)
     }
 
-    func testBadgeNotificationHasRegularFieldsSet() {
-        let note = loadBadgeNotification()
+    func testBadgeNotificationHasRegularFieldsSet() throws {
+        let note = try loadBadgeNotification()
         XCTAssertNotNil(note.type)
         XCTAssertNotNil(note.noticon)
         XCTAssertNotNil(note.iconURL)
@@ -34,16 +34,16 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(note.timestampAsDate)
     }
 
-    func testBadgeNotificationProperlyLoadsItsSubjectContent() {
-        let note = utility.loadBadgeNotification()
+    func testBadgeNotificationProperlyLoadsItsSubjectContent() throws {
+        let note = try utility.loadBadgeNotification()
 
         XCTAssert(note.subjectContentGroup?.blocks.count == 1)
         XCTAssertNotNil(note.subjectContentGroup?.blocks.first)
         XCTAssertNotNil(note.renderSubject())
     }
 
-    func testBadgeNotificationContainsOneImageContentGroup() {
-        let note = utility.loadBadgeNotification()
+    func testBadgeNotificationContainsOneImageContentGroup() throws {
+        let note = try utility.loadBadgeNotification()
         let group = note.contentGroup(ofKind: .image)
         XCTAssertNotNil(group)
 
@@ -55,13 +55,13 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(media?.mediaURL)
     }
 
-    func testLikeNotificationReturnsTheProperKindValue() {
-        let note = loadLikeNotification()
+    func testLikeNotificationReturnsTheProperKindValue() throws {
+        let note = try loadLikeNotification()
         XCTAssert(note.kind == .like)
     }
 
-    func testLikeNotificationContainsHeaderContent() {
-        let note = loadLikeNotification()
+    func testLikeNotificationContainsHeaderContent() throws {
+        let note = try loadLikeNotification()
         let header = note.headerContentGroup
         XCTAssertNotNil(header)
 
@@ -76,44 +76,44 @@ class NotificationTests: XCTestCase {
     }
 
 
-    func testLikeNotificationContainsUserContentGroupsInTheBody() {
-        let note = utility.loadLikeNotification()
+    func testLikeNotificationContainsUserContentGroupsInTheBody() throws {
+        let note = try utility.loadLikeNotification()
         for group in note.bodyContentGroups {
             XCTAssertTrue(group.kind == .user)
         }
     }
 
-    func testLikeNotificationContainsPostAndSiteID() {
-        let note = loadLikeNotification()
+    func testLikeNotificationContainsPostAndSiteID() throws {
+        let note = try loadLikeNotification()
         XCTAssertNotNil(note.metaSiteID)
         XCTAssertNotNil(note.metaPostID)
     }
 
-    func testFollowerNotificationReturnsTheProperKindValue() {
-        let note = loadFollowerNotification()
+    func testFollowerNotificationReturnsTheProperKindValue() throws {
+        let note = try loadFollowerNotification()
         XCTAssert(note.kind == .follow)
     }
 
-    func testFollowerNotificationHasFollowFlagSetToTrue() {
-        let note = loadFollowerNotification()
+    func testFollowerNotificationHasFollowFlagSetToTrue() throws {
+        let note = try loadFollowerNotification()
         XCTAssertTrue(note.kind == .follow)
     }
 
-    func testFollowerNotificationContainsOneSubjectContent() {
-        let note = loadFollowerNotification()
+    func testFollowerNotificationContainsOneSubjectContent() throws {
+        let note = try loadFollowerNotification()
 
         let content = note.subjectContentGroup?.blocks.first
         XCTAssertNotNil(content)
         XCTAssertNotNil(content?.text)
     }
 
-    func testFollowerNotificationContainsSiteID() {
-        let note = loadFollowerNotification()
+    func testFollowerNotificationContainsSiteID() throws {
+        let note = try loadFollowerNotification()
         XCTAssertNotNil(note.metaSiteID)
     }
 
-    func testFollowerNotificationContainsUserAndFooterGroupsInTheBody() {
-        let note = utility.loadFollowerNotification()
+    func testFollowerNotificationContainsUserAndFooterGroupsInTheBody() throws {
+        let note = try utility.loadFollowerNotification()
 
         // Note: Account for 'View All Followers'
         for group in note.bodyContentGroups {
@@ -121,8 +121,8 @@ class NotificationTests: XCTestCase {
         }
     }
 
-    func testFollowerNotificationContainsFooterContentWithFollowRangeAtTheEnd() {
-        let note = loadFollowerNotification()
+    func testFollowerNotificationContainsFooterContentWithFollowRangeAtTheEnd() throws {
+        let note = try loadFollowerNotification()
 
         let lastGroup = note.bodyContentGroups.last
         XCTAssertNotNil(lastGroup)
@@ -138,25 +138,25 @@ class NotificationTests: XCTestCase {
         XCTAssert(range?.kind == .follow)
     }
 
-    func testCommentNotificationReturnsTheProperKindValue() {
-        let note = loadCommentNotification()
+    func testCommentNotificationReturnsTheProperKindValue() throws {
+        let note = try loadCommentNotification()
         XCTAssert(note.kind == .comment)
     }
 
-    func testCommentNotificationHasCommentFlagSetToTrue() {
-        let note = loadCommentNotification()
+    func testCommentNotificationHasCommentFlagSetToTrue() throws {
+        let note = try loadCommentNotification()
         XCTAssertTrue(note.kind == .comment)
     }
 
-    func testCommentNotificationRendersSubjectWithSnippet() {
-        let note = loadCommentNotification()
+    func testCommentNotificationRendersSubjectWithSnippet() throws {
+        let note = try loadCommentNotification()
 
         XCTAssertNotNil(note.renderSubject())
         XCTAssertNotNil(note.renderSnippet())
     }
 
-    func testCommentNotificationContainsHeaderContent() {
-        let note = loadCommentNotification()
+    func testCommentNotificationContainsHeaderContent() throws {
+        let note = try loadCommentNotification()
 
         let header = note.headerContentGroup
         XCTAssertNotNil(header)
@@ -174,56 +174,56 @@ class NotificationTests: XCTestCase {
         XCTAssertNotNil(snippetBlock?.text)
     }
 
-    func testCommentNotificationContainsCommentAndSiteID() {
-        let note = loadCommentNotification()
+    func testCommentNotificationContainsCommentAndSiteID() throws {
+        let note = try loadCommentNotification()
         XCTAssertNotNil(note.metaSiteID)
         XCTAssertNotNil(note.metaCommentID)
     }
 
-    func testCommentNotificationProperlyChecksIfItWasRepliedTo() {
-        let note = loadCommentNotification()
+    func testCommentNotificationProperlyChecksIfItWasRepliedTo() throws {
+        let note = try loadCommentNotification()
         XCTAssert(note.isRepliedComment)
     }
 
-    func testCommentNotificationIsUnapproved() {
-        let note = utility.loadUnapprovedCommentNotification()
+    func testCommentNotificationIsUnapproved() throws {
+        let note = try utility.loadUnapprovedCommentNotification()
         XCTAssertTrue(note.isUnapprovedComment)
     }
 
-    func testCommentNotificationIsApproved() {
-        let note = utility.loadCommentNotification()
+    func testCommentNotificationIsApproved() throws {
+        let note = try utility.loadCommentNotification()
         XCTAssertFalse(note.isUnapprovedComment)
     }
 
 
-    func testFooterContentIsIdentifiedAndCreated() {
-        let note = loadCommentNotification()
+    func testFooterContentIsIdentifiedAndCreated() throws {
+        let note = try loadCommentNotification()
         let footerBlock: FooterTextContent? = note.contentGroup(ofKind: .footer)?.blockOfKind(.text)
 
         XCTAssertNotNil(footerBlock)
     }
 
-    func testFindingContentRangeSearchingByURL() {
-        let note = loadBadgeNotification()
+    func testFindingContentRangeSearchingByURL() throws {
+        let note = try loadBadgeNotification()
         let targetURL = URL(string: "http://www.wordpress.com")!
         let range = note.contentRange(with: targetURL)
 
         XCTAssertNotNil(range)
     }
 
-    func testPingbackNotificationIsPingback() {
-        let notification = utility.loadPingbackNotification()
+    func testPingbackNotificationIsPingback() throws {
+        let notification = try utility.loadPingbackNotification()
         XCTAssertTrue(notification.isPingback)
     }
 
-    func testPingbackBodyContainsFooter() {
-        let notification = utility.loadPingbackNotification()
+    func testPingbackBodyContainsFooter() throws {
+        let notification = try utility.loadPingbackNotification()
         let footer = notification.bodyContentGroups.filter { $0.kind == .footer }
         XCTAssertEqual(footer.count, 1)
     }
 
-    func testHeaderAndBodyContentGroups() {
-        let note = utility.loadCommentNotification()
+    func testHeaderAndBodyContentGroups() throws {
+        let note = try utility.loadCommentNotification()
         let headerGroupsCount = note.headerContentGroup != nil ? 1 : 0
         let bodyGroupsCount = note.bodyContentGroups.count
         let totalGroupsCount = headerGroupsCount + bodyGroupsCount
@@ -235,19 +235,19 @@ class NotificationTests: XCTestCase {
 
     // MARK: - Helpers
 
-    func loadBadgeNotification() -> WordPress.Notification {
-        return utility.loadBadgeNotification()
+    func loadBadgeNotification() throws -> WordPress.Notification {
+        return try utility.loadBadgeNotification()
     }
 
-    func loadLikeNotification() -> WordPress.Notification {
-        return utility.loadLikeNotification()
+    func loadLikeNotification() throws -> WordPress.Notification {
+        return try utility.loadLikeNotification()
     }
 
-    func loadFollowerNotification() -> WordPress.Notification {
-        return utility.loadFollowerNotification()
+    func loadFollowerNotification() throws -> WordPress.Notification {
+        return try utility.loadFollowerNotification()
     }
 
-    func loadCommentNotification() -> WordPress.Notification {
-        return utility.loadCommentNotification()
+    func loadCommentNotification() throws -> WordPress.Notification {
+        return try utility.loadCommentNotification()
     }
 }

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -87,16 +87,12 @@ final class NotificationTextContentTests: XCTestCase {
         XCTAssertEqual(action?.identifier, approveCommentIdentifier)
     }
 
-    private func mockDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-text-content.json")
+    private func mockDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-text-content.json")
     }
 
-    private func mockButtonContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-button-text-content.json")
-    }
-
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
+    private func mockButtonContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-button-text-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -13,9 +13,9 @@ final class NotificationTextContentTests: XCTestCase {
         static let trashAction = TrashCommentAction(on: true, command: TrashComment(on: true))
     }
 
-    override func setUp() {
-        super.setUp()
-        subject = NotificationTextContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        subject = try NotificationTextContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
     }
 
     override func tearDown() {
@@ -54,15 +54,15 @@ final class NotificationTextContentTests: XCTestCase {
         XCTAssertNil(value)
     }
 
-    func testKindReturnsButtonForButtonContent() {
-        subject = NotificationTextContent(dictionary: mockButtonContentDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
+    func testKindReturnsButtonForButtonContent() throws {
+        subject = try NotificationTextContent(dictionary: mockButtonContentDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
         let notificationKind = subject?.kind
 
         XCTAssertEqual(notificationKind, .button)
     }
 
-    func testParentReturnsValuePassedAsParameter() {
-        let injectedParent = loadLikeNotification()
+    func testParentReturnsValuePassedAsParameter() throws {
+        let injectedParent = try loadLikeNotification()
 
         let parent = subject?.parent
 
@@ -87,20 +87,20 @@ final class NotificationTextContentTests: XCTestCase {
         XCTAssertEqual(action?.identifier, approveCommentIdentifier)
     }
 
-    private func mockDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-text-content.json")
+    private func mockDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-text-content.json")
     }
 
-    private func mockButtonContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-button-text-content.json")
+    private func mockButtonContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-button-text-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 
-    private func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
+    private func loadLikeNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -20,38 +20,38 @@ class NotificationUtility {
         return Notification.classNameWithoutNamespaces()
     }
 
-    func loadBadgeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-badge.json", insertInto: contextManager.mainContext)
+    func loadBadgeNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-badge.json", insertInto: contextManager.mainContext)
     }
 
-    func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
+    func loadLikeNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 
-    func loadFollowerNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-new-follower.json", insertInto: contextManager.mainContext)
+    func loadFollowerNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-new-follower.json", insertInto: contextManager.mainContext)
     }
 
-    func loadCommentNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-replied-comment.json", insertInto: contextManager.mainContext)
+    func loadCommentNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-replied-comment.json", insertInto: contextManager.mainContext)
     }
 
-    func loadUnapprovedCommentNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-unapproved-comment.json", insertInto: contextManager.mainContext)
+    func loadUnapprovedCommentNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-unapproved-comment.json", insertInto: contextManager.mainContext)
     }
 
-    func loadPingbackNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-pingback.json", insertInto: contextManager.mainContext)
+    func loadPingbackNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-pingback.json", insertInto: contextManager.mainContext)
     }
 
-    func mockCommentContent() -> FormattableCommentContent {
-        let dictionary = JSONObject.loadFile(named: "notifications-replied-comment.json")
+    func mockCommentContent() throws -> FormattableCommentContent {
+        let dictionary = try JSONObject.loadFile(named: "notifications-replied-comment.json")
         let body = dictionary["body"]
         let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent
     }
 
-    func mockCommentContext() -> ActionContext<FormattableCommentContent> {
-        return ActionContext(block: mockCommentContent())
+    func mockCommentContext() throws -> ActionContext<FormattableCommentContent> {
+        return try ActionContext(block: mockCommentContent())
     }
 }

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -5,41 +5,41 @@ final class NotificationsContentFactoryTests: XCTestCase {
     private let contextManager = TestContextManager()
     private let entityName = Notification.classNameWithoutNamespaces()
 
-    func testTextNotificationReturnsExpectedImplementationOfFormattableContent() {
-        let subject = NotificationContentFactory.content(from: [mockTextContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? NotificationTextContent
+    func testTextNotificationReturnsExpectedImplementationOfFormattableContent() throws {
+        let subject = try NotificationContentFactory.content(from: [mockTextContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? NotificationTextContent
 
         XCTAssertNotNil(subject)
     }
 
-    func testCommentNotificationReturnsExpectedImplementationOfFormattableContent() {
-        let subject = NotificationContentFactory.content(from: [mockCommentContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? FormattableCommentContent
+    func testCommentNotificationReturnsExpectedImplementationOfFormattableContent() throws {
+        let subject = try NotificationContentFactory.content(from: [mockCommentContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? FormattableCommentContent
 
         XCTAssertNotNil(subject)
     }
 
-    func testUserNotificationReturnsExpectedImplementationOfFormattableContent() {
-        let subject = NotificationContentFactory.content(from: [mockUserContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? FormattableUserContent
+    func testUserNotificationReturnsExpectedImplementationOfFormattableContent() throws {
+        let subject = try NotificationContentFactory.content(from: [mockUserContentDictionary()], actionsParser: NotificationActionParser(), parent: loadLikeNotification()).first as? FormattableUserContent
 
         XCTAssertNotNil(subject)
     }
 
-    private func mockTextContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-text-content.json")
+    private func mockTextContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-text-content.json")
     }
 
-    private func mockCommentContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-comment-content.json")
+    private func mockCommentContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-comment-content.json")
     }
 
-    private func mockUserContentDictionary() -> [String: AnyObject] {
-        return getDictionaryFromFile(named: "notifications-user-content.json")
+    private func mockUserContentDictionary() throws -> [String: AnyObject] {
+        return try getDictionaryFromFile(named: "notifications-user-content.json")
     }
 
-    private func getDictionaryFromFile(named fileName: String) -> [String: AnyObject] {
-        return JSONObject.loadFile(named: fileName)
+    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
+        return try JSONObject.loadFile(named: fileName)
     }
 
-    func loadLikeNotification() -> WordPress.Notification {
-        return .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
+    func loadLikeNotification() throws -> WordPress.Notification {
+        return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
     }
 }

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -23,20 +23,16 @@ final class NotificationsContentFactoryTests: XCTestCase {
         XCTAssertNotNil(subject)
     }
 
-    private func mockTextContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-text-content.json")
+    private func mockTextContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-text-content.json")
     }
 
-    private func mockCommentContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-comment-content.json")
+    private func mockCommentContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-comment-content.json")
     }
 
-    private func mockUserContentDictionary() throws -> [String: AnyObject] {
-        return try getDictionaryFromFile(named: "notifications-user-content.json")
-    }
-
-    private func getDictionaryFromFile(named fileName: String) throws -> [String: AnyObject] {
-        return try JSONObject.loadFile(named: fileName)
+    private func mockUserContentDictionary() throws -> JSONObject {
+        return try .loadFile(named: "notifications-user-content.json")
     }
 
     func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/PinghubTests.swift
+++ b/WordPress/WordPressTest/PinghubTests.swift
@@ -106,7 +106,7 @@ class PingHubTests: XCTestCase {
 
 private extension PingHubTests {
     func loadJSONMessage(name: String) throws -> [String: AnyObject]? {
-        return try JSONObject.loadFile(name, type: "json")
+        return try .loadFile(name, type: "json")
     }
 }
 

--- a/WordPress/WordPressTest/PinghubTests.swift
+++ b/WordPress/WordPressTest/PinghubTests.swift
@@ -13,8 +13,8 @@ class PingHubTests: XCTestCase {
         super.tearDown()
     }
 
-    func testActionPush() {
-        let message = loadJSONMessage(name: "notes-action-push")!
+    func testActionPush() throws {
+        let message = try loadJSONMessage(name: "notes-action-push")!
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.push(let noteID, let userID, _, _)) = action else {
@@ -25,8 +25,8 @@ class PingHubTests: XCTestCase {
         XCTAssertEqual(userID, 12345)
     }
 
-    func testActionDelete() {
-        let message = loadJSONMessage(name: "notes-action-delete")!
+    func testActionDelete() throws {
+        let message = try loadJSONMessage(name: "notes-action-delete")!
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.delete(let noteID)) = action else {
@@ -36,8 +36,8 @@ class PingHubTests: XCTestCase {
         XCTAssertEqual(noteID, 67890)
     }
 
-    func testActionUnsupported() {
-        let message = loadJSONMessage(name: "notes-action-unsupported")!
+    func testActionUnsupported() throws {
+        let message = try loadJSONMessage(name: "notes-action-unsupported")!
         let action = PinghubClient.Action.from(message: message)
         XCTAssertNil(action)
     }
@@ -105,8 +105,8 @@ class PingHubTests: XCTestCase {
 }
 
 private extension PingHubTests {
-    func loadJSONMessage(name: String) -> [String: AnyObject]? {
-        return JSONObject.loadFile(name, type: "json")
+    func loadJSONMessage(name: String) throws -> [String: AnyObject]? {
+        return try JSONObject.loadFile(name, type: "json")
     }
 }
 

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -46,8 +46,8 @@ final class ReplyToCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, ReplyToComment.title)
     }
 
-    func testExecuteCallsReply() {
-        action?.execute(context: utility.mockCommentContext())
+    func testExecuteCallsReply() throws {
+        action?.execute(context: try utility.mockCommentContext())
 
         guard let mockService = action?.actionsService as? MockNotificationActionsService else {
             XCTFail()

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 typealias JSONObject = Dictionary<String, AnyObject>
 
@@ -8,8 +9,8 @@ extension JSONObject {
     ///
     /// - Parameter fileName: The full name of the json file to load.
     /// - Returns: A dictionary representing the contents of the json file.
-    static func loadFile(named fileName: String) -> JSONObject {
-        return loadFile(
+    static func loadFile(named fileName: String) throws -> JSONObject {
+        return try loadFile(
             (fileName as NSString).deletingPathExtension,
             type: (fileName as NSString).pathExtension
         )
@@ -21,20 +22,11 @@ extension JSONObject {
     ///   - name: The name of the file
     ///   - type: The extension of the file
     /// - Returns: A dictionary representing the contents of the JSON file.
-    static func loadFile(_ name: String, type: String) -> JSONObject {
-        guard let url = Bundle(for: BundlerFinder.self).url(forResource: name, withExtension: type) else {
-            fatalError("File not found in the test bundle: \(name).\(type)")
-        }
-        guard let data = try? Data(contentsOf: url) else {
-            fatalError("Can't read content of file: \(name).\(type)")
-        }
-        guard let parseResult = try? JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .mutableLeaves]) else {
-            fatalError("Can't parse file as JSON: \(name).\(type)")
-        }
-        guard let result = parseResult as? JSONObject else {
-            fatalError("File content isn't a JSON object: \(name).\(type)")
-        }
-        return result
+    static func loadFile(_ name: String, type: String) throws -> JSONObject {
+        let url = try XCTUnwrap(Bundle(for: BundlerFinder.self).url(forResource: name, withExtension: type))
+        let data = try Data(contentsOf: url)
+        let parseResult = try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .mutableLeaves])
+        return try XCTUnwrap(parseResult as? JSONObject)
     }
 
 }

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -44,11 +44,11 @@ final class TrashCommentActionTests: XCTestCase {
         XCTAssertEqual(action?.actionTitle, TrashComment.title)
     }
 
-    func testExecuteCallsTrash() {
+    func testExecuteCallsTrash() throws {
         action?.on = false
 
         var executionCompleted = false
-        let context = ActionContext(block: utils.mockCommentContent(), content: "content") { (request, success) in
+        let context = ActionContext(block: try utils.mockCommentContent(), content: "content") { (request, success) in
             executionCompleted = true
         }
 


### PR DESCRIPTION
Following up PR for https://github.com/wordpress-mobile/WordPress-iOS/pull/18478#discussion_r863479696

## Changes
Even though there are lots of changes in this PR, but the core is at [the first commit](https://github.com/wordpress-mobile/WordPress-iOS/commit/ac58f549d6a966cf55f622974e48cec3753b40dc), which changes `JSONObject.loadFile(named:)` to throw error, instead of crash via `fatalError`, so that the error can be surfaced as unit test failures.

This function signature change of course requires call sites in unit test to change too, which is done in [the second commit](https://github.com/wordpress-mobile/WordPress-iOS/commit/bd4604c2a2e3c22e88627cbd79f8b2bef8f582ee). This commit simply adds try / throw to make the compiler happy. This change propagates the error from `JSONObject.loadFile(named:)` all the way up to unit test methods.

[The third and last commit](https://github.com/wordpress-mobile/WordPress-iOS/commit/00cb24ffa99e19e161eff2ef12be3b382478dc36) removes `getDictionaryFromFile(name:)` private methods duplicated in a few unit test cases, replacing it with calling `JSONObject.loadFile(named:)` instead.

## Test Instructions
Make sure unit test passes. No impact on the app quality.

## Regression Notes
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
