### PR TITLE
Move instantiating ContextManagerMock out from NotificationUtility

### DIFF
--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -31,15 +31,14 @@ final class ApproveCommentActionTests: CoreDataTestCase {
     }
 
     private var action: ApproveComment?
-    private let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         action = TestableApproveComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
@@ -47,8 +46,7 @@ final class ApproveCommentActionTests: CoreDataTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testStatusPassedInInitialiserIsPreserved() {

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -25,22 +25,20 @@ final class EditCommentActionTests: CoreDataTestCase {
     }
 
     private var action: EditComment?
-    private let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         action = TestableEditComment(on: Constants.initialStatus, coreDataStack: contextManager)
     }
 
     override func tearDown() {
         action = nil
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testActionTitleIsExpected() {

--- a/WordPress/WordPressTest/FormattableCommentContentTests.swift
+++ b/WordPress/WordPressTest/FormattableCommentContentTests.swift
@@ -1,11 +1,11 @@
 import XCTest
 @testable import WordPress
 
-final class FormattableCommentContentTests: XCTestCase {
+final class FormattableCommentContentTests: CoreDataTestCase {
     private let entityName = Notification.classNameWithoutNamespaces()
 
     private var subject: FormattableCommentContent?
-    private var utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Expectations {
         static let text = "This is an unapproved comment"
@@ -17,15 +17,13 @@ final class FormattableCommentContentTests: XCTestCase {
     }
 
     override func setUpWithError() throws {
-        try super.setUpWithError()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         subject = try FormattableCommentContent(dictionary: mockDictionary(), actions: mockedActions(), ranges: [], parent: loadLikeNotification())
     }
 
     override func tearDown() {
         subject = nil
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testKindReturnsExpectation() {

--- a/WordPress/WordPressTest/FormattableContentGroupTests.swift
+++ b/WordPress/WordPressTest/FormattableContentGroupTests.swift
@@ -1,26 +1,22 @@
 import XCTest
 @testable import WordPress
 
-final class FormattableContentGroupTests: XCTestCase {
+final class FormattableContentGroupTests: CoreDataTestCase {
     private var subject: FormattableContentGroup?
-    private let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let kind: FormattableContentGroup.Kind = .activity
     }
 
     override func setUpWithError() throws {
-        try super.setUpWithError()
-        utility.setUp()
-        ContextManager.overrideSharedInstance(nil)
+        utility = NotificationUtility(coreDataStack: contextManager)
         subject = FormattableContentGroup(blocks: [try mockContent()], kind: Constants.kind)
     }
 
     override func tearDown() {
-        utility.tearDown()
         subject = nil
-        ContextManager.overrideSharedInstance(nil)
-        super.tearDown()
+        utility = nil
     }
 
     func testKindRemainsAsInitialised() {

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -31,15 +31,14 @@ final class LikeCommentActionTests: CoreDataTestCase {
     }
 
     private var action: LikeComment?
-    private let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         action = TestableLikeComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
@@ -47,8 +46,7 @@ final class LikeCommentActionTests: CoreDataTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testStatusPassedInInitialiserIsPreserved() {

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -22,15 +22,14 @@ final class MarkAsSpamActionTests: CoreDataTestCase {
     }
 
     private var action: MarkAsSpam?
-    let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         action = TestableMarkAsSpam(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
@@ -38,8 +37,7 @@ final class MarkAsSpamActionTests: CoreDataTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testStatusPassedInInitialiserIsPreserved() {

--- a/WordPress/WordPressTest/NotificationContentRouterTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRouterTests.swift
@@ -2,26 +2,12 @@
 import XCTest
 @testable import WordPress
 
-class NotificationContentRouterTests: XCTestCase {
-
-    let utility = NotificationUtility()
-    var sut: NotificationContentRouter!
-    var coordinator: MockContentCoordinator!
-
-    override func setUp() {
-        super.setUp()
-        utility.setUp()
-        coordinator = MockContentCoordinator()
-    }
-
-    override func tearDown() {
-        utility.tearDown()
-        super.tearDown()
-    }
-
+class NotificationContentRouterTests: CoreDataTestCase {
     func testFollowNotificationSourceRoutesToStream() throws {
+        let utility = NotificationUtility(coreDataStack: contextManager)
+        let coordinator = MockContentCoordinator()
         let notification = try utility.loadFollowerNotification()
-        sut = NotificationContentRouter(activity: notification, coordinator: coordinator)
+        let sut = NotificationContentRouter(activity: notification, coordinator: coordinator)
         try! sut.routeToNotificationSource()
 
         XCTAssertTrue(coordinator.streamWasDisplayed)

--- a/WordPress/WordPressTest/NotificationContentRouterTests.swift
+++ b/WordPress/WordPressTest/NotificationContentRouterTests.swift
@@ -3,6 +3,7 @@ import XCTest
 @testable import WordPress
 
 class NotificationContentRouterTests: CoreDataTestCase {
+
     func testFollowNotificationSourceRoutesToStream() throws {
         let utility = NotificationUtility(coreDataStack: contextManager)
         let coordinator = MockContentCoordinator()

--- a/WordPress/WordPressTest/NotificationTests.swift
+++ b/WordPress/WordPressTest/NotificationTests.swift
@@ -6,18 +6,16 @@ import XCTest
 
 /// Notifications Tests
 ///
-class NotificationTests: XCTestCase {
+class NotificationTests: CoreDataTestCase {
 
-    let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
     }
 
     override func tearDown() {
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testBadgeNotificationHasBadgeFlagSetToTrue() throws {

--- a/WordPress/WordPressTest/NotificationUtility.swift
+++ b/WordPress/WordPressTest/NotificationUtility.swift
@@ -1,17 +1,16 @@
-
+import CoreData
 import Foundation
 import XCTest
 @testable import WordPress
 
 class NotificationUtility {
-    var contextManager: ContextManagerMock!
-
-    func setUp() {
-        contextManager = ContextManagerMock()
+    private let coreDataStack: CoreDataStack
+    private var context: NSManagedObjectContext {
+        coreDataStack.mainContext
     }
 
-    func tearDown() {
-        // Do nothing
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
     }
 
     private var entityName: String {
@@ -19,33 +18,33 @@ class NotificationUtility {
     }
 
     func loadBadgeNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-badge.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-badge.json", insertInto: context)
     }
 
     func loadLikeNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-like.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-like.json", insertInto: context)
     }
 
     func loadFollowerNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-new-follower.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-new-follower.json", insertInto: context)
     }
 
     func loadCommentNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-replied-comment.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-replied-comment.json", insertInto: context)
     }
 
     func loadUnapprovedCommentNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-unapproved-comment.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-unapproved-comment.json", insertInto: context)
     }
 
     func loadPingbackNotification() throws -> WordPress.Notification {
-        return try .fixture(fromFile: "notifications-pingback.json", insertInto: contextManager.mainContext)
+        return try .fixture(fromFile: "notifications-pingback.json", insertInto: context)
     }
 
     func mockCommentContent() throws -> FormattableCommentContent {
         let dictionary = try JSONObject(fromFileNamed: "notifications-replied-comment.json")
         let body = dictionary["body"]
-        let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: contextManager.mainContext))
+        let blocks = NotificationContentFactory.content(from: body as! [[String: AnyObject]], actionsParser: NotificationActionParser(), parent: WordPress.Notification(context: context))
         return blocks.filter { $0.kind == .comment }.first! as! FormattableCommentContent
     }
 

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -23,15 +23,14 @@ final class ReplyToCommentActionTests: CoreDataTestCase {
     }
 
     private var action: ReplyToComment?
-    let utility = NotificationUtility()
+    private var utility: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utility.setUp()
+        utility = NotificationUtility(coreDataStack: contextManager)
         action = TestableReplyToComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
@@ -39,8 +38,7 @@ final class ReplyToCommentActionTests: CoreDataTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utility.tearDown()
-        super.tearDown()
+        utility = nil
     }
 
     func testStatusPassedInInitialiserIsPreserved() {

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -21,15 +21,14 @@ final class TrashCommentActionTests: CoreDataTestCase {
     }
 
     private var action: TrashComment?
-    let utils = NotificationUtility()
+    private var utils: NotificationUtility!
 
     private struct Constants {
         static let initialStatus: Bool = false
     }
 
     override func setUp() {
-        super.setUp()
-        utils.setUp()
+        utils = NotificationUtility(coreDataStack: contextManager)
         action = TestableTrashComment(on: Constants.initialStatus, coreDataStack: contextManager)
         makeNetworkAvailable()
     }
@@ -37,8 +36,7 @@ final class TrashCommentActionTests: CoreDataTestCase {
     override func tearDown() {
         action = nil
         makeNetworkUnavailable()
-        utils.tearDown()
-        super.tearDown()
+        utils = nil
     }
 
     func testStatusPassedInInitialiserIsPreserved() {


### PR DESCRIPTION
Follow up of https://github.com/wordpress-mobile/WordPress-iOS/pull/18579#discussion_r873346033.

Using the in-memory database created from test case, instead of creating its own one in `NotificationUtility`. This'll reduce the chances that two different in-memory database is used during a test run, which may have unexpected side effect on the test.

## Test Instructions
Make sure full test suite passes.

## Regression Notes
N/A. No impact on the app.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
