### PR TITLE
Quick Start for Existing Users: Fix suggestion for next tour after completing "View your site"

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -243,7 +243,8 @@ extension SitePickerViewController {
             url: url,
             blog: blog,
             source: Constants.viewSiteSource,
-            withDeviceModes: true
+            withDeviceModes: true,
+            onClose: self.startAlertTimer
         )
 
         let navigationController = LightNavigationController(rootViewController: webViewController)


### PR DESCRIPTION
Fixes #18521

## Description
- Fixed a bug where the next tour wasn't being automatically suggested after completing the "View your site" tour

## How to test
1. Enable Quick Start for Existing Sites from the debug menu
2. Complete the "View  your site" tour
3. ✅ Verify: The next available tour should be automatically suggested


https://user-images.githubusercontent.com/6711616/168103880-8a30812b-daca-4917-bc3a-c4919a92ab53.mp4



## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
