### PR TITLE
Stats Revamp: Insights Management updates

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -1,3 +1,4 @@
+import UIKit
 /**
  ImmuTable represents the view model for a static UITableView.
 
@@ -291,6 +292,26 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         return viewModel.sections[section].footerText
     }
 
+    open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        if target.responds(to: #selector(UITableViewDataSource.tableView(_:canEditRowAt:))) {
+            return target.tableView?(tableView, canEditRowAt: indexPath) ?? false
+        }
+
+        return false
+    }
+
+    open func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        if target.responds(to: #selector(UITableViewDataSource.tableView(_:canMoveRowAt:))) {
+            return target.tableView?(tableView, canMoveRowAt: indexPath) ?? false
+        }
+
+        return false
+    }
+
+    open func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        target.tableView?(tableView, moveRowAt: sourceIndexPath, to: destinationIndexPath)
+    }
+
     // MARK: UITableViewDelegate
 
     open func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
@@ -352,13 +373,26 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         return nil
     }
 
-    open func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        if target.responds(to: #selector(UITableViewDataSource.tableView(_:canEditRowAt:))) {
-            return target.tableView?(tableView, canEditRowAt: indexPath) ?? false
+    open func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:targetIndexPathForMoveFromRowAt:toProposedIndexPath:))) {
+            return target.tableView?(tableView, targetIndexPathForMoveFromRowAt: sourceIndexPath, toProposedIndexPath: proposedDestinationIndexPath) ?? proposedDestinationIndexPath
         }
 
-        return false
+        return proposedDestinationIndexPath
     }
+
+    open func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:editingStyleForRowAt:))) {
+            return target.tableView?(tableView, editingStyleForRowAt: indexPath)  ?? .none
+        }
+
+        return .none
+    }
+
+    open func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return target.tableView?(tableView, shouldIndentWhileEditingRowAt: indexPath) ?? true
+    }
+
 
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         if target.responds(to: #selector(UITableViewDelegate.tableView(_:trailingSwipeActionsConfigurationForRowAt:))) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -1,13 +1,30 @@
 import UIKit
 import Gridicons
 
+// This exists in addition to `SiteStatsInsightsDelegate` because `[StatSection]`
+// can't be represented in an Obj-C protocol.
+protocol StatsInsightsManagementDelegate: AnyObject {
+    func userUpdatedActiveInsights(_ insights: [StatSection])
+    func insightsManagementDismissed()
+}
+
 class AddInsightTableViewController: UITableViewController {
 
     // MARK: - Properties
-
+    private weak var insightsManagementDelegate: StatsInsightsManagementDelegate?
     private weak var insightsDelegate: SiteStatsInsightsDelegate?
-    private var insightsShown = [StatSection]()
+
+    /// Stored so that we can check if the user has made any changes.
+    private var originalInsightsShown = [StatSection]()
+    private var insightsShown = [StatSection]() {
+        didSet {
+            updateSaveButton()
+        }
+    }
+
     private var selectedStat: StatSection?
+
+    private lazy var saveButton = UIBarButtonItem(barButtonSystemItem: .save, target: self, action: #selector(saveInsights))
 
     private lazy var tableHandler: ImmuTableViewHandler = {
         return ImmuTableViewHandler(takeOver: self)
@@ -17,17 +34,20 @@ class AddInsightTableViewController: UITableViewController {
 
     override init(style: UITableView.Style) {
         super.init(style: style)
-        navigationItem.title = NSLocalizedString("Add New Stats Card", comment: "Add New Stats Card view title")
+
+        navigationItem.title = TextContent.title
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    convenience init(insightsDelegate: SiteStatsInsightsDelegate, insightsShown: [StatSection]) {
+    convenience init(insightsDelegate: SiteStatsInsightsDelegate, insightsManagementDelegate: StatsInsightsManagementDelegate? = nil, insightsShown: [StatSection]) {
         self.init(style: .grouped)
         self.insightsDelegate = insightsDelegate
+        self.insightsManagementDelegate = insightsManagementDelegate
         self.insightsShown = insightsShown
+        self.originalInsightsShown = insightsShown
     }
 
     // MARK: - View
@@ -39,7 +59,12 @@ class AddInsightTableViewController: UITableViewController {
         reloadViewModel()
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
-        tableView.accessibilityIdentifier = "Add Insight Table"
+        tableView.accessibilityIdentifier = TextContent.title
+
+        if FeatureFlag.statsNewAppearance.enabled {
+            tableView.isEditing = true
+            tableView.allowsSelectionDuringEditing = true
+        }
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(image: .gridicon(.cross), style: .plain, target: self, action: #selector(doneTapped))
     }
@@ -47,10 +72,16 @@ class AddInsightTableViewController: UITableViewController {
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
-        if selectedStat == nil {
-            insightsDelegate?.addInsightDismissed?()
+        if FeatureFlag.statsNewAppearance.enabled {
+            // TODO: Check for any changes, prompt user
+        } else {
+            if selectedStat == nil {
+                insightsDelegate?.addInsightDismissed?()
+            }
         }
     }
+
+    // MARK: TableView Data Source / Delegate Overrides
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
         return 38
@@ -60,9 +91,81 @@ class AddInsightTableViewController: UITableViewController {
         return 0
     }
 
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return false
+        }
+
+        return isActiveCardsSection(indexPath.section)
+    }
+
+    override func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return
+        }
+
+        if isActiveCardsSection(sourceIndexPath.section) && isActiveCardsSection(destinationIndexPath.section) {
+            let item = insightsShown.remove(at: sourceIndexPath.row)
+            insightsShown.insert(item, at: destinationIndexPath.row)
+            reloadViewModel()
+        }
+    }
+
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return false
+        }
+
+        return insightsShown.count > 0 && isActiveCardsSection(indexPath.section)
+    }
+    
+    override func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
+        if isActiveCardsSection(proposedDestinationIndexPath.section) {
+            return proposedDestinationIndexPath
+        }
+
+        return IndexPath(row: insightsShown.count - 1, section: 0)
+    }
+
+    override func tableView(_ tableView: UITableView, shouldIndentWhileEditingRowAt indexPath: IndexPath) -> Bool {
+        return false
+    }
+
+    private func isActiveCardsSection(_ sectionIndex: Int) -> Bool {
+        return sectionIndex == 0
+    }
+
+    // MARK: - Actions
+
+    private func updateSaveButton() {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return
+        }
+
+        if insightsShown != originalInsightsShown {
+            navigationItem.rightBarButtonItem = saveButton
+        } else {
+            navigationItem.rightBarButtonItem = nil
+        }
+    }
+
+    @objc func saveInsights() {
+        insightsManagementDelegate?.userUpdatedActiveInsights(insightsShown)
+
+        dismiss(animated: true, completion: nil)
+    }
+
     @objc private func doneTapped() {
         WPAnalytics.trackEvent(.statsInsightsManagementDismissed)
         dismiss(animated: true, completion: nil)
+
+        // TODO: Prompt user if they have unsaved changes
+    }
+
+    fileprivate enum TextContent {
+        static let title = NSLocalizedString("stats.insights.management.title", value: "Manage Stats Cards", comment: "Title of the Stats Insights Management screen")
+        static let activeCardsHeader = NSLocalizedString("stats.insights.management.activeCards", value: "Active Cards", comment: "Header title indicating which Stats Insights cards the user currently has set to active.")
+        static let placeholderRowTitle = NSLocalizedString("stats.insights.management.selectCardsPrompt", value: "Select cards from the list below", comment: "Prompt displayed on the Stats Insights management screen telling the user to tap a row to add it to their list of active cards.")
     }
 }
 
@@ -75,33 +178,84 @@ private extension AddInsightTableViewController {
     }
 
     func tableViewModel() -> ImmuTable {
-        return ImmuTable(sections: [ sectionForCategory(.general),
+        return ImmuTable(sections: [ selectedStatsSection(),
+                                     sectionForCategory(.general),
                                      sectionForCategory(.postsAndPages),
-                                     sectionForCategory(.activity) ]
+                                     sectionForCategory(.activity) ].compactMap({$0})
         )
     }
 
     // MARK: - Table Sections
 
-    func sectionForCategory(_ category: InsightsCategories) -> ImmuTableSection {
-        return ImmuTableSection(headerText: category.title,
-                                rows: category.insights.map {
-                                    let enabled = !insightsShown.contains($0)
+    func selectedStatsSection() -> ImmuTableSection? {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return nil
+        }
 
+        guard insightsShown.count > 0 else {
+            return ImmuTableSection(headerText: TextContent.activeCardsHeader, rows: [placeholderRow])
+        }
+
+        return ImmuTableSection(headerText: TextContent.activeCardsHeader,
+                                rows: insightsShown.map {
                                     return AddInsightStatRow(title: $0.insightManagementTitle,
-                                                             enabled: enabled,
-                                                             action: enabled ? rowActionFor($0) : nil) }
+                                                             enabled: true,
+                                                             action: rowActionFor($0)) }
+        )
+    }
+
+    func sectionForCategory(_ category: InsightsCategories) -> ImmuTableSection? {
+        guard FeatureFlag.statsNewAppearance.enabled else {
+            return ImmuTableSection(headerText: category.title,
+                                    rows: category.insights.map {
+                                        let enabled = !insightsShown.contains($0)
+                                        return AddInsightStatRow(title: $0.insightManagementTitle,
+                                                                 enabled: enabled,
+                                                                 action: enabled ? rowActionFor($0) : nil) }
+            )
+        }
+
+        let rows = category.insights.filter({ !self.insightsShown.contains($0) })
+        guard rows.count > 0 else {
+            return nil
+        }
+
+        return ImmuTableSection(headerText: category.title,
+                                rows: rows.map {
+                                    return AddInsightStatRow(title: $0.insightManagementTitle,
+                                                             enabled: false,
+                                                             action: rowActionFor($0)) }
         )
     }
 
     func rowActionFor(_ statSection: StatSection) -> ImmuTableAction {
         return { [unowned self] row in
-            self.selectedStat = statSection
-            self.insightsDelegate?.addInsightSelected?(statSection)
+            if FeatureFlag.statsNewAppearance.enabled {
+                toggleRow(for: statSection)
+            } else {
+                self.selectedStat = statSection
+                self.insightsDelegate?.addInsightSelected?(statSection)
 
-            WPAnalytics.track(.statsInsightsManagementSaved, properties: ["types": [statSection.title]])
-            self.dismiss(animated: true, completion: nil)
+                WPAnalytics.track(.statsInsightsManagementSaved, properties: ["types": [statSection.title]])
+                self.dismiss(animated: true, completion: nil)
+            }
         }
+    }
+
+    func toggleRow(for statSection: StatSection) {
+        if let index = insightsShown.firstIndex(of: statSection) {
+            insightsShown.remove(at: index)
+        } else {
+            insightsShown.append(statSection)
+        }
+
+        reloadViewModel()
+    }
+
+    var placeholderRow: ImmuTableRow {
+        return AddInsightStatRow(title: TextContent.placeholderRowTitle,
+                                 enabled: false,
+                                 action: nil)
     }
 
     // MARK: - Insights Categories

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/AddInsightTableViewController.swift
@@ -128,7 +128,7 @@ class AddInsightTableViewController: UITableViewController {
 
         return insightsShown.count > 0 && isActiveCardsSection(indexPath.section)
     }
-    
+
     override func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
         if isActiveCardsSection(proposedDestinationIndexPath.section) {
             return proposedDestinationIndexPath
@@ -171,7 +171,7 @@ class AddInsightTableViewController: UITableViewController {
 
     @objc func saveTapped() {
         dismissedViaButton = true
-        
+
         saveChanges()
 
         dismiss(animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -104,7 +104,7 @@ class SiteStatsInsightsTableViewController: UIViewController, StoryboardLoadable
         }
 
         let controller = AddInsightTableViewController(insightsDelegate: self,
-                insightsShown: insightsToShow.compactMap { $0.statSection })
+                insightsManagementDelegate: self, insightsShown: insightsToShow.compactMap { $0.statSection })
         let navigationController = UINavigationController(rootViewController: controller)
         present(navigationController, animated: true, completion: nil)
     }
@@ -633,7 +633,27 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         alert.popoverPresentationController?.sourceView = fromButton
         present(alert, animated: true)
     }
+}
 
+// MARK: - StatsInsightsManagementDelegate
+
+extension SiteStatsInsightsTableViewController: StatsInsightsManagementDelegate {
+    func userUpdatedActiveInsights(_ insights: [StatSection]) {
+        let insightTypes = insights.compactMap({ $0.insightType })
+
+        guard insightTypes.count == insights.count else {
+            return
+        }
+
+        // TODO: Tracks events
+        insightsToShow = insightTypes
+        refreshInsights(forceRefresh: true)
+        updateView()
+    }
+
+    func insightsManagementDismissed() {
+        
+    }
 }
 
 // MARK: - SharingViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -106,6 +106,7 @@ class SiteStatsInsightsTableViewController: UIViewController, StoryboardLoadable
         let controller = AddInsightTableViewController(insightsDelegate: self,
                 insightsManagementDelegate: self, insightsShown: insightsToShow.compactMap { $0.statSection })
         let navigationController = UINavigationController(rootViewController: controller)
+        navigationController.presentationController?.delegate = self
         present(navigationController, animated: true, completion: nil)
     }
 
@@ -648,6 +649,19 @@ extension SiteStatsInsightsTableViewController: StatsInsightsManagementDelegate 
         insightsToShow = insightTypes
         refreshInsights(forceRefresh: true)
         updateView()
+    }
+}
+
+// MARK: - Presentation delegate
+
+extension SiteStatsInsightsTableViewController: UIAdaptivePresentationControllerDelegate {
+    func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
+        guard let navigationController = presentationController.presentedViewController as? UINavigationController,
+        let controller = navigationController.topViewController as? AddInsightTableViewController else {
+            return
+        }
+
+        controller.handleDismissViaGesture(from: self)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -645,14 +645,9 @@ extension SiteStatsInsightsTableViewController: StatsInsightsManagementDelegate 
             return
         }
 
-        // TODO: Tracks events
         insightsToShow = insightTypes
         refreshInsights(forceRefresh: true)
         updateView()
-    }
-
-    func insightsManagementDismissed() {
-        
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Gridicons
 
 // MARK: - Shared Rows
 
@@ -380,8 +381,14 @@ struct AddInsightStatRow: ImmuTableRow {
 
         cell.accessibilityLabel = title
         cell.isAccessibilityElement = true
-        cell.accessibilityTraits = enabled ? .button : .notEnabled
-        cell.accessibilityHint = enabled ? enabledHint : disabledHint
+
+        let canTap = FeatureFlag.statsNewAppearance.enabled ? action != nil : enabled
+        cell.accessibilityTraits = canTap ? .button : .notEnabled
+        cell.accessibilityHint = canTap && enabled ? disabledHint : enabledHint
+
+        if FeatureFlag.statsNewAppearance.enabled {
+            cell.accessoryView = canTap ? UIImageView(image: .gridicon(.addOutline)) : nil
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds extra functionality to the Insights Management screen to allow adding and removing multiple cards as well as rearranging cards. These actions are no longer possible on individual cards as of the revamp / redesign, so we've moved them to Insights Management.

Please note: this functionality has had no design input, so we may want to tweak things after this PR once we've had some designer feedback.

|   |   |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-18 at 16 33 53](https://user-images.githubusercontent.com/4780/169085198-43753d1d-1c3d-47a1-8f2a-37410f3cee41.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-18 at 16 41 19](https://user-images.githubusercontent.com/4780/169085211-7c2b2b95-7a32-47f1-b8c1-b14706bb0728.png) |

### To test

**Feature Flag disabled**
- With the stats feature flags disabled, navigate to Stats > Insights, and choose the settings icon.
- Ensure the screen still has the regular appearance, and you can just add a single card by selecting one. Ensure you can't select an item with grey text.
- When dismissing the screen with the X ensure the `stats_insights_management_dismissed` event is posted (check your console)
- When selecting a card to add, ensure the `stats_add_insight_item_selected` event is posted.

**Feature Flag enabled, screen functionality**
- Enable the `statsNewAppearance` feature flag and and navigate to Stats > Insights, and choose the settings icon.
- Check that your currently visible stats cards are displayed in the Active Cards area at the top.
- Ensure you can tap an active card to move it back to one of the sections below.
- Tap a row with grey text in the lower section to make it an Active card.
- Try this with multiple cards! Try removing all cards from the active section, and adding all cards from other sections. Try a mix.
- Ensure that you can rearrange items in the Active Cards section.
- Tap Save and ensure that your changes are reflected on the Insights screen and you can see the cards you selected in the correct order.
- The `stats_insights_management_saved` event should be posted.

**Save button behavior**
- Enable the `statsNewAppearance` feature flag and and navigate to Stats > Insights, and choose the settings icon.
- Make one or two changes to the Active Cards selection and ensure the Save button appears
- Put the Active Cards back to how they were originally, and ensure the Save button disappears

**Dismiss button behavior**
- Enable the `statsNewAppearance` feature flag and and navigate to Stats > Insights, and choose the settings icon.
- Without changing anything, tap the X to dismiss the screen. Ensure nothing has changed on the Insights screen and the `stats_insights_management_dismissed` event is posted.
- Head back into insights management, and make a change to your Active Cards.
- Tap X again and you should see a prompt at the bottom of the screen (shown in the screenshots above)
- Tap Discard Changes, ensure nothing has changed on the Insights screen and that the `stats_insights_management_dismissed` event is posted.
- Head back into insights management, and make a change to your Active Cards.
- Tap X again and you should see the prompt
- Tap Save Changes, and your cards should be updated and the `stats_insights_management_saved` event should be posted.
- Finally, head back into insights management, make a change to your Active Cards, and tap X again to see the prompt.
- Tap Cancel. You should remain on the insights management screen.

**Swipe down behaviour**
- Run through the previous set of instructions but instead of tapping X, swipe the screen down to dismiss it. The same behaviour should happen.

## Regression Notes

1. Potential unintended areas of impact

The Insights Management screen with the feature flag disabled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested both with and without the feature flag enabled.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
