### PR TITLE
Blogging Prompts: Add saving the prompt settings to the fetch and update calls

### DIFF
--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -4,17 +4,14 @@ import WordPressKit
 
 public class BloggingPromptSettings: NSManagedObject {
 
-    convenience init(context: NSManagedObjectContext,
-                     siteID: Int32,
-                     remoteSettings: RemoteBloggingPromptsSettings) {
-        self.init(context: context)
+    func configure(with remoteSettings: RemoteBloggingPromptsSettings, siteID: Int32, context: NSManagedObjectContext) {
         self.siteID = siteID
         self.promptCardEnabled = remoteSettings.promptCardEnabled
         self.reminderTime = remoteSettings.reminderTime
         self.promptRemindersEnabled = remoteSettings.promptRemindersEnabled
         self.isPotentialBloggingSite = remoteSettings.isPotentialBloggingSite
-        self.reminderDays = BloggingPromptSettingsReminderDays(context: context,
-                                                               remoteReminderDays: remoteSettings.reminderDays)
+        self.reminderDays = reminderDays ?? BloggingPromptSettingsReminderDays(context: context)
+        reminderDays?.configure(with: remoteSettings.reminderDays)
     }
 
 }

--- a/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
@@ -4,9 +4,7 @@ import WordPressKit
 
 public class BloggingPromptSettingsReminderDays: NSManagedObject {
 
-    convenience init(context: NSManagedObjectContext,
-                     remoteReminderDays: RemoteBloggingPromptsSettings.ReminderDays) {
-        self.init(context: context)
+    func configure(with remoteReminderDays: RemoteBloggingPromptsSettings.ReminderDays) {
         self.monday = remoteReminderDays.monday
         self.tuesday = remoteReminderDays.tuesday
         self.wednesday = remoteReminderDays.wednesday

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -120,6 +120,11 @@ class BloggingPromptsService {
 
     // MARK: - Settings
 
+    /// Fetches the blogging prompt settings for the configured `siteID`.
+    ///
+    /// - Parameters:
+    ///   - success: Closure to be called on success with an optional `BloggingPromptSettings` object.
+    ///   - failure: Closure to be called on failure with an optional `Error` object.
     func fetchSettings(success: @escaping (BloggingPromptSettings?) -> Void,
                        failure: @escaping (Error?) -> Void) {
         remote.fetchSettings(for: siteID) { result in
@@ -133,6 +138,13 @@ class BloggingPromptsService {
         }
     }
 
+    /// Updates the blogging prompt settings for the configured `siteID`.
+    ///
+    /// - Parameters:
+    ///   - settings: The new settings to update the remote with
+    ///   - success: Closure to be called on success with an optional `BloggingPromptSettings` object. `nil` is passed
+    ///              when the call is successful but there were no updated settings on the remote.
+    ///   - failure: Closure to be called on failure with an optional `Error` object.
     func updateSettings(settings: RemoteBloggingPromptsSettings,
                         success: @escaping (BloggingPromptSettings?) -> Void,
                         failure: @escaping (Error?) -> Void) {
@@ -287,6 +299,11 @@ private extension BloggingPromptsService {
         }
     }
 
+    /// Updates existing settings or creates new settings from the remote prompt settings.
+    ///
+    /// - Parameters:
+    ///   - remoteSettings: The blogging prompt settings from the remote.
+    ///   - completion: Closure to be called on completion. Result object with `Void` on success and an `Error` on failure.
     func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping (Result<Void, Error>) -> Void) {
         let derivedContext = contextManager.newDerivedContext()
         derivedContext.perform {
@@ -315,6 +332,12 @@ private extension BloggingPromptsService {
         return fetchRequest
     }
 
+    /// A completion closure that will load the settings on success and calls the failure closure on an error.
+    ///
+    /// - Parameters:
+    ///   - success: Closure to be called on success with an optional `BloggingPromptSettings` object.
+    ///   - failure: Closure to be called on failure with an optional `Error` object.
+    /// - Returns: A closure which takes a `Result<Void, Error>` input
     func loadSettingsCompletion(success: @escaping (BloggingPromptSettings?) -> Void,
                                 failure: @escaping (Error?) -> Void) -> (Result<Void, Error>) -> Void {
         return { result in


### PR DESCRIPTION
See: #18549

## Description

Saves the blogging prompt settings when fetched and when updated.

## Testing

The network calls need to be manually added. For my testing, I updated `DashboardPromptsCardCell` with the following:

```swift
// private let removeFromDashboardEnabled = false
private let removeFromDashboardEnabled = true
```

```swift
    func skipMenuTapped() {
//        saveSkippedPromptForSite()
//        presenterViewController?.reloadCardsLocally()
        bloggingPromptsService?.fetchSettings(success: { settings in }, failure: { error in })
    }

    func removeMenuTapped() {
        // TODO.
        let jsonData = """
                       {
                           "prompts_card_opted_in": true,
                           "prompts_reminders_opted_in": true,
                           "reminders_days": {
                               "monday": true,
                               "tuesday": true,
                               "wednesday": true,
                               "thursday": true,
                               "friday": true,
                               "saturday": true,
                               "sunday": true
                           },
                           "reminders_time": "12.30",
                           "is_potential_blogging_site": true
                       }
                       """.data(using: .utf8)!
        // TODO: Public init for `RemoteBloggingPromptsSettings`
        let settings = try! JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: jsonData)
        bloggingPromptsService?.updateSettings(settings: settings,
                success: { settings in },
                failure: { error in })
    }
```

To test:
- Call `fetchSettings`
- Verify a `BloggingPromptsSettings` object is mapped and saved
- Call `updateSettings` with different settings than what was returned in `fetchSettings`
- Verify `BloggingPromptsSettings` is returned with the different settings and updated
- Call `updateSettings` again with the same settings
- Verify `nil` is returned and no settings were updated or loaded

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
