### PR TITLE
Blogging Prompt Dashboard Card: show a real prompt

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -35,6 +35,18 @@ class BloggingPromptsService {
         }
     }
 
+    /// Convenience method to fetch the blogging prompt for the current day.
+    ///
+    /// - Parameters:
+    ///   - success: Closure to be called when the fetch process succeeded.
+    ///   - failure: Closure to be called when the fetch process failed.
+    func fetchTodaysPrompt(success: @escaping (BloggingPrompt?) -> Void,
+                           failure: @escaping (Error?) -> Void) {
+        fetchPrompts(from: Date(), number: 1, success: { (prompts) in
+            success(prompts.first)
+        }, failure: failure)
+    }
+
     required init?(context: NSManagedObjectContext = ContextManager.shared.mainContext,
                    remote: BloggingPromptsServiceRemote? = nil,
                    blog: Blog? = nil) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -4,14 +4,7 @@ import WordPressUI
 
 class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
-
-    /// Controls available actions on the bottom row.
-    /// TODO: Might need to review this once we have a better picture of what the Prompt model looks like.
-    var isAnswered: Bool = true {
-        didSet {
-            refreshStackView()
-        }
-    }
+    // MARK: - Public Properties
 
     // This is public so it can be accessed from the BloggingPromptsFeatureDescriptionView.
     private(set) lazy var cardFrameView: BlogDashboardCardFrameView = {
@@ -39,20 +32,38 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     // MARK: - Private Properties
 
+    private var blog: Blog?
+
+    private var prompt: BloggingPrompt? {
+        didSet {
+            refreshStackView()
+        }
+    }
+
+    private lazy var isAnswered: Bool = {
+        if forExampleDisplay {
+            return false
+        }
+
+        return prompt?.answered ?? false
+    }()
+
+    private lazy var bloggingPromptsService: BloggingPromptsService? = {
+        return BloggingPromptsService(blog: blog)
+    }()
+
     /// When set to true, a "default" version of the card is displayed. That is:
     /// - `maxAvatarCount` number of avatars.
-    /// - `maxAvatarCount` answer count.
+    /// - `exampleAnswerCount` answer count.
     /// - `examplePrompt` prompt label.
     /// - disabled user interaction.
     private var forExampleDisplay: Bool = false {
         didSet {
             isUserInteractionEnabled = false
             cardFrameView.isUserInteractionEnabled = false
-            isAnswered = false
+            refreshStackView()
         }
     }
-
-    private var blog: Blog?
 
     // Used to present:
     // - The menu sheet for contextual menu in iOS13.
@@ -95,8 +106,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         if forExampleDisplay {
             return Constants.exampleAnswerCount
         }
-        // TODO: For testing purposes. Remove once we actually have real avatar URLs.
-        return 3
+
+        return prompt?.answerCount ?? 0
     }()
 
     private var answerInfoText: String {
@@ -109,8 +120,12 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
             if forExampleDisplay {
                 return (0..<Constants.maxAvatarCount).map { _ in nil }
             }
-            // TODO: Refactor this once we have real avatar URLs.
-            return (0..<min(answerCount, Constants.maxAvatarCount)).map { _ in nil }
+
+            guard let displayAvatarURLs = prompt?.displayAvatarURLs else {
+                return []
+            }
+
+            return Array(displayAvatarURLs.prefix(min(answerCount, Constants.maxAvatarCount)))
         }()
 
         let avatarTrainView = AvatarTrainView(avatarURLs: avatarURLs, placeholderImage: Style.avatarPlaceholderImage)
@@ -285,13 +300,15 @@ extension DashboardPromptsCardCell: BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         self.blog = blog
         self.presenterViewController = viewController
-        refreshStackView()
+        fetchPrompt()
     }
 }
 
 // MARK: - Private Helpers
 
 private extension DashboardPromptsCardCell {
+
+    // MARK: Configure View
 
     func setupViews() {
         contentView.addSubview(cardFrameView)
@@ -303,9 +320,7 @@ private extension DashboardPromptsCardCell {
         // clear existing views.
         containerStackView.removeAllSubviews()
 
-        // TODO: Remove the hard coded string once we can pull content from remote.
-        promptLabel.text = forExampleDisplay ? Strings.examplePrompt : "Cast the movie of your life."
-
+        promptLabel.text = forExampleDisplay ? Strings.examplePrompt : prompt?.text.stringByDecodingXMLCharacters().trim()
         containerStackView.addArrangedSubview(promptTitleView)
 
         if answerCount > 0 {
@@ -313,6 +328,23 @@ private extension DashboardPromptsCardCell {
         }
 
         containerStackView.addArrangedSubview((isAnswered ? answeredStateView : answerButton))
+    }
+
+    // MARK: Prompt Fetching
+
+    func fetchPrompt() {
+        // TODO: check for cached prompt first.
+
+        guard let bloggingPromptsService = bloggingPromptsService else {
+            DDLogError("Failed creating BloggingPromptsService instance.")
+            return
+        }
+
+        bloggingPromptsService.fetchTodaysPrompt(success: { [weak self] (prompt) in
+            self?.prompt = prompt
+        }, failure: { (error) in
+            DDLogError("Failed fetching blogging prompt: \(String(describing: error))")
+        })
     }
 
     // MARK: Button actions


### PR DESCRIPTION
Ref: #18429

The dashboard prompt card now fetches one prompt and updates the card accordingly.

To test:
- Enable `bloggingPrompts` feature flag.
- Verify the example card on the Feature Introduction has not changed.
- Go to `Home` tab > prompt card.
- Verify a prompt is displayed.

| Feature Introduction Card | Dashboard Card |
|--------|-------|
| <img width="350" alt="fi_card" src="https://user-images.githubusercontent.com/1816888/167226557-7f11a3b5-2b36-48a1-af7c-a6679a855e81.png"> | <img width="421" alt="dashboard_card" src="https://user-images.githubusercontent.com/1816888/167226556-77074c34-5cdd-4308-80aa-0cdab667842b.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
