### PR TITLE
Site Design Revamp - Add large serif titles to categories

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -57,6 +57,12 @@ class CategorySectionTableViewCell: UITableViewCell {
         }
     }
 
+    var categoryTitleFont: UIFont? {
+        didSet {
+            categoryTitle.font = categoryTitleFont ?? WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.headline, fontWeight: .semibold)
+        }
+    }
+
     var isGhostCell: Bool = false
     var ghostThumbnailSize: CGSize = defaultThumbnailSize {
         didSet {
@@ -71,12 +77,13 @@ class CategorySectionTableViewCell: UITableViewCell {
         delegate = nil
         super.prepareForReuse()
         collectionView.contentOffset.x = 0
+        categoryTitleFont = nil
     }
 
     override func awakeFromNib() {
         super.awakeFromNib()
         collectionView.register(CollapsableHeaderCollectionViewCell.nib, forCellWithReuseIdentifier: CollapsableHeaderCollectionViewCell.cellReuseIdentifier)
-        categoryTitle.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.headline, fontWeight: .semibold)
+        categoryTitle.font = categoryTitleFont ?? WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.headline, fontWeight: .semibold)
         categoryTitle.layer.masksToBounds = true
         categoryTitle.layer.cornerRadius = 4
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -288,6 +288,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
+        cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
         return cell
     }
 }


### PR DESCRIPTION
Fixes #18581
Fixes #18673 

This PR adds large serif titles to the categories in Site Design

before | after
-- | --
<img height="500" src="https://user-images.githubusercontent.com/34376330/169872368-1b619515-7f60-4891-b843-7512c656fb4d.png"> | <img  height="500" src="https://user-images.githubusercontent.com/34376330/169872382-7c522b2e-f83f-4ddc-90fc-9adb70fcd2b7.png">


To test:

- checkout/build/run this branch
- Start the site creation flow
- make sure the categories titles have a serif large title
- Optionally, check with the view hierarchy on Xcode that the font is

`.NewYork-Semibold 22.00pt` (unless you have scaled the text from the system)
- Close the site creation flow, then tap on the FAB then "site page" and make sure the category titles fonts are unchanged in this section

## Regression Notes
1. Potential unintended areas of impact
None, this PR just changes fonts on the `CategorySectionTableViewCell` type

2. What I did to test those areas of impact (or what existing automated tests I relied on)
test both parts of the app where this type is used

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
