### PR TITLE
Blogging Prompts: Add attribution to prompts header view in action sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -5,6 +5,9 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var titleStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var promptLabel: UILabel!
+    @IBOutlet private weak var attributionStackView: UIStackView!
+    @IBOutlet private weak var attributionImage: UIImageView!
+    @IBOutlet private weak var attributionLabel: UILabel!
     @IBOutlet private weak var answerPromptButton: UIButton!
     @IBOutlet private weak var answeredStackView: UIStackView!
     @IBOutlet private weak var answeredLabel: UILabel!
@@ -94,6 +97,17 @@ private extension BloggingPromptsHeaderView {
         let answered = prompt?.answered ?? false
         answerPromptButton.isHidden = answered
         answeredStackView.isHidden = !answered
+
+        if let promptAttribution = prompt?.attribution.lowercased(),
+           let attribution = BloggingPromptsAttribution(rawValue: promptAttribution) {
+            attributionStackView.isHidden = false
+            attributionImage.image = attribution.iconImage
+            attributionLabel.attributedText = attribution.attributedText
+            containerStackView.setCustomSpacing(Constants.promptSpacing, after: promptLabel)
+        } else {
+            attributionStackView.isHidden = true
+            containerStackView.setCustomSpacing(.zero, after: promptLabel)
+        }
     }
 
     // MARK: - Button Actions
@@ -110,6 +124,7 @@ private extension BloggingPromptsHeaderView {
 
     struct Constants {
         static let titleSpacing: CGFloat = 8.0
+        static let promptSpacing: CGFloat = 8.0
         static let answeredViewSpacing: CGFloat = 9.0
         static let answerPromptButtonSpacing: CGFloat = 9.0
         static let buttonContentEdgeInsets = UIEdgeInsets(top: 16.0, left: 0.0, bottom: 16.0, right: 0.0)

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -11,11 +11,11 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="iN0-l3-epB" customClass="BloggingPromptsHeaderView" customModule="WordPress" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="349" height="120"/>
+            <rect key="frame" x="0.0" y="0.0" width="349" height="138"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="HBh-15-Hby">
-                    <rect key="frame" x="0.0" y="0.0" width="349" height="92"/>
+                    <rect key="frame" x="0.0" y="0.0" width="349" height="110"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="stO-XN-YJp">
                             <rect key="frame" x="131" y="0.0" width="87.5" height="24"/>
@@ -47,8 +47,26 @@
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
                         </label>
+                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Gef-vX-Eh7">
+                            <rect key="frame" x="111" y="48" width="127" height="18"/>
+                            <subviews>
+                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tPu-fo-0nQ">
+                                    <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="18" id="PGa-fz-qU1"/>
+                                        <constraint firstAttribute="height" constant="18" id="ReF-to-kfP"/>
+                                    </constraints>
+                                </imageView>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="From Day One" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q82-Ru-Asj">
+                                    <rect key="frame" x="18" y="0.0" width="109" height="18"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqk-gy-gv5">
-                            <rect key="frame" x="113" y="48" width="123" height="23.5"/>
+                            <rect key="frame" x="113" y="66" width="123" height="23.5"/>
                             <state key="normal" title="Button"/>
                             <buttonConfiguration key="configuration" style="plain" title="Answer Prompt"/>
                             <connections>
@@ -56,7 +74,7 @@
                             </connections>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="74j-gh-nmq">
-                            <rect key="frame" x="88.5" y="71.5" width="172" height="20.5"/>
+                            <rect key="frame" x="88.5" y="89.5" width="172" height="20.5"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="✓ Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ttu-81-Rjc">
                                     <rect key="frame" x="0.0" y="0.0" width="94.5" height="20.5"/>
@@ -75,7 +93,7 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9KN-UC-IRC">
-                            <rect key="frame" x="0.0" y="92" width="349" height="0.0"/>
+                            <rect key="frame" x="0.0" y="110" width="349" height="0.0"/>
                             <color key="backgroundColor" systemColor="separatorColor"/>
                         </view>
                     </subviews>
@@ -99,6 +117,9 @@
                 <outlet property="answerPromptButton" destination="fqk-gy-gv5" id="g2H-Pl-Cot"/>
                 <outlet property="answeredLabel" destination="ttu-81-Rjc" id="qUD-tY-fry"/>
                 <outlet property="answeredStackView" destination="74j-gh-nmq" id="mWB-ce-YU3"/>
+                <outlet property="attributionImage" destination="tPu-fo-0nQ" id="7PG-uf-nAc"/>
+                <outlet property="attributionLabel" destination="Q82-Ru-Asj" id="r7a-iR-WXv"/>
+                <outlet property="attributionStackView" destination="Gef-vX-Eh7" id="vqC-5V-Z1L"/>
                 <outlet property="containerStackView" destination="HBh-15-Hby" id="ce7-Wx-TUC"/>
                 <outlet property="dividerView" destination="9KN-UC-IRC" id="Wnd-hZ-yio"/>
                 <outlet property="promptLabel" destination="Rye-vB-0gG" id="VoE-0W-soe"/>
@@ -106,7 +127,7 @@
                 <outlet property="titleLabel" destination="BJN-uB-YYG" id="zxX-90-kDD"/>
                 <outlet property="titleStackView" destination="stO-XN-YJp" id="Mjx-Bg-Wpo"/>
             </connections>
-            <point key="canvasLocation" x="180.43478260869566" y="-91.741071428571431"/>
+            <point key="canvasLocation" x="180.43478260869566" y="-85.714285714285708"/>
         </view>
     </objects>
     <resources>


### PR DESCRIPTION
See: #18558

## Description

Adds the prompts attribution to the header view in the action sheet.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Modify the header view to use the example prompt if the current days prompt is not attributed to Day One
- Launch and navigate to 'My Site' tab
- Tap on create new '+'
- Verify:
  - Day One icon is correct
  - Attribution is correct

## Screenshots

| Light | Dark |
|------|------|
| <img width="378" alt="Screen Shot 2022-05-12 at 4 01 56 PM" src="https://user-images.githubusercontent.com/2454408/168158653-d969d682-65f3-41c9-b1d8-1305711aa240.png"> | <img width="384" alt="Screen Shot 2022-05-12 at 4 02 05 PM" src="https://user-images.githubusercontent.com/2454408/168158679-12cb086c-e383-43f0-b3e4-095b4ad5d258.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
