### PR TITLE
Prompts List: don't show table behind empty views

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -85,21 +85,21 @@ private extension BloggingPromptsViewController {
 
     func showNoResultsView() {
         hideNoResults()
-        configureAndDisplayNoResults(on: tableView,
+        configureAndDisplayNoResults(on: view,
                                      title: NoResults.emptyTitle,
                                      image: NoResults.imageName)
     }
 
     func showLoadingView() {
         hideNoResults()
-        configureAndDisplayNoResults(on: tableView,
+        configureAndDisplayNoResults(on: view,
                                      title: NoResults.loadingTitle,
                                      accessoryView: NoResultsViewController.loadingAccessoryView())
     }
 
     func showErrorView() {
         hideNoResults()
-        configureAndDisplayNoResults(on: tableView,
+        configureAndDisplayNoResults(on: view,
                                      title: NoResults.errorTitle,
                                      subtitle: NoResults.errorSubtitle,
                                      image: NoResults.imageName)


### PR DESCRIPTION
Ref: #18515
Depends on: #18658

This fixes an issue where the table could be seen behind the loading, error, and no results views.

To test:
- Start with a fresh install to purge any cached prompts.
- Enable `bloggingPrompts` feature flag.
- Go to the prompts list.
- Verify the loading view is displayed correctly.
- Following the hacks below for each view, verify the error and no results views are displayed correctly.

Hacks:
- To show error view: in `BloggingPromptsViewController:fetchPrompts`, `showErrorView()` instead of setting `prompts` in the `success` block:

```
bloggingPromptsService.listPrompts(success: { [weak self] (prompts) in
    self?.isLoading = false
    self?.showErrorView()
    // self?.prompts = prompts.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
}, 
...
```

- To show no results view: in `BloggingPromptsViewController:showNoResultsViewIfNeeded`, comment out everything except `showNoResultsView()`:
```
    func showNoResultsViewIfNeeded() {
//        guard !isLoading else {
//            showLoadingView()
//            return
//        }
//
//        guard prompts.isEmpty else {
//            hideNoResults()
//            return
//        }

        showNoResultsView()
    }
```

---
| Before | After |
|--------|-------|
| ![loading_before](https://user-images.githubusercontent.com/1816888/169181963-26247c6c-66b5-4620-a4de-4e6ab113ff91.png) | ![loading_after](https://user-images.githubusercontent.com/1816888/169182052-71b13661-e466-4856-8a99-ad9c46a106fe.png) |
| ![error_before](https://user-images.githubusercontent.com/1816888/169181966-ca67bd68-4cb4-47c6-97a0-873e910ed5d6.png) | ![error_after](https://user-images.githubusercontent.com/1816888/169182041-2319b5c4-2ed6-484f-9c4e-7e6623bbc3be.png) |
| ![empty_before](https://user-images.githubusercontent.com/1816888/169181965-acfdfe10-9617-4347-94ab-74d7cbc204d2.png) | ![empty_after](https://user-images.githubusercontent.com/1816888/169182046-2810f6de-a05d-47d7-b16f-7a3f4f34ef43.png) |

---

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
