### PR TITLE
Blogging Prompt Cards: hide Share button

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -73,9 +73,11 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         }
     }
 
-    // This provides a quick way to toggle the `Remove from dashboard` menu item.
-    // Since it (probably) will not be included in Blogging Prompts V1, it is disabled by default.
+    // This provides a quick way to toggle in flux features.
+    // Since they probably will not be included in Blogging Prompts V1,
+    // they are disabled by default.
     private let removeFromDashboardEnabled = false
+    private let sharePromptEnabled = false
 
     // Used to present:
     // - The menu sheet for contextual menu in iOS13.
@@ -257,7 +259,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.spacing = Constants.answeredButtonsSpacing
-        stackView.addArrangedSubviews([answeredLabel, shareButton])
+        stackView.addArrangedSubviews(sharePromptEnabled ? [answeredLabel, shareButton] : [answeredLabel])
 
         // center the stack view's contents based on its total intrinsic width (instead of having it stretched edge to edge).
         let containerView = UIView()

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -16,6 +16,11 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
 
     var answerPromptHandler: (() -> Void)?
 
+    // This provides a quick way to toggle the shareButton.
+    // Since it probably will not be included in Blogging Prompts V1,
+    // it is disabled by default.
+    private let sharePromptEnabled = false
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureView()
@@ -98,6 +103,7 @@ private extension BloggingPromptsHeaderView {
         let answered = prompt?.answered ?? false
         answerPromptButton.isHidden = answered
         answeredStackView.isHidden = !answered
+        shareButton.isHidden = !sharePromptEnabled
 
         if let promptAttribution = prompt?.attribution.lowercased(),
            let attribution = BloggingPromptsAttribution(rawValue: promptAttribution) {


### PR DESCRIPTION
Ref: #18429

This hides this `Share` button on the dashboard prompt card and FAB prompt header.

To test:
- Implement the hacks below to show Answered states on the cards.
- Enable `bloggingPrompts` feature flag.
- Verify the `Share` button is not displayed on the dashboard prompt card or the FAB prompt header.

Hacks to show Answered states:
- `DashboardPromptsCardCell` - `return true` for `isAnswered`.
- `BloggingPromptsHeaderView` - set `answered = true` in `configure`.

<kbd>![no_share](https://user-images.githubusercontent.com/1816888/169352812-6a8d831a-ccaf-45b9-95e6-b0d5e1942274.png)</kbd>

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
