### PR TITLE
Fix an issue where the FAB was not correctly displayed in the post screen on iPad split screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Block Editor: Gallery block: Fix broken "Link To" settings and add "Image Size" settings [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4841]
 * [*] Block Editor: Unsupported Block Editor: Prevent WordPress.com tour banner from displaying. [https://github.com/wordpress-mobile/gutenberg-mobile/pull/4820]
 * [*] Widgets: we fixed an issue where text appeared flipped in rtl languages [#18567]
+* [*] Posts list: we fixed an issue where the create button was not shown on iPad in split screen [#18609]
 
 19.8
 -----

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -217,6 +217,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     /// Shows/hides the create button based on the trait collection horizontal size class
+    @objc
     private func toggleCreateButton() {
         if traitCollection.horizontalSizeClass == .compact {
             createButtonCoordinator.showCreateButton(for: blog)
@@ -387,13 +388,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     /// Listens for the app coming to foreground in order to properly set the create button
     private func listenForAppComingToForeground() {
-        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
-                                               object: nil,
-                                               queue: nil) { [weak self] _ in
-            self?.toggleCreateButton()
-        }
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(toggleCreateButton),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
     }
-
     // Mark - Layout Methods
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -174,6 +174,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         configureNavigationButtons()
 
         configureInitialFilterIfNeeded()
+        listenForAppComingToForeground()
 
         createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
     }
@@ -212,6 +213,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        toggleCreateButton()
+    }
+
+    /// Shows/hides the create button based on the trait collection horizontal size class
+    private func toggleCreateButton() {
         if traitCollection.horizontalSizeClass == .compact {
             createButtonCoordinator.showCreateButton(for: blog)
         } else {
@@ -377,6 +383,15 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         filterSettings.setFilterWithPostStatus(initialFilterWithPostStatus)
+    }
+
+    /// Listens for the app coming to foreground in order to properly set the create button
+    private func listenForAppComingToForeground() {
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification,
+                                               object: nil,
+                                               queue: nil) { [weak self] _ in
+            self?.toggleCreateButton()
+        }
     }
 
     // Mark - Layout Methods


### PR DESCRIPTION

Fixes #17661

To test:

- checkout/build and run this branch on an iPad (device or sim)
- go to the post list
- play around with different sizes and rotations of split screen, and make sure the FAB appears correctly in each condition
- Repeat the test on iPhone and make sure the FAB in the post list screen appears correctly both in portrait and landscape

<p align=center>
<img height=500 src=https://user-images.githubusercontent.com/34376330/168339439-8af26549-4c8f-4b4f-9c06-1d3aca591baf.gif>
</p>


## Regression Notes
1. Potential unintended areas of impact
None, this code only adds handling the FAB in the post list.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
visually test that the FAB in the post list behaves correctly, on a variety of devices and orientations.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
