### PR TITLE
Comments: Fix comment moderation bar padding in multitasking context

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -67,6 +67,14 @@ class CommentModerationBar: UIView {
         NotificationCenter.default.removeObserver(self)
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        // readjust stack view width when horizontal size class changes.
+        if let previousTraitCollection = previousTraitCollection,
+           previousTraitCollection.horizontalSizeClass != traitCollection.horizontalSizeClass {
+            configureStackViewWidth()
+        }
+    }
+
 }
 
 // MARK: - Private Extension
@@ -113,6 +121,7 @@ private extension CommentModerationBar {
         let horizontalPadding: CGFloat = {
             if WPDeviceIdentification.isiPad() &&
                 UIDevice.current.orientation.isLandscape &&
+                !isInMultitasking &&
                 traitCollection.horizontalSizeClass == .regular {
                 return bounds.width * iPadPaddingMultiplier
             }
@@ -302,6 +311,15 @@ private extension UIView {
 
     func hideDivider(_ hidden: Bool) {
         backgroundColor = hidden ? Style.dividerHiddenColor : Style.dividerColor
+    }
+
+    /// Detects if the current view is displayed in multitasking context.
+    var isInMultitasking: Bool {
+        guard let window = window else {
+            return false
+        }
+
+        return window.frame.width != window.screen.bounds.width
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -112,7 +112,8 @@ private extension CommentModerationBar {
         // - Non split view iPhone landscape
         let horizontalPadding: CGFloat = {
             if WPDeviceIdentification.isiPad() &&
-                UIDevice.current.orientation.isLandscape {
+                UIDevice.current.orientation.isLandscape &&
+                traitCollection.horizontalSizeClass == .regular {
                 return bounds.width * iPadPaddingMultiplier
             }
 

--- a/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentModerationBar.swift
@@ -68,6 +68,8 @@ class CommentModerationBar: UIView {
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
         // readjust stack view width when horizontal size class changes.
         if let previousTraitCollection = previousTraitCollection,
            previousTraitCollection.horizontalSizeClass != traitCollection.horizontalSizeClass {


### PR DESCRIPTION
Fixes #18743

This fixes a layout bug affecting iPad in multitasking context. The bug affected both Split View and Slide Over mode, but **only in landscape orientation**. Here are some screenshots:

### Landscape

• | Before | After
--|--|--
Full | ![before_landscape](https://user-images.githubusercontent.com/1299411/170720817-b6dfbef3-639a-4761-afdd-bc0ba205e8af.png) | ![after_landscape](https://user-images.githubusercontent.com/1299411/170720791-4885b02d-9cea-4ab5-8d22-157678d1f5cd.png)
Split View ⚠️  | ![before_multi_landscape](https://user-images.githubusercontent.com/1299411/170720810-079f82ea-a81c-42d2-b0d8-90310da1249e.png) | ![after_multi_landscape](https://user-images.githubusercontent.com/1299411/170720748-c03f76bb-1700-433e-b71f-bd74d4a17175.png)
Slide Over ⚠️ | ![before_floating_landscape](https://user-images.githubusercontent.com/1299411/170720803-2c567df4-6dc5-4781-8f8f-7446b425e017.png) | ![after_floating_landscape](https://user-images.githubusercontent.com/1299411/170720800-bd1a5815-540b-49f6-96f0-b09180c84ac6.png)

For completeness, here are screenshots for the portrait orientation — to ensure that they are unaffected by this change:

### Portrait

• | Before | After
--|--|--
Full | ![before_portrait](https://user-images.githubusercontent.com/1299411/170720823-bd3fb901-2b1c-419d-83c0-cfb4a68850ff.png) | ![after_portrait](https://user-images.githubusercontent.com/1299411/170720783-92ac2d89-9826-4abe-9128-0d47299d1652.png)
Split View | ![before_multi_portrait](https://user-images.githubusercontent.com/1299411/170720812-aae42187-e78c-4e29-8d19-5cb6a5403c31.png) | ![after_multi_portrait](https://user-images.githubusercontent.com/1299411/170720770-80ccc8c3-9583-4ec5-9c8d-14430a0fae8a.png)
Slide Over | ![before_floating_portrait](https://user-images.githubusercontent.com/1299411/170720806-d4a9ce46-31c1-455e-8d4c-c5192a22e808.png) | ![after_floating_portrait](https://user-images.githubusercontent.com/1299411/170720799-0bd73bd9-739a-4ddf-9ede-29d5b1655cfb.png)

## To test:

- Run the app on iPad in landscape orientation.
- Open WordPress-iOS in Split View context.
- Navigate to any comment.
- 🔍  Verify that the moderation bar is displayed correctly.
- Open the WordPress-iOS in Slide Over context.
- 🔍  Verify that the moderation bar is displayed correctly.
- Also ensure that the moderation bar behavior in portrait orientation works well.

Pro Tip: Here's a [link](https://stackoverflow.com/a/71509093/1266558) that shows you how to multitask on iPad! 😆 

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
The changes were visual.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
