### PR TITLE
Blogging Prompts: Fix warnings in `BloggingPromptsHeaderView.xib`

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -36,6 +36,7 @@ private extension BloggingPromptsHeaderView {
         configureStrings()
         configureStyles()
         configureConstraints()
+        configureInsets()
     }
 
     func configureSpacing() {
@@ -55,11 +56,14 @@ private extension BloggingPromptsHeaderView {
 
     func configureStyles() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        titleLabel.adjustsFontForContentSizeCategory = true
         promptLabel.font = WPStyleGuide.BloggingPrompts.promptContentFont
+        promptLabel.adjustsFontForContentSizeCategory = true
         answerPromptButton.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         answerPromptButton.titleLabel?.adjustsFontForContentSizeCategory = true
         answerPromptButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
         answeredLabel.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
+        answeredLabel.adjustsFontForContentSizeCategory = true
         answeredLabel.textColor = WPStyleGuide.BloggingPrompts.answeredLabelColor
         shareButton.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         shareButton.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -73,12 +77,26 @@ private extension BloggingPromptsHeaderView {
         ])
     }
 
+    func configureInsets() {
+        if #available(iOS 15.0, *) {
+            var config: UIButton.Configuration = .plain()
+            config.contentInsets = Constants.buttonContentInsets
+            answerPromptButton.configuration = config
+            shareButton.configuration = config
+        } else {
+            answerPromptButton.contentEdgeInsets = Constants.buttonContentEdgeInsets
+            shareButton.contentEdgeInsets = Constants.buttonContentEdgeInsets
+        }
+    }
+
     // MARK: - Constants
 
     struct Constants {
         static let titleSpacing: CGFloat = 8.0
         static let answeredViewSpacing: CGFloat = 9.0
         static let answerPromptButtonSpacing: CGFloat = 9.0
+        static let buttonContentEdgeInsets = UIEdgeInsets(top: 16.0, left: 0.0, bottom: 16.0, right: 0.0)
+        static let buttonContentInsets = NSDirectionalEdgeInsets(top: 16.0, leading: 0.0, bottom: 16.0, trailing: 0.0)
     }
 
     struct Strings {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -27,7 +27,7 @@
                                         <constraint firstAttribute="height" constant="18" id="Wgm-8p-3As"/>
                                     </constraints>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Prompts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJN-uB-YYG">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Prompts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="BJN-uB-YYG">
                                     <rect key="frame" x="23" y="0.0" width="64.5" height="24"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="5Im-WR-keg"/>
@@ -38,7 +38,7 @@
                                 </label>
                             </subviews>
                         </stackView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Cast the movie of your life." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rye-vB-0gG">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Cast the movie of your life." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rye-vB-0gG">
                             <rect key="frame" x="73.5" y="24" width="202.5" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="24" id="XJS-Qq-aST"/>
@@ -48,30 +48,26 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqk-gy-gv5">
-                            <rect key="frame" x="125" y="48" width="99" height="23.5"/>
+                            <rect key="frame" x="113" y="48" width="123" height="23.5"/>
                             <state key="normal" title="Button"/>
-                            <buttonConfiguration key="configuration" style="plain" title="Answer Prompt">
-                                <directionalEdgeInsets key="contentInsets" top="16" leading="0.0" bottom="16" trailing="0.0"/>
-                            </buttonConfiguration>
+                            <buttonConfiguration key="configuration" style="plain" title="Answer Prompt"/>
                             <connections>
                                 <action selector="answerPromptTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="maK-JO-Huc"/>
                             </connections>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="74j-gh-nmq">
-                            <rect key="frame" x="100.5" y="71.5" width="148" height="20.5"/>
+                            <rect key="frame" x="88.5" y="71.5" width="172" height="20.5"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓ Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ttu-81-Rjc">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓ Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ttu-81-Rjc">
                                     <rect key="frame" x="0.0" y="0.0" width="94.5" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="deu-kl-qJY">
-                                    <rect key="frame" x="110.5" y="0.0" width="37.5" height="20.5"/>
+                                    <rect key="frame" x="110.5" y="0.0" width="61.5" height="20.5"/>
                                     <state key="normal" title="Button"/>
-                                    <buttonConfiguration key="configuration" style="plain" title="Share">
-                                        <directionalEdgeInsets key="contentInsets" top="16" leading="0.0" bottom="16" trailing="0.0"/>
-                                    </buttonConfiguration>
+                                    <buttonConfiguration key="configuration" style="plain" title="Share"/>
                                     <connections>
                                         <action selector="shareTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="ABZ-P1-FDh"/>
                                     </connections>


### PR DESCRIPTION
See: #18402

## Description

Fixes:
- Using iOS 15+ features in `BloggingPromptsHeaderView` nib file
- Some dynamic text warnings about the font used in the same file

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Launch the app on iOS 15.0+
- Navigate to the 'My Site' tab
- Tap on the create new '+'
- Verify layout still matches previous layout
- Repeat above on a lower version than iOS 15.0 (this may require setting `mySiteDashboard` to `false` if it crashes)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
