### PR TITLE
My Site Dashboard: Fix crash on non-iOS 15 when loading posts cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -56,6 +56,7 @@ class DashboardPostsListCardCell: UICollectionViewCell, Reusable {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        tableView.dataSource = nil
         viewModel?.stopObserving()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -40,7 +40,7 @@ class PostsCardViewModel: NSObject {
         didSet {
             if oldValue != currentState {
                 forceReloadSnapshot()
-                trackCardDisaplyedIfNeeded()
+                trackCardDisplayedIfNeeded()
             }
         }
     }
@@ -259,7 +259,7 @@ private extension PostsCardViewModel {
         return false
     }
 
-    func trackCardDisaplyedIfNeeded() {
+    func trackCardDisplayedIfNeeded() {
         switch currentState {
         case .posts:
             BlogDashboardAnalytics.shared.track(.dashboardCardShown, properties: ["type": "post", "sub_type": status.rawValue])

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/PostsCardViewModel.swift
@@ -8,7 +8,7 @@ protocol PostsCardView: AnyObject {
     func removeIfNeeded()
 }
 
-enum PostsListSection {
+enum PostsListSection: CaseIterable {
     case posts
     case error
     case loading
@@ -336,12 +336,12 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
 
     private func createSnapshot(currentSnapshot: Snapshot, postsSnapshot: PostsSnapshot) -> Snapshot {
         var snapshot = Snapshot()
+        snapshot.appendSections(PostsListSection.allCases)
         switch currentState {
         case .posts:
             var adjustedPostsSnapshot = postsSnapshot
             adjustedPostsSnapshot.deleteItems(adjustedPostsSnapshot.itemIdentifiers.enumerated().filter { $0.offset > fetchedResultsController.fetchRequest.fetchLimit - 1 }.map { $0.element })
             let postItems: [PostsListItem] = adjustedPostsSnapshot.itemIdentifiers.map { .post($0) }
-            snapshot.appendSections([.posts])
             snapshot.appendItems(postItems, toSection: .posts)
 
             let reloadIdentifiers: [PostsListItem] = snapshot.itemIdentifiers.compactMap { item in
@@ -358,21 +358,18 @@ extension PostsCardViewModel: NSFetchedResultsControllerDelegate {
             snapshot.reloadItems(reloadIdentifiers)
 
         case .error:
-            snapshot.appendSections([.error])
             snapshot.appendItems([.error], toSection: .error)
 
         case .loading:
             let items: [PostsListItem] = (0..<Constants.numberOfPosts).map { .ghost($0) }
-            snapshot.appendSections([.loading])
             snapshot.appendItems(items, toSection: .loading)
         }
         return snapshot
     }
 
     private func applySnapshot(_ snapshot: Snapshot, to dataSource: DataSource) {
-        let shouldAnimate = view?.tableView.numberOfSections != 0 && view?.tableView.numberOfRows(inSection: 0) != 0
         dataSource.defaultRowAnimation = .fade
-        dataSource.apply(snapshot, animatingDifferences: shouldAnimate, completion: nil)
+        dataSource.apply(snapshot, animatingDifferences: true, completion: nil)
         view?.tableView.allowsSelection = currentState == .posts
     }
 }


### PR DESCRIPTION
## Description
- This PR fixes a crash happening on iOS 13 and 14 when loading the dashboard.
- I've also cherry-picked 503c0630a5cde0e674d3534a1fad797e6aa269e6 from #18531 in case we end up closing it.

## Testing Instructions

1. Run the app on iOS 13 or iOS 14
2. Make sure to test using a site with no cached data, so that the ghost cells inside posts card would appear
3. Go to the dashboard
4. ✅ Make sure the post list loads correctly and the app does not crash

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
