### PR TITLE
Site Design Revamp - Add Helper Text at the bottom

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -37,6 +37,11 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         false
     }
 
+    // Set this property to true to add a custom footerView with custom sizing when scrollableView is UITableView.
+    var allowCustomTableFooterView: Bool {
+        false
+    }
+
     private let hasDefaultAction: Bool
     private var notificationObservers: [NSObjectProtocol] = []
     @IBOutlet weak var containerView: UIView!
@@ -466,6 +471,11 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         let distanceToBottom = scrollableView.frame.height - minHeaderHeight - estimatedContentSize().height
         let newHeight: CGFloat = max(footerHeight, distanceToBottom)
         if let tableView = scrollableView as? UITableView {
+
+            guard !allowCustomTableFooterView else {
+                return
+            }
+
             tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.width, height: newHeight))
             tableView.tableFooterView?.isGhostableDisabled = true
             tableView.tableFooterView?.backgroundColor = .clear

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -114,9 +114,12 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = WPStyleGuide.fontForTextStyle(.body)
-        label.numberOfLines = 0
+        label.numberOfLines = Metrics.helperTextNumberOfLines
         label.text = TextContent.helperText
         label.textColor = .secondaryLabel
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Metrics.helperTextMinimumScaleFactor
         return label
     }()
 
@@ -131,6 +134,14 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     private func setupHelperView() {
         tableView.tableFooterView = helperView
         activateHelperConstraints()
+
+        helperSeparator.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        helperContentView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        helperSeparator.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
+        helperContentView.isHidden = traitCollection.preferredContentSizeCategory.isAccessibilityCategory
     }
 
     let selectedPreviewDevice = PreviewDevice.mobile
@@ -243,6 +254,9 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         static let helperImageWidth: CGFloat = 24.0
         static let helperPadding = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         static let helperSpacing: CGFloat = 16
+
+        static let helperTextNumberOfLines = 2
+        static let helperTextMinimumScaleFactor: CGFloat = 0.6
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -1,3 +1,4 @@
+import Gridicons
 import UIKit
 import WordPressKit
 
@@ -47,6 +48,91 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         return SiteDesignCategoryThumbnailSize.category.value
     }
 
+    // MARK: Helper Footer View
+    override var allowCustomTableFooterView: Bool {
+        true
+    }
+
+    private lazy var helperView: UIView = {
+        let view = UIView(frame: Metrics.helperFrame)
+        view.addSubview(helperStackView)
+        view.pinSubviewToAllEdges(helperStackView)
+        return view
+    }()
+
+    private lazy var helperStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [helperSeparator, helperContentView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    private lazy var helperSeparator: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .separator
+        return view
+    }()
+
+    private lazy var helperContentView: UIView = {
+        let view = UIView()
+        view.addSubview(helperContentStackView)
+        view.pinSubviewToAllEdges(helperContentStackView, insets: Metrics.helperPadding)
+        return view
+    }()
+
+    private lazy var helperContentStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [helperImageStackView, helperLabeStackView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.spacing = Metrics.helperSpacing
+        return stackView
+    }()
+
+    private lazy var helperImageStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [helperImageView, UIView()])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    private lazy var helperImageView: UIImageView = {
+        let imageView = UIImageView(image: .gridicon(.infoOutline))
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.tintColor = .secondaryLabel
+        return imageView
+    }()
+
+    private lazy var helperLabeStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [helperLabel, UIView()])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
+    private lazy var helperLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.font = WPStyleGuide.fontForTextStyle(.body)
+        label.numberOfLines = 0
+        label.text = TextContent.helperText
+        label.textColor = .secondaryLabel
+        return label
+    }()
+
+    private func activateHelperConstraints() {
+        NSLayoutConstraint.activate([
+            helperImageView.heightAnchor.constraint(equalToConstant: Metrics.helperImageWidth),
+            helperImageView.widthAnchor.constraint(equalToConstant: Metrics.helperImageWidth),
+            helperSeparator.heightAnchor.constraint(equalToConstant: .hairlineBorderWidth)
+        ])
+    }
+
+    private func setupHelperView() {
+        tableView.tableFooterView = helperView
+        activateHelperConstraints()
+    }
+
     let selectedPreviewDevice = PreviewDevice.mobile
 
     init(createsSite: Bool, _ completion: @escaping SiteDesignStep.SiteDesignSelection) {
@@ -93,6 +179,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
                 case .success(let result):
                     self?.dismissNoResultsController()
                     self?.siteDesigns = result
+                    self?.setupHelperView()
                 case .failure(let error):
                     self?.handleError(error)
                 }
@@ -134,12 +221,28 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     }
 
     private enum TextContent {
-        static let mainTitle = NSLocalizedString("Choose a theme", comment: "Title for the screen to pick a theme and homepage for a site.")
-        static let backButtonTitle = NSLocalizedString("Design", comment: "Shortened version of the main title to be used in back navigation.")
-        static let skipButtonTitle = NSLocalizedString("Skip", comment: "Continue without making a selection.")
-        static let cancelButtonTitle = NSLocalizedString("Cancel", comment: "Cancel site creation.")
-        static let errorTitle = NSLocalizedString("Unable to load this content right now.", comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
-        static let errorSubtitle = NSLocalizedString("Check your network connection and try again.", comment: "Default subtitle for no-results when there is no connection.")
+        static let mainTitle = NSLocalizedString("Choose a theme",
+                                                 comment: "Title for the screen to pick a theme and homepage for a site.")
+        static let backButtonTitle = NSLocalizedString("Design",
+                                                       comment: "Shortened version of the main title to be used in back navigation.")
+        static let skipButtonTitle = NSLocalizedString("Skip",
+                                                       comment: "Continue without making a selection.")
+        static let cancelButtonTitle = NSLocalizedString("Cancel",
+                                                         comment: "Cancel site creation.")
+        static let errorTitle = NSLocalizedString("Unable to load this content right now.",
+                                                  comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
+        static let errorSubtitle = NSLocalizedString("Check your network connection and try again.",
+                                                     comment: "Default subtitle for no-results when there is no connection.")
+        static let helperText = NSLocalizedString("Can’t decide? You can change the theme at any time",
+                                                  comment: "Helper text that appears at the bottom of the design screen.")
+    }
+
+    private enum Metrics {
+        // Frame of the bottom helper: width will be automatically calucuated by assigning it to tableview.tableFooterView
+        static let helperFrame = CGRect(x: 0, y: 0, width: 0, height: 90)
+        static let helperImageWidth: CGFloat = 24.0
+        static let helperPadding = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        static let helperSpacing: CGFloat = 16
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -82,7 +82,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     }()
 
     private lazy var helperContentStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [helperImageStackView, helperLabeStackView])
+        let stackView = UIStackView(arrangedSubviews: [helperImageStackView, helperLabelStackView])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.spacing = Metrics.helperSpacing
@@ -103,7 +103,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         return imageView
     }()
 
-    private lazy var helperLabeStackView: UIStackView = {
+    private lazy var helperLabelStackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [helperLabel, UIView()])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
@@ -230,7 +230,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         static let cancelButtonTitle = NSLocalizedString("Cancel",
                                                          comment: "Cancel site creation.")
         static let errorTitle = NSLocalizedString("Unable to load this content right now.",
-                                                  comment: "Informing the user that a network request failed becuase the device wasn't able to establish a network connection.")
+                                                  comment: "Informing the user that a network request failed because the device wasn't able to establish a network connection.")
         static let errorSubtitle = NSLocalizedString("Check your network connection and try again.",
                                                      comment: "Default subtitle for no-results when there is no connection.")
         static let helperText = NSLocalizedString("Can’t decide? You can change the theme at any time",


### PR DESCRIPTION
Fixes #18510

This PR adds an helper text at the bottom of the template list (see screenshots)

To test:

- checkout/build/run this branch
- start the site creation flow
- when you get to site design, make sure that the helper text and icon appear at the bottom (see screenshots and linked issue for more details)

iPhone Light | iPad Dark
-- | --
<img height=320 src="https://user-images.githubusercontent.com/34376330/169166601-16a73d59-b74e-466f-824f-f42600f7d7b8.png"> | <img height=320 src="https://user-images.githubusercontent.com/34376330/169166653-e94ce572-41d8-423a-8f59-b684d15e7da7.png">



## Regression Notes
1. Potential unintended areas of impact
None, this adds a view to the design selection screen in the site creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
test the site creation flow on a variety of devices

3. What automated tests I added (or what prevented me from doing so)
None
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
