### PR TITLE
Stats Revamp: Followers Details Screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -412,14 +412,27 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         }
 
         if FeatureFlag.statsNewInsights.enabled {
-            let detailTableViewController = SiteStatsInsightsDetailsTableViewController()
-            detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
-            navigationController?.pushViewController(detailTableViewController, animated: true)
+            switch statSection {
+            case .insightsViewsVisitors, .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals:
+                segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
+            default:
+                segueToDetails(statSection: statSection, selectedDate: selectedDate)
+            }
         } else {
-            let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
-            detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
-            navigationController?.pushViewController(detailTableViewController, animated: true)
+            segueToDetails(statSection: statSection, selectedDate: selectedDate)
         }
+    }
+
+    func segueToInsightsDetails(statSection: StatSection, selectedDate: Date?) {
+        let detailTableViewController = SiteStatsInsightsDetailsTableViewController()
+        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
+        navigationController?.pushViewController(detailTableViewController, animated: true)
+    }
+
+    func segueToDetails(statSection: StatSection, selectedDate: Date?) {
+        let detailTableViewController = SiteStatsDetailTableViewController.loadFromStoryboard()
+        detailTableViewController.configure(statSection: statSection, selectedDate: selectedDate)
+        navigationController?.pushViewController(detailTableViewController, animated: true)
     }
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -613,7 +613,7 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {
-        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount(), difference: 100, percentage: 50)
+        return StatsTotalInsightsData.followersCount(insightsStore: insightsStore)
     }
 
     func createPublicizeRows() -> [StatsTotalRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -61,7 +61,11 @@ class StatsBaseCell: UITableViewCell {
         }
     }
 
-    weak var siteStatsInsightDetailsDelegate: SiteStatsInsightsDelegate?
+    weak var siteStatsInsightDetailsDelegate: SiteStatsInsightsDelegate? {
+        didSet {
+            updateHeader()
+        }
+    }
 
     private func configureHeading(with topConstraint: NSLayoutConstraint) {
         guard FeatureFlag.statsNewAppearance.enabled else {
@@ -106,7 +110,9 @@ class StatsBaseCell: UITableViewCell {
 
             switch statSection {
             case .insightsViewsVisitors:
-                showDetailsButton.setTitle(LocalizedText.buttonTitle, for: .normal)
+                showDetailsButton.setTitle(LocalizedText.buttonTitleThisWeek, for: .normal)
+            case .insightsFollowerTotals:
+                showDetailsButton.setTitle(LocalizedText.buttonTitleViewMore, for: .normal)
             default:
                 showDetailsButton.setTitle("", for: .normal)
             }
@@ -158,7 +164,8 @@ class StatsBaseCell: UITableViewCell {
     }
 
     private enum LocalizedText {
-        static let buttonTitle = NSLocalizedString("This week", comment: "Title of a button. A call to action to view more stats for this week")
+        static let buttonTitleThisWeek = NSLocalizedString("This week", comment: "Title of a button. A call to action to view more stats for this week")
+        static let buttonTitleViewMore = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         static let buttonAccessibilityHint = NSLocalizedString("Tap to view more stats for this week", comment: "VoiceOver accessibility hint, informing the user the button can be used to access more stats about this week")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -7,6 +7,10 @@ struct StatsTotalInsightsData {
     var difference: Int
     var percentage: Int
     var sparklineData: [Int]? = nil
+
+    public static func followersCount(insightsStore: StatsInsightsStore) -> StatsTotalInsightsData {
+        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount(), difference: 100, percentage: 50)
+    }
 }
 
 class StatsTotalInsightsCell: StatsBaseCell {
@@ -86,6 +90,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
     func configure(count: Int, difference: Int, percentage: Int, sparklineData: [Int]? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
+        self.siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
 
         graphView.data = sparklineData ?? []
         graphView.chartColor = chartColor(for: difference)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -9,7 +9,7 @@ struct StatsTotalInsightsData {
     var sparklineData: [Int]? = nil
 
     public static func followersCount(insightsStore: StatsInsightsStore) -> StatsTotalInsightsData {
-        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount(), difference: 100, percentage: 50)
+        return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount())
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -50,6 +50,11 @@ class SiteStatsInsightsDetailsTableViewController: SiteStatsBaseTableViewControl
         addWillEnterForegroundObserver()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        removeWillEnterForegroundObserver()
+    }
+
     func configure(statSection: StatSection,
                    selectedDate: Date? = nil,
                    selectedPeriod: StatsPeriodUnit? = nil,
@@ -161,7 +166,8 @@ private extension SiteStatsInsightsDetailsTableViewController {
                 StatsGhostTopHeaderImmutableRow.self,
                 StatsGhostDetailRow.self,
                 ViewsVisitorsRow.self,
-                PeriodEmptyCellHeaderRow.self]
+                PeriodEmptyCellHeaderRow.self,
+                TotalInsightStatsRow.self]
     }
 
     // MARK: - Table Refreshing


### PR DESCRIPTION
This PR adds the Details (2nd level) Followers screen

Ref #18605

Note:
 * Donut graph has not been integrated
 * All Totals cards now have a "View More" disclosure; however Likes and Comments will segue to an empty screen
 * this PR does not handle View More taps from the 2nd level that navigate to the 3rd level
 * clicking on the Email tab of Followers card causes a resize issue if there is no data which is not part of this PR

Implementation:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/88816724/170541766-85630248-fc8d-4cf0-bb9a-376cef7733e3.png">


Design:
<img width="355" alt="image" src="https://user-images.githubusercontent.com/88816724/170541968-e0c909a1-aa06-4ba8-9db6-938a80925a22.png">

To test:
	1. Build and run + navigate to Stats Insights for a site
	2. Followers Total card should not be available
	3. Clicking View more on the Followers card should take you to the same screen as in current appstore version
	4. Click around insights, period stats and ensure there are no crashes
	5. Now enable both of the new stats feature flags and build and run again
```
statsNewAppearance
statsNewInsights
```
	
6. From Stats Insights screen, click "View More" at the bottom of the followers card.  You should see Followers Total card followed by the Followers card
Tap back to go to main Insights screen.  Find the Followers Total card and tap "View More". You should see Followers Total card followed by the Followers card


## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
