### PR TITLE
My Site Dashboard: Fix posts cards not loaded after logout

### DIFF
--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -97,8 +97,6 @@ import Foundation
         StatsDataHelper.clearWidgetsData()
 
         // Delete donated user activities (e.g., for Siri Shortcuts)
-        if #available(iOS 12.0, *) {
-            NSUserActivity.deleteAllSavedUserActivities {}
-        }
+        NSUserActivity.deleteAllSavedUserActivities {}
     }
 }

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -84,6 +84,9 @@ import Foundation
 
         service.removeDefaultWordPressComAccount()
 
+        // Delete saved dashboard states
+        BlogDashboardState.resetAllStates()
+
         // Delete local notification on logout
         PushNotificationsManager.shared.deletePendingLocalNotifications()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardState.swift
@@ -43,4 +43,10 @@ class BlogDashboardState {
             return states[dotComID]!
         }
     }
+
+    /// Purge all saved dashboard states.
+    /// Should be called on logout
+    static func resetAllStates() {
+        states.removeAll()
+    }
 }


### PR DESCRIPTION
Fixes #18538

## Description
This PR resets the cached dashboard states on logout. This fixes an issue where posts cards are inaccurate after logging out and then logging in.

## Testing Instructions

1. Log in
2. Open site with drafts
3. Navigate to home and wait for the drafts card to load
4. Log out
5. Login using the same account
6. Open the same site
7. Navigate to home
8. Make sure that the drafts card is displayed normally

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
