### PR TITLE
Blogging Prompts: Add syncing reminder UI with remote prompts schedule

### DIFF
--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -14,4 +14,13 @@ public class BloggingPromptSettings: NSManagedObject {
         reminderDays?.configure(with: remoteSettings.reminderDays)
     }
 
+    func reminderTimeDate() -> Date? {
+        guard let reminderTime = reminderTime else {
+            return nil
+        }
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "HH.mm"
+        return dateFormatter.date(from: reminderTime)
+    }
+
 }

--- a/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
@@ -23,7 +23,7 @@ public class BloggingPromptSettingsReminderDays: NSManagedObject {
             thursday,
             friday,
             saturday
-        ].enumerated().flatMap { (index: Int, isReminderActive: Bool) in
+        ].enumerated().compactMap { (index: Int, isReminderActive: Bool) in
             guard isReminderActive else {
                 return nil
             }

--- a/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
@@ -14,4 +14,21 @@ public class BloggingPromptSettingsReminderDays: NSManagedObject {
         self.sunday = remoteReminderDays.sunday
     }
 
+    func getActiveWeekdays() -> [BloggingRemindersScheduler.Weekday] {
+        return [
+            sunday,
+            monday,
+            tuesday,
+            wednesday,
+            thursday,
+            friday,
+            saturday
+        ].enumerated().flatMap { (index: Int, isReminderActive: Bool) in
+            guard isReminderActive else {
+                return nil
+            }
+            return BloggingRemindersScheduler.Weekday(rawValue: index)
+        }
+    }
+
 }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -101,10 +101,13 @@ class BloggingRemindersScheduler {
             return daysWithTime.time
         default:
             let settings = BloggingPromptsService(blog: blog)?.localSettings
+            let defaultTime = Calendar.current.date(from: DateComponents(calendar: Calendar.current, hour: Weekday.defaultHour, minute: 0)) ?? Date()
 
-            return settings?.reminderTimeDate()
-                    ?? Calendar.current.date(from: DateComponents(calendar: Calendar.current, hour: Weekday.defaultHour, minute: 0))
-                    ?? Date()
+            if FeatureFlag.bloggingPrompts.enabled, setings?.promptRemindersEnabled {
+                return settings?.reminderTimeDate() ?? defaultTime
+            } else {
+                return defaultTime
+            }
         }
     }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -103,7 +103,7 @@ class BloggingRemindersScheduler {
             let settings = BloggingPromptsService(blog: blog)?.localSettings
             let defaultTime = Calendar.current.date(from: DateComponents(calendar: Calendar.current, hour: Weekday.defaultHour, minute: 0)) ?? Date()
 
-            if FeatureFlag.bloggingPrompts.enabled, setings?.promptRemindersEnabled {
+            if FeatureFlag.bloggingPrompts.enabled, settings?.promptRemindersEnabled ?? false {
                 return settings?.reminderTimeDate() ?? defaultTime
             } else {
                 return defaultTime

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -100,7 +100,11 @@ class BloggingRemindersScheduler {
         case .weekDaysWithTime(let daysWithTime):
             return daysWithTime.time
         default:
-            return Calendar.current.date(from: DateComponents(calendar: Calendar.current, hour: Weekday.defaultHour, minute: 0)) ?? Date()
+            let settings = BloggingPromptsService(blog: blog)?.localSettings
+
+            return settings?.reminderTimeDate()
+                    ?? Calendar.current.date(from: DateComponents(calendar: Calendar.current, hour: Weekday.defaultHour, minute: 0))
+                    ?? Date()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -177,7 +177,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     private lazy var bloggingPromptsSwitch: UISwitch = {
         let bloggingPromptsSwitch = UISwitch()
         bloggingPromptsSwitch.translatesAutoresizingMaskIntoConstraints = false
-        bloggingPromptsSwitch.isOn = bloggingPromptsService?.localSettings?.promptRemindersEnabled ?? true
+        bloggingPromptsSwitch.isOn = true
         bloggingPromptsSwitch.addTarget(self, action: #selector(bloggingPromptsSwitchChanged), for: .valueChanged)
         return bloggingPromptsSwitch
     }()
@@ -241,7 +241,11 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
         switch self.scheduler.schedule(for: blog) {
         case .none:
-            previousWeekdays = settings?.reminderDays?.getActiveWeekdays() ?? []
+            if FeatureFlag.bloggingPrompts.enabled, settings?.promptRemindersEnabled {
+                previousWeekdays = settings?.reminderDays?.getActiveWeekdays() ?? []
+            } else {
+                previousWeekdays = []
+            }
         case .weekdays(let scheduledWeekdays):
             previousWeekdays = scheduledWeekdays
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -177,7 +177,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     private lazy var bloggingPromptsSwitch: UISwitch = {
         let bloggingPromptsSwitch = UISwitch()
         bloggingPromptsSwitch.translatesAutoresizingMaskIntoConstraints = false
-        bloggingPromptsSwitch.isOn = true
+        bloggingPromptsSwitch.isOn = bloggingPromptsService?.localSettings?.promptRemindersEnabled ?? true
         bloggingPromptsSwitch.addTarget(self, action: #selector(bloggingPromptsSwitchChanged), for: .valueChanged)
         return bloggingPromptsSwitch
     }()
@@ -236,11 +236,12 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         }()
         self.delegate = delegate
 
+        let settings = BloggingPromptsService(blog: blog)?.localSettings
         scheduler = try BloggingRemindersScheduler()
 
         switch self.scheduler.schedule(for: blog) {
         case .none:
-            previousWeekdays = []
+            previousWeekdays = settings?.reminderDays?.getActiveWeekdays() ?? []
         case .weekdays(let scheduledWeekdays):
             previousWeekdays = scheduledWeekdays
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -241,7 +241,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
 
         switch self.scheduler.schedule(for: blog) {
         case .none:
-            if FeatureFlag.bloggingPrompts.enabled, settings?.promptRemindersEnabled {
+            if FeatureFlag.bloggingPrompts.enabled, settings?.promptRemindersEnabled ?? false {
                 previousWeekdays = settings?.reminderDays?.getActiveWeekdays() ?? []
             } else {
                 previousWeekdays = []


### PR DESCRIPTION
See: #18429

## Description

Syncs the reminders UI with the remote settings if it exists. The order of priority for which schedule to display is as follows:
`Local schedule > Remote prompt settings > None`

So if a user already has reminders scheduled but it wasn't synced with the remote backend, their schedule would still be preserved.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Open a site and go to My Site > Menu > Site Settings > Blogging Reminders
- Set a schedule and hit 'Notify me'
- Verify the network call to update the schedule is successful
- Delete the app and relaunch
- Pick the same site and navigate back to the reminders screen
- Verify the schedule matches what was saved

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
