### PR TITLE
Blogging Prompts: Update prompts header view attribution label to be dynamic

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -24,6 +24,7 @@ class ActionSheetViewController: UIViewController {
         static let buttonSpacing: CGFloat = 8
         static let additionalSafeAreaInsetsRegular: UIEdgeInsets = UIEdgeInsets(top: 20, left: 0, bottom: 20, right: 0)
         static let minimumWidth: CGFloat = 300
+        static let maximumWidth: CGFloat = 600
 
         enum Header {
             static let spacing: CGFloat = 16
@@ -206,6 +207,8 @@ class ActionSheetViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        return preferredContentSize = CGSize(width: Constants.minimumWidth, height: view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height)
+        let compressedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
+        let width = min(max(Constants.minimumWidth, compressedSize.width), Constants.maximumWidth)
+        preferredContentSize = CGSize(width: width, height: compressedSize.height)
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -49,6 +49,9 @@ class ActionSheetViewController: UIViewController {
     let headerView: UIView?
     let buttons: [ActionSheetButton]
     let headerTitle: String
+    private weak var scrollView: UIScrollView?
+    private var scrollViewHeightConstraint: NSLayoutConstraint?
+    private var scrollViewTopConstraint: NSLayoutConstraint?
 
     init(headerView: UIView? = nil, headerTitle: String, buttons: [ActionSheetButton]) {
         self.headerView = headerView
@@ -88,52 +91,60 @@ class ActionSheetViewController: UIViewController {
         headerLabel.font = WPStyleGuide.fontForTextStyle(.headline)
         headerLabel.text = headerTitle
         headerLabel.translatesAutoresizingMaskIntoConstraints = false
+        headerLabel.adjustsFontForContentSizeCategory = true
 
         let buttonViews = buttons.map({ (buttonInfo) -> UIButton in
             return button(buttonInfo)
         })
 
-        NSLayoutConstraint.activate([
-            gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight)
-        ])
 
-        let buttonConstraints = buttonViews.map { button in
-            return button.heightAnchor.constraint(equalToConstant: Constants.Button.height)
+        let buttonConstraints = buttonViews.flatMap { button in
+            [
+                button.heightAnchor.constraint(equalToConstant: Constants.Button.height),
+                button.widthAnchor.constraint(equalTo: view.widthAnchor),
+            ]
         }
 
-        NSLayoutConstraint.activate(buttonConstraints)
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubviews([gripButton, scrollView])
 
-        let stackView = UIStackView(arrangedSubviews: [gripButton])
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        scrollView.addSubview(stackView)
+        scrollView.pinSubviewToAllEdges(stackView)
 
         if let headerView = headerView {
             stackView.addArrangedSubview(headerView)
         }
 
         stackView.addArrangedSubviews([headerLabelView] + buttonViews)
-
-        stackView.setCustomSpacing(Constants.Header.spacing, after: gripButton)
         stackView.setCustomSpacing(Constants.Header.spacing, after: headerLabelView)
 
         buttonViews.forEach { button in
             stackView.setCustomSpacing(Constants.buttonSpacing, after: button)
         }
 
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
+        let topConstraint = scrollView.topAnchor.constraint(equalTo: gripButton.bottomAnchor, constant: Constants.Header.spacing)
+        scrollViewTopConstraint = topConstraint
+        let secondaryTopConstraint = scrollView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
+        secondaryTopConstraint.priority = .defaultHigh
+        NSLayoutConstraint.activate([
+            gripButton.heightAnchor.constraint(equalToConstant: Constants.gripHeight),
+            gripButton.widthAnchor.constraint(equalTo: view.widthAnchor),
+            gripButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            gripButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: Constants.Stack.insets.top),
+            topConstraint,
+            secondaryTopConstraint,
+            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+        ] + buttonConstraints)
 
+        self.scrollView = scrollView
         refreshForTraits()
-
-        view.addSubview(stackView)
-        let stackViewConstraints = [
-            view.safeAreaLayoutGuide.leadingAnchor.constraint(equalTo: stackView.leadingAnchor, constant: -Constants.Stack.insets.left),
-            view.safeAreaLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor, constant: Constants.Stack.insets.right),
-            view.safeAreaLayoutGuide.topAnchor.constraint(equalTo: stackView.topAnchor, constant: -Constants.Stack.insets.top),
-        ]
-
-        let bottomAnchor = view.safeAreaLayoutGuide.bottomAnchor.constraint(equalTo: stackView.bottomAnchor, constant: Constants.Stack.insets.bottom)
-        bottomAnchor.priority = .defaultHigh
-
-        NSLayoutConstraint.activate(stackViewConstraints + [bottomAnchor])
+        updateScrollViewHeight()
     }
 
     private func createButton(_ handler: @escaping () -> Void) -> UIButton {
@@ -155,6 +166,7 @@ class ActionSheetViewController: UIViewController {
         button.contentEdgeInsets = Constants.Button.contentInsets
         button.translatesAutoresizingMaskIntoConstraints = false
         button.flipInsetsForRightToLeftLayoutDirection()
+        button.titleLabel?.adjustsFontForContentSizeCategory = true
         return button
     }
 
@@ -199,16 +211,32 @@ class ActionSheetViewController: UIViewController {
         if presentingViewController?.traitCollection.horizontalSizeClass == .regular && presentingViewController?.traitCollection.verticalSizeClass != .compact {
             gripButton.isHidden = true
             additionalSafeAreaInsets = Constants.additionalSafeAreaInsetsRegular
+            scrollViewTopConstraint?.isActive = false
         } else {
             gripButton.isHidden = false
             additionalSafeAreaInsets = .zero
+            scrollViewTopConstraint?.isActive = true
         }
     }
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
+        updateScrollViewHeight()
         let compressedSize = view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize)
         let width = min(max(Constants.minimumWidth, compressedSize.width), Constants.maximumWidth)
         preferredContentSize = CGSize(width: width, height: compressedSize.height)
+    }
+
+    private func updateScrollViewHeight() {
+        guard let scrollView = scrollView else {
+            return
+        }
+        scrollView.layoutIfNeeded()
+        let scrollViewHeight = scrollView.contentSize.height
+        let heightConstraint = scrollViewHeightConstraint ?? scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: scrollViewHeight)
+        heightConstraint.constant = scrollViewHeight
+        heightConstraint.priority = .defaultHigh
+        heightConstraint.isActive = true
+        scrollViewHeightConstraint = heightConstraint
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -71,6 +71,7 @@ private extension BloggingPromptsHeaderView {
         shareButton.titleLabel?.adjustsFontForContentSizeCategory = true
         shareButton.titleLabel?.adjustsFontSizeToFitWidth = true
         shareButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
+        attributionLabel.adjustsFontForContentSizeCategory = true
     }
 
     func configureConstraints() {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -98,8 +98,18 @@
                         </view>
                     </subviews>
                     <constraints>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Rye-vB-0gG" secondAttribute="trailing" priority="750" constant="16" id="7hG-vk-yAU"/>
+                        <constraint firstItem="fqk-gy-gv5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HBh-15-Hby" secondAttribute="leading" priority="750" constant="16" id="8hu-N3-Rjy"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="stO-XN-YJp" secondAttribute="trailing" priority="750" constant="16" id="JWf-1J-w5c"/>
+                        <constraint firstItem="Gef-vX-Eh7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HBh-15-Hby" secondAttribute="leading" priority="750" constant="16" id="LeV-jp-Rqn"/>
+                        <constraint firstItem="74j-gh-nmq" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HBh-15-Hby" secondAttribute="leading" priority="750" constant="16" id="Wrb-3D-Kq6"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Gef-vX-Eh7" secondAttribute="trailing" priority="750" constant="16" id="XNR-nY-tnp"/>
+                        <constraint firstItem="Rye-vB-0gG" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HBh-15-Hby" secondAttribute="leading" priority="750" constant="16" id="ecE-Ow-fJb"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="74j-gh-nmq" secondAttribute="trailing" priority="750" constant="16" id="gvu-DP-wnp"/>
                         <constraint firstItem="9KN-UC-IRC" firstAttribute="leading" secondItem="HBh-15-Hby" secondAttribute="leading" id="i3E-vF-ouk"/>
-                        <constraint firstAttribute="trailing" secondItem="9KN-UC-IRC" secondAttribute="trailing" id="j2W-Lj-CP5"/>
+                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fqk-gy-gv5" secondAttribute="trailing" priority="750" constant="16" id="itk-Uy-mwF"/>
+                        <constraint firstAttribute="trailing" secondItem="9KN-UC-IRC" secondAttribute="trailing" priority="750" id="j2W-Lj-CP5"/>
+                        <constraint firstItem="stO-XN-YJp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HBh-15-Hby" secondAttribute="leading" priority="750" constant="16" id="qRg-sD-Bvk"/>
                     </constraints>
                 </stackView>
             </subviews>

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -48,17 +48,17 @@
                             <nil key="highlightedColor"/>
                         </label>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="Gef-vX-Eh7">
-                            <rect key="frame" x="111" y="48" width="127" height="18"/>
+                            <rect key="frame" x="111" y="48" width="127" height="20.5"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tPu-fo-0nQ">
-                                    <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                    <rect key="frame" x="0.0" y="1.5" width="18" height="18"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="18" id="PGa-fz-qU1"/>
                                         <constraint firstAttribute="height" constant="18" id="ReF-to-kfP"/>
                                     </constraints>
                                 </imageView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="From Day One" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q82-Ru-Asj">
-                                    <rect key="frame" x="18" y="0.0" width="109" height="18"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="From Day One" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Q82-Ru-Asj">
+                                    <rect key="frame" x="18" y="0.0" width="109" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -66,7 +66,7 @@
                             </subviews>
                         </stackView>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fqk-gy-gv5">
-                            <rect key="frame" x="113" y="66" width="123" height="23.5"/>
+                            <rect key="frame" x="113" y="68.5" width="123" height="21"/>
                             <state key="normal" title="Button"/>
                             <buttonConfiguration key="configuration" style="plain" title="Answer Prompt"/>
                             <connections>

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
@@ -3,22 +3,21 @@ class BottomSheetPresentationController: FancyAlertPresentationController {
 
     private enum Constants {
         static let maxWidthPercentage: CGFloat = 0.66 /// Used to constrain the width to a smaller size (instead of full width) when sheet is too wide
+        static let topSpacing: CGFloat = 16.0
     }
 
     private weak var tapGestureRecognizer: UITapGestureRecognizer?
     private weak var panGestureRecognizer: UIPanGestureRecognizer?
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-    }
 
     override var frameOfPresentedViewInContainerView: CGRect {
         guard let containerView = containerView else { /// If we don't have a container view we're out of luck
             return .zero
         }
 
-        /// Height calculated by autolayout, Width equal to the container view minus insets
-        let height: CGFloat = presentedViewController.view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height
+        let topSpacing = traitCollection.verticalSizeClass == .regular ? Constants.topSpacing : .zero
+        let maxHeight = containerView.bounds.height - containerView.safeAreaInsets.top - topSpacing
+        /// Height calculated by autolayout or a set maximum, Width equal to the container view minus insets
+        let height: CGFloat = min(presentedViewController.view.systemLayoutSizeFitting(UIView.layoutFittingCompressedSize).height, maxHeight)
         var width: CGFloat = containerView.bounds.width - (containerView.safeAreaInsets.left + containerView.safeAreaInsets.right)
 
         /// If we're in a compact vertical size class, constrain the width a bit more so it doesn't get overly wide.

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BottomSheetPresentationController.swift
@@ -76,14 +76,15 @@ class BottomSheetPresentationController: FancyAlertPresentationController {
         let translate = gesture.translation(in: gestureView)
         let percent   = translate.y / gestureView.bounds.size.height
 
-        if gesture.state == .began {
+        switch gesture.state {
+        case .began:
             /// Begin the dismissal transition
             interactionController = UIPercentDrivenInteractiveTransition()
             dismiss()
-        } else if gesture.state == .changed {
+        case .changed:
             /// Update the transition based on our calculated percent of completion
             interactionController?.update(percent)
-        } else if gesture.state == .ended {
+        case .ended:
             /// Calculate the velocity of the ended gesture.
             /// - If the gesture has no downward velocity but is greater than half way down, complete the dismissal
             /// - If there is downward velocity, dismiss
@@ -95,6 +96,11 @@ class BottomSheetPresentationController: FancyAlertPresentationController {
                 interactionController?.cancel()
             }
             interactionController = nil
+        case .cancelled:
+            interactionController?.cancel()
+            interactionController = nil
+        default:
+            break
         }
     }
 


### PR DESCRIPTION
See #18558

## Description

Updates the attribution label for the header view to be dynamic with the text size. Additionally, changes how the popover size is calculated to better fit the content in the FAB.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Launch on an iPhone or iPad
- Navigate to the 'My Site' tab
- Tap on the FAB '+'
- Modify the accessibility font size
- Verify:
  - Header view content fits correctly
  - Attribution label properly resizes
- Repeat same steps with an iPhone or iPad depending on what was used originally

## Screenshots

### iPad

#### Default text size (popover width unchanged)
| Before - Portrait | After - Portrait | Before - Landscape | After - Landscape |
|-----------------|----------------|---------------------|-------------------|
| ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 54 22](https://user-images.githubusercontent.com/2454408/168341243-fba730ed-aa31-488a-bdd9-8b53d7f1de9b.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 56 01](https://user-images.githubusercontent.com/2454408/168341284-a56dbcd8-786f-48f1-90fd-29d7ba3694f6.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 54 35](https://user-images.githubusercontent.com/2454408/168341304-0e9fe31a-abe6-4f65-9f62-9555668bbba9.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 56 09](https://user-images.githubusercontent.com/2454408/168341334-b3ea27be-cfdb-40f4-b394-4fad7a1cb6a0.png) |

#### Large text size (new popover width)

| Before - Portrait | After - Portrait | Before - Landscape | After - Landscape |
|-----------------|----------------|---------------------|-------------------|
| ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 54 52](https://user-images.githubusercontent.com/2454408/168341525-81b888f5-e602-4155-a8eb-35a8ff32a899.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 56 20](https://user-images.githubusercontent.com/2454408/168341561-eac6a66b-0aad-4262-875c-8c9cf59be3a8.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 55 00](https://user-images.githubusercontent.com/2454408/168341589-b2f7ab9b-05e2-4c7a-bc70-e4fa38ac2588.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-05-13 at 13 56 36](https://user-images.githubusercontent.com/2454408/168341628-60663b5e-507d-40b0-ad39-5d72fe689362.png) |

### iPhone

| Before | After |
|--------|------|
| ![Simulator Screen Shot - iPhone 11 - 2022-05-13 at 14 12 57](https://user-images.githubusercontent.com/2454408/168342963-f48aad58-98bb-4010-bd5f-78f2e9a7e0ec.png) | ![Simulator Screen Shot - iPhone 11 - 2022-05-13 at 14 09 44](https://user-images.githubusercontent.com/2454408/168342587-2115635f-c71e-4b3e-a9bf-ff6da7103157.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
