### PR TITLE
Answer Prompt: do not pre-populate post title

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -4,7 +4,7 @@ extension Post {
         guard let prompt = prompt else {
             return
         }
-        postTitle = prompt.title
+
         content = prompt.content
     }
 


### PR DESCRIPTION
Ref: #18473, p1652819351305729-slack-C01CW1VMLAF

To match Android (referenced Slack conversation), the post title is no longer populated when answering a prompt.

To test:
- Enable `bloggingPrompts` feature flag.
- Select `Answer prompt` on either the Dashboard prompt card or the FAB header card.
- Verify the post does not have a title.

| Before | After |
|--------|-------|
| ![title](https://user-images.githubusercontent.com/1816888/168913069-f05766d4-4246-4550-b372-20d56553ccea.png) | ![no_title](https://user-images.githubusercontent.com/1816888/168913075-f5916116-ceb5-4128-b222-e1edb994cb7a.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.