### PR TITLE
Blogging Prompts List: add the ability to show empty views for different scenarios.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 
-class BloggingPromptsViewController: UIViewController {
+class BloggingPromptsViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Properties
 
@@ -9,6 +9,11 @@ class BloggingPromptsViewController: UIViewController {
     @IBOutlet private weak var filterTabBar: FilterTabBar!
 
     private var blog: Blog?
+
+    // TODO: remove when prompts are fetched, use fetched prompts count.
+    private var promptCount: Int = 10
+    // TODO: set when prompt fetching is added.
+    private var isLoading: Bool = false
 
     // MARK: - Init
 
@@ -30,6 +35,7 @@ class BloggingPromptsViewController: UIViewController {
         title = Strings.viewTitle
         configureFilterTabBar()
         configureTableView()
+        showNoResultsViewIfNeeded()
     }
 
 }
@@ -47,8 +53,52 @@ private extension BloggingPromptsViewController {
         WPStyleGuide.configureColors(view: view, tableView: tableView)
     }
 
+    func showNoResultsViewIfNeeded() {
+        hideNoResults()
+
+        guard !isLoading else {
+            showLoadingView()
+            return
+        }
+
+        // TODO: use fetched prompts count.
+        guard promptCount == 0 else {
+            return
+        }
+
+        showNoResultsView()
+    }
+
+    func showNoResultsView() {
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResults.emptyTitle,
+                                     image: NoResults.imageName)
+    }
+
+    func showLoadingView() {
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResults.loadingTitle,
+                                     accessoryView: NoResultsViewController.loadingAccessoryView())
+    }
+
+    func showErrorView() {
+        hideNoResults()
+        configureAndDisplayNoResults(on: tableView,
+                                     title: NoResults.errorTitle,
+                                     subtitle: NoResults.errorSubtitle,
+                                     image: NoResults.imageName)
+    }
+
     enum Strings {
         static let viewTitle = NSLocalizedString("Prompts", comment: "View title for Blogging Prompts list.")
+    }
+
+    enum NoResults {
+        static let loadingTitle = NSLocalizedString("Loading prompts...", comment: "Displayed while blogging prompts are being loaded.")
+        static let errorTitle = NSLocalizedString("Oops", comment: "Title for the view when there's an error loading blogging prompts.")
+        static let errorSubtitle = NSLocalizedString("There was an error loading prompts.", comment: "Text displayed when there is a failure loading blogging prompts.")
+        static let emptyTitle = NSLocalizedString("No prompts yet", comment: "Title displayed when there are no blogging prompts to display.")
+        static let imageName = "wp-illustration-empty-results"
     }
 
 }
@@ -59,7 +109,7 @@ extension BloggingPromptsViewController: UITableViewDataSource, UITableViewDeleg
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // TODO: use fetched prompts count.
-        return 10
+        return promptCount
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -102,6 +152,7 @@ private extension BloggingPromptsViewController {
         // TODO:
         // - track selected filter changed
         // - refresh view for selected filter
+        showNoResultsViewIfNeeded()
     }
 
 }


### PR DESCRIPTION
Ref: #18502

This adds the ability to show empty views for different scenarios.
- No results
- No connection
- Loading prompts
- Loading error

Since the view is not fetching prompts yet, some hacking in `BloggingPromptsViewController` is required to get each empty view to show, which is noted below. The logic to toggle these states appropriately will be added later.

For the uninitiated 😄 , the `NoResultsViewController` provides this magic:
- If there is no connection, it detects it and creates the no connection view regardless of what it was configured with.
- In compact height, the image is automatically hidden.

---
To test:
- Enable `bloggingPrompts` feature flag.
- Make the changes below for each empty view type.
- Go to `Home` tab > prompt card > `View more prompts`.
- Verify each view appears as shown below.

View hacking:
- No results view:
  - Set `promptCount` = 0.
- No connection view:
  - Set `promptCount` = 0. 
  - Disconnect internet connection.
- Loading view:
  - Set `isLoading` = true.
- Error view:
  - In `viewDidLoad`, replace `showNoResultsViewIfNeeded` with `showErrorView`.

---
| No Results | No Connection |
|--------|-------|
| ![no_results](https://user-images.githubusercontent.com/1816888/166846898-ab5d162d-029a-4596-a2a6-792722e886fe.jpg) | ![no_connection](https://user-images.githubusercontent.com/1816888/166846900-69ff55c3-486d-4685-bafd-8aa960113f18.jpg) |

| Loading | Loading Error |
|--------|-------|
| ![loading](https://user-images.githubusercontent.com/1816888/166846894-980beb19-e744-4f4d-a40b-3b4b6ba38abd.jpg) | ![loading_error](https://user-images.githubusercontent.com/1816888/166846889-f9708d2d-c31d-4d49-9f56-cc113522b51a.jpg) |

---
## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
