### PR TITLE
Blogging Prompts Feature Introduction: use real prompt for new post

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -35,6 +35,10 @@ class BloggingPromptsIntroductionPresenter: NSObject {
         (accountSites?.count ?? 0) == 0
     }()
 
+    private lazy var bloggingPromptsService: BloggingPromptsService? = {
+        return BloggingPromptsService(blog: blogToUse())
+    }()
+
     // MARK: - Present Feature Introduction
 
     func present(from presentingViewController: UIViewController) {
@@ -103,15 +107,21 @@ private extension BloggingPromptsIntroductionPresenter {
             return
         }
 
-        // TODO: pre-populate post content with prompt from backend instead
-        // of example prompt
-        let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
-        editor.modalPresentationStyle = .fullScreen
-        editor.entryPoint = .bloggingPromptsFeatureIntroduction
+        fetchPrompt(completion: { [weak self] (prompt) in
+            guard let prompt = prompt else {
+                self?.dispatchErrorNotice()
+                self?.navigationController.dismiss(animated: true)
+                return
+            }
 
-        navigationController.dismiss(animated: true, completion: { [weak self] in
-            presentingViewController.present(editor, animated: false)
-            self?.trackPostEditorShown(blog)
+            let editor = EditPostViewController(blog: blog, prompt: prompt)
+            editor.modalPresentationStyle = .fullScreen
+            editor.entryPoint = .bloggingPromptsFeatureIntroduction
+
+            self?.navigationController.dismiss(animated: true, completion: { [weak self] in
+                presentingViewController.present(editor, animated: false)
+                self?.trackPostEditorShown(blog)
+            })
         })
     }
 
@@ -137,6 +147,29 @@ private extension BloggingPromptsIntroductionPresenter {
         WPAppAnalytics.track(.editorCreatedPost,
                              withProperties: [WPAppAnalyticsKeyTapSource: "blogging_prompts_feature_introduction", WPAppAnalyticsKeyPostType: "post"],
                              with: blog)
+    }
+
+    // MARK: Prompt Fetching
+
+    func fetchPrompt(completion: @escaping ((_ prompt: BloggingPrompt?) -> Void)) {
+        // TODO: check for cached prompt first.
+
+        guard let bloggingPromptsService = bloggingPromptsService else {
+            DDLogError("Feature Introduction: failed creating BloggingPromptsService instance.")
+            return
+        }
+
+        bloggingPromptsService.fetchTodaysPrompt(success: { (prompt) in
+            completion(prompt)
+        }, failure: { (error) in
+            completion(nil)
+            DDLogError("Feature Introduction: failed fetching blogging prompt: \(String(describing: error))")
+        })
+    }
+
+    func dispatchErrorNotice() {
+        let message = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
+        presentingViewController?.displayNotice(title: message)
     }
 
 }


### PR DESCRIPTION
Ref: #18429

When `Try it now` is selected on the Blogging Prompts feature introduction, a prompt is fetched and passed to the post editor. 

To test:
- Enable `bloggingPrompts` feature flag.
- Select `Try it now` on the feature introduction.
- Verify the post content matches the prompt. (It should match the dashboard prompt card and FAB header prompt.)
- In `BloggingPromptsIntroductionPresenter:fetchPrompt`, call `completion(nil)` in the success block to fake a failure.

```
bloggingPromptsService.fetchTodaysPrompt(success: { (prompt) in
    completion(nil)
    // completion(prompt)
}, failure: { (error) in
...
```
- Select `Try it now` on the feature introduction.
- Verify:
  - The feature introduction is dismissed.
  - An error notice is displayed.
 
| Post Editor | Error Notice |
|--------|-------|
| ![post](https://user-images.githubusercontent.com/1816888/168156156-3556c4de-f033-4b6b-9333-d04c9871e935.png) | ![error](https://user-images.githubusercontent.com/1816888/168155781-c68d62b9-49dc-4e68-acb2-0f455d53316b.png) |


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
