### PR TITLE
Adds feature config for fetching beta site designs

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.53.0-beta.1):
+  - WordPressKit (4.53.0-beta.2):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -853,7 +853,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: 3d9781df3270ec652660a207994867e354fe7ca2
+  WordPressKit: ee6802965ae7550eecb792dafe0f9de9780df37f
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -28,6 +28,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case statsNewInsights
     case siteName
     case quickStartForExistingUsers
+    case betaSiteDesigns
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -92,6 +93,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .quickStartForExistingUsers:
             return true
+        case .betaSiteDesigns:
+            return false
         }
     }
 
@@ -174,6 +177,8 @@ extension FeatureFlag {
             return "Site Name"
         case .quickStartForExistingUsers:
             return "Quick Start For Existing Users"
+        case .betaSiteDesigns:
+            return "Fetch Beta Site Designs"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -28,7 +28,7 @@ class SiteDesignSection: CategorySection {
 class SiteDesignContentCollectionViewController: FilterableCategoriesViewController, UIPopoverPresentationControllerDelegate {
     typealias TemplateGroup = SiteDesignRequest.TemplateGroup
     private let createsSite: Bool
-    private let templateGroups: [TemplateGroup] = [.stable, .singlePage]
+    private let templateGroups: [TemplateGroup] = FeatureFlag.betaSiteDesigns.enabled ? [.stable, .beta] : []
 
     let completion: SiteDesignStep.SiteDesignSelection
     let restAPI = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)


### PR DESCRIPTION
**Depends on** https://github.com/wordpress-mobile/WordPressKit-iOS/pull/508

## Description
Adds feature config for fetching beta site designs

## To test:
1. Enable the `Fetch Beta Site Designs` from the Debug settings of the app
2. Start the site creation
3. Verify that the correct designs are fetched

Note:
* You can test with a sandbox pointing at `D80579-code`

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
