### PR TITLE
Upgrade Charts to latest 3.x version, 3.6.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -174,7 +174,7 @@ abstract_target 'Apps' do
     ## Third party libraries
     ## =====================
     ##
-    pod 'Charts', '~> 3.2.2'
+    pod 'Charts', '~> 3.6'
     pod 'Gifu', '3.2.0'
 
     app_center_version = '~> 4.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,9 +28,9 @@ PODS:
   - boost (1.76.0)
   - BVLinearGradient (2.5.6-wp-2):
     - React-Core
-  - Charts (3.2.2):
-    - Charts/Core (= 3.2.2)
-  - Charts/Core (3.2.2)
+  - Charts (3.6.0):
+    - Charts/Core (= 3.6.0)
+  - Charts/Core (3.6.0)
   - CocoaLumberjack (3.7.4):
     - CocoaLumberjack/Core (= 3.7.4)
   - CocoaLumberjack/Core (3.7.4)
@@ -527,7 +527,7 @@ DEPENDENCIES:
   - Automattic-Tracks-iOS (~> 0.11.1)
   - boost (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.75.0/third-party-podspecs/boost.podspec.json`)
   - BVLinearGradient (from `https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.75.0/third-party-podspecs/BVLinearGradient.podspec.json`)
-  - Charts (~> 3.2.2)
+  - Charts (~> 3.6)
   - CocoaLumberjack (~> 3.0)
   - CropViewController (= 2.5.3)
   - Down (~> 0.6.6)
@@ -779,7 +779,7 @@ SPEC CHECKSUMS:
   Automattic-Tracks-iOS: 5cd49d3acf76c26b92b4094d34ba84e6b55e5425
   boost: 32a63928ef0a5bf8b60f6b930c8864113fa28779
   BVLinearGradient: 9373b32b8f749c00fe59e3482b45091eeacec08b
-  Charts: f69cf0518b6d1d62608ca504248f1bbe0b6ae77e
+  Charts: b1e3a1f5a1c9ba5394438ca3b91bd8c9076310af
   CocoaLumberjack: 543c79c114dadc3b1aba95641d8738b06b05b646
   CropViewController: a5c143548a0fabcd6cc25f2d26e40460cfb8c78c
   DoubleConversion: e22e0762848812a87afd67ffda3998d9ef29170c
@@ -869,6 +869,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 13184db128ca32c81524a8b7237063aed84a2deb
+PODFILE CHECKSUM: a9583cec2bc246d23cf0045230cd179dc03c5adb
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/Charts+Support.swift
@@ -12,7 +12,7 @@ extension BarChartData {
 
 extension BarChartDataSet {
     convenience init(values: [BarChartDataEntry], label: String?, valueFormatter: IValueFormatter?) {
-        self.init(values: values, label: label)
+        self.init(entries: values, label: label)
         self.valueFormatter = valueFormatter
     }
 }


### PR DESCRIPTION
We want to migrate away from CocoaPods and on to SPM. 

To support SPM, we need to be at least on version 4.0.1.

Before doing that breaking change jump, let's get on the latest 3.x and make sure it builds. 😅

## Testing

Given this is a minor version bump, a green build in CI should give us most of the coverage. Still, I have never worked with charts so pinging @momo-ozawa, @shiki, @frosty, and @ScoutHarris whom I [can](https://github.com/wordpress-mobile/WordPress-iOS/commits/trunk/WordPress/Classes/ViewRelated/Stats/Charts/PeriodChart.swift) [see](https://github.com/wordpress-mobile/WordPress-iOS/commits/trunk/WordPress/Classes/ViewRelated/Stats/Charts/StatsBarChartView.swift) did some work around this area recently.

I run the app in the Simulator and the charts still looked fine to me, but maybe there are gotchas I'm not aware of.

<table>
<tr>
	<td>
<img alt="image" src="https://user-images.githubusercontent.com/1218433/167049121-922a7cb0-165f-4ec3-8469-a868eb552756.png" />
	</td>
    <td>
<img alt="image" src="https://user-images.githubusercontent.com/1218433/167049187-47eb1e5e-5131-4a16-b4e2-765e0f2443bf.png">
	</td>
</tr>
</table>

## Regression Notes
1. Potential unintended areas of impact: The charts, but this is a minor version upgrade and we didn't add any new feature.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – _I'll update them once we jump to 4.x_
