### PR TITLE
Quick Start for Existing Users: Update track events 

### DIFF
--- a/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
+++ b/WordPress/Classes/Categories/UIViewController+RemoveQuickStart.m
@@ -15,11 +15,11 @@
 
     UIAlertController *removeConfirmation = [UIAlertController alertControllerWithTitle:removeTitle message:removeMessage preferredStyle:UIAlertControllerStyleAlert];
     [removeConfirmation addCancelActionWithTitle:cancelTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped];
+        [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonCancelTapped blog: blog];
         [NoticesDispatch unlock];
     }];
     [removeConfirmation addDefaultActionWithTitle:confirmationTitle handler:^(UIAlertAction * _Nonnull action) {
-        [WPAnalytics track:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped];
+        [WPAnalytics trackQuickStartStat:WPAnalyticsStatQuickStartRemoveDialogButtonRemoveTapped blog: blog];
         [[QuickStartTourGuide shared] removeFrom:blog];
         [NoticesDispatch unlock];
     }];

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension WPAnalytics {
+
+    private static let WPAppAnalyticsKeyQuickStartSiteType: String = "site_type"
+
+    /// Track a Quick Start event
+    ///
+    /// This will call each registered tracker and fire the given event
+    /// - Parameter event: a `WPAnalyticsEvent` that represents the Quick Start event to track
+    /// - Parameter properties: a `Hash` that represents the properties
+    /// - Parameter blog: a `Blog` to which the Quick Start event relates to. Used to determine the Quick Start Type
+    ///
+    static func trackQuickStartEvent(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any] = [:], blog: Blog) {
+        var props = properties
+        props[WPAppAnalyticsKeyQuickStartSiteType] = blog.quickStartType.key
+        WPAnalytics.track(event, properties: props)
+    }
+
+    /// Track a Quick Start stat
+    ///
+    /// This will call each registered tracker and fire the given stat
+    /// - Parameter stat: a `WPAnalyticsStat` that represents the Quick Start stat to track
+    /// - Parameter properties: a `Hash` that represents the properties
+    /// - Parameter blog: a `Blog` to which the Quick Start stat relates to. Used to determine the Quick Start Type
+    ///
+    static func trackQuickStartStat(_ stat: WPAnalyticsStat, properties: [AnyHashable: Any] = [:], blog: Blog) {
+        var props = properties
+        props[WPAppAnalyticsKeyQuickStartSiteType] = blog.quickStartType.key
+        WPAnalytics.track(stat, withProperties: props)
+    }
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
@@ -2,7 +2,7 @@ import Foundation
 
 extension WPAnalytics {
 
-    private static let WPAppAnalyticsKeyQuickStartSiteType: String = "site_type"
+    static let WPAppAnalyticsKeyQuickStartSiteType: String = "site_type"
 
     /// Track a Quick Start event
     ///

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+QuickStart.swift
@@ -29,4 +29,15 @@ extension WPAnalytics {
         props[WPAppAnalyticsKeyQuickStartSiteType] = blog.quickStartType.key
         WPAnalytics.track(stat, withProperties: props)
     }
+
+    /// Track a Quick Start stat in Obj-C
+    ///
+    /// This will call each registered tracker and fire the given stat
+    /// - Parameter stat: a `WPAnalyticsStat` that represents the Quick Start stat to track
+    /// - Parameter blog: a `Blog` to which the Quick Start stat relates to. Used to determine the Quick Start Type
+    ///
+    @objc static func trackQuickStartStat(_ stat: WPAnalyticsStat, blog: Blog) {
+        let props = [WPAppAnalyticsKeyQuickStartSiteType: blog.quickStartType.key]
+        WPAnalytics.track(stat, withProperties: props)
+    }
 }

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -427,9 +427,11 @@ extension PushNotificationsManager {
         }
         WPTabBarController.sharedInstance()?.showMySitesTab()
 
-        if let taskName = userInfo.string(forKey: QuickStartTracking.taskNameKey) {
+        if let taskName = userInfo.string(forKey: QuickStartTracking.taskNameKey),
+            let quickStartType = userInfo.string(forKey: QuickStartTracking.quickStartTypeKey) {
             WPAnalytics.track(.quickStartNotificationTapped,
-                              withProperties: [QuickStartTracking.taskNameKey: taskName])
+                              withProperties: [QuickStartTracking.taskNameKey: taskName,
+                                               QuickStartTracking.quickStartTypeKey: quickStartType])
         }
 
         completionHandler?(.newData)
@@ -437,7 +439,7 @@ extension PushNotificationsManager {
         return true
     }
 
-    func postNotification(for tour: QuickStartTour) {
+    func postNotification(for tour: QuickStartTour, quickStartType: QuickStartType) {
         deletePendingLocalNotifications()
 
         let content = UNMutableNotificationContent()
@@ -459,7 +461,8 @@ extension PushNotificationsManager {
         UNUserNotificationCenter.current().add(request)
 
         WPAnalytics.track(.quickStartNotificationStarted,
-                          withProperties: [QuickStartTracking.taskNameKey: tour.analyticsKey])
+                          withProperties: [QuickStartTracking.taskNameKey: tour.analyticsKey,
+                                           QuickStartTracking.quickStartTypeKey: quickStartType.key])
     }
 
     @objc func deletePendingLocalNotifications() {
@@ -473,6 +476,7 @@ extension PushNotificationsManager {
 
     private enum QuickStartTracking {
         static let taskNameKey = "task_name"
+        static let quickStartTypeKey = "site_type"
     }
 }
 

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -431,7 +431,7 @@ extension PushNotificationsManager {
             let quickStartType = userInfo.string(forKey: QuickStartTracking.quickStartTypeKey) {
             WPAnalytics.track(.quickStartNotificationTapped,
                               withProperties: [QuickStartTracking.taskNameKey: taskName,
-                                               QuickStartTracking.quickStartTypeKey: quickStartType])
+                                               WPAnalytics.WPAppAnalyticsKeyQuickStartSiteType: quickStartType])
         }
 
         completionHandler?(.newData)
@@ -462,7 +462,7 @@ extension PushNotificationsManager {
 
         WPAnalytics.track(.quickStartNotificationStarted,
                           withProperties: [QuickStartTracking.taskNameKey: tour.analyticsKey,
-                                           QuickStartTracking.quickStartTypeKey: quickStartType.key])
+                                           WPAnalytics.WPAppAnalyticsKeyQuickStartSiteType: quickStartType.key])
     }
 
     @objc func deletePendingLocalNotifications() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartTourStateView.swift
@@ -53,9 +53,9 @@ extension QuickStartTourStateView {
     private func showQuickStart(with collection: QuickStartToursCollection, from sourceController: UIViewController, for blog: Blog, tracker: QuickStartChecklistTappedTracker? = nil) {
 
         if let tracker = tracker {
-            WPAnalytics.track(tracker.event,
-                              properties: tracker.properties,
-                              blog: blog)
+            WPAnalytics.trackQuickStartEvent(tracker.event,
+                                             properties: tracker.properties,
+                                             blog: blog)
         }
 
         let checklist = QuickStartChecklistViewController(blog: blog, collection: collection)

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistManager.swift
@@ -196,8 +196,9 @@ private extension QuickStartChecklistManager {
         completedTours.append(tour)
         completedToursKeys.insert(tour.key)
 
-        WPAnalytics.track(.quickStartListItemSkipped,
-                          withProperties: ["task_name": tour.analyticsKey])
+        WPAnalytics.trackQuickStartStat(.quickStartListItemSkipped,
+                                        properties: ["task_name": tour.analyticsKey],
+                                        blog: blog)
 
         tableView.perform(update: { tableView in
             tableView.deleteRows(at: [indexPath], with: .automatic)

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -73,7 +73,9 @@ class QuickStartChecklistViewController: UITableViewController {
             }
         }, didTapHeader: { [unowned self] expand in
             let event: WPAnalyticsStat = expand ? .quickStartListExpanded : .quickStartListCollapsed
-            WPAnalytics.track(event, withProperties: [Constants.analyticsTypeKey: self.collection.analyticsKey])
+            WPAnalytics.trackQuickStartStat(event,
+                                            properties: [Constants.analyticsTypeKey: self.collection.analyticsKey],
+                                            blog: blog)
             self.checkForSuccessScreen(expand)
         })
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistViewController.swift
@@ -57,11 +57,13 @@ class QuickStartChecklistViewController: UITableViewController {
                                                  tours: collection.tours,
                                                  didSelectTour: { [weak self] tour in
             DispatchQueue.main.async { [weak self] in
-                WPAnalytics.track(.quickStartChecklistItemTapped, withProperties: ["task_name": tour.analyticsKey])
-
                 guard let self = self else {
                     return
                 }
+
+                WPAnalytics.trackQuickStartStat(.quickStartChecklistItemTapped,
+                                                properties: ["task_name": tour.analyticsKey],
+                                                blog: self.blog)
 
                 QuickStartTourGuide.shared.prepare(tour: tour, for: self.blog)
 
@@ -83,8 +85,9 @@ class QuickStartChecklistViewController: UITableViewController {
 
         // should display bg and trigger qs notification
 
-        WPAnalytics.track(.quickStartChecklistViewed,
-                          withProperties: [Constants.analyticsTypeKey: collection.analyticsKey])
+        WPAnalytics.trackQuickStartStat(.quickStartChecklistViewed,
+                                        properties: [Constants.analyticsTypeKey: collection.analyticsKey],
+                                        blog: blog)
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -146,8 +149,9 @@ private extension QuickStartChecklistViewController {
     }
 
     @objc private func closeWasPressed(sender: UIButton) {
-        WPAnalytics.track(.quickStartTypeDismissed,
-                          withProperties: [Constants.analyticsTypeKey: collection.analyticsKey])
+        WPAnalytics.trackQuickStartStat(.quickStartTypeDismissed,
+                                        properties: [Constants.analyticsTypeKey: collection.analyticsKey],
+                                        blog: blog)
         dismiss(animated: true, completion: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartFactory.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartFactory.swift
@@ -4,6 +4,17 @@ enum QuickStartType: Int {
     case undefined
     case newSite
     case existingSite
+
+    var key: String {
+        switch self {
+        case .undefined:
+            return "undefined"
+        case .newSite:
+            return "new_site"
+        case .existingSite:
+            return "existing_site"
+        }
+    }
 }
 
 class QuickStartFactory {

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartPromptViewController.swift
@@ -139,7 +139,9 @@ final class QuickStartPromptViewController: UIViewController {
         onDismiss?(blog, true)
         dismiss(animated: true)
 
-        WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "positive"])
+        WPAnalytics.trackQuickStartStat(.quickStartRequestAlertButtonTapped,
+                                        properties: ["type": "positive"],
+                                        blog: blog)
     }
 
     @IBAction private func noThanksButtonTapped(_ sender: Any) {
@@ -147,7 +149,9 @@ final class QuickStartPromptViewController: UIViewController {
         onDismiss?(blog, false)
         dismiss(animated: true)
 
-        WPAnalytics.track(.quickStartRequestAlertButtonTapped, withProperties: ["type": "neutral"])
+        WPAnalytics.trackQuickStartStat(.quickStartRequestAlertButtonTapped,
+                                        properties: ["type": "neutral"],
+                                        blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -381,7 +381,7 @@ private extension QuickStartTourGuide {
             shouldShowCongratsNotice = true
         } else {
             if let nextTour = tourToSuggest(for: blog) {
-                PushNotificationsManager.shared.postNotification(for: nextTour)
+                PushNotificationsManager.shared.postNotification(for: nextTour, quickStartType: blog.quickStartType)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -58,7 +58,7 @@ open class QuickStartTourGuide: NSObject {
         blog.quickStartType = type
 
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
-        WPAnalytics.track(.quickStartStarted)
+        WPAnalytics.trackQuickStartEvent(.quickStartStarted, blog: blog)
 
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification,
                                         object: self,
@@ -143,17 +143,21 @@ open class QuickStartTourGuide: NSObject {
                                     self?.prepare(tour: tour, for: blog)
                                     self?.begin()
                                     cancelTimer(false)
-                                    WPAnalytics.track(.quickStartSuggestionButtonTapped, withProperties: ["type": "positive"])
+                                    WPAnalytics.trackQuickStartStat(.quickStartSuggestionButtonTapped,
+                                                                    properties: ["type": "positive"],
+                                                                    blog: blog)
                                 } else {
                                     self?.skipped(tour, for: blog)
                                     cancelTimer(true)
-                                    WPAnalytics.track(.quickStartSuggestionButtonTapped, withProperties: ["type": "negative"])
+                                    WPAnalytics.trackQuickStartStat(.quickStartSuggestionButtonTapped,
+                                                                    properties: ["type": "negative"],
+                                                                    blog: blog)
                                 }
         }
 
         ActionDispatcher.dispatch(NoticeAction.post(notice))
 
-        WPAnalytics.track(.quickStartSuggestionViewed)
+        WPAnalytics.trackQuickStartStat(.quickStartSuggestionViewed, blog: blog)
     }
 
     /// Prepares to begin the specified tour.
@@ -247,7 +251,7 @@ open class QuickStartTourGuide: NSObject {
 
         ActionDispatcher.dispatch(NoticeAction.post(notice))
 
-        WPAnalytics.track(.quickStartCongratulationsViewed)
+        WPAnalytics.trackQuickStartStat(.quickStartCongratulationsViewed, blog: blog)
     }
 
     // we have this because poor stupid ObjC doesn't know what the heck an optional is
@@ -360,7 +364,9 @@ private extension QuickStartTourGuide {
 
             // Create a site is completed automatically, we don't want to track
             if tour.analyticsKey != "create_site" {
-                WPAnalytics.track(.quickStartTourCompleted, withProperties: ["task_name": tour.analyticsKey])
+                WPAnalytics.trackQuickStartStat(.quickStartTourCompleted,
+                                                properties: ["task_name": tour.analyticsKey],
+                                                blog: blog)
             }
 
             recentlyTouredBlog = blog
@@ -369,7 +375,7 @@ private extension QuickStartTourGuide {
         }
 
         if allToursCompleted(for: blog) {
-            WPAnalytics.track(.quickStartAllToursCompleted)
+            WPAnalytics.trackQuickStartStat(.quickStartAllToursCompleted, blog: blog)
             grantCongratulationsAward(for: blog)
             tourInProgress = false
             shouldShowCongratsNotice = true

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -359,15 +359,15 @@ private extension QuickStartTourGuide {
 
         blog.completeTour(tour.key)
 
+        // Create a site is completed automatically, we don't want to track
+        if tour.analyticsKey != "create_site" {
+            WPAnalytics.trackQuickStartStat(.quickStartTourCompleted,
+                                            properties: ["task_name": tour.analyticsKey],
+                                            blog: blog)
+        }
+
         if postNotification {
             NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.tourCompleted])
-
-            // Create a site is completed automatically, we don't want to track
-            if tour.analyticsKey != "create_site" {
-                WPAnalytics.trackQuickStartStat(.quickStartTourCompleted,
-                                                properties: ["task_name": tour.analyticsKey],
-                                                blog: blog)
-            }
 
             recentlyTouredBlog = blog
         } else {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1373,6 +1373,8 @@
 		80EF929028105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
 		80EF929128105CFA0064A971 /* QuickStartFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF928F28105CFA0064A971 /* QuickStartFactory.swift */; };
 		80EF92932810FA5A0064A971 /* QuickStartFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */; };
+		80F8DAC1282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */; };
+		80F8DAC2282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */; };
 		820ADD701F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */; };
 		820ADD721F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */; };
 		821738091FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 821738081FE04A9E00BEC94C /* DateAndTimeFormatSettingsViewController.swift */; };
@@ -6144,6 +6146,7 @@
 		80EF928C280E83110064A971 /* QuickStartToursCollection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartToursCollection.swift; sourceTree = "<group>"; };
 		80EF928F28105CFA0064A971 /* QuickStartFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactory.swift; sourceTree = "<group>"; };
 		80EF92922810FA5A0064A971 /* QuickStartFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartFactoryTests.swift; sourceTree = "<group>"; };
+		80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPAnalytics+QuickStart.swift"; sourceTree = "<group>"; };
 		820ADD6C1F3A0DA0002D7F93 /* WordPress 64.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 64.xcdatamodel"; sourceTree = "<group>"; };
 		820ADD6F1F3A1F88002D7F93 /* ThemeBrowserSectionHeaderView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ThemeBrowserSectionHeaderView.xib; sourceTree = "<group>"; };
 		820ADD711F3A226E002D7F93 /* ThemeBrowserSectionHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -11572,6 +11575,7 @@
 				8BAD53D5241922B900230F4B /* WPAnalyticsEvent.swift */,
 				0828D7F91E6E09AE00C7C7D4 /* WPAppAnalytics+Media.swift */,
 				175CC17B2723103000622FB4 /* WPAnalytics+Domains.swift */,
+				80F8DAC0282B6546007434A0 /* WPAnalytics+QuickStart.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -18413,6 +18417,7 @@
 				2FA6511721F26A24009AA935 /* ChangePasswordViewController.swift in Sources */,
 				D816C1F020E0893A00C4D82F /* LikeComment.swift in Sources */,
 				982DA9A7263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
+				80F8DAC1282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */,
 				59E1D46E1CEF77B500126697 /* Page.swift in Sources */,
 				321955BF24BE234C00E3F316 /* ReaderInterestsCoordinator.swift in Sources */,
 				FAE4327425874D140039EB8C /* ReaderSavedPostCellActions.swift in Sources */,
@@ -21176,6 +21181,7 @@
 				FABB24CC2602FC2C00C8785C /* CollapsableHeaderViewController.swift in Sources */,
 				FABB24CD2602FC2C00C8785C /* Blog+Lookup.swift in Sources */,
 				FABB24CE2602FC2C00C8785C /* ReaderTopicService.m in Sources */,
+				80F8DAC2282B6546007434A0 /* WPAnalytics+QuickStart.swift in Sources */,
 				FABB24CF2602FC2C00C8785C /* HeaderDetailsContentStyles.swift in Sources */,
 				FABB24D02602FC2C00C8785C /* RewindStatusRow.swift in Sources */,
 				8BD34F0C27D14B3C005E931C /* Blog+DashboardState.swift in Sources */,


### PR DESCRIPTION
Closes #18408

## Description
Adds a property `site_type` to all quick start events. Its value can be either `existing_site` for the new tour or `new_site` for the old tours.

## Testing Instructions

### For all the events checked, make sure the property `site_type` is added and its value is correct based on the quick start you've chosen (existing/new)

### Starting quick start

1. Enable quick start from debug menu
2. Check logs for the event `quick_start_started`

### Tapping Quick Start

1. Make sure the initial screen is Home
2. Tap on the quick start card
3. Check logs for the event `my_site_dashboard_card_item_tapped`
4. Change the initial screen to Menu
5. Tap on the quick start card
6. Check logs for the event `quick_start_tapped`

### Expanded Quick Start view

1. Tap on the quick start card to open the expanded view
2. Check logs for the event `quick_start_list_viewed`
3. Skip a tour by swiping it left and then tapping skip
4. Check logs for the event `quick_start_list_item_skipped`
5. Expand the completed tasks list
6. Check logs for the event `quick_start_list_expanded`
7. Collapse the completed tasks list
8. Check logs for the event `quick_start_list_collapsed`
9. Dismiss the quick start view
10. Check logs for the event `quick_start_type_dismissed`

### Completing tours

1. Open the quick start view
2. Tap on a tour to start it
3. Check logs for the event `quick_start_list_item_tapped`
4. Complete the tour
5. Check logs for the event `quick_start_task_completed`
6. Go back to My Site
7. Wait for the suggestion to be displayed
8. Check logs for the event `quick_start_dialog_viewed`
9. Tap "Not now" or "Yes, show me"
10. Check logs for the event `quick_start_dialog_button_tapped`
11. Complete all tours
12. Check logs for the event `quick_start_all_tasks_completed`
13. Check logs for the event `quick_start_list_completed_viewed`

### Removing Quick Start

1. Tap on the ellipsis button in the quick start card
2. Tap "Remove Next Steps"
3. Tap "Cancel"
4. Check logs for the event `quick_start_remove_dialog_button_tapped`
5. Tap on the ellipsis button in the quick start card
6. Tap "Remove Next Steps"
7. Tap "Remove"
8. Check logs for the event `quick_start_remove_dialog_button_tapped`

### Local Notifications

1. Make sure push notifications are enabled on the device you're testing with
2. Open `PushNotificationsManager.swift`
3. Replace `.day` in line 452 by `.minute`
4. Complete a tour
5. Check logs for the event `quick_start_notification_sent`
6. Move the app to the background
7. Wait for 2 minutes
8. When the notification arrives, tap it
9. Check logs for the event `quick_start_notification_tapped`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
