### PR TITLE
My Site Dashboard: track tap on "Write first post" and "Write next post" prompts

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardEmptyPostsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardEmptyPostsCardCell.swift
@@ -84,6 +84,7 @@ class DashboardEmptyPostsCardCell: UICollectionViewCell, Reusable {
     /// The VC presenting this cell
     private weak var viewController: BlogDashboardViewController?
     private var blog: Blog?
+    private var cardType: DashboardCard?
 
     // MARK: Initializers
 
@@ -126,6 +127,7 @@ extension DashboardEmptyPostsCardCell {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?, cardType: DashboardCard) {
         self.blog = blog
         self.viewController = viewController
+        self.cardType = cardType
 
         switch cardType {
         case .createPost:
@@ -147,6 +149,7 @@ extension DashboardEmptyPostsCardCell {
 
 private extension DashboardEmptyPostsCardCell {
     func presentEditor() {
+        BlogDashboardAnalytics.shared.track(.dashboardCardItemTapped, properties: ["type": "post", "sub_type": cardType?.rawValue ?? ""])
         let controller = viewController?.tabBarController as? WPTabBarController
         controller?.showPostTab()
     }


### PR DESCRIPTION
This PR adds two missing tracks:

* When tapping "Write your first post": `🔵 Tracked: my_site_dashboard_card_item_tapped <default_tab_experiment: site_menu, sub_type: create_first, type: post>`
* When tapping "Write your next post": `🔵 Tracked: my_site_dashboard_card_item_tapped <default_tab_experiment: site_menu, sub_type: create_next, type: post>`

### To test

1. Run the app
2. For a site without any posts, tap the "Write your first post" card
3. ✅ Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: create_first` prop
4. Publish a post
5. Tap the "Write your next post" card
6. ✅ Make sure `my_site_dashboard_card_item_tapped` is fired with `sub_type: create_next` prop

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
