### PR TITLE
Site Design Revamp - Add Caption to Recommended Section

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -51,6 +51,7 @@ class CategorySectionTableViewCell: UITableViewCell {
             thumbnails = section?.thumbnails ?? []
             categoryTitle.text = section?.title
             collectionView.contentOffset = section?.scrollOffset ?? .zero
+            setCaption()
 
             if let section = section {
                 collectionViewHeight.constant = section.thumbnailSize.height
@@ -65,14 +66,8 @@ class CategorySectionTableViewCell: UITableViewCell {
         }
     }
 
-    var categoryCaption: String? {
-        didSet {
-            setCaption()
-        }
-    }
-
     private func setCaption() {
-        guard let caption = categoryCaption else {
+        guard let caption = section?.caption else {
             categoryCaptionLabel.isHidden = true
             return
         }
@@ -96,7 +91,6 @@ class CategorySectionTableViewCell: UITableViewCell {
         super.prepareForReuse()
         collectionView.contentOffset.x = 0
         categoryTitleFont = nil
-        categoryCaption = nil
     }
 
     override func awakeFromNib() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -17,6 +17,7 @@ protocol Thumbnail {
 
 protocol CategorySection {
     var categorySlug: String { get }
+    var caption: String? { get }
     var title: String { get }
     var emoji: String? { get }
     var description: String? { get }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -36,6 +36,7 @@ class CategorySectionTableViewCell: UITableViewCell {
     @IBOutlet weak var categoryTitle: UILabel!
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var collectionViewHeight: NSLayoutConstraint!
+    @IBOutlet weak var categoryCaptionLabel: UILabel!
 
     weak var delegate: CategorySectionTableViewCellDelegate?
 
@@ -64,6 +65,22 @@ class CategorySectionTableViewCell: UITableViewCell {
         }
     }
 
+    var categoryCaption: String? {
+        didSet {
+            setCaption()
+        }
+    }
+
+    private func setCaption() {
+        guard let caption = categoryCaption else {
+            categoryCaptionLabel.isHidden = true
+            return
+        }
+
+        categoryCaptionLabel.isHidden = false
+        categoryCaptionLabel.setText(caption)
+    }
+
     var isGhostCell: Bool = false
     var ghostThumbnailSize: CGSize = defaultThumbnailSize {
         didSet {
@@ -79,6 +96,7 @@ class CategorySectionTableViewCell: UITableViewCell {
         super.prepareForReuse()
         collectionView.contentOffset.x = 0
         categoryTitleFont = nil
+        categoryCaption = nil
     }
 
     override func awakeFromNib() {
@@ -87,6 +105,8 @@ class CategorySectionTableViewCell: UITableViewCell {
         categoryTitle.font = categoryTitleFont ?? WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.headline, fontWeight: .semibold)
         categoryTitle.layer.masksToBounds = true
         categoryTitle.layer.cornerRadius = 4
+        categoryCaptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        setCaption()
     }
 
     private func deselectItem(_ indexPath: IndexPath) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -14,12 +14,12 @@
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="CategorySectionTableViewCell" customModule="WordPress" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="320" height="309"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
+            <tableViewCellContentView key="contentView" opaque="NO" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
                 <rect key="frame" x="0.0" y="0.0" width="320" height="309"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="53" width="320" height="240"/>
+                        <rect key="frame" x="0.0" y="71.5" width="320" height="240"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="240" id="iK4-y8-V36"/>
@@ -35,37 +35,52 @@
                             <outlet property="delegate" destination="KGk-i7-Jjw" id="7er-Am-6i2"/>
                         </connections>
                     </collectionView>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                        <rect key="frame" x="20" y="20" width="80" height="17"/>
-                        <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>
-                        </constraints>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
-                        <nil key="textColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
+                        <rect key="frame" x="20" y="20" width="80" height="31.5"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ujI-Bw-5eP">
+                                <rect key="frame" x="0.0" y="0.0" width="80" height="14.5"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
+                                <rect key="frame" x="0.0" y="14.5" width="80" height="17"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                 </subviews>
                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 <constraints>
-                    <constraint firstItem="3pe-2p-9as" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="Cmz-W8-Egx"/>
-                    <constraint firstItem="mQ0-DH-hTW" firstAttribute="top" secondItem="3pe-2p-9as" secondAttribute="bottom" constant="16" id="Lj1-O3-zk4"/>
-                    <constraint firstItem="3pe-2p-9as" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="Mrq-dy-dGi"/>
+                    <constraint firstItem="b14-QX-4ea" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="20" id="P4l-8Z-ZNT"/>
                     <constraint firstAttribute="trailing" secondItem="mQ0-DH-hTW" secondAttribute="trailing" id="XIg-vD-05h"/>
                     <constraint firstAttribute="bottom" secondItem="mQ0-DH-hTW" secondAttribute="bottom" constant="30" id="aLq-Bg-Bfl"/>
+                    <constraint firstItem="b14-QX-4ea" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="kG8-NH-vz0"/>
+                    <constraint firstItem="mQ0-DH-hTW" firstAttribute="top" secondItem="b14-QX-4ea" secondAttribute="bottom" constant="20" id="mCX-ZL-0ie"/>
                     <constraint firstItem="mQ0-DH-hTW" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="yp2-Zm-WoY"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="categoryCaptionLabel" destination="ujI-Bw-5eP" id="WIy-Lh-Ats"/>
                 <outlet property="categoryTitle" destination="3pe-2p-9as" id="iIk-5g-rMD"/>
                 <outlet property="collectionView" destination="mQ0-DH-hTW" id="E99-YA-UbE"/>
                 <outlet property="collectionViewHeight" destination="iK4-y8-V36" id="Zzr-4L-Fr9"/>
             </connections>
-            <point key="canvasLocation" x="153.62318840579712" y="169.75446428571428"/>
+            <point key="canvasLocation" x="158" y="152"/>
         </tableViewCell>
     </objects>
     <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -9,6 +9,8 @@ extension PageTemplateLayout: Thumbnail {
 }
 
 class GutenbergLayoutSection: CategorySection {
+    var caption: String?
+
     var section: PageTemplateCategory
     var layouts: [PageTemplateLayout]
     var scrollOffset: CGPoint

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -289,6 +289,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
         cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
+        cell.categoryCaption = sections[safe: indexPath.row]?.caption
         return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -289,7 +289,6 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
         cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
-        cell.categoryCaption = cell.section?.caption
         return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -289,7 +289,7 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.clipsToBounds = false
         cell.collectionView.allowsSelection = !isLoading
         cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
-        cell.categoryCaption = sections[safe: indexPath.row]?.caption
+        cell.categoryCaption = cell.section?.caption
         return cell
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
@@ -4,6 +4,7 @@ struct SiteDesignSection: CategorySection {
     var designs: [RemoteSiteDesign]
     var thumbnailSize: CGSize
 
+    var caption: String?
     var categorySlug: String
     var title: String
     var emoji: String?
@@ -13,13 +14,14 @@ struct SiteDesignSection: CategorySection {
 }
 
 extension SiteDesignSection {
-    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign], thumbnailSize: CGSize) {
+    init(category: RemoteSiteDesignCategory, designs: [RemoteSiteDesign], thumbnailSize: CGSize, caption: String? = nil) {
         self.designs = designs
         self.thumbnailSize = thumbnailSize
         self.categorySlug = category.slug
         self.title = category.title
         self.emoji = category.emoji
         self.description = category.description
+        self.caption = caption
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSectionLoader.swift
@@ -2,7 +2,6 @@ import Foundation
 import WordPressKit
 
 struct SiteDesignSectionLoader {
-    static let recommendedTitle = NSLocalizedString("Best for %@", comment: "Title for a section of recommended site designs. The %@ will be replaced with the related site intent topic, such as Food or Blogging.")
 
     static func fetchSections(vertical: SiteIntentVertical?, completion: @escaping (Result<[SiteDesignSection], Error>) -> Void) {
         typealias TemplateGroup = SiteDesignRequest.TemplateGroup
@@ -48,8 +47,9 @@ struct SiteDesignSectionLoader {
         return SiteDesignSection(
             designs: designsForVertical,
             thumbnailSize: SiteDesignCategoryThumbnailSize.recommended.value,
+            caption: TextContent.recommendedCaption,
             categorySlug: "recommended_" + vertical.slug,
-            title: String(format: recommendedTitle, vertical.localizedTitle)
+            title: String(format: TextContent.recommendedTitle, vertical.localizedTitle)
         )
     }
 
@@ -81,12 +81,23 @@ struct SiteDesignSectionLoader {
 
         if var recommendedFallback = categorySections.first(where: { $0.categorySlug.lowercased() == "blog" }) {
             // Recommended designs for the vertical weren't found, so we used the fallback category
-            recommendedFallback.title = String(format: recommendedTitle, "Blogging")
+            recommendedFallback.title = String(format: TextContent.recommendedTitle, "Blogging")
             recommendedFallback.thumbnailSize = SiteDesignCategoryThumbnailSize.recommended.value
+            recommendedFallback.caption = TextContent.recommendedCaption
             return [recommendedFallback] + categorySections.filter { $0 != recommendedFallback }
         }
 
         // No recommended designs were found
         return categorySections
+    }
+}
+
+private extension SiteDesignSectionLoader {
+
+    enum TextContent {
+        static let recommendedTitle = NSLocalizedString("Best for %@",
+                                                        comment: "Title for a section of recommended site designs. The %@ will be replaced with the related site intent topic, such as Food or Blogging.")
+        static let recommendedCaption = NSLocalizedString("PICKED FOR YOU",
+                                                          comment: "Caption for the recommended sections in site designs.")
     }
 }


### PR DESCRIPTION
Fixes #18674

This PR adds a caption to the recommended section in the Site Design Picker

<p align=center>
<img height="500" src="https://user-images.githubusercontent.com/34376330/169914905-2753b8fc-6bde-4972-952c-9e9f8e20e31e.png">
</p>


To test:

- checkout/build/run this branch
- Start the site creation flow and get to the design picker (either skip the vertical selection or select any vertical)
- Make sure that the recommended section (the one with larger thumbnails on top) has a "PICKED FOR YOU" caption
- Make sure the other sections do not have captions
- Cancel the site creation flow, tap the FAB then "Site Page"
- Make sure the page layout picker does not have captions in any section

## Regression Notes
1. Potential unintended areas of impact
Low - Page design picker uses part of the same code

2. What I did to test those areas of impact (or what existing automated tests I relied on)
test that the page design picker was not impacted

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
