### PR TITLE
Blogging Prompts: Tracks for events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -359,7 +359,11 @@ import Foundation
     case promptsIntroductionModalTryItNow
     case promptsIntroductionModalRemindMe
     case promptsIntroductionModalGotIt
-
+    case promptsDashboardCardAnswerPrompt
+    case promptsDashboardCardMenu
+    case promptsDashboardCardMenuViewMore
+    case promptsDashboardCardMenuSkip
+    case promptsDashboardCardMenuRemove
 
     /// A String that represents the event
     var value: String {
@@ -966,6 +970,17 @@ import Foundation
             return "blogging_prompts_introduction_modal_remind_me_tapped"
         case .promptsIntroductionModalGotIt:
             return "blogging_prompts_introduction_modal_got_it_tapped"
+        case .promptsDashboardCardAnswerPrompt:
+            return "blogging_prompts_my_site_card_answer_prompt_tapped"
+        case .promptsDashboardCardMenu:
+            return "blogging_prompts_my_site_card_menu_tapped"
+        case .promptsDashboardCardMenuViewMore:
+            return "blogging_prompts_my_site_card_menu_view_more_prompts_tapped"
+        case .promptsDashboardCardMenuSkip:
+            return "blogging_prompts_my_site_card_menu_skip_this_prompt_tapped"
+        case .promptsDashboardCardMenuRemove:
+            return "blogging_prompts_my_site_card_menu_remove_from_dashboard_tapped"
+
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -364,6 +364,7 @@ import Foundation
     case promptsDashboardCardMenuViewMore
     case promptsDashboardCardMenuSkip
     case promptsDashboardCardMenuRemove
+    case promptsListViewed
 
     /// A String that represents the event
     var value: String {
@@ -980,6 +981,8 @@ import Foundation
             return "blogging_prompts_my_site_card_menu_skip_this_prompt_tapped"
         case .promptsDashboardCardMenuRemove:
             return "blogging_prompts_my_site_card_menu_remove_from_dashboard_tapped"
+        case .promptsListViewed:
+            return "blogging_prompts_prompts_list_viewed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -354,6 +354,12 @@ import Foundation
 
     // Blogging Prompts
     case promptsBottomSheetAnswerPrompt
+    case promptsIntroductionModalViewed
+    case promptsIntroductionModalDismissed
+    case promptsIntroductionModalTryItNow
+    case promptsIntroductionModalRemindMe
+    case promptsIntroductionModalGotIt
+
 
     /// A String that represents the event
     var value: String {
@@ -950,6 +956,16 @@ import Foundation
         // Blogging Prompts
         case .promptsBottomSheetAnswerPrompt:
             return "my_site_create_sheet_answer_prompt_tapped"
+        case .promptsIntroductionModalViewed:
+            return "blogging_prompts_introduction_modal_viewed"
+        case .promptsIntroductionModalDismissed:
+            return "blogging_prompts_introduction_modal_dismissed"
+        case .promptsIntroductionModalTryItNow:
+            return "blogging_prompts_introduction_modal_try_it_now_tapped"
+        case .promptsIntroductionModalRemindMe:
+            return "blogging_prompts_introduction_modal_remind_me_tapped"
+        case .promptsIntroductionModalGotIt:
+            return "blogging_prompts_introduction_modal_got_it_tapped"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -352,6 +352,9 @@ import Foundation
     case onboardingEnableNotificationsSkipped
     case onboardingEnableNotificationsEnableTapped
 
+    // Blogging Prompts
+    case promptsBottomSheetAnswerPrompt
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -944,6 +947,9 @@ import Foundation
         case .enhancedSiteCreationSiteNameExperiment:
             return "enhanced_site_creation_site_name_experiment"
 
+        // Blogging Prompts
+        case .promptsBottomSheetAnswerPrompt:
+            return "my_site_create_sheet_answer_prompt_tapped"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -13,8 +13,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         frameView.title = Strings.cardFrameTitle
         frameView.icon = Style.frameIconImage
 
-        // NOTE: Remove the logic for iOS 13 once we drop that version.
-        if #available (iOS 14.0, *) {
+        // NOTE: Remove the logic when support for iOS 14 is dropped
+        if #available (iOS 15.0, *) {
             // assign an empty closure so the button appears.
             frameView.onEllipsisButtonTap = {}
             frameView.ellipsisButton.showsMenuAsPrimaryAction = true
@@ -22,6 +22,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         } else {
             // Show a fallback implementation using `MenuSheetViewController`.
             // iOS 13 doesn't support showing UIMenu programmatically.
+            // iOS 14 doesn't support `UIDeferredMenuElement.uncached`.
             frameView.onEllipsisButtonTap = { [weak self] in
                 self?.showMenuSheet()
             }
@@ -291,9 +292,16 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         return [defaultItems]
     }
 
+    @available(iOS 15.0, *)
     private var contextMenu: UIMenu {
         return .init(title: String(), options: .displayInline, children: contextMenuItems.map { menuSection in
-            UIMenu(title: String(), options: .displayInline, children: menuSection.map { $0.toAction })
+            UIMenu(title: String(), options: .displayInline, children: [
+                // Use an uncached deferred element so we can track each time the menu is shown
+                UIDeferredMenuElement.uncached { completion in
+                    WPAnalytics.track(.promptsDashboardCardMenu)
+                    completion(menuSection.map { $0.toAction })
+                }
+            ])
         })
     }
 
@@ -418,6 +426,7 @@ private extension DashboardPromptsCardCell {
               let prompt = prompt else {
             return
         }
+        WPAnalytics.track(.promptsDashboardCardAnswerPrompt)
 
         let editor = EditPostViewController(blog: blog, prompt: prompt)
         editor.modalPresentationStyle = .fullScreen
@@ -434,15 +443,18 @@ private extension DashboardPromptsCardCell {
             return
         }
 
+        WPAnalytics.track(.promptsDashboardCardMenuViewMore)
         BloggingPromptsViewController.show(for: blog, from: presenterViewController)
     }
 
     func skipMenuTapped() {
+        WPAnalytics.track(.promptsDashboardCardMenuSkip)
         saveSkippedPromptForSite()
         presenterViewController?.reloadCardsLocally()
     }
 
     func removeMenuTapped() {
+        WPAnalytics.track(.promptsDashboardCardMenuRemove)
         // TODO.
     }
 
@@ -451,6 +463,7 @@ private extension DashboardPromptsCardCell {
         guard let presenterViewController = presenterViewController else {
             return
         }
+        WPAnalytics.track(.promptsDashboardCardMenu)
 
         let menuViewController = MenuSheetViewController(items: contextMenuItems.map { menuSection in
             menuSection.map { $0.toMenuSheetItem }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -37,6 +37,7 @@ class BloggingPromptsViewController: UIViewController, NoResultsViewHost {
     }
 
     class func show(for blog: Blog, from presentingViewController: UIViewController) {
+        WPAnalytics.track(.promptsListViewed)
         let controller = BloggingPromptsViewController.controllerWithBlog(blog)
         presentingViewController.navigationController?.pushViewController(controller, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
@@ -72,16 +72,23 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
         addHeaderImageGradient()
     }
 
+    override func closeButtonTapped() {
+        WPAnalytics.track(.promptsIntroductionModalDismissed)
+        super.closeButtonTapped()
+    }
+
 }
 
 extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
 
     func primaryActionSelected() {
         guard interactionType == .actionable else {
+            WPAnalytics.track(.promptsIntroductionModalGotIt)
             super.closeButtonTapped()
             return
         }
 
+        WPAnalytics.track(.promptsIntroductionModalTryItNow)
         presenter?.primaryButtonSelected()
     }
 
@@ -90,6 +97,7 @@ extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
             return
         }
 
+        WPAnalytics.track(.promptsIntroductionModalRemindMe)
         presenter?.secondaryButtonSelected()
     }
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -42,6 +42,7 @@ class BloggingPromptsIntroductionPresenter: NSObject {
     // MARK: - Present Feature Introduction
 
     func present(from presentingViewController: UIViewController) {
+        WPAnalytics.track(.promptsIntroductionModalViewed)
 
         // We shouldn't get here, but just in case - verify the account actually has a site.
         // If not, fallback to the non-actionable/informational view.

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -332,6 +332,7 @@ private extension CreateButtonCoordinator {
         let promptsHeaderView = BloggingPromptsHeaderView.view(for: prompt)
 
         promptsHeaderView.answerPromptHandler = { [weak self] in
+            WPAnalytics.track(.promptsBottomSheetAnswerPrompt)
             self?.viewController?.dismiss(animated: true) {
                 let editor = EditPostViewController(blog: blog, prompt: prompt)
                 editor.modalPresentationStyle = .fullScreen


### PR DESCRIPTION
See: #18472 

## Description

Adds analytic tracking to some of the blogging prompt events.

## Testing

- Enable `bloggingPrompts` feature flag

### Feature introduction

- Launch the app
- Tap 'Try it now'
- Verify it's tracked
- Cancel site selection
- Tap 'Remind me'
- Verify it's tracked
- Cancel site selection
- Tap on the 'X' in the corner
- Verify it's tracked
- Go to My Site > Menu > Site Settings > Blogging Reminders
- Tap on the '?' next to 'Include Prompt'
- Tap on 'Got it'
- Verify it's tracked

### Action sheet
- Navigate to 'My Site'
- Tap on FAB '+'
- Tap on 'Answer Prompt'
- Verify it's tracked

### Dashboard Card
- Navigate to 'My Site'
- Tap on 'Answer Prompt'
- Verify it's tracked
- Tap on the menu '...'
- Verify it's tracked
- Tap on 'View more prompts'
- Verify it's tracked
- Tap on 'Skip this prompt'
- Verify it's tracked
- Enable remove menu item
- Open dashboard menu
- Tap on 'Remove from dashboard
- Verify it's tracked

### List view

- Navigate to 'My Site'
- In the card menu, tap on 'View more prompts'
- Verify the list being shown is tracked

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
