### PR TITLE
Feature/highlights tooltip container

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -12,12 +12,18 @@ final class Tooltip: UIView {
             static let contentStackViewBottom: CGFloat = 4
             static let contentStackViewHorizontal: CGFloat = 16
             static let superHorizontalMargin: CGFloat = 16
+            static let buttonStackViewHeight: CGFloat = 40
         }
     }
 
     enum ButtonAlignment {
         case left
         case right
+    }
+
+    enum ArrowPosition {
+        case top
+        case bottom
     }
 
     /// Determines whether a leading icon for the title, should be placed or not.
@@ -70,6 +76,8 @@ final class Tooltip: UIView {
         }
     }
 
+    var arrowPosition: ArrowPosition = .bottom
+
     private lazy var titleLabel: UILabel = {
         $0.font = WPStyleGuide.fontForTextStyle(.body)
         $0.textColor = .invertedLabel
@@ -85,13 +93,13 @@ final class Tooltip: UIView {
 
     private(set) lazy var primaryButton: UIButton = {
         $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        $0.setTitleColor(.primary, for: .normal)
+        $0.setTitleColor(.primaryLight, for: .normal)
         return $0
     }(UIButton())
 
     private(set) lazy var secondaryButton: UIButton = {
         $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
-        $0.setTitleColor(.primary, for: .normal)
+        $0.setTitleColor(.primaryLight, for: .normal)
         return $0
     }(UIButton())
 
@@ -149,7 +157,7 @@ final class Tooltip: UIView {
             trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
             bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom),
             widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.width - Constants.Spacing.superHorizontalMargin),
-            buttonsStackView.heightAnchor.constraint(equalToConstant: 40)
+            buttonsStackView.heightAnchor.constraint(equalToConstant: Constants.Spacing.buttonStackViewHeight)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -128,6 +128,8 @@ final class Tooltip: UIView {
         }
     }
 
+    private let containerView = UIView()
+
     init() {
         super.init(frame: .zero)
         commonInit()
@@ -139,25 +141,42 @@ final class Tooltip: UIView {
     }
 
     private func commonInit() {
-        backgroundColor = .invertedSystem5
-        layer.cornerRadius = Constants.cornerRadius
+        backgroundColor = .clear
 
+        setUpContainerView()
         setUpConstraints()
     }
 
-    private func setUpConstraints() {
-        translatesAutoresizingMaskIntoConstraints = false
-        contentStackView.translatesAutoresizingMaskIntoConstraints = false
-        buttonsStackView.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(contentStackView)
+    private func setUpContainerView() {
+        containerView.backgroundColor = .invertedSystem5
+        containerView.layer.cornerRadius = Constants.cornerRadius
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(containerView)
 
         NSLayoutConstraint.activate([
-            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.Spacing.contentStackViewTop),
-            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
-            trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
-            bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom),
-            widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.width - Constants.Spacing.superHorizontalMargin),
+            containerView.topAnchor.constraint(equalTo: topAnchor, constant: 20),
+            containerView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
+        ])
+    }
+
+    private func setUpConstraints() {
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonsStackView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.addSubview(contentStackView)
+
+        NSLayoutConstraint.activate([
+            contentStackView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: Constants.Spacing.contentStackViewTop),
+            contentStackView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
+            containerView.trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
+            containerView.bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom),
+            containerView.widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.width - Constants.Spacing.superHorizontalMargin),
             buttonsStackView.heightAnchor.constraint(equalToConstant: Constants.Spacing.buttonStackViewHeight)
         ])
+    }
+
+    private func addArrowHead() {
+        let arrowPath = UIBezierPath()
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+final class Tooltip: UIView {
+    private enum Constants {
+        static let leadingIconUnicode = "✨"
+    }
+
+    var title: String? {
+        didSet {
+            guard let title = title else {
+                titleLabel.text = nil
+                return
+            }
+
+            Self.updateTitleLabel(
+                titleLabel,
+                with: title,
+                shouldPrefixLeadingIcon: shouldPrefixLeadingIcon
+            )
+        }
+    }
+
+    var shouldPrefixLeadingIcon: Bool = true {
+        didSet {
+            guard let title = title else { return }
+
+            Self.updateTitleLabel(
+                titleLabel,
+                with: title,
+                shouldPrefixLeadingIcon: shouldPrefixLeadingIcon
+            )
+        }
+    }
+
+    private let titleLabel: UILabel = {
+        $0.font = WPStyleGuide.fontForTextStyle(.body)
+        return $0
+    }(UILabel())
+
+    private let descriptionLabel: UILabel = {
+        $0.font = WPStyleGuide.fontForTextStyle(.body)
+        return $0
+    }(UILabel())
+
+    private let primaryButton: UIButton = {
+        $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        return $0
+    }(UIButton())
+
+    private let secondaryButton: UIButton = {
+        return $0
+    }(UIButton())
+
+    private let contentStackView: UIStackView = {
+        return $0
+    }(UIStackView())
+
+    private let buttonsStackView: UIStackView = {
+        return $0
+    }(UIStackView())
+
+    private static func updateTitleLabel(
+        _ titleLabel: UILabel,
+        with text: String,
+        shouldPrefixLeadingIcon: Bool) {
+
+        if shouldPrefixLeadingIcon {
+            titleLabel.text = Constants.leadingIconUnicode + " " + text
+        } else {
+            titleLabel.text = text
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -145,6 +145,7 @@ final class Tooltip: UIView {
 
         setUpContainerView()
         setUpConstraints()
+        addArrowHead()
     }
 
     private func setUpContainerView() {
@@ -178,5 +179,27 @@ final class Tooltip: UIView {
 
     private func addArrowHead() {
         let arrowPath = UIBezierPath()
+        arrowPath.move(to: CGPoint(x: 0, y: 0))
+        arrowPath.addLine(to: CGPoint(x: 9, y: -11))
+        arrowPath.addQuadCurve(to: CGPoint(x: 11, y: -11), controlPoint: CGPoint(x: 10, y: -12))
+        arrowPath.addLine(to: CGPoint(x: 19, y: 0))
+        arrowPath.close()
+
+        // Create a CAShapeLayer
+        let shapeLayer = CAShapeLayer()
+
+        // The Bezier path that we made needs to be converted to
+        // a CGPath before it can be used on a layer.
+        shapeLayer.path = arrowPath.cgPath
+
+        // apply other properties related to the path
+        shapeLayer.strokeColor = UIColor.invertedSystem5.cgColor
+        shapeLayer.fillColor = UIColor.invertedSystem5.cgColor
+        shapeLayer.lineWidth = 1.0
+
+        shapeLayer.position = CGPoint(x: 20, y: 0)
+
+        // add the new layer to our custom view
+        containerView.layer.addSublayer(shapeLayer)
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -6,14 +6,21 @@ final class Tooltip: UIView {
         static let cornerRadius: CGFloat = 4
 
         enum Spacing {
-            static let contentStackView: CGFloat = 4
-            static let buttonsStackView: CGFloat = 16
+            static let contentStackViewInterItemSpacing: CGFloat = 4
+            static let buttonsStackViewInterItemSpacing: CGFloat = 16
             static let contentStackViewTop: CGFloat = 12
-            static let contentStackViewBottom: CGFloat = 12
+            static let contentStackViewBottom: CGFloat = 4
             static let contentStackViewHorizontal: CGFloat = 16
+            static let superHorizontalMargin: CGFloat = 16
         }
     }
 
+    enum ButtonAlignment {
+        case left
+        case right
+    }
+
+    /// Determines whether a leading icon for the title, should be placed or not.
     var shouldPrefixLeadingIcon: Bool = true {
         didSet {
             guard let title = title else { return }
@@ -26,6 +33,8 @@ final class Tooltip: UIView {
         }
     }
 
+    /// String for primary label. To be used as the title.
+    /// If `shouldPrefixLeadingIcon` is `true`, a leading icon will be prefixed.
     var title: String? {
         didSet {
             guard let title = title else {
@@ -41,9 +50,23 @@ final class Tooltip: UIView {
         }
     }
 
+    /// String for secondary label. To be used as description
     var message: String? {
         didSet {
             messageLabel.text = message
+        }
+    }
+
+    /// Determines the alignment for the action buttons.
+    var buttonAlignment: ButtonAlignment = .left {
+        didSet {
+            buttonsStackView.removeAllSubviews()
+            switch buttonAlignment {
+            case .left:
+                buttonsStackView.addArrangedSubviews([primaryButton, secondaryButton, UIView()])
+            case .right:
+                buttonsStackView.addArrangedSubviews([UIView(), primaryButton, secondaryButton])
+            }
         }
     }
 
@@ -55,31 +78,33 @@ final class Tooltip: UIView {
 
     private lazy var messageLabel: UILabel = {
         $0.font = WPStyleGuide.fontForTextStyle(.body)
-        $0.textColor = .secondaryLabel
+        $0.textColor = .invertedSecondaryLabel
         $0.numberOfLines = 3
         return $0
     }(UILabel())
 
     private(set) lazy var primaryButton: UIButton = {
         $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        $0.setTitleColor(.primary, for: .normal)
         return $0
     }(UIButton())
 
     private(set) lazy var secondaryButton: UIButton = {
         $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        $0.setTitleColor(.primary, for: .normal)
         return $0
     }(UIButton())
 
     private lazy var contentStackView: UIStackView = {
         $0.addArrangedSubviews([titleLabel, messageLabel, buttonsStackView])
-        $0.spacing = Constants.Spacing.contentStackView
+        $0.spacing = Constants.Spacing.contentStackViewInterItemSpacing
         $0.axis = .vertical
         return $0
     }(UIStackView())
 
     private lazy var buttonsStackView: UIStackView = {
-        $0.addArrangedSubviews([primaryButton, secondaryButton])
-        $0.spacing = Constants.Spacing.buttonsStackView
+        $0.addArrangedSubviews([primaryButton, secondaryButton, UIView()])
+        $0.spacing = Constants.Spacing.buttonsStackViewInterItemSpacing
         return $0
     }(UIStackView())
 
@@ -113,14 +138,18 @@ final class Tooltip: UIView {
     }
 
     private func setUpConstraints() {
+        translatesAutoresizingMaskIntoConstraints = false
         contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        buttonsStackView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(contentStackView)
 
         NSLayoutConstraint.activate([
             contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.Spacing.contentStackViewTop),
             contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
             trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
-            bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom)
+            bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom),
+            widthAnchor.constraint(lessThanOrEqualToConstant: UIScreen.main.bounds.width - Constants.Spacing.superHorizontalMargin),
+            buttonsStackView.heightAnchor.constraint(equalToConstant: 40)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -62,6 +62,7 @@ final class Tooltip: UIView {
                 with: title,
                 shouldPrefixLeadingIcon: shouldPrefixLeadingIcon
             )
+            accessibilityLabel = title
         }
     }
 
@@ -69,6 +70,7 @@ final class Tooltip: UIView {
     var message: String? {
         didSet {
             messageLabel.text = message
+            accessibilityValue = message
         }
     }
 
@@ -202,6 +204,7 @@ final class Tooltip: UIView {
 
         setUpContainerView()
         setUpConstraints()
+        isAccessibilityElement = true
     }
 
     private func setUpContainerView() {

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -3,6 +3,27 @@ import UIKit
 final class Tooltip: UIView {
     private enum Constants {
         static let leadingIconUnicode = "✨"
+        static let cornerRadius: CGFloat = 4
+
+        enum Spacing {
+            static let contentStackView: CGFloat = 4
+            static let buttonsStackView: CGFloat = 16
+            static let contentStackViewTop: CGFloat = 12
+            static let contentStackViewBottom: CGFloat = 12
+            static let contentStackViewHorizontal: CGFloat = 16
+        }
+    }
+
+    var shouldPrefixLeadingIcon: Bool = true {
+        didSet {
+            guard let title = title else { return }
+
+            Self.updateTitleLabel(
+                titleLabel,
+                with: title,
+                shouldPrefixLeadingIcon: shouldPrefixLeadingIcon
+            )
+        }
     }
 
     var title: String? {
@@ -20,42 +41,45 @@ final class Tooltip: UIView {
         }
     }
 
-    var shouldPrefixLeadingIcon: Bool = true {
+    var message: String? {
         didSet {
-            guard let title = title else { return }
-
-            Self.updateTitleLabel(
-                titleLabel,
-                with: title,
-                shouldPrefixLeadingIcon: shouldPrefixLeadingIcon
-            )
+            messageLabel.text = message
         }
     }
 
-    private let titleLabel: UILabel = {
+    private lazy var titleLabel: UILabel = {
         $0.font = WPStyleGuide.fontForTextStyle(.body)
+        $0.textColor = .invertedLabel
         return $0
     }(UILabel())
 
-    private let descriptionLabel: UILabel = {
+    private lazy var messageLabel: UILabel = {
         $0.font = WPStyleGuide.fontForTextStyle(.body)
+        $0.textColor = .secondaryLabel
+        $0.numberOfLines = 3
         return $0
     }(UILabel())
 
-    private let primaryButton: UIButton = {
+    private(set) lazy var primaryButton: UIButton = {
         $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         return $0
     }(UIButton())
 
-    private let secondaryButton: UIButton = {
+    private(set) lazy var secondaryButton: UIButton = {
+        $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         return $0
     }(UIButton())
 
-    private let contentStackView: UIStackView = {
+    private lazy var contentStackView: UIStackView = {
+        $0.addArrangedSubviews([titleLabel, messageLabel, buttonsStackView])
+        $0.spacing = Constants.Spacing.contentStackView
+        $0.axis = .vertical
         return $0
     }(UIStackView())
 
-    private let buttonsStackView: UIStackView = {
+    private lazy var buttonsStackView: UIStackView = {
+        $0.addArrangedSubviews([primaryButton, secondaryButton])
+        $0.spacing = Constants.Spacing.buttonsStackView
         return $0
     }(UIStackView())
 
@@ -69,5 +93,34 @@ final class Tooltip: UIView {
         } else {
             titleLabel.text = text
         }
+    }
+
+    init() {
+        super.init(frame: .zero)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        backgroundColor = .invertedSystem5
+        layer.cornerRadius = Constants.cornerRadius
+
+        setUpConstraints()
+    }
+
+    private func setUpConstraints() {
+        contentStackView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentStackView)
+
+        NSLayoutConstraint.activate([
+            contentStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.Spacing.contentStackViewTop),
+            contentStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
+            trailingAnchor.constraint(equalTo: contentStackView.trailingAnchor, constant: Constants.Spacing.contentStackViewHorizontal),
+            bottomAnchor.constraint(equalTo: contentStackView.bottomAnchor, constant: Constants.Spacing.contentStackViewBottom)
+        ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipAnchor.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipAnchor.swift
@@ -39,7 +39,7 @@ final class TooltipAnchor: UIControl {
     }
 
     func dismissByFadingOut() {
-        UIView.animate(withDuration: 0.3) {
+        UIView.animate(withDuration: 0.2) {
             self.alpha = 0
         } completion: { _ in
             self.removeFromSuperview()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		08D345531CD7F50900358E8C /* MenusSelectionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D3454F1CD7F50900358E8C /* MenusSelectionView.m */; };
 		08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D345551CD7FBA900358E8C /* MenuHeaderViewController.m */; };
 		08D499671CDD20450004809A /* Menus.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08D499661CDD20450004809A /* Menus.storyboard */; };
+		08D553662821286300AA1E8D /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D553652821286300AA1E8D /* Tooltip.swift */; };
 		08D978551CD2AF7D0054F19A /* Menu+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */; };
 		08D978561CD2AF7D0054F19A /* MenuItem+ViewDesign.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D9784E1CD2AF7D0054F19A /* MenuItem+ViewDesign.m */; };
 		08D978571CD2AF7D0054F19A /* MenuItemCheckButtonView.m in Sources */ = {isa = PBXBuildFile; fileRef = 08D978501CD2AF7D0054F19A /* MenuItemCheckButtonView.m */; };
@@ -4930,6 +4931,7 @@
 		08D345551CD7FBA900358E8C /* MenuHeaderViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuHeaderViewController.m; sourceTree = "<group>"; };
 		08D499661CDD20450004809A /* Menus.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Menus.storyboard; sourceTree = "<group>"; };
 		08D4C0E61C76F14E002E5BF6 /* WordPress 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 47.xcdatamodel"; sourceTree = "<group>"; };
+		08D553652821286300AA1E8D /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
 		08D9784B1CD2AF7D0054F19A /* Menu+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Menu+ViewDesign.h"; sourceTree = "<group>"; };
 		08D9784C1CD2AF7D0054F19A /* Menu+ViewDesign.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Menu+ViewDesign.m"; sourceTree = "<group>"; };
 		08D9784D1CD2AF7D0054F19A /* MenuItem+ViewDesign.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "MenuItem+ViewDesign.h"; sourceTree = "<group>"; };
@@ -8232,6 +8234,7 @@
 			isa = PBXGroup;
 			children = (
 				081E4B4B281C019A0085E89C /* TooltipAnchor.swift */,
+				08D553652821286300AA1E8D /* Tooltip.swift */,
 			);
 			path = "Feature Highlight";
 			sourceTree = "<group>";
@@ -18868,6 +18871,7 @@
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
 				46F583AB2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
+				08D553662821286300AA1E8D /* Tooltip.swift in Sources */,
 				FAB985C12697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
 				40C403EC2215CD1300E8C894 /* SearchResultsStatsRecordValue+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
Refs:  pbArwn-4oo-p2

This PR adds the Tooltip Container View. It includes drawing of the arrow head for the tooltip. It can be placed at either top or bottom vertically and horizontally anywhere within the bounds of the tooltip itself.

 - [x] Create the tooltip container
 - [x] Header component with the sparkle image.
  - Note that while SFSymbols provide a "sparkles" symbol, the one that's used seems to be from the emoji.
 - [x] Body component.
 - [x] Dismiss action button.
 - [x] Provide optional secondary action button.
 - [x] Create the pointer view.
 - [ ] Create the pulsing target indicator view. (I think we can reuse the existing one).
 - [x] Add logic to place the pointer.
 - [x] Review accessibility.

To test:
As this PR only adds the component and no entry point for it, adding the snippet below to a `UIViewController` (`viewDidLoad` or `viewDidAppear` would work) subclass should display it on top of other views:

One can play with the configuration values to see if the component adapts to the changes.

```Swift
        let tooltip = Tooltip()
        tooltip.translatesAutoresizingMaskIntoConstraints = false
        view.addSubview(tooltip)

        // Modify these to test various cases.
        tooltip.title = "Follow the conversation"
        tooltip.message = "Get notified when new comments are added to this post."
        tooltip.primaryButton.setTitle("Got it", for: .normal)
        tooltip.secondaryButton.setTitle("Learn more", for: .normal)
        tooltip.addArrowHead(toXPosition: 270, arrowPosition: .top)


        NSLayoutConstraint.activate([
            tooltip.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 200),
            tooltip.centerXAnchor.constraint(equalTo: view.centerXAnchor)
        ])
```

## Regression Notes
1. Potential unintended areas of impact
N/A. It is a standalone, new UI component.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
All UI code. And the component is not being displayed yet.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

| Bottom  | Top |
| ------------- | ------------- |
|  ![Screenshot on 2022-05-05 at 18:29:03](https://user-images.githubusercontent.com/15968946/166973237-63f34f4b-c380-490a-8016-a503b7cd814b.png)  | ![Screenshot on 2022-05-05 at 18:30:42](https://user-images.githubusercontent.com/15968946/166973330-ac0f200f-1075-400d-ae41-18478a4de3e9.png)  |


