### PR TITLE
[Tooling] Include Jetpack bundle ID when using register_new_device

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -12,8 +12,10 @@ platform :ios do
   lane :register_new_device do |options|
     device_name = UI.input('Device Name: ') if options[:device_name].nil?
     device_id = UI.input('Device ID: ') if options[:device_id].nil?
+    all_bundle_ids = ALL_BUNDLE_IDENTIFIERS + [JETPACK_APP_IDENTIFIER]
+
     UI.message "Registering #{device_name} with ID #{device_id} and registering it with any provisioning profiles associated with these bundle identifiers:"
-    ALL_BUNDLE_IDENTIFIERS.each do |identifier|
+    all_bundle_ids.each do |identifier|
       puts "\t#{identifier}"
     end
 
@@ -27,13 +29,13 @@ platform :ios do
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
       team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-      app_identifier: ALL_BUNDLE_IDENTIFIERS
+      app_identifier: all_bundle_ids
     )
 
     # Add all devices to the provisioning profiles
     add_all_devices_to_provisioning_profiles(
       team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-      app_identifier: ALL_BUNDLE_IDENTIFIERS
+      app_identifier: all_bundle_ids
     )
   end
 


### PR DESCRIPTION
When an Automattic developer asks us to add a new development device to our development account, we use the `register_new_device` lane to do so and automate the device addition to all relevant Provisioning Profiles.

Up until now, we only added the new device to WordPress-related profiles. This PR now also adds new devices to the "Jetpack iOS Development" profile too.