### PR TITLE
Quick Start for Existing Users: Move site title waypoint to trailing edge

### DIFF
--- a/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Spotlightable.swift
@@ -1,3 +1,4 @@
+import UIKit
 
 protocol Spotlightable: UIView {
     var spotlight: QuickStartSpotlightView? { get }
@@ -6,8 +7,32 @@ protocol Spotlightable: UIView {
 
 class SpotlightableButton: UIButton, Spotlightable {
 
+    enum SpotlightHorizontalPosition {
+        case leading
+        case trailing
+
+        var defaultOffset: UIOffset {
+            switch self {
+            case .leading:
+                return Constants.leadingDefaultOffset
+            case .trailing:
+                return Constants.trailingDefaultOffset
+            }
+        }
+    }
+
     var spotlight: QuickStartSpotlightView?
     var originalTitle: String?
+    var spotlightHorizontalPosition: SpotlightHorizontalPosition = .leading
+
+    private var spotlightHorizontalAnchor: NSLayoutXAxisAnchor {
+        switch spotlightHorizontalPosition {
+        case .leading:
+            return leadingAnchor
+        case .trailing:
+            return trailingAnchor
+        }
+    }
 
     /// If this property is set, the default offset will be overridden.
     ///
@@ -61,7 +86,7 @@ class SpotlightableButton: UIButton, Spotlightable {
         addSubview(spotlightView)
         spotlightView.translatesAutoresizingMaskIntoConstraints = false
 
-        let spotlightXConstraint = spotlightView.centerXAnchor.constraint(equalTo: leadingAnchor)
+        let spotlightXConstraint = spotlightView.centerXAnchor.constraint(equalTo: spotlightHorizontalAnchor)
         let spotlightYConstraint = spotlightView.centerYAnchor.constraint(equalTo: centerYAnchor)
 
         self.spotlightXConstraint = spotlightXConstraint
@@ -82,7 +107,7 @@ class SpotlightableButton: UIButton, Spotlightable {
     }
 
     private func updateConstraintConstants() {
-        let offset = spotlightOffset ?? Constants.defaultOffset
+        let offset = spotlightOffset ?? spotlightHorizontalPosition.defaultOffset
 
         spotlightXConstraint?.constant = offset.horizontal
         spotlightYConstraint?.constant = offset.vertical
@@ -90,6 +115,7 @@ class SpotlightableButton: UIButton, Spotlightable {
 
     private enum Constants {
         static let spotlightDiameter: CGFloat = 40
-        static let defaultOffset = UIOffset(horizontal: -10, vertical: 0)
+        static let leadingDefaultOffset = UIOffset(horizontal: -10, vertical: 0)
+        static let trailingDefaultOffset = UIOffset(horizontal: 10, vertical: 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -277,6 +277,7 @@ fileprivate extension BlogDetailHeaderView {
 
         let titleButton: SpotlightableButton = {
             let button = SpotlightableButton(type: .custom)
+            button.spotlightHorizontalPosition = .trailing
             button.contentHorizontalAlignment = .leading
             button.titleLabel?.font = AppStyleGuide.blogDetailHeaderTitleFont
             button.titleLabel?.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
Ref: p5T066-3dZ-p2#comment-12369

> not sure if it has changed recently but the Check your site title focus point is being displayed maybe a bit closer to the site image than the to site title?.

## Description
Moved the site title waypoint from the leading edge to the trailing edge.

![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 15 57 28](https://user-images.githubusercontent.com/6711616/169090425-3531df67-405b-48fa-bfcc-be1036076377.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 04 35](https://user-images.githubusercontent.com/6711616/169089596-a0039456-ec8b-47bd-975b-75239ac959c8.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 07 51](https://user-images.githubusercontent.com/6711616/169090201-edd83ae0-fde3-4f6d-bea1-b554d7c606d5.png)
-- | -- | --

## Notes
@osullivanchris I ended up keeping the default offset (i.e. 10 px), since the only time it looks like there's too much padding is when the title is truncated. I tried 2 px, 4 px -- while it looked fine when the title is truncated, I think it's not enough padding for non-trucated situations. Lmk what you think.

2px | 2px truncated | 4px | 4 px truncated
-- | -- | -- | --
![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 09 53](https://user-images.githubusercontent.com/6711616/169091000-77163c98-5bda-4c0b-9027-96225574161a.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 10 36](https://user-images.githubusercontent.com/6711616/169091002-ab57f074-9f03-44f0-aabb-978d9bfe2d74.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 11 44](https://user-images.githubusercontent.com/6711616/169090935-29924fdd-21bb-4447-9263-96f6272a3b7d.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-18 at 17 13 48](https://user-images.githubusercontent.com/6711616/169091312-cb25f1b2-be4e-4533-83f9-f51d169112c4.png)

## How to test

1. Enable the Quick Start for New Sites via the debug menu or creating a new site
2. Start the Site Title tour
3. ✅ Verify: The waypoint is displayed at the trailing edge of the title

## Regression Notes
1. Potential unintended areas of impact
- RtL languages

4. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested manually

5. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.