### PR TITLE
[Site Design Revamp] Clip collapsable header view controller to bounds

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.xib
@@ -42,7 +42,7 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" id="U3M-sT-nKQ">
+        <view clipsSubviews="YES" contentMode="scaleToFill" id="U3M-sT-nKQ">
             <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>


### PR DESCRIPTION
Fixes #18703

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/2092798/170354479-2903c253-5811-4ecd-8d2b-540f4f608f4f.mp4" /> | <video src="https://user-images.githubusercontent.com/2092798/170354525-86e7fb5d-ce57-4c58-8f17-313511072736.mp4" /> |

## To test:

1. Start the Site Creation flow and navigate to the Site Design screen
2. In a section with multiple designs, scroll horizontally to the end (swiping left)
3. Top "Topic" at the top left to navigate back to the Site Intent screen
4. Expect that the left edge of the view is clipped to its bounds as it transitions to the Site Intent screen


## Regression Notes
1. Potential unintended areas of impact
  - Any view that uses `CollapsableHeaderViewController`, though I can't think of a reason why any of those would need to paint outside of the its bounds.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manual testing above

3. What automated tests I added (or what prevented me from doing so)
  - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
