### PR TITLE
Stats Revamp: Populate comparison hint for Likes / Comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -67,7 +67,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         comparisonLabel.font = .preferredFont(forTextStyle: .subheadline)
         comparisonLabel.textColor = .textSubtle
-        comparisonLabel.text = "+87 (40%) compared to last week"
+        comparisonLabel.numberOfLines = 0
     }
 
     private func configureConstraints() {
@@ -91,14 +91,41 @@ class StatsTotalInsightsCell: StatsBaseCell {
         graphView.chartColor = chartColor(for: difference)
         
         countLabel.text = count.abbreviatedString()
+
         let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
         let differencePrefix = difference < 0 ? "" : "+"
+        let formattedText = String(format: differenceText, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
 
-        comparisonLabel.text = String(format: differenceText, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
+        comparisonLabel.attributedText = attributedDifferenceString(formattedText, highlightAttributes: [.foregroundColor: differenceTextColor(for: difference)])
+    }
+
+    private func differenceTextColor(for difference: Int) -> UIColor {
+        return difference < 0 ? WPStyleGuide.Stats.negativeColor : WPStyleGuide.Stats.positiveColor
     }
 
     private func chartColor(for difference: Int) -> UIColor {
         return difference < 0 ? WPStyleGuide.Stats.neutralColor : WPStyleGuide.Stats.positiveColor
+    }
+
+    private func attributedDifferenceString(_ string: String, highlightAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString? {
+        let defaultAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .subheadline), NSAttributedString.Key.foregroundColor: UIColor.textSubtle]
+
+        guard let firstIndex = string.firstIndex(of: TextContent.differenceDelimiter),
+              let lastIndex = string.lastIndex(of: TextContent.differenceDelimiter),
+              firstIndex != lastIndex else {
+                  return nil
+              }
+
+        let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
+
+        // Move the end of the range back by one as we've removed a character
+        let range: Range<String.Index> = firstIndex..<string.index(lastIndex, offsetBy: -1)
+        let nsRange = NSRange(range, in: string)
+
+        let mutableString = NSMutableAttributedString(string: string, attributes: defaultAttributes)
+        mutableString.addAttributes(highlightAttributes, range: nsRange)
+
+        return NSAttributedString(attributedString: mutableString)
     }
 
     private enum Metrics {
@@ -108,7 +135,8 @@ class StatsTotalInsightsCell: StatsBaseCell {
     }
 
     private enum TextContent {
-        static let differenceHigher = NSLocalizedString("%@%@ (%@%%) higher than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous week'")
-        static let differenceLower = NSLocalizedString("%@%@ (%@%%) lower than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous week'")
+        static let differenceDelimiter = Character("*")
+        static let differenceHigher = NSLocalizedString("*%@%@ (%@%%)* higher than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
+        static let differenceLower = NSLocalizedString("*%@%@ (%@%%)* lower than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
     }
 }


### PR DESCRIPTION
Refs #18500. This PR populates the comparison label on the new Likes and Comments cards:

![Simulator Screen Shot - iPhone 13 Pro - 2022-05-24 at 22 06 06](https://user-images.githubusercontent.com/4780/170136081-7a0d6a0c-8adf-44c2-a8e8-3c5164e91bbf.png)

This PR also removes the comparison label from the Followers total cell, as we don't currently have data for that.

**To test**

* Enable the new stats feature flags and build and run
* Navigate to Stats > Insights for a site with recent Likes and Comments
* Ensure that the Likes and Comments rows show live data in the comparison label, and that the colour correctly reflects the positive or negative change. You can check the data in `intervalData(summaryType:)` of SiteStatsInsightsViewModel.
* Ensure that the Followers total row doesn't show a comparison label.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
