### PR TITLE
Update site title when it changes from site settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 19.9
 -----
-
+[*] Site Settings: we fixed an issue that prevented the site title to be updated when it changed in Site Settings [#18543]
 
 19.8
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -45,6 +45,7 @@ final class SitePickerViewController: UIViewController {
         super.viewDidLoad()
         setupHeaderView()
         startObservingQuickStart()
+        startObservingTitleChanges()
     }
 
     deinit {
@@ -56,6 +57,15 @@ final class SitePickerViewController: UIViewController {
         blogDetailHeaderView.delegate = self
         view.addSubview(blogDetailHeaderView)
         view.pinSubviewToAllEdges(blogDetailHeaderView)
+    }
+
+    private func startObservingTitleChanges() {
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.WPBlogUpdated,
+                                               object: nil,
+                                               queue: .main) { [weak self] _ in
+
+            self?.updateTitles()
+        }
     }
 }
 
@@ -191,7 +201,6 @@ extension SitePickerViewController {
                                             silentlyForBlog: blog)
 
         blogService.updateSettings(for: blog, success: { [weak self] in
-            NotificationCenter.default.post(name: NSNotification.Name.WPBlogUpdated, object: nil)
 
             let notice = Notice(title: title,
                                 message: SiteTitleStrings.titleChangeSuccessfulMessage,
@@ -199,14 +208,7 @@ extension SitePickerViewController {
             ActionDispatcher.global.dispatch(NoticeAction.post(notice))
 
             self?.blogDetailHeaderView.setTitleLoading(false)
-            self?.blogDetailHeaderView.refreshSiteTitle()
-
-            guard let parent = self?.parent as? MySiteViewController else {
-                return
-            }
-
-            parent.updateNavigationTitle(for: blog)
-
+            NotificationCenter.default.post(name: NSNotification.Name.WPBlogUpdated, object: nil)
         }, failure: { [weak self] error in
             self?.blog.settings?.name = existingBlogTitle
             self?.blogDetailHeaderView.setTitleLoading(false)
@@ -217,6 +219,16 @@ extension SitePickerViewController {
 
             DDLogError("Error while trying to update blog settings: \(error.localizedDescription)")
         })
+    }
+
+    /// Updates site title and navigation bar title
+    private func updateTitles() {
+        blogDetailHeaderView.refreshSiteTitle()
+
+        guard let parent = parent as? MySiteViewController else {
+            return
+        }
+        parent.updateNavigationTitle(for: blog)
     }
 
     private func showViewSite() {


### PR DESCRIPTION
Fixes #18484

This PR fixes an issue that prevented the site title in My Site to be updated when it changed from site settings

To test:
- checkout/build/run this branch
- Go to My Site -> Site Setitngs
- Tap on Site Title and update the existing title
- Navigate back to My Site, and ensure that both the site title and the navigation bar title reflect the new title
- Still on My Site, tap on the site title, and update the title
- Make sure that:
    - The spinner appears on the site title while the update is in progress
    - The title is correctly updated when the spinner stops
    - The notice of update title appears at the bottom of the screen (see screenshot below)

updates from Site Settings | Updates from My Site
-- | --
<img height="500" src="https://user-images.githubusercontent.com/34376330/167498697-371973a2-8d98-415f-b15b-09c4b1fbe3dc.png"> | <img height="500" src="https://user-images.githubusercontent.com/34376330/167498751-470343ab-0cd3-4281-ac96-dfd20b5c81d8.png">



## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
None
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
