### PR TITLE
Blogging Prompt Dashboard Card: show error when fetching prompt fails

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -357,6 +357,7 @@ private extension DashboardPromptsCardCell {
 
         bloggingPromptsService.fetchTodaysPrompt(success: { [weak self] (prompt) in
             self?.prompt = prompt
+            self?.didFailLoadingPrompt = false
         }, failure: { [weak self] (error) in
             self?.didFailLoadingPrompt = true
             DDLogError("Failed fetching blogging prompt: \(String(describing: error))")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -65,6 +65,14 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         }
     }
 
+    private var didFailLoadingPrompt: Bool = false {
+        didSet {
+            if didFailLoadingPrompt != oldValue {
+                refreshStackView()
+            }
+        }
+    }
+
     // Used to present:
     // - The menu sheet for contextual menu in iOS13.
     // - The Blogging Prompts list when selected from the contextual menu.
@@ -320,6 +328,12 @@ private extension DashboardPromptsCardCell {
         // clear existing views.
         containerStackView.removeAllSubviews()
 
+        guard !didFailLoadingPrompt else {
+            promptLabel.text = Strings.errorTitle
+            containerStackView.addArrangedSubview(promptTitleView)
+            return
+        }
+
         promptLabel.text = forExampleDisplay ? Strings.examplePrompt : prompt?.text.stringByDecodingXMLCharacters().trim()
         containerStackView.addArrangedSubview(promptTitleView)
 
@@ -336,13 +350,15 @@ private extension DashboardPromptsCardCell {
         // TODO: check for cached prompt first.
 
         guard let bloggingPromptsService = bloggingPromptsService else {
+            didFailLoadingPrompt = true
             DDLogError("Failed creating BloggingPromptsService instance.")
             return
         }
 
         bloggingPromptsService.fetchTodaysPrompt(success: { [weak self] (prompt) in
             self?.prompt = prompt
-        }, failure: { (error) in
+        }, failure: { [weak self] (error) in
+            self?.didFailLoadingPrompt = true
             DDLogError("Failed fetching blogging prompt: \(String(describing: error))")
         })
     }
@@ -412,6 +428,7 @@ private extension DashboardPromptsCardCell {
                                                                 + "that answered the blogging prompt.")
         static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users "
                                                               + "that answered the blogging prompt.")
+        static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
     }
 
     struct Style {


### PR DESCRIPTION
Ref: #18429, https://github.com/wordpress-mobile/WordPress-iOS/pull/18534#discussion_r868188271

When obtaining a prompt fails, an error message is now displayed on the dashboard prompt card.

To test:
- Hack prompt fetching to fail - in `BloggingPromptsService.fetchTodaysPrompt`, call `failure(nil)` in the success block.
```
    func fetchTodaysPrompt(success: @escaping (BloggingPrompt?) -> Void,
                           failure: @escaping (Error?) -> Void) {
        fetchPrompts(from: Date(), number: 1, success: { (prompts) in
            failure(nil)
//            success(prompts.first)
        }, failure: failure)
    }
```
- Enable `Blogging Prompts` feature.
- Go to My Site Dashboard.
- Verify the prompt card displays an error message.

<kbd><img width="421" alt="prompt_error" src="https://user-images.githubusercontent.com/1816888/167521429-04e1f74b-b7aa-445b-8287-0807db006a1d.png"></kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
