### PR TITLE
[Site Design Revamp] Main View - Enlarge design thumbnails

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -22,17 +22,19 @@ protocol CategorySection {
     var description: String? { get }
     var thumbnails: [Thumbnail] { get }
     var scrollOffset: CGPoint { get set }
+    var thumbnailSize: CGSize { get }
 }
 
 class CategorySectionTableViewCell: UITableViewCell {
 
     static let cellReuseIdentifier = "\(CategorySectionTableViewCell.self)"
     static let nib = UINib(nibName: "\(CategorySectionTableViewCell.self)", bundle: Bundle.main)
-    static let expectedThumbnailSize = CGSize(width: 160.0, height: 240)
-    static let estimatedCellHeight: CGFloat = 310.0
+    static let defaultThumbnailSize = CGSize(width: 160, height: 240)
+    static let cellVerticalPadding: CGFloat = 70
 
     @IBOutlet weak var categoryTitle: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
+    @IBOutlet weak var collectionViewHeight: NSLayoutConstraint!
 
     weak var delegate: CategorySectionTableViewCellDelegate?
 
@@ -47,10 +49,21 @@ class CategorySectionTableViewCell: UITableViewCell {
             thumbnails = section?.thumbnails ?? []
             categoryTitle.text = section?.title
             collectionView.contentOffset = section?.scrollOffset ?? .zero
+
+            if let section = section {
+                collectionViewHeight.constant = section.thumbnailSize.height
+                setNeedsUpdateConstraints()
+            }
         }
     }
 
     var isGhostCell: Bool = false
+    var ghostThumbnailSize: CGSize = defaultThumbnailSize {
+        didSet {
+            collectionViewHeight.constant = ghostThumbnailSize.height
+            setNeedsUpdateConstraints()
+        }
+    }
     var showsCheckMarkWhenSelected = true
 
     override func prepareForReuse() {
@@ -107,7 +120,7 @@ extension CategorySectionTableViewCell: UICollectionViewDelegate {
 
 extension CategorySectionTableViewCell: UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        return CategorySectionTableViewCell.expectedThumbnailSize
+        return section?.thumbnailSize ?? ghostThumbnailSize
      }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,10 +19,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="56.5" width="320" height="240"/>
+                        <rect key="frame" x="0.0" y="53" width="320" height="240"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="240" id="1rt-yd-g3n"/>
+                            <constraint firstAttribute="height" constant="240" id="iK4-y8-V36"/>
                         </constraints>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="8Ds-sb-bxf">
                             <size key="itemSize" width="160" height="230"/>
@@ -36,9 +36,9 @@
                         </connections>
                     </collectionView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                        <rect key="frame" x="20" y="20" width="80" height="20.5"/>
+                        <rect key="frame" x="20" y="20" width="80" height="17"/>
                         <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="13" id="Cne-bu-2aD"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>
                         </constraints>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
@@ -52,7 +52,7 @@
                     <constraint firstItem="mQ0-DH-hTW" firstAttribute="top" secondItem="3pe-2p-9as" secondAttribute="bottom" constant="16" id="Lj1-O3-zk4"/>
                     <constraint firstItem="3pe-2p-9as" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="Mrq-dy-dGi"/>
                     <constraint firstAttribute="trailing" secondItem="mQ0-DH-hTW" secondAttribute="trailing" id="XIg-vD-05h"/>
-                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mQ0-DH-hTW" secondAttribute="bottom" constant="30" id="aLq-Bg-Bfl"/>
+                    <constraint firstAttribute="bottom" secondItem="mQ0-DH-hTW" secondAttribute="bottom" constant="30" id="aLq-Bg-Bfl"/>
                     <constraint firstItem="mQ0-DH-hTW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="yp2-Zm-WoY"/>
                 </constraints>
             </tableViewCellContentView>
@@ -60,6 +60,7 @@
             <connections>
                 <outlet property="categoryTitle" destination="3pe-2p-9as" id="iIk-5g-rMD"/>
                 <outlet property="collectionView" destination="mQ0-DH-hTW" id="E99-YA-UbE"/>
+                <outlet property="collectionViewHeight" destination="iK4-y8-V36" id="Zzr-4L-Fr9"/>
             </connections>
             <point key="canvasLocation" x="153.62318840579712" y="169.75446428571428"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -139,7 +139,9 @@ extension FilterableCategoriesViewController: UITableViewDataSource {
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         cell.section = isLoading ? nil : visibleSections[indexPath.row]
         cell.isGhostCell = isLoading
-        cell.ghostThumbnailSize = ghostThumbnailSize
+        if isLoading {
+            cell.ghostThumbnailSize = ghostThumbnailSize
+        }
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -31,6 +31,11 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     private var filteredSections: [CategorySection]?
     private var visibleSections: [CategorySection] { filteredSections ?? categorySections }
 
+    /// Should be overidden if a subclass uses different sized thumbnails.
+    var ghostThumbnailSize: CGSize {
+        return CategorySectionTableViewCell.defaultThumbnailSize
+    }
+
     internal var isLoading: Bool = true {
         didSet {
             if isLoading {
@@ -64,6 +69,9 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
         tableView.separatorStyle = .singleLine
         tableView.separatorInset = .zero
         tableView.showsVerticalScrollIndicator = false
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = UITableView.automaticDimension
+
         filterBar = CollapsableHeaderFilterBar()
         super.init(scrollableView: tableView,
                    mainTitle: mainTitle,
@@ -95,10 +103,18 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     }
 
     override func estimatedContentSize() -> CGSize {
-        let rowCount = CGFloat(max(visibleSections.count, 1))
-        let estimatedRowHeight: CGFloat = CategorySectionTableViewCell.estimatedCellHeight
-        let estimatedHeight = (estimatedRowHeight * rowCount)
-        return CGSize(width: tableView.contentSize.width, height: estimatedHeight)
+        let height = calculateContentHeight()
+        return CGSize(width: tableView.contentSize.width, height: height)
+    }
+
+    private func calculateContentHeight() -> CGFloat {
+        guard !isLoading, visibleSections.count > 0 else {
+            return ghostThumbnailSize.height + CategorySectionTableViewCell.cellVerticalPadding
+        }
+
+        return visibleSections
+            .map { $0.thumbnailSize.height + CategorySectionTableViewCell.cellVerticalPadding }
+            .reduce(0, +)
     }
 
     public func loadingStateChanged(_ isLoading: Bool) {
@@ -108,11 +124,9 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
     }
 }
 
-extension FilterableCategoriesViewController: UITableViewDataSource {
+// MARK: - UITableViewDataSource
 
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return CategorySectionTableViewCell.estimatedCellHeight
-    }
+extension FilterableCategoriesViewController: UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return isLoading ? 1 : (visibleSections.count)
@@ -127,6 +141,7 @@ extension FilterableCategoriesViewController: UITableViewDataSource {
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         cell.section = isLoading ? nil : visibleSections[indexPath.row]
         cell.isGhostCell = isLoading
+        cell.ghostThumbnailSize = ghostThumbnailSize
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
@@ -143,6 +158,8 @@ extension FilterableCategoriesViewController: UITableViewDataSource {
         return (sectionSlug == rowSection.categorySlug)
     }
 }
+
+// MARK: - CategorySectionTableViewCellDelegate
 
 extension FilterableCategoriesViewController: CategorySectionTableViewCellDelegate {
     func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String) {
@@ -174,6 +191,8 @@ extension FilterableCategoriesViewController: CategorySectionTableViewCellDelega
         }
     }
 }
+
+// MARK: - CollapsableHeaderFilterBarDelegate
 
 extension FilterableCategoriesViewController: CollapsableHeaderFilterBarDelegate {
     func numberOfFilters() -> Int {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/FilterableCategoriesViewController.swift
@@ -69,8 +69,6 @@ class FilterableCategoriesViewController: CollapsableHeaderViewController {
         tableView.separatorStyle = .singleLine
         tableView.separatorInset = .zero
         tableView.showsVerticalScrollIndicator = false
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = UITableView.automaticDimension
 
         filterBar = CollapsableHeaderFilterBar()
         super.init(scrollableView: tableView,

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -12,6 +12,7 @@ class GutenbergLayoutSection: CategorySection {
     var section: PageTemplateCategory
     var layouts: [PageTemplateLayout]
     var scrollOffset: CGPoint
+    var thumbnailSize: CGSize
 
     var title: String { section.title }
     var emoji: String? { section.emoji }
@@ -19,11 +20,12 @@ class GutenbergLayoutSection: CategorySection {
     var description: String? { section.desc }
     var thumbnails: [Thumbnail] { layouts }
 
-    init(_ section: PageTemplateCategory) {
+    init(_ section: PageTemplateCategory, thumbnailSize: CGSize) {
         let layouts = Array(section.layouts ?? []).sorted()
         self.section = section
         self.layouts = layouts
         self.scrollOffset = .zero
+        self.thumbnailSize = thumbnailSize
     }
 }
 
@@ -39,6 +41,12 @@ class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
     let completion: PageCoordinator.TemplateSelectionCompletion
     let blog: Blog
     var previewDeviceButtonItem: UIBarButtonItem?
+
+    static let thumbnailSize = CGSize(width: 160, height: 240)
+
+    override var ghostThumbnailSize: CGSize {
+        return GutenbergLayoutPickerViewController.thumbnailSize
+    }
 
     init(blog: Blog, completion: @escaping PageCoordinator.TemplateSelectionCompletion) {
         self.blog = blog
@@ -108,8 +116,7 @@ class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
 
     private func fetchLayouts() {
         isLoading = resultsController.isEmpty()
-        let expectedThumbnailSize = CategorySectionTableViewCell.expectedThumbnailSize
-        PageLayoutService.fetchLayouts(forBlog: blog, withThumbnailSize: expectedThumbnailSize) { [weak self] result in
+        PageLayoutService.fetchLayouts(forBlog: blog, withThumbnailSize: GutenbergLayoutPickerViewController.thumbnailSize) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success:
@@ -131,7 +138,7 @@ class GutenbergLayoutPickerViewController: FilterableCategoriesViewController {
 
     private func makeSectionData(with controller: NSFetchedResultsController<PageTemplateCategory>?) -> [GutenbergLayoutSection] {
         return controller?.fetchedObjects?.map({ (category) -> GutenbergLayoutSection in
-            return GutenbergLayoutSection(category)
+            return GutenbergLayoutSection(category, thumbnailSize: GutenbergLayoutPickerViewController.thumbnailSize)
         }) ?? []
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignCategoryThumbnailSize.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignCategoryThumbnailSize.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum SiteDesignCategoryThumbnailSize {
+    case category
+    case recommended
+
+    var value: CGSize {
+        switch self {
+        case .category where UIDevice.isPad():
+            return .init(width: 250, height: 325)
+        case .category:
+            return .init(width: 200, height: 260)
+        case .recommended where UIDevice.isPad():
+            return .init(width: 327, height: 450)
+        case .recommended:
+            return .init(width: 350, height: 450)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -64,8 +64,6 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         tableView.separatorStyle = .singleLine
         tableView.separatorInset = .zero
         tableView.showsVerticalScrollIndicator = false
-        tableView.rowHeight = UITableView.automaticDimension
-        tableView.estimatedRowHeight = UITableView.automaticDimension
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -169,7 +169,9 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         cell.section = isLoading ? nil : sections[indexPath.row]
         cell.isGhostCell = isLoading
-        cell.ghostThumbnailSize = ghostThumbnailSize
+        if isLoading {
+            cell.ghostThumbnailSize = ghostThumbnailSize
+        }
         cell.showsCheckMarkWhenSelected = false
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -32,22 +32,27 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
                 scrollableView.setContentOffset(.zero, animated: false)
             }
             sections = siteDesigns.categories.map { category in
-                SiteDesignSection(category: category, designs: siteDesigns.designs.filter { design in design.categories.map({$0.slug}).contains(category.slug)
-                })
+                SiteDesignSection(
+                    category: category,
+                    designs: siteDesigns.designs.filter { design in design.categories.map({$0.slug}).contains(category.slug) },
+                    thumbnailSize: SiteDesignCategoryThumbnailSize.category.value
+                )
             }
             contentSizeWillChange()
             tableView.reloadData()
         }
     }
+
+    private var ghostThumbnailSize: CGSize {
+        return SiteDesignCategoryThumbnailSize.category.value
+    }
+
     let selectedPreviewDevice = PreviewDevice.mobile
 
     init(createsSite: Bool, _ completion: @escaping SiteDesignStep.SiteDesignSelection) {
         self.completion = completion
         self.createsSite = createsSite
         tableView = UITableView(frame: .zero, style: .plain)
-        tableView.separatorStyle = .singleLine
-        tableView.separatorInset = .zero
-        tableView.showsVerticalScrollIndicator = false
 
         super.init(
             scrollableView: tableView,
@@ -55,6 +60,12 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
             // the primary action button is never shown
             primaryActionTitle: ""
         )
+
+        tableView.separatorStyle = .singleLine
+        tableView.separatorInset = .zero
+        tableView.showsVerticalScrollIndicator = false
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = UITableView.automaticDimension
     }
 
     required init?(coder: NSCoder) {
@@ -74,8 +85,10 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
 
     private func fetchSiteDesigns() {
         isLoading = true
-        let thumbnailSize = CategorySectionTableViewCell.expectedThumbnailSize
-        let request = SiteDesignRequest(withThumbnailSize: thumbnailSize, withGroups: templateGroups)
+        let request = SiteDesignRequest(
+            withThumbnailSize: SiteDesignCategoryThumbnailSize.category.value,
+            withGroups: templateGroups
+        )
         SiteDesignServiceRemote.fetchSiteDesigns(restAPI, request: request) { [weak self] (response) in
             DispatchQueue.main.async {
                 switch response {
@@ -135,6 +148,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
 // MARK: - NoResultsViewControllerDelegate
 
 extension SiteDesignContentCollectionViewController: NoResultsViewControllerDelegate {
+
     func actionButtonPressed() {
         fetchSiteDesigns()
     }
@@ -143,10 +157,6 @@ extension SiteDesignContentCollectionViewController: NoResultsViewControllerDele
 // MARK: - UITableViewDataSource
 
 extension SiteDesignContentCollectionViewController: UITableViewDataSource {
-
-    func tableView(_ tableView: UITableView, estimatedHeightForRowAt indexPath: IndexPath) -> CGFloat {
-        return CategorySectionTableViewCell.estimatedCellHeight
-    }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return isLoading ? 1 : (sections.count)
@@ -161,6 +171,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
         cell.section = isLoading ? nil : sections[indexPath.row]
         cell.isGhostCell = isLoading
+        cell.ghostThumbnailSize = ghostThumbnailSize
         cell.showsCheckMarkWhenSelected = false
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
@@ -172,6 +183,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
 // MARK: - CategorySectionTableViewCellDelegate
 
 extension SiteDesignContentCollectionViewController: CategorySectionTableViewCellDelegate {
+
     func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String) {
         guard let sectionIndex = sections.firstIndex(where: { $0.categorySlug == slug }) else { return }
         let design = sections[sectionIndex].designs[position]

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
@@ -3,6 +3,7 @@ import Foundation
 class SiteDesignSection: CategorySection {
     var category: RemoteSiteDesignCategory
     var designs: [RemoteSiteDesign]
+    var thumbnailSize: CGSize
 
     var categorySlug: String { category.slug }
     var title: String { category.title }
@@ -11,9 +12,10 @@ class SiteDesignSection: CategorySection {
     var thumbnails: [Thumbnail] { designs }
     var scrollOffset: CGPoint
 
-    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign]) {
+    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign], thumbnailSize: CGSize) {
         self.category = category
         self.designs = designs
+        self.thumbnailSize = thumbnailSize
         self.scrollOffset = .zero
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2202,6 +2202,8 @@
 		C3234F4F27EB96AB004ADB29 /* IntentCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3302CC527EB67D0004229D3 /* IntentCell.swift */; };
 		C3234F5427EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */; };
 		C3234F5527EBBACA004ADB29 /* SiteIntentVertical.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */; };
+		C32A6A2C2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32A6A2B2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift */; };
+		C32A6A2D2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32A6A2B2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift */; };
 		C3439B5F27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3439B5E27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift */; };
 		C352870527FDD35C004E2E51 /* SiteNameStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352870427FDD35C004E2E51 /* SiteNameStep.swift */; };
 		C352870627FDD35C004E2E51 /* SiteNameStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352870427FDD35C004E2E51 /* SiteNameStep.swift */; };
@@ -7005,6 +7007,7 @@
 		C2988A406A3D5697C2984F3E /* Pods-WordPressStatsWidgets.release-internal.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.release-internal.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.release-internal.xcconfig"; sourceTree = "<group>"; };
 		C314543A262770BE005B216B /* BlogServiceAuthorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceAuthorTests.swift; sourceTree = "<group>"; };
 		C3234F5327EBBACA004ADB29 /* SiteIntentVertical.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentVertical.swift; sourceTree = "<group>"; };
+		C32A6A2B2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignCategoryThumbnailSize.swift; sourceTree = "<group>"; };
 		C3302CC427EB67D0004229D3 /* IntentCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = IntentCell.xib; sourceTree = "<group>"; };
 		C3302CC527EB67D0004229D3 /* IntentCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentCell.swift; sourceTree = "<group>"; };
 		C3439B5E27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationWizardLauncherTests.swift; sourceTree = "<group>"; };
@@ -10186,6 +10189,7 @@
 				46241C0E2540BD01002B8A12 /* SiteDesignStep.swift */,
 				46241C3A2540D483002B8A12 /* SiteDesignContentCollectionViewController.swift */,
 				C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */,
+				C32A6A2B2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift */,
 			);
 			path = "Design Selection";
 			sourceTree = "<group>";
@@ -18492,6 +18496,7 @@
 				9A4E61F821A2C3BC0017A925 /* RevisionDiff+CoreData.swift in Sources */,
 				7E7947AB210BAC5E005BB851 /* NotificationCommentRange.swift in Sources */,
 				FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */,
+				C32A6A2C2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift in Sources */,
 				D816C1E920E0880400C4D82F /* NotificationAction.swift in Sources */,
 				E19B17B01E5C69A5007517C6 /* NSManagedObject.swift in Sources */,
 				FF355D981FB492DD00244E6D /* ExportableAsset.swift in Sources */,
@@ -21633,6 +21638,7 @@
 				FABB25EA2602FC2C00C8785C /* PeopleRoleBadgeLabel.swift in Sources */,
 				FABB25EB2602FC2C00C8785C /* ActivityDetailViewController.swift in Sources */,
 				FABB25EC2602FC2C00C8785C /* BlogListViewController+BlogDetailsFactory.swift in Sources */,
+				C32A6A2D2832BF02002E9394 /* SiteDesignCategoryThumbnailSize.swift in Sources */,
 				FABB25ED2602FC2C00C8785C /* WebViewControllerConfiguration.swift in Sources */,
 				FABB25EE2602FC2C00C8785C /* ViewMoreRow.swift in Sources */,
 				FABB25EF2602FC2C00C8785C /* ReaderWebView.swift in Sources */,


### PR DESCRIPTION
Fixes #18448

## Overview
- Allows `CategorySectionTableViewCell`s to have varying heights
- Enlarges thumbnails to match the project designs
  - See [SiteDesignCategoryThumbnailSize.swift](https://github.com/wordpress-mobile/WordPress-iOS/blob/task/site-design-enlarge-screenshots/WordPress/Classes/ViewRelated/Site%20Creation/Design%20Selection/SiteDesignCategoryThumbnailSize.swift) for values
- Adds support for mixing `CategorySection`s for various heights to prepare for #18434
- Sets iPhone Site Design thumbnails to `200x260`
- Sets iPad Site Design thumbnails to `250x325`

### iPhone

#### Site Design

| Before | After |
| - | - |
| <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722344-6c110a7b-8474-4dd4-adfd-f1102d282de7.png"> | <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722363-6c08a1bf-935e-4078-be1a-d7940b7d7de8.png" /> |

#### Page Layout (no changes expected)

| Before | After |
| - | - |
| <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722386-cb1e135b-ef33-4d28-b192-98da5bb5ac8a.png" /> | <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722402-45ae2de3-7752-4c8e-b444-9d83fe6b32d9.png" /> |

### iPad

#### Site Design

| Before | After |
| - | - |
| <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722436-2db99724-0045-4edd-bd52-09f7105c02ed.png" /> | <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722454-9e7b457f-9b0d-4bb0-8e43-b761b77fc839.png" /> |

#### Page Layout (no changes expected)

| Before | After |
| - | - |
| <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722501-7fb7ea53-7dcf-44fa-8fa1-18f319e87ede.png" /> | <img width="300px" src="https://user-images.githubusercontent.com/2092798/168722535-945dccae-c372-4ec5-9126-f1b3277a1821.png" /> |

## Notes

### This PR:
- Does not change the size of category labels.
- Does not address a large gap of space under the view's title. We can do this after adding the [recommended designs section](https://github.com/wordpress-mobile/WordPress-iOS/issues/18434).
- Does not address [this UITableView warning](https://github.com/wordpress-mobile/WordPress-iOS/issues/18514) (that predates the Site Design revamp project).

## Testing

### Site Design picker

1. Start the Site Creation flow
2. Navigate to the Site Design picker

#### Expectations:
- "Ghost cells" are shown while the designs are loading and they fit the expected dimensions for iPhone and iPad (it can help to [slow down your network connection](https://nshipster.com/network-link-conditioner/))
- The thumbnails have dimensions of `200x260` on iPhone, and `250x325` on iPad
- Designs can be scrolled horizontally and vertically
- A row separator is shown between categories
- Rotating the view renders properly
- Tapping a design shows its preview
- Tapping "Choose" or "Create Site" (depending on Site Name experiment track) successfully creates a site with the chosen design
- Tapping "Skip" skips choosing a design
- (Running from Xcode only) No `UICollectionView` warnings are shown in the target output

### Page Design picker

1. Tap the FAB on the My Site view
2. Select "Site page"

#### Expectations:
- "Ghost cells" are shown while the designs are loading and they fit the expected dimensions for iPhone and iPad (it can help to [slow down your network connection](https://nshipster.com/network-link-conditioner/))
- The thumbnails have dimensions of `160x240` on both iPhone and iPad
- Designs can be scrolled horizontally and vertically
- A row separator is shown between categories
- Rotating the view renders properly
- Filtering categories works as expected
- (Running from Xcode only) No `UICollectionView` warnings are shown in the target output

## Regression Notes
1. Potential unintended areas of impact
  - Page Design picker (high risk)
    - Ghost views (shown when loading)
    - Filtering designs and scrolling
  - Site Creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manual testing across multiple devices.

3. What automated tests I added (or what prevented me from doing so)
  - No automated tests were added as this is very little logic and mostly UI code.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
