### PR TITLE
[Site Design Revamp] Add period to helper text

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -239,7 +239,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
                                                   comment: "Informing the user that a network request failed because the device wasn't able to establish a network connection.")
         static let errorSubtitle = NSLocalizedString("Check your network connection and try again.",
                                                      comment: "Default subtitle for no-results when there is no connection.")
-        static let helperText = NSLocalizedString("Can’t decide? You can change the theme at any time",
+        static let helperText = NSLocalizedString("Can’t decide? You can change the theme at any time.",
                                                   comment: "Helper text that appears at the bottom of the design screen.")
     }
 


### PR DESCRIPTION
Fixes #18724

<img width="328" alt="image" src="https://user-images.githubusercontent.com/2092798/170162287-619da1b5-5598-4189-aff2-cf72d520b3d8.png">

### To test:
1. Start the Site Creation flow
2. Navigate to the Site Design screen
3. Scroll to the bottom
4. Expect helper text to read: "Can't decide? You can change the theme at any time."

## Regression Notes
1. Potential unintended areas of impact
- None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- None

3. What automated tests I added (or what prevented me from doing so)
- None, this was a simple verbiage change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
