### PR TITLE
My Site Dashboard: change Quick Actions order

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -13,10 +13,10 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable {
 
     private lazy var stackView: UIStackView = {
         let stackView = UIStackView(arrangedSubviews: [
-            pagesButton,
+            statsButton,
             postsButton,
-            mediaButton,
-            statsButton
+            pagesButton,
+            mediaButton
         ])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal


### PR DESCRIPTION
This PR changes the Quick Actions order.

* Before: Pages, Posts, Media, Stats
* Now: Stats, Posts, Pages, Media

<img src="https://user-images.githubusercontent.com/7040243/169865615-14d7a309-9cb7-48bc-b1b0-35c930c636d9.png" width="300">

### To test

First, check that the order is correct! Then:

1. Enable Quick Start for existing sites
2. Start the "Check your stats" task
3. Make sure the correct button has the spotlight
4. Tap on it
5. ✅ Task should be completed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
