### PR TITLE
Stats Revamp: Views Visitors Details Screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Helper class to encapsulate ImmuTableRows creation
+/// Stats Revamp results in the same ImmuTableRows created in different screens
+///
+class SiteStatsImmuTableRows {
+
+    static func viewVisitorsImmuTableRows(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, periodDate: Date, statsLineChartViewDelegate: StatsLineChartViewDelegate?, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) -> [ImmuTableRow] {
+        var tableRows = [ImmuTableRow]()
+
+        let viewsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .views)
+        let viewsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewViews.tabTitle,
+                segmentData: viewsData.count,
+                segmentPrevData: viewsData.prevCount,
+                difference: viewsData.difference,
+                differenceText: viewsData.difference < 0 ? Constants.viewsLower : Constants.viewsHigher,
+                date: periodDate,
+                period: StatsPeriodUnit.week,
+                analyticsStat: .statsOverviewTypeTappedViews,
+                accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint,
+                differencePercent: viewsData.percentage)
+
+        let visitorsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .visitors)
+        let visitorsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewVisitors.tabTitle,
+                segmentData: visitorsData.count,
+                segmentPrevData: visitorsData.prevCount,
+                difference: visitorsData.difference,
+                differenceText: viewsData.difference < 0 ? Constants.viewsLower : Constants.viewsHigher,
+                date: periodDate,
+                period: StatsPeriodUnit.week,
+                analyticsStat: .statsOverviewTypeTappedViews,
+                accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint,
+                differencePercent: visitorsData.percentage)
+
+        var lineChartData = [LineChartDataConvertible]()
+        var lineChartStyling = [LineChartStyling]()
+
+        if let chartData = statsSummaryTimeIntervalData {
+            let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(chartData)
+            let viewsChart = InsightsLineChart(data: splitSummaryTimeIntervalData, filterDimension: .views)
+            lineChartData.append(contentsOf: viewsChart.lineChartData)
+            lineChartStyling.append(contentsOf: viewsChart.lineChartStyling)
+
+            let visitorsChart = InsightsLineChart(data: splitSummaryTimeIntervalData, filterDimension: .visitors)
+            lineChartData.append(contentsOf: visitorsChart.lineChartData)
+            lineChartStyling.append(contentsOf: visitorsChart.lineChartStyling)
+
+            var xAxisDates = [Date]()
+            splitSummaryTimeIntervalData.forEach { week in
+                switch week {
+                case .thisWeek(let data):
+                    xAxisDates = data.summaryData.map { $0.periodStartDate }
+                default:
+                    break
+                }
+            }
+
+            let row = ViewsVisitorsRow(
+                    segmentsData: [viewsSegmentData, visitorsSegmentData],
+                    chartData: lineChartData,
+                    chartStyling: lineChartStyling,
+                    period: StatsPeriodUnit.day,
+                    statsLineChartViewDelegate: statsLineChartViewDelegate,
+                    siteStatsInsightsDelegate: siteStatsInsightsDelegate, xAxisDates: xAxisDates
+            )
+            tableRows.append(row)
+        }
+
+        return tableRows
+    }
+
+    enum Constants {
+        static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
+        static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
+        static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
+        static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -304,6 +304,41 @@
         }
     }
 
+    // MARK: - analyticsEvent on ViewMore tapped
+
+    var analyticsViewMoreEvent: WPAnalyticsStat? {
+        switch self {
+        case .periodAuthors, .insightsCommentsAuthors:
+            return .statsViewMoreTappedAuthors
+        case .periodClicks:
+            return .statsViewMoreTappedClicks
+        case .periodOverviewComments:
+            return .statsViewMoreTappedComments
+        case .periodCountries:
+            return .statsViewMoreTappedCountries
+        case .insightsFollowerTotals, .insightsFollowersEmail, .insightsFollowersWordPress:
+            return .statsViewMoreTappedFollowers
+        case .periodPostsAndPages:
+            return .statsViewMoreTappedPostsAndPages
+        case .insightsPublicize:
+            return .statsViewMoreTappedPublicize
+        case .periodReferrers:
+            return .statsViewMoreTappedReferrers
+        case .periodSearchTerms:
+            return .statsViewMoreTappedSearchTerms
+        case .insightsTagsAndCategories:
+            return .statsViewMoreTappedTagsAndCategories
+        case .periodVideos:
+            return .statsViewMoreTappedVideoPlays
+        case .periodFileDownloads:
+            return .statsViewMoreTappedFileDownloads
+        case .insightsAnnualSiteStats:
+            return .statsViewMoreTappedThisYear
+        default:
+            return nil
+        }
+    }
+
     // MARK: - Image Size Accessor
 
     static let defaultImageSize = CGFloat(24)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 enum InsightType: Int, SiteStatsPinnable {
-    case viewsVisitors
     case growAudience
     case customize
     case latestPostSummary
@@ -20,6 +19,7 @@ enum InsightType: Int, SiteStatsPinnable {
     case allComments
     case allTagsAndCategories
     case allAnnual
+    case viewsVisitors
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
     static let defaultInsights: [InsightType] = [.mostPopularTime,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -1,0 +1,47 @@
+import UIKit
+
+/// Base class for site stats table view controllers
+///
+
+class SiteStatsBaseTableViewController: UIViewController {
+
+    let refreshControl = UIRefreshControl()
+
+    // MARK: - Properties
+    lazy var tableView: UITableView = {
+        UITableView(frame: .zero, style: FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .plain)
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        initTableView()
+    }
+
+    func initTableView() {
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(tableView)
+        view.pinSubviewToAllEdges(tableView)
+
+        tableView.refreshControl = refreshControl
+    }
+}
+
+// MARK: - Tableview Datasource
+
+// These methods aren't actually needed as the tableview is controlled by an instance of ImmuTableViewHandler.
+// However, ImmuTableViewHandler requires that the owner of the tableview is a data source and delegate.
+
+extension SiteStatsBaseTableViewController: TableViewContainer, UITableViewDataSource, UITableViewDelegate {
+    func numberOfSections(in tableView: UITableView) -> Int {
+        0
+    }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        return UITableViewCell()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -7,9 +7,11 @@ class SiteStatsBaseTableViewController: UIViewController {
 
     let refreshControl = UIRefreshControl()
 
+    var tableStyle: UITableView.Style = .grouped
+
     // MARK: - Properties
     lazy var tableView: UITableView = {
-        UITableView(frame: .zero, style: FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .plain)
+        UITableView(frame: .zero, style: tableStyle)
     }()
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -7,6 +7,8 @@ class SiteStatsBaseTableViewController: UIViewController {
 
     let refreshControl = UIRefreshControl()
 
+    /// This property must be set before viewDidLoad is called - currently the classes that inherit are created from storyboards
+    /// When storyboard is removed it can be passed in as a parameter in an initializer
     var tableStyle: UITableView.Style = .grouped
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -1,15 +1,8 @@
 import UIKit
 import WordPressFlux
 
-class SiteStatsInsightsTableViewController: UIViewController, StoryboardLoadable {
+class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, StoryboardLoadable {
     static var defaultStoryboardName: String = "SiteStatsDashboard"
-
-    // MARK: - Properties
-    lazy var tableView: UITableView = {
-        UITableView(frame: .zero, style: FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .grouped)
-    }()
-
-    let refreshControl = UIRefreshControl()
 
     var isGrowAudienceShowing: Bool {
         return insightsToShow.contains(.growAudience)
@@ -67,7 +60,6 @@ class SiteStatsInsightsTableViewController: UIViewController, StoryboardLoadable
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        initTableView()
         SiteStatsInformation.sharedInstance.upgradeInsights()
         clearExpandedRows()
         WPStyleGuide.Stats.configureTable(tableView)
@@ -111,36 +103,9 @@ class SiteStatsInsightsTableViewController: UIViewController, StoryboardLoadable
 
 }
 
-// MARK: - Tableview Datasource
-
-// These methods aren't actually needed as the tableview is controlled by an instance of ImmuTableViewHandler.
-// However, ImmuTableViewHandler requires that the owner of the tableview is a data source and delegate.
-
-extension SiteStatsInsightsTableViewController: TableViewContainer, UITableViewDataSource, UITableViewDelegate {
-    func numberOfSections(in tableView: UITableView) -> Int {
-        0
-    }
-
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        0
-    }
-
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
-    }
-}
-
 // MARK: - Private Extension
 
 private extension SiteStatsInsightsTableViewController {
-
-    func initTableView() {
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(tableView)
-        view.pinSubviewToAllEdges(tableView)
-
-        tableView.refreshControl = refreshControl
-    }
 
     func initViewModel() {
         viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow,
@@ -172,29 +137,8 @@ private extension SiteStatsInsightsTableViewController {
     }
 
     func tableRowTypes() -> [ImmuTableRow.Type] {
-        if FeatureFlag.statsNewInsights.enabled {
-            return [InsightCellHeaderRow.self,
-                    ViewsVisitorsRow.self,
-                    GrowAudienceRow.self,
-                    CustomizeInsightsRow.self,
-                    LatestPostSummaryRow.self,
-                    TwoColumnStatsRow.self,
-                    PostingActivityRow.self,
-                    TabbedTotalsStatsRow.self,
-                    TopTotalsInsightStatsRow.self,
-                    MostPopularTimeInsightStatsRow.self,
-                    TotalInsightStatsRow.self,
-                    TableFooterRow.self,
-                    StatsErrorRow.self,
-                    StatsGhostGrowAudienceImmutableRow.self,
-                    StatsGhostChartImmutableRow.self,
-                    StatsGhostTwoColumnImmutableRow.self,
-                    StatsGhostTopImmutableRow.self,
-                    StatsGhostTabbedImmutableRow.self,
-                    StatsGhostPostingActivitiesImmutableRow.self]
-        }
-
         return [InsightCellHeaderRow.self,
+                ViewsVisitorsRow.self,
                 GrowAudienceRow.self,
                 CustomizeInsightsRow.self,
                 LatestPostSummaryRow.self,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -411,7 +411,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         }
 
         let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
-        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
+        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate, tableStyle: FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .grouped)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -64,7 +64,7 @@ class SiteStatsInsightsViewModel: Observable {
         self.periodStore = periodStore
         let viewsCount = insightsStore.getAllTimeStats()?.viewsCount ?? 0
         self.itemToDisplay = pinnedItemStore?.itemToDisplay(for: viewsCount)
-        self.lastRequestedDate = Date()
+        self.lastRequestedDate = StatsDataHelper.currentDateForSite()
         self.lastRequestedPeriod = StatsPeriodUnit.day
 
         insightsChangeReceipt = self.insightsStore.onChange { [weak self] in
@@ -427,73 +427,16 @@ private extension SiteStatsInsightsViewModel {
         let periodDate = self.lastRequestedDate
         let period = StatsPeriodUnit.week
 
-        let viewsData = intervalData(summaryType: .views)
-        let viewsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewViews.tabTitle,
-                                                         segmentData: viewsData.count,
-                                                         segmentPrevData: viewsData.prevCount,
-                                                         difference: viewsData.difference,
-                                                         differenceText: viewsData.difference < 0 ? Constants.viewsLower : Constants.viewsHigher,
-                                                         date: periodDate,
-                                                         period: period,
-                                                         analyticsStat: .statsOverviewTypeTappedViews,
-                                                         accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint,
-                                                         differencePercent: viewsData.percentage)
-
-        let visitorsData = intervalData(summaryType: .visitors)
-        let visitorsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewVisitors.tabTitle,
-                                                            segmentData: visitorsData.count,
-                                                            segmentPrevData: visitorsData.prevCount,
-                                                            difference: visitorsData.difference,
-                                                            differenceText: visitorsData.difference < 0 ? Constants.visitorsLower : Constants.visitorsHigher,
-                                                            date: periodDate,
-                                                            period: period,
-                                                            analyticsStat: .statsOverviewTypeTappedViews,
-                                                            accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint,
-                                                            differencePercent: visitorsData.percentage)
-
-        var lineChartData = [LineChartDataConvertible]()
-        var lineChartStyling = [LineChartStyling]()
-
-        if let chartData = mostRecentChartData {
-            let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(chartData)
-            let viewsChart = InsightsLineChart(data: splitSummaryTimeIntervalData, filterDimension: .views)
-            lineChartData.append(contentsOf: viewsChart.lineChartData)
-            lineChartStyling.append(contentsOf: viewsChart.lineChartStyling)
-
-            let visitorsChart = InsightsLineChart(data: splitSummaryTimeIntervalData, filterDimension: .visitors)
-            lineChartData.append(contentsOf: visitorsChart.lineChartData)
-            lineChartStyling.append(contentsOf: visitorsChart.lineChartStyling)
-
-            var xAxisDates = [Date]()
-            splitSummaryTimeIntervalData.forEach { week in
-                switch week {
-                case .thisWeek(let data):
-                    xAxisDates = data.summaryData.map { $0.periodStartDate }
-                default:
-                    break
-                }
-            }
-
-            let row = ViewsVisitorsRow(
-                    segmentsData: [viewsSegmentData, visitorsSegmentData],
-                    chartData: lineChartData,
-                    chartStyling: lineChartStyling,
-                    period: lastRequestedPeriod,
-                    statsLineChartViewDelegate: statsLineChartViewDelegate,
-                    xAxisDates: xAxisDates
-            )
-            tableRows.append(row)
-        }
-
-        return tableRows
+        return SiteStatsImmuTableRows.viewVisitorsImmuTableRows(mostRecentChartData, periodDate: periodDate,
+                statsLineChartViewDelegate: statsLineChartViewDelegate, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 
-    func intervalData(summaryType: StatsSummaryType) -> (count: Int, prevCount: Int, difference: Int, percentage: Int) {
-        guard let chartData = mostRecentChartData else {
+    public static func intervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, summaryType: StatsSummaryType) -> (count: Int, prevCount: Int, difference: Int, percentage: Int) {
+        guard let statsSummaryTimeIntervalData = statsSummaryTimeIntervalData else {
             return (0, 0, 0, 0)
         }
 
-        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(chartData)
+        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(statsSummaryTimeIntervalData)
 
         var currentCount: Int = 0
         var previousCount: Int = 0
@@ -897,9 +840,5 @@ extension SiteStatsInsightsViewModel: AsyncBlocksLoadable {
 
     enum Constants {
         static let fourteenDays = 14
-        static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
-        static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
-        static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
-        static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -16,7 +16,7 @@ class StatsBaseCell: UITableViewCell {
         button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
         button.tintColor = .secondaryLabel
         button.setTitleColor(.secondaryLabel, for: .normal)
-        button.setImage(UIImage(named: "disclosure-chevron")?.withTintColor(UIColor(color: WPStyleGuide.greyLighten20())), for: .normal)
+        button.setImage(UIImage.gridicon(.chevronRight).withTintColor(UIColor(color: WPStyleGuide.greyLighten20())), for: .normal)
 
         if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
             button.semanticContentAttribute = .forceLeftToRight

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -1,7 +1,44 @@
 import UIKit
 
 class StatsBaseCell: UITableViewCell {
-    let headingLabel: UILabel = UILabel()
+
+    private let headingLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = UIFont.preferredFont(forTextStyle: .headline)
+        return label
+    }()
+
+    private let showDetailsButton: UIButton = {
+        let button = UIButton()
+        button.translatesAutoresizingMaskIntoConstraints = true
+        button.addTarget(self, action: #selector(detailsButtonTapped), for: .touchUpInside)
+        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .callout)
+        button.tintColor = .secondaryLabel
+        button.setTitleColor(.secondaryLabel, for: .normal)
+        button.setImage(UIImage(named: "disclosure-chevron")?.withTintColor(UIColor(color: WPStyleGuide.greyLighten20())), for: .normal)
+
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            button.semanticContentAttribute = .forceLeftToRight
+            button.titleEdgeInsets = Metrics.rtlButtonTitleInsets
+        } else {
+            button.semanticContentAttribute = .forceRightToLeft
+            button.titleEdgeInsets = Metrics.buttonTitleInsets
+        }
+
+        button.accessibilityHint = LocalizedText.buttonAccessibilityHint
+        return button
+    }()
+
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = Metrics.stackSpacing
+        stackView.axis = .horizontal
+        stackView.alignment = .fill
+        stackView.distribution = .equalSpacing
+        return stackView
+    }()
 
     @IBOutlet var topConstraint: NSLayoutConstraint!
 
@@ -20,55 +57,108 @@ class StatsBaseCell: UITableViewCell {
 
     var statSection: StatSection? {
         didSet {
-            let title = statSection?.title ?? ""
-            updateHeadingLabel(with: title)
+            updateHeader()
         }
     }
 
-    func configureHeadingLabel(with topConstraint: NSLayoutConstraint) {
+    weak var siteStatsInsightDetailsDelegate: SiteStatsInsightsDelegate?
+
+    private func configureHeading(with topConstraint: NSLayoutConstraint) {
         guard FeatureFlag.statsNewAppearance.enabled else {
             return
         }
 
-        headingLabel.translatesAutoresizingMaskIntoConstraints = false
-        headingLabel.font = UIFont.preferredFont(forTextStyle: .headline)
+        contentView.addSubview(stackView)
 
-        contentView.addSubview(headingLabel)
         NSLayoutConstraint.activate([
-            headingLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Metrics.padding),
-            headingLabel.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Metrics.padding),
-            headingLabel.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metrics.padding)
+            stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: Metrics.padding),
+            stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -Metrics.padding),
+            stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: Metrics.padding)
         ])
+
+        stackView.addArrangedSubviews([headingLabel, showDetailsButton])
 
         if let anchor = topConstraintTargetView?.topAnchor {
             // Deactivate the existing top constraint of the cell
             let constant = topConstraint.constant
             topConstraint.isActive = false
 
-            // Create a new constraint between the heading label and the first item of the existing top constraint
-            headingBottomConstraint = headingLabel.bottomAnchor.constraint(equalTo: anchor, constant: -(Metrics.padding + constant))
+            // Create a new constraint between the stackView containing the heading label and the first item of the existing top constraint
+            headingBottomConstraint = stackView.bottomAnchor.constraint(equalTo: anchor, constant: -(Metrics.padding + constant))
             headingBottomConstraint?.isActive = true
         }
     }
 
-    private func updateHeadingLabel(with title: String) {
+    private func updateHeader() {
         guard FeatureFlag.statsNewAppearance.enabled else {
             return
         }
 
         if headingBottomConstraint == nil {
-            configureHeadingLabel(with: topConstraint)
+            configureHeading(with: topConstraint)
         }
 
+        let title = statSection?.title ?? ""
         headingLabel.text = title
 
-        let hasTitle = !title.isEmpty
+        if shouldShowDetailsButton() {
+            showDetailsButton.isHidden = false
 
-        headingBottomConstraint?.isActive = hasTitle
-        topConstraint.isActive = !hasTitle
+            switch statSection {
+            case .insightsViewsVisitors:
+                showDetailsButton.setTitle(LocalizedText.buttonTitle, for: .normal)
+            default:
+                showDetailsButton.setTitle("", for: .normal)
+            }
+        } else {
+            showDetailsButton.isHidden = true
+        }
+
+        let hasTitleOrButton = !title.isEmpty || !showDetailsButton.isHidden
+
+        headingBottomConstraint?.isActive = hasTitleOrButton
+        topConstraint.isActive = !hasTitleOrButton
+    }
+
+    func shouldShowDetailsButton () -> Bool {
+        return siteStatsInsightDetailsDelegate != nil
+    }
+
+    @objc private func detailsButtonTapped() {
+        guard let statSection = statSection else {
+            return
+        }
+
+        captureAnalyticsEventsFor(statSection)
+        siteStatsInsightDetailsDelegate?.viewMoreSelectedForStatSection?(statSection)
+    }
+
+    private func captureAnalyticsEventsFor(_ statSection: StatSection) {
+        let legacyEvent: WPAnalyticsStat = .statsViewAllAccessed
+        captureAnalyticsEvent(legacyEvent)
+
+        if let modernEvent = statSection.analyticsViewMoreEvent {
+            captureAnalyticsEvent(modernEvent)
+        }
+    }
+
+    private func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
+        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
+            WPAppAnalytics.track(event, withBlogID: blogIdentifier)
+        } else {
+            WPAppAnalytics.track(event)
+        }
     }
 
     enum Metrics {
         static let padding: CGFloat = 16.0
+        static let stackSpacing: CGFloat = 8.0
+        static let buttonTitleInsets = UIEdgeInsets(top: 0, left: -12.0, bottom: 0, right: 12.0)
+        static let rtlButtonTitleInsets = UIEdgeInsets(top: 0, left: 12.0, bottom: 0, right: -12.0)
+    }
+
+    private enum LocalizedText {
+        static let buttonTitle = NSLocalizedString("This week", comment: "Title of a button. A call to action to view more stats for this week")
+        static let buttonAccessibilityHint = NSLocalizedString("Tap to view more stats for this week", comment: "VoiceOver accessibility hint, informing the user the button can be used to access more stats about this week")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -103,18 +103,4 @@ private extension TwoColumnCell {
             WPAppAnalytics.track(event)
         }
     }
-
-}
-
-// MARK: - Analytics support
-
-private extension StatSection {
-    var analyticsViewMoreEvent: WPAnalyticsStat? {
-        switch self {
-        case .insightsAnnualSiteStats:
-            return .statsViewMoreTappedThisYear
-        default:
-            return nil
-        }
-    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -114,6 +114,7 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
                    delegate: SiteStatsInsightsDelegate? = nil
     ) {
         siteStatsInsightsDelegate = delegate
+        siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
         statSection = .insightsViewsVisitors
 
         self.segmentsData = segmentsData

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -93,7 +93,7 @@ class SiteStatsPeriodTableViewController: UITableViewController, StoryboardLoada
     }
 
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-        guard let cell = tableView.dequeueReusableHeaderFooterView(withIdentifier: SiteStatsTableHeaderView.defaultNibName) as? SiteStatsTableHeaderView else {
+        guard let cell = Bundle.main.loadNibNamed("SiteStatsTableHeaderView", owner: nil, options: nil)?.first as? SiteStatsTableHeaderView else {
             return nil
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -8,7 +8,7 @@ protocol SiteStatsTableHeaderDateButtonDelegate: SiteStatsTableHeaderDelegate {
     func didTouchHeaderButton(forward: Bool)
 }
 
-class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Accessible {
+class SiteStatsTableHeaderView: UIView, NibLoadable, Accessible {
 
     // MARK: - Properties
 
@@ -143,7 +143,7 @@ class SiteStatsTableHeaderView: UITableViewHeaderFooterView, NibLoadable, Access
 private extension SiteStatsTableHeaderView {
 
     func applyStyles() {
-        contentView.backgroundColor = .listForeground
+        backgroundColor = .listForeground
         Style.configureLabelAsCellRowTitle(dateLabel)
         Style.configureLabelAsChildRowTitle(timezoneLabel)
         Style.configureViewAsSeparator(bottomSeparatorLine)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.storyboard
@@ -1,34 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Site Stats Detail Table View Controller-->
-        <scene sceneID="2AU-P1-qMy">
+        <scene sceneID="vgZ-Km-xzv">
             <objects>
-                <tableViewController storyboardIdentifier="SiteStatsDetailTableViewController" id="stm-hy-Neq" customClass="SiteStatsDetailTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
-                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="58g-G7-FEx">
+                <viewController storyboardIdentifier="SiteStatsDetailTableViewController" id="uXj-6h-Y1P" customClass="SiteStatsDetailTableViewController" customModule="WordPress" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="KiU-8p-DXA">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <connections>
-                            <outlet property="dataSource" destination="stm-hy-Neq" id="qW9-JT-QGD"/>
-                            <outlet property="delegate" destination="stm-hy-Neq" id="X0W-Pn-A7r"/>
-                        </connections>
-                    </tableView>
-                    <refreshControl key="refreshControl" opaque="NO" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" id="5aC-t9-VAq">
-                        <autoresizingMask key="autoresizingMask"/>
-                    </refreshControl>
-                </tableViewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dou-7X-7Oq" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                        <viewLayoutGuide key="safeArea" id="S7r-Vg-SBK"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="s3w-ea-j6p" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-430" y="149"/>
+            <point key="canvasLocation" x="-1137" y="161"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -56,11 +56,13 @@ class SiteStatsDetailTableViewController: SiteStatsBaseTableViewController, Stor
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        updateHeader()
         clearExpandedRows()
         Style.configureTable(tableView)
         refreshControl.addTarget(self, action: #selector(refreshData), for: .valueChanged)
+        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
+        tableView.register(SiteStatsTableHeaderView.defaultNib,
+                forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         addWillEnterForegroundObserver()
     }
 
@@ -72,14 +74,21 @@ class SiteStatsDetailTableViewController: SiteStatsBaseTableViewController, Stor
     func configure(statSection: StatSection,
                    selectedDate: Date? = nil,
                    selectedPeriod: StatsPeriodUnit? = nil,
-                   postID: Int? = nil) {
+                   postID: Int? = nil,
+                   tableStyle: UITableView.Style = .grouped
+    ) {
         self.statSection = statSection
         self.selectedDate = selectedDate ?? StatsDataHelper.currentDateForSite()
         self.selectedPeriod = selectedPeriod
         self.postID = postID
+        self.tableStyle = tableStyle
         statType = StatSection.allInsights.contains(statSection) ? .insights : .period
         title = statSection.detailsTitle
         initViewModel()
+
+        if FeatureFlag.statsNewInsights.enabled && tableStyle == .insetGrouped {
+            updateHeader()
+        }
     }
 
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
@@ -120,7 +129,7 @@ class SiteStatsDetailTableViewController: SiteStatsBaseTableViewController, Stor
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        if FeatureFlag.statsNewInsights.enabled {
+        if FeatureFlag.statsNewInsights.enabled && tableStyle == .insetGrouped {
             guard section == 0 else {
                 return 0
             }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -9,7 +9,7 @@ import WordPressFlux
     @objc optional func displayMediaWithID(_ mediaID: NSNumber)
 }
 
-class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoadable {
+class SiteStatsDetailTableViewController: SiteStatsBaseTableViewController, StoryboardLoadable {
 
     // MARK: - StoryboardLoadable Protocol
 
@@ -24,6 +24,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     private var selectedPeriod: StatsPeriodUnit?
 
     private var viewModel: SiteStatsDetailsViewModel?
+    private var tableHeaderView: SiteStatsTableHeaderView?
 
     private var receipt: Receipt?
 
@@ -55,13 +56,11 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        updateHeader()
         clearExpandedRows()
         Style.configureTable(tableView)
-        refreshControl?.addTarget(self, action: #selector(refreshData), for: .valueChanged)
-        tableView.estimatedSectionHeaderHeight = SiteStatsTableHeaderView.estimatedHeight
+        refreshControl.addTarget(self, action: #selector(refreshData), for: .valueChanged)
         ImmuTable.registerRows(tableRowTypes(), tableView: tableView)
-        tableView.register(SiteStatsTableHeaderView.defaultNib,
-                           forHeaderFooterViewReuseIdentifier: SiteStatsTableHeaderView.defaultNibName)
         addWillEnterForegroundObserver()
     }
 
@@ -92,7 +91,7 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         })
     }
 
-    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
 
         // Only show the date bar for Insights Annual details
         guard let statSection = statSection,
@@ -120,7 +119,15 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
         return cell
     }
 
-    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        if FeatureFlag.statsNewInsights.enabled {
+            guard section == 0 else {
+                return 0
+            }
+
+            return UITableView.automaticDimension
+        }
+
         // Only show the date bar for Insights Annual details
         guard let statSection = statSection,
             statSection == .insightsAnnualSiteStats,
@@ -131,7 +138,6 @@ class SiteStatsDetailTableViewController: UITableViewController, StoryboardLoada
 
         return UITableView.automaticDimension
     }
-
 }
 
 extension SiteStatsDetailTableViewController: StatsForegroundObservable {
@@ -144,6 +150,30 @@ extension SiteStatsDetailTableViewController: StatsForegroundObservable {
 // MARK: - Table Methods
 
 private extension SiteStatsDetailTableViewController {
+
+    private func updateHeader() {
+        guard let siteStatsTableHeaderView = Bundle.main.loadNibNamed("SiteStatsTableHeaderView", owner: nil, options: nil)?.first as? SiteStatsTableHeaderView else {
+            return
+        }
+
+        siteStatsTableHeaderView.configure(date: selectedDate, period: StatsPeriodUnit.week, delegate: self)
+
+        tableView.tableHeaderView = siteStatsTableHeaderView
+
+        guard let tableHeaderView = tableView.tableHeaderView else {
+            return
+        }
+
+        tableHeaderView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            tableHeaderView.topAnchor.constraint(equalTo: tableView.topAnchor),
+            tableHeaderView.safeLeadingAnchor.constraint(equalTo: tableView.safeLeadingAnchor),
+            tableHeaderView.safeTrailingAnchor.constraint(equalTo: tableView.safeTrailingAnchor),
+            tableHeaderView.heightAnchor.constraint(equalToConstant: 60)
+        ])
+        tableView.tableHeaderView?.layoutIfNeeded()
+    }
 
     func initViewModel() {
         viewModel = SiteStatsDetailsViewModel(detailsDelegate: self,
@@ -173,7 +203,9 @@ private extension SiteStatsDetailTableViewController {
                 CountriesMapRow.self,
                 StatsErrorRow.self,
                 StatsGhostTopHeaderImmutableRow.self,
-                StatsGhostDetailRow.self]
+                StatsGhostDetailRow.self,
+                ViewsVisitorsRow.self,
+                PeriodEmptyCellHeaderRow.self]
     }
 
     // MARK: - Table Refreshing
@@ -184,7 +216,7 @@ private extension SiteStatsDetailTableViewController {
         }
 
         tableHandler.viewModel = viewModel.tableViewModel()
-        refreshControl?.endRefreshing()
+        refreshControl.endRefreshing()
 
         if viewModel.fetchDataHasFailed() {
             displayFailureViewIfNecessary()
@@ -199,7 +231,7 @@ private extension SiteStatsDetailTableViewController {
         }
 
         clearExpandedRows()
-        refreshControl?.beginRefreshing()
+        refreshControl.beginRefreshing()
 
         switch statSection {
         case .insightsFollowersWordPress, .insightsFollowersEmail:
@@ -231,7 +263,7 @@ private extension SiteStatsDetailTableViewController {
         case .postStatsMonthsYears, .postStatsAverageViews:
             viewModel?.refreshPostStats()
         default:
-            refreshControl?.endRefreshing()
+            refreshControl.endRefreshing()
         }
     }
 
@@ -266,7 +298,6 @@ private extension SiteStatsDetailTableViewController {
 
         initViewModel()
     }
-
 }
 
 // MARK: - SiteStatsDetailsDelegate Methods

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -118,15 +118,12 @@ class SiteStatsDetailsViewModel: Observable {
             if FeatureFlag.statsNewInsights.enabled {
                 switch statSection {
                 case .insightsViewsVisitors:
-                    guard let storeQueryViewsVisitors = queryForPeriodStatSection(statSection) else {
+                    guard let storeQueryViewsVisitors = queryForPeriodStatSection(statSection),
+                          let storeQueryReferrers = queryForPeriodStatSection(.periodReferrers),
+                          let storeQueryCountries = queryForPeriodStatSection(.periodCountries) else {
                         return true
                     }
-                    guard let storeQueryReferrers = queryForPeriodStatSection(.periodReferrers) else {
-                        return true
-                    }
-                    guard let storeQueryCountries = queryForPeriodStatSection(.periodCountries) else {
-                        return true
-                    }
+
                     return periodStore.fetchingFailed(for: storeQueryViewsVisitors) &&
                             periodStore.fetchingFailed(for: storeQueryReferrers) &&
                             periodStore.fetchingFailed(for: storeQueryCountries)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -66,38 +66,3 @@ private extension ViewMoreRow {
         }
     }
 }
-
-// MARK: - Analytics support
-
-private extension StatSection {
-    var analyticsViewMoreEvent: WPAnalyticsStat? {
-        switch self {
-        case .periodAuthors, .insightsCommentsAuthors:
-            return .statsViewMoreTappedAuthors
-        case .periodClicks:
-            return .statsViewMoreTappedClicks
-        case .periodOverviewComments:
-            return .statsViewMoreTappedComments
-        case .periodCountries:
-            return .statsViewMoreTappedCountries
-        case .insightsFollowerTotals, .insightsFollowersEmail, .insightsFollowersWordPress:
-            return .statsViewMoreTappedFollowers
-        case .periodPostsAndPages:
-            return .statsViewMoreTappedPostsAndPages
-        case .insightsPublicize:
-            return .statsViewMoreTappedPublicize
-        case .periodReferrers:
-            return .statsViewMoreTappedReferrers
-        case .periodSearchTerms:
-            return .statsViewMoreTappedSearchTerms
-        case .insightsTagsAndCategories:
-            return .statsViewMoreTappedTagsAndCategories
-        case .periodVideos:
-            return .statsViewMoreTappedVideoPlays
-        case .periodFileDownloads:
-            return .statsViewMoreTappedFileDownloads
-        default:
-            return nil
-        }
-    }
-}

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -83,12 +83,17 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureInsightsTableView()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedPeriodFromUserDefaults()
         addWillEnterForegroundObserver()
         configureNavBar()
         view.accessibilityIdentifier = "stats-dashboard"
+    }
+
+    func configureInsightsTableView() {
+        insightsTableViewController.tableStyle = FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .grouped
     }
 
     func configureNavBar() {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -42,6 +42,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
     let chartStyling: [LineChartStyling]
     let period: StatsPeriodUnit?
     weak var statsLineChartViewDelegate: StatsLineChartViewDelegate?
+    weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     let xAxisDates: [Date]
 
     func configureCell(_ cell: UITableViewCell) {
@@ -50,7 +51,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(segmentsData: segmentsData, lineChartData: chartData, lineChartStyling: chartStyling, period: period, statsLineChartViewDelegate: statsLineChartViewDelegate, xAxisDates: xAxisDates)
+        cell.configure(segmentsData: segmentsData, lineChartData: chartData, lineChartStyling: chartStyling, period: period, statsLineChartViewDelegate: statsLineChartViewDelegate, xAxisDates: xAxisDates, delegate: siteStatsInsightsDelegate)
     }
 }
 
@@ -418,6 +419,7 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
     let itemSubtitle: String
     let dataSubtitle: String
     let dataRows: [StatsTotalRowData]
+    var statSection: StatSection?
     weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     weak var siteStatsReferrerDelegate: SiteStatsReferrerDelegate?
     let action: ImmuTableAction? = nil
@@ -431,6 +433,7 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
         cell.configure(itemSubtitle: itemSubtitle,
                        dataSubtitle: dataSubtitle,
                        dataRows: dataRows,
+                       statSection: statSection,
                        siteStatsPeriodDelegate: siteStatsPeriodDelegate,
                        siteStatsReferrerDelegate: siteStatsReferrerDelegate)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2480,6 +2480,12 @@
 		DC8F61F827032B3F0087AC5D /* TimeZoneFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F61F627032B3F0087AC5D /* TimeZoneFormatter.swift */; };
 		DC8F61FC2703321F0087AC5D /* TimeZoneFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC8F61FB2703321F0087AC5D /* TimeZoneFormatterTests.swift */; };
 		DCC662512810915D00962D0C /* BlogVideoLimitsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC662502810915D00962D0C /* BlogVideoLimitsTests.swift */; };
+		DCF892C9282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892C8282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift */; };
+		DCF892CA282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892C8282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift */; };
+		DCF892CC282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892CB282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift */; };
+		DCF892CD282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892CB282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift */; };
+		DCF892D0282FA42A00BB71E1 /* SiteStatsImmuTableRowsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892CF282FA42A00BB71E1 /* SiteStatsImmuTableRowsTests.swift */; };
+		DCF892D2282FA45500BB71E1 /* StatsMockDataLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF892D1282FA45500BB71E1 /* StatsMockDataLoader.swift */; };
 		E100C6BB1741473000AE48D8 /* WordPress-11-12.xcmappingmodel in Sources */ = {isa = PBXBuildFile; fileRef = E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */; };
 		E10290741F30615A00DAC588 /* Role.swift in Sources */ = {isa = PBXBuildFile; fileRef = E10290731F30615A00DAC588 /* Role.swift */; };
 		E102B7901E714F24007928E8 /* RecentSitesService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E102B78F1E714F24007928E8 /* RecentSitesService.swift */; };
@@ -7286,6 +7292,10 @@
 		DC8F61F627032B3F0087AC5D /* TimeZoneFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneFormatter.swift; sourceTree = "<group>"; };
 		DC8F61FB2703321F0087AC5D /* TimeZoneFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeZoneFormatterTests.swift; sourceTree = "<group>"; };
 		DCC662502810915D00962D0C /* BlogVideoLimitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogVideoLimitsTests.swift; sourceTree = "<group>"; };
+		DCF892C8282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsBaseTableViewController.swift; sourceTree = "<group>"; };
+		DCF892CB282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsImmuTableRows.swift; sourceTree = "<group>"; };
+		DCF892CF282FA42A00BB71E1 /* SiteStatsImmuTableRowsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStatsImmuTableRowsTests.swift; sourceTree = "<group>"; };
+		DCF892D1282FA45500BB71E1 /* StatsMockDataLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsMockDataLoader.swift; sourceTree = "<group>"; };
 		E100C6BA1741472F00AE48D8 /* WordPress-11-12.xcmappingmodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcmappingmodel; path = "WordPress-11-12.xcmappingmodel"; sourceTree = "<group>"; };
 		E10290731F30615A00DAC588 /* Role.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Role.swift; sourceTree = "<group>"; };
 		E102B78F1E714F24007928E8 /* RecentSitesService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RecentSitesService.swift; sourceTree = "<group>"; };
@@ -12269,6 +12279,7 @@
 				9826AE8421B5C6D500C851FA /* Posting Activity */,
 				98880A4722B2E3FC00464538 /* Two Column Stats */,
 				DC772AF7282009FC00664C02 /* ViewsVisitors */,
+				DCF892C8282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift */,
 				988056022183CCE50083B643 /* SiteStatsInsightsTableViewController.swift */,
 				9865257C2194D77E0078B916 /* SiteStatsInsightsViewModel.swift */,
 				93F7214E271831820021A09F /* SiteStatsPinnedItemStore.swift */,
@@ -12293,6 +12304,7 @@
 				98B52AE021F7AF4A006FF6B4 /* StatsDataHelper.swift */,
 				98CAD295221B4ED1003E8F45 /* StatSection.swift */,
 				17D4153B22C2308D006378EF /* StatsPeriodHelper.swift */,
+				DCF892CB282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -14195,6 +14207,7 @@
 		DC772AFB28200A3600664C02 /* Stats */ = {
 			isa = PBXGroup;
 			children = (
+				DCF892CE282FA40000BB71E1 /* Helpers */,
 				DC772AFC28200A3600664C02 /* Insights */,
 			);
 			name = Stats;
@@ -14228,6 +14241,15 @@
 				DC3B9B2E27739887003F7249 /* TimeZoneSelectorViewModelTests.swift */,
 			);
 			path = "Time Zone";
+			sourceTree = "<group>";
+		};
+		DCF892CE282FA40000BB71E1 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				DCF892D1282FA45500BB71E1 /* StatsMockDataLoader.swift */,
+				DCF892CF282FA42A00BB71E1 /* SiteStatsImmuTableRowsTests.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		E10520591F2B1CD400A948F6 /* 61-62 */ = {
@@ -18447,6 +18469,7 @@
 				735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */,
 				2F161B0622CC2DC70066A5C5 /* LoadingStatusView.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
+				DCF892C9282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift in Sources */,
 				2FA6511B21F26A57009AA935 /* InlineErrorRetryTableViewCell.swift in Sources */,
 				08216FCF1CDBF96000304BA7 /* MenuItemSourceCell.m in Sources */,
 				462F4E0A18369F0B0028D2F8 /* BlogDetailsViewController.m in Sources */,
@@ -18864,6 +18887,7 @@
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
 				46F583AB2624CE790010A723 /* BlockEditorSettings+CoreDataProperties.swift in Sources */,
+				DCF892CC282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift in Sources */,
 				08D553662821286300AA1E8D /* Tooltip.swift in Sources */,
 				FAB985C12697550C00B172A3 /* NoResultsViewController+StatsModule.swift in Sources */,
 				B55086211CC15CCB004EADB4 /* PromptViewController.swift in Sources */,
@@ -19940,6 +19964,7 @@
 				2481B1E8260D4EAC00AE59DB /* WPAccount+LookupTests.swift in Sources */,
 				E10F3DA11E5C2CE0008FAADA /* PostListFilterTests.swift in Sources */,
 				57D66B9D234BB78B005A2D74 /* PostServiceWPComTests.swift in Sources */,
+				DCF892D0282FA42A00BB71E1 /* SiteStatsImmuTableRowsTests.swift in Sources */,
 				8B939F4323832E5D00ACCB0F /* PostListViewControllerTests.swift in Sources */,
 				93EF094C19ED533500C89770 /* ContextManagerTests.swift in Sources */,
 				F17A2A2023BFBD84001E96AC /* UIView+ExistingConstraints.swift in Sources */,
@@ -20022,6 +20047,7 @@
 				FAE8EE9C273AD0A800A65307 /* QuickStartSettingsTests.swift in Sources */,
 				400A2C912217B308000A8A59 /* CountryStatsRecordValueTests.swift in Sources */,
 				8BD8201D24BF9E5200FF25FD /* ReaderWelcomeBannerTests.swift in Sources */,
+				DCF892D2282FA45500BB71E1 /* StatsMockDataLoader.swift in Sources */,
 				02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */,
 				8B749E9025AF8D2E00023F03 /* JetpackCapabilitiesServiceTests.swift in Sources */,
 				F1450CF72437E8F800A28BFE /* MediaHostTests.swift in Sources */,
@@ -20843,6 +20869,7 @@
 				FABB234C2602FC2C00C8785C /* PostSettingsViewController+FeaturedImageUpload.swift in Sources */,
 				F158542E267D3B8A00A2E966 /* BloggingRemindersFlowSettingsViewController.swift in Sources */,
 				FABB234D2602FC2C00C8785C /* ReaderLikeAction.swift in Sources */,
+				DCF892CD282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift in Sources */,
 				FABB234E2602FC2C00C8785C /* ReaderMenuAction.swift in Sources */,
 				FABB234F2602FC2C00C8785C /* PostSharingController.swift in Sources */,
 				FABB23502602FC2C00C8785C /* LongPressGestureLabel.swift in Sources */,
@@ -21193,6 +21220,7 @@
 				FABB24802602FC2C00C8785C /* JetpackRestoreStatusViewController.swift in Sources */,
 				FABB24812602FC2C00C8785C /* BindableTapGestureRecognizer.swift in Sources */,
 				FABB24822602FC2C00C8785C /* ReaderSearchSuggestion.swift in Sources */,
+				DCF892CA282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift in Sources */,
 				FABB24832602FC2C00C8785C /* ReaderSearchViewController.swift in Sources */,
 				FABB24842602FC2C00C8785C /* SiteStatsTableHeaderView.swift in Sources */,
 				FABB24852602FC2C00C8785C /* MediaSizeSliderCell.swift in Sources */,

--- a/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+class SiteStatsImmuTableRowsTests: XCTestCase {
+
+    func testViewVisitorsImmuTableRows() throws {
+        // Given statsSummaryTimeIntervalData with 14 days data
+        guard let statsSummaryTimeIntervalData = try! StatsMockDataLoader.createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-14.json") else {
+            XCTFail("Failed to create statsSummaryTimeIntervalData")
+            return
+        }
+
+        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let date = Calendar.autoupdatingCurrent.date(from: feb21)!
+
+        // When creating rows from statsSummaryTimeIntervalData
+        let rows = SiteStatsImmuTableRows.viewVisitorsImmuTableRows(statsSummaryTimeIntervalData, periodDate: date, statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil)
+
+        // Then
+        XCTAssertTrue(rows.count == 1)
+    }
+}

--- a/WordPress/WordPressTest/ViewRelated/Stats/Helpers/StatsMockDataLoader.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Helpers/StatsMockDataLoader.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct StatsMockDataLoader {
+
+    static func createStatsSummaryTimeIntervalData(fileName: String) throws -> StatsSummaryTimeIntervalData? {
+        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
+        let date = Calendar.autoupdatingCurrent.date(from: feb21)!
+
+        let jsonDictionary = try JSONObject.loadFile(named: fileName)
+
+        guard let statsSummaryTimeIntervalData = StatsSummaryTimeIntervalData(date: date,
+                period: .day,
+                jsonDictionary: jsonDictionary) else {
+            XCTFail()
+            return nil
+        }
+
+        return statsSummaryTimeIntervalData
+    }
+}

--- a/WordPress/WordPressTest/ViewRelated/Stats/Helpers/StatsMockDataLoader.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Helpers/StatsMockDataLoader.swift
@@ -6,7 +6,7 @@ struct StatsMockDataLoader {
         let feb21 = DateComponents(year: 2019, month: 2, day: 21)
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
-        let jsonDictionary = try JSONObject.loadFile(named: fileName)
+        let jsonDictionary = try JSONObject.init(fromFileNamed: fileName)
 
         guard let statsSummaryTimeIntervalData = StatsSummaryTimeIntervalData(date: date,
                 period: .day,

--- a/WordPress/WordPressTest/ViewRelated/Stats/Insights/SiteStatsInsightViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Insights/SiteStatsInsightViewModelTests.swift
@@ -7,7 +7,7 @@ class SiteStatsInsightsViewModelTests: XCTestCase {
     /// The standard api result for a normal user
     func testSummarySplitIntervalData14DaysBasecase() throws {
         // Given statsSummaryTimeIntervalData with 14 days data
-        guard let statsSummaryTimeIntervalData = try! createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-14.json") else {
+        guard let statsSummaryTimeIntervalData = try! StatsMockDataLoader.createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-14.json") else {
             XCTFail("Failed to create statsSummaryTimeIntervalData")
             return
         }
@@ -19,7 +19,7 @@ class SiteStatsInsightsViewModelTests: XCTestCase {
     /// The api result for a new user that has full data for this week but a partial dataset for the previous week
     func testSummarySplitIntervalData11Days() throws {
         // Given statsSummaryTimeIntervalData with 11 days data
-        guard let statsSummaryTimeIntervalData = try! createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-11.json") else {
+        guard let statsSummaryTimeIntervalData = try! StatsMockDataLoader.createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-11.json") else {
             XCTFail(Constants.failCreateStatsSummaryTimeIntervalData)
             return
         }
@@ -31,7 +31,7 @@ class SiteStatsInsightsViewModelTests: XCTestCase {
     /// The api result for a new user that has an incomplete dataset for this week and no data for prev week
     func testSummarySplitIntervalData4Days() throws {
         // Given statsSummaryTimeIntervalData with 4 days data
-        guard let statsSummaryTimeIntervalData = try! createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-4.json") else {
+        guard let statsSummaryTimeIntervalData = try! StatsMockDataLoader.createStatsSummaryTimeIntervalData(fileName: "stats-visits-day-4.json") else {
             XCTFail(Constants.failCreateStatsSummaryTimeIntervalData)
             return
         }
@@ -56,51 +56,6 @@ class SiteStatsInsightsViewModelTests: XCTestCase {
                 XCTAssertEqual(prevWeek.summaryData.first?.periodStartDate, Calendar.autoupdatingCurrent.date(from: DateComponents(year: 2019, month: 2, day: 8)))
             }
         }
-    }
-
-    func convertStringToDictionary(text: String) -> [String: AnyObject]? {
-        if let data = text.data(using: .utf8) {
-            do {
-                let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String: AnyObject]
-                return json
-            } catch {
-                print("Something went wrong")
-            }
-        }
-        return nil
-    }
-
-    func createStatsSummaryTimeIntervalData(fileName: String) throws -> StatsSummaryTimeIntervalData? {
-        let feb21 = DateComponents(year: 2019, month: 2, day: 21)
-        let date = Calendar.autoupdatingCurrent.date(from: feb21)!
-
-        let data = try load(fileName: fileName, fromBundle: Bundle(for: type(of: self)))
-        let str = String(decoding: data, as: UTF8.self)
-        let jsonDictionary = convertStringToDictionary(text: str)
-
-        guard let json = jsonDictionary else {
-            return nil
-        }
-
-        guard let statsSummaryTimeIntervalData = StatsSummaryTimeIntervalData(date: date,
-                period: .day,
-                jsonDictionary: json) else {
-            XCTFail()
-            return nil
-        }
-
-        return statsSummaryTimeIntervalData
-    }
-
-    func load(fileName: String, fromBundle bundle: Bundle) throws -> Data {
-        let fileUrl = URL(fileURLWithPath: fileName)
-        let baseName = fileUrl.deletingPathExtension().path
-        let ext = fileUrl.pathExtension
-
-        guard let path = bundle.path(forResource: baseName, ofType: ext) else { XCTFail("Could not find file: \(fileName)"); throw NSError() }
-        let url = URL(fileURLWithPath: path)
-        guard let data = try? Data(contentsOf: url, options: [.mappedIfSafe]) else { XCTFail("Could not load data from file: \(fileName)"); throw NSError() }
-        return data
     }
 }
 


### PR DESCRIPTION
This PR adds the Details (2nd level) Views / Visitors screen

Ref #18601

Note:
 * this PR does not handle the logic to re-request data when changing the date selection header at top
 * the date selection header does not fully match the design (it has an extra detail text line) as I've chosen to re-use the existing header for now from the Period screens
 * this PR does not add the PIeChart for Referrers
 * this PR does not have the Countries Header as pat of Stats Revamp (Countries hasn't been converted for Stats Revamp yet)
 * this PR does not handle Ghost cards
 * this PR does not handle dynamically showing the date picker on 2nd level based on the stat section type.  will be done in future PR

Design
![image](https://user-images.githubusercontent.com/88816724/168612198-f1434fd2-35d7-48e3-882e-4b9f14169658.png)


Implementation
![image](https://user-images.githubusercontent.com/88816724/168612315-11a93518-4040-4465-9a22-fabeec86bc4d.png)
![image](https://user-images.githubusercontent.com/88816724/168612343-33efe758-05c2-4f00-b6ca-769eaf41e186.png)


To test:
1.  First, build and run, navigate to Stats Insights for a site and ensure that there is no option to add a Views & Visitors card like in s/shot below2. 

2. Click around insights, period stats (days, months, years) and ensure there are no crashes
4. Navigate out of stats to posts, media etc, and back to stats again and insights, period stats etc. + ensure there is no issue.
5. Now enable both of the new stats feature flags and build and run again

```
statsNewAppearance
statsNewInsights
```

6. Add New Stats Card = Views & Visitors.  New Views & Visitors Card and Graph should be added to the screen
7. Tap "This week" on the upper right of the Views / Visitors card.  Screen will segue / navigate to the Details card like below

8. Scroll up / down the details  screen.  There shouldn't be anything amiss / crashing 


## Regression Notes
1. Potential unintended areas of impact
Stats screens (insights and periods)

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and added a unit test

4. What automated tests I added (or what prevented me from doing so)
I added a unit test for ImmuTableRow creation

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
