### PR TITLE
`git pull` before finalizing an hotfix or stable release

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -115,6 +115,8 @@ platform :ios do
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
     ios_finalize_prechecks(options)
+    git_pull
+
     version = ios_get_app_version
     trigger_release_build(branch_to_build: "release/#{version}")
   end
@@ -133,6 +135,7 @@ platform :ios do
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
     ios_finalize_prechecks(options)
+    git_pull
 
     check_all_translations(interactive: true)
 


### PR DESCRIPTION
I got myself in a bad place today when finalizing WordPress iOS 19.9 because I didn't `git pull` before finalizing the build and I run the automation from a machine other than the one where I launched the latest beta build from.

The result was that the `git push` of the changes made by the release finalization automation failed, because the remote had changes not present locally.

I think what I experienced today is an edge case, and I'm usually compulsively `git pull`-ing anyways, so there's low chance of this happening again. Still, doesn't hurt to have the check in the codebase, does it?

I decided to make the change here as opposed to the toolkit for two reasons:

1. It's faster to ship it here, and I can always backport to the toolkit if we consider it a valuable addition (which is possible, as it would DRY and save us from forgetting to add it if we'll ever create new
   similar automations)
2. Recently, we've take to not perform Git operations via the toolkit, but let the calling `Fastfile` do that. This is in line with that pattern, even though the Git operations we've moved to `Fastfile` so far were all committing and pushing and, as far as I know, this is the first pulling.

## To test

Apply this patch and run `bundle exec fastlane finalize_release` and `bundle exec fastlane finalize_hotfix_release`. They should both attempt a `git pull` before failing.

```patch
diff --git a/fastlane/lanes/release.rb b/fastlane/lanes/release.rb
index 8fe842a9b3..fe1a8a8fa4 100644
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -114,8 +114,9 @@ platform :ios do
   #
   desc 'Performs the final checks and triggers a release build for the hotfix in the current branch'
   lane :finalize_hotfix_release do |options|
-    ios_finalize_prechecks(options)
+    # ios_finalize_prechecks(options)
     git_pull
+    UI.user_error!('done')
 
     version = ios_get_app_version
     trigger_release_build(branch_to_build: "release/#{version}")
@@ -134,8 +135,9 @@ platform :ios do
   lane :finalize_release do |options|
     UI.user_error!('To finalize a hotfix, please use the finalize_hotfix_release lane instead') if ios_current_branch_is_hotfix
 
-    ios_finalize_prechecks(options)
+    # ios_finalize_prechecks(options)
     git_pull
+    UI.user_error!('done')
 
     check_all_translations(interactive: true)
```

<img width="1253" alt="image" src="https://user-images.githubusercontent.com/1218433/170636584-034942ea-bb0f-4442-b5ba-587887fd73b7.png">

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
4. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
