### PR TITLE
Blogging Prompts: use prompt date fix

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.51.0'
+    # pod 'WordPressKit', '~> 4.51.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/18375-fix_prompt_date'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.51.0):
+  - WordPressKit (4.52.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -591,7 +591,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
-  - WordPressKit (~> 4.51.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/18375-fix_prompt_date`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.1)
   - WordPressUI (~> 1.12.5)
@@ -640,7 +640,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -753,6 +752,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
+  WordPressKit:
+    :branch: feature/18375-fix_prompt_date
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.75.0/third-party-podspecs/Yoga.podspec.json
 
@@ -768,6 +770,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.75.0
+  WordPressKit:
+    :commit: 6fc3130514a889093a9c3dd37474437ce42c6d83
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -853,7 +858,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: 79d309801a09fabe9564ac9e1e06554274fc5022
+  WordPressKit: 1af05d9ab2a434290be54b091094e54af081fc58
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -869,6 +874,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: a9583cec2bc246d23cf0045230cd179dc03c5adb
+PODFILE CHECKSUM: 655bca8e1838d45b018f7ff12fcfde786b1bdf1a
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -771,7 +771,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.75.0
   WordPressKit:
-    :commit: 6fc3130514a889093a9c3dd37474437ce42c6d83
+    :commit: 954576e0f99cd598eb8f093308f89e967d44453f
     :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -73,6 +73,7 @@ struct BloggingPrompt {
     let answered: Bool
     let answerCount: Int
     let displayAvatarURLs: [URL]
+    let attribution: String
 
     init(with remotePrompt: RemoteBloggingPrompt) {
         promptID = remotePrompt.promptID
@@ -83,5 +84,6 @@ struct BloggingPrompt {
         answered = remotePrompt.answered
         answerCount = remotePrompt.answeredUsersCount
         displayAvatarURLs = remotePrompt.answeredUserAvatarURLs
+        attribution = remotePrompt.attribution
     }
 }

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -83,7 +83,8 @@ struct BloggingPrompt {
             date: Date(),
             answered: false,
             answerCount: 5,
-            displayAvatarURLs: []
+            displayAvatarURLs: [],
+            attribution: ""
     )
 }
 


### PR DESCRIPTION
Ref: #18375
WPKit PR: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/502

This updates WPKit so the dates on the blogging prompts are correct.

Bonus: the `attribution` property that was [added to the remote prompt](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/501) is now added to the local `BloggingPrompt` object. It has no effect, but will facilitate adding the attribution UI. (cc @wargcm )

To test:
- Enable the `Blogging Prompts` feature.
- Go to My Site Dashboard, causing the prompt to load for the prompt card.
  - Verify the logged object date and prompt date are the same.
- On the prompt card, select `View more prompts`. 
- On the Prompts list, verify:
  - The dates are updated in the list.
  - The logged object dates and prompt dates are the same.

<details>
<summary>Example date differences</summary>

Before:
```
🔴 endpoint object date:  2022-04-29
🔴 RemoteBloggingPrompt date:  2022-01-29 07:04:00 +0000
🔴 endpoint object date:  2022-04-30
🔴 RemoteBloggingPrompt date:  2022-01-30 07:04:00 +0000
🔴 endpoint object date:  2022-05-01
🔴 RemoteBloggingPrompt date:  2022-01-01 07:05:00 +0000
🔴 endpoint object date:  2022-05-02
🔴 RemoteBloggingPrompt date:  2022-01-02 07:05:00 +0000
🔴 endpoint object date:  2022-05-03
🔴 RemoteBloggingPrompt date:  2022-01-03 07:05:00 +0000
```

After:
```
🔴 endpoint object date:  2022-04-29
🔴 RemoteBloggingPrompt date:  2022-04-29 06:00:00 +0000
🔴 endpoint object date:  2022-04-30
🔴 RemoteBloggingPrompt date:  2022-04-30 06:00:00 +0000
🔴 endpoint object date:  2022-05-01
🔴 RemoteBloggingPrompt date:  2022-05-01 06:00:00 +0000
🔴 endpoint object date:  2022-05-02
🔴 RemoteBloggingPrompt date:  2022-05-02 06:00:00 +0000
🔴 endpoint object date:  2022-05-03
🔴 RemoteBloggingPrompt date:  2022-05-03 06:00:00 +0000
```
</details>

<details>
<summary>Prompts List differences</summary>

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/1816888/167514943-73553a03-baa3-4ecc-938b-600e3dfeedc8.png) | ![after](https://user-images.githubusercontent.com/1816888/167514942-d1c624ed-b4f3-4f77-a0ff-0848e8963d45.png) |

</details>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
