### PR TITLE
Hotfix: fix dashboard/site menu assignment

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -521,7 +521,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     // This should be removed once the experiment is done
     //
     private func assignMySiteExperimentIfNeeded(event: WPAnalyticsStat) {
-        if event == .signedIn {
+        if event == .signedIn || event == .createdAccount {
             if FeatureFlag.mySiteDashboard.enabled {
                 let isTreatment = BlogDashboardAB.shared.variant == .treatment
                 MySiteSettings().setDefaultSection(isTreatment ? .dashboard : .siteMenu)


### PR DESCRIPTION
**Update: See https://github.com/wordpress-mobile/WordPress-iOS/pull/18647 ( – @mokagio )**

---

More details in #18625

@mokagio it would be possible to release a hotfix with this change? This is not a crash, but we've identified that we're not assigning users to the dashboard/site menu correctly.

Basically, every user that login with SIWA or Google is not getting assigned to the experiment. At first, I thought the issue was just in the triggering of the `account_created` event but it's worst.

Sorry for any inconvenience.

Ps.: I created this branch from `19.8.0.2` tag.

Ps2.: the only required hotfix here is for WPiOS (Jetpack is not necessary). I don't know if that makes something easier for you but it's ok if we don't hotfix Jetpack.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
