### PR TITLE
Blogging Prompts Dashboard Card: don't show remove menu item.

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -73,6 +73,10 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         }
     }
 
+    // This provides a quick way to toggle the `Remove from dashboard` menu item.
+    // Since it (probably) will not be included in Blogging Prompts V1, it is disabled by default.
+    private let removeFromDashboardEnabled = false
+
     // Used to present:
     // - The menu sheet for contextual menu in iOS13.
     // - The Blogging Prompts list when selected from the contextual menu.
@@ -273,15 +277,16 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     // Defines the structure of the contextual menu items.
     private var contextMenuItems: [[MenuItem]] {
-        return [
-            [
-                .viewMore(viewMoreMenuTapped),
-                .skip(skipMenuTapped)
-            ],
-            [
-                .remove(removeMenuTapped)
-            ]
+        let defaultItems: [MenuItem] = [
+            .viewMore(viewMoreMenuTapped),
+            .skip(skipMenuTapped)
         ]
+
+        if removeFromDashboardEnabled {
+            return [defaultItems, [.remove(removeMenuTapped)]]
+        }
+
+        return [defaultItems]
     }
 
     private var contextMenu: UIMenu {


### PR DESCRIPTION
Ref: #18429, #18250, p1652262324746539-slack-C01CW1VMLAF

Per the referenced Slack conversation, the `Remove from dashboard` option on the dashboard prompt card is removed as it probably won't be implemented for V1.

To test:
- Run on an iOS 14+ device.
- Go to My Site > Home > Prompts.
- Tap on the ellipsis menu.
- Verify `Remove from dashboard` does not appear.
- Repeat on an iOS 13 device.

| iOS 15 Before | iOS 15 After |
|--------|-------|
| <img width="439" alt="15_before" src="https://user-images.githubusercontent.com/1816888/168674954-76d6026b-dc7e-4aa3-af78-c95b36e63b2c.png"> | <img width="439" alt="15_after" src="https://user-images.githubusercontent.com/1816888/168674946-0077dff5-8c30-4a62-a746-bcf4f1741f99.png"> |


| iOS 13 Before | iOS 13 After |
|--------|-------|
| <img width="441" alt="13_before" src="https://user-images.githubusercontent.com/1816888/168674982-e2fc0bd8-e81c-4b98-ba42-5c1abc223b78.png"> | <img width="440" alt="13_after" src="https://user-images.githubusercontent.com/1816888/168674985-9f238316-a009-4045-8bb9-8cb06c584d23.png"> |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.