### PR TITLE
Blogging Prompts List: limit to 11 prompts, no filtering

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -47,6 +47,18 @@ class BloggingPromptsService {
         }, failure: failure)
     }
 
+    /// Convenience method to fetch the blogging prompts for the Prompts List.
+    /// Fetches 11 prompts - the current day and 10 previous.
+    ///
+    /// - Parameters:
+    ///   - success: Closure to be called when the fetch process succeeded.
+    ///   - failure: Closure to be called when the fetch process failed.
+    func fetchListPrompts(success: @escaping ([BloggingPrompt]) -> Void,
+                          failure: @escaping (Error?) -> Void) {
+        let fromDate = calendar.date(byAdding: .day, value: -9, to: Date()) ?? Date()
+        fetchPrompts(from: fromDate, number: 11, success: success, failure: failure)
+    }
+
     required init?(context: NSManagedObjectContext = ContextManager.shared.mainContext,
                    remote: BloggingPromptsServiceRemote? = nil,
                    blog: Blog? = nil) {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.storyboard
@@ -20,7 +20,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bno-oB-pDf" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
+                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bno-oB-pDf" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="46"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
@@ -28,7 +28,7 @@
                                 </constraints>
                             </view>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7aR-Vp-g6a">
-                                <rect key="frame" x="0.0" y="46" width="375" height="621"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <connections>
@@ -41,12 +41,18 @@
                         <constraints>
                             <constraint firstItem="bno-oB-pDf" firstAttribute="leading" secondItem="gDw-cc-yIW" secondAttribute="leading" id="7Jf-su-8WM"/>
                             <constraint firstAttribute="trailing" secondItem="bno-oB-pDf" secondAttribute="trailing" id="AgG-aE-VG8"/>
+                            <constraint firstItem="7aR-Vp-g6a" firstAttribute="top" secondItem="gDw-cc-yIW" secondAttribute="top" id="Ndp-h3-R7q"/>
                             <constraint firstItem="7aR-Vp-g6a" firstAttribute="leading" secondItem="gDw-cc-yIW" secondAttribute="leading" id="Nt5-JK-DbB"/>
-                            <constraint firstItem="uCp-uQ-tOJ" firstAttribute="top" secondItem="7aR-Vp-g6a" secondAttribute="bottom" id="Oly-V9-tho"/>
+                            <constraint firstAttribute="bottom" secondItem="7aR-Vp-g6a" secondAttribute="bottom" id="Oly-V9-tho"/>
                             <constraint firstItem="7aR-Vp-g6a" firstAttribute="top" secondItem="bno-oB-pDf" secondAttribute="bottom" id="Rmm-F3-kCp"/>
                             <constraint firstAttribute="trailing" secondItem="7aR-Vp-g6a" secondAttribute="trailing" id="htA-bQ-QaF"/>
-                            <constraint firstItem="bno-oB-pDf" firstAttribute="top" secondItem="MpO-o7-pbX" secondAttribute="bottom" id="tfA-U7-Sc2"/>
+                            <constraint firstItem="bno-oB-pDf" firstAttribute="top" secondItem="gDw-cc-yIW" secondAttribute="top" id="tfA-U7-Sc2"/>
                         </constraints>
+                        <variation key="default">
+                            <mask key="constraints">
+                                <exclude reference="Rmm-F3-kCp"/>
+                            </mask>
+                        </variation>
                     </view>
                     <connections>
                         <outlet property="filterTabBar" destination="bno-oB-pDf" id="fxk-Bw-WWL"/>

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -116,7 +116,7 @@ private extension BloggingPromptsViewController {
 
         isLoading = true
 
-        bloggingPromptsService.fetchPrompts(success: { [weak self] (prompts) in
+        bloggingPromptsService.fetchListPrompts(success: { [weak self] (prompts) in
             self?.isLoading = false
             self?.prompts = prompts.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
         }, failure: { [weak self] (error) in

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -164,6 +164,13 @@ extension BloggingPromptsViewController: UITableViewDataSource, UITableViewDeleg
 
 private extension BloggingPromptsViewController {
 
+    // For Blogging Prompts V1, there is a single unfiltered prompts list.
+    // The expectation is it will be filtered at some point. So the FilterTabBar is hidden instead of removed.
+    // To show it, in the storyboard:
+    // - Unhide the FilterTabBar.
+    // - Remove the tableView top constraint to superview.
+    // - Enable the tableView top constraint to the FilterTabBar bottom.
+
     enum PromptFilter: Int, FilterTabBarItem, CaseIterable {
         case all
         case answered


### PR DESCRIPTION
Ref: #18523

This removes the filter tab bar from the Prompts List, and limits the list to 11 prompts - the current day and 10 previous.

To test:
- Enable `bloggingPrompts` feature flag.
- Go to `Home` tab > prompt card > `View more prompts`.
- Verify:
  - 11 prompts are displayed, today's and 10 previous days.
  - The filter tab bar is not shown.

<kbd>![list](https://user-images.githubusercontent.com/1816888/167965893-26af95fc-ecff-4e0b-af96-4474af85bdfd.png)</kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
