### PR TITLE
Fix navigation buttons not scaling with large fonts in Site Intent

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Site Settings: we fixed an issue that prevented the site title to be updated when it changed in Site Settings [#18543]
 * [*] Media Picker: Fixed an issue where the empty state view was being displayed incorrectly. [#18471]
+* [*] Site Creation: we fixed an issue where the navigation buttons were not scaling when large fonts were selected on the device [#18559]
 
 19.8
 -----

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 // MARK: - WizardNavigation
-final class WizardNavigation: GutenbergLightNavigationController {
+final class WizardNavigation: UINavigationController {
     private let steps: [WizardStep]
     private let pointer: WizardNavigationPointer
 


### PR DESCRIPTION

Fixes #18230 

To test:

- Checkout this branch
- Enable site name, in order to test the full navigation: this can be done by overriding

```
private var shouldShowSiteName: Bool {
        return nameVariant == .treatment(nil) && FeatureFlag.siteName.enabled
}
```
in `SiteCreationWizardLauncher` and temporarily set it to true

- Build/run and start the site creation flow
- make sure the appearance of the navigation bar and button looks correct in all the navigation steps
- Go to the device settings and change the font size in Accessibility
- Restart the site creation flow, and verify that the Cancel and Skip buttons scale correctly
- Check that the navigation bar looks correct in the rest of the flow


<p align=center>
<img height=500, src=https://user-images.githubusercontent.com/34376330/167724485-1a161bc8-b22a-4730-83f0-950dff7b2175.PNG>
</p>

## Regression Notes
1. Potential unintended areas of impact
Low, this change only affects the appearance of the navigation bar in the site creation flow.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Test the entire site creation flow

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
