### PR TITLE
Quick Start: don’t display quick start prompt for self-hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -329,14 +329,16 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
-        let onDismissQuickStartPromptForNewSiteHandler = onDismissQuickStartPromptHandler(type: .newSite, onDismiss: onDismiss)
-        let onDismissQuickStartPromptForExistingSiteHandler = onDismissQuickStartPromptHandler(type: .existingSite, onDismiss: onDismiss)
-
         // If adding a self-hosted site, skip the Epilogue
         if let wporg = credentials.wporg,
            let blog = Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: ContextManager.shared.mainContext) {
-            let onDismissHandler = FeatureFlag.quickStartForExistingUsers.enabled ? onDismissQuickStartPromptForExistingSiteHandler : onDismissQuickStartPromptForNewSiteHandler
-            presentQuickStartPrompt(for: blog, in: navigationController, onDismiss: onDismissHandler)
+
+            if self.windowManager.isShowingFullscreenSignIn {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+            } else {
+                navigationController.dismiss(animated: true)
+            }
+
             return
         }
 
@@ -371,6 +373,8 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.credentials = credentials
         epilogueViewController.onBlogSelected = onBlogSelected
+
+        let onDismissQuickStartPromptForNewSiteHandler = onDismissQuickStartPromptHandler(type: .newSite, onDismiss: onDismiss)
 
         epilogueViewController.onCreateNewSite = {
             let wizardLauncher = SiteCreationWizardLauncher(onDismiss: onDismissQuickStartPromptForNewSiteHandler)


### PR DESCRIPTION
Fixes #18547 
Fixes #18458

## Description
- Quick Start (and the prompt) shouldn't be displayed for self-hosted sites.

## How to test
1. Add a self-hosted site
2. ✅ Verify: the quick start prompt is NOT displayed


https://user-images.githubusercontent.com/6711616/168314585-dd09c296-b50b-4d02-a237-838d14f777d9.mp4



## Regression Notes
1. Potential unintended areas of impact
- Self-hosted login

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested manually

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
