### PR TITLE
Disable the nullability completeness warning 

### DIFF
--- a/config/SDKVersions.xcconfig
+++ b/config/SDKVersions.xcconfig
@@ -4,3 +4,6 @@ _WP_IOS_120000 = XCODE10
 WP_IOS_SDK = $(_WP_IOS_$(SDK_VERSION_MAJOR))
 
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) $(WP_IOS_SDK)
+
+// TODO: Move to dedicated file
+WARNING_CFLAGS = -Wno-nullability-completeness


### PR DESCRIPTION
We're seeing an insane amount of warnings recently:

<img width="655" alt="Screen Shot 2022-05-19 at 4 54 37 pm" src="https://user-images.githubusercontent.com/1218433/169229337-476cd9cc-7ac3-4f92-b82a-be01327923a9.png">

A large amount of those seems to be due to a bug in Xcode (what's new...).

In the ideal world, I'd like to run with _all warnings_ enabled as well as _treat warnings as errors_, but I think this situation calls for accepting the tradeoff of having one less warning in favor of reducing the noise. With such high numbers, it's impossible to notice new, legit warnings we might want to tackle promptly. 

For more details on the source of the issues and its workaround see:

- https://developer.apple.com/forums/thread/686448
- https://stackoverflow.com/questions/32539285/pointer-is-missing-a-nullability-type-specifier

_I also tried on Xcode 13.4 (13F17a) and the warnings were still there._

## Testing

Checkout this branch, purge your `DerivedData` folder, and run a build. You should see way less warnings that recently. I say way less because I haven't been able to get a stable number 🤔 

I've seen ~510 and ~620:

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1218433/169236618-3dc3600b-d0d3-43aa-85a5-1697593102ac.png">

<img width="777" alt="image" src="https://user-images.githubusercontent.com/1218433/169237977-32be127a-e79b-4244-9771-2626d497338a.png">


Also interesting, we still have some nullability warnings 🙃 E.g. in `CommentService.h`

<img width="1445" alt="image" src="https://user-images.githubusercontent.com/1218433/169236844-fea2a9a6-9da5-4fba-9c91-2f7526576dd4.png">

But, as far as I can see, those are for files that already specify nullability in some methods, so I guess it makes sense as a sort of consistency indication? 🤷 

## Regression Notes
1. Potential unintended areas of impact. None, only a small loss in the information the compiler gives us.
2. What I did to test those areas of impact (or what existing automated tests I relied on). N.A.
3. What automated tests I added (or what prevented me from doing so). N.A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.