### PR TITLE
Blogging Prompts: Add unscheduling logic

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/PromptRemindersScheduler.swift
@@ -363,7 +363,7 @@ private extension PromptRemindersScheduler {
     /// Loads a dictionary containing all of the pending notification IDs for all sites.
     ///
     /// - Parameter fileURL: The file store location.
-    /// - Returns: A dictionary containing `siteID` and an array of `String`representing pending notification IDs.
+    /// - Returns: A dictionary containing `siteID` and an array of `String` representing pending notification IDs.
     func fetchAllReceipts(from fileURL: URL) throws -> [Int: [String]] {
         if !localStore.fileExists(at: fileURL) {
             let data = try PropertyListEncoder().encode([Int: [String]]())


### PR DESCRIPTION
Refs #18542
Depends on #18728 👈🏼 please review this one first. 🙂 

This PR adds the logic for un-scheduling pending notification requests. Unscheduling reminders should clear `UNNotificationRequest`s and notification identifiers that are stored locally.

## To test

Ensure that the unit tests are passing.

## Regression Notes
1. Potential unintended areas of impact
N/A. Feature is unreleased, and the component is not yet used.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A. Feature is unreleased, and the component is not yet used.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
