### PR TITLE
My Site Dashboard: fix `default_tab_experiment ` property for `account_created` event

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -521,7 +521,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     // This should be removed once the experiment is done
     //
     private func assignMySiteExperimentIfNeeded(event: WPAnalyticsStat) {
-        if event == .signedIn {
+        if event == .signedIn || event == .createdAccount {
             if FeatureFlag.mySiteDashboard.enabled {
                 let isTreatment = BlogDashboardAB.shared.variant == .treatment
                 MySiteSettings().setDefaultSection(isTreatment ? .dashboard : .siteMenu)


### PR DESCRIPTION
This PR makes sure the user is assigned to an experiment before the `account_created` event, to ensure the `default_tab_experiment ` property is not `nonexistent`.

### To test

1. Run the app
2. Create an account
3. Make sure`account_created` event has `default_tab_experiment` equal to `dashboard` or `site_menu`
4. Make sure`signed_in` is fired with `default_tab_experiment` equal to the above


## Regression Notes
1. Potential unintended areas of impact
-

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
