### PR TITLE
Blogging Prompts List: show real prompts

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -27,12 +27,12 @@ class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
         configureView()
     }
 
-    // TODO: remove answered param. Add BloggingPrompt, configure with its properties.
-    func configure(answered: Bool) {
-        titleLabel.text = "Cast the movie of your life."
-        dateLabel.text = dateFormatter.string(from: Date())
+    func configure(_ prompt: BloggingPrompt) {
+        self.prompt = prompt
+        titleLabel.text = prompt.text.stringByDecodingXMLCharacters().trim()
+        dateLabel.text = dateFormatter.string(from: prompt.date)
         answerCountLabel.text = answerInfoText
-        answeredStateView.isHidden = !answered
+        answeredStateView.isHidden = !prompt.answered
     }
 }
 
@@ -52,11 +52,7 @@ private extension BloggingPromptTableViewCell {
     }
 
     var answerInfoText: String {
-        // TODO: remove when we have a prompt.
-        guard let answerCount = prompt?.answerCount else {
-            return "99 answers"
-        }
-
+        let answerCount = prompt?.answerCount ?? 0
         let stringFormat = (answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat)
         return String(format: stringFormat, answerCount)
     }


### PR DESCRIPTION
Ref: #18523

This uses the default fetching method, `fetchPrompts`,  in `BloggingPromptsService` to get a list of prompts to display in the Prompts List.

Notes: 
- The logic for what exactly the list shows is still being debated, so the fetching will have to be updated later. For now, the goal is simply to show some real prompts.
- The filter bar still does nothing.

To test:
- Enable `bloggingPrompts` feature flag.
- Go to `Home` tab > prompt card > `View more prompts`.
- Verify a list of 24 prompts is displayed in descending order.
 
<kbd>![prompts_list](https://user-images.githubusercontent.com/1816888/167205984-1763100d-3a3c-477f-9422-2445e69f1ee7.png)</kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
