### PR TITLE
Use ContextManager directly in ContextManagerTests

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -3,6 +3,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+/**
+ A constant representing current version of data model.
+
+ @see -[ContextManager initWithModelName:storeURL:]
+ */
+FOUNDATION_EXTERN NSString * const ContextManagerModelNameCurrent;
+
 @protocol CoreDataStack
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
 - (NSManagedObjectContext *const)newDerivedContext;
@@ -33,6 +40,18 @@ NS_ASSUME_NONNULL_BEGIN
  @return instance of ContextManager
 */
 + (instancetype)internalSharedInstance;
+
+/**
+ Create a ContextManager instance with given model name and database location.
+
+ Note: This initialiser is only used for testing purpose at the moment.
+
+ @param modelName Model name in Core Data data model file.
+                  Use ContextManagerModelNameCurrent for current version, or
+                  "WordPress <version>" for specific version.
+ @param storeURL Database location.
+ */
+- (instancetype)initWithModelName:(NSString *)modelName storeURL:(NSURL *)storeURL NS_DESIGNATED_INITIALIZER;
 
 
 ///--------------------------

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -4,7 +4,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 /**
- A constant representing current version of data model.
+ A constant representing the current version of the data model.
 
  @see -[ContextManager initWithModelName:storeURL:]
  */

--- a/WordPress/WordPressTest/ContextManagerMock.h
+++ b/WordPress/WordPressTest/ContextManagerMock.h
@@ -4,21 +4,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@protocol ManagerMock
-@property (nonatomic, readwrite, strong) NSManagedObjectContext         *mainContext;
-@property (nonatomic, readwrite, strong) NSManagedObjectModel           *managedObjectModel;
-@property (nonatomic, readwrite, strong) NSPersistentStoreCoordinator   *persistentStoreCoordinator;
-@property (nonatomic, readonly,  strong) NSPersistentStoreCoordinator   *standardPSC;
-@property (nonatomic, readonly,  strong) NSURL                          *storeURL;
-@end
-
 /**
  *  @class      ContextManagerMock
  *  @brief      This class overrides standard ContextManager functionality, for testing purposes.
  *  @details    The SQLite-Backed PSC is replaced by an InMemory store. This allows us to easily reset
  *              the contents of the database, without even hitting the filesystem.
  */
-@interface ContextManagerMock : ContextManager <ManagerMock, CoreDataStack>
+@interface ContextManagerMock : ContextManager
 
 - (void)setUpAsSharedInstance;
 - (void)tearDown;

--- a/WordPress/WordPressTest/ContextManagerMock.m
+++ b/WordPress/WordPressTest/ContextManagerMock.m
@@ -1,61 +1,10 @@
 #import "ContextManagerMock.h"
 
-// This deserves a little bit of explanation – this was previously part of the public interface for `ContextManager`, which shouldn't make this API
-// public to the hosting app. Rather than rework the `CoreDataMigrationTests` right away (which will be done later as part of adopting Woo's
-// updated and well-tested migrator), we can use this hack for now to preserve the behaviour for those tests and come back to them later.
-@interface ContextManager(DeprecatedAccessors)
-    - (NSPersistentStoreCoordinator *) persistentStoreCoordinator;
-    - (NSManagedObjectModel *) managedObjectModel;
-@end
-
 @implementation ContextManagerMock
 
-@synthesize persistentStoreCoordinator = _persistentStoreCoordinator;
-@synthesize mainContext = _mainContext;
-@synthesize managedObjectModel = _managedObjectModel;
-
-- (NSManagedObjectModel *)managedObjectModel
+- (instancetype)init
 {
-    return _managedObjectModel ?: [super managedObjectModel];
-}
-
-- (NSPersistentStoreCoordinator *)persistentStoreCoordinator
-{
-    if (_persistentStoreCoordinator) {
-        return _persistentStoreCoordinator;
-    }
-
-    // This is important for automatic version migration. Leave it here!
-    NSDictionary *options = @{
-        NSInferMappingModelAutomaticallyOption          : @(YES),
-        NSMigratePersistentStoresAutomaticallyOption    : @(YES)
-    };
-
-    NSError *error = nil;
-    _persistentStoreCoordinator = [[NSPersistentStoreCoordinator alloc]
-                                   initWithManagedObjectModel:self.managedObjectModel];
-
-    if (![_persistentStoreCoordinator addPersistentStoreWithType:NSInMemoryStoreType
-                                                   configuration:nil
-                                                             URL:nil
-                                                         options:options
-                                                           error:&error]) {
-        NSLog(@"Unresolved error %@, %@", error, [error userInfo]);
-        abort();
-    }
-
-    return _persistentStoreCoordinator;
-}
-
-- (NSPersistentStoreCoordinator *)standardPSC
-{
-    return [super persistentStoreCoordinator];
-}
-
-- (void)createMainContext
-{
-    self.mainContext = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
-    self.mainContext.persistentStoreCoordinator = self.persistentStoreCoordinator;
+    return [super initWithModelName:ContextManagerModelNameCurrent storeURL:[NSURL fileURLWithPath:@"/dev/null"]];
 }
 
 - (void)saveContextAndWait:(NSManagedObjectContext *)context
@@ -65,15 +14,6 @@
     // This log magically resolves a deadlock in
     // `ZDashboardCardTests.testShouldNotShowQuickStartIfDefaultSectionIsSiteMenu`
     NSLog(@"Context save completed");
-}
-
-- (NSURL *)storeURL
-{
-    NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
-                                                                        NSUserDomainMask,
-                                                                        YES) lastObject];
-
-    return [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPressTest.sqlite"]];
 }
 
 - (void)setUpAsSharedInstance

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -5,82 +5,64 @@ import CoreData
 @testable import WordPress
 
 class ContextManagerTests: XCTestCase {
-    var contextManager: ContextManagerMock!
+    let storeURL = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("ContextManagerTests.sqlite")
 
-    override func setUp() {
-        super.setUp()
-
-        contextManager = ContextManagerMock()
+    override func setUpWithError() throws {
+        if FileManager.default.fileExistsAtURL(storeURL) {
+            try FileManager.default.removeItem(at: storeURL)
+        }
     }
 
-    func testIterativeMigration() {
-        let model19Name = "WordPress 19"
+    func testIterativeMigration() throws {
+        var objectID: NSManagedObjectID? = nil
 
-        // Instantiate a Model 19 Stack
-        startupCoredataStack(model19Name)
+        try prepareForMigration(withModelName: "WordPress 19") { context in
+            // Insert a Theme Entity
+            let objectOriginal = NSEntityDescription.insertNewObject(forEntityName: "Theme", into: context)
+            try context.obtainPermanentIDs(for: [objectOriginal])
+            try context.save()
 
-        let mocOriginal = contextManager.mainContext
-        let psc = contextManager.persistentStoreCoordinator
+            XCTAssertFalse(objectOriginal.objectID.isTemporaryID, "Should be a permanent object")
+            objectID = objectOriginal.objectID
 
-        // Insert a Theme Entity
-        let objectOriginal = NSEntityDescription.insertNewObject(forEntityName: "Theme", into: mocOriginal)
-        try! mocOriginal.obtainPermanentIDs(for: [objectOriginal])
-        try! mocOriginal.save()
-
-        let objectID = objectOriginal.objectID
-        XCTAssertFalse(objectID.isTemporaryID, "Should be a permanent object")
-
-        try XCTAssertThrowsError(
-            WPException.objcTry({
-                objectOriginal.value(forKey: "author")
-            }),
-            "Theme.author doesn't exist in \(model19Name)"
-        )
+            try XCTAssertThrowsError(
+                WPException.objcTry({
+                    objectOriginal.value(forKey: "author")
+                }),
+                "Theme.author doesn't exist in WordPress 19"
+            )
+        }
 
         // Migrate to the latest
-        let persistentStore = psc.persistentStores.first!
-        try! psc.remove(persistentStore)
-
-        let standardPSC = contextManager.standardPSC
-
-        XCTAssertNotNil(standardPSC, "New store should exist")
-        XCTAssertTrue(standardPSC.persistentStores.count == 1, "Should be one persistent store.")
-
-        // Verify if the Theme Entity is there
-        let mocSecond = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
-        mocSecond.persistentStoreCoordinator = standardPSC
-        let object = try! mocSecond.existingObject(with: objectID)
-        XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author exists in current version")
-
+        let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL)
+        let object = try contextManager.mainContext.existingObject(with: XCTUnwrap(objectID))
         XCTAssertNotNil(object, "Object should exist in new PSC")
+        XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author exists in current version")
     }
 
-    func testMigrate24to25AvatarURLtoBasePost() {
+    func testMigrate24to25AvatarURLtoBasePost() throws {
         let model24Name = "WordPress 24"
         let model25Name = "WordPress 25"
 
-        // Instantiate a Model 24 Stack
-        startupCoredataStack(model24Name)
-
-        let mainContext = contextManager.mainContext
-        _ = contextManager.persistentStoreCoordinator
-
-        let account = newAccountInContext(context: mainContext)
-        let blog = newBlogInAccount(account: account)
-
         let authorAvatarURL = "http://lorempixum.com/"
 
-        let post = NSEntityDescription.insertNewObject(forEntityName: "Post", into: mainContext) as! Post
-        post.blog = blog
-        post.authorAvatarURL = authorAvatarURL
+        try prepareForMigration(withModelName: model24Name) { context in
+            let account = newAccountInContext(context: context)
+            let blog = newBlogInAccount(account: account)
 
-        let readerPost = NSEntityDescription.insertNewObject(forEntityName: "ReaderPost", into: mainContext) as! ReaderPost
-        readerPost.authorAvatarURL = authorAvatarURL
+            let post = NSEntityDescription.insertNewObject(forEntityName: "Post", into: context) as! Post
+            post.blog = blog
+            post.authorAvatarURL = authorAvatarURL
 
-        try! mainContext.save()
+            let readerPost = NSEntityDescription.insertNewObject(forEntityName: "ReaderPost", into: context) as! ReaderPost
+            readerPost.authorAvatarURL = authorAvatarURL
+
+            try context.save()
+        }
 
         // Initialize 24 > 25 Migration
-        let secondContext = performCoredataMigration(model25Name)
+        let contextManager = ContextManager(modelName: model25Name, store: storeURL)
+        let secondContext = contextManager.mainContext
 
         // Test the existence of Post object after migration
         let allPostsRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "Post")
@@ -114,78 +96,6 @@ class ContextManagerTests: XCTestCase {
         }
     }
 
-    // MARK: - Helper Methods
-
-    fileprivate func startupCoredataStack(_ modelName: String) {
-        let modelURL = urlForModelName(modelName)!
-        let model = NSManagedObjectModel(contentsOf: modelURL)!
-        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
-
-        let storeUrl = contextManager.storeURL
-        removeStoresBasedOnStoreURL(storeUrl)
-        do {
-            _ = try persistentStoreCoordinator.addPersistentStore(ofType: NSSQLiteStoreType, configurationName: nil, at: storeUrl, options: nil)
-        } catch let error as NSError {
-            XCTAssertNil(error, "Store should exist")
-        }
-
-        let mainContext = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
-        mainContext.persistentStoreCoordinator = persistentStoreCoordinator
-
-        contextManager.managedObjectModel = model
-        contextManager.mainContext = mainContext
-        contextManager.persistentStoreCoordinator = persistentStoreCoordinator
-    }
-
-    fileprivate func performCoredataMigration(_ newModelName: String) -> NSManagedObjectContext {
-        let psc = contextManager.persistentStoreCoordinator
-        _ = contextManager.mainContext
-
-        let persistentStore = psc.persistentStores.first!
-        try! psc.remove(persistentStore)
-
-        let newModelURL = urlForModelName(newModelName)!
-        contextManager.managedObjectModel = NSManagedObjectModel(contentsOf: newModelURL)!
-        let standardPSC = contextManager.standardPSC
-
-        XCTAssertNotNil(standardPSC, "New store should exist")
-        XCTAssertTrue(standardPSC.persistentStores.count == 1, "Should be one persistent store.")
-
-        let secondContext = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
-        secondContext.persistentStoreCoordinator = standardPSC
-        return secondContext
-    }
-
-    fileprivate func urlForModelName(_ name: String) -> URL? {
-        let bundle = Bundle.main
-        var url = bundle.url(forResource: name, withExtension: "mom")
-
-        if url == nil {
-            let momdPaths = bundle.urls(forResourcesWithExtension: "momd", subdirectory: nil)!
-            for momdPath in momdPaths {
-                url = bundle.url(forResource: name, withExtension: "mom", subdirectory: momdPath.lastPathComponent)
-            }
-        }
-
-        return url
-    }
-
-    fileprivate func removeStoresBasedOnStoreURL(_ storeURL: URL) {
-        if storeURL.lastPathComponent.isEmpty {
-            return
-        }
-
-        let fileManager = FileManager.default
-        let directoryUrl = storeURL.deletingLastPathComponent
-        let files = try! fileManager.contentsOfDirectory(at: directoryUrl(), includingPropertiesForKeys: nil, options: FileManager.DirectoryEnumerationOptions.skipsSubdirectoryDescendants)
-        for file in files {
-            let range = file.lastPathComponent.range(of: storeURL.lastPathComponent)
-            if range?.lowerBound != range?.upperBound {
-                try! fileManager.removeItem(at: file)
-            }
-        }
-    }
-
     private func newAccountInContext(context: NSManagedObjectContext) -> WPAccount {
         let account = NSEntityDescription.insertNewObject(forEntityName: "Account", into: context) as! WPAccount
         account.username = "username"
@@ -201,5 +111,39 @@ class ContextManagerTests: XCTestCase {
         blog.url = "http://test.blog/"
         blog.account = account
         return blog
+    }
+
+    /// Insert data into `storeURL` using the context object provided by this function.
+    ///
+    /// This function ensures created Core Data stack is cleaned up properly, so that the database file
+    /// is ready to be used by `ContextManager` to perform migration.
+    private func prepareForMigration(withModelName modelName: String, block: (NSManagedObjectContext) throws -> Void) throws {
+        let model = try XCTUnwrap(NSManagedObjectModel(contentsOf: XCTUnwrap(urlForModelName(modelName))))
+        let container = NSPersistentContainer(name: "WordPress", managedObjectModel: model)
+        let storeDesc = NSPersistentStoreDescription(url: storeURL)
+        storeDesc.type = NSSQLiteStoreType
+        container.persistentStoreDescriptions = [storeDesc]
+        container.loadPersistentStores { _, error in
+            XCTAssertNil(error)
+        }
+
+        try block(container.viewContext)
+
+        let store = try XCTUnwrap(container.persistentStoreCoordinator.persistentStores.first)
+        try container.persistentStoreCoordinator.remove(store)
+    }
+
+    fileprivate func urlForModelName(_ name: String) -> URL? {
+        let bundle = Bundle.main
+        var url = bundle.url(forResource: name, withExtension: "mom")
+
+        if url == nil {
+            let momdPaths = bundle.urls(forResourcesWithExtension: "momd", subdirectory: nil)!
+            for momdPath in momdPaths {
+                url = bundle.url(forResource: name, withExtension: "mom", subdirectory: momdPath.lastPathComponent)
+            }
+        }
+
+        return url
     }
 }

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -37,7 +37,7 @@ class ContextManagerTests: XCTestCase {
         let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL)
         let object = try contextManager.mainContext.existingObject(with: XCTUnwrap(objectID))
         XCTAssertNotNil(object, "Object should exist in new PSC")
-        XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author exists in current version")
+        XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author should exist in current model version, but we were unable to fetch it")
     }
 
     func testMigrate24to25AvatarURLtoBasePost() throws {

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -29,7 +29,7 @@ class ContextManagerTests: XCTestCase {
                 WPException.objcTry({
                     objectOriginal.value(forKey: "author")
                 }),
-                "Theme.author doesn't exist in WordPress 19"
+                "Theme.author doesn't exist in WordPress 19 but we were able to fetch it"
             )
         }
 

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -30,6 +30,13 @@ class ContextManagerTests: XCTestCase {
         let objectID = objectOriginal.objectID
         XCTAssertFalse(objectID.isTemporaryID, "Should be a permanent object")
 
+        try XCTAssertThrowsError(
+            WPException.objcTry({
+                objectOriginal.value(forKey: "author")
+            }),
+            "Theme.author doesn't exist in \(model19Name)"
+        )
+
         // Migrate to the latest
         let persistentStore = psc.persistentStores.first!
         try! psc.remove(persistentStore)
@@ -43,6 +50,7 @@ class ContextManagerTests: XCTestCase {
         let mocSecond = NSManagedObjectContext(concurrencyType: NSManagedObjectContextConcurrencyType.mainQueueConcurrencyType)
         mocSecond.persistentStoreCoordinator = standardPSC
         let object = try! mocSecond.existingObject(with: objectID)
+        XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author exists in current version")
 
         XCTAssertNotNil(object, "Object should exist in new PSC")
     }


### PR DESCRIPTION
This PR is part of paaHJt-3ky-p2.

## Changes

The main change is adding a new initialiser to `ContextManager`: `initWithModelName:storeURL:`. Using this initialiser, `ContextManager` can be instantiated with a specific version of data model and a path to database file. I don't think this change has any negative impact on the app. The app uses the same `NSManagedObjectModel` instance and `storeURL` as before.

With this new initialiser, it's now possible to use `ContextManager` directly in unit tests, rather than using the mock implementation `ContextManagerMock`, which is what's been done to `ContextManagerTests`. The original `testIterativeMigration` test actually produced a false pass. The database wasn't migrated, but there is no assertion in place to catch that error. This issue is fixed in this PR.

`ContextManagerMock` is simplified as result of the new `ContextManager` initialiser. The mock now reuses its superclass `ContextManager`'s implementation, rather than creating its own Core Data stack. In an ideally world, `ContextManagerMock` doesn't even need to exist, since all test case needs is a in memory Core Data stack, which is basically `ContextManager(modelName: .current, storeURL: "/dev/null")`. But due to an existing deadlock issue(see the comments in `ContextManagerMocks.saveContextAndWait`), this mock has to exist for now.

## Test Instructions

Kill and launch app, try a use case that accesses Core Data database. Repeat for a few different use cases.

I don't see a great risk in this change, so probably don't need to do a full feature regression test.

## Regression Notes

1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I've done what's mentioned in "Test Instructions".

3. What automated tests I added (or what prevented me from doing so)
Updated an existing one to use changes in this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
