### PR TITLE
[Tooling] Improvements on the AppLocalizedString linter

### DIFF
--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
@@ -15,7 +15,7 @@ if [ ! -x "${LINTER_EXEC}" ] || ! (shasum -c "${LINTER_EXEC}.shasum" >/dev/null 
 fi
 
 if [ -z "${PROJECT_FILE_PATH:=${1:-}}" ]; then
-  echo "Please provide the path to the xcodeproj to scan"
+  echo "error: Please provide the path to the xcodeproj to scan"
   exit 1
 fi
 "$LINTER_EXEC" "${PROJECT_FILE_PATH}" "${@:2}"

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
@@ -8,7 +8,7 @@ LINTER_EXEC="${LINTER_BUILD_DIR}/$(basename "${SCRIPT_SRC}" .swift)"
 
 if [ ! -x "${LINTER_EXEC}" ] || ! (shasum -c "${LINTER_EXEC}.shasum" >/dev/null 2>/dev/null); then
   echo "Pre-compiling linter script to ${LINTER_EXEC}..."
-  swiftc -sdk "$(xcrun --sdk macosx --show-sdk-path)" "${SCRIPT_SRC}" -o "${LINTER_EXEC}"
+  swiftc -O -sdk "$(xcrun --sdk macosx --show-sdk-path)" "${SCRIPT_SRC}" -o "${LINTER_EXEC}"
   shasum "${SCRIPT_SRC}" >"${LINTER_EXEC}.shasum"
   chmod +x "${LINTER_EXEC}"
   echo "Pre-compiled linter script ready"

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.sh
@@ -14,4 +14,8 @@ if [ ! -x "${LINTER_EXEC}" ] || ! (shasum -c "${LINTER_EXEC}.shasum" >/dev/null 
   echo "Pre-compiled linter script ready"
 fi
 
-"$LINTER_EXEC" "${PROJECT_FILE_PATH:-$1}" # "${TARGET_NAME:-$2}"
+if [ -z "${PROJECT_FILE_PATH:=${1:-}}" ]; then
+  echo "Please provide the path to the xcodeproj to scan"
+  exit 1
+fi
+"$LINTER_EXEC" "${PROJECT_FILE_PATH}" "${@:2}"

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -305,8 +305,10 @@ let project = try Xcodeproj(path: projectPath)
 // 2nd arg (optional) = name of target to lint
 let targetsToLint: [Xcodeproj.PBXNativeTarget]
 if let targetName = args.dropFirst().first, !targetName.isEmpty {
+    print("Selected target: \(targetName)")
     targetsToLint = project.nativeTargets.filter { $0.name == targetName }
 } else {
+    print("Linting all app extension targets")
     targetsToLint = project.nativeTargets.filter { $0.productType == .appExtension }
 }
 

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -53,8 +53,8 @@ extension Xcodeproj {
 
     /// Finds the full path / URL of a `PBXBuildFile` based on the groups it belongs to and their `sourceTree` attribute
     func resolveURL(to buildFile: PBXBuildFile) throws -> URL? {
-        if let fileRef = try? self.pbxproj.object(id: buildFile.fileRef) as PBXFileReference {
-            return try resolveURL(objectUUID: buildFile.fileRef, object: fileRef)
+        if let fileRefID = buildFile.fileRef, let fileRefObject = try? self.pbxproj.object(id: fileRefID) as PBXFileReference {
+            return try resolveURL(objectUUID: fileRefID, object: fileRefObject)
         } else {
             // If the `PBXBuildFile` is pointing to `XCVersionGroup` (like `*.xcdatamodel`) and `PBXVariantGroup` (like `*.strings`)
             // (instead of a `PBXFileReference`), then in practice each file in the group's `children` will be built by the Build Phase.
@@ -195,7 +195,7 @@ extension Xcodeproj {
     /// One of the many `PBXObject` types encountered in the `.pbxproj` file format.
     /// Represents a single build file in a `PBXSourcesBuildPhase` build phase.
     struct PBXBuildFile: PBXObject {
-        let fileRef: ObjectUUID
+        let fileRef: ObjectUUID?
     }
 
     /// This type is used to indicate what a file reference in the project is actually relative to

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -39,7 +39,7 @@ class Xcodeproj {
 
 // Convenience methods and properties
 extension Xcodeproj {
-    /// Builds an `Xcodeproj` instance by parsing the an `.xcodeproj` or `pbxproj` file at the provided path
+    /// Builds an `Xcodeproj` instance by parsing the `.xcodeproj` or `pbxproj` file at the provided path
     convenience init(path: String) throws {
         try self.init(url: URL(fileURLWithPath: path))
     }
@@ -95,7 +95,7 @@ protocol PBXReference: PBXObject {
     var sourceTree: Xcodeproj.SourceTree { get }
 }
 
-/// Types used to parse and decode the internals of an `.xcodeproj/project.pbxproj` file
+/// Types used to parse and decode the internals of a `*.xcodeproj/project.pbxproj` file
 extension Xcodeproj {
     /// An error `thrown` when an inconsistency is found while parsing the `.pbxproj` file.
     enum DecodingError: Swift.Error, CustomStringConvertible {

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -114,13 +114,13 @@ extension Xcodeproj {
         var description: String {
             switch self {
             case .objectNotFound(id: let id):
-                return "Unable to find object with UUID \(id)"
+                return "Unable to find object with UUID `\(id)`"
             case .unexpectedObjectType(id: let id, expectedType: let expectedType, found: let found):
-                return  "Object with UUID \(id) was expected to be of type \(expectedType) but found \(found) instead"
+                return  "Object with UUID `\(id)` was expected to be of type \(expectedType) but found \(found) instead"
             case .incorrectAbsolutePath(id: let id):
-                return "Object \(id) has `sourceTree = \(Xcodeproj.SourceTree.absolute)` but no `path`"
+                return "Object `\(id)` has `sourceTree = \(Xcodeproj.SourceTree.absolute)` but no `path`"
             case .orphanObject(id: let id, object: let object):
-                return "Unable to find parent group of \(object) (\(id)) during file path resolution"
+                return "Unable to find parent group of \(object) (`\(id)`) during file path resolution"
             }
         }
     }
@@ -277,6 +277,7 @@ func lint(fileAt url: URL, targetName: String) throws -> LintResult {
         guard line.range(of: "\\s*//", options: .regularExpression) == nil else { return } // Skip commented lines
         guard let range = line.range(of: "NSLocalizedString") else { return }
         
+        // Violation found, report it
         let colNo = line.distance(from: line.startIndex, to: range.lowerBound)
         let message = "Use `AppLocalizedString` instead of `NSLocalizedString` in source files that are used in the `\(targetName)` extension target. See paNNhX-nP-p2 for more info."
         print("\(url.path):\(lineNo):\(colNo): error: \(message)")
@@ -320,6 +321,6 @@ do {
     print("Done! \(violationsFound) violation(s) found.")
     exit(violationsFound > 0 ? 1 : 0)
 } catch let error {
-    print("\n\nError while parsing `\(projectPath)`: \(error)")
+    print("\(projectPath): error: Error while parsing the project file \(projectPath): \(error.localizedDescription)")
     exit(2)
 }

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -247,8 +247,8 @@ extension Xcodeproj {
 
         init(from decoder: Decoder) throws {
             let untypedObject = try UnknownPBXObject(from: decoder)
-            if let objectType = Self.knownTypes.first(where: { $0.isa == untypedObject.isa }), let typedObject = try? objectType.init(from: decoder) {
-                self.wrappedValue = typedObject
+            if let objectType = Self.knownTypes.first(where: { $0.isa == untypedObject.isa }) {
+                self.wrappedValue = try objectType.init(from: decoder)
              } else {
                 self.wrappedValue = untypedObject
              }

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -124,6 +124,34 @@ extension Xcodeproj {
             }
         }
     }
+
+    @propertyWrapper
+    enum AllowUnknownRawValue<T: RawRepresentable>: Decodable where T.RawValue == String {
+        case known(T)
+        case other(String)
+
+        var wrappedValue: T? {
+            switch self {
+            case .known(let v): return v
+            case .other: return nil
+            }
+        }
+        var projectedValue: String {
+            switch self {
+            case .known(let v): return v.rawValue
+            case .other(let s): return s
+            }
+        }
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            if let known = T(rawValue: string) {
+                self = .known(known)
+            } else {
+                self = .other(string)
+            }
+        }
+    }
     
     /// Type used to represent and decode the root object of a `.pbxproj` file.
     struct PBXProjFile: Decodable {
@@ -175,13 +203,14 @@ extension Xcodeproj {
     struct PBXNativeTarget: PBXObject {
         let name: String
         let buildPhases: [ObjectUUID]
-        let productType: ProductType
+        @AllowUnknownRawValue var productType: ProductType?
 
         enum ProductType: String, Decodable {
             case app = "com.apple.product-type.application"
             case appExtension = "com.apple.product-type.app-extension"
             case unitTest = "com.apple.product-type.bundle.unit-test"
             case uiTest = "com.apple.product-type.bundle.ui-testing"
+            case framework = "com.apple.product-type.framework"
         }
     }
 

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -87,12 +87,10 @@ extension Xcodeproj {
 
 /// "Parent" type for all the PBX... types of objects encountered in a pbxproj 
 protocol PBXObject: Decodable {
-    static func match(isa: String) -> Bool
+    static var isa: String { get}
 }
 extension PBXObject {
-    static func match(isa: String) -> Bool {
-        isa == String(describing: self)
-    }
+    static var isa: String { String(describing: self) }
 }
 
 /// "Parent" type for PBXObjects referencing relative path information (`PBXFileReference`, `PBXGroup`)
@@ -212,8 +210,6 @@ extension Xcodeproj {
     /// One of the many `PBXObject` types encountered in the `.pbxproj` file format.
     /// Represents a group (aka "folder") contained in the project tree.
     struct PBXGroup: PBXReference {
-        static func match(isa: String) -> Bool { ["PBXGroup", "XCVersionGroup", "PBXVariantGroup"].contains(isa) }
-
         let name: String?
         let path: String?
         let sourceTree: SourceTree
@@ -222,8 +218,6 @@ extension Xcodeproj {
 
     /// Fallback type for any unknown `PBXObject` type.
     struct UnknownPBXObject: PBXObject {
-        static func match(isa: String) -> Bool { true }
-
         let isa: String
     }
 
@@ -243,7 +237,7 @@ extension Xcodeproj {
 
         init(from decoder: Decoder) throws {
             let untypedObject = try UnknownPBXObject(from: decoder)
-            if let objectType = Self.knownTypes.first(where: { $0.match(isa: untypedObject.isa) }), let typedObject = try? objectType.init(from: decoder) {
+            if let objectType = Self.knownTypes.first(where: { $0.isa == untypedObject.isa }), let typedObject = try? objectType.init(from: decoder) {
                 self.wrappedValue = typedObject
              } else {
                 self.wrappedValue = untypedObject

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -69,7 +69,8 @@ extension Xcodeproj {
 
         switch object.sourceTree {
         case .absolute:
-            return URL(fileURLWithPath: object.path!)
+            guard let path = object.path else { fatalError("Object \(objectUUID) has a `sourceTree` = \(object.sourceTree) but no `path`!") }
+            return URL(fileURLWithPath: path)
         case .group:
             guard let parentUUID = referrers[objectUUID] else { fatalError("Unable to find parent of \(object) (\(objectUUID))") }
             let parentGroup = try! self.pbxproj.object(id: parentUUID) as PBXGroup
@@ -106,12 +107,13 @@ extension Xcodeproj {
     enum DecodingError: Swift.Error, CustomStringConvertible {
         case objectNotFound(id: ObjectUUID)
         case unexpectedObjectType(id: ObjectUUID, expectedType: Any.Type, found: PBXObject)
+
         var description: String {
             switch self {
                 case .objectNotFound(id: let id):
                     return "Unable to find object with UUID \(id)"
-                case .unexpectedObjectType(let id, let expectedType, let found):
-                    return  "Object with UUID \(id) was expected to be of type \(expectedType) but found \(found) instead."
+                case .unexpectedObjectType(id: let id, expectedType: let expectedType, found: let found):
+                    return  "Object with UUID \(id) was expected to be of type \(expectedType) but found \(found) instead"
             }
         }
     }

--- a/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
+++ b/Scripts/BuildPhases/LintAppLocalizedStringsUsage.swift
@@ -25,11 +25,11 @@ class Xcodeproj {
     ///   up into the chain of parent `PBXGroup` containers to construct the successive relative paths of groups using `sourceTree = "<group>"`
     private lazy var referrers: [ObjectUUID: ObjectUUID] = {
         var referrers: [ObjectUUID: ObjectUUID] = [:]
-        func recurseIfGroup(objectID: ObjectUUID, indent: String = "") {
+        func recurseIfGroup(objectID: ObjectUUID) {
             guard let group = try? (self.pbxproj.object(id: objectID) as PBXGroup) else { return }
             for childID in group.children {
                 referrers[childID] = objectID
-                recurseIfGroup(objectID: childID, indent: "\(indent)  ")
+                recurseIfGroup(objectID: childID)
             }
         }
         recurseIfGroup(objectID: self.pbxproj.rootProject.mainGroup)


### PR DESCRIPTION
This is a follow-up on https://github.com/wordpress-mobile/WordPress-iOS/pull/18462 to address the remaining improvements I had in mind for the swift implementation back then:

## What was changed

 - Turn on optimizations when compiling the swift code (honestly doesn't change much, but 🤷 )
 - Remove debugging leftovers, fix typos in comments
 - Better strategy for parsing the `PBXObjects` based on their `isa`
 - Fix handling of `XCVersionGroup` and `PBXVariantGroup`
    - First by better understanding how to deal with the case of a `PBXBuildFile` pointing to such group was supposed to be handled in the first place…
    - … then by deciding to ignore those cases completely because they are only used for compiled resource "packages" like localized files (`*.strings`) and versioned files (`xcdatamodeld`), but we're only interested in source files (`*.swift`/`*.m`) anyway
 - Remove all force-unwraps and `fatalError`
    - Replace them with thrown errors
    - Provide better error messages and error reporting at top-level for any `.pbxproj` inconsistencies
    - More consistent reporting when encountering objects of known `isa` but with invalid data — as opposed to parse them as `UnknownPXBObject` at first and throw an unrelated error like `.orphanObject` only later
    - Protect against unknown values of some `PBXObject`'s fields, like an unknown `productType` or a `PBXBuildFile` pointing to a `productRef` (e.g. Swift Package dependency) instead of a `fileRef`

## To Test

 - Check that the project compiles in Xcode with a clean build
 - Check that the project compiles in Xcode with an incremental build
 - Check that the time taken by the Script Build phase in the build logs didn't jump to some crazy value and taking too long
 - Introduce a violation by replacing a random `AppLocalizedString` in code by `NSLocalizedString`, rebuild and validate the linter still detects it
 - Introduce an error in the `pbxproj` file to make it invalid, then check that the running the script from the terminal shows the expected error nicely. e.g.:
    - Replacing a `sourceTree = "<group>"` by `sourceTree = "wut"` to get a `DecodingError`
    - Changing a `PBXGroup` to have a `sourceTree = "<absolute>"` but removing its `path = …` value to get the `.incorrectAbsolutePath` error
    - Find the UUID of one of the parsed file, and remove it from the `children` list of its parent `PBXGroup` to get the `.orphanObject` error
    - Change an UUID randomly to get the `.objectNotFound` error
