### PR TITLE
Quick Start: Fix notifications waypoint for RTL locales

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+QuickStart.swift
@@ -61,6 +61,9 @@ extension WPTabBarController {
         tabBar.layoutIfNeeded()
         var tabs = tabBar.subviews.compactMap { return $0 is UIControl ? $0 : nil }
         tabs.sort { $0.frame.origin.x < $1.frame.origin.x }
+        if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
+            tabs.reverse()
+        }
         return tabs[safe: index]
     }
 


### PR DESCRIPTION
Fixes #18641

## Description
Fixes a bug where the notification waypoint was added to the My Site tab instaed of notifications tab in RTL locales.

LTR | RTL
-|-
![Simulator Screen Shot - iPhone 13 Pro - 2022-05-19 at 01 16 21](https://user-images.githubusercontent.com/25306722/169171135-fbb7fc76-0891-4098-96c9-fb887ed825e0.png)|![Simulator Screen Shot - iPhone 13 Pro - 2022-05-19 at 01 18 22](https://user-images.githubusercontent.com/25306722/169171131-0c34f593-e195-419a-bb41-56d577e87fce.png)


## Testing Instructions

1. Set device locale to an RTL language (Arabic)
2. Enable quick start for existing site
3. Start notifications tour
4. Make sure that the waypoint is attached to the correct tab

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.