### PR TITLE
Use ASC API key in register_new_device lane

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -25,7 +25,8 @@ platform :ios do
     register_device(
       name: device_name,
       udid: device_id,
-      team_id: team_id
+      team_id: team_id,
+      api_key_path: APP_STORE_CONNECT_KEY_PATH
     )
 
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -19,22 +19,24 @@ platform :ios do
       puts "\t#{identifier}"
     end
 
+    team_id = get_required_env('EXT_EXPORT_TEAM_ID')
+
     # Register the user's device
     register_device(
       name: device_name,
       udid: device_id,
-      team_id: get_required_env('EXT_EXPORT_TEAM_ID')
+      team_id: team_id
     )
 
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
-      team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+      team_id: team_id,
       app_identifier: all_bundle_ids
     )
 
     # Add all devices to the provisioning profiles
     add_all_devices_to_provisioning_profiles(
-      team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
+      team_id: team_id,
       app_identifier: all_bundle_ids
     )
   end


### PR DESCRIPTION
I recently addressed a platform request to add a device to the WordPress iOS profiles and thought I'd upgrade the setup just a little.

Unfortunately, even with this change, we still need to provide some credentials to the lane because of the subsequent steps to `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`. Those are actions defined in our release toolkit and they interface [with the developer portal](https://github.com/wordpress-mobile/release-toolkit/blob/bead08d00c2cf7bdf96eaa909362c89cd2339e23/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/add_development_certificates_to_provisioning_profiles.rb#L7). The portal doesn't support API keys yet, and Fastlane/Spaceship only connects to it [via username and password](https://rdoc.info/gems/fastlane/Spaceship.login).

## Testing

Is it okay to say: "trust me, it worked?"

<img width="830" alt="image" src="https://user-images.githubusercontent.com/1218433/170899586-8f13578d-b0bf-4ade-af49-2940f8e17ec1.png">

Otherwise, I think it should be okay to try and run the lane with one of your iOS test devices, even if already registered.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
