### PR TITLE
Blogging Prompts List: prompt table cell

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -1,0 +1,69 @@
+class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
+
+    // MARK: - Properties
+
+    @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var dateLabel: UILabel!
+    @IBOutlet private weak var dateToAnswersSeparatorDot: UILabel!
+    @IBOutlet private weak var answerCountLabel: UILabel!
+
+    @IBOutlet private weak var answeredStateView: UIView!
+    @IBOutlet private weak var answersToStateSeparatorDot: UILabel!
+    @IBOutlet private weak var answeredStateLabel: UILabel!
+
+    private var prompt: BloggingPrompt?
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
+        return formatter
+    }()
+
+
+    // MARK: Init
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        configureView()
+    }
+
+    // TODO: remove answered param. Add BloggingPrompt, configure with its properties.
+    func configure(answered: Bool) {
+        titleLabel.text = "Cast the movie of your life."
+        dateLabel.text = dateFormatter.string(from: Date())
+        answerCountLabel.text = answerInfoText
+        answeredStateView.isHidden = !answered
+    }
+}
+
+private extension BloggingPromptTableViewCell {
+
+    func configureView() {
+        titleLabel.textColor = .text
+        titleLabel.font = WPStyleGuide.notoBoldFontForTextStyle(.headline)
+
+        dateLabel.textColor = .text
+        dateToAnswersSeparatorDot.textColor = .text
+        answerCountLabel.textColor = .text
+        answersToStateSeparatorDot.textColor = .text
+
+        answeredStateLabel.text = Strings.answeredLabel
+        answeredStateLabel.textColor = WPStyleGuide.BloggingPrompts.answeredLabelColor
+    }
+
+    var answerInfoText: String {
+        // TODO: remove when we have a prompt.
+        guard let answerCount = prompt?.answerCount else {
+            return "99 answers"
+        }
+
+        let stringFormat = (answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat)
+        return String(format: stringFormat, answerCount)
+    }
+
+    enum Strings {
+        static let answeredLabel = NSLocalizedString("✓ Answered", comment: "Label that indicates a blogging prompt has been answered.")
+        static let answerInfoSingularFormat = NSLocalizedString("%1$d answer", comment: "Singular format string for displaying the number of users that answered the blogging prompt.")
+        static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users that answered the blogging prompt.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="BloggingPromptTableViewCell" customModule="WordPress" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="368" height="67"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+                <rect key="frame" x="0.0" y="0.0" width="368" height="67"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9EJ-O9-rUs" userLabel="Title Label">
+                        <rect key="frame" x="16" y="10" width="336" height="17"/>
+                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-e1-8mj" userLabel="Subtitle Stack View">
+                        <rect key="frame" x="16" y="29" width="336" height="28"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ing-nT-4vc" userLabel="Date Label">
+                                <rect key="frame" x="0.0" y="0.0" width="26.5" height="28"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hFE-3l-xA6" userLabel="Separator Dot">
+                                <rect key="frame" x="32.5" y="0.0" width="4" height="28"/>
+                                <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="99 answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZmC-VB-tZs" userLabel="Answer Count Label">
+                                <rect key="frame" x="42.5" y="0.0" width="65.5" height="28"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hLQ-2r-lrL" userLabel="Answered State View">
+                                <rect key="frame" x="114" y="0.0" width="222" height="28"/>
+                                <subviews>
+                                    <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jxn-g5-OtR" userLabel="Separator Dot">
+                                        <rect key="frame" x="0.0" y="7" width="4" height="14.5"/>
+                                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MGq-ZW-fgb" userLabel="Answered State Label">
+                                        <rect key="frame" x="10" y="0.0" width="212" height="28"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="MGq-ZW-fgb" secondAttribute="trailing" id="68Y-Hc-DBg"/>
+                                    <constraint firstItem="Jxn-g5-OtR" firstAttribute="leading" secondItem="hLQ-2r-lrL" secondAttribute="leading" id="Lmu-jA-SLi"/>
+                                    <constraint firstItem="Jxn-g5-OtR" firstAttribute="centerY" secondItem="hLQ-2r-lrL" secondAttribute="centerY" id="MLC-DG-Tty"/>
+                                    <constraint firstAttribute="bottom" secondItem="MGq-ZW-fgb" secondAttribute="bottom" id="RCv-zG-krh"/>
+                                    <constraint firstItem="MGq-ZW-fgb" firstAttribute="leading" secondItem="Jxn-g5-OtR" secondAttribute="trailing" constant="6" id="bmL-rU-ENh"/>
+                                    <constraint firstItem="MGq-ZW-fgb" firstAttribute="top" secondItem="hLQ-2r-lrL" secondAttribute="top" id="i79-0y-a1t"/>
+                                </constraints>
+                            </view>
+                        </subviews>
+                    </stackView>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="NgJ-e1-8mj" secondAttribute="trailing" constant="16" id="NLC-oa-eTa"/>
+                    <constraint firstAttribute="bottom" secondItem="NgJ-e1-8mj" secondAttribute="bottom" constant="10" id="XDv-Bx-crE"/>
+                    <constraint firstAttribute="trailing" secondItem="9EJ-O9-rUs" secondAttribute="trailing" constant="16" id="adH-Dv-Kxj"/>
+                    <constraint firstItem="9EJ-O9-rUs" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="mxH-wp-psh"/>
+                    <constraint firstItem="NgJ-e1-8mj" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="rC4-OZ-GzD"/>
+                    <constraint firstItem="NgJ-e1-8mj" firstAttribute="top" secondItem="9EJ-O9-rUs" secondAttribute="bottom" constant="2" id="rJj-cx-ri9"/>
+                    <constraint firstItem="9EJ-O9-rUs" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="xlc-gR-Yni"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="answerCountLabel" destination="ZmC-VB-tZs" id="ES1-HG-7ps"/>
+                <outlet property="answeredStateLabel" destination="MGq-ZW-fgb" id="IMd-4Q-u2x"/>
+                <outlet property="answeredStateView" destination="hLQ-2r-lrL" id="tbz-zi-842"/>
+                <outlet property="answersToStateSeparatorDot" destination="Jxn-g5-OtR" id="bzX-TR-0Yy"/>
+                <outlet property="dateLabel" destination="ing-nT-4vc" id="V1i-lL-LCF"/>
+                <outlet property="dateToAnswersSeparatorDot" destination="hFE-3l-xA6" id="cbF-I5-1OK"/>
+                <outlet property="titleLabel" destination="9EJ-O9-rUs" id="FHY-7V-WNQ"/>
+            </connections>
+            <point key="canvasLocation" x="198.55072463768118" y="133.59375"/>
+        </tableViewCell>
+    </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
@@ -22,7 +22,7 @@
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-e1-8mj" userLabel="Subtitle Stack View">
+                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-e1-8mj" userLabel="Prompt Information Stack View">
                         <rect key="frame" x="16" y="29" width="336" height="28"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ing-nT-4vc" userLabel="Date Label">

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.storyboard
@@ -27,9 +27,10 @@
                                     <constraint firstAttribute="height" constant="46" id="mN2-YL-PRM"/>
                                 </constraints>
                             </view>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7aR-Vp-g6a">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7aR-Vp-g6a">
                                 <rect key="frame" x="0.0" y="46" width="375" height="621"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
                                     <outlet property="dataSource" destination="cBt-Sc-5RS" id="ACo-bR-be2"/>
                                     <outlet property="delegate" destination="cBt-Sc-5RS" id="hKz-4a-sNu"/>

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -29,17 +29,26 @@ class BloggingPromptsViewController: UIViewController {
         super.viewDidLoad()
         title = Strings.viewTitle
         configureFilterTabBar()
+        configureTableView()
     }
 
 }
 
-// MARK: - Private Helpers
+// MARK: - Private Methods
 
 private extension BloggingPromptsViewController {
 
+    func configureTableView() {
+        tableView.register(BloggingPromptTableViewCell.defaultNib,
+                           forCellReuseIdentifier: BloggingPromptTableViewCell.defaultReuseID)
+
+        tableView.accessibilityIdentifier  = "Blogging Prompts List"
+        WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        WPStyleGuide.configureColors(view: view, tableView: tableView)
+    }
+
     enum Strings {
         static let viewTitle = NSLocalizedString("Prompts", comment: "View title for Blogging Prompts list.")
-
     }
 
 }
@@ -54,8 +63,13 @@ extension BloggingPromptsViewController: UITableViewDataSource, UITableViewDeleg
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // TODO: use custom prompt cell.
-        return UITableViewCell()
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: BloggingPromptTableViewCell.defaultReuseID) as? BloggingPromptTableViewCell else {
+            return UITableViewCell()
+        }
+
+        // TODO: replace answered with BloggingPrompt.
+        cell.configure(answered: indexPath.row > 4)
+        return cell
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -42,7 +42,7 @@ private extension BloggingPromptsViewController {
         tableView.register(BloggingPromptTableViewCell.defaultNib,
                            forCellReuseIdentifier: BloggingPromptTableViewCell.defaultReuseID)
 
-        tableView.accessibilityIdentifier  = "Blogging Prompts List"
+        tableView.accessibilityIdentifier = "Blogging Prompts List"
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1742,6 +1742,10 @@
 		984B4EF320742FCC00F87888 /* ZendeskUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984B4EF220742FCC00F87888 /* ZendeskUtils.swift */; };
 		984BE91523CE72D600B37D90 /* Double+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C82B52193A7B900A06E84 /* Double+Stats.swift */; };
 		984F86FB21DEDB070070E0E3 /* TopTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */; };
+		98517E5928220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98517E5828220411001FFD45 /* BloggingPromptTableViewCell.swift */; };
+		98517E5A28220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98517E5828220411001FFD45 /* BloggingPromptTableViewCell.swift */; };
+		98517E5C28220475001FFD45 /* BloggingPromptTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98517E5B28220474001FFD45 /* BloggingPromptTableViewCell.xib */; };
+		98517E5D28220475001FFD45 /* BloggingPromptTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98517E5B28220474001FFD45 /* BloggingPromptTableViewCell.xib */; };
 		98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */; };
 		98563DDE21BF30C40006F5E9 /* TabbedTotalsCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */; };
 		9856A389261FC206008D6354 /* UserProfileUserInfoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */; };
@@ -6516,6 +6520,8 @@
 		984B4EF220742FCC00F87888 /* ZendeskUtils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ZendeskUtils.swift; sourceTree = "<group>"; };
 		984F86FA21DEDB060070E0E3 /* TopTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTotalsCell.swift; sourceTree = "<group>"; };
 		984FB2B22646001E00878DE0 /* WordPress 124.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 124.xcdatamodel"; sourceTree = "<group>"; };
+		98517E5828220411001FFD45 /* BloggingPromptTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptTableViewCell.swift; sourceTree = "<group>"; };
+		98517E5B28220474001FFD45 /* BloggingPromptTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = BloggingPromptTableViewCell.xib; sourceTree = "<group>"; };
 		98563DDB21BF30C40006F5E9 /* TabbedTotalsCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedTotalsCell.swift; sourceTree = "<group>"; };
 		98563DDC21BF30C40006F5E9 /* TabbedTotalsCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TabbedTotalsCell.xib; sourceTree = "<group>"; };
 		9856A388261FC206008D6354 /* UserProfileUserInfoCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = UserProfileUserInfoCell.xib; sourceTree = "<group>"; };
@@ -12298,6 +12304,8 @@
 			children = (
 				98A047712821CEBF001B4E2D /* BloggingPromptsViewController.swift */,
 				98A047742821D069001B4E2D /* BloggingPromptsViewController.storyboard */,
+				98517E5828220411001FFD45 /* BloggingPromptTableViewCell.swift */,
+				98517E5B28220474001FFD45 /* BloggingPromptTableViewCell.xib */,
 			);
 			path = "Blogging Prompts";
 			sourceTree = "<group>";
@@ -16186,6 +16194,7 @@
 				5D6C4AFF1B603CE9005E3C43 /* EditCommentViewController.xib in Resources */,
 				1E5D00142493E8C90004B708 /* GutenGhostView.xib in Resources */,
 				B51535D41BBB16AA0029B84B /* Launch Screen.storyboard in Resources */,
+				98517E5C28220475001FFD45 /* BloggingPromptTableViewCell.xib in Resources */,
 				08216FAA1CDBF95100304BA7 /* MenuItemEditing.storyboard in Resources */,
 				981676D7221B7A4300B81C3F /* CountriesCell.xib in Resources */,
 				43D74AD420FB5ABA004AD934 /* RegisterDomainSectionHeaderView.xib in Resources */,
@@ -16469,6 +16478,7 @@
 				FABB1FC72602FC2C00C8785C /* RegisterDomainDetailsFooterView.xib in Resources */,
 				FABB1FC82602FC2C00C8785C /* EpilogueSectionHeaderFooter.xib in Resources */,
 				FE23EB4C26E7C91F005A1698 /* richCommentStyle.css in Resources */,
+				98517E5D28220475001FFD45 /* BloggingPromptTableViewCell.xib in Resources */,
 				FABB1FC92602FC2C00C8785C /* reader.css in Resources */,
 				FABB1FCB2602FC2C00C8785C /* AlertView.xib in Resources */,
 				FABB1FCC2602FC2C00C8785C /* SiteStatsTableHeaderView.xib in Resources */,
@@ -18517,6 +18527,7 @@
 				C81CCD7F243BF7A600A83E27 /* TenorMediaGroup.swift in Sources */,
 				B0F2EFBF259378E600C7EB6D /* SiteSuggestionService.swift in Sources */,
 				4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */,
+				98517E5928220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */,
 				5D3D559718F88C3500782892 /* ReaderPostService.m in Sources */,
 				7EA30DB521ADA20F0092F894 /* EditorMediaUtility.swift in Sources */,
 				C35D4FF1280077F100DB90B5 /* SiteCreationStep.swift in Sources */,
@@ -20824,6 +20835,7 @@
 				FABB23AC2602FC2C00C8785C /* ReachabilityUtils.m in Sources */,
 				FABB23AD2602FC2C00C8785C /* TenorDataSource.swift in Sources */,
 				FABB23AE2602FC2C00C8785C /* ReaderTopicService+Subscriptions.swift in Sources */,
+				98517E5A28220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */,
 				FABB23AF2602FC2C00C8785C /* TopCommentedPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB23B02602FC2C00C8785C /* Data.swift in Sources */,
 				FABB23B12602FC2C00C8785C /* AccountSettingsViewController.swift in Sources */,


### PR DESCRIPTION
Ref: #18502

This adds a custom table cell to display a blogging prompt in the prompts list. It is now displayed in the table instead of blank rows.

NOTE: The prompt information doesn't adjust very well with large text. I'll address that later.

To test:
- Enable `bloggingPrompts` feature flag.
- Select the My Site `Home` tab.
- On the prompt card menu, select `View more prompts`.
- Verify prompt cells are shown, with stub information.

| ![iphone](https://user-images.githubusercontent.com/1816888/166832307-08a785c8-eb54-4575-a957-7bd9196f97b2.png) | ![ipad](https://user-images.githubusercontent.com/1816888/166832313-f461924c-fb0f-4446-9744-e521c77379d3.png) |
|--------|-------|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
