### PR TITLE
My Site Dashboard: fix crash on iOS 13/14

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -370,7 +370,13 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
     }
 
     private func applySnapshot(_ snapshot: Snapshot, to dataSource: DataSource) {
-        let shouldAnimate = view?.tableView.numberOfSections != 0 && view?.tableView.numberOfRows(inSection: 0) != 0
+        var shouldAnimate: Bool
+        if #available(iOS 15.0, *) {
+            shouldAnimate = view?.tableView.numberOfSections != 0 && view?.tableView.numberOfRows(inSection: 0) != 0
+        } else {
+            shouldAnimate = false
+        }
+
         dataSource.defaultRowAnimation = .fade
         dataSource.apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
         view?.tableView.allowsSelection = currentState == .posts

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -40,7 +40,7 @@ class PostsCardViewModel: NSObject {
         didSet {
             if oldValue != currentState {
                 forceReloadSnapshot()
-                trackCardDisaplyedIfNeeded()
+                trackCardDisplayedIfNeeded()
             }
         }
     }
@@ -259,7 +259,7 @@ private extension PostsCardViewModel {
         return false
     }
 
-    func trackCardDisaplyedIfNeeded() {
+    func trackCardDisplayedIfNeeded() {
         switch currentState {
         case .posts:
             BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue])


### PR DESCRIPTION
This PR fixes a crash happening on iOS 13 and 14 when loading the dashboard.

Thanks @wargcm for reporting it.

### To test

1. Run the app on iOS 13 or iOS 14
2. Go to the dashboard
3. ✅ Make sure the post list loads correctly and the app does not crash

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
