### PR TITLE
[Site Design Revamp] Fix constraint warning for collection view

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -19,10 +19,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="71.5" width="320" height="240"/>
+                        <rect key="frame" x="0.0" y="55" width="320" height="224"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstAttribute="height" constant="240" id="iK4-y8-V36"/>
+                            <constraint firstAttribute="height" priority="999" constant="240" id="iK4-y8-V36"/>
                         </constraints>
                         <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="10" minimumInteritemSpacing="16" id="8Ds-sb-bxf">
                             <size key="itemSize" width="160" height="230"/>
@@ -36,16 +36,16 @@
                         </connections>
                     </collectionView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
-                        <rect key="frame" x="20" y="20" width="80" height="31.5"/>
+                        <rect key="frame" x="20" y="20" width="80" height="15"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ujI-Bw-5eP">
-                                <rect key="frame" x="0.0" y="0.0" width="80" height="14.5"/>
+                                <rect key="frame" x="0.0" y="0.0" width="80" height="0.0"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                                <rect key="frame" x="0.0" y="14.5" width="80" height="17"/>
+                                <rect key="frame" x="0.0" y="0.0" width="80" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>


### PR DESCRIPTION
Fixes #18675

[See reasoning here](https://stackoverflow.com/a/25795758), though I'm not entirely sure I understand it (along with many others in that thread).

## To test:
1. Start Site Creation flow
2. Navigate to the Site Design screen
3. Scroll to the bottom of the site designs
4. Tap "Topic" at the top left to navigate back
5. Choose a vertical on the Site Intent screen
6. Expect there to be no constraint warnings

## Regression Notes
1. Potential unintended areas of impact
  - Site Design picker layout

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manual steps above

3. What automated tests I added (or what prevented me from doing so)
  - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
