### PR TITLE
Blogging Prompts: Add `fetchSettings` and `updateSettings` blogging prompt calls

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    pod 'WordPressKit', '~> 4.52.0'
+    # pod 'WordPressKit', '~> 4.52.0'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => ''
+    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/blogging-prompts-settings-sync'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile
+++ b/Podfile
@@ -47,9 +47,9 @@ def wordpress_ui
 end
 
 def wordpress_kit
-    # pod 'WordPressKit', '~> 4.52.0'
+    pod 'WordPressKit', '~> 4.53.0-beta'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
-    pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/blogging-prompts-settings-sync'
+    # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'feature/blogging-prompts-settings-sync'
     # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
     # pod 'WordPressKit', :path => '../WordPressKit-iOS'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -487,7 +487,7 @@ PODS:
     - WordPressKit (~> 4.18-beta)
     - WordPressShared (~> 1.12-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (4.52.0):
+  - WordPressKit (4.53.0-beta.1):
     - Alamofire (~> 4.8.0)
     - CocoaLumberjack (~> 3.4)
     - NSObject-SafeExpectations (= 0.0.4)
@@ -591,7 +591,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
-  - WordPressKit (~> 4.52.0)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/blogging-prompts-settings-sync`)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.1)
   - WordPressUI (~> 1.12.5)
@@ -603,7 +603,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
   trunk:
     - Alamofire
     - AlamofireImage
@@ -753,6 +752,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.76.1
+  WordPressKit:
+    :branch: feature/blogging-prompts-settings-sync
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.76.1/third-party-podspecs/Yoga.podspec.json
 
@@ -768,6 +770,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.76.1
+  WordPressKit:
+    :commit: 82982b27636ba5479ebe1dfb9044ea387cdbc55a
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -853,7 +858,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
-  WordPressKit: 231ec33b670c443cebd9ebeac92d66f1e732831d
+  WordPressKit: 3d9781df3270ec652660a207994867e354fe7ca2
   WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
   WordPressShared: 0c4bc5e25765732fcf5d07f28c81970ab28493fb
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -869,6 +874,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 0a1cd3711eadb59c5f839f986de2bbc3af6dfa15
+PODFILE CHECKSUM: 636e82ae158039192e73aeb07d01d76f2416496a
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -591,7 +591,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, branch `feature/blogging-prompts-settings-sync`)
+  - WordPressKit (~> 4.53.0-beta)
   - WordPressMocks (~> 0.0.15)
   - WordPressShared (~> 1.17.1)
   - WordPressUI (~> 1.12.5)
@@ -640,6 +640,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressKit
     - WordPressMocks
     - WordPressShared
     - WordPressUI
@@ -752,9 +753,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.76.1
-  WordPressKit:
-    :branch: feature/blogging-prompts-settings-sync
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.76.1/third-party-podspecs/Yoga.podspec.json
 
@@ -770,9 +768,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.76.1
-  WordPressKit:
-    :commit: 82982b27636ba5479ebe1dfb9044ea387cdbc55a
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -874,6 +869,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 636e82ae158039192e73aeb07d01d76f2416496a
+PODFILE CHECKSUM: b0e5bbd0c17dca3b2ae21eb36ddc3942c3538b38
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -124,10 +124,8 @@ class BloggingPromptsService {
         remote.fetchSettings(for: siteID) { result in
             switch result {
             case .success(let remoteSettings):
-                print("🔴 Blogging prompts > fetch settings > success:\n\(remoteSettings)")
                 success()
             case .failure(let error):
-                print("🔴 Blogging prompts > fetch settings > failure: \(String(describing: error))")
                 failure(error)
             }
         }
@@ -139,10 +137,8 @@ class BloggingPromptsService {
         remote.updateSettings(for: siteID, with: settings) { result in
             switch result {
             case .success(let updatedSettings):
-                print("🔴 Blogging prompts > update settings > success:\n\(String(describing: updatedSettings))")
                 success()
             case .failure(let error):
-                print("🔴 Blogging prompts > update settings > failure: \(String(describing: error))")
                 failure(error)
             }
         }

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -117,6 +117,37 @@ class BloggingPromptsService {
         fetchListPrompts(success: success, failure: failure)
     }
 
+    // MARK: - Settings
+
+    func fetchSettings(success: @escaping () -> Void,
+                       failure: @escaping (Error?) -> Void) {
+        remote.fetchSettings(for: siteID) { result in
+            switch result {
+            case .success(let remoteSettings):
+                print("🔴 Blogging prompts > fetch settings > success:\n\(remoteSettings)")
+                success()
+            case .failure(let error):
+                print("🔴 Blogging prompts > fetch settings > failure: \(String(describing: error))")
+                failure(error)
+            }
+        }
+    }
+
+    func updateSettings(settings: RemoteBloggingPromptsSettings,
+                        success: @escaping () -> Void,
+                        failure: @escaping (Error?) -> Void) {
+        remote.updateSettings(for: siteID, with: settings) { result in
+            switch result {
+            case .success(let updatedSettings):
+                print("🔴 Blogging prompts > update settings > success:\n\(String(describing: updatedSettings))")
+                success()
+            case .failure(let error):
+                print("🔴 Blogging prompts > update settings > failure: \(String(describing: error))")
+                failure(error)
+            }
+        }
+    }
+
     // MARK: - Init
 
     required init?(contextManager: CoreDataStack = ContextManager.shared,


### PR DESCRIPTION
See: #18549
WordPressKit PR: wordpress-mobile/WordPressKit-iOS#504

## Description

Adds the `fetchSettings` and `updateSettings` network calls to the `BloggingPromptsService` class.

## Testing

The network calls need to be manually added. For my testing, I updated `DashboardPromptsCardCell` with the following:

```swift
// private let removeFromDashboardEnabled = false
private let removeFromDashboardEnabled = true
```

```swift
    func skipMenuTapped() {
//        saveSkippedPromptForSite()
//        presenterViewController?.reloadCardsLocally()
        bloggingPromptsService?.fetchSettings(success: {}, failure: { error in })
    }

    func removeMenuTapped() {
        // TODO.
        let jsonData = """
        {
            "prompts_card_opted_in": true,
            "prompts_reminders_opted_in": true,
            "reminders_days": {
                "monday": false,
                "tuesday": true,
                "wednesday": false,
                "thursday": true,
                "friday": false,
                "saturday": true,
                "sunday": false
            },
            "reminders_time": "14.30",
            "is_potential_blogging_site": true
        }
        """.data(using: .utf8)!
        let settings = try! JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: jsonData)
        bloggingPromptsService?.updateSettings(settings: settings,
                                               success: {},
                                               failure: { error in })
    }
```

After the network calls are added somewhere:
- Call `fetchSettings`
- Verify a `RemoteBloggingPromptsSettings` object is mapped and returned
- Call `updateSettings` with different settings than what was returned in `fetchSettings`
- Verify `RemoteBloggingPromptsSettings` is returned with the different settings
- Call `updateSettings` again with the same settings
- Verify `nil` is returned
- Disable network connection
- Call `fetchSettings`
- Verify an error is returned
- Call `updateSettings`
- Verify an error is returned

Checking the `RemoteBlog` options:
- Add a breakpoint to a spot where the `RemoteBlog` is mapped. I used: [BlogService.m#L965](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/Services/BlogService.m#L965)
- Debug the app and login if necessary
- Verify the `blogging_prompts_settings` is in the options dictionary when the blogs get fetched


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
