### PR TITLE
Blogging Prompts: Add blogging prompts attribution to prompts dashboard card

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -84,7 +84,7 @@ struct BloggingPrompt {
             answered: false,
             answerCount: 5,
             displayAvatarURLs: [],
-            attribution: ""
+            attribution: "dayone"
     )
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/BloggingPromptsAttribution.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/BloggingPromptsAttribution.swift
@@ -25,7 +25,7 @@ enum BloggingPromptsAttribution: String {
     }
 
     private struct Strings {
-        static let fromTextFormat = NSLocalizedString("From %@", comment: "From string format for blogging prompts attribution")
+        static let fromTextFormat = NSLocalizedString("From %1$@", comment: "Format for blogging prompts attribution. %1$@ is the attribution source.")
         static let dayOne = "Day One"
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/BloggingPromptsAttribution.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/BloggingPromptsAttribution.swift
@@ -1,0 +1,44 @@
+enum BloggingPromptsAttribution: String {
+    case dayone
+
+    var attributedText: NSAttributedString {
+        let baseText = String(format: Strings.fromTextFormat, source)
+        let attributedText = NSMutableAttributedString(string: baseText, attributes: Constants.baseAttributes)
+        guard let range = baseText.range(of: source) else {
+            return attributedText
+        }
+        attributedText.addAttributes(Constants.sourceAttributes, range: NSRange(range, in: baseText))
+
+        return attributedText
+    }
+
+    var source: String {
+        switch self {
+        case .dayone: return Strings.dayOne
+        }
+    }
+
+    var iconImage: UIImage? {
+        switch self {
+        case .dayone: return Constants.dayOneIcon
+        }
+    }
+
+    private struct Strings {
+        static let fromTextFormat = NSLocalizedString("From %@", comment: "From string format for blogging prompts attribution")
+        static let dayOne = "Day One"
+    }
+
+    private struct Constants {
+        static let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(.caption1),
+            .foregroundColor: UIColor.secondaryLabel,
+        ]
+        static let sourceAttributes: [NSAttributedString.Key: Any] = [
+            .font: WPStyleGuide.fontForTextStyle(.caption1, fontWeight: .medium),
+            .foregroundColor: UIColor.text,
+        ]
+        static let iconSize = CGSize(width: 18, height: 18)
+        static let dayOneIcon = UIImage(named: "logo-dayone")?.resizedImage(Constants.iconSize, interpolationQuality: .default)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -81,6 +81,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     private lazy var containerStackView: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
+        stackView.alignment = .center
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.spacing = Constants.spacing
         return stackView
@@ -187,6 +188,20 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
         return containerView
     }
+
+    private lazy var attributionIcon = UIImageView()
+
+    private lazy var attributionSourceLabel: UILabel = {
+        let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        return label
+    }()
+
+    private lazy var attributionStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [attributionIcon, attributionSourceLabel])
+        stackView.alignment = .center
+        return stackView
+    }()
 
     // MARK: Bottom row views
 
@@ -336,6 +351,13 @@ private extension DashboardPromptsCardCell {
 
         promptLabel.text = forExampleDisplay ? Strings.examplePrompt : prompt?.text.stringByDecodingXMLCharacters().trim()
         containerStackView.addArrangedSubview(promptTitleView)
+
+        if let promptAttribution = prompt?.attribution.lowercased(),
+           let attribution = BloggingPromptsAttribution(rawValue: promptAttribution) {
+            attributionIcon.image = attribution.iconImage
+            attributionSourceLabel.attributedText = attribution.attributedText
+            containerStackView.addArrangedSubview(attributionStackView)
+        }
 
         if answerCount > 0 {
             containerStackView.addArrangedSubview(answerInfoView)

--- a/WordPress/Resources/AppImages.xcassets/logo-dayone.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/logo-dayone.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "logo-dayone.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/logo-dayone.imageset/logo-dayone.pdf
+++ b/WordPress/Resources/AppImages.xcassets/logo-dayone.imageset/logo-dayone.pdf
@@ -1,0 +1,317 @@
+%PDF-1.7
+
+1 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << /ExtGState << /E1 << /ca 0.100000 >> >> >>
+     /Subtype /Form
+     /Length 2 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+/E1 gs
+1.000000 0.000000 -0.000000 1.000000 25.531250 28.274597 cm
+0.200000 0.231373 0.250980 scn
+0.000000 -0.000031 m
+20.941893 -0.000031 l
+20.941893 27.640259 l
+0.000000 27.640259 l
+0.000000 -0.000031 l
+h
+f*
+n
+Q
+
+endstream
+endobj
+
+2 0 obj
+  244
+endobj
+
+3 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << >>
+     /Subtype /Form
+     /Length 4 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 25.691406 28.431458 cm
+1.000000 1.000000 1.000000 scn
+0.000000 0.000006 m
+20.619026 0.000006 l
+20.619026 27.483398 l
+0.000000 27.483398 l
+0.000000 0.000006 l
+h
+f*
+n
+Q
+
+endstream
+endobj
+
+4 0 obj
+  234
+endobj
+
+5 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << >>
+     /Subtype /Form
+     /Length 6 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 16.085938 16.085083 cm
+0.266667 0.752941 1.000000 scn
+0.000000 -0.000015 m
+39.829788 -0.000015 l
+39.829788 39.829773 l
+0.000000 39.829773 l
+0.000000 -0.000015 l
+h
+f*
+n
+Q
+
+endstream
+endobj
+
+6 0 obj
+  237
+endobj
+
+7 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << >>
+     /Subtype /Form
+     /Length 8 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 27.445312 29.939331 cm
+1.000000 1.000000 1.000000 scn
+17.112104 24.060669 m
+17.112104 1.373161 l
+17.112104 0.436932 16.422052 0.000029 15.572798 0.396450 c
+9.163341 3.388050 l
+8.798094 3.558516 8.209341 3.558399 7.841950 3.384718 c
+1.529809 0.401085 l
+0.684919 0.001715 0.000000 0.434443 0.000000 1.373161 c
+0.000000 24.060669 l
+17.112104 24.060669 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+8 0 obj
+  426
+endobj
+
+9 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << >>
+     /Subtype /Form
+     /Length 10 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 27.605469 30.129456 cm
+1.000000 1.000000 1.000000 scn
+16.789253 23.870544 m
+16.789253 1.192383 l
+16.789253 0.380697 16.195215 -0.000023 15.460011 0.343204 c
+9.004481 3.356672 l
+8.638392 3.527557 8.044737 3.525757 7.680103 3.353376 c
+1.330966 0.351896 l
+0.595915 0.004381 0.000000 0.381119 0.000000 1.192383 c
+0.000000 23.870544 l
+16.789253 23.870544 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+10 0 obj
+  427
+endobj
+
+11 0 obj
+  << /BBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources << >>
+     /Subtype /Form
+     /Length 12 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Type /XObject
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 18.000000 18.000000 cm
+1.000000 1.000000 1.000000 scn
+33.092079 36.000000 m
+34.698063 36.000000 36.000000 34.697491 36.000000 33.092079 c
+36.000000 2.907921 l
+36.000000 1.301937 34.697491 0.000000 33.092079 0.000000 c
+2.907919 0.000000 l
+1.301936 0.000000 0.000000 1.302509 0.000000 2.907921 c
+0.000000 33.092079 l
+0.000000 34.698063 1.302511 36.000000 2.907919 36.000000 c
+33.092079 36.000000 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+12 0 obj
+  471
+endobj
+
+13 0 obj
+  << /XObject << /X2 1 0 R
+                 /X3 3 0 R
+                 /X1 5 0 R
+              >>
+     /ExtGState << /E2 << /SMask << /Type /Mask
+                                    /G 7 0 R
+                                    /S /Alpha
+                                 >>
+                          /Type /ExtGState
+                       >>
+                   /E3 << /SMask << /Type /Mask
+                                    /G 9 0 R
+                                    /S /Alpha
+                                 >>
+                          /Type /ExtGState
+                       >>
+                   /E1 << /SMask << /Type /Mask
+                                    /G 11 0 R
+                                    /S /Alpha
+                                 >>
+                          /Type /ExtGState
+                       >>
+                >>
+  >>
+endobj
+
+14 0 obj
+  << /Length 15 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+/E1 gs
+/X1 Do
+Q
+q
+/E2 gs
+/X2 Do
+Q
+q
+/E3 gs
+/X3 Do
+Q
+
+endstream
+endobj
+
+15 0 obj
+  82
+endobj
+
+16 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 72.000000 72.000000 ]
+     /Resources 13 0 R
+     /Contents 14 0 R
+     /Parent 17 0 R
+  >>
+endobj
+
+17 0 obj
+  << /Kids [ 16 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+18 0 obj
+  << /Type /Catalog
+     /Pages 17 0 R
+  >>
+endobj
+
+xref
+0 19
+0000000000 65535 f
+0000000010 00000 n
+0000000542 00000 n
+0000000564 00000 n
+0000001046 00000 n
+0000001068 00000 n
+0000001553 00000 n
+0000001575 00000 n
+0000002249 00000 n
+0000002271 00000 n
+0000002947 00000 n
+0000002970 00000 n
+0000003691 00000 n
+0000003714 00000 n
+0000004586 00000 n
+0000004726 00000 n
+0000004748 00000 n
+0000004925 00000 n
+0000005001 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 18 0 R
+   /Size 19
+>>
+startxref
+5062
+%%EOF

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1412,6 +1412,8 @@
 		8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 8370D10911FA499A009D650F /* WPTableViewActivityCell.m */; };
 		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
+		83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
+		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
@@ -6196,6 +6198,7 @@
 		8370D10811FA499A009D650F /* WPTableViewActivityCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPTableViewActivityCell.h; sourceTree = "<group>"; };
 		8370D10911FA499A009D650F /* WPTableViewActivityCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WPTableViewActivityCell.m; sourceTree = "<group>"; };
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
+		83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsAttribution.swift; sourceTree = "<group>"; };
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
@@ -15240,8 +15243,9 @@
 		FE18495627F5ACA400D26879 /* Prompts */ = {
 			isa = PBXGroup;
 			children = (
-				FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */,
 				FEAC916D28001FC4005026E7 /* AvatarTrainView.swift */,
+				83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */,
+				FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */,
 			);
 			path = Prompts;
 			sourceTree = "<group>";
@@ -18963,6 +18967,7 @@
 				E125F1E41E8E595E00320B67 /* SharePost.swift in Sources */,
 				B56FEB791CD8E13C00E621F9 /* RoleViewController.swift in Sources */,
 				D82253DC2199411F0014D0E2 /* SiteAddressService.swift in Sources */,
+				83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */,
 				B5B56D3319AFB68800B4E29B /* WPStyleGuide+Notifications.swift in Sources */,
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				9A3BDA0E22944F3500FBF510 /* CountriesMapView.swift in Sources */,
@@ -20306,6 +20311,7 @@
 				8B45C12727B2B08900EA3257 /* DashboardStatsCardCell.swift in Sources */,
 				FABB21E02602FC2C00C8785C /* SupportTableViewController.swift in Sources */,
 				FABB21E12602FC2C00C8785C /* DetailDataCell.swift in Sources */,
+				83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */,
 				C7F7AC75261CF1F300CE547F /* JetpackLoginErrorViewController.swift in Sources */,
 				FABB21E22602FC2C00C8785C /* PluginViewModel.swift in Sources */,
 				FABB21E32602FC2C00C8785C /* NSCalendar+Helpers.swift in Sources */,


### PR DESCRIPTION
See: #18558

## Description

Adds Day One attribution to the dashboard prompts card.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Modify the prompt being fetched to be the example prompt
- Launch the app and navigate to the 'My Site' tab
- Verify:
  - Day One icon
  - Text
    - Accessibility
    - Dark mode
- Modify prompt back to non-attributed prompt
- Launch the app and navigate to the 'My Site' tab
- Verify attribution doesn't appear

## Screenshots

| Light | Dark |
|------|------|
| <img alt="Screen Shot 2022-05-11 at 5 55 58 PM" src="https://user-images.githubusercontent.com/2454408/167954655-837be64e-7df6-4172-8c59-47d706703ffb.png"> | <img alt="Screen Shot 2022-05-11 at 6 02 39 PM" src="https://user-images.githubusercontent.com/2454408/167955043-48c85637-6b08-491d-83b3-1981f3defd7b.png"> |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
