### PR TITLE
[Gutenberg] Analytics - Add editor block moved event

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -48,6 +48,7 @@ import Foundation
     case gutenbergEditorSettingsFetched
     case gutenbergEditorHelpShown
     case gutenbergEditorBlockInserted
+    case gutenbergEditorBlockMoved
 
     // Notifications Permissions
     case pushNotificationsPrimerSeen
@@ -426,6 +427,8 @@ import Foundation
             return "editor_help_shown"
         case .gutenbergEditorBlockInserted:
             return "editor_block_inserted"
+        case .gutenbergEditorBlockMoved:
+            return "editor_block_moved"
         // Notifications permissions
         case .pushNotificationsPrimerSeen:
             return "notifications_primer_seen"
@@ -1095,6 +1098,7 @@ extension WPAnalytics {
         var event: WPAnalyticsEvent?
         switch eventName {
         case "editor_block_inserted": event = .gutenbergEditorBlockInserted
+        case "editor_block_moved": event = .gutenbergEditorBlockMoved
         default: event = nil
         }
 


### PR DESCRIPTION
- `Gutenberg Mobile PR` -> https://github.com/wordpress-mobile/gutenberg-mobile/pull/4833

To test check the Gutenberg Mobile PR description.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually testing that the events are getting through.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
