### PR TITLE
Blogging Prompts: Remove extra `Prompt` object and use `BloggingPrompt`

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -1,76 +1,11 @@
-
 extension Post {
 
-    func prepareForPrompt(_ prompt: Prompt?) {
+    func prepareForPrompt(_ prompt: BloggingPrompt?) {
         guard let prompt = prompt else {
             return
         }
-        postTitle = prompt.postTitle
-        let pullquoteBlock = getPullquoteBlock(title: prompt.promptText,
-                                               promptUrl: prompt.promptUrl?.absoluteString,
-                                               answerUrl: prompt.answerUrl?.absoluteString,
-                                               answerCount: prompt.answerCount)
-        content = pullquoteBlock + Strings.emptyParagraph
+        postTitle = prompt.title
+        content = prompt.content
     }
 
-}
-
-// MARK: - Private methods
-
-private extension Post {
-
-    func getPullquoteBlock(title: String,
-                           promptUrl: String?,
-                           answerUrl: String?,
-                           answerCount: Int) -> String {
-        let answerFormat = answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat
-        let answerText = String(format: answerFormat, answerCount)
-        let promptUrlHtml = getUrlHtml(url: promptUrl, urlText: Strings.prompt)
-        let answerUrlHtml = getUrlHtml(url: answerUrl, urlText: answerText)
-        let separatorText = promptUrlHtml.isEmpty || answerUrlHtml.isEmpty ? "" : " — "
-        let subtitleHtml = promptUrlHtml.isEmpty && answerUrlHtml.isEmpty ? "" :  "<cite>\(promptUrlHtml)\(separatorText)\(answerUrlHtml)</cite>"
-        return """
-            <!-- wp:pullquote -->
-            <figure class="wp-block-pullquote"><blockquote><p>\(title)</p>\(subtitleHtml)</blockquote></figure>
-            <!-- /wp:pullquote -->
-            """
-    }
-
-    func getUrlHtml(url: String?, urlText: String) -> String {
-        guard let url = url else {
-            return ""
-        }
-        return "<a href=\"\(url)\">\(urlText)</a>"
-    }
-
-    // MARK: - Strings
-
-    struct Strings {
-        static let prompt = NSLocalizedString("Prompt", comment: "Prompt link text in a new blogging prompts post")
-        static let answerInfoSingularFormat = NSLocalizedString("%1$d answer", comment: "Singular format string for displaying the number of users that answered the blogging prompt.")
-        static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users that answered the blogging prompt.")
-        static let emptyParagraph = """
-            <!-- wp:paragraph -->
-            <p></p>
-            <!-- /wp:paragraph -->
-            """
-    }
-
-}
-
-// MARK: - Temporary prompt object
-
-// TODO: Remove after prompt object is created and use that
-struct Prompt {
-    let postTitle: String
-    let promptText: String
-    let promptUrl: URL?
-    let answerUrl: URL?
-    let answerCount: Int
-
-    static let examplePrompt = Prompt(postTitle: "Cast the movie of my life",
-                                      promptText: "Cast the movie of your life.",
-                                      promptUrl: URL(string: "https://wordpress.com"),
-                                      answerUrl: URL(string: "https://wordpress.com"),
-                                      answerCount: 19)
 }

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -74,6 +74,19 @@ struct BloggingPrompt {
     let answerCount: Int
     let displayAvatarURLs: [URL]
 
+    static let examplePrompt = BloggingPrompt(
+            promptID: 239,
+            text: "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
+            title: "Prompt number 1",
+            content: "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
+            date: Date(),
+            answered: false,
+            answerCount: 5,
+            displayAvatarURLs: []
+    )
+}
+
+extension BloggingPrompt {
     init(with remotePrompt: RemoteBloggingPrompt) {
         promptID = remotePrompt.promptID
         text = remotePrompt.text

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -23,7 +23,7 @@ class EditPostViewController: UIViewController {
     private let loadAutosaveRevision: Bool
 
     @objc fileprivate(set) var post: Post?
-    private let prompt: Prompt?
+    private let prompt: BloggingPrompt?
     fileprivate var hasShownEditor = false
     fileprivate var editingExistingPost = false
     fileprivate let blog: Blog
@@ -65,7 +65,7 @@ class EditPostViewController: UIViewController {
     ///
     /// - Parameter blog: blog to create a new post for
     /// - Parameter prompt: blogging prompt to configure the new post for
-    convenience init(blog: Blog, prompt: Prompt) {
+    convenience init(blog: Blog, prompt: BloggingPrompt) {
         self.init(post: nil, blog: blog, prompt: prompt)
     }
 
@@ -75,7 +75,7 @@ class EditPostViewController: UIViewController {
     ///   - post: the post to edit
     ///   - blog: the blog to create a post for, if post is nil
     /// - Note: it's preferable to use one of the convenience initializers
-    fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: Prompt? = nil) {
+    fileprivate init(post: Post?, blog: Blog, loadAutosaveRevision: Bool = false, prompt: BloggingPrompt? = nil) {
         self.post = post
         self.loadAutosaveRevision = loadAutosaveRevision
         if let post = post {


### PR DESCRIPTION
Resolves #18473 

## Description

Consolidates the two prompt objects into one and adds an example prompt for use in the answer prompt flow.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Launch app
- In blogging prompts feature introduction, tap on try it now
- Verify example prompt is shown in the editor
- Navigate to the 'My Site' dashboard
- Tap on 'Answer Prompt' in the prompts dashboard card
- Verify example prompt is shown in the editor
- Navigate back
- Tap on create new '+'
- Tap on 'Answer Prompt' in the prompts header view
- Verify example prompt is shown in the editor

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
