### PR TITLE
Blogging Prompts: use cached prompts for compact card and prompts list

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -81,10 +81,11 @@ class BloggingPromptsService {
     func todaysPrompt(success: @escaping (BloggingPrompt?) -> Void,
                       failure: @escaping (Error?) -> Void) {
         guard localTodaysPrompt == nil else {
+            print("🔴 todaysPrompt > returning local.")
             success(localTodaysPrompt)
             return
         }
-
+        print("🔴 todaysPrompt > fetching.")
         fetchTodaysPrompt(success: success, failure: failure)
     }
 
@@ -110,10 +111,12 @@ class BloggingPromptsService {
 
         // If there aren't maxListPrompts cached, need to fetch more.
         guard localListPrompts.count < maxListPrompts else {
+            print("🔴 listPrompts > returning local.")
             success(localListPrompts)
             return
         }
 
+        print("🔴 listPrompts > fetching.")
         fetchListPrompts(success: success, failure: failure)
     }
 

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -81,11 +81,10 @@ class BloggingPromptsService {
     func todaysPrompt(success: @escaping (BloggingPrompt?) -> Void,
                       failure: @escaping (Error?) -> Void) {
         guard localTodaysPrompt == nil else {
-            print("🔴 todaysPrompt > returning local.")
             success(localTodaysPrompt)
             return
         }
-        print("🔴 todaysPrompt > fetching.")
+
         fetchTodaysPrompt(success: success, failure: failure)
     }
 
@@ -111,12 +110,10 @@ class BloggingPromptsService {
 
         // If there aren't maxListPrompts cached, need to fetch more.
         guard localListPrompts.count < maxListPrompts else {
-            print("🔴 listPrompts > returning local.")
             success(localListPrompts)
             return
         }
 
-        print("🔴 listPrompts > fetching.")
         fetchListPrompts(success: success, failure: failure)
     }
 

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -6,6 +6,7 @@ class BloggingPromptsService {
     private let siteID: NSNumber
     private let remote: BloggingPromptsServiceRemote
     private let calendar: Calendar = .autoupdatingCurrent
+    private let maxListPrompts = 11
 
     /// A UTC date formatter that ignores time information.
     private static var dateFormatter: DateFormatter = {
@@ -21,6 +22,12 @@ class BloggingPromptsService {
     ///
     var localTodaysPrompt: BloggingPrompt? {
         loadPrompts(from: Date(), number: 1).first
+    }
+
+    /// Convenience computed variable that returns prompts for the prompts list from local store.
+    ///
+    var localListPrompts: [BloggingPrompt] {
+        loadPrompts(from: listStartDate, number: maxListPrompts)
     }
 
     /// Fetches a number of blogging prompts starting from the specified date.
@@ -89,9 +96,28 @@ class BloggingPromptsService {
     ///   - failure: Closure to be called when the fetch process failed.
     func fetchListPrompts(success: @escaping ([BloggingPrompt]) -> Void,
                           failure: @escaping (Error?) -> Void) {
-        let fromDate = calendar.date(byAdding: .day, value: -9, to: Date()) ?? Date()
-        fetchPrompts(from: fromDate, number: 11, success: success, failure: failure)
+        fetchPrompts(from: listStartDate, number: maxListPrompts, success: success, failure: failure)
     }
+
+    /// Convenience method to obtain the blogging prompts for the prompts list,
+    /// either from local cache or remote.
+    ///
+    /// - Parameters:
+    ///   - success: Closure to be called when the fetch process succeeded.
+    ///   - failure: Closure to be called when the fetch process failed.
+    func listPrompts(success: @escaping ([BloggingPrompt]) -> Void,
+                     failure: @escaping (Error?) -> Void) {
+
+        // If there aren't maxListPrompts cached, need to fetch more.
+        guard localListPrompts.count < maxListPrompts else {
+            success(localListPrompts)
+            return
+        }
+
+        fetchListPrompts(success: success, failure: failure)
+    }
+
+    // MARK: - Init
 
     required init?(contextManager: CoreDataStack = ContextManager.shared,
                    remote: BloggingPromptsServiceRemote? = nil,
@@ -113,6 +139,10 @@ private extension BloggingPromptsService {
 
     var defaultStartDate: Date {
         calendar.date(byAdding: .day, value: -10, to: Date()) ?? Date()
+    }
+
+    var listStartDate: Date {
+        calendar.date(byAdding: .day, value: -(maxListPrompts - 2), to: Date()) ?? Date()
     }
 
     /// Converts the given date to UTC and ignores the time information.

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -116,7 +116,7 @@ private extension BloggingPromptsViewController {
 
         isLoading = true
 
-        bloggingPromptsService.fetchListPrompts(success: { [weak self] (prompts) in
+        bloggingPromptsService.listPrompts(success: { [weak self] (prompts) in
             self?.isLoading = false
             self?.prompts = prompts.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
         }, failure: { [weak self] (error) in

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -106,8 +106,6 @@ private extension BloggingPromptsViewController {
     }
 
     func fetchPrompts() {
-        // TODO: show cached prompts first.
-
         guard let bloggingPromptsService = bloggingPromptsService else {
             DDLogError("Failed creating BloggingPromptsService instance.")
             showErrorView()

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -309,16 +309,16 @@ private extension CreateButtonCoordinator {
         // TODO: check for cached prompt first.
 
         guard let bloggingPromptsService = bloggingPromptsService else {
-            DDLogError("FAB > failed creating BloggingPromptsService instance.")
+            DDLogError("FAB: failed creating BloggingPromptsService instance.")
             prompt = nil
             return
         }
 
-        bloggingPromptsService.fetchTodaysPrompt(success: { [weak self] (prompt) in
+        bloggingPromptsService.todaysPrompt(success: { [weak self] (prompt) in
             self?.prompt = prompt
         }, failure: { [weak self] (error) in
             self?.prompt = nil
-            DDLogError("FAB > failed fetching blogging prompt: \(String(describing: error))")
+            DDLogError("FAB: failed fetching blogging prompt: \(String(describing: error))")
         })
     }
 


### PR DESCRIPTION
Ref: #18429

This updates the FAB header prompt and the Prompts List to use cached prompts if available.

To easily confirm which prompts are used, messages are logged when cached prompts are used and when prompts are fetched from remote. These will be removed before merging.

To test:
- Start with a fresh install to purge any cached prompts.
- Enable `bloggingPrompts` feature flag.
- When the app first launches, the FAB gets a prompt. Verify this is logged: `🔴 todaysPrompt > fetching.`.
- Navigate away from and back to My Site. The FAB once again needs a prompt. Verify this is logged: `🔴 todaysPrompt > returning local.`. (If you're on the Dashboard, you may see this twice - for the FAB and for the dashboard card.)
- Go to the Prompts List. Verify:
  - `🔴 listPrompts > fetching.` is logged.
  - The loading view is displayed. (The table can be seen behind the loading view. I'll address that separately.)
  - 11 prompts are displayed once loaded.
- Navigate away from and back to the Prompts List. Verify:
  - `🔴 listPrompts > returning local.` is logged.
  - The loading view may not display since this is a quick action.
  - 11 prompts are displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
