### PR TITLE
Blogging Prompts: Add answer prompt flow to prompts action sheet header

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+FAB.swift
@@ -35,7 +35,7 @@ extension MySiteViewController {
         actions.append(PostAction(handler: newPost, source: source))
         actions.append(PageAction(handler: newPage, source: source))
 
-        let coordinator = CreateButtonCoordinator(self, actions: actions, source: source)
+        let coordinator = CreateButtonCoordinator(self, actions: actions, source: source, blog: blog)
         return coordinator
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -155,4 +155,5 @@ enum PostEditorEntryPoint: String {
     case postsList
     case dashboard
     case bloggingPromptsFeatureIntroduction
+    case bloggingPromptsActionSheetHeader
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -193,7 +193,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
                 (self.tabBarController as? WPTabBarController)?.showStoryEditor(blog: self.blog, title: nil, content: nil)
             }, source: Constants.source), at: 0)
         }
-        return CreateButtonCoordinator(self, actions: actions, source: Constants.source)
+        return CreateButtonCoordinator(self, actions: actions, source: Constants.source, blog: blog)
     }()
 
     override func viewDidAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -11,13 +11,15 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var shareButton: UIButton!
     @IBOutlet private weak var dividerView: UIView!
 
+    var answerPromptHandler: (() -> Void)?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
     }
 
     @IBAction private func answerPromptTapped(_ sender: Any) {
-        // TODO
+        answerPromptHandler?()
     }
 
     @IBAction private func shareTapped(_ sender: Any) {
@@ -31,7 +33,7 @@ private extension BloggingPromptsHeaderView {
 
     func configureView() {
         // TODO: Hide correct UI based on if prompt is answered
-        answerPromptButton.isHidden = true
+        answeredStackView.isHidden = true
         configureSpacing()
         configureStrings()
         configureStyles()

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonActionSheet.swift
@@ -10,8 +10,7 @@ class CreateButtonActionSheet: ActionSheetViewController {
         static let title = NSLocalizedString("Create New", comment: "Create New header text")
     }
 
-    init(actions: [ActionSheetItem]) {
-        let headerView = FeatureFlag.bloggingPrompts.enabled ? BloggingPromptsHeaderView.loadFromNib() : nil
+    init(headerView: UIView?, actions: [ActionSheetItem]) {
         let buttons = actions.map { $0.makeButton() }
         super.init(headerView: headerView, headerTitle: Constants.title, buttons: buttons)
     }


### PR DESCRIPTION
See #18473

## Description

Adds showing an example prompt from the blogging prompts action sheet header view.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Navigate to the 'My Site' tab
- Tap on create new '+'
- Tap on 'Answer Prompt' in the prompts header view
- Verify:
  - Action sheet is dismissed
  - A new post is created with the example prompt info

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
