### PR TITLE
Stats Insights: Separate Likes and Comments cards with live data

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
@@ -98,12 +98,21 @@ class SparklineView: UIView {
         maskLayer.frame = bounds
         gradientLayer.frame = bounds
 
+        guard bounds.width > 0,
+              bounds.height > 0,
+              chartData.count > 1 else {
+                  lineLayer.path = nil
+                  maskLayer.path = nil
+                  CATransaction.commit()
+                  return
+              }
+
         // Calculate points to fit along X axis, using existing interpolated Y values
         let segmentWidth = bounds.width / CGFloat(chartData.count-1)
         let points = chartData.enumerated().map({ CGPoint(x: CGFloat($0.offset) * segmentWidth, y: $0.element) })
 
         // Scale Y values to fit within our bounds
-        let maxYValue = points.map(\.y).max() ?? 1.0
+        let maxYValue = max(1.0, points.map(\.y).max() ?? 1.0)
         let scaleFactor = bounds.height / maxYValue
         var transform = CGAffineTransform(scaleX: 1.0, y: scaleFactor)
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
@@ -12,6 +12,8 @@ class SparklineView: UIView {
             if chartColor == nil {
                 chartColor = SparklineView.defaultChartColor
             }
+
+            updateChartColors()
         }
     }
 
@@ -42,9 +44,9 @@ class SparklineView: UIView {
         layoutChart()
     }
 
-    func initializeChart() {layer.isGeometryFlipped = true
+    func initializeChart() {
+        layer.isGeometryFlipped = true
 
-        lineLayer.strokeColor = chartColor.cgColor
         lineLayer.lineWidth = Constants.lineWidth
         lineLayer.fillColor = UIColor.clear.cgColor
 
@@ -53,12 +55,17 @@ class SparklineView: UIView {
 
         gradientLayer.startPoint = Constants.gradientStart
         gradientLayer.endPoint = Constants.gradientEnd
-        gradientLayer.colors = [chartColor.cgColor, UIColor(white: 1.0, alpha: 0.0).cgColor]
         gradientLayer.mask = maskLayer
         gradientLayer.opacity = Constants.gradientOpacity
 
+        updateChartColors()
         layer.addSublayer(gradientLayer)
         layer.addSublayer(lineLayer)
+    }
+
+    private func updateChartColors() {
+        lineLayer.strokeColor = chartColor.cgColor
+        gradientLayer.colors = [chartColor.cgColor, UIColor(white: 1.0, alpha: 0.0).cgColor]
     }
 
     private func interpolateData(_ inputData: [CGFloat]) -> [CGFloat] {

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -230,6 +230,7 @@ extension WPStyleGuide {
 
         static let positiveColor = UIColor.success
         static let negativeColor = UIColor.error
+        static let neutralColor = UIColor.primary
 
         static let gridiconSize = CGSize(width: 24, height: 24)
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -16,6 +16,7 @@
     case insightsLatestPostSummary
     case insightsAllTime
     case insightsLikesTotals
+    case insightsCommentsTotals
     case insightsFollowerTotals
     case insightsMostPopularTime
     case insightsTagsAndCategories
@@ -38,6 +39,7 @@
                                      .insightsLatestPostSummary,
                                      .insightsAllTime,
                                      .insightsLikesTotals,
+                                     .insightsCommentsTotals,
                                      .insightsFollowerTotals,
                                      .insightsMostPopularTime,
                                      .insightsTagsAndCategories,
@@ -97,6 +99,8 @@
             return InsightsHeaders.allTimeStats
         case .insightsLikesTotals:
             return InsightsHeaders.likesTotals
+        case .insightsCommentsTotals:
+            return InsightsHeaders.commentsTotals
         case .insightsFollowerTotals:
             return InsightsHeaders.followerTotals
         case .insightsMostPopularTime:
@@ -287,6 +291,8 @@
             return .allTimeStats
         case.insightsLikesTotals:
             return .likesTotals
+        case .insightsCommentsTotals:
+            return .commentsTotals
         case .insightsFollowerTotals:
             return .followersTotals
         case .insightsMostPopularTime:
@@ -342,6 +348,7 @@
             }
         }
         static let likesTotals = NSLocalizedString("Likes Total", comment: "Insights 'Likes Total' header")
+        static let commentsTotals = NSLocalizedString("Comments Total", comment: "Insights 'Comments Total' header")
         static let followerTotals = NSLocalizedString("Followers Total", comment: "Insights 'Followers Total' header")
         static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
         static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -15,6 +15,7 @@
     case insightsViewsVisitors
     case insightsLatestPostSummary
     case insightsAllTime
+    case insightsLikesTotals
     case insightsFollowerTotals
     case insightsMostPopularTime
     case insightsTagsAndCategories
@@ -36,6 +37,7 @@
                                     [StatSection.insightsViewsVisitors,
                                      .insightsLatestPostSummary,
                                      .insightsAllTime,
+                                     .insightsLikesTotals,
                                      .insightsFollowerTotals,
                                      .insightsMostPopularTime,
                                      .insightsTagsAndCategories,
@@ -93,6 +95,8 @@
             return InsightsHeaders.latestPostSummary
         case .insightsAllTime:
             return InsightsHeaders.allTimeStats
+        case .insightsLikesTotals:
+            return InsightsHeaders.likesTotals
         case .insightsFollowerTotals:
             return InsightsHeaders.followerTotals
         case .insightsMostPopularTime:
@@ -281,6 +285,8 @@
             return .latestPostSummary
         case .insightsAllTime:
             return .allTimeStats
+        case.insightsLikesTotals:
+            return .likesTotals
         case .insightsFollowerTotals:
             return .followersTotals
         case .insightsMostPopularTime:
@@ -335,7 +341,8 @@
                 return NSLocalizedString("Most Popular Time", comment: "Insights 'Most Popular Time' header")
             }
         }
-        static let followerTotals = NSLocalizedString("Follower Totals", comment: "Insights 'Follower Totals' header")
+        static let likesTotals = NSLocalizedString("Likes Total", comment: "Insights 'Likes Total' header")
+        static let followerTotals = NSLocalizedString("Followers Total", comment: "Insights 'Followers Total' header")
         static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
         static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")
         static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -22,12 +22,14 @@ enum InsightType: Int, SiteStatsPinnable {
     // New stats revamp cards – May 2022
     case viewsVisitors
     case likesTotals
+    case commentsTotals
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
     static let defaultInsights: [InsightType] = {
         if FeatureFlag.statsNewInsights.enabled {
             return [.viewsVisitors,
                     .likesTotals,
+                    .commentsTotals,
                     .followersTotals,
                     .mostPopularTime,
                     .latestPostSummary]
@@ -77,6 +79,8 @@ enum InsightType: Int, SiteStatsPinnable {
             return .insightsAllTime
         case .likesTotals:
             return .insightsLikesTotals
+        case .commentsTotals:
+            return .insightsCommentsTotals
         case .followersTotals:
             return .insightsFollowerTotals
         case .mostPopularTime:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -19,22 +19,43 @@ enum InsightType: Int, SiteStatsPinnable {
     case allComments
     case allTagsAndCategories
     case allAnnual
+    // New stats revamp cards – May 2022
     case viewsVisitors
+    case likesTotals
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
-    static let defaultInsights: [InsightType] = [.mostPopularTime,
-                                                 .allTimeStats,
-                                                 .todaysStats,
-                                                 .followers,
-                                                 .comments
-    ]
+    static let defaultInsights: [InsightType] = {
+        if FeatureFlag.statsNewInsights.enabled {
+            return [.viewsVisitors,
+                    .likesTotals,
+                    .followersTotals,
+                    .mostPopularTime,
+                    .latestPostSummary]
+        } else {
+            return [.mostPopularTime,
+                    .allTimeStats,
+                    .todaysStats,
+                    .followers,
+                    .comments]
+        }
+    }()
+
     // This property is here to update the default list on existing installations.
     // If the list saved on UserDefaults matches the old one, it will be updated to the new one above.
-    static let oldDefaultInsights: [InsightType] = [.latestPostSummary,
-                                                    .todaysStats,
-                                                    .allTimeStats,
-                                                    .followersTotals
-    ]
+    static let oldDefaultInsights: [InsightType] = {
+        if FeatureFlag.statsNewInsights.enabled {
+            return [.mostPopularTime,
+                    .allTimeStats,
+                    .todaysStats,
+                    .followers,
+                    .comments]
+        } else {
+            return [.latestPostSummary,
+                    .todaysStats,
+                    .allTimeStats,
+                    .followersTotals]
+        }
+    }()
 
     static let defaultInsightsValues = InsightType.defaultInsights.map { $0.rawValue }
 
@@ -54,6 +75,8 @@ enum InsightType: Int, SiteStatsPinnable {
             return .insightsLatestPostSummary
         case .allTimeStats:
             return .insightsAllTime
+        case .likesTotals:
+            return .insightsLikesTotals
         case .followersTotals:
             return .insightsFollowerTotals
         case .mostPopularTime:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -175,6 +175,17 @@ class SiteStatsInsightsViewModel: Observable {
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
                 }, error: errorBlock))
+            case .likesTotals:
+                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLikesTotals,
+                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
+                tableRows.append(blocks(for: .likesTotals,
+                                           type: .period,
+                                           status: insightsStore.followersTotalsStatus,
+                                           block: {
+                    return TotalInsightStatsRow(dataRow: createLikesTotalInsightsRow(), statSection: .insightsLikesTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                }, loading: {
+                    return StatsGhostTwoColumnImmutableRow()
+                }, error: errorBlock))
             case .followersTotals:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowerTotals,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
@@ -621,6 +632,11 @@ private extension SiteStatsInsightsViewModel {
                                                    rightColumnData: totalPublicize.abbreviatedString()))
 
         return dataRows
+    }
+
+    func createLikesTotalInsightsRow() -> StatsTotalInsightsData {
+        // TODO: Populate with real data!
+        return StatsTotalInsightsData(count: 12.abbreviatedString())
     }
 
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -511,8 +511,8 @@ private extension SiteStatsInsightsViewModel {
                     currentCount = data.summaryData.compactMap({$0.viewsCount}).reduce(0, +)
                 case .visitors:
                     currentCount = data.summaryData.compactMap({$0.visitorsCount}).reduce(0, +)
-                default:
-                    break
+                case .likes:
+                    currentCount = data.summaryData.compactMap({$0.likesCount}).reduce(0, +)
                 case .comments:
                     currentCount = data.summaryData.compactMap({$0.commentsCount}).reduce(0, +)
                 }
@@ -522,8 +522,8 @@ private extension SiteStatsInsightsViewModel {
                     previousCount = data.summaryData.compactMap({$0.viewsCount}).reduce(0, +)
                 case .visitors:
                     previousCount = data.summaryData.compactMap({$0.visitorsCount}).reduce(0, +)
-                default:
-                    break
+                case .likes:
+                    previousCount = data.summaryData.compactMap({$0.likesCount}).reduce(0, +)
                 case .comments:
                     previousCount = data.summaryData.compactMap({$0.commentsCount}).reduce(0, +)
                 }
@@ -633,13 +633,16 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func createLikesTotalInsightsRow() -> StatsTotalInsightsData {
-        // TODO: Populate with real data!
-        return StatsTotalInsightsData(count: 12.abbreviatedString())
+        let periodSummary = periodStore.getSummary()
+        updateMostRecentChartData(periodSummary)
+
+        let sparklineData: [Int] = makeSparklineData(countKey: \StatsSummaryData.likesCount)
+        let likesData = intervalData(summaryType: .likes)
+
+        return StatsTotalInsightsData(count: likesData.count.abbreviatedString(), sparklineData: sparklineData)
     }
 
     func createCommentsTotalInsightsRow() -> StatsTotalInsightsData {
-        // TODO: Populate with real data!
-        return StatsTotalInsightsData(count: 15.abbreviatedString())
         let periodSummary = periodStore.getSummary()
         updateMostRecentChartData(periodSummary)
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -186,6 +186,17 @@ class SiteStatsInsightsViewModel: Observable {
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
                 }, error: errorBlock))
+            case .commentsTotals:
+                tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsCommentsTotals,
+                                                      siteStatsInsightsDelegate: siteStatsInsightsDelegate))
+                tableRows.append(blocks(for: .commentsTotals,
+                                           type: .period,
+                                           status: insightsStore.followersTotalsStatus,
+                                           block: {
+                    return TotalInsightStatsRow(dataRow: createCommentsTotalInsightsRow(), statSection: .insightsCommentsTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                }, loading: {
+                    return StatsGhostTwoColumnImmutableRow()
+                }, error: errorBlock))
             case .followersTotals:
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsFollowerTotals,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
@@ -637,6 +648,11 @@ private extension SiteStatsInsightsViewModel {
     func createLikesTotalInsightsRow() -> StatsTotalInsightsData {
         // TODO: Populate with real data!
         return StatsTotalInsightsData(count: 12.abbreviatedString())
+    }
+
+    func createCommentsTotalInsightsRow() -> StatsTotalInsightsData {
+        // TODO: Populate with real data!
+        return StatsTotalInsightsData(count: 15.abbreviatedString())
     }
 
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -639,7 +639,7 @@ private extension SiteStatsInsightsViewModel {
         let sparklineData: [Int] = makeSparklineData(countKey: \StatsSummaryData.likesCount)
         let likesData = intervalData(summaryType: .likes)
 
-        return StatsTotalInsightsData(count: likesData.count.abbreviatedString(), sparklineData: sparklineData)
+        return StatsTotalInsightsData(count: likesData.count, difference: likesData.difference, percentage: likesData.percentage, sparklineData: sparklineData)
     }
 
     func createCommentsTotalInsightsRow() -> StatsTotalInsightsData {
@@ -649,7 +649,7 @@ private extension SiteStatsInsightsViewModel {
         let sparklineData: [Int] = makeSparklineData(countKey: \StatsSummaryData.commentsCount)
         let commentsData = intervalData(summaryType: .comments)
 
-        return StatsTotalInsightsData(count: commentsData.count.abbreviatedString(), sparklineData: sparklineData)
+        return StatsTotalInsightsData(count: commentsData.count, difference: commentsData.difference, percentage: commentsData.percentage, sparklineData: sparklineData)
     }
 
     func makeSparklineData(countKey: KeyPath<StatsSummaryData, Int>) -> [Int] {
@@ -673,7 +673,7 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {
-        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount().abbreviatedString(), sparklineData: [0, 1, 2, 3, 4, 5, 6])
+        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount(), difference: 100, percentage: 50)
     }
 
     func createPublicizeRows() -> [StatsTotalRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -87,12 +87,9 @@ class StatsTotalInsightsCell: StatsBaseCell {
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
 
-        graphView.isHidden = sparklineData == nil
-        if let sparklineData = sparklineData {
-            graphView.data = sparklineData
-            graphView.chartColor = chartColor(for: difference)
-        }
-
+        graphView.data = sparklineData ?? []
+        graphView.chartColor = chartColor(for: difference)
+        
         countLabel.text = count.abbreviatedString()
         let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
         let differencePrefix = difference < 0 ? "" : "+"

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -89,7 +89,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         graphView.data = sparklineData ?? []
         graphView.chartColor = chartColor(for: difference)
-        
+
         countLabel.text = count.abbreviatedString()
         let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
         let differencePrefix = difference < 0 ? "" : "+"

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -4,6 +4,7 @@ import WordPressShared
 
 struct StatsTotalInsightsData {
     var count: String
+    var sparklineData: [Int]
     var comparison: String = ""
 }
 
@@ -81,12 +82,11 @@ class StatsTotalInsightsCell: StatsBaseCell {
         ])
     }
 
-    // TODO: This will need updating to pass some graph data too.
-    // Assuming this will be something like a small array of ints
-    func configure(count: String, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(count: String, sparklineData: [Int], statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
 
+        graphView.data = sparklineData
         countLabel.text = count
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -3,9 +3,10 @@ import WordPressShared
 
 
 struct StatsTotalInsightsData {
-    var count: String
-    var sparklineData: [Int]
-    var comparison: String = ""
+    var count: Int
+    var difference: Int
+    var percentage: Int
+    var sparklineData: [Int]? = nil
 }
 
 class StatsTotalInsightsCell: StatsBaseCell {
@@ -82,17 +83,35 @@ class StatsTotalInsightsCell: StatsBaseCell {
         ])
     }
 
-    func configure(count: String, sparklineData: [Int], statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(count: Int, difference: Int, percentage: Int, sparklineData: [Int]? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
 
-        graphView.data = sparklineData
-        countLabel.text = count
+        graphView.isHidden = sparklineData == nil
+        if let sparklineData = sparklineData {
+            graphView.data = sparklineData
+            graphView.chartColor = chartColor(for: difference)
+        }
+
+        countLabel.text = count.abbreviatedString()
+        let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
+        let differencePrefix = difference < 0 ? "" : "+"
+
+        comparisonLabel.text = String(format: differenceText, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
+    }
+
+    private func chartColor(for difference: Int) -> UIColor {
+        return difference < 0 ? WPStyleGuide.Stats.neutralColor : WPStyleGuide.Stats.positiveColor
     }
 
     private enum Metrics {
         static let outerStackViewSpacing: CGFloat = 16.0
         static let stackViewSpacing: CGFloat = 8.0
         static let graphViewAspectRatio: CGFloat = 3.27
+    }
+
+    private enum TextContent {
+        static let differenceHigher = NSLocalizedString("%@%@ (%@%%) higher than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous week'")
+        static let differenceLower = NSLocalizedString("%@%@ (%@%%) lower than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous week'")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -331,7 +331,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(count: dataRow.count, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(count: dataRow.count, sparklineData: dataRow.sparklineData, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -331,7 +331,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(count: dataRow.count, sparklineData: dataRow.sparklineData, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 


### PR DESCRIPTION
Refs #18500. This PR splits out separate Likes and Comments Totals cards, and hooks them up to live data.

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-23 at 20 38 57](https://user-images.githubusercontent.com/4780/169895958-6643455d-1e2a-4ce1-97d9-99094327f996.png)

**Known issues**

- The difference text at the bottom of the cell current isn't colored according to the +/- difference. I'll add this in a followup PR.
- The new cards don't yet appear in the Insights Management screen.

**To test**

* Build and run with the new Stats Insights feature flags disabled and ensure you don't see the cards above.


* Enable the two Stats insights feature flags. Build and run.
* Navigate to a site where you haven't yet customised the Insights cards (the new cards don't yet appear in the Insights management screen).
* You should see the two new cards in Stats Insights, below Views & Visitors. Check that the data is correct!
* Check that you see a green chart for + changes and a blue chart for - changes. You can hardcode some data in `createCommentsTotalInsightsRow` in `SiteStatsInsightsViewModel` if you need to.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
