### PR TITLE
Blogging Prompts: Local notification scheduler (part 1)

### DIFF
--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -43,42 +43,17 @@ public class BloggingPrompt: NSManagedObject {
         return text.stringByDecodingXMLCharacters().trim()
     }
 
-    var localDate: Date? {
-        let dateString = DateFormatters.utc.string(from: date)
-        return DateFormatters.local.date(from: dateString)
-    }
-
-    /// Convenience method that matches local date to the prompt's UTC date.
+    /// Convenience method that checks if the given date is within the same day of the prompt's date without considering the timezone information.
     ///
-    /// Before checking, the prompt date is "localized" to avoid -1/+1 day issue due to local timezone. This method only checks if the prompt date
-    /// matches the year, month, and day of the given `localDate`. The time information is ignored.
+    /// Example: `2022-05-19 23:00:00 UTC-5` and `2022-05-20 00:00:00 UTC` are both dates within the same day (when the UTC date is converted to UTC-5),
+    /// but this method will return `false`.
     ///
     /// - Parameters:
     ///   - localDate: The date to compare against in local timezone.
     /// - Returns: True if the year, month, and day components of the `localDate` matches the prompt's localized date.
     func inSameDay(as dateToCompare: Date) -> Bool {
-        guard let localDate = localDate else {
-            return false
-        }
-
-        return Calendar.current.isDate(dateToCompare, inSameDayAs: localDate)
-//
-//        guard let utcTimeZone = TimeZone(secondsFromGMT: 0) else {
-//            return false
-//        }
-//
-//        let calendar = Calendar.current
-//        let localizedComponents = calendar.dateComponents(in: utcTimeZone, from: date)
-//        let components: Set<Calendar.Component> = [.year, .month, .day]
-//        let diffs = calendar.dateComponents(components, from: localDate.dateAndTimeComponents(), to: localizedComponents)
-//
-//        return components.reduce(true) { partialResult, component in
-//            let value = diffs.value(for: component) ?? -1
-//            return partialResult && (value == 0)
-//        }
+        return DateFormatters.utc.string(from: date) == DateFormatters.local.string(from: dateToCompare)
     }
-
-
 }
 
 // MARK: - Private Helpers

--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -42,4 +42,64 @@ public class BloggingPrompt: NSManagedObject {
     func textForDisplay() -> String {
         return text.stringByDecodingXMLCharacters().trim()
     }
+
+    var localDate: Date? {
+        let dateString = DateFormatters.utc.string(from: date)
+        return DateFormatters.local.date(from: dateString)
+    }
+
+    /// Convenience method that matches local date to the prompt's UTC date.
+    ///
+    /// Before checking, the prompt date is "localized" to avoid -1/+1 day issue due to local timezone. This method only checks if the prompt date
+    /// matches the year, month, and day of the given `localDate`. The time information is ignored.
+    ///
+    /// - Parameters:
+    ///   - localDate: The date to compare against in local timezone.
+    /// - Returns: True if the year, month, and day components of the `localDate` matches the prompt's localized date.
+    func inSameDay(as dateToCompare: Date) -> Bool {
+        guard let localDate = localDate else {
+            return false
+        }
+
+        return Calendar.current.isDate(dateToCompare, inSameDayAs: localDate)
+//
+//        guard let utcTimeZone = TimeZone(secondsFromGMT: 0) else {
+//            return false
+//        }
+//
+//        let calendar = Calendar.current
+//        let localizedComponents = calendar.dateComponents(in: utcTimeZone, from: date)
+//        let components: Set<Calendar.Component> = [.year, .month, .day]
+//        let diffs = calendar.dateComponents(components, from: localDate.dateAndTimeComponents(), to: localizedComponents)
+//
+//        return components.reduce(true) { partialResult, component in
+//            let value = diffs.value(for: component) ?? -1
+//            return partialResult && (value == 0)
+//        }
+    }
+
+
+}
+
+// MARK: - Private Helpers
+
+private extension BloggingPrompt {
+
+    struct DateFormatters {
+        static let local: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = .init(identifier: "en_US_POSIX")
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter
+        }()
+
+        static let utc: DateFormatter = {
+            let formatter = DateFormatter()
+            formatter.locale = .init(identifier: "en_US_POSIX")
+            formatter.timeZone = .init(secondsFromGMT: 0)
+            formatter.dateFormat = "yyyy-MM-dd"
+            return formatter
+        }()
+    }
+
 }

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -35,11 +35,11 @@ class BloggingPromptsService {
     ///
     /// - Parameters:
     ///   - date: When specified, only prompts from the specified date will be returned. Defaults to 10 days ago.
-    ///   - number: The amount of prompts to return. Defaults to 24 when unspecified.
+    ///   - number: The amount of prompts to return. Defaults to 25 when unspecified (10 days back, today, 14 days ahead).
     ///   - success: Closure to be called when the fetch process succeeded.
     ///   - failure: Closure to be called when the fetch process failed.
     func fetchPrompts(from date: Date? = nil,
-                      number: Int = 24,
+                      number: Int = 25,
                       success: @escaping ([BloggingPrompt]) -> Void,
                       failure: @escaping (Error?) -> Void) {
         let fromDate = date ?? defaultStartDate
@@ -53,6 +53,7 @@ class BloggingPromptsService {
                     }
 
                     success(self.loadPrompts(from: fromDate, number: number))
+
                 }
             case .failure(let error):
                 failure(error)

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -134,6 +134,24 @@ class BloggingPromptsService {
     }
 }
 
+// MARK: - Service Factory
+
+/// Convenience factory to generate `BloggingPromptsService` for different blogs.
+///
+class BloggingPromptsServiceFactory {
+    let contextManager: ContextManager
+    let remote: BloggingPromptsServiceRemote?
+
+    init(contextManager: ContextManager, remote: BloggingPromptsServiceRemote? = nil) {
+        self.contextManager = contextManager
+        self.remote = remote
+    }
+
+    func makeService(for blog: Blog) -> BloggingPromptsService? {
+        return .init(contextManager: contextManager, remote: remote, blog: blog)
+    }
+}
+
 // MARK: - Private Helpers
 
 private extension BloggingPromptsService {

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -9,8 +9,6 @@ class PromptRemindersScheduler {
         case unknown
     }
 
-    private static var gmtTimeZone = TimeZone(secondsFromGMT: 0)!
-
     private let promptsServiceFactory: BloggingPromptsServiceFactory
     private let notificationScheduler: NotificationScheduler
     private let pushAuthorizer: PushNotificationAuthorizer
@@ -130,10 +128,14 @@ private extension PromptRemindersScheduler {
     ///   - time: The preferred reminder time for the notification.
     /// - Returns: String representing the notification identifier.
     func scheduleNotification(for prompt: BloggingPrompt, blog: Blog, at time: Time) -> String? {
-        let utcDateComponents = Calendar.current.dateComponents(in: Self.gmtTimeZone, from: prompt.date)
-        guard let year = utcDateComponents.year,
-              let month = utcDateComponents.month,
-              let day = utcDateComponents.day else {
+        guard let gmtTimeZone = TimeZone(secondsFromGMT: 0) else {
+            return nil
+        }
+
+        let gmtDateComponents = Calendar.current.dateComponents(in: gmtTimeZone, from: prompt.date)
+        guard let year = gmtDateComponents.year,
+              let month = gmtDateComponents.month,
+              let day = gmtDateComponents.day else {
             return nil
         }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -1,0 +1,161 @@
+import Foundation
+import UserNotifications
+
+/// Encapsulates the local notification scheduling logic for Blogging Prompts.
+///
+class PromptRemindersScheduler {
+    typealias Schedule = BloggingRemindersScheduler.Schedule
+    typealias Weekday = BloggingRemindersScheduler.Weekday
+
+    enum Errors: Error {
+        case invalidSite
+        case unknown
+    }
+
+    private let notificationScheduler: NotificationScheduler
+    private let pushAuthorizer: PushNotificationAuthorizer
+
+    // MARK: Public Methods
+
+    init(notificationScheduler: NotificationScheduler = UNUserNotificationCenter.current(),
+         pushAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared) {
+        self.notificationScheduler = notificationScheduler
+        self.pushAuthorizer = pushAuthorizer
+    }
+
+    /// Schedule local notifications that will show prompts on selected weekdays based on the given `Schedule`.
+    /// Prompt notifications will be bulk-scheduled for 2 weeks ahead.
+    ///
+    /// - Parameters:
+    ///   - schedule: The preferred notification schedule.
+    ///   - blog: The blog that will upload the user's post.
+    ///   - time: The user's preferred time to be notified.
+    ///   - completion: Closure called after the process completes.
+    func schedule(_ schedule: Schedule, for blog: Blog, time: Date? = nil, completion: @escaping(Result<Void, Error>) -> Void) {
+
+        // TODO: Add push authorization before proceeding with the logic.
+
+        guard case .weekdays(let weekdays) = schedule else {
+            unschedule(for: blog)
+            completion(.success(()))
+            return
+        }
+
+        guard let promptsService = BloggingPromptsService(blog: blog) else {
+            completion(.failure(Errors.invalidSite))
+            return
+        }
+
+        let reminderTime = Time(from: time) ?? Constants.defaultTime
+        let currentDate = Date()
+        promptsService.fetchPrompts(from: currentDate, number: Constants.promptsToFetch) { [weak self] prompts in
+            guard let self = self else {
+                completion(.failure(Errors.unknown))
+                return
+            }
+
+            // Filter prompts based on the Schedule.
+            prompts.filter { prompt in
+                guard let promptLocalDate = prompt.localDate,
+                      let weekdayComponent = promptLocalDate.dateAndTimeComponents().weekday,
+                      let weekday = Weekday(rawValue: weekdayComponent - 1) else { // Calendar.Component.weekday starts from 1 (Sunday)
+                    return false
+                }
+                // only select prompts that matches the weekdays listed in the schedule.
+                // additionally, if today's prompt is included, only include it if the reminder time has not passed.
+                return weekdays.contains(weekday) && (!prompt.inSameDay(as: currentDate) || reminderTime.compare(with: currentDate) == .orderedAscending)
+            }.forEach { promptToSchedule in
+                let _ = self.scheduleNotification(for: promptToSchedule, blog: blog, at: reminderTime)
+            }
+
+            // TODO: Save notification identifiers to local store.
+
+            // TODO: Schedule static notifications.
+
+            completion(.success(()))
+
+        } failure: { error in
+            completion(.failure(error ?? Errors.unknown))
+        }
+    }
+
+    func unschedule(for blog: Blog) {
+        // TODO: Implement
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension PromptRemindersScheduler {
+
+    /// A simple structure representing hour and minute.
+    struct Time {
+        let hour: Int
+        let minute: Int
+
+        func compare(with date: Date) -> ComparisonResult {
+            let hourToCompare = Calendar.current.component(.hour, from: date)
+            let minuteToCompare = Calendar.current.component(.minute, from: date)
+
+            if hour == hourToCompare && minute == minuteToCompare {
+                return .orderedSame
+            } else if hour < hourToCompare || (hour < hourToCompare && minute < minuteToCompare) {
+                return .orderedAscending
+            }
+
+            return .orderedDescending
+        }
+    }
+
+    enum Constants {
+        static let defaultTime = Time(hour: 10, minute: 0) // 10:00 AM
+        static let promptsToFetch = 15 // fetch prompts for today + two weeks ahead
+        static let notificationTitle = NSLocalizedString("Today's Prompt 💡", comment: "Title for a push notification showing today's blogging prompt.")
+    }
+
+    /// Schedules the local notification.
+    ///
+    /// - Parameters:
+    ///   - prompt: The `BloggingPrompt` instance used to populate the content.
+    ///   - blog: The user's blog.
+    ///   - time: The preferred reminder time for the notification.
+    /// - Returns: String representing the notification identifier.
+    func scheduleNotification(for prompt: BloggingPrompt, blog: Blog, at time: Time) -> String? {
+        let content = UNMutableNotificationContent()
+        content.title = Constants.notificationTitle
+        content.subtitle = blog.title ?? String()
+        content.body = prompt.text
+
+        // craft the date component based on the prompt date and preferred time.
+        guard let promptLocalDate = prompt.localDate,
+              let reminderDate = Calendar.current.date(bySettingHour: time.hour, minute: time.minute, second: .zero, of: promptLocalDate) else {
+            return nil
+        }
+
+        // craft the notification trigger.
+        let trigger = UNCalendarNotificationTrigger(dateMatching: reminderDate.dateAndTimeComponents(), repeats: false)
+        let identifier = UUID().uuidString
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        // schedule the notification.
+        notificationScheduler.add(request) { error in
+            if let error = error {
+                DDLogError("[PromptRemindersScheduler] Error adding notification request: \(error.localizedDescription)")
+            }
+        }
+
+        return identifier
+    }
+}
+
+private extension PromptRemindersScheduler.Time {
+    init?(from date: Date?) {
+        guard let dateComponents = date?.dateAndTimeComponents(),
+              let hourComponent = dateComponents.hour,
+              let minuteComponent = dateComponents.minute else {
+            return nil
+        }
+
+        self.init(hour: hourComponent, minute: minuteComponent)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4653,6 +4653,7 @@
 		FEC3B81A26C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */; };
 		FECA442F28350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
 		FECA443028350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
+		FECA44322836647100D01F15 /* PromptRemindersSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA44312836647100D01F15 /* PromptRemindersSchedulerTests.swift */; };
 		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
@@ -7933,6 +7934,7 @@
 		FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleButtonTableViewCell.swift; sourceTree = "<group>"; };
 		FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleButtonTableViewCell.xib; sourceTree = "<group>"; };
 		FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersScheduler.swift; sourceTree = "<group>"; };
+		FECA44312836647100D01F15 /* PromptRemindersSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersSchedulerTests.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEF93A01F06919BDB9486A8E /* Pods-WordPressHomeWidgetToday.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressHomeWidgetToday/Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -14829,6 +14831,7 @@
 			children = (
 				F15D1FB9265C41A900854EE5 /* BloggingRemindersStoreTests.swift */,
 				F151EC822665271200AEA89E /* BloggingRemindersSchedulerTests.swift */,
+				FECA44312836647100D01F15 /* PromptRemindersSchedulerTests.swift */,
 			);
 			name = "Blogging Reminders";
 			sourceTree = "<group>";
@@ -19995,6 +19998,7 @@
 				4688E6CC26AB571D00A5D894 /* RequestAuthenticatorTests.swift in Sources */,
 				7E442FC720F677CB00DEACA5 /* ActivityLogRangesTest.swift in Sources */,
 				938466B92683CA0E00A538DC /* ReferrerDetailsViewModelTests.swift in Sources */,
+				FECA44322836647100D01F15 /* PromptRemindersSchedulerTests.swift in Sources */,
 				FE3D057E26C3D5C1002A51B0 /* ShareAppContentPresenterTests.swift in Sources */,
 				8B25F8DA24B7683A009DD4C9 /* ReaderCSSTests.swift in Sources */,
 				AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -4651,6 +4651,8 @@
 		FEC3B81826C2915A00A395C7 /* SingleButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */; };
 		FEC3B81926C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */; };
 		FEC3B81A26C2915A00A395C7 /* SingleButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */; };
+		FECA442F28350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
+		FECA443028350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
 		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
@@ -7930,6 +7932,7 @@
 		FEB7A8922718852A00A8CF85 /* WordPress 134.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 134.xcdatamodel"; sourceTree = "<group>"; };
 		FEC3B81526C2915A00A395C7 /* SingleButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleButtonTableViewCell.swift; sourceTree = "<group>"; };
 		FEC3B81626C2915A00A395C7 /* SingleButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SingleButtonTableViewCell.xib; sourceTree = "<group>"; };
+		FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersScheduler.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEF93A01F06919BDB9486A8E /* Pods-WordPressHomeWidgetToday.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressHomeWidgetToday/Pods-WordPressHomeWidgetToday.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -14816,6 +14819,7 @@
 				F117B11F265C53AB00D2CAA9 /* BloggingRemindersScheduler.swift */,
 				F111B87726580FCE00057942 /* BloggingRemindersStore.swift */,
 				17F11EDA268623BA00D1BBA7 /* BloggingRemindersScheduleFormatter.swift */,
+				FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */,
 			);
 			path = "Blogging Reminders";
 			sourceTree = "<group>";
@@ -18912,6 +18916,7 @@
 				93E6336F272C1074009DACF8 /* LoginEpilogueCreateNewSiteCell.swift in Sources */,
 				8261B4CC1EA8E13700668298 /* SVProgressHUD+Dismiss.m in Sources */,
 				329F8E5624DDAC61002A5311 /* DynamicHeightCollectionView.swift in Sources */,
+				FECA442F28350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */,
 				436D56242117312700CEAA33 /* RegisterDomainDetailsViewModel+RowList.swift in Sources */,
 				C81CCD65243AECA200A83E27 /* TenorGIF.swift in Sources */,
 				596C035E1B84F21D00899EEB /* ThemeBrowserViewController.swift in Sources */,
@@ -21556,6 +21561,7 @@
 				FABB25952602FC2C00C8785C /* NSURL+Exporters.swift in Sources */,
 				FABB25962602FC2C00C8785C /* FileDownloadsStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB25972602FC2C00C8785C /* BlogToAccount.m in Sources */,
+				FECA443028350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */,
 				FABB25982602FC2C00C8785C /* JetpackRestoreHeaderView.swift in Sources */,
 				FABB25992602FC2C00C8785C /* StoryboardLoadable.swift in Sources */,
 				FABB259A2602FC2C00C8785C /* ReaderBlockSiteAction.swift in Sources */,

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -141,7 +141,7 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
     func test_fetchPrompts_givenNoParameters_assignsDefaultValue() {
         let expectedDifferenceInHours = 10 * 24 // 10 days ago.
-        let expectedNumber = 24
+        let expectedNumber = 25
         remote.shouldReturnSuccess = false
 
         // call the fetch just to trigger default parameter assignment. the completion blocks can be ignored.

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -1,42 +1,53 @@
-//
-//  PromptRemindersSchedulerTests.swift
-//  WordPressTest
-//
-//  Created by David Christiandy on 19/05/22.
-//  Copyright © 2022 WordPress. All rights reserved.
-//
-
 import XCTest
 import OHHTTPStubs
+import CoreData
 
 @testable import WordPress
 
 class PromptRemindersSchedulerTests: XCTestCase {
-
     typealias Schedule = BloggingRemindersScheduler.Schedule
     typealias Weekday = BloggingRemindersScheduler.Weekday
 
-    private static var dateFormatter: DateFormatter = {
+    private let timeout: TimeInterval = 1
+    private let currentDate = ISO8601DateFormatter().date(from: "2022-05-20T09:00:00+00:00")! // friday
+
+    private static var gmtTimeZone = TimeZone(secondsFromGMT: 0)!
+    private static var gmtCalendar: Calendar = {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = gmtTimeZone
+        return calendar
+    }()
+
+    private static var gmtDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = gmtTimeZone
         return formatter
     }()
 
-    var contextManager: ContextManagerMock!
-    var serviceFactory: BloggingPromptsServiceFactory!
-    var notificationScheduler: NotificationScheduler!
-    var pushAuthorizer: PushNotificationAuthorizer!
-    var scheduler: PromptRemindersScheduler!
+    private var contextManager: ContextManagerMock!
+    private var serviceFactory: BloggingPromptsServiceFactory!
+    private var notificationScheduler: MockNotificationScheduler!
+    private var pushAuthorizer: PushNotificationAuthorizer!
+    private var blog: Blog!
+    private var accountService: AccountService!
+    private var scheduler: PromptRemindersScheduler!
+    private var dateProvider: MockCurrentDateProvider!
 
     override func setUp() {
         contextManager = ContextManagerMock()
         serviceFactory = BloggingPromptsServiceFactory(contextManager: contextManager)
         notificationScheduler = MockNotificationScheduler()
         pushAuthorizer = PushNotificationsAuthorizerMock()
+        dateProvider = MockCurrentDateProvider(currentDate)
+        blog = makeBlog()
+        accountService = makeAccountService()
         scheduler = PromptRemindersScheduler(bloggingPromptsServiceFactory: serviceFactory,
                                              notificationScheduler: notificationScheduler,
-                                             pushAuthorizer: pushAuthorizer)
+                                             pushAuthorizer: pushAuthorizer,
+                                             currentDateProvider: dateProvider)
+        NSTimeZone.default = Self.gmtTimeZone
 
         super.setUp()
     }
@@ -46,8 +57,12 @@ class PromptRemindersSchedulerTests: XCTestCase {
         serviceFactory = nil
         notificationScheduler = nil
         pushAuthorizer = nil
+        dateProvider = nil
+        blog = nil
+        accountService = nil
         scheduler = nil
         HTTPStubs.removeAllStubs()
+        NSTimeZone.default = NSTimeZone.system
 
         super.tearDown()
     }
@@ -55,25 +70,141 @@ class PromptRemindersSchedulerTests: XCTestCase {
     // MARK: Tests
 
     func test_schedule_addsNotificationRequestsCorrectly() {
+        // the mocked current date is friday.
+        let schedule = Schedule.weekdays([.saturday])
+        stubFetchPromptsResponse()
 
+        struct Expected {
+            let body: String
+            let dateComponents: DateComponents
+
+            static let values = [
+                Expected(
+                    body: "Prompt text 1",
+                    dateComponents: DateComponents(year: 2022, month: 5, day: 21, hour: 10, minute: 0)
+                ),
+                Expected(
+                    body: "Prompt text 8",
+                    dateComponents: DateComponents(year: 2022, month: 5, day: 28, hour: 10, minute: 0)
+                )
+            ]
+        }
+
+        let expectation = expectation(description: "Notification scheduling should succeed")
+        scheduler.schedule(schedule, for: blog) { result in
+            guard case .success = result else {
+                XCTFail("Expected a success result")
+                expectation.fulfill()
+                return
+            }
+
+            XCTAssertEqual(self.notificationScheduler.requests.count, Expected.values.count)
+
+            // verify mappings to notification request.
+            for (index, request) in self.notificationScheduler.requests.enumerated() {
+                let value = Expected.values[index]
+                XCTAssertEqual(request.content.body, value.body)
+                XCTAssertNotNil(request.trigger)
+                XCTAssertNotNil(request.trigger as? UNCalendarNotificationTrigger)
+
+                let trigger = request.trigger as! UNCalendarNotificationTrigger
+                XCTAssertEqual(trigger.dateComponents.year, value.dateComponents.year)
+                XCTAssertEqual(trigger.dateComponents.month, value.dateComponents.month)
+                XCTAssertEqual(trigger.dateComponents.day, value.dateComponents.day)
+                XCTAssertEqual(trigger.dateComponents.hour, value.dateComponents.hour)
+                XCTAssertEqual(trigger.dateComponents.minute, value.dateComponents.minute)
+            }
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
     }
 
     func test_schedule_givenEmptySchedule_doesNothing() {
+        let schedule = Schedule.none
+        stubFetchPromptsResponse()
 
+        let expectation = expectation(description: "Notification scheduling should succeed")
+        scheduler.schedule(schedule, for: blog) { result in
+            guard case .success = result else {
+                XCTFail("Expected a success result")
+                expectation.fulfill()
+                return
+            }
+
+            XCTAssertTrue(self.notificationScheduler.requests.isEmpty)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
     }
 
     func test_schedule_givenTodayIsIncluded_withReminderTimeAfterCurrentTime_includesTodayInSchedule() {
+        let schedule = Schedule.weekdays([.friday])
+        stubFetchPromptsResponse()
 
+        let expectation = expectation(description: "Notification scheduling should succeed")
+        scheduler.schedule(schedule, for: blog) { result in
+            guard case .success = result else {
+                XCTFail("Expected a success result")
+                expectation.fulfill()
+                return
+            }
+
+            XCTAssertEqual(self.notificationScheduler.requests.count, 3)
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
     }
 
     func test_schedule_givenTodayIsIncluded_withReminderTimeBeforeCurrentTime_excludesTodayFromSchedule() {
+        let schedule = Schedule.weekdays([.friday])
+        let expectedHour = 8
+        let expectedMinute = 30
+        let timeComponents = DateComponents(hour: expectedHour, minute: expectedMinute)
+        let dateForTime = Calendar.current.date(from: timeComponents)
 
+        stubFetchPromptsResponse()
+
+        let expectation = expectation(description: "Notification scheduling should succeed")
+        scheduler.schedule(schedule, for: blog, time: dateForTime) { result in
+            guard case .success = result else {
+                XCTFail("Expected a success result")
+                expectation.fulfill()
+                return
+            }
+
+            // today should be skipped because the reminder is set to 8:30 while current time is 9:00.
+            XCTAssertEqual(self.notificationScheduler.requests.count, 2)
+
+            // verify that the reminder time is set correctly.
+            let request = self.notificationScheduler.requests.first!
+            let trigger = request.trigger! as! UNCalendarNotificationTrigger
+            XCTAssertEqual(trigger.dateComponents.hour, expectedHour)
+            XCTAssertEqual(trigger.dateComponents.minute, expectedMinute)
+
+            expectation.fulfill()
+        }
+
+        wait(for: [expectation], timeout: timeout)
     }
 }
 
 // MARK: - Private Helpers
 
 private extension PromptRemindersSchedulerTests {
+
+    var mainContext: NSManagedObjectContext {
+        contextManager.mainContext
+    }
+
+    var weekdayForTomorrow: Weekday {
+        /// `DateComponent`'s weekday is 1-based, while `Weekday` is 0-based.
+        /// We want to get the next weekday, so no need to decrement the weekday from `DateComponent`.
+        return Weekday(rawValue: Calendar.current.dateComponents([.weekday], from: Date()).weekday! % 7)!
+    }
 
     func stubFetchPromptsResponse() {
         stub(condition: isMethodGET()) { _ in
@@ -83,18 +214,17 @@ private extension PromptRemindersSchedulerTests {
 
     func makeDynamicPromptObjects(count: Int = 15) -> Any {
         var objects = [Any]()
-        let calendar = Calendar.current
-        let currentDate = Date()
+        let currentDate = dateProvider.date()
 
         for i in 0..<count {
-            let date = calendar.date(byAdding: .day, value: i, to: currentDate)!
+            let date = Self.gmtCalendar.date(byAdding: .day, value: i, to: currentDate)!
             objects.append([
                 "id": 100 + i,
                 "text": "Prompt text \(i)",
                 "title": "Prompt title \(i)",
                 "content": "Prompt content \(i)",
                 "attribution": "",
-                "date": Self.dateFormatter.string(from: date),
+                "date": Self.gmtDateFormatter.string(from: date),
                 "answered": false,
                 "answered_users_count": 0,
                 "answered_users_sample": []
@@ -104,6 +234,18 @@ private extension PromptRemindersSchedulerTests {
         return ["prompts": objects]
     }
 
+    func makeBlog() -> Blog {
+        return BlogBuilder(mainContext).isHostedAtWPcom().build()
+    }
+
+    func makeAccountService() -> AccountService {
+        let service = AccountService(managedObjectContext: mainContext)
+        let account = service.createOrUpdateAccount(withUsername: "testuser", authToken: "authtoken")
+        account.userID = NSNumber(value: 1)
+        service.setDefaultWordPressComAccount(account)
+
+        return service
+    }
 
     class MockNotificationScheduler: NotificationScheduler {
         var requests = [UNNotificationRequest]()
@@ -115,6 +257,18 @@ private extension PromptRemindersSchedulerTests {
 
         func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
             // no-op
+        }
+    }
+
+    class MockCurrentDateProvider: CurrentDateProvider {
+        var dateToReturn: Date
+
+        init(_ date: Date) {
+            dateToReturn = date
+        }
+
+        func date() -> Date {
+            return dateToReturn
         }
     }
 }

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -200,12 +200,6 @@ private extension PromptRemindersSchedulerTests {
         contextManager.mainContext
     }
 
-    var weekdayForTomorrow: Weekday {
-        /// `DateComponent`'s weekday is 1-based, while `Weekday` is 0-based.
-        /// We want to get the next weekday, so no need to decrement the weekday from `DateComponent`.
-        return Weekday(rawValue: Calendar.current.dateComponents([.weekday], from: Date()).weekday! % 7)!
-    }
-
     func stubFetchPromptsResponse() {
         stub(condition: isMethodGET()) { _ in
             return .init(jsonObject: self.makeDynamicPromptObjects(), statusCode: 200, headers: ["Content-Type": "application/json"])

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -1,0 +1,120 @@
+//
+//  PromptRemindersSchedulerTests.swift
+//  WordPressTest
+//
+//  Created by David Christiandy on 19/05/22.
+//  Copyright © 2022 WordPress. All rights reserved.
+//
+
+import XCTest
+import OHHTTPStubs
+
+@testable import WordPress
+
+class PromptRemindersSchedulerTests: XCTestCase {
+
+    typealias Schedule = BloggingRemindersScheduler.Schedule
+    typealias Weekday = BloggingRemindersScheduler.Weekday
+
+    private static var dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter
+    }()
+
+    var contextManager: ContextManagerMock!
+    var serviceFactory: BloggingPromptsServiceFactory!
+    var notificationScheduler: NotificationScheduler!
+    var pushAuthorizer: PushNotificationAuthorizer!
+    var scheduler: PromptRemindersScheduler!
+
+    override func setUp() {
+        contextManager = ContextManagerMock()
+        serviceFactory = BloggingPromptsServiceFactory(contextManager: contextManager)
+        notificationScheduler = MockNotificationScheduler()
+        pushAuthorizer = PushNotificationsAuthorizerMock()
+        scheduler = PromptRemindersScheduler(bloggingPromptsServiceFactory: serviceFactory,
+                                             notificationScheduler: notificationScheduler,
+                                             pushAuthorizer: pushAuthorizer)
+
+        super.setUp()
+    }
+
+    override func tearDown() {
+        contextManager = nil
+        serviceFactory = nil
+        notificationScheduler = nil
+        pushAuthorizer = nil
+        scheduler = nil
+        HTTPStubs.removeAllStubs()
+
+        super.tearDown()
+    }
+
+    // MARK: Tests
+
+    func test_schedule_addsNotificationRequestsCorrectly() {
+
+    }
+
+    func test_schedule_givenEmptySchedule_doesNothing() {
+
+    }
+
+    func test_schedule_givenTodayIsIncluded_withReminderTimeAfterCurrentTime_includesTodayInSchedule() {
+
+    }
+
+    func test_schedule_givenTodayIsIncluded_withReminderTimeBeforeCurrentTime_excludesTodayFromSchedule() {
+
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension PromptRemindersSchedulerTests {
+
+    func stubFetchPromptsResponse() {
+        stub(condition: isMethodGET()) { _ in
+            return .init(jsonObject: self.makeDynamicPromptObjects(), statusCode: 200, headers: ["Content-Type": "application/json"])
+        }
+    }
+
+    func makeDynamicPromptObjects(count: Int = 15) -> Any {
+        var objects = [Any]()
+        let calendar = Calendar.current
+        let currentDate = Date()
+
+        for i in 0..<count {
+            let date = calendar.date(byAdding: .day, value: i, to: currentDate)!
+            objects.append([
+                "id": 100 + i,
+                "text": "Prompt text \(i)",
+                "title": "Prompt title \(i)",
+                "content": "Prompt content \(i)",
+                "attribution": "",
+                "date": Self.dateFormatter.string(from: date),
+                "answered": false,
+                "answered_users_count": 0,
+                "answered_users_sample": []
+            ])
+        }
+
+        return ["prompts": objects]
+    }
+
+
+    class MockNotificationScheduler: NotificationScheduler {
+        var requests = [UNNotificationRequest]()
+
+        func add(_ request: UNNotificationRequest, withCompletionHandler completionHandler: ((Error?) -> Void)?) {
+            requests.append(request)
+            completionHandler?(nil)
+        }
+
+        func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {
+            // no-op
+        }
+    }
+}


### PR DESCRIPTION
Refs #18542

This adds the core scheduler component to register local notifications. I've split the work into three parts to make the changes a bit more digestible. For this PR, here are the highlights:

- Some minor changes on `BloggingPromptsService`: I've bumped up the default `number` value from 24 to 25. This is to account for today and the next 14 days.
- Added `PromptRemindersScheduler`. This accepts `BloggingRemindersScheduler.Schedule` data structure, fetches the prompts, and bulk-registers local notifications.
- The unit tests should cover the various tricky time-related scenarios. Let me know if you've thought of any other cases that I've missed!
- I've added some TODO comments within the scheduler code, but to summarize, here are the TODOs:
  - Save notification identifiers to the local store. This is used to cancel pending/upcoming notifications.
  - Implement `unschedule` to delete pending local notifications.
  - Schedule static notifications after the prompts have run out.

## To Test

Since this is pure logic and not hooked anywhere yet, please run the unit tests and ensure they pass. 

## Regression Notes
1. Potential unintended areas of impact
N/A. The component is still isolated, and feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. The component is still isolated, and feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests for the scheduler logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
