### PR TITLE
Replace child contexts in test cases with mainContext

### DIFF
--- a/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
+++ b/WordPress/WordPressTest/Analytics/EditorAnalytics/PostEditorAnalyticsSessionTests.swift
@@ -14,11 +14,7 @@ class PostEditorAnalyticsSessionTests: CoreDataTestCase {
         """
     }
 
-    private var context: NSManagedObjectContext!
-
     override func setUp() {
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = mainContext
         TestAnalyticsTracker.setup()
     }
 
@@ -158,10 +154,10 @@ class PostEditorAnalyticsSessionTests: CoreDataTestCase {
 
 extension PostEditorAnalyticsSessionTests {
     func createPost(title: String? = nil, body: String? = nil, blogID: NSNumber? = nil) -> AbstractPost {
-        let post = AbstractPost(context: context)
+        let post = AbstractPost(context: mainContext)
         post.postTitle = title
         post.content = body
-        post.blog = Blog(context: context)
+        post.blog = Blog(context: mainContext)
         post.blog.dotComID = blogID
         return post
     }

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -3,7 +3,6 @@ import XCTest
 
 class GutenbergSettingsTests: CoreDataTestCase {
 
-    fileprivate var context: NSManagedObjectContext!
     private let gutenbergContent = "<!-- wp:paragraph -->\n<p>Hello world</p>\n<!-- /wp:paragraph -->"
 
     var database: EphemeralKeyValueDatabase!
@@ -12,19 +11,19 @@ class GutenbergSettingsTests: CoreDataTestCase {
     var post: Post!
 
     fileprivate func newTestPost(with blog: Blog) -> Post {
-        let post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
+        let post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: mainContext) as! Post
         post.blog = blog
         return post
     }
 
     private func newTestBlog(isWPComAPIEnabled: Bool = true) -> Blog {
         if isWPComAPIEnabled {
-            let blog = ModelTestHelper.insertDotComBlog(context: context)
+            let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
             blog.account?.authToken = "auth"
             blog.dotComID = 1
             return blog
         } else {
-            return ModelTestHelper.insertSelfHostedBlog(context: context)
+            return ModelTestHelper.insertSelfHostedBlog(context: mainContext)
         }
     }
 
@@ -42,8 +41,6 @@ class GutenbergSettingsTests: CoreDataTestCase {
 
     override func setUp() {
         super.setUp()
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
         Environment.replaceEnvironment(contextManager: contextManager)
         database = EphemeralKeyValueDatabase()
         settings = GutenbergSettings(database: database)
@@ -53,7 +50,6 @@ class GutenbergSettingsTests: CoreDataTestCase {
     }
 
     override func tearDown() {
-        context.rollback()
         TestAnalyticsTracker.tearDown()
         super.tearDown()
     }
@@ -333,11 +329,11 @@ class GutenbergSettingsTests: CoreDataTestCase {
     }
 
     func setupAccount(withId userId: Int) {
-        let account = ModelTestHelper.insertAccount(context: context)
+        let account = ModelTestHelper.insertAccount(context: mainContext)
         account.authToken = "auth"
         account.uuid = UUID().uuidString
         account.userID = NSNumber(value: userId)
-        contextManager.saveContextAndWait(context)
-        AccountService(managedObjectContext: context).setDefaultWordPressComAccount(account)
+        contextManager.saveContextAndWait(mainContext)
+        AccountService(managedObjectContext: mainContext).setDefaultWordPressComAccount(account)
     }
 }

--- a/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
+++ b/WordPress/WordPressTest/MediaProgressCoordinatorTests.swift
@@ -3,11 +3,10 @@ import Foundation
 
 class MediaProgressCoordinatorTests: CoreDataTestCase {
 
-    fileprivate var context: NSManagedObjectContext!
     var mediaProgressCoordinator: MediaProgressCoordinator!
 
     fileprivate func makeTestMedia() -> Media {
-        return NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: context) as! Media
+        return NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: mainContext) as! Media
     }
 
     fileprivate func makeTestError() -> NSError {
@@ -16,13 +15,10 @@ class MediaProgressCoordinatorTests: CoreDataTestCase {
 
     override func setUp() {
         super.setUp()
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
         mediaProgressCoordinator = MediaProgressCoordinator()
     }
 
     override func tearDown() {
-        context.rollback()
         mediaProgressCoordinator = nil
         super.tearDown()
     }

--- a/WordPress/WordPressTest/MediaTests.swift
+++ b/WordPress/WordPressTest/MediaTests.swift
@@ -3,21 +3,8 @@ import XCTest
 
 class MediaTests: CoreDataTestCase {
 
-    fileprivate var context: NSManagedObjectContext!
-
     fileprivate func newTestMedia() -> Media {
-        return NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: context) as! Media
-    }
-
-    override func setUp() {
-        super.setUp()
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
-    }
-
-    override func tearDown() {
-        context.rollback()
-        super.tearDown()
+        return NSEntityDescription.insertNewObject(forEntityName: Media.classNameWithoutNamespaces(), into: mainContext) as! Media
     }
 
     func testThatAbsoluteURLsWork() {
@@ -65,7 +52,7 @@ class MediaTests: CoreDataTestCase {
     }
 
     func testMediaHasAssociatedPost() {
-        let post = PostBuilder(context).build()
+        let post = PostBuilder(mainContext).build()
         let media = newTestMedia()
         media.addPostsObject(post)
 

--- a/WordPress/WordPressTest/PostTests.swift
+++ b/WordPress/WordPressTest/PostTests.swift
@@ -5,18 +5,16 @@ import XCTest
 
 class PostTests: CoreDataTestCase {
 
-    fileprivate var context: NSManagedObjectContext!
-
     fileprivate func newTestBlog() -> Blog {
-        return NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
+        return NSEntityDescription.insertNewObject(forEntityName: "Blog", into: mainContext) as! Blog
     }
 
     fileprivate func newTestPost() -> Post {
-        return NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
+        return NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: mainContext) as! Post
     }
 
     fileprivate func newTestPostCategory() -> PostCategory {
-        return NSEntityDescription.insertNewObject(forEntityName: "Category", into: context) as! PostCategory
+        return NSEntityDescription.insertNewObject(forEntityName: "Category", into: mainContext) as! PostCategory
     }
 
     fileprivate func newTestPostCategory(_ name: String) -> PostCategory {
@@ -24,17 +22,6 @@ class PostTests: CoreDataTestCase {
         category.categoryName = name
 
         return category
-    }
-
-    override func setUp() {
-        super.setUp()
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
-    }
-
-    override func tearDown() {
-        context.rollback()
-        super.tearDown()
     }
 
     func testThatNoCategoriesReturnEmptyStringWhenCallingCategoriesText() {
@@ -228,7 +215,7 @@ class PostTests: CoreDataTestCase {
             ("z", "Z")
         ]
 
-        let blog = BlogBuilder(context)
+        let blog = BlogBuilder(mainContext)
             .with(postFormats: postFormats)
             .build()
 
@@ -521,7 +508,7 @@ class PostTests: CoreDataTestCase {
     /// When removing the featured image hasLocalChanges returns true
     func testLocalChangesWhenfeaturedImageIsRemoved() {
         let post = newTestPost()
-        post.featuredImage = Media.makeMedia(in: context)
+        post.featuredImage = Media.makeMedia(in: mainContext)
         let revision = post.createRevision()
         revision.featuredImage = nil
 
@@ -532,7 +519,7 @@ class PostTests: CoreDataTestCase {
     func testLocalChangesWhenfeaturedImageIsAdded() {
         let post = newTestPost()
         let revision = post.createRevision()
-        revision.featuredImage = Media.makeMedia(in: context)
+        revision.featuredImage = Media.makeMedia(in: mainContext)
 
         XCTAssertTrue(revision.hasLocalChanges())
     }
@@ -540,7 +527,7 @@ class PostTests: CoreDataTestCase {
     /// When keeping the featured image hasLocalChanges returns false
     func testLocalChangesWhenFeaturedImageIsTheSame() {
         let post = newTestPost()
-        let media = Media.makeMedia(in: context)
+        let media = Media.makeMedia(in: mainContext)
         post.featuredImage = media
         let revision = post.createRevision()
         revision.featuredImage = media

--- a/WordPress/WordPressTest/QuickStartFactoryTests.swift
+++ b/WordPress/WordPressTest/QuickStartFactoryTests.swift
@@ -3,14 +3,10 @@ import XCTest
 
 class QuickStartFactoryTests: CoreDataTestCase {
 
-    private var context: NSManagedObjectContext!
-
     override func setUp() {
         super.setUp()
 
         contextManager.useAsSharedInstance(untilTestFinished: self)
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
     }
 
     func testCollectionsForExistingSite() {
@@ -106,7 +102,7 @@ class QuickStartFactoryTests: CoreDataTestCase {
     }
 
     private func newTestBlog(id: Int) -> Blog {
-        let blog = ModelTestHelper.insertDotComBlog(context: context)
+        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.dotComID = id as NSNumber
         return blog
     }

--- a/WordPress/WordPressTest/QuickStartSettingsTests.swift
+++ b/WordPress/WordPressTest/QuickStartSettingsTests.swift
@@ -3,15 +3,11 @@ import XCTest
 
 class QuickStartSettingsTests: CoreDataTestCase {
 
-    private var context: NSManagedObjectContext!
     private var userDefaults: UserDefaults!
     private var quickStartSettings: QuickStartSettings!
 
     override func setUp() {
         super.setUp()
-
-        context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = contextManager.mainContext
 
         let name = String(describing: QuickStartSettingsTests.self)
         userDefaults = UserDefaults(suiteName: name)
@@ -33,7 +29,7 @@ class QuickStartSettingsTests: CoreDataTestCase {
     }
 
     private func newTestBlog(id: Int) -> Blog {
-        let blog = ModelTestHelper.insertDotComBlog(context: context)
+        let blog = ModelTestHelper.insertDotComBlog(context: mainContext)
         blog.dotComID = id as NSNumber
         return blog
     }


### PR DESCRIPTION
As a result of discussion with @jkmassel and @mokagio, I don't think using a child context in unit test provide much value, `mainContext` is sufficient for testing purposes. This PR replaces child contexts used in test cases with `mainContext`.

## Test Instructions
Make sure full unit test suite passes.

## Regression Notes
N/A. No impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
