### PR TITLE
Fix onboarding enable notifications localization

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
@@ -87,6 +87,8 @@ private extension OnboardingEnableNotificationsViewController {
     }
 
     func updateContent() {
+        titleLabel.text = Strings.title
+
         let text: String
         let notificationContent: UnifiedPrologueNotificationsContent?
 
@@ -125,6 +127,10 @@ private extension OnboardingEnableNotificationsViewController {
 }
 
 // MARK: - Constants / Strings
+private struct Strings {
+    static let title = NSLocalizedString("Enable Notifications?", comment: "Title of the view, asking the user if they want to enable notifications.")
+}
+
 private struct StatsStrings {
     static let subTitle = NSLocalizedString("Know when your site is getting more traffic, new followers, or when it passes a new milestone!", comment: "Subtitle giving the user more context about why to enable notifications.")
 

--- a/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.swift
@@ -4,6 +4,8 @@ class OnboardingEnableNotificationsViewController: UIViewController {
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var subTitleLabel: UILabel!
     @IBOutlet weak var detailView: UIView!
+    @IBOutlet weak var enableButton: UIButton!
+    @IBOutlet weak var cancelButton: UIButton!
 
     let option: OnboardingOption
     let coordinator: OnboardingQuestionsCoordinator
@@ -26,6 +28,7 @@ class OnboardingEnableNotificationsViewController: UIViewController {
         navigationController?.delegate = self
 
         applyStyles()
+        applyLocalization()
         updateContent()
 
         coordinator.notificationsDisplayed(option: option)
@@ -86,9 +89,13 @@ private extension OnboardingEnableNotificationsViewController {
         subTitleLabel.textColor = .secondaryLabel
     }
 
-    func updateContent() {
+    func applyLocalization() {
         titleLabel.text = Strings.title
+        enableButton.setTitle(Strings.enableButton, for: .normal)
+        cancelButton.setTitle(Strings.cancelButton, for: .normal)
+    }
 
+    func updateContent() {
         let text: String
         let notificationContent: UnifiedPrologueNotificationsContent?
 
@@ -129,6 +136,8 @@ private extension OnboardingEnableNotificationsViewController {
 // MARK: - Constants / Strings
 private struct Strings {
     static let title = NSLocalizedString("Enable Notifications?", comment: "Title of the view, asking the user if they want to enable notifications.")
+    static let enableButton = NSLocalizedString("Enable Notifications", comment: "Title of button that enables push notifications when tapped")
+    static let cancelButton = NSLocalizedString("Not Now", comment: "Title of a button that cancels enabling notifications when tapped")
 }
 
 private struct StatsStrings {

--- a/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingEnableNotificationsViewController.xib
@@ -13,7 +13,9 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="OnboardingEnableNotificationsViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
+                <outlet property="cancelButton" destination="TsX-gV-qHT" id="LwJ-1J-eDF"/>
                 <outlet property="detailView" destination="E9E-nc-B5q" id="H5P-Fa-E6T"/>
+                <outlet property="enableButton" destination="0z0-r0-F4b" id="MYg-CR-0wL"/>
                 <outlet property="subTitleLabel" destination="50P-8O-Ctu" id="4dY-dn-nT7"/>
                 <outlet property="titleLabel" destination="cpw-1P-GER" id="tqX-v7-b8v"/>
                 <outlet property="view" destination="Mlb-pH-BGO" id="zZL-y0-ws4"/>


### PR DESCRIPTION
Fixes localization of the enable notifications title label. 

### Screenshot
<img src="https://user-images.githubusercontent.com/793774/168379371-4bf13128-97b4-41b0-9652-f40dd89c4dc7.png" width="320" />



### To test:
1. Launch the app
1. Tap login or sign up with WordPress.com
1. Enter an email of a user that exists
1. Enter your password / 2FA
1. Tap on any item displayed on the questions prompt
2. Verify the title of the Enable Notifications view is "Enable Notifications?"
3. Verify the title of the approve button is "Enable Notifications"
3. Verify the title of the cancel button is "Not Now"

## Regression Notes
1. Potential unintended areas of impact
None.

5. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

6. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
