### PR TITLE
Enhance the stability of flaky unit tests

### DIFF
--- a/WordPress/WordPressTest/Extensions/XCTestCase+Wait.swift
+++ b/WordPress/WordPressTest/Extensions/XCTestCase+Wait.swift
@@ -7,6 +7,6 @@ extension XCTestCase {
             waitExpectation.fulfill()
         }
 
-        waitForExpectations(timeout: duration)
+        waitForExpectations(timeout: duration + 1)
     }
 }

--- a/WordPress/WordPressTest/Extensions/XCTestCase+Wait.swift
+++ b/WordPress/WordPressTest/Extensions/XCTestCase+Wait.swift
@@ -7,6 +7,8 @@ extension XCTestCase {
             waitExpectation.fulfill()
         }
 
+        // We wait for the duration + 1 second to allow some buffer in case the dispatched block gets
+        // delayed by GCD for any reason for even 1 microsecond.
         waitForExpectations(timeout: duration + 1)
     }
 }


### PR DESCRIPTION
## Description
This PR should enhance the stability of some flaky tests.

Failing tests: https://buildkite.com/automattic/wordpress-ios/builds/7506#2c49fda4-3abc-40fa-9066-bba62a4e5bbf

In `XCTestCase.wait` we were fulfilling an expectation after the passed duration using an async dispatched block. And we were waiting for the exact same duration. If the dispatched block got delayed for a microsecond that would fail the test. I added a 1-second buffer to fix this issue.

## Testing Instructions

No need to test anything. This PR only affects our unit tests.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
