### PR TITLE
Blogging Prompt Cards: pass real prompt to post editor

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -86,18 +86,6 @@ struct BloggingPrompt {
     let answerCount: Int
     let displayAvatarURLs: [URL]
     let attribution: String
-
-    static let examplePrompt = BloggingPrompt(
-            promptID: 239,
-            text: "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.",
-            title: "Prompt number 1",
-            content: "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->",
-            date: Date(),
-            answered: false,
-            answerCount: 5,
-            displayAvatarURLs: [],
-            attribution: "dayone"
-    )
 }
 
 extension BloggingPrompt {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -390,11 +390,12 @@ private extension DashboardPromptsCardCell {
     // MARK: Button actions
 
     @objc func answerButtonTapped() {
-        guard let blog = blog else {
+        guard let blog = blog,
+        let prompt = prompt else {
             return
         }
 
-        let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
+        let editor = EditPostViewController(blog: blog, prompt: prompt)
         editor.modalPresentationStyle = .fullScreen
         editor.entryPoint = .dashboard
         presenterViewController?.present(editor, animated: true)

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -333,8 +333,7 @@ private extension CreateButtonCoordinator {
 
         promptsHeaderView.answerPromptHandler = { [weak self] in
             self?.viewController?.dismiss(animated: true) {
-                // TODO: pass prompt to post editor
-                let editor = EditPostViewController(blog: blog, prompt: .examplePrompt)
+                let editor = EditPostViewController(blog: blog, prompt: prompt)
                 editor.modalPresentationStyle = .fullScreen
                 editor.entryPoint = .bloggingPromptsActionSheetHeader
                 self?.viewController?.present(editor, animated: true)


### PR DESCRIPTION
Ref: #18429

When answering a prompt from the dashboard card or the compact card, the post is now populated with the actual post.

To test:
- Enable `bloggingPrompts` feature flag.
- Select `Answer prompt` from the FAB header.
  - Verify the post is populated with the prompt.
- Select `Answer prompt` from the dashboard prompt card.
  - Verify the post is populated with the prompt.

| ![fab](https://user-images.githubusercontent.com/1816888/168175114-f6bbc487-d112-4601-b92f-39071ba239c1.png) | ![dashboard](https://user-images.githubusercontent.com/1816888/168175124-857b37c5-def2-4d84-a6a1-539484d6d073.png) | ![post](https://user-images.githubusercontent.com/1816888/168175119-b1cb0778-010d-4152-bdaa-82a48b09fff5.png) |
|--------|-------|-------|


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
