### PR TITLE
Build Warnings: Removed call to deprecated background tasks API

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -354,8 +354,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
                 DDLogError("Error scheduling background tasks: \(error)")
             }
         }
-
-        application.setMinimumBackgroundFetchInterval(UIApplication.backgroundFetchIntervalMinimum)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Description
Fixes a warning caused by an unneeded call to a deprecated API.
Calling `setMinimumBackgroundFetchInterval` is no longer relevant since we already now use the new `BackgroundTasks` framework.

## Testing Instructions

1. Test on device. When app launches go to Me -> App Settings -> Debug. Tap Weekly Roundup
2. If you don't have enough blogs / history also slide to the right to "Include A8c P2s"
3. Tap one of the options ie immediately and then minimise the app in background
4. Weekly Round up Notification should eventually appear as normal.

## Regression Notes
1. Potential unintended areas of impact
Weekly roundup

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.