### PR TITLE
[Site Design Revamp] Randomize designs

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Extensions/RemoteSiteDesigns.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Extensions/RemoteSiteDesigns.swift
@@ -1,0 +1,14 @@
+import Foundation
+import WordPressKit
+
+extension RemoteSiteDesigns {
+    func designsForCategory(_ category: RemoteSiteDesignCategory) -> [RemoteSiteDesign] {
+       return designs.filter {
+           $0.categories.map { $0.slug }.contains(category.slug)
+       }
+    }
+
+    func shuffledDesignsForCategory(_ category: RemoteSiteDesignCategory) -> [RemoteSiteDesign] {
+        return designsForCategory(category).shuffled()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Extensions/RemoteSiteDesigns.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/Extensions/RemoteSiteDesigns.swift
@@ -8,7 +8,7 @@ extension RemoteSiteDesigns {
        }
     }
 
-    func shuffledDesignsForCategory(_ category: RemoteSiteDesignCategory) -> [RemoteSiteDesign] {
+    func randomizedDesignsForCategory(_ category: RemoteSiteDesignCategory) -> [RemoteSiteDesign] {
         return designsForCategory(category).shuffled()
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
@@ -4,6 +4,11 @@ import WordPressKit
 struct SiteDesignSectionLoader {
     static let recommendedTitle = NSLocalizedString("Best for %@", comment: "Title for a section of recommended site designs. The %@ will be replaced with the related site intent topic, such as Food or Blogging.")
 
+    /// Fetches and assembles `SiteDesignSection`s from the API.
+    ///
+    /// - Parameters:
+    ///   - vertical: An optional Site Intent vertical.
+    ///   - completion: The result closure.
     static func fetchSections(vertical: SiteIntentVertical?, completion: @escaping (Result<[SiteDesignSection], Error>) -> Void) {
         typealias TemplateGroup = SiteDesignRequest.TemplateGroup
         let templateGroups: [TemplateGroup] = [.stable, .singlePage]
@@ -29,12 +34,13 @@ struct SiteDesignSectionLoader {
         }
     }
 
-    /// Returns designs whose `group` property contains a vertical's slug.
+    /// Returns a single recommended section of designs whose `group` property contains a vertical's slug.
+    ///
     /// - Parameters:
-    ///   - vertical: `SiteIntentVertical`
-    ///   - remoteDesigns: `RemoteSiteDesigns`
-    /// - Returns: Optional `SiteDesignSection`
-    static func getSectionForVerticalSlug(_ vertical: SiteIntentVertical, remoteDesigns: RemoteSiteDesigns) -> SiteDesignSection? {
+    ///   - vertical: A Site Intent vertical.
+    ///   - remoteDesigns: Remote Site Designs.
+    /// - Returns: A `SiteDesignSection` if there was a match, otherwise `nil`.
+    static func getRecommendedSectionForVertical(_ vertical: SiteIntentVertical, remoteDesigns: RemoteSiteDesigns) -> SiteDesignSection? {
         let designsForVertical = remoteDesigns.designs.filter({
             $0.group?
                 .map { $0.lowercased() }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
@@ -62,15 +62,15 @@ struct SiteDesignSectionLoader {
     /// Gets `SiteDesignSection`s for the supplied `RemoteSiteDesigns`
     ///
     /// - If there are no designs for a category, it won't be included.
-    /// - Designs for categories are shuffled, but the order of categories is not.
+    /// - Order of designs for each category are randomized, but the order of categories is not.
     ///
     /// - Parameter remoteDesigns: Remote Site Designs.
-    /// - Returns: Array of Site Design sections with the designs shuffled.
+    /// - Returns: Array of Site Design sections with the designs randomized.
     static func getCategorySectionsForRemoteSiteDesigns(_ remoteDesigns: RemoteSiteDesigns) -> [SiteDesignSection] {
         return remoteDesigns.categories.map { category in
             SiteDesignSection(
                 category: category,
-                designs: remoteDesigns.shuffledDesignsForCategory(category),
+                designs: remoteDesigns.randomizedDesignsForCategory(category),
                 thumbnailSize: SiteDesignCategoryThumbnailSize.category.value
             )
         }.filter { !$0.designs.isEmpty }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -936,10 +936,9 @@
 		46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F58501262605930010A723 /* BlockEditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */; };
 		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
-		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift */; };
-		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
 		4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B8E282B05210089CF3D /* JSONObjectTests.swift */; };
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
+		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
 		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
@@ -2223,6 +2222,8 @@
 		C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
+		C3C21EB928385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
+		C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C70C562835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C70C552835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift */; };
@@ -5754,10 +5755,9 @@
 		46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceTests.swift; sourceTree = "<group>"; };
 		46F84612185A8B7E009D0DA5 /* PostContentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostContentProvider.h; sourceTree = "<group>"; };
 		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
-		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContextManagerMock+AutomaticTeardown.swift"; sourceTree = "<group>"; };
-		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
 		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
+		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock+AutomaticTeardown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContextManagerMock+AutomaticTeardown.swift"; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
 		528B9926294302CD0A4EB5C4 /* Pods-WordPressScreenshotGeneration.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressScreenshotGeneration/Pods-WordPressScreenshotGeneration.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -7034,6 +7034,7 @@
 		C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSiteDesign+Thumbnail.swift"; sourceTree = "<group>"; };
 		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
+		C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSiteDesigns.swift; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
 		C3C70C552835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSectionLoaderTests.swift; sourceTree = "<group>"; };
 		C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationNameTracksEventTests.swift; sourceTree = "<group>"; };
@@ -10205,6 +10206,7 @@
 		46241BD72540B403002B8A12 /* Design Selection */ = {
 			isa = PBXGroup;
 			children = (
+				C3C21EB728385EB4002296E2 /* Extensions */,
 				464688D5255C719500ECA61C /* Preview */,
 				C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */,
 				46241C0E2540BD01002B8A12 /* SiteDesignStep.swift */,
@@ -13732,6 +13734,14 @@
 				C7B7CC7228134347007B9807 /* OnboardingQuestionsPromptScreen.swift */,
 			);
 			path = Login;
+			sourceTree = "<group>";
+		};
+		C3C21EB728385EB4002296E2 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */,
+			);
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 		C3E42AAD27F4D2CF00546706 /* Menus */ = {
@@ -19309,6 +19319,7 @@
 				98B3FA8421C05BDC00148DD4 /* ViewMoreRow.swift in Sources */,
 				8BADF16524801BCE005AD038 /* ReaderWebView.swift in Sources */,
 				8B260D7E2444FC9D0010F756 /* PostVisibilitySelectorViewController.swift in Sources */,
+				C3C21EB928385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */,
 				B5416D011C17693B00006DD8 /* UIApplication+Helpers.m in Sources */,
 				731E88CA21C9A10B0055C014 /* ErrorStateView.swift in Sources */,
 				08D345501CD7F50900358E8C /* MenusSelectionDetailView.m in Sources */,
@@ -21563,6 +21574,7 @@
 				FABB25842602FC2C00C8785C /* NoResultsViewController+FollowedSites.swift in Sources */,
 				DC76668626FD9AC9009254DD /* TimeZoneTableViewCell.swift in Sources */,
 				FABB25862602FC2C00C8785C /* WordPress-11-12.xcmappingmodel in Sources */,
+				C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */,
 				FABB25872602FC2C00C8785C /* DiffAbstractValue.swift in Sources */,
 				9822A8422624CFB900FD8A03 /* UserProfileSiteCell.swift in Sources */,
 				FABB25882602FC2C00C8785C /* Routes+Notifications.swift in Sources */,

--- a/WordPress/WordPressTest/SiteCreation/SiteDesignSectionLoaderTests.swift
+++ b/WordPress/WordPressTest/SiteCreation/SiteDesignSectionLoaderTests.swift
@@ -17,7 +17,7 @@ class SiteDesignSectionLoaderTests: XCTestCase {
         let validVertical = SiteIntentVertical(slug: "test-vertical", localizedTitle: "Testing", emoji: "")
 
         // When
-        let section = SiteDesignSectionLoader.getSectionForVerticalSlug(
+        let section = SiteDesignSectionLoader.getRecommendedSectionForVertical(
             validVertical,
             remoteDesigns: remoteDesigns
         )
@@ -34,13 +34,24 @@ class SiteDesignSectionLoaderTests: XCTestCase {
         let invalidVertical = SiteIntentVertical(slug: "invalid-vertical", localizedTitle: "Testing", emoji: "")
 
         // When
-        let section = SiteDesignSectionLoader.getSectionForVerticalSlug(
+        let section = SiteDesignSectionLoader.getRecommendedSectionForVertical(
             invalidVertical,
             remoteDesigns: remoteDesigns
         )
 
         // Then
         XCTAssertNil(section)
+    }
+
+    func testCategorySectionsForRemoteSiteSiteDesigns() throws {
+        // When
+        let sections = SiteDesignSectionLoader.getCategorySectionsForRemoteSiteDesigns(remoteDesigns)
+
+        // Then
+        // The Slugs category has no designs so it isn't returned
+        XCTAssertEqual(sections.count, 2)
+        XCTAssertEqual(sections[0].categorySlug, "about")
+        XCTAssertEqual(sections[1].categorySlug, "blog")
     }
 
     /// Tests entire assembly of sections when a recommended vertical is used


### PR DESCRIPTION
Fixes #18676

## Description

- Randomizes the order of designs for all non-recommended sections
- Randomizes the order of the recommended section _only_ when it's the fallback category (e.g. Blog)

<img src="https://user-images.githubusercontent.com/2092798/169851955-10d0420f-0d2f-4968-8cc6-08a3d560f277.png" width="350px" />

## Notes:
- [This issue has been created](https://github.com/wordpress-mobile/WordPress-iOS/issues/18703) to track a visual glitch when navigating back to the Site Intent screen.
- Shuffling the designs when a user navigates to and from the Site Design screen is a subpar UX and will be addressed with [this issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/18689) or one similar.

## To test:

### Designs for non-recommended sections have random order upon load
1. Start the Site Creation flow
2. Tap "Skip", or choose a vertical that doesn't have any recommended designs
3. Note the design order of the non-recommended sections
4. Tap "Topic" at the top left to navigate back to the Site Intent screen
5. Tap "Skip", or choose a vertical that doesn't have any recommended designs
6. Expect that the design order has changed for each section
7. Repeat step 5-7 a few times to confirm that the order is randomized
8. Expect that the order of categories (e.g. About, Links, Slash, etc.) does _not_ change

### Designs for the recommended section have random order upon load if the section is "Best for Blogging"
1. Start the Site Creation flow
2. Tap "Skip", or choose a vertical that doesn't have any recommended designs
3. Note the design order of the "Best for Blogging" section
4. Tap "Topic" at the top left to navigate back to the Site Intent screen
5. Tap "Skip", or choose a vertical that doesn't have any recommended designs
6. Expect that the order of the designs has changed for the recommended section
7. Repeat step 5-7 a few times to confirm that the order is randomized

## Regression Notes
1. Potential unintended areas of impact
  - The order of recommended designs that match a vertical should not change

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manually tested the steps above
  - Relied on `SiteDesignSectionLoaderTests`

3. What automated tests I added (or what prevented me from doing so)
  - Unit tests don't seem like a good place to test for randomness and I checked to see if Swift supported a seed mechanism for [`shuffled()`](https://developer.apple.com/documentation/swift/array/2994757-shuffled). I didn't find anything but am open to ideas.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
