### PR TITLE
Define `JetpackModuleHelperDelegate` in ObjC layer to avoid warning

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/JetpackModuleHelper.swift
@@ -3,10 +3,6 @@ import UIKit
 
 public typealias JetpackModuleHelperViewController = JetpackModuleHelperDelegate & UIViewController
 
-@objc public protocol JetpackModuleHelperDelegate: AnyObject {
-    func jetpackModuleEnabled()
-}
-
 /// Shows a NoResultsViewController on a given VC and handle enabling
 /// a Jetpack module
 @objc class JetpackModuleHelper: NSObject {

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.h
@@ -6,7 +6,11 @@
 
 @end
 
-@protocol JetpackModuleHelperDelegate;
+@protocol JetpackModuleHelperDelegate
+
+- (void)jetpackModuleEnabled;
+
+@end
 
 @class Blog;
 


### PR DESCRIPTION
The previous approach, with the `protocol` being defined in the Swift source and then "soft redefined" where needed in the Objective-C source, resulting in 101 warnings:

> cannot find protocol definition for 'JetpackModuleHelperDelegate'

<img alt="image" src="https://user-images.githubusercontent.com/1218433/169472462-6c7919b1-3d26-4b0f-955f-dde24e839bb8.png" width=400/>

## Testing

Checkout this branch and verify filtering the warnings for "JetpackModuleHelperDelegate" returns no warning.

@leandroalonso (GitHub suggest you as a recent author) let me know what you think of the change. I'm pretty confident it's just a bit of compiler Tetris, so the fact the app builds should be enough.

Still, I also run on device and pocked at the sharing view controller, and it loaded and behaved fine. I didn't look into how to trigger the `JetpackModuleHelperDelegate` code path, though.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**