### PR TITLE
Quick Start for Existing Users: Fix "Preview your site" waypoint

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -739,6 +739,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
         embedChildInStackView(blogDetailsViewController)
 
+        // This ensures that the spotlight views embedded in the site picker don't get clipped.
+        stackView.sendSubviewToBack(blogDetailsViewController.view)
+
         blogDetailsViewController.showInitialDetailsForBlog()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -282,9 +282,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     ///
     /// - Scroll view
     ///   - Stack view
+    ///     - Site picker view controller
     ///     - Segmented control container view
     ///       - Segmented control
-    ///     - Child view controller
+    ///     - Blog dashboard view controller OR blog details view controller
     /// 
     private func setupConstraints() {
         view.addSubview(scrollView)


### PR DESCRIPTION
Fixes #18585

## Description

Fixed a bug where the waypoint getting cut off for "Preview your site" quick start task on iPad.

## How to test

1. Install the app on an iPad
2. Enable quick start via the debug menu
3. Start the Preview Your Site tour
4. Notice that the waypoint isn't cut off

![Simulator Screen Shot - iPhone 13 - 2022-05-16 at 12 34 05](https://user-images.githubusercontent.com/6711616/168585245-5c274fa9-143d-4867-ac81-e3fce2388aca.png) | ![Simulator Screen Shot - iPad Air (4th generation) - 2022-05-16 at 12 30 38](https://user-images.githubusercontent.com/6711616/168585236-af734098-aeb7-49db-a0d3-3ae585f8d901.png)
-- | --


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
