### PR TITLE
Remove dispatch_once calls from mainContext and writerContext

### DIFF
--- a/WordPress/WordPressTest/ContextManagerMock.m
+++ b/WordPress/WordPressTest/ContextManagerMock.m
@@ -52,16 +52,10 @@
     return [super persistentStoreCoordinator];
 }
 
-- (NSManagedObjectContext *)mainContext
+- (void)createMainContext
 {
-    if (_mainContext) {
-        return _mainContext;
-    }
-
-    _mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-    _mainContext.persistentStoreCoordinator = self.persistentStoreCoordinator;
-
-    return _mainContext;
+    self.mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    self.mainContext.persistentStoreCoordinator = self.persistentStoreCoordinator;
 }
 
 - (void)saveContextAndWait:(NSManagedObjectContext *)context


### PR DESCRIPTION
This change is part of paaHJt-3ky-p2.

**TL;DR** Moving the creation of `mainContext` and `writerContext` into initialiser, to avoid using `dispatch_once` to guard them.

Tip: Use [this link](https://github.com/wordpress-mobile/WordPress-iOS/pull/18561/files?w=1) to see the code change without whitespaces.

## Problem

The creation of [`mainContext`](https://github.com/wordpress-mobile/WordPress-iOS/blob/ab3b51e02b4a62937450339b9ff0208498f6b2ea/WordPress/Classes/Utility/ContextManager.m#L74-L80) and [`writerContext`](https://github.com/wordpress-mobile/WordPress-iOS/blob/ab3b51e02b4a62937450339b9ff0208498f6b2ea/WordPress/Classes/Utility/ContextManager.m#L62-L67) are guarded by `dispatch_once`, with the purpose of making sure the instance variables are created once and once only, _if_ they are called from multiple threads at the same time.

But there is a side effect:  only _one_ instance gets to create the context object properties, all other instances' are nil.

This isn't an issue for the app though, since there is only one single `ContextManager` instance, but this issue makes testing `ContextManager` a bit difficult. For example, in [ContextManagerTests](https://github.com/wordpress-mobile/WordPress-iOS/blob/ab3b51e02b4a62937450339b9ff0208498f6b2ea/WordPress/WordPressTest/ContextManagerTests.swift), a mock instance, along with a Core Data stack created on the test case side, is used to test migration logic in `ContextManager`. I think this can be improved, _without_ changing the runtime behaviour on the app side.

## Current behaviour

Currently both context object properties are created during initialisation process of `ContextManager`, passively by [`startListeningToMainContextNotifications`](https://github.com/wordpress-mobile/WordPress-iOS/blob/ab3b51e02b4a62937450339b9ff0208498f6b2ea/WordPress/Classes/Utility/ContextManager.m#L255) method, which means `dispatch_once` is actually redundant, since it's impossible to have concurrency issue on assigning instance's property in the process of creating the instance.

I had a chat about this with @jleandroperez, he raised a good point that this thread-safety is granted by an implicit behaviour. Which leads me to propose changes in this PR.

## Solution

Explicitly create `mainContext` and `writerContext` in initialiser. Runtime behaviour during initialisation are not changed by this code change, the order of the calls are still the same: 

1. Initialisation begins.
1. Create `writerContext`.
1. Create `mainContext`.
1. Observe change notifications on `mainContext`.
1. Initialisation completes.

## Next step

I'm making this change to prepare for improving [ContextManagerTests](https://github.com/wordpress-mobile/WordPress-iOS/blob/ab3b51e02b4a62937450339b9ff0208498f6b2ea/WordPress/WordPressTest/ContextManagerTests.swift), by allowing `ContextManager` to be created with a specific model version and database location. This change will be in a separate PR.

## Test Instructions:

Kill and launch app, try a use case that accesses Core Data database. Repeat for a few different use cases.

I don't see a great risk in this change, so probably don't need to do a full feature regression test.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I've done what's mentioned in "Test Instructions", logged onto my personal WP.com account, created a draft post, killed and relaunched the app, read the draft, deleted the draft.

3. What automated tests I added (or what prevented me from doing so)
None. I don't think it's possible to write automated test for this particular change at the moment. But my follow up PR mentioned in "Next steps" will change that, and I'll update the `ContextManagerTests` to run through this code change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
