### PR TITLE
Establish CoreDataStack mock usage pattern - Part I

### DIFF
--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -3,9 +3,15 @@ import XCTest
 
 final class ApproveCommentActionTests: XCTestCase {
     private class TestableApproveComment: ApproveComment {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
+
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -26,6 +32,7 @@ final class ApproveCommentActionTests: XCTestCase {
 
     private var action: ApproveComment?
     private let utility = NotificationUtility()
+    private var contextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -34,7 +41,8 @@ final class ApproveCommentActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utility.setUp()
-        action = TestableApproveComment(on: Constants.initialStatus)
+        contextManager = TestContextManager()
+        action = TestableApproveComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
 

--- a/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/ActivityStoreTests.swift
@@ -9,17 +9,20 @@ class ActivityStoreTests: XCTestCase {
     private var store: ActivityStore!
     private var activityServiceMock: ActivityServiceRemoteMock!
     private var backupServiceMock: JetpackBackupServiceMock!
+    private var contextManager: TestContextManager!
 
     override func setUp() {
         super.setUp()
 
+        contextManager = TestContextManager()
         dispatcher = ActionDispatcher()
         activityServiceMock = ActivityServiceRemoteMock()
-        backupServiceMock = JetpackBackupServiceMock()
+        backupServiceMock = JetpackBackupServiceMock(managedObjectContext: contextManager.mainContext)
         store = ActivityStore(dispatcher: dispatcher, activityServiceRemote: activityServiceMock, backupService: backupServiceMock)
     }
 
     override func tearDown() {
+        ContextManager.overrideSharedInstance(nil)
         dispatcher = nil
         store = nil
 
@@ -247,10 +250,6 @@ extension ActivityGroup {
 
 class JetpackBackupServiceMock: JetpackBackupService {
     var didCallGetAllBackupStatusWithSite: JetpackSiteRef?
-
-    init() {
-        super.init(managedObjectContext: TestContextManager.sharedInstance().mainContext)
-    }
 
     override func getAllBackupStatus(for site: JetpackSiteRef, success: @escaping ([JetpackBackup]) -> Void, failure: @escaping (Error) -> Void) {
         didCallGetAllBackupStatusWithSite = site

--- a/WordPress/WordPressTest/ContextManagerMock.m
+++ b/WordPress/WordPressTest/ContextManagerMock.m
@@ -14,18 +14,6 @@
 @synthesize mainContext = _mainContext;
 @synthesize managedObjectModel = _managedObjectModel;
 
-- (instancetype)init
-{
-    self = [super init];
-    if (self) {
-        // Override the shared ContextManager
-        [ContextManager internalSharedInstance];
-        [ContextManager overrideSharedInstance:self];
-    }
-
-    return self;
-}
-
 - (NSManagedObjectModel *)managedObjectModel
 {
     return _managedObjectModel ?: [super managedObjectModel];

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -3,9 +3,15 @@ import XCTest
 
 final class EditCommentActionTests: XCTestCase {
     private class TestableEditComment: EditComment {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
+
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -20,6 +26,7 @@ final class EditCommentActionTests: XCTestCase {
 
     private var action: EditComment?
     private let utility = NotificationUtility()
+    private var contextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -28,12 +35,14 @@ final class EditCommentActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utility.setUp()
-        action = TestableEditComment(on: Constants.initialStatus)
+        contextManager = TestContextManager()
+        action = TestableEditComment(on: Constants.initialStatus, coreDataStack: contextManager)
     }
 
     override func tearDown() {
         action = nil
         utility.tearDown()
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -3,9 +3,15 @@ import XCTest
 
 final class LikeCommentActionTests: XCTestCase {
     private class TestableLikeComment: LikeComment {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
+
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -26,6 +32,7 @@ final class LikeCommentActionTests: XCTestCase {
 
     private var action: LikeComment?
     private let utility = NotificationUtility()
+    private var contextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -34,7 +41,8 @@ final class LikeCommentActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utility.setUp()
-        action = TestableLikeComment(on: Constants.initialStatus)
+        contextManager = TestContextManager()
+        action = TestableLikeComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
 

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -3,9 +3,15 @@ import XCTest
 
 final class MarkAsSpamActionTests: XCTestCase {
     private class TestableMarkAsSpam: MarkAsSpam {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
+
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -17,6 +23,7 @@ final class MarkAsSpamActionTests: XCTestCase {
 
     private var action: MarkAsSpam?
     let utility = NotificationUtility()
+    private var testContextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -25,7 +32,8 @@ final class MarkAsSpamActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utility.setUp()
-        action = TestableMarkAsSpam(on: Constants.initialStatus)
+        testContextManager = TestContextManager()
+        action = TestableMarkAsSpam(on: Constants.initialStatus, coreDataStack: testContextManager)
         makeNetworkAvailable()
     }
 

--- a/WordPress/WordPressTest/Menus/Controllers/MenuItemsViewControllerTests.swift
+++ b/WordPress/WordPressTest/Menus/Controllers/MenuItemsViewControllerTests.swift
@@ -11,7 +11,7 @@ class MenuItemsViewControllerTests: XCTestCase {
 
     override func tearDownWithError() throws {
         context = nil
-        TestContextManager.overrideSharedInstance(nil)
+        ContextManager.overrideSharedInstance(nil)
         try super.tearDownWithError()
     }
 

--- a/WordPress/WordPressTest/Menus/MenuItemTests.swift
+++ b/WordPress/WordPressTest/Menus/MenuItemTests.swift
@@ -3,16 +3,20 @@ import Foundation
 
 class MenuItemTests: XCTestCase {
 
-    private var context: NSManagedObjectContext!
-
-    override func setUpWithError() throws {
-        context = TestContextManager().mainContext
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext! {
+        contextManager.mainContext
     }
 
-    override func tearDownWithError() throws {
-        TestContextManager.overrideSharedInstance(nil)
+    override func setUp() {
+        super.setUp()
+        contextManager = TestContextManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        ContextManager.overrideSharedInstance(nil)
         context.reset()
-        context = nil
     }
 
     /// Tests detection of descendants.

--- a/WordPress/WordPressTest/Menus/MenuItemTests.swift
+++ b/WordPress/WordPressTest/Menus/MenuItemTests.swift
@@ -9,12 +9,10 @@ class MenuItemTests: XCTestCase {
     }
 
     override func setUp() {
-        super.setUp()
         contextManager = TestContextManager()
     }
 
     override func tearDown() {
-        super.tearDown()
         ContextManager.overrideSharedInstance(nil)
         context.reset()
     }

--- a/WordPress/WordPressTest/Pages/Controllers/PageListViewControllerTests.swift
+++ b/WordPress/WordPressTest/Pages/Controllers/PageListViewControllerTests.swift
@@ -6,16 +6,18 @@ import Nimble
 
 class PageListViewControllerTests: XCTestCase {
 
-    private var context: NSManagedObjectContext!
+    private var contextManager: TestContextManager!
+    private var context: NSManagedObjectContext! {
+        contextManager.mainContext
+    }
 
     override func setUp() {
-        context = TestContextManager().mainContext
+        contextManager = TestContextManager()
         super.setUp()
     }
 
     override func tearDown() {
-        context = nil
-        TestContextManager.overrideSharedInstance(nil)
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 

--- a/WordPress/WordPressTest/ReaderPostTest.m
+++ b/WordPress/WordPressTest/ReaderPostTest.m
@@ -15,13 +15,11 @@
 
 - (void)setUp
 {
-    [super setUp];
     self.coreDataStack = [[TestContextManager alloc] init];
 }
 
 - (void)tearDown
 {
-    [super tearDown];
     self.coreDataStack = nil;
 }
 

--- a/WordPress/WordPressTest/ReaderPostTest.m
+++ b/WordPress/WordPressTest/ReaderPostTest.m
@@ -4,13 +4,30 @@
 @import WordPressShared;
 
 @interface ReaderPostTest : XCTestCase
+
+@property (nonatomic, strong) id<CoreDataStack> coreDataStack;
+
 @end
 
 @implementation ReaderPostTest
 
+@synthesize coreDataStack = coreDataStack;
+
+- (void)setUp
+{
+    [super setUp];
+    self.coreDataStack = [[TestContextManager alloc] init];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    self.coreDataStack = nil;
+}
+
 - (void)testSiteIconForDisplay
 {
-    NSManagedObjectContext *context = [[TestContextManager sharedInstance] mainContext];
+    NSManagedObjectContext *context = [self.coreDataStack mainContext];
     ReaderPost *post = [NSEntityDescription insertNewObjectForEntityForName:@"ReaderPost"
                                          inManagedObjectContext:context];
 
@@ -33,7 +50,7 @@
 
 - (void)testDisplayDate
 {
-    NSManagedObjectContext *context = [[TestContextManager sharedInstance] mainContext];
+    NSManagedObjectContext *context = [self.coreDataStack mainContext];
     ReaderPost *post = [NSEntityDescription insertNewObjectForEntityForName:@"ReaderPost"
                                                      inManagedObjectContext:context];
 

--- a/WordPress/WordPressTest/ReaderSelectInterestsCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ReaderSelectInterestsCoordinatorTests.swift
@@ -5,12 +5,10 @@ class ReaderSelectInterestsCoordinatorTests: XCTestCase {
     private var contextManager: TestContextManager!
 
     override func setUp() {
-        super.setUp()
         contextManager = TestContextManager()
     }
 
     override func tearDown() {
-        super.tearDown()
         ContextManager.overrideSharedInstance(nil)
     }
 

--- a/WordPress/WordPressTest/ReaderStreamViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderStreamViewControllerTests.swift
@@ -6,12 +6,10 @@ class ReaderStreamViewControllerTests: XCTestCase {
     private var contextManager: TestContextManager!
 
     override func setUp() {
-        super.setUp()
         contextManager = TestContextManager()
     }
 
     override func tearDown() {
-        super.tearDown()
         ContextManager.overrideSharedInstance(nil)
     }
 

--- a/WordPress/WordPressTest/ReaderStreamViewControllerTests.swift
+++ b/WordPress/WordPressTest/ReaderStreamViewControllerTests.swift
@@ -3,10 +3,21 @@ import XCTest
 @testable import WordPress
 
 class ReaderStreamViewControllerTests: XCTestCase {
+    private var contextManager: TestContextManager!
+
+    override func setUp() {
+        super.setUp()
+        contextManager = TestContextManager()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        ContextManager.overrideSharedInstance(nil)
+    }
 
     // Tests that a ReaderStreamViewController is returned
     func testControllerWithTopic() {
-        let context = TestContextManager.sharedInstance().mainContext
+        let context = contextManager.mainContext
         let topic = NSEntityDescription.insertNewObject(forEntityName: "ReaderTagTopic", into: context) as! ReaderTagTopic
         topic.path = "foo"
 

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -6,21 +6,21 @@ import CoreData
 
 final class ReaderTopicSwiftTest: XCTestCase {
 
-    private var testContextManager: CoreDataStack?
-    private var context: NSManagedObjectContext?
+    private var testContextManager: TestContextManager!
+    private var context: NSManagedObjectContext? {
+        testContextManager.mainContext
+    }
     let expectationTimeout = 5.0
 
     // MARK: - Lifecycle
 
     override func setUp() {
         super.setUp()
-        testContextManager = TestContextManager.sharedInstance()
-        context = testContextManager?.mainContext
+        testContextManager = TestContextManager()
     }
 
     override func tearDown() {
-        context = nil
-        TestContextManager.overrideSharedInstance(nil)
+        ContextManager.overrideSharedInstance(nil)
         testContextManager = nil
         super.tearDown()
     }

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -3,9 +3,14 @@ import XCTest
 
 final class ReplyToCommentActionTests: XCTestCase {
     private class TestableReplyToComment: ReplyToComment {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -19,6 +24,7 @@ final class ReplyToCommentActionTests: XCTestCase {
 
     private var action: ReplyToComment?
     let utility = NotificationUtility()
+    private var testContextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -27,7 +33,8 @@ final class ReplyToCommentActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utility.setUp()
-        action = TestableReplyToComment(on: Constants.initialStatus)
+        testContextManager = TestContextManager()
+        action = TestableReplyToComment(on: Constants.initialStatus, coreDataStack: testContextManager)
         makeNetworkAvailable()
     }
 

--- a/WordPress/WordPressTest/TestContextManager.h
+++ b/WordPress/WordPressTest/TestContextManager.h
@@ -21,9 +21,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly,  strong) NSURL                          *storeURL;
 @property (nonatomic, strong, nullable) id<ManagerMock, CoreDataStack>  stack;
 
-+ (instancetype)sharedInstance;
-+ (void)overrideSharedInstance:(id <CoreDataStack> _Nullable)contextManager;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -6,8 +6,6 @@
 // Based on the Feature Flag value
 @implementation TestContextManager
 
-static TestContextManager *_instance;
-
 - (instancetype)init
 {
     self = [super init];
@@ -80,21 +78,6 @@ static TestContextManager *_instance;
                                                                         YES) lastObject];
 
     return [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPressTest.sqlite"]];
-}
-
-+ (instancetype)sharedInstance
-{
-    if (_instance) {
-        return _instance;
-    }
-
-    _instance = [[TestContextManager alloc] init];
-    return _instance;
-}
-
-+ (void)overrideSharedInstance:(id <CoreDataStack> _Nullable)contextManager
-{
-    [ContextManager overrideSharedInstance: contextManager];
 }
 
 @end

--- a/WordPress/WordPressTest/TestContextManager.m
+++ b/WordPress/WordPressTest/TestContextManager.m
@@ -10,11 +10,22 @@
 {
     self = [super init];
     if (self) {
-        // Override the shared ContextManager
-        _stack = [[ContextManagerMock alloc] init];
+        self.stack = [[ContextManagerMock alloc] init];
     }
 
     return self;
+}
+
+- (void)setStack:(id<ManagerMock, CoreDataStack>)stack
+{
+    if (stack == _stack) {
+        return;
+    }
+
+    _stack = stack;
+    // Override the shared ContextManager
+    [ContextManager internalSharedInstance];
+    [ContextManager overrideSharedInstance:_stack];
 }
 
 - (NSManagedObjectModel *)managedObjectModel

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -3,9 +3,14 @@ import XCTest
 
 final class TrashCommentActionTests: XCTestCase {
     private class TestableTrashComment: TrashComment {
-        let service = MockNotificationActionsService(managedObjectContext: TestContextManager.sharedInstance().mainContext)
+        let service: MockNotificationActionsService
         override var actionsService: NotificationActionsService? {
             return service
+        }
+
+        init(on: Bool, coreDataStack: CoreDataStack) {
+            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            super.init(on: on)
         }
     }
 
@@ -17,6 +22,7 @@ final class TrashCommentActionTests: XCTestCase {
 
     private var action: TrashComment?
     let utils = NotificationUtility()
+    private var testContextManager: TestContextManager!
 
     private struct Constants {
         static let initialStatus: Bool = false
@@ -25,7 +31,8 @@ final class TrashCommentActionTests: XCTestCase {
     override func setUp() {
         super.setUp()
         utils.setUp()
-        action = TestableTrashComment(on: Constants.initialStatus)
+        testContextManager = TestContextManager()
+        action = TestableTrashComment(on: Constants.initialStatus, coreDataStack: testContextManager)
         makeNetworkAvailable()
     }
 
@@ -33,6 +40,7 @@ final class TrashCommentActionTests: XCTestCase {
         action = nil
         makeNetworkUnavailable()
         utils.tearDown()
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 

--- a/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Controllers/PostListViewControllerTests.swift
@@ -15,7 +15,7 @@ class PostListViewControllerTests: XCTestCase {
 
     override func tearDown() {
         context = nil
-        TestContextManager.overrideSharedInstance(nil)
+        ContextManager.overrideSharedInstance(nil)
         super.tearDown()
     }
 


### PR DESCRIPTION
This PR is part of paaHJt-3ky-p2.

## Changes
The ultimate goal is making `ContextManagerMock` the only mock implementation of `CoreDataStack`. This PR is first step towards that goal.

A couple changes involved:
* Removes `TextContextManager.sharedInstance`. I don't think this singleton is particularly useful. By removing it, `TestContextManager` is now created in each individual test case, this will simplify the clean up work down the road.
* Moves overriding `ContextManager.sharedInstance` logic from `ContextManagerMock` to `TestContextManager`. This will help us understand which test case relies on the `ContextManager` singleton, when later all `TestContextManager` usage is replaced by `ContextManagerMock`.

## Test Instructions
Make sure all unit tests pass.

## Regression Notes
N/A. All changes in this PR are in unit test, they don't have any impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
