### PR TITLE
Blogging Prompts: Add push notification authorization

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -139,10 +139,10 @@ class BloggingPromptsService {
 /// Convenience factory to generate `BloggingPromptsService` for different blogs.
 ///
 class BloggingPromptsServiceFactory {
-    let contextManager: ContextManager
+    let contextManager: CoreDataStack
     let remote: BloggingPromptsServiceRemote?
 
-    init(contextManager: ContextManager, remote: BloggingPromptsServiceRemote? = nil) {
+    init(contextManager: CoreDataStack = ContextManager.shared, remote: BloggingPromptsServiceRemote? = nil) {
         self.contextManager = contextManager
         self.remote = remote
     }

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -142,7 +142,6 @@ private extension PromptRemindersScheduler {
 
             // TODO: Schedule static notifications.
 
-            print("[BloggingPrompt] Prompt reminder scheduled!")
             completion(.success(()))
 
         } failure: { error in

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -78,13 +78,11 @@ private extension PromptRemindersScheduler {
             let hourToCompare = Calendar.current.component(.hour, from: date)
             let minuteToCompare = Calendar.current.component(.minute, from: date)
 
-            if hour == hourToCompare && minute == minuteToCompare {
-                return .orderedSame
-            } else if hour < hourToCompare || (hour < hourToCompare && minute < minuteToCompare) {
-                return .orderedAscending
+            if hour == hourToCompare {
+                return NSNumber(value: minute).compare(NSNumber(value: minuteToCompare))
             }
 
-            return .orderedDescending
+            return NSNumber(value: hour).compare(NSNumber(value: hourToCompare))
         }
     }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -37,7 +37,7 @@ class PromptRemindersScheduler {
     ///   - blog: The blog that will upload the user's post.
     ///   - time: The user's preferred time to be notified.
     ///   - completion: Closure called after the process completes.
-    func schedule(_ schedule: BloggingRemindersScheduler.Schedule, for blog: Blog, time: Date? = nil, completion: @escaping(Result<Void, Error>) -> Void) {
+    func schedule(_ schedule: BloggingRemindersScheduler.Schedule, for blog: Blog, time: Date? = nil, completion: @escaping (Result<Void, Error>) -> Void) {
         guard schedule != .none else {
             // If there's no schedule, then we don't need to request authorization
             processSchedule(schedule, blog: blog, time: time, completion: completion)
@@ -142,6 +142,7 @@ private extension PromptRemindersScheduler {
 
             // TODO: Schedule static notifications.
 
+            print("[BloggingPrompt] Prompt reminder scheduled!")
             completion(.success(()))
 
         } failure: { error in

--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -17,7 +17,7 @@ class PromptRemindersScheduler {
 
     // MARK: Public Methods
 
-    init(bloggingPromptsServiceFactory: BloggingPromptsServiceFactory,
+    init(bloggingPromptsServiceFactory: BloggingPromptsServiceFactory = .init(),
          notificationScheduler: NotificationScheduler = UNUserNotificationCenter.current(),
          pushAuthorizer: PushNotificationAuthorizer = InteractiveNotificationsManager.shared,
          currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {


### PR DESCRIPTION
Ref #18542 

This adds the push notification authorization step for `PromptRemindersScheduler`, and skips the authorization when a `.none` Schedule is set (similar to blogging reminders). I've also added unit tests.

Additionally: I've fixed a small bug concerning hour & minute calculation. Also added tests for this.

## To test

### Unit tests

- Ensure that unit tests are passing.

### Manual tests

Since the component is not used anywhere yet, you'll need to place a custom code. Here's an example in `CommentDetailViewController`:

```swift
/// FIXME: Don't forget to remove this!

// Store the scheduler instance so closures are executed.
private var scheduler = PromptRemindersScheduler()

override func viewDidAppear(_ animated: Bool) {
    super.viewDidAppear(animated)

    scheduler.schedule(.weekdays([.sunday]), for: comment.blog!) { result in
        if case .success = result {
            print(">>> Blogging prompts scheduled.")
        }
    }
}
```

#### With push notifications authorized:
- Compile the app with the above modifications applied. 
- Go to My Sites > Comments and tap any comment.
- Verify that `>>> Blogging prompts scheduled.` is printed in the console.

#### With fresh install:
- Compile the app with the above modifications applied. 
- Go to My Sites > Comments and tap any comment.
- Verify that a push notification system prompt is shown.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is unreleased.

3. What automated tests I added (or what prevented me from doing so)
N/A. Feature is unreleased.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
