### PR TITLE
Quick Start: Dismiss Reader tour notice when navigating away from Reader screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/QuickStartChecklistView.swift
@@ -35,6 +35,9 @@ final class QuickStartChecklistView: UIView {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
         label.font = WPStyleGuide.serifFontForTextStyle(.body, fontWeight: .semibold)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.minimumScaleFactor = Metrics.labelMinimumScaleFactor
         label.textColor = .text
         return label
     }()
@@ -152,6 +155,7 @@ extension QuickStartChecklistView {
         static let mainStackViewSpacing = 16.0
         static let labelStackViewSpacing = 4.0
         static let progressIndicatorViewSize = 24.0
+        static let labelMinimumScaleFactor = 0.5
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -78,6 +78,8 @@ class ReaderTabViewController: UIViewController {
         super.viewWillDisappear(animated)
 
         ReaderTracker.shared.stop(.main)
+
+        QuickStartTourGuide.shared.endCurrentTour()
     }
 
     func setupNavigationButtons() {


### PR DESCRIPTION
Fixes #18700
Fixes #18698

Ref: p5T066-3dZ-p2#comment-12413

## Description

- Fixed a bug where the Reader tour notice wasn't being dismissed when navigating away from the Reader tab screen
- Updated the Quick Start title label to adjust the font scale so it doesn't get truncated 

## How to test

### Navigating away from Reader screen
1. Enable Quick Start for Existing Users via the debug menu
2. Start the "Connect with other sites" tour
3. Switch to the Reader tab
4. Navigate away from ReaderTabViewController (i.e. switch to different tabs, tap on the search icon, tap on a post)
5. ✅ Verify: The Quick Start notice is dismissed

https://user-images.githubusercontent.com/6711616/169803975-739073d5-8344-4d73-8f72-2a418251bb0f.mp4

### Completing the Reader task (regression testing)
1. Enable Quick Start for Existing Users via the debug menu
2. Start the "Connect with other sites" tour
3. Switch to the Reader tab
4. Complete the tour by tapping on the cog icon
5. Go back to My Site
6. ✅ Verify: The Reader tour is marked as completed

https://user-images.githubusercontent.com/6711616/169804067-b234817b-8d50-4f33-be5f-c4b424cfe668.mp4

### Title shouldn't be truncated
1. Run the app on a smaller device, like the iPhone SE
2. Enable Quick Start for Existing Users via the debug menu
3. ✅ Verify: "Get to know the WordPress app" isn't truncated

<img src="https://user-images.githubusercontent.com/6711616/169842909-0966a2fa-98b9-45b1-8e42-162f40d22f29.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/169842912-5318615a-6c81-4ab6-b4c0-b4f969073f49.png" width=200>
-- | --


## Regression Notes
1. Potential unintended areas of impact
- Completing the Reader task

7. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the steps above

8. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.