### PR TITLE
Quick Start: Refresh Quick Start card location when the default section changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -190,12 +190,8 @@ final class BlogDashboardViewController: UIViewController {
         viewModel.loadCards()
     }
 
-    /// Load card from cache if view is appearing
+    /// Load card from cache
     @objc private func loadCardsFromCache() {
-        guard view.superview != nil else {
-            return
-        }
-
         viewModel.loadCardsFromCache()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -34,6 +34,7 @@ protocol DefaultSectionProvider {
 
     func setDefaultSection(_ tab: MySiteViewController.Section) {
         userDefaults.set(tab.rawValue, forKey: Constants.defaultSectionKey)
+        QuickStartTourGuide.shared.refreshQuickStart()
         WPAnalytics.track(.mySiteDefaultTabExperimentVariantAssigned, properties: ["default_tab_experiment": experimentAssignment])
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -181,6 +181,11 @@ open class QuickStartTourGuide: NSObject {
         }
     }
 
+    /// Posts an empty notification to trigger updates to Quick Start Cards if needed.
+    func refreshQuickStart() {
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
+    }
+
     private func addSiteMenuWayPointIfNeeded(for tour: QuickStartTour) -> QuickStartTour {
 
         if currentEntryPoint == .blogDashboard &&

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -60,9 +60,7 @@ open class QuickStartTourGuide: NSObject {
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
         WPAnalytics.trackQuickStartEvent(.quickStartStarted, blog: blog)
 
-        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification,
-                                        object: self,
-                                        userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.setupQuickStart])
+        refreshQuickStart()
     }
 
     func setupWithDelay(for blog: Blog, type: QuickStartType, withCompletedSteps steps: [QuickStartTour] = []) {
@@ -181,9 +179,11 @@ open class QuickStartTourGuide: NSObject {
         }
     }
 
-    /// Posts an empty notification to trigger updates to Quick Start Cards if needed.
+    /// Posts a notification to trigger updates to Quick Start Cards if needed.
     func refreshQuickStart() {
-        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self)
+        NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification,
+                                        object: self,
+                                        userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.setupQuickStart])
     }
 
     private func addSiteMenuWayPointIfNeeded(for tour: QuickStartTour) -> QuickStartTour {


### PR DESCRIPTION
Fixes #18563

## Description
Immediately refresh the quick start card location when the initial screen is updated

## Testing Instructions

1. Set Initial Screen to be Home
2. Enable quick start for a site
3. Observe that the QuickStart card appears under Home
4. Go to App Settings and change the initial screen to Menu
5. Go back to Home
6. Make sure that the Quick Start card is not displayed under Home but under Menu

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
