### PR TITLE
Rename JSONObject.loadFile(named:) to loadJSONFile(named:)

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -925,6 +925,7 @@
 		46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F58501262605930010A723 /* BlockEditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */; };
 		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
+		4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B8E282B05210089CF3D /* JSONObjectTests.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
 		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
@@ -5702,6 +5703,7 @@
 		46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceTests.swift; sourceTree = "<group>"; };
 		46F84612185A8B7E009D0DA5 /* PostContentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostContentProvider.h; sourceTree = "<group>"; };
 		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
+		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		528B9926294302CD0A4EB5C4 /* Pods-WordPressScreenshotGeneration.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -11386,6 +11388,7 @@
 				FAE8EE9B273AD0A800A65307 /* QuickStartSettingsTests.swift */,
 				179501CC27A01D4100882787 /* PublicizeAuthorizationURLComponentsTests.swift */,
 				80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */,
+				4A266B8E282B05210089CF3D /* JSONObjectTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -19631,6 +19634,7 @@
 				C3DA0EE02807062600DA3250 /* SiteCreationNameTracksEventTests.swift in Sources */,
 				73C8F06621BEF76B00DDDF7E /* SiteAssemblyViewTests.swift in Sources */,
 				73178C2821BEE09300E37C9A /* SiteCreationDataCoordinatorTests.swift in Sources */,
+				4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */,
 				D81C2F6020F891C4002AE1F1 /* TrashCommentActionTests.swift in Sources */,
 				570BFD8D22823DE5007859A8 /* PostActionSheetTests.swift in Sources */,
 				FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -11,7 +11,7 @@ final class ActivityContentFactoryTests: XCTestCase {
     }
 
     private func mockBlock() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-activity-content.json")
+        return try .loadJSONFile(named: "activity-log-activity-content.json")
     }
 
 }

--- a/WordPress/WordPressTest/ActivityContentFactoryTests.swift
+++ b/WordPress/WordPressTest/ActivityContentFactoryTests.swift
@@ -11,7 +11,7 @@ final class ActivityContentFactoryTests: XCTestCase {
     }
 
     private func mockBlock() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-activity-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-activity-content.json")
     }
 
 }

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -28,39 +28,39 @@ class ActivityLogTestData {
     }
 
     func getCommentEventDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-comment.json")
+        return try .loadJSONFile(named: "activity-log-comment.json")
     }
 
     func getPostEventDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-post.json")
+        return try .loadJSONFile(named: "activity-log-post.json")
     }
 
     func getPingbackDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-pingback-content.json")
+        return try .loadJSONFile(named: "activity-log-pingback-content.json")
     }
 
     func getPostContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-post-content.json")
+        return try .loadJSONFile(named: "activity-log-post-content.json")
     }
 
     func getCommentContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-comment-content.json")
+        return try .loadJSONFile(named: "activity-log-comment-content.json")
     }
 
     func getThemeContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-theme-content.json")
+        return try .loadJSONFile(named: "activity-log-theme-content.json")
     }
 
     func getSettingsContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-settings-content.json")
+        return try .loadJSONFile(named: "activity-log-settings-content.json")
     }
 
     func getSiteContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-site-content.json")
+        return try .loadJSONFile(named: "activity-log-site-content.json")
     }
 
     func getPluginContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-plugin-content.json")
+        return try .loadJSONFile(named: "activity-log-plugin-content.json")
     }
 
     func getCommentRangeDictionary() throws -> JSONObject {

--- a/WordPress/WordPressTest/ActivityLogTestData.swift
+++ b/WordPress/WordPressTest/ActivityLogTestData.swift
@@ -28,39 +28,39 @@ class ActivityLogTestData {
     }
 
     func getCommentEventDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-comment.json")
+        return try JSONObject(fromFileNamed: "activity-log-comment.json")
     }
 
     func getPostEventDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-post.json")
+        return try JSONObject(fromFileNamed: "activity-log-post.json")
     }
 
     func getPingbackDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-pingback-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-pingback-content.json")
     }
 
     func getPostContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-post-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-post-content.json")
     }
 
     func getCommentContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-comment-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-comment-content.json")
     }
 
     func getThemeContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-theme-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-theme-content.json")
     }
 
     func getSettingsContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-settings-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-settings-content.json")
     }
 
     func getSiteContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-site-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-site-content.json")
     }
 
     func getPluginContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-plugin-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-plugin-content.json")
     }
 
     func getCommentRangeDictionary() throws -> JSONObject {

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -134,7 +134,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-comment-content.json")
+        return try JSONObject(fromFileNamed: "notifications-comment-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
@@ -142,7 +142,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func loadMeta() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-comment-meta.json")
+        return try JSONObject(fromFileNamed: "notifications-comment-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -134,7 +134,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-comment-content.json")
+        return try .loadJSONFile(named: "notifications-comment-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
@@ -142,7 +142,7 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     private func loadMeta() throws -> JSONObject {
-        return try .loadFile(named: "notifications-comment-meta.json")
+        return try .loadJSONFile(named: "notifications-comment-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -60,7 +60,7 @@ final class FormattableContentGroupTests: XCTestCase {
     }
 
     private func mockActivity() throws -> JSONObject {
-        return try .loadFile(named: "activity-log-activity-content.json")
+        return try .loadJSONFile(named: "activity-log-activity-content.json")
     }
 
 }

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -60,7 +60,7 @@ final class FormattableContentGroupTests: XCTestCase {
     }
 
     private func mockActivity() throws -> JSONObject {
-        return try .loadJSONFile(named: "activity-log-activity-content.json")
+        return try JSONObject(fromFileNamed: "activity-log-activity-content.json")
     }
 
 }

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -130,7 +130,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-user-content.json")
+        return try JSONObject(fromFileNamed: "notifications-user-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
@@ -138,7 +138,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func loadMeta() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-user-content-meta.json")
+        return try JSONObject(fromFileNamed: "notifications-user-content-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/FormattableUserContentTests.swift
+++ b/WordPress/WordPressTest/FormattableUserContentTests.swift
@@ -130,7 +130,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-user-content.json")
+        return try .loadJSONFile(named: "notifications-user-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {
@@ -138,7 +138,7 @@ final class FormattableUserContentTests: XCTestCase {
     }
 
     private func loadMeta() throws -> JSONObject {
-        return try .loadFile(named: "notifications-user-content-meta.json")
+        return try .loadJSONFile(named: "notifications-user-content-meta.json")
     }
 
     private func mockedActions() -> [FormattableContentAction] {

--- a/WordPress/WordPressTest/JSONObjectTests.swift
+++ b/WordPress/WordPressTest/JSONObjectTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+
+class JSONObjectTests: XCTestCase {
+    func testParsingFileWithUnexpectedFileExtension() throws {
+        try XCTAssertThrowsError(JSONObject(fromFileNamed: "notifications.josn"))
+    }
+
+    func testParsingNonexistentFiles() throws {
+        try XCTAssertThrowsError(JSONObject(fromFileNamed: "a-file-that-does-not-exist"))
+        try XCTAssertThrowsError(JSONObject(fromFileNamed: "a-file-that-does-not-exist.json"))
+    }
+
+    func testAllowedFileNames() throws {
+        try XCTAssertNoThrow(JSONObject(fromFileNamed: "authtoken"))
+        try XCTAssertNoThrow(JSONObject(fromFileNamed: "authtoken.json"))
+    }
+}

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -9,7 +9,7 @@ extension NSManagedObject {
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
     static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) throws -> Self {
-        let jsonObject = try JSONObject.loadFile(named: fileName)
+        let jsonObject = try JSONObject.loadJSONFile(named: fileName)
         let model = Self.init(context: context)
         for (key, value) in jsonObject {
             model.setValue(value, forKey: key)

--- a/WordPress/WordPressTest/NSManagedObject+Fixture.swift
+++ b/WordPress/WordPressTest/NSManagedObject+Fixture.swift
@@ -9,7 +9,7 @@ extension NSManagedObject {
     ///   - context: The managed object context to use
     /// - Returns: A new instance with property values of the given JSON file.
     static func fixture(fromFile fileName: String, insertInto context: NSManagedObjectContext) throws -> Self {
-        let jsonObject = try JSONObject.loadJSONFile(named: fileName)
+        let jsonObject = try JSONObject(fromFileNamed: fileName)
         let model = Self.init(context: context)
         for (key, value) in jsonObject {
             model.setValue(value, forKey: key)

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -41,27 +41,27 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
     }
 
     private func mockCommentRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-comment-range.json")
+        return try JSONObject(fromFileNamed: "notifications-comment-range.json")
     }
 
     private func mockIconRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-icon-range.json")
+        return try JSONObject(fromFileNamed: "notifications-icon-range.json")
     }
 
     private func mockPostRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-post-range.json")
+        return try JSONObject(fromFileNamed: "notifications-post-range.json")
     }
 
     private func mockSiteRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-site-range.json")
+        return try JSONObject(fromFileNamed: "notifications-site-range.json")
     }
 
     private func mockUserRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-user-range.json")
+        return try JSONObject(fromFileNamed: "notifications-user-range.json")
     }
 
     private func mockBlockQuoteRange() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-blockquote-range.json")
+        return try JSONObject(fromFileNamed: "notifications-blockquote-range.json")
     }
 
 }

--- a/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRangeFactoryTests.swift
@@ -41,27 +41,27 @@ final class NotificationContentRangeFactoryTests: XCTestCase {
     }
 
     private func mockCommentRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-comment-range.json")
+        return try .loadJSONFile(named: "notifications-comment-range.json")
     }
 
     private func mockIconRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-icon-range.json")
+        return try .loadJSONFile(named: "notifications-icon-range.json")
     }
 
     private func mockPostRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-post-range.json")
+        return try .loadJSONFile(named: "notifications-post-range.json")
     }
 
     private func mockSiteRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-site-range.json")
+        return try .loadJSONFile(named: "notifications-site-range.json")
     }
 
     private func mockUserRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-user-range.json")
+        return try .loadJSONFile(named: "notifications-user-range.json")
     }
 
     private func mockBlockQuoteRange() throws -> JSONObject {
-        return try .loadFile(named: "notifications-blockquote-range.json")
+        return try .loadJSONFile(named: "notifications-blockquote-range.json")
     }
 
 }

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -88,11 +88,11 @@ final class NotificationTextContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-text-content.json")
+        return try .loadJSONFile(named: "notifications-text-content.json")
     }
 
     private func mockButtonContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-button-text-content.json")
+        return try .loadJSONFile(named: "notifications-button-text-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationTextContentTests.swift
+++ b/WordPress/WordPressTest/NotificationTextContentTests.swift
@@ -88,11 +88,11 @@ final class NotificationTextContentTests: XCTestCase {
     }
 
     private func mockDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-text-content.json")
+        return try JSONObject(fromFileNamed: "notifications-text-content.json")
     }
 
     private func mockButtonContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-button-text-content.json")
+        return try JSONObject(fromFileNamed: "notifications-button-text-content.json")
     }
 
     private func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -45,7 +45,7 @@ class NotificationUtility {
     }
 
     func mockCommentContent() throws -> FormattableCommentContent {
-        let dictionary = try JSONObject.loadJSONFile(named: "notifications-replied-comment.json")
+        let dictionary = try JSONObject(fromFileNamed: "notifications-replied-comment.json")
         let body = dictionary["body"]
         let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -45,7 +45,7 @@ class NotificationUtility {
     }
 
     func mockCommentContent() throws -> FormattableCommentContent {
-        let dictionary = try JSONObject.loadFile(named: "notifications-replied-comment.json")
+        let dictionary = try JSONObject.loadJSONFile(named: "notifications-replied-comment.json")
         let body = dictionary["body"]
         let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -24,15 +24,15 @@ final class NotificationsContentFactoryTests: XCTestCase {
     }
 
     private func mockTextContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-text-content.json")
+        return try JSONObject(fromFileNamed: "notifications-text-content.json")
     }
 
     private func mockCommentContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-comment-content.json")
+        return try JSONObject(fromFileNamed: "notifications-comment-content.json")
     }
 
     private func mockUserContentDictionary() throws -> JSONObject {
-        return try .loadJSONFile(named: "notifications-user-content.json")
+        return try JSONObject(fromFileNamed: "notifications-user-content.json")
     }
 
     func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
+++ b/WordPress/WordPressTest/NotificationsContentFactoryTests.swift
@@ -24,15 +24,15 @@ final class NotificationsContentFactoryTests: XCTestCase {
     }
 
     private func mockTextContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-text-content.json")
+        return try .loadJSONFile(named: "notifications-text-content.json")
     }
 
     private func mockCommentContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-comment-content.json")
+        return try .loadJSONFile(named: "notifications-comment-content.json")
     }
 
     private func mockUserContentDictionary() throws -> JSONObject {
-        return try .loadFile(named: "notifications-user-content.json")
+        return try .loadJSONFile(named: "notifications-user-content.json")
     }
 
     func loadLikeNotification() throws -> WordPress.Notification {

--- a/WordPress/WordPressTest/PinghubTests.swift
+++ b/WordPress/WordPressTest/PinghubTests.swift
@@ -14,7 +14,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionPush() throws {
-        let message = try loadJSONMessage(name: "notes-action-push")!
+        let message = try JSONObject.loadJSONFile(named: "notes-action-push")
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.push(let noteID, let userID, _, _)) = action else {
@@ -26,7 +26,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionDelete() throws {
-        let message = try loadJSONMessage(name: "notes-action-delete")!
+        let message = try JSONObject.loadJSONFile(named: "notes-action-delete")
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.delete(let noteID)) = action else {
@@ -37,7 +37,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionUnsupported() throws {
-        let message = try loadJSONMessage(name: "notes-action-unsupported")!
+        let message = try JSONObject.loadJSONFile(named: "notes-action-unsupported")
         let action = PinghubClient.Action.from(message: message)
         XCTAssertNil(action)
     }
@@ -101,12 +101,6 @@ class PingHubTests: XCTestCase {
 
         XCTAssertNil(delegate.receivedAction)
         XCTAssertNotNil(delegate.unexpected)
-    }
-}
-
-private extension PingHubTests {
-    func loadJSONMessage(name: String) throws -> [String: AnyObject]? {
-        return try .loadFile(name, type: "json")
     }
 }
 

--- a/WordPress/WordPressTest/PinghubTests.swift
+++ b/WordPress/WordPressTest/PinghubTests.swift
@@ -14,7 +14,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionPush() throws {
-        let message = try JSONObject.loadJSONFile(named: "notes-action-push")
+        let message = try JSONObject(fromFileNamed: "notes-action-push")
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.push(let noteID, let userID, _, _)) = action else {
@@ -26,7 +26,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionDelete() throws {
-        let message = try JSONObject.loadJSONFile(named: "notes-action-delete")
+        let message = try JSONObject(fromFileNamed: "notes-action-delete")
         let action = PinghubClient.Action.from(message: message)
 
         guard case .some(.delete(let noteID)) = action else {
@@ -37,7 +37,7 @@ class PingHubTests: XCTestCase {
     }
 
     func testActionUnsupported() throws {
-        let message = try JSONObject.loadJSONFile(named: "notes-action-unsupported")
+        let message = try JSONObject(fromFileNamed: "notes-action-unsupported")
         let action = PinghubClient.Action.from(message: message)
         XCTAssertNil(action)
     }

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -5,7 +5,7 @@ typealias JSONObject = Dictionary<String, AnyObject>
 
 extension JSONObject {
 
-    /// Creat a dictionary represented by the specified json file.
+    /// Create a dictionary represented by the specified json file.
     ///
     /// - Parameter fileName: The name of the json file to load. The "json" file extension can be omitted.
     init(fromFileNamed fileName: String) throws {

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -7,23 +7,34 @@ extension JSONObject {
 
     /// Loads the specified json file and returns a dictionary representing it.
     ///
-    /// - Parameter fileName: The full name of the json file to load.
+    /// - Parameter fileName: The name of the json file to load. The "json" file extension can be omitted.
     /// - Returns: A dictionary representing the contents of the json file.
-    static func loadFile(named fileName: String) throws -> JSONObject {
-        return try loadFile(
-            (fileName as NSString).deletingPathExtension,
-            type: (fileName as NSString).pathExtension
-        )
-    }
+    static func loadJSONFile(named fileName: String) throws -> JSONObject {
+        let type = (fileName as NSString).pathExtension
+        if type != "" && type != "json" {
+            throw NSError(
+                domain: "JSONObject",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "File extension should be 'json': \(fileName)"
+                ]
+            )
+        }
 
-    /// Loads the specified JSON file and returns a dictionary representing it.
-    ///
-    /// - Parameters:
-    ///   - name: The name of the file
-    ///   - type: The extension of the file
-    /// - Returns: A dictionary representing the contents of the JSON file.
-    static func loadFile(_ name: String, type: String) throws -> JSONObject {
-        let url = try XCTUnwrap(Bundle(for: BundlerFinder.self).url(forResource: name, withExtension: type))
+        let testBundle = Bundle(for: BundlerFinder.self)
+        let candidates = [
+            testBundle.url(forResource: fileName, withExtension: nil),
+            testBundle.url(forResource: fileName, withExtension: "json"),
+        ]
+        guard let url = candidates.compactMap({ $0 }).first else {
+            throw NSError(
+                domain: "JSONObject",
+                code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Can't find JSON file named \(fileName) or \(fileName).json"
+                ]
+            )
+        }
         let data = try Data(contentsOf: url)
         let parseResult = try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .mutableLeaves])
         return try XCTUnwrap(parseResult as? JSONObject)

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -5,11 +5,10 @@ typealias JSONObject = Dictionary<String, AnyObject>
 
 extension JSONObject {
 
-    /// Loads the specified json file and returns a dictionary representing it.
+    /// Creat a dictionary represented by the specified json file.
     ///
     /// - Parameter fileName: The name of the json file to load. The "json" file extension can be omitted.
-    /// - Returns: A dictionary representing the contents of the json file.
-    static func loadJSONFile(named fileName: String) throws -> JSONObject {
+    init(fromFileNamed fileName: String) throws {
         let type = (fileName as NSString).pathExtension
         if type != "" && type != "json" {
             throw NSError(
@@ -37,7 +36,7 @@ extension JSONObject {
         }
         let data = try Data(contentsOf: url)
         let parseResult = try JSONSerialization.jsonObject(with: data, options: [.mutableContainers, .mutableLeaves])
-        return try XCTUnwrap(parseResult as? JSONObject)
+        self = try XCTUnwrap(parseResult as? JSONObject)
     }
 
 }

--- a/WordPress/WordPressTest/TestUtilities/JSONObject.swift
+++ b/WordPress/WordPressTest/TestUtilities/JSONObject.swift
@@ -28,7 +28,7 @@ extension JSONObject {
         guard let url = candidates.compactMap({ $0 }).first else {
             throw NSError(
                 domain: "JSONObject",
-                code: 1,
+                code: 2,
                 userInfo: [
                     NSLocalizedDescriptionKey: "Can't find JSON file named \(fileName) or \(fileName).json"
                 ]


### PR DESCRIPTION
Implement a simple change discussed in [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/18507#discussion_r865605510). The new function name `loadJSONFile` makes it explicit that the function parses a JSON file. The implementation is also updated to be smarter, allowing callers to omit ".json" file extension.

## Test Instructions
The expected behaviour where `fileName` argument can include or omit "json" is verified by the existing test cases. So only error handling needs some extra testing.

The `loadJSONFile` function should throw an error when:
* `fileName` argument has an extension which isn't "json", like "file.png".
* Neither `<fileName>` nor `<fileName>.json` exists in test bundle.

## Regression Notes
N/A. No impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
