### PR TITLE
[Site Design Revamp] UI Tweaks

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -229,6 +229,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         super.viewDidLoad()
         insertChildView()
         insertAccessoryView()
+        configureSubtitleToCategoryBarSpacing()
         configureHeaderImageView()
         navigationItem.titleView = titleView
         largeTitleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold)
@@ -389,6 +390,12 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     private func configureHeaderImageView() {
         headerImageView.isHidden = (headerImage == nil)
         headerImageView.image = headerImage
+    }
+
+    private func configureSubtitleToCategoryBarSpacing() {
+        if prompt?.isEmpty ?? true {
+            subtitleToCategoryBarSpacing.constant = 0
+        }
     }
 
     func configureHeaderTitleVisibility() {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="55" width="320" height="224"/>
+                        <rect key="frame" x="0.0" y="59" width="320" height="220"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="999" constant="240" id="iK4-y8-V36"/>
@@ -35,8 +35,8 @@
                             <outlet property="delegate" destination="KGk-i7-Jjw" id="7er-Am-6i2"/>
                         </connections>
                     </collectionView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
-                        <rect key="frame" x="20" y="20" width="80" height="15"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
+                        <rect key="frame" x="20" y="20" width="80" height="19"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ujI-Bw-5eP">
                                 <rect key="frame" x="0.0" y="0.0" width="80" height="0.0"/>
@@ -45,7 +45,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                                <rect key="frame" x="0.0" y="0.0" width="80" height="15"/>
+                                <rect key="frame" x="0.0" y="4" width="80" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>


### PR DESCRIPTION
Fixes #18677

This PR fixes two visual issues:
1. The spacing below the large title
2. The margin between the recommended category name and caption

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/2092798/170608380-79d7be99-e947-4eac-b9cb-06b12412d0cc.png) | ![image](https://user-images.githubusercontent.com/2092798/170608641-72082ef3-413f-4465-9824-b9bec22a3687.png) |


## To test:
1. Start the Site Creation flow
2. Navigate to the Site Design picker
4. Observe area A (see screenshot)
5. Observe area B (see screenshot)
6. Scroll upwards and expect the header to collapse
7. Scroll downwards and expect the header to expand

## Regression Notes
1. Potential unintended areas of impact
  - Any other views that use a `CollapsableHeaderViewController`
    - Page Design picker
    - Other views in the Site Creation flow

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
  - None, as these are visual changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
