### PR TITLE
Blogging Prompt Compact Card: correctly display prompt text

### DIFF
--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -38,4 +38,8 @@ public class BloggingPrompt: NSManagedObject {
         self.answerCount = Int32(remotePrompt.answeredUsersCount)
         self.displayAvatarURLs = remotePrompt.answeredUserAvatarURLs
     }
+
+    func textForDisplay() -> String {
+        return text.stringByDecodingXMLCharacters().trim()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -354,7 +354,7 @@ private extension DashboardPromptsCardCell {
             return
         }
 
-        promptLabel.text = forExampleDisplay ? Strings.examplePrompt : prompt?.text.stringByDecodingXMLCharacters().trim()
+        promptLabel.text = forExampleDisplay ? Strings.examplePrompt : prompt?.textForDisplay()
         containerStackView.addArrangedSubview(promptTitleView)
 
         if let attribution = prompt?.promptAttribution {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -29,7 +29,7 @@ class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
 
     func configure(_ prompt: BloggingPrompt) {
         self.prompt = prompt
-        titleLabel.text = prompt.text.stringByDecodingXMLCharacters().trim()
+        titleLabel.text = prompt.textForDisplay()
         dateLabel.text = dateFormatter.string(from: prompt.date)
         answerCountLabel.text = answerInfoText
         answeredStateView.isHidden = !prompt.answered

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -93,7 +93,7 @@ private extension BloggingPromptsHeaderView {
     }
 
     func configure(_ prompt: BloggingPrompt?) {
-        promptLabel.text = prompt?.text
+        promptLabel.text = prompt?.textForDisplay()
 
         let answered = prompt?.answered ?? false
         answerPromptButton.isHidden = answered


### PR DESCRIPTION
Ref: #18572

The prompt text displayed on the compact card is now decoded so XML characters are displayed correctly. 

In addition, a `textForDisplay` method is added to `BloggingPrompt`, and all prompt displays now use it.

To test:
- Enable `bloggingPrompts` feature flag.
- Verify the prompt text in the FAB header, dashboard prompt card, and prompts list is displayed correctly.
  - Today's prompt may not have XML characters, but since all three views use the new method, verifying the prompts list should suffice.

| Compact Card Before | Compact Card After |
|--------|-------|
| <img width="432" alt="compact_before" src="https://user-images.githubusercontent.com/1816888/169140727-34069ef1-2afa-4c07-b08e-a763f11172e2.png"> | <img width="434" alt="compact_after" src="https://user-images.githubusercontent.com/1816888/169140723-a12282ed-693b-4af1-8e27-2363d54a9c7a.png"> |

| Cards | List |
|--------|-------|
| ![cards_after](https://user-images.githubusercontent.com/1816888/169140906-347e1a26-e474-4fdd-ad14-98510ed9c9ae.png) | ![prompts_list](https://user-images.githubusercontent.com/1816888/169140898-38ae3a40-5226-4b6c-b719-5a960a1d801a.png) |

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
