### PR TITLE
Fix text flipping in rtl languages

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Site Settings: we fixed an issue that prevented the site title to be updated when it changed in Site Settings [#18543]
 * [*] Media Picker: Fixed an issue where the empty state view was being displayed incorrectly. [#18471]
 * [*] Site Creation: we fixed an issue where the navigation buttons were not scaling when large fonts were selected on the device [#18559]
+* [*] Widgets: we fixed an issue where text appeared flipped in rtl languages [#18567]
 
 19.8
 -----

--- a/WordPress/WordPressStatsWidgets/Views/Cards/FlexibleCard.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Cards/FlexibleCard.swift
@@ -62,7 +62,6 @@ struct FlexibleCard: View {
                 Spacer()
                 titleView
             }
-            .flipsForRightToLeftLayoutDirection(true)
         }
     }
 }

--- a/WordPress/WordPressStatsWidgets/Views/Cards/ListRow.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Cards/ListRow.swift
@@ -80,7 +80,6 @@ struct ListRow: View {
         .frame(height: rowHeight)
         .offset(x: 0, y: Constants.verticalCenteringOffset) // each row isn't _quite_ centered vertically
                                                             // and we're not entirely sure why yet, but this fixes it
-        .flipsForRightToLeftLayoutDirection(true)
     }
 }
 

--- a/WordPress/WordPressStatsWidgets/Views/Cards/VerticalCard.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Cards/VerticalCard.swift
@@ -30,7 +30,6 @@ struct VerticalCard: View {
                 .accessibility(label: accessibilityLabel)
 
         }
-        .flipsForRightToLeftLayoutDirection(true)
     }
 }
 

--- a/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/SingleStatView.swift
@@ -15,6 +15,5 @@ struct SingleStatView: View {
             }
             Spacer()
         }
-        .flipsForRightToLeftLayoutDirection(true)
     }
 }


### PR DESCRIPTION
Fixes #17731 

This PR fixes an issue where text appeared flipped in rtl languages.

before | after
-- | --
<img height="500" src="https://user-images.githubusercontent.com/34376330/167900299-ec459bde-cbea-483d-87ea-41889cced9d0.png"> | <img height="500" src="https://user-images.githubusercontent.com/34376330/167900366-5a964164-546a-41f9-8fe0-3c829342519f.png">



To test:
- checkout/build/run `trunk` (or any other branch different than this one)
- Set the device language to an rtl language
- Install some widgets
- verify that text appears flipped: numbers and site names are easy to spot, but you can also look at the translations inside the `Localizable.strings` file of the language of your choice
- checkout/build/run this branch
- verify that text is not flipped anymore in the widgets

see above screenshots for more details.

## Regression Notes
1. Potential unintended areas of impact
None. this PR only affects text in Widgets, for rtl languages

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested widgets in a rtl language

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
