### PR TITLE
Quick Start: Fix orientation-related issues with quick start notices 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] App Settings: refreshed the UI with updated colors for Media Cache Size controls, Clear Spot Index row button, and Clear Siri Shortcut Suggestions row button. From destructive (red color) to standard and brand colors. [#18636]
 * [*] [internal] Quick Start: Fixed an issue where the Quick Start modal was not displayed after login if the user's default tab is Home. [#18721]
 * [*] Quick Start: The Next Steps modal has a fresh new look [#18711]
+* [*] [internal] Quick Start: Fixed a couple of layout issues with the Quick Start notices when rotating the device. [#18758]
 
 19.9
 -----

--- a/WordPress/Classes/Extensions/UIViewController+Notice.swift
+++ b/WordPress/Classes/Extensions/UIViewController+Notice.swift
@@ -26,4 +26,8 @@ extension UIViewController {
     @objc func dismissNotice() {
         ActionDispatcher.dispatch(NoticeAction.dismiss)
     }
+
+    @objc func dismissQuickStartTaskCompleteNotice() {
+        QuickStartTourGuide.shared.dismissTaskCompleteNotice()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -17,6 +17,7 @@ open class QuickStartTourGuide: NSObject {
     private var suggestionWorkItem: DispatchWorkItem?
     private weak var recentlyTouredBlog: Blog?
     private let noticeTag: Notice.Tag = "QuickStartTour"
+    private let noticeCompleteTag: Notice.Tag = "QuickStartTaskComplete"
     static let notificationElementKey = "QuickStartElementKey"
     static let notificationDescriptionKey = "QuickStartDescriptionKey"
 
@@ -184,6 +185,10 @@ open class QuickStartTourGuide: NSObject {
                                         userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.updateQuickStart])
     }
 
+    func dismissTaskCompleteNotice() {
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeCompleteTag))
+    }
+
     private func addSiteMenuWayPointIfNeeded(for tour: QuickStartTour) -> QuickStartTour {
 
         if currentEntryPoint == .blogDashboard &&
@@ -316,7 +321,7 @@ open class QuickStartTourGuide: NSObject {
         }
 
         let noticeStyle = QuickStartNoticeStyle(attributedMessage: taskCompleteDescription, isDismissable: true)
-        let notice = Notice(title: "", style: noticeStyle, tag: noticeTag)
+        let notice = Notice(title: "", style: noticeStyle, tag: noticeCompleteTag)
 
         DispatchQueue.main.asyncAfter(deadline: .now() + Constants.quickStartDelay) {
             ActionDispatcher.dispatch(NoticeAction.post(notice))
@@ -462,6 +467,7 @@ private extension QuickStartTourGuide {
     // - TODO: Research if dispatching `NoticeAction.empty` is still necessary now that we use `.clearWithTag`.
     func dismissCurrentNotice() {
         ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeTag))
+        ActionDispatcher.dispatch(NoticeAction.clearWithTag(noticeCompleteTag))
         ActionDispatcher.dispatch(NoticeAction.empty)
         NotificationCenter.default.post(name: .QuickStartTourElementChangedNotification, object: self, userInfo: [QuickStartTourGuide.notificationElementKey: QuickStartTourElement.noSuchElement])
     }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -84,7 +84,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [self dismissNotice];
+    [self dismissQuickStartTaskCompleteNotice];
 }
 
 - (void)setBlog:(Blog *)blog

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -219,6 +219,8 @@ class NoticePresenter {
 
         // At regular width, the notice shouldn't be any wider than 1/2 the app's width
         noticeContainerView.noticeWidthConstraint = noticeView.widthAnchor.constraint(equalTo: noticeContainerView.widthAnchor, multiplier: 0.5)
+        let isRegularWidth = noticeContainerView.traitCollection.containsTraits(in: UITraitCollection(horizontalSizeClass: .regular))
+        noticeContainerView.noticeWidthConstraint?.isActive = isRegularWidth
 
         NSLayoutConstraint.activate([
             noticeContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticePresenter.swift
@@ -137,7 +137,7 @@ class NoticePresenter {
     /// device is rotated.
     private func listenToOrientationChangeEvents() {
         let nc = NotificationCenter.default
-        nc.addObserver(forName: UIDevice.orientationDidChangeNotification, object: nil, queue: nil) { [weak self] _ in
+        nc.addObserver(forName: NSNotification.Name.WPTabBarHeightChanged, object: nil, queue: nil) { [weak self] _ in
             guard let self = self,
                 let containerView = self.currentNoticePresentation?.containerView else {
                     return

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -5,6 +5,7 @@ extern NSString * const WPNewPostURLParamTagsKey;
 extern NSString * const WPTabBarCurrentlySelectedScreenSites;
 extern NSString * const WPTabBarCurrentlySelectedScreenReader;
 extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
+extern NSNotificationName const WPTabBarHeightChangedNotification;
 
 @class AbstractPost;
 @class Blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -41,6 +41,9 @@ NSString * const WPTabBarCurrentlySelectedScreenSites = @"Blog List";
 NSString * const WPTabBarCurrentlySelectedScreenReader = @"Reader";
 NSString * const WPTabBarCurrentlySelectedScreenNotifications = @"Notifications";
 
+NSNotificationName const WPTabBarHeightChangedNotification = @"WPTabBarHeightChangedNotification";
+static NSString * const WPTabBarFrameKeyPath = @"frame";
+
 static NSInteger const WPTabBarIconOffsetiPad = 7;
 static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
@@ -61,6 +64,8 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 @property (nonatomic, strong) UIImage *meTabBarImage;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadUnselected;
 @property (nonatomic, strong) UIImage *meTabBarImageUnreadSelected;
+
+@property (nonatomic, assign) CGFloat tabBarHeight;
 
 @end
 
@@ -127,12 +132,18 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                                             forKeyPath:WPApplicationIconBadgeNumberKeyPath
                                                options:NSKeyValueObservingOptionNew
                                                context:nil];
+
+        [self.tabBar addObserver:self
+                      forKeyPath:WPTabBarFrameKeyPath
+                         options:NSKeyValueObservingOptionNew
+                         context:nil];
     }
     return self;
 }
 
 - (void)dealloc
 {
+    [self.tabBar removeObserver:self forKeyPath:WPTabBarFrameKeyPath];
     [self stopWatchingQuickTours];
     [[UIApplication sharedApplication] removeObserver:self forKeyPath:WPApplicationIconBadgeNumberKeyPath];
 }
@@ -558,8 +569,22 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if ([keyPath isEqualToString:WPApplicationIconBadgeNumberKeyPath]) {
+    if (object == self.tabBar && [keyPath isEqualToString:WPTabBarFrameKeyPath]) {
+        [self notifyOfTabBarHeightChangeIfNeeded];
+    }
+
+    if (object == [UIApplication sharedApplication] && [keyPath isEqualToString:WPApplicationIconBadgeNumberKeyPath]) {
         [self updateNotificationBadgeVisibility];
+    }
+}
+
+- (void)notifyOfTabBarHeightChangedIfNeeded
+{
+    CGFloat newTabBarHeight = self.tabBar.frame.size.height;
+    if (newTabBarHeight != self.tabBarHeight) {
+        self.tabBarHeight = newTabBarHeight;
+        [[NSNotificationCenter defaultCenter] postNotificationName:WPTabBarHeightChangedNotification
+                                                            object:nil];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -570,7 +570,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
     if (object == self.tabBar && [keyPath isEqualToString:WPTabBarFrameKeyPath]) {
-        [self notifyOfTabBarHeightChangeIfNeeded];
+        [self notifyOfTabBarHeightChangedIfNeeded];
     }
 
     if (object == [UIApplication sharedApplication] && [keyPath isEqualToString:WPApplicationIconBadgeNumberKeyPath]) {


### PR DESCRIPTION
Fixes #18493
Fixes #18757

## Description
- Fixes an issue where the notice was filing the whole screen width on large devices
- Fixes an issue where the notice would get misaligned after changing orientation.
    - The root cause was due to the `UIDevice.orientationDidChangeNotification` notification being posted before the tab bar has updated its height. And since we depend on the tab bar height to align the notice, this causes the misalignment.

## Testing Instructions

### Notice Width

1. Test on a large device (13 Pro Max)
2. Enable quick start for existing sites
3. Put the device in landscape mode
4. Start notifications task
5. Make sure that the notice fills 50% of the whole screen
6. Rotate the device to portrait
7. Make sure that the notice fills 100% of the whole screen
8. Rotate again
9. Make sure that the notice fills 50% of the whole screen

### Notice Misalignment

1. Test on iPhone 13 Pro Max or XS
2. Enable quick start for existing sites
3. Start notifications task
4. Note the position of the notice
5. Keep changing the orientation
6. Make sure the distance between notice and tab bar is always the same

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.