### PR TITLE
QuickStart for Existing Users V2: Mark reader task as done when user taps on a tag

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderSelectInterestsViewController.swift
@@ -344,6 +344,9 @@ extension ReaderSelectInterestsViewController: UICollectionViewDelegate {
             spotlightIsShown = false
         }
 
+        // End reader quick start tour if user selects a topic.
+        QuickStartTourGuide.shared.visited(.readerDiscoverSettings)
+
         dataSource.interest(for: indexPath.row).toggleSelected()
         updateNextButtonState()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -38,6 +38,7 @@ class ReaderTabViewController: UIViewController {
 
         NotificationCenter.default.addObserver(self, selector: #selector(defaultAccountDidChange(_:)), name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(willEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
+        startObservingQuickStart()
 
         viewModel.fetchReaderMenu()
     }
@@ -123,12 +124,23 @@ class ReaderTabViewController: UIViewController {
 // MARK: - Navigation Buttons
 extension ReaderTabViewController {
     @objc private func didTapSettingsButton() {
-        settingsButton.shouldShowSpotlight = false
         viewModel.presentManage(from: self)
     }
 
     @objc private func didTapSearchButton() {
         viewModel.navigateToSearch()
+    }
+}
+
+// MARK: Observing Quick Start
+extension ReaderTabViewController {
+    private func startObservingQuickStart() {
+        NotificationCenter.default.addObserver(forName: .QuickStartTourElementChangedNotification, object: nil, queue: nil) { [weak self] notification in
+            if let info = notification.userInfo,
+               let element = info[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
+                self?.settingsButton.shouldShowSpotlight = element == .readerDiscoverSettings
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #18565

## Description
The reader tour can now be marked as completed by either tapping the settings button or tapping on any topic in the discover onboarding screen

https://user-images.githubusercontent.com/25306722/168106304-e591fa71-5a47-48e4-82a8-5e172dad44e8.mp4

## Testing Instructions

### New way to complete the tour

1. Make sure to have no topics followed
2. Enable Quick Start for an existing site
3. Start the Reader tour
4. Navigate to Reader
5. Tap on any topic
6. Make sure that the notice gets dismissed
7. Make sure that the waypoint on the Settings button gets hidden
8. Go back and make sure that the tour is marked as completed

### Regression

1. Enable Quick Start for an existing site
2. Start the Reader tour
3. Navigate to Reader
4. Tap on the Settings button
5. Dismiss the settings modal
6. Make sure that the notice gets dismissed
7. Make sure that the waypoint on the settings button gets hidden
8. Go back and make sure that the tour is marked as completed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
