### PR TITLE
Empty Stats: Fix crash during Reader Discover tour

### DIFF
--- a/WordPress/Classes/Utility/Animator.swift
+++ b/WordPress/Classes/Utility/Animator.swift
@@ -58,7 +58,7 @@ class Animator: NSObject {
             preamble?()
         }
 
-        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: animations) { [unowned self] _ in
+        UIView.animate(withDuration: duration, delay: 0, options: .curveEaseOut, animations: animations) { _ in
             self.animationsInProgress -= 1
 
             if self.animationsInProgress == 0 {

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -38,7 +38,7 @@ class ExpandableCell: WPReusableTableViewCell {
                 alpha = 0
             }
 
-            UIView.animate(withDuration: 0.2) { [unowned self] in
+            UIView.animate(withDuration: 0.2) {
                 self.chevronImageView?.transform = transform
                 self.expandableTextView?.alpha = alpha
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderCardsStreamViewController.swift
@@ -265,7 +265,7 @@ private extension ReaderCardsStreamViewController {
 
         UIView.animate(withDuration: 0.2, animations: {
             self.selectInterestsViewController.view.alpha = 0
-        }) { [unowned self] _ in
+        }) { _ in
             self.selectInterestsViewController.remove()
             self.selectInterestsViewController.view.alpha = 1
         }


### PR DESCRIPTION
Fixes #18568

## Description
This PR fixes a crash due to accessing a deallocated unowned reference.

```
Fatal error: Attempted to read an unowned reference but the object was already deallocated
```

The unowned reference was in the completion block of `UIView.animate`. The view was getting removed from the view hierarchy during the animation, so `self` turned to nil.

An unowned reference is not needed when dealing with animation/completion blocks of `UIView.animate`, as this is a global func, and the blocks are not retained by `self`, so there's no risk of a retain cycle. In this case, we can either leave it as a strong reference or use a weak reference. But an unowned reference causes a crash when the view gets deallocated.

More detailed explanation in this [SO answer](https://stackoverflow.com/a/53584282). 

I also updated similar instances of the same pattern to avoid other potential crashes.

## Testing Instructions

1. Make sure to test with a site with low stats
2. Open Reader discover and make sure no topics are added
3. Make sure "Discover and follow blogs you love" is displayed
4. Go to My Site
5. Open Stats
6. Dismiss Pinned items until "Discover blogs to follow" is reached
7. Tap "Discover blogs to follow"
8. Choose a topic, then tap done
9. Make sure the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
