### PR TITLE
Blogging Prompt Compact Card: show a real prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -359,6 +359,7 @@ private extension DashboardPromptsCardCell {
             self?.prompt = prompt
             self?.didFailLoadingPrompt = false
         }, failure: { [weak self] (error) in
+            self?.prompt = nil
             self?.didFailLoadingPrompt = true
             DDLogError("Failed fetching blogging prompt: \(String(describing: error))")
         })

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -18,22 +18,21 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
         configureView()
     }
 
-    @IBAction private func answerPromptTapped(_ sender: Any) {
-        answerPromptHandler?()
+    static func view(for prompt: BloggingPrompt?) -> BloggingPromptsHeaderView {
+        let promptsHeaderView = BloggingPromptsHeaderView.loadFromNib()
+        promptsHeaderView.configure(prompt)
+        return promptsHeaderView
     }
 
-    @IBAction private func shareTapped(_ sender: Any) {
-        // TODO
-    }
 }
 
 // MARK: - Private methods
 
 private extension BloggingPromptsHeaderView {
 
+    // MARK: - Configure View
+
     func configureView() {
-        // TODO: Hide correct UI based on if prompt is answered
-        answeredStackView.isHidden = true
         configureSpacing()
         configureStrings()
         configureStyles()
@@ -49,8 +48,6 @@ private extension BloggingPromptsHeaderView {
 
     func configureStrings() {
         titleLabel.text = Strings.title
-        // TODO: Use prompt from backend
-        promptLabel.text = Strings.examplePrompt
         answerPromptButton.titleLabel?.text = Strings.answerButtonTitle
         answeredLabel.text = Strings.answeredLabelTitle
         shareButton.titleLabel?.text = Strings.shareButtonTitle
@@ -91,6 +88,24 @@ private extension BloggingPromptsHeaderView {
         }
     }
 
+    func configure(_ prompt: BloggingPrompt?) {
+        promptLabel.text = prompt?.text ?? nil
+
+        let answered = prompt?.answered ?? false
+        answerPromptButton.isHidden = answered
+        answeredStackView.isHidden = !answered
+    }
+
+    // MARK: - Button Actions
+
+    @IBAction func answerPromptTapped(_ sender: Any) {
+        answerPromptHandler?()
+    }
+
+    @IBAction func shareTapped(_ sender: Any) {
+        // TODO
+    }
+
     // MARK: - Constants
 
     struct Constants {
@@ -102,7 +117,6 @@ private extension BloggingPromptsHeaderView {
     }
 
     struct Strings {
-        static let examplePrompt = NSLocalizedString("Cast the movie of your life.", comment: "Example prompt for blogging prompts in the create new bottom action sheet.")
         static let title = NSLocalizedString("Prompts", comment: "Title label for blogging prompts in the create new bottom action sheet.")
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button in the create new bottom action sheet.")
         static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -89,7 +89,7 @@ private extension BloggingPromptsHeaderView {
     }
 
     func configure(_ prompt: BloggingPrompt?) {
-        promptLabel.text = prompt?.text ?? nil
+        promptLabel.text = prompt?.text
 
         let answered = prompt?.answered ?? false
         answerPromptButton.isHidden = answered

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -56,20 +56,11 @@ import WordPressFlux
         }
     }
 
-    private lazy var promptsHeaderView: BloggingPromptsHeaderView? = {
-        let headerView = FeatureFlag.bloggingPrompts.enabled ? BloggingPromptsHeaderView.loadFromNib() : nil
-        headerView?.answerPromptHandler = { [weak self] in
-            self?.viewController?.dismiss(animated: true) {
-                guard let blog = self?.blog else {
-                    return
-                }
-                let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
-                editor.modalPresentationStyle = .fullScreen
-                editor.entryPoint = .bloggingPromptsActionSheetHeader
-                self?.viewController?.present(editor, animated: true)
-            }
-        }
-        return headerView
+    // TODO: when prompt is used, get prompt from cache so it's using the latest.
+    private var prompt: BloggingPrompt?
+
+    private lazy var bloggingPromptsService: BloggingPromptsService? = {
+        return BloggingPromptsService(blog: blog)
     }()
 
     private weak var noticeContainerView: NoticeContainerView?
@@ -92,6 +83,7 @@ import WordPressFlux
         super.init()
 
         listenForQuickStart()
+        fetchBloggingPrompt()
     }
 
     deinit {
@@ -161,7 +153,7 @@ import WordPressFlux
     }
 
     private func actionSheetController(with traitCollection: UITraitCollection) -> UIViewController {
-        let actionSheetVC = CreateButtonActionSheet(headerView: promptsHeaderView, actions: actions)
+        let actionSheetVC = CreateButtonActionSheet(headerView: createPromptHeaderView(), actions: actions)
         setupPresentation(on: actionSheetVC, for: traitCollection)
         return actionSheetVC
     }
@@ -301,4 +293,51 @@ extension UserDefaults {
             set(newValue, forKey: Keys.createButtonTooltipWasDisplayed.rawValue)
         }
     }
+}
+
+
+// MARK: - Blogging Prompts Methods
+
+private extension CreateButtonCoordinator {
+
+    private func fetchBloggingPrompt() {
+
+        // TODO: check for cached prompt first.
+
+        guard let bloggingPromptsService = bloggingPromptsService else {
+            DDLogError("FAB > failed creating BloggingPromptsService instance.")
+            prompt = nil
+            return
+        }
+
+        bloggingPromptsService.fetchTodaysPrompt(success: { [weak self] (prompt) in
+            self?.prompt = prompt
+        }, failure: { [weak self] (error) in
+            self?.prompt = nil
+            DDLogError("FAB > failed fetching blogging prompt: \(String(describing: error))")
+        })
+    }
+
+    private func createPromptHeaderView() -> BloggingPromptsHeaderView? {
+        guard FeatureFlag.bloggingPrompts.enabled,
+              let blog = blog,
+              let prompt = prompt else {
+            return nil
+        }
+
+        let promptsHeaderView = BloggingPromptsHeaderView.view(for: prompt)
+
+        promptsHeaderView.answerPromptHandler = { [weak self] in
+            self?.viewController?.dismiss(animated: true) {
+                // TODO: pass prompt to post editor
+                let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
+                editor.modalPresentationStyle = .fullScreen
+                editor.entryPoint = .bloggingPromptsActionSheetHeader
+                self?.viewController?.present(editor, animated: true)
+            }
+        }
+
+        return promptsHeaderView
+    }
+
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -83,7 +83,11 @@ import WordPressFlux
         super.init()
 
         listenForQuickStart()
-        fetchBloggingPrompt()
+
+        // Only fetch the prompt if it is actually needed, i.e. on the FAB that has multiple actions.
+        if actions.count > 1 {
+            fetchBloggingPrompt()
+        }
     }
 
     deinit {


### PR DESCRIPTION
Ref: #18429

The compact prompt card now fetches one prompt and updates the card accordingly.

To test:
- Enable `bloggingPrompts` feature flag.
- Tap on the FAB.
- Verify the prompt is displayed in the header.
- HACK: In `BloggingPromptsHeaderView:configure`, set `answered` to `true`.
```
    func configure(_ prompt: BloggingPrompt?) {
        promptLabel.text = prompt?.text ?? nil

//        let answered = prompt?.answered ?? false
        let answered = true
        
        answerPromptButton.isHidden = answered
        answeredStackView.isHidden = !answered
    }
```
- Verify the answered state on the card is toggled correctly.

| Not Answered | Answered |
|--------|-------|
| <img width="449" alt="unanswered" src="https://user-images.githubusercontent.com/1816888/167934312-53a34443-ee15-4cd1-b7fd-5fdaf6dbaa4e.png"> | <img width="449" alt="answered" src="https://user-images.githubusercontent.com/1816888/167934322-3261b389-764a-45c7-a720-965092dbec58.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
