### PR TITLE
Feature/highlights tooltip presenter

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -224,6 +224,7 @@ final class Tooltip: UIView {
 
         setUpContainerView()
         setUpConstraints()
+        addShadow()
         isAccessibilityElement = true
     }
 
@@ -269,6 +270,12 @@ final class Tooltip: UIView {
             containerView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth),
             buttonsStackView.heightAnchor.constraint(equalToConstant: Constants.Spacing.buttonStackViewHeight)
         ])
+    }
+
+    private func addShadow() {
+        containerView.layer.shadowColor = UIColor.black.cgColor
+        containerView.layer.shadowOffset = CGSize(width: 0, height: 2)
+        containerView.layer.shadowOpacity = 0.5
     }
 
     private static func height(

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -243,18 +243,8 @@ final class Tooltip: UIView {
 
         setUpContainerView()
         setUpConstraints()
-
+        addShadow()
         isAccessibilityElement = true
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(contentSizeCategoryChanged(_:)),
-            name: UIContentSizeCategory.didChangeNotification, object: nil
-        )
-    }
-
-    @objc private func contentSizeCategoryChanged(_ notification: Notification) {
-        arrowShapeLayer?.layoutIfNeeded()
-        arrowShapeLayer?.layoutSublayers()
     }
 
     private func setUpContainerView() {

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -10,6 +10,10 @@ final class Tooltip: UIView {
         static let arrowTipYControlLength: CGFloat = 9
         static let maxWidth: CGFloat = UIScreen.main.bounds.width - Spacing.superHorizontalMargin
         static let maxContentWidth = maxWidth - (Constants.Spacing.contentStackViewHorizontal * 2)
+        static let invertedTooltipBackgroundColor = UIColor(
+            light: UIColor.systemGray5.color(for: UITraitCollection(userInterfaceStyle: .dark)),
+            dark: .white
+        )
 
 
         enum Spacing {
@@ -179,8 +183,8 @@ final class Tooltip: UIView {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        arrowShapeLayer?.strokeColor = UIColor.invertedSystem5.cgColor
-        arrowShapeLayer?.fillColor = UIColor.invertedSystem5.cgColor
+        arrowShapeLayer?.strokeColor = Constants.invertedTooltipBackgroundColor.cgColor
+        arrowShapeLayer?.fillColor = Constants.invertedTooltipBackgroundColor.cgColor
 
         containerView.layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.5 : 0
     }
@@ -231,8 +235,8 @@ final class Tooltip: UIView {
         }
 
         arrowShapeLayer.path = arrowPath.cgPath
-        arrowShapeLayer.strokeColor = UIColor.invertedSystem5.cgColor
-        arrowShapeLayer.fillColor = UIColor.invertedSystem5.cgColor
+        arrowShapeLayer.strokeColor = Constants.invertedTooltipBackgroundColor.cgColor
+        arrowShapeLayer.fillColor = Constants.invertedTooltipBackgroundColor.cgColor
         arrowShapeLayer.lineWidth = 2.0
 
         arrowShapeLayer.position = CGPoint(x: offsetX - Self.arrowWidth/2, y: offsetY)
@@ -265,7 +269,7 @@ final class Tooltip: UIView {
     }
 
     private func setUpContainerView() {
-        containerView.backgroundColor = .invertedSystem5
+        containerView.backgroundColor = Constants.invertedTooltipBackgroundColor
         containerView.layer.cornerRadius = Constants.cornerRadius
         containerView.translatesAutoresizingMaskIntoConstraints = false
         addSubview(containerView)

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -25,12 +25,6 @@ final class Tooltip: UIView {
             static let superHorizontalMargin: CGFloat = 16
             static let buttonStackViewHeight: CGFloat = 40
         }
-
-        enum Font {
-            static let title = WPStyleGuide.fontForTextStyle(.body)
-            static let message = WPStyleGuide.fontForTextStyle(.body)
-            static let button = WPStyleGuide.fontForTextStyle(.subheadline)
-        }
     }
 
     enum ButtonAlignment {
@@ -88,9 +82,13 @@ final class Tooltip: UIView {
             buttonsStackView.removeAllSubviews()
             switch buttonAlignment {
             case .left:
+                buttonsStackView.spacing = Constants.Spacing.buttonsStackViewInterItemSpacing
                 buttonsStackView.addArrangedSubviews([primaryButton, secondaryButton, UIView()])
+                buttonsStackView.setCustomSpacing(0, after: secondaryButton)
             case .right:
+                buttonsStackView.spacing = 0
                 buttonsStackView.addArrangedSubviews([UIView(), primaryButton, secondaryButton])
+                buttonsStackView.setCustomSpacing(Constants.Spacing.buttonsStackViewInterItemSpacing, after: primaryButton)
             }
         }
     }
@@ -107,11 +105,11 @@ final class Tooltip: UIView {
         }
     }
 
-    var primaryButtonAction: (() -> Void)?
+    var dismissalAction: (() -> Void)?
     var secondaryButtonAction: (() -> Void)?
 
     private lazy var titleLabel: UILabel = {
-        $0.font = Constants.Font.title
+        $0.font = WPStyleGuide.fontForTextStyle(.body)
         $0.textColor = .invertedLabel
         $0.adjustsFontForContentSizeCategory = true
         $0.numberOfLines = 0
@@ -119,7 +117,7 @@ final class Tooltip: UIView {
     }(UILabel())
 
     private lazy var messageLabel: UILabel = {
-        $0.font = Constants.Font.message
+        $0.font = WPStyleGuide.fontForTextStyle(.body)
         $0.textColor = .invertedSecondaryLabel
         $0.adjustsFontForContentSizeCategory = true
         $0.numberOfLines = 0
@@ -127,7 +125,7 @@ final class Tooltip: UIView {
     }(UILabel())
 
     private lazy var primaryButton: UIButton = {
-        $0.titleLabel?.font = Constants.Font.button
+        $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         $0.setTitleColor(.invertedLink, for: .normal)
         $0.addTarget(self, action: #selector(didTapPrimaryButton), for: .touchUpInside)
         $0.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -135,7 +133,7 @@ final class Tooltip: UIView {
     }(UIButton())
 
     private lazy var secondaryButton: UIButton = {
-        $0.titleLabel?.font = Constants.Font.button
+        $0.titleLabel?.font = WPStyleGuide.fontForTextStyle(.subheadline)
         $0.setTitleColor(.invertedLink, for: .normal)
         $0.addTarget(self, action: #selector(didTapSecondaryButton), for: .touchUpInside)
         $0.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -152,6 +150,7 @@ final class Tooltip: UIView {
     private lazy var buttonsStackView: UIStackView = {
         $0.addArrangedSubviews([primaryButton, secondaryButton, UIView()])
         $0.spacing = Constants.Spacing.buttonsStackViewInterItemSpacing
+        $0.setCustomSpacing(0, after: secondaryButton)
         return $0
     }(UIStackView())
 
@@ -320,7 +319,7 @@ final class Tooltip: UIView {
     }
 
     @objc private func didTapPrimaryButton() {
-        primaryButtonAction?()
+        dismissalAction?()
     }
 
     @objc private func didTapSecondaryButton() {
@@ -336,13 +335,13 @@ final class Tooltip: UIView {
         totalHeight += Constants.Spacing.contentStackViewTop
 
         if let title = title {
-            totalHeight += title.height(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.title)
+            totalHeight += title.height(withMaxWidth: Constants.maxContentWidth, font: WPStyleGuide.fontForTextStyle(.body))
         }
 
         totalHeight += Constants.Spacing.contentStackViewInterItemSpacing * 2
 
         if let message = message {
-            totalHeight += message.height(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.message)
+            totalHeight += message.height(withMaxWidth: Constants.maxContentWidth, font: WPStyleGuide.fontForTextStyle(.body))
         }
 
         totalHeight += Constants.Spacing.buttonStackViewHeight
@@ -358,18 +357,18 @@ final class Tooltip: UIView {
         secondaryButtonTitle: String?
     ) -> CGFloat {
 
-        let titleWidth = title?.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.title) ?? 0
-        let messageWidth = message?.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.message) ?? 0
+        let titleWidth = title?.width(withMaxWidth: Constants.maxContentWidth, font: WPStyleGuide.fontForTextStyle(.body)) ?? 0
+        let messageWidth = message?.width(withMaxWidth: Constants.maxContentWidth, font: WPStyleGuide.fontForTextStyle(.body)) ?? 0
 
         var buttonsWidth: CGFloat = 0
         if let primaryButtonTitle = primaryButtonTitle {
-            buttonsWidth += primaryButtonTitle.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.button)
+            buttonsWidth += primaryButtonTitle.width(withMaxWidth: Constants.maxContentWidth, font: WPStyleGuide.fontForTextStyle(.subheadline))
         }
 
         if let secondaryButtonTitle = secondaryButtonTitle {
             buttonsWidth += secondaryButtonTitle.width(
                 withMaxWidth: Constants.maxContentWidth,
-                font: Constants.Font.button
+                font: WPStyleGuide.fontForTextStyle(.subheadline)
             ) + Constants.Spacing.buttonsStackViewInterItemSpacing
         }
 

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -91,6 +91,21 @@ final class Tooltip: UIView {
         }
     }
 
+    var primaryButtonTitle: String? {
+        didSet {
+            primaryButton.setTitle(primaryButtonTitle, for: .normal)
+        }
+    }
+
+    var secondaryButtonTitle: String? {
+        didSet {
+            secondaryButton.setTitle(secondaryButtonTitle, for: .normal)
+        }
+    }
+
+    var primaryButtonAction: (() -> Void)?
+    var secondaryButtonAction: (() -> Void)?
+
     private lazy var titleLabel: UILabel = {
         $0.font = Constants.Font.title
         $0.textColor = .invertedLabel
@@ -106,16 +121,18 @@ final class Tooltip: UIView {
         return $0
     }(UILabel())
 
-    private(set) lazy var primaryButton: UIButton = {
+    private lazy var primaryButton: UIButton = {
         $0.titleLabel?.font = Constants.Font.button
         $0.setTitleColor(.invertedLink, for: .normal)
+        $0.addTarget(self, action: #selector(didTapPrimaryButton), for: .touchUpInside)
         $0.titleLabel?.adjustsFontForContentSizeCategory = true
         return $0
     }(UIButton())
 
-    private(set) lazy var secondaryButton: UIButton = {
+    private lazy var secondaryButton: UIButton = {
         $0.titleLabel?.font = Constants.Font.button
         $0.setTitleColor(.invertedLink, for: .normal)
+        $0.addTarget(self, action: #selector(didTapSecondaryButton), for: .touchUpInside)
         $0.titleLabel?.adjustsFontForContentSizeCategory = true
         return $0
     }(UIButton())
@@ -295,6 +312,14 @@ final class Tooltip: UIView {
         containerView.layer.shadowColor = UIColor.black.cgColor
         containerView.layer.shadowOffset = CGSize(width: 0, height: 2)
         containerView.layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.5 : 0
+    }
+
+    @objc private func didTapPrimaryButton() {
+        primaryButtonAction?()
+    }
+
+    @objc private func didTapSecondaryButton() {
+        secondaryButtonAction?()
     }
 
     private static func height(

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -114,6 +114,7 @@ final class Tooltip: UIView {
         $0.font = Constants.Font.title
         $0.textColor = .invertedLabel
         $0.adjustsFontForContentSizeCategory = true
+        $0.numberOfLines = 0
         return $0
     }(UILabel())
 
@@ -335,11 +336,7 @@ final class Tooltip: UIView {
         totalHeight += Constants.Spacing.contentStackViewTop
 
         if let title = title {
-            totalHeight += title.height(
-                withMaxWidth: Constants.maxContentWidth,
-                font: Constants.Font.title,
-                options: []
-            )
+            totalHeight += title.height(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.title)
         }
 
         totalHeight += Constants.Spacing.contentStackViewInterItemSpacing * 2
@@ -361,11 +358,7 @@ final class Tooltip: UIView {
         secondaryButtonTitle: String?
     ) -> CGFloat {
 
-        let titleWidth = title?.width(
-            withMaxWidth: Constants.maxContentWidth,
-            font: Constants.Font.title,
-            options: []
-        ) ?? 0
+        let titleWidth = title?.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.title) ?? 0
         let messageWidth = message?.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.message) ?? 0
 
         var buttonsWidth: CGFloat = 0
@@ -374,7 +367,10 @@ final class Tooltip: UIView {
         }
 
         if let secondaryButtonTitle = secondaryButtonTitle {
-            buttonsWidth += secondaryButtonTitle.width(withMaxWidth: Constants.maxContentWidth, font: Constants.Font.button) + Constants.Spacing.buttonsStackViewInterItemSpacing
+            buttonsWidth += secondaryButtonTitle.width(
+                withMaxWidth: Constants.maxContentWidth,
+                font: Constants.Font.button
+            ) + Constants.Spacing.buttonsStackViewInterItemSpacing
         }
 
         return max(max(titleWidth, messageWidth), buttonsWidth) + Constants.Spacing.contentStackViewHorizontal * 2
@@ -382,15 +378,11 @@ final class Tooltip: UIView {
 }
 
 private extension String {
-    private func size(
-        withMaxWidth maxWidth: CGFloat,
-        font: UIFont,
-        options: NSStringDrawingOptions = .usesLineFragmentOrigin
-    ) -> CGRect {
+    private func size(withMaxWidth maxWidth: CGFloat, font: UIFont) -> CGRect {
         let constraintRect = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
         let boundingBox = self.boundingRect(
             with: constraintRect,
-            options: options,
+            options: .usesLineFragmentOrigin,
             attributes: [.font: font],
             context: nil
         )
@@ -398,19 +390,11 @@ private extension String {
         return boundingBox
     }
 
-    func height(
-        withMaxWidth maxWidth: CGFloat,
-        font: UIFont,
-        options: NSStringDrawingOptions = .usesLineFragmentOrigin
-    ) -> CGFloat {
-        ceil(size(withMaxWidth: maxWidth, font: font, options: options).height)
+    func height(withMaxWidth maxWidth: CGFloat, font: UIFont) -> CGFloat {
+        ceil(size(withMaxWidth: maxWidth, font: font).height)
     }
 
-    func width(
-        withMaxWidth maxWidth: CGFloat,
-        font: UIFont,
-        options: NSStringDrawingOptions = .usesLineFragmentOrigin
-    ) -> CGFloat {
-        ceil(size(withMaxWidth: maxWidth, font: font, options: options).width)
+    func width(withMaxWidth maxWidth: CGFloat, font: UIFont) -> CGFloat {
+        ceil(size(withMaxWidth: maxWidth, font: font).width)
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -181,11 +181,9 @@ final class Tooltip: UIView {
         commonInit()
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
+    override func layoutSubviews() {
         arrowShapeLayer?.strokeColor = Constants.invertedTooltipBackgroundColor.cgColor
         arrowShapeLayer?.fillColor = Constants.invertedTooltipBackgroundColor.cgColor
-
         containerView.layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 0.5 : 0
     }
 
@@ -235,6 +233,7 @@ final class Tooltip: UIView {
         }
 
         arrowShapeLayer.path = arrowPath.cgPath
+
         arrowShapeLayer.strokeColor = Constants.invertedTooltipBackgroundColor.cgColor
         arrowShapeLayer.fillColor = Constants.invertedTooltipBackgroundColor.cgColor
         arrowShapeLayer.lineWidth = 2.0

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -84,8 +84,6 @@ final class TooltipPresenter {
         }
     }
 
-    private var cons: [NSLayoutConstraint] = []
-
     private func setUpConstraints() {
         tooltip.translatesAutoresizingMaskIntoConstraints = false
 
@@ -107,7 +105,6 @@ final class TooltipPresenter {
         }
 
         tooltipConstraints.append(tooltipTopConstraint!)
-        cons = tooltipConstraints
         NSLayoutConstraint.activate(tooltipConstraints)
     }
 

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -6,6 +6,8 @@ final class TooltipPresenter {
     private enum Constants {
         static let verticalTooltipDistanceToFocus: CGFloat = 8
         static let horizontalBufferMargin: CGFloat = 20
+        static let tooltipTopConstraintAnimationOffset: CGFloat = 8
+        static let tooltipAnimationDuration: TimeInterval = 0.2
     }
 
     private let containerView: UIView
@@ -45,21 +47,35 @@ final class TooltipPresenter {
 
     func show() {
         containerView.addSubview(tooltip)
+        self.tooltip.alpha = 0
         tooltip.addArrowHead(toXPosition: arrowOffsetX(), arrowPosition: tooltipOrientation())
         setUpConstraints()
+        containerView.layoutIfNeeded()
+
+        UIView.animate(
+            withDuration: Constants.tooltipAnimationDuration,
+            delay: 0,
+            options: .curveEaseOut
+        ) {
+            guard let tooltipTopConstraint = self.tooltipTopConstraint else { return }
+
+            self.tooltip.alpha = 1
+            tooltipTopConstraint.constant -= Constants.tooltipTopConstraintAnimationOffset
+            self.containerView.layoutIfNeeded()
+        }
     }
 
     private func configureDismissal() {
         tooltip.primaryButtonAction = {
             UIView.animate(
-                withDuration: 0.2,
+                withDuration: Constants.tooltipAnimationDuration,
                 delay: 0,
-                options: .curveEaseIn
+                options: .curveEaseOut
             ) {
                 guard let tooltipTopConstraint = self.tooltipTopConstraint else { return }
 
                 self.tooltip.alpha = 0
-                tooltipTopConstraint.constant += 8
+                tooltipTopConstraint.constant += Constants.tooltipTopConstraintAnimationOffset
                 self.containerView.layoutIfNeeded()
             } completion: { isSuccess in
                 self.primaryTooltipAction?()
@@ -79,12 +95,12 @@ final class TooltipPresenter {
         case .bottom:
             tooltipTopConstraint = targetView.topAnchor.constraint(
                 equalTo: tooltip.bottomAnchor,
-                constant: Constants.verticalTooltipDistanceToFocus
+                constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
             )
         case .top:
             tooltipTopConstraint = tooltip.topAnchor.constraint(
                 equalTo: targetView.bottomAnchor,
-                constant: Constants.verticalTooltipDistanceToFocus
+                constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
             )
         }
 

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -25,20 +25,20 @@ final class TooltipPresenter {
     private func setUpConstraints() {
         tooltip.translatesAutoresizingMaskIntoConstraints = false
 
-        var tooltipConstriants: [NSLayoutConstraint] = [
+        var tooltipConstraints: [NSLayoutConstraint] = [
             tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
         ]
 
         switch tooltipOrientation() {
         case .bottom:
-            tooltipConstriants.append(
+            tooltipConstraints.append(
                 targetView.topAnchor.constraint(
                     equalTo: tooltip.bottomAnchor,
                     constant: Constants.verticalTooltipDistanceToFocus
                 )
             )
         case .top:
-            tooltipConstriants.append(
+            tooltipConstraints.append(
                 tooltip.topAnchor.constraint(
                     equalTo: targetView.bottomAnchor,
                     constant: Constants.verticalTooltipDistanceToFocus
@@ -46,13 +46,27 @@ final class TooltipPresenter {
             )
         }
 
-        NSLayoutConstraint.activate(tooltipConstriants)
+        NSLayoutConstraint.activate(tooltipConstraints)
     }
 
+    /// Calculates where the arrow needs to place in the borders of the tooltia.
+    /// This depends on the position of the `targetView` relative to `tooltip`.
     private func arrowOffsetX() -> CGFloat {
         return targetView.frame.midX - ((containerView.bounds.width - tooltip.size().width) / 2) - extraArrowOffsetX()
     }
 
+    /// If the tooltip is alwyas vertically centered, tooltip's width may not be big enough to reach to the `targetView`
+    /// If `xxxxxxxx` is the Tooltip and `oo` is the `targetView`:
+    /// |                                               |
+    /// |                xxxxxxxx                 |
+    /// |                                    oo       |
+    /// The tooltip needs an extra X offset to be aligned with target so that tooltip arrow points to the correct position.
+    /// Here the tooltip is pushed to the right so the arrow
+    /// |                                               |
+    /// |                           xxxxxxxx     |
+    /// |                                    oo       |
+    /// It would be retracted instead of the `targetView` was at the left of the screen.
+    ///
     private func extraArrowOffsetX() -> CGFloat {
         let tooltipWidth = tooltip.size().width
         let extraPushOffset = max(

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -34,12 +34,12 @@ final class TooltipPresenter {
 
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(recalculatePosition),
+            selector: #selector(resetTooltipAndShow),
             name: UIContentSizeCategory.didChangeNotification, object: nil
         )
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(recalculatePosition),
+            selector: #selector(resetTooltipAndShow),
             name: UIDevice.orientationDidChangeNotification,
             object: nil
         )
@@ -66,7 +66,7 @@ final class TooltipPresenter {
     }
 
     private func configureDismissal() {
-        tooltip.primaryButtonAction = {
+        tooltip.dismissalAction = {
             UIView.animate(
                 withDuration: Constants.tooltipAnimationDuration,
                 delay: 0,
@@ -83,6 +83,8 @@ final class TooltipPresenter {
             }
         }
     }
+
+    private var cons: [NSLayoutConstraint] = []
 
     private func setUpConstraints() {
         tooltip.translatesAutoresizingMaskIntoConstraints = false
@@ -105,27 +107,28 @@ final class TooltipPresenter {
         }
 
         tooltipConstraints.append(tooltipTopConstraint!)
+        cons = tooltipConstraints
         NSLayoutConstraint.activate(tooltipConstraints)
     }
 
-    @objc private func recalculatePosition() {
+    @objc private func resetTooltipAndShow() {
         tooltip.removeFromSuperview()
         show()
     }
 
-    /// Calculates where the arrow needs to place in the borders of the tooltia.
+    /// Calculates where the arrow needs to place in the borders of the tooltip.
     /// This depends on the position of the `targetView` relative to `tooltip`.
     private func arrowOffsetX() -> CGFloat {
         return targetView.frame.midX - ((containerView.bounds.width - tooltip.size().width) / 2) - extraArrowOffsetX()
     }
 
-    /// If the tooltip is alwyas vertically centered, tooltip's width may not be big enough to reach to the `targetView`
+    /// If the tooltip is always vertically centered, tooltip's width may not be big enough to reach to the `targetView`
     /// If `xxxxxxxx` is the Tooltip and `oo` is the `targetView`:
     /// |                                               |
     /// |                xxxxxxxx                 |
     /// |                                    oo       |
     /// The tooltip needs an extra X offset to be aligned with target so that tooltip arrow points to the correct position.
-    /// Here the tooltip is pushed to the right so the arrow
+    /// Here the tooltip is pushed to the right so the arrow is pointing at the `targetView`
     /// |                                               |
     /// |                           xxxxxxxx     |
     /// |                                    oo       |

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -55,8 +55,14 @@ final class TooltipPresenter {
 
     private func extraArrowOffsetX() -> CGFloat {
         let tooltipWidth = tooltip.size().width
-        let extraPushOffset = max((targetView.frame.midX + Constants.horizontalBufferMargin) - (containerView.frame.midX + tooltipWidth / 2), 0)
-        let extraRetractOffset = min((targetView.frame.midX - Constants.horizontalBufferMargin) - (containerView.frame.midX - tooltipWidth / 2), 0)
+        let extraPushOffset = max(
+            (targetView.frame.midX + Constants.horizontalBufferMargin) - (containerView.frame.midX + tooltipWidth / 2),
+            0
+        )
+        let extraRetractOffset = min(
+            (targetView.frame.midX - Constants.horizontalBufferMargin) - (containerView.frame.midX - tooltipWidth / 2),
+            0
+        )
 
         if extraPushOffset > 0 {
             return extraPushOffset

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -1,0 +1,75 @@
+import UIKit
+
+final class TooltipPresenter {
+    private enum Constants {
+        static let verticalTooltipDistanceToFocus: CGFloat = 8
+        static let horizontalBufferMargin: CGFloat = 20
+    }
+
+    private let containerView: UIView
+    private let tooltip: Tooltip
+    private let targetView: UIView
+
+    init(containerView: UIView, tooltip: Tooltip, targetView: UIView) {
+        self.containerView = containerView
+        self.tooltip = tooltip
+        self.targetView = targetView
+    }
+
+    func show() {
+        containerView.addSubview(tooltip)
+        tooltip.addArrowHead(toXPosition: arrowOffsetX(), arrowPosition: tooltipOrientation())
+        setUpConstraints()
+    }
+
+    private func setUpConstraints() {
+        tooltip.translatesAutoresizingMaskIntoConstraints = false
+
+        var tooltipConstriants: [NSLayoutConstraint] = [
+            tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
+        ]
+
+        switch tooltipOrientation() {
+        case .bottom:
+            tooltipConstriants.append(
+                targetView.topAnchor.constraint(
+                    equalTo: tooltip.bottomAnchor,
+                    constant: Constants.verticalTooltipDistanceToFocus
+                )
+            )
+        case .top:
+            tooltipConstriants.append(
+                tooltip.topAnchor.constraint(
+                    equalTo: targetView.bottomAnchor,
+                    constant: Constants.verticalTooltipDistanceToFocus
+                )
+            )
+        }
+
+        NSLayoutConstraint.activate(tooltipConstriants)
+    }
+
+    private func arrowOffsetX() -> CGFloat {
+        return targetView.frame.midX - ((containerView.bounds.width - tooltip.size().width) / 2) - extraArrowOffsetX()
+    }
+
+    private func extraArrowOffsetX() -> CGFloat {
+        let tooltipWidth = tooltip.size().width
+        let extraPushOffset = max((targetView.frame.midX + Constants.horizontalBufferMargin) - (containerView.frame.midX + tooltipWidth / 2), 0)
+        let extraRetractOffset = min((targetView.frame.midX - Constants.horizontalBufferMargin) - (containerView.frame.midX - tooltipWidth / 2), 0)
+
+        if extraPushOffset > 0 {
+            return extraPushOffset
+        }
+
+        return extraRetractOffset
+    }
+
+
+    private func tooltipOrientation() -> Tooltip.ArrowPosition {
+        if containerView.frame.midY < targetView.frame.minY {
+            return .bottom
+        }
+        return .top
+    }
+}

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+/// A helper class for presentation of the Tooltip in respect to a `targetView`.
+/// Must be retained to respond to device orientation and size category changes.
 final class TooltipPresenter {
     private enum Constants {
         static let verticalTooltipDistanceToFocus: CGFloat = 8
@@ -14,6 +16,18 @@ final class TooltipPresenter {
         self.containerView = containerView
         self.tooltip = tooltip
         self.targetView = targetView
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(recalculatePosition),
+            name: UIContentSizeCategory.didChangeNotification, object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(recalculatePosition),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
     }
 
     func show() {
@@ -47,6 +61,11 @@ final class TooltipPresenter {
         }
 
         NSLayoutConstraint.activate(tooltipConstraints)
+    }
+
+    @objc private func recalculatePosition() {
+        tooltip.removeFromSuperview()
+        show()
     }
 
     /// Calculates where the arrow needs to place in the borders of the tooltia.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -107,6 +107,7 @@
 		087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */; };
 		0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */; };
 		088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */; };
+		088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088CC593282BEC41007B9421 /* TooltipPresenter.swift */; };
 		08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */; };
 		08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */; };
 		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
@@ -4898,6 +4899,7 @@
 		087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailService.swift; sourceTree = "<group>"; };
 		0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLIncrementalFilenameTests.swift; sourceTree = "<group>"; };
 		088B89881DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostCardContentLabel.swift; sourceTree = "<group>"; };
+		088CC593282BEC41007B9421 /* TooltipPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenter.swift; sourceTree = "<group>"; };
 		08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagServiceTests.m; sourceTree = "<group>"; };
 		08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategoryServiceTests.m; sourceTree = "<group>"; };
 		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
@@ -8233,8 +8235,9 @@
 		081E4B4A281BFB520085E89C /* Feature Highlight */ = {
 			isa = PBXGroup;
 			children = (
-				081E4B4B281C019A0085E89C /* TooltipAnchor.swift */,
 				08D553652821286300AA1E8D /* Tooltip.swift */,
+				081E4B4B281C019A0085E89C /* TooltipAnchor.swift */,
+				088CC593282BEC41007B9421 /* TooltipPresenter.swift */,
 			);
 			path = "Feature Highlight";
 			sourceTree = "<group>";
@@ -18186,6 +18189,7 @@
 				17C2FF0925D4852400CDB712 /* UnifiedProloguePages.swift in Sources */,
 				400A2C882217A985000A8A59 /* CountryStatsRecordValue+CoreDataClass.swift in Sources */,
 				08D345561CD7FBA900358E8C /* MenuHeaderViewController.m in Sources */,
+				088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */,
 				B5120B381D47CC6C0059361A /* NotificationDetailsViewController.swift in Sources */,
 				08F8CD391EBD2C970049D0C0 /* MediaURLExporter.swift in Sources */,
 				E125443C12BF5A7200D87A0A /* WordPress.xcdatamodeld in Sources */,


### PR DESCRIPTION
Refs pbArwn-4oo-p2

This PR adds `TooltipPresenter` which calculates where to place the Tooltip in respect to another view. One only needs to provide the `containerView` (most commonly `viewController.view`)  which contains the `targetView` and will contain the `Tooltip`. The `targetView` is where the tooltip will point at and `Tooltip` should be instantiated & configured before it is passed in.

The tooltip & the arrow will be placed to point at the `midX` of the `targetView`.

To test:

- Please first place the following code in the `viewDidAppear` of `ReaderDetailViewController`.
- Then select a post from "Reader" and the tooltip should appear with a `dummySquare` which you can change its frame to see how the tooltip reacts.

```Swift
        // FIXME: Remove test code!
        let dummySquare = UIView()
        dummySquare.backgroundColor = .red
        dummySquare.translatesAutoresizingMaskIntoConstraints = false
        dummySquare.layer.cornerRadius = 4
        view.addSubview(dummySquare)

        NSLayoutConstraint.activate([
            dummySquare.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 180),
            dummySquare.heightAnchor.constraint(equalToConstant: 30),
            dummySquare.widthAnchor.constraint(equalToConstant: 30),
            dummySquare.topAnchor.constraint(equalTo: view.topAnchor, constant: 120)
        ])

        view.layoutIfNeeded()

        let tooltip = Tooltip()

        tooltip.title = "Follow the conversation"
        tooltip.message = "Get notified."
        tooltip.primaryButtonTitle = "Got it"
        tooltip.secondaryButtonTitle = "Learn more"

        tooltipPresenter = TooltipPresenter(
            containerView: view,
            tooltip: tooltip,
            targetView: dummySquare
        )
        tooltipPresenter?.show()
```
Also retain the `tooltipPresenter` to respond to orientation and system font size changes:
```Swift 
private var tooltipPresenter: TooltipPresenter?
```

## Regression Notes
1. Potential unintended areas of impact
N/A. Isolated addition that has no impact on rest of the code.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A. It is purely UI logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Screenshots

| Full Width  | Narrow |
| ------------- | ------------- |
| ![Screenshot on 2022-05-13 at 10:48:14](https://user-images.githubusercontent.com/15968946/168276644-dcbbf7dd-8cbe-42aa-a364-ce9ee47c808c.png)  | ![Screenshot on 2022-05-13 at 11:08:55](https://user-images.githubusercontent.com/15968946/168276783-502a927c-2041-40f8-83c5-a497bca081d1.png) |
| ![Screenshot on 2022-05-13 at 10:52:04](https://user-images.githubusercontent.com/15968946/168276684-6bca642e-2039-4893-92a4-efb3bd07877e.png) | ![Screenshot on 2022-05-13 at 11:03:06](https://user-images.githubusercontent.com/15968946/168276757-44e2e4ec-2f08-44c0-8e05-165eadc171be.png)  |
