### PR TITLE
Remove 'Z' prefix from a couple test case classes

### DIFF
--- a/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardServiceTests.swift
@@ -3,15 +3,7 @@ import Nimble
 
 @testable import WordPress
 
-/// This test stuite is clashing with other tests
-/// Specifically:
-/// - [BlogJetpackTest testJetpackSetupDoesntReplaceDotcomAccount]
-/// - CommentServiceTests.testFailingFetchCommentLikesShouldCallFailureBlock()
-///
-/// We weren't able to figure out why but it seems a race condition + Core data
-/// For now, renaming the suite to change the execution order solves the issue.
-class ZBlogDashboardServiceTests: XCTestCase {
-    private var contextManager: ContextManagerMock!
+class BlogDashboardServiceTests: CoreDataTestCase {
     private var context: NSManagedObjectContext!
 
     private var service: BlogDashboardService!
@@ -26,7 +18,6 @@ class ZBlogDashboardServiceTests: XCTestCase {
 
         remoteServiceMock = DashboardServiceRemoteMock()
         persistenceMock = BlogDashboardPersistenceMock()
-        contextManager = ContextManagerMock()
         context = contextManager.newDerivedContext()
         postsParserMock = BlogDashboardPostsParserMock(managedObjectContext: context)
         service = BlogDashboardService(managedObjectContext: context, remoteService: remoteServiceMock, persistence: persistenceMock, postsParser: postsParserMock)
@@ -35,7 +26,6 @@ class ZBlogDashboardServiceTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         context = nil
-        contextManager = nil
     }
 
     func testCallServiceWithCorrectIDAndCards() {
@@ -260,7 +250,7 @@ class ZBlogDashboardServiceTests: XCTestCase {
     }
 
     func dictionary(from file: String) -> NSDictionary? {
-        let fileURL: URL = Bundle(for: ZBlogDashboardServiceTests.self).url(forResource: file, withExtension: nil)!
+        let fileURL: URL = Bundle(for: BlogDashboardServiceTests.self).url(forResource: file, withExtension: nil)!
         let data: Data = try! Data(contentsOf: fileURL)
         return try? JSONSerialization.jsonObject(with: data, options: []) as? NSDictionary
     }
@@ -295,7 +285,7 @@ class DashboardServiceRemoteMock: DashboardServiceRemote {
         didCallWithBlogID = blogID
         didRequestCards = cards
 
-        if let fileURL: URL = Bundle(for: ZBlogDashboardServiceTests.self).url(forResource: respondWith.rawValue, withExtension: nil),
+        if let fileURL: URL = Bundle(for: BlogDashboardServiceTests.self).url(forResource: respondWith.rawValue, withExtension: nil),
         let data: Data = try? Data(contentsOf: fileURL),
            let jsonObject = try? JSONSerialization.jsonObject(with: data, options: []) as AnyObject {
             success(jsonObject as! NSDictionary)

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -9,7 +9,7 @@ class MockDefaultSectionProvider: DefaultSectionProvider {
     }
 }
 
-class ZDashboardCardTests: CoreDataTestCase {
+class DashboardCardTests: CoreDataTestCase {
 
     private var context: NSManagedObjectContext!
     private var blog: Blog!


### PR DESCRIPTION
Follow up of https://github.com/wordpress-mobile/WordPress-iOS/pull/18632#discussion_r875459145

With recent changes of how `ContextManagerMock` is used in test cases, the issue described in the comments seems disappeared.

## Test Instructions
Make sure unit test suite passes.

## Regression Notes
N/A. No impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
