### PR TITLE
 Quick Start for Existing Users: End current tour when switching blogs

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -8,19 +8,17 @@ extension MySiteViewController {
             if let info = notification.userInfo,
                let element = info[QuickStartTourGuide.notificationElementKey] as? QuickStartTourElement {
 
+                self?.siteMenuSpotlightIsShown = element == .siteMenu
+
                 switch element {
                 case .noSuchElement, .newpost:
                     self?.additionalSafeAreaInsets = .zero
 
                 case .siteIcon, .siteTitle, .viewSite:
                     self?.scrollView.scrollToTop(animated: true)
-                    self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
-
-                case .siteMenu:
-                    self?.siteMenuSpotlightIsShown = true
                     fallthrough
 
-                case .pages, .sharing, .stats, .readerTab, .notifications:
+                case .siteMenu, .pages, .sharing, .stats, .readerTab, .notifications:
                     self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
                 default:

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -150,6 +150,10 @@ extension SitePickerViewController {
     private func switchToBlog(_ blog: Blog) {
         self.blog = blog
         blogDetailHeaderView.blog = blog
+
+        QuickStartTourGuide.shared.endCurrentTour()
+        toggleSpotlightOnHeaderView()
+
         onBlogSwitched?(blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -148,6 +148,10 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
 extension SitePickerViewController {
 
     private func switchToBlog(_ blog: Blog) {
+        guard self.blog != blog else {
+            return
+        }
+
         self.blog = blog
         blogDetailHeaderView.blog = blog
 


### PR DESCRIPTION
Fixes #18645

## Notes
Identical to #18648, but this one targets `release/19.9` instead of `trunk` 

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
