### PR TITLE
Stats Insights: Hide comparison from Followers total card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -613,7 +613,7 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {
-        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount(), difference: 100, percentage: 50)
+        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount())
     }
 
     func createPublicizeRows() -> [StatsTotalRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -4,8 +4,8 @@ import WordPressShared
 
 struct StatsTotalInsightsData {
     var count: Int
-    var difference: Int
-    var percentage: Int
+    var difference: Int? = nil
+    var percentage: Int? = nil
     var sparklineData: [Int]? = nil
 }
 
@@ -83,19 +83,26 @@ class StatsTotalInsightsCell: StatsBaseCell {
         ])
     }
 
-    func configure(count: Int, difference: Int, percentage: Int, sparklineData: [Int]? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
 
         graphView.data = sparklineData ?? []
-        graphView.chartColor = chartColor(for: difference)
+        graphView.chartColor = chartColor(for: difference ?? 0)
 
         countLabel.text = count.abbreviatedString()
+
+        guard let difference = difference,
+              let percentage = percentage else {
+                  comparisonLabel.isHidden = true
+                  return
+              }
 
         let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
         let differencePrefix = difference < 0 ? "" : "+"
         let formattedText = String(format: differenceText, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
 
+        comparisonLabel.isHidden = false
         comparisonLabel.attributedText = attributedDifferenceString(formattedText, highlightAttributes: [.foregroundColor: differenceTextColor(for: difference)])
     }
 


### PR DESCRIPTION
Just a small tweak to remove the comparison row from the new Followers total card and ensure that the total count is shown even though there's no graph:

<img src="https://user-images.githubusercontent.com/4780/170466587-58c86d95-1623-45a3-9acf-180b620b5c36.png" width=350>

**To test**

* Enable the two new stats feature flags and build and run
* Navigate to Stats > Insights for a site where you haven't yet customised Insights (so you get the standard set of cards)
* Ensure that the Followers card just shows a count, whereas the Likes and Comments cards show the comparison and chart

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
