### PR TITLE
Quick Start: Rename quick start tour title on Jetpack

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -59,4 +59,9 @@ extension AppConstants {
     struct Zendesk {
         static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
     }
+
+    struct QuickStart {
+        static let getToKnowTheAppTourTitle = NSLocalizedString("Get to know the WordPress app",
+                                                                comment: "Name of the Quick Start list that guides users through a few tasks to explore the WordPress app.")
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartToursCollection.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartToursCollection.swift
@@ -67,10 +67,9 @@ struct QuickStartGetToKnowAppCollection: QuickStartToursCollection {
     let tours: [QuickStartTour]
 
     init(blog: Blog) {
-        self.title = NSLocalizedString("Get to know the WordPress app",
-                                      comment: "Name of the Quick Start list that guides users through a few tasks to explore the WordPress app.")
+        self.title = AppConstants.QuickStart.getToKnowTheAppTourTitle
         self.hint = NSLocalizedString("A series of steps helping you to explore the app.",
-                                     comment: "A VoiceOver hint to explain what the user gets when they select the 'Get to know the WordPress app' button.")
+                                     comment: "A VoiceOver hint to explain what the user gets when they select the 'Get to know the WordPress/Jetpack app' button.")
         self.completedImageName = "wp-illustration-tasks-complete-site"
         self.analyticsKey = "get-to-know"
         self.tours = [

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -56,4 +56,9 @@ extension AppConstants {
     struct Zendesk {
         static let ticketSubject = NSLocalizedString("Jetpack for iOS Support", comment: "Subject of new Zendesk ticket.")
     }
+
+    struct QuickStart {
+        static let getToKnowTheAppTourTitle = NSLocalizedString("Get to know the Jetpack app",
+                                                                comment: "Name of the Quick Start list that guides users through a few tasks to explore the Jetpack app.")
+    }
 }


### PR DESCRIPTION
Closes #18586

## Description
Change the new tour title on Jeptpack to read "Get to know the Jetpack app"

/ | WordPress | Jetpack
-|-|-
Card|![WP-Card](https://user-images.githubusercontent.com/25306722/168094768-ee2d00c9-be37-4ac7-a404-c9cdac9add37.png)|![JP-Card](https://user-images.githubusercontent.com/25306722/168094762-6851e096-0428-46ed-8952-064e5997b865.png)
Modal|![WP-Modal](https://user-images.githubusercontent.com/25306722/168094746-373b890b-e040-47fa-b186-03fdfc0e6843.png)|![JP-Modal](https://user-images.githubusercontent.com/25306722/168094753-9d802580-7fea-48ac-b01e-ea5cea74ac21.png)

## Testing Instructions

### Jetpack

1. Install the JP app
2. Enable Quick Start for an existing site
3. Go to My Site
4. Make sure the title of the QS tour read "Get to know the Jetpack app"
5. Tap on the QS card
6. Make sure the title of the modal reads "Get to know the Jetpack app"

### WordPress

1. Install the WP app
2. Enable Quick Start for an existing site
3. Go to My Site
4. Make sure the title of the QS tour read "Get to know the WordPress app"
5. Tap on the QS card
6. Make sure the title of the modal reads "Get to know the WordPress app"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
