### PR TITLE
Blogging Prompts: Show or hide prompt dashboard card based on cached settings

### DIFF
--- a/WordPress/Classes/Services/BlogService+BloggingPrompts.swift
+++ b/WordPress/Classes/Services/BlogService+BloggingPrompts.swift
@@ -1,0 +1,24 @@
+import CoreData
+
+extension BlogService {
+
+    @objc func updatePromptSettings(for blog: RemoteBlog?, context: NSManagedObjectContext) {
+        guard let blog = blog,
+              let siteID = blog.blogID,
+              let jsonSettings = blog.options?["blogging_prompts_settings"] as? [String: Any],
+              let settingsValue = jsonSettings["value"],
+              let data = try? JSONSerialization.data(withJSONObject: settingsValue),
+              let remoteSettings = try? JSONDecoder().decode(RemoteBloggingPromptsSettings.self, from: data) else {
+            return
+        }
+
+        let fetchRequest = BloggingPromptSettings.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "\(#keyPath(BloggingPromptSettings.siteID)) = %@", siteID)
+        fetchRequest.fetchLimit = 1
+        let existingSettings = (try? context.fetch(fetchRequest))?.first as? BloggingPromptSettings
+        let settings = existingSettings ?? BloggingPromptSettings(context: context)
+        settings.configure(with: remoteSettings, siteID: siteID.int32Value, context: context)
+        print("🟣 Created/updated:\nSite ID: \(settings.siteID)\n\(settings)")
+    }
+
+}

--- a/WordPress/Classes/Services/BlogService+BloggingPrompts.swift
+++ b/WordPress/Classes/Services/BlogService+BloggingPrompts.swift
@@ -18,7 +18,6 @@ extension BlogService {
         let existingSettings = (try? context.fetch(fetchRequest))?.first as? BloggingPromptSettings
         let settings = existingSettings ?? BloggingPromptSettings(context: context)
         settings.configure(with: remoteSettings, siteID: siteID.int32Value, context: context)
-        print("🟣 Created/updated:\nSite ID: \(settings.siteID)\n\(settings)")
     }
 
 }

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -691,6 +691,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
     // Also adds any blogs we don't have
     for (RemoteBlog *remoteBlog in blogs) {
         [self updateBlogWithRemoteBlog:remoteBlog account:account];
+        [self updatePromptSettingsFor:remoteBlog context:self.managedObjectContext];
     }
 
     /*
@@ -969,6 +970,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
                                                                                error:&error];
                 if (blog) {
                     [self updateBlog:blog withRemoteBlog:blogs.firstObject];
+                    [self updatePromptSettingsFor:blogs.firstObject context:self.managedObjectContext];
 
                     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
                 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -331,11 +331,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
               let settings = promptsService.localSettings,
               settings.isPotentialBloggingSite,
               settings.promptCardEnabled else {
-            print("🟣 Hiding prompt card")
             return false
         }
-
-        print("🟣 Settings is cached:\n\(settings)")
 
         guard let todaysPrompt = promptsService.localTodaysPrompt else {
             // If there is no cached prompt, it can't have been skipped. So show the card.

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -326,11 +326,18 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     // Specifically, it checks if today's prompt has been skipped,
     // and therefore should not be shown.
     static func shouldShowCard(for blog: Blog) -> Bool {
-        guard FeatureFlag.bloggingPrompts.enabled else {
+        guard FeatureFlag.bloggingPrompts.enabled,
+              let promptsService = BloggingPromptsService(blog: blog),
+              let settings = promptsService.localSettings,
+              settings.isPotentialBloggingSite,
+              settings.promptCardEnabled else {
+            print("🟣 Hiding prompt card")
             return false
         }
 
-        guard let todaysPrompt = BloggingPromptsService(blog: blog)?.localTodaysPrompt else {
+        print("🟣 Settings is cached:\n\(settings)")
+
+        guard let todaysPrompt = promptsService.localTodaysPrompt else {
             // If there is no cached prompt, it can't have been skipped. So show the card.
             return true
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1412,6 +1412,8 @@
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		830A58D82793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
 		830A58D92793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
+		8320BDE5283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
+		8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
@@ -6239,6 +6241,7 @@
 		82FFBF4E1F45E03D00F4573F /* WordPress 66.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 66.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueAnimator.swift; sourceTree = "<group>"; };
+		8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
 		834CE7331256D0DE0046A4A3 /* CFNetwork.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
@@ -12068,9 +12071,10 @@
 				822D60B81F4CCC7A0016C46D /* BlogJetpackSettingsService.swift */,
 				93C1148318EDF6E100DAC95C /* BlogService.h */,
 				93C1148418EDF6E100DAC95C /* BlogService.m */,
-				F1BC842D27035A1800C39993 /* BlogService+Domains.swift */,
 				9A341E5221997A1E0036662E /* BlogService+BlogAuthors.swift */,
+				8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */,
 				E18549D8230EED73003C620E /* BlogService+Deduplicate.swift */,
+				F1BC842D27035A1800C39993 /* BlogService+Domains.swift */,
 				9A2D0B22225CB92B009E585F /* BlogService+JetpackConvenience.swift */,
 				176BA53A268266DE0025E4A3 /* BlogService+Reminders.swift */,
 				E1556CF0193F6FE900FC52EA /* CommentService.h */,
@@ -18776,6 +18780,7 @@
 				C99B08FC26081AD600CA71EB /* TemplatePreviewViewController.swift in Sources */,
 				B5D889411BEBE30A007C4684 /* BlogSettings.swift in Sources */,
 				F12E500323C7C5330068CB5E /* WKWebView+UserAgent.swift in Sources */,
+				8320BDE5283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */,
 				8B749E7225AF522900023F03 /* JetpackCapabilitiesService.swift in Sources */,
 				5DF7F7781B223916003A05C8 /* PostToPost30To31.m in Sources */,
 				1E5D00102493CE240004B708 /* GutenGhostView.swift in Sources */,
@@ -20883,6 +20888,7 @@
 				FABB231B2602FC2C00C8785C /* PluginListViewModel.swift in Sources */,
 				FABB231C2602FC2C00C8785C /* WPStyleGuide+People.swift in Sources */,
 				FABB231D2602FC2C00C8785C /* PlanGroup.swift in Sources */,
+				8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */,
 				FABB231E2602FC2C00C8785C /* MenuItemPostsViewController.m in Sources */,
 				FABB231F2602FC2C00C8785C /* SignupUsernameTableViewController.swift in Sources */,
 				FABB23202602FC2C00C8785C /* Blog+Editor.swift in Sources */,


### PR DESCRIPTION
See: #18549

## Description

Saves the prompt settings on blog sync and shows/hides the dashboard card based on the prompt settings.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Launch and verify settings are saved
- Select a blogging site (`is_potential_blogging_site` = `true`)
- Verify:
  - Dashboard card is shown
  - Settings are loaded from cache
- Select a non-blogging site (`is_potential_blogging_site` = `false`)
- Verify the dashboard card is hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
