### PR TITLE
Blogging Prompts: Reminders coordinator integration

### DIFF
--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -24,3 +24,21 @@ public class BloggingPromptSettings: NSManagedObject {
     }
 
 }
+
+extension RemoteBloggingPromptsSettings {
+
+    init(with model: BloggingPromptSettings) {
+        self.init(promptCardEnabled: model.promptCardEnabled,
+                  promptRemindersEnabled: model.promptRemindersEnabled,
+                  reminderDays: ReminderDays(monday: model.reminderDays?.monday ?? false,
+                                             tuesday: model.reminderDays?.tuesday ?? false,
+                                             wednesday: model.reminderDays?.wednesday ?? false,
+                                             thursday: model.reminderDays?.thursday ?? false,
+                                             friday: model.reminderDays?.friday ?? false,
+                                             saturday: model.reminderDays?.saturday ?? false,
+                                             sunday: model.reminderDays?.sunday ?? false),
+                  reminderTime: model.reminderTime ?? String(),
+                  isPotentialBloggingSite: model.isPotentialBloggingSite)
+    }
+
+}

--- a/WordPress/Classes/Services/BlogService+Reminders.swift
+++ b/WordPress/Classes/Services/BlogService+Reminders.swift
@@ -3,13 +3,13 @@ import Foundation
 extension BlogService {
     @objc func unscheduleBloggingReminders(for blog: Blog) {
         do {
-            let scheduler = try BloggingRemindersScheduler()
+            let scheduler = try ReminderScheduleCoordinator()
             scheduler.schedule(.none, for: blog, completion: { _ in })
             // We're currently not propagating success / failure here, as it's
             // it's only used when removing blogs or accounts, and there's
             // no extra action we can take if it fails anyway.
         } catch {
-            DDLogError("Could not instantiate the blogging reminders scheduler: \(error.localizedDescription)")
+            DDLogError("Could not instantiate the reminders scheduler: \(error.localizedDescription)")
         }
     }
 }

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -77,9 +77,10 @@ import Foundation
         // Unschedule any scheduled blogging reminders for the account's blogs.
         // We don't just clear all reminders, in case the user has self-hosted
         // sites added to the app.
-        if let account = service.defaultWordPressComAccount() {
-            let scheduler = try? BloggingRemindersScheduler()
-            scheduler?.unschedule(for: Array(account.blogs))
+        if let account = service.defaultWordPressComAccount(),
+           let blogs = account.blogs,
+           let scheduler = try? ReminderScheduleCoordinator() {
+            blogs.forEach { scheduler.unschedule(for: $0) }
         }
 
         service.removeDefaultWordPressComAccount()

--- a/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
@@ -6,7 +6,6 @@ import UserNotifications
 class PromptRemindersScheduler {
     enum Errors: Error {
         case invalidSite
-        case needsPushAuthorization
         case fileSaveError
         case unknown
     }

--- a/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
@@ -56,7 +56,7 @@ class PromptRemindersScheduler {
             }
 
             guard allowed else {
-                completion(.failure(Errors.needsPushAuthorization))
+                completion(.failure(BloggingRemindersScheduler.Error.needsPermissionForPushNotifications))
                 return
             }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -166,7 +166,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
     // Populates the prompt label with formatted text detailing the reminders set by the user.
     //
     private func configurePromptLabel() {
-        guard let scheduler = try? BloggingRemindersScheduler() else {
+        guard let scheduler = try? ReminderScheduleCoordinator() else {
             return
         }
 
@@ -196,7 +196,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
     }
 
     private func configureTitleLabel() {
-        guard let scheduler = try? BloggingRemindersScheduler() else {
+        guard let scheduler = try? ReminderScheduleCoordinator() else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -177,7 +177,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     private lazy var bloggingPromptsSwitch: UISwitch = {
         let bloggingPromptsSwitch = UISwitch()
         bloggingPromptsSwitch.translatesAutoresizingMaskIntoConstraints = false
-        bloggingPromptsSwitch.isOn = true
+        bloggingPromptsSwitch.isOn = promptRemindersEnabled
         bloggingPromptsSwitch.addTarget(self, action: #selector(bloggingPromptsSwitchChanged), for: .valueChanged)
         return bloggingPromptsSwitch
     }()
@@ -236,16 +236,11 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         }()
         self.delegate = delegate
 
-        let settings = BloggingPromptsService(blog: blog)?.localSettings
         scheduler = try ReminderScheduleCoordinator()
 
         switch self.scheduler.schedule(for: blog) {
         case .none:
-            if FeatureFlag.bloggingPrompts.enabled, settings?.promptRemindersEnabled ?? false {
-                previousWeekdays = settings?.reminderDays?.getActiveWeekdays() ?? []
-            } else {
-                previousWeekdays = []
-            }
+            previousWeekdays = []
         case .weekdays(let scheduledWeekdays):
             previousWeekdays = scheduledWeekdays
         }
@@ -676,6 +671,21 @@ extension BloggingRemindersFlowSettingsViewController: ChildDrawerPositionable {
     var preferredDrawerPosition: DrawerPosition {
         return .expanded
     }
+}
+
+// MARK: - Blogging Prompts Helpers
+
+private extension BloggingRemindersFlowSettingsViewController {
+
+    var promptRemindersEnabled: Bool {
+        guard FeatureFlag.bloggingPrompts.enabled,
+              let settings = bloggingPromptsService?.localSettings else {
+            return false
+        }
+
+        return settings.promptRemindersEnabled
+    }
+
 }
 
 // MARK: - Constants

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -197,7 +197,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     // MARK: - Properties
 
     private let calendar: Calendar
-    private let scheduler: BloggingRemindersScheduler
+    private let scheduler: ReminderScheduleCoordinator
     private let scheduleFormatter = BloggingRemindersScheduleFormatter()
     private var weekdays: [BloggingRemindersScheduler.Weekday] {
         didSet {
@@ -237,7 +237,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         self.delegate = delegate
 
         let settings = BloggingPromptsService(blog: blog)?.localSettings
-        scheduler = try BloggingRemindersScheduler()
+        scheduler = try ReminderScheduleCoordinator()
 
         switch self.scheduler.schedule(for: blog) {
         case .none:

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -724,11 +724,6 @@ private extension BloggingRemindersFlowSettingsViewController {
         }
     }
 
-    /// Synchronizes the prompt settings to remote when `shouldSyncSchedule` parameter is `true`.
-    ///
-    /// - Parameters:
-    ///   - completion: Closure called when the process completes.
-
     /// Synchronizes the prompt settings to remote.
     ///
     /// - Parameter completion: Closure called when the process completes.
@@ -742,7 +737,6 @@ private extension BloggingRemindersFlowSettingsViewController {
 
         let newSettings = RemoteBloggingPromptsSettings(with: settings)
         service.updateSettings(settings: newSettings) { updatedSettings in
-            DDLogInfo("Updated prompt reminder schedule")
             completion()
         } failure: { error in
             DDLogError("Error saving prompt reminder schedule: \(String(describing: error))")

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -325,7 +325,7 @@ extension SiteSettingsViewController {
     // MARK: - Schedule Description
 
     private func schedule(for blog: Blog) -> String {
-        guard let scheduler = try? BloggingRemindersScheduler() else {
+        guard let scheduler = try? ReminderScheduleCoordinator() else {
             return ""
         }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -363,7 +363,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
     }
 
     private func schedule(for blog: Blog) -> String {
-        guard let scheduler = try? BloggingRemindersScheduler() else {
+        guard let scheduler = try? ReminderScheduleCoordinator() else {
             return NSLocalizedString("None set", comment: "Title shown on table row where no blogging reminders have been set up yet")
         }
 

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -289,7 +289,11 @@ class PromptRemindersSchedulerTests: XCTestCase {
                 return
             }
 
-            XCTAssertEqual(error as! PromptRemindersScheduler.Errors, PromptRemindersScheduler.Errors.needsPushAuthorization)
+            guard case BloggingRemindersScheduler.Error.needsPermissionForPushNotifications = error else {
+                XCTFail("Expected BloggingRemindersScheduler.Error.needsPermissionForPushNotifications, instead got: \(String(describing: error))")
+                return
+            }
+
             expectation.fulfill()
         }
 


### PR DESCRIPTION
Refs #18761

This PR integrates the `ReminderScheduleCoordinator` everywhere. Basically, this replaces all direct usage of `BloggingRemindersScheduler` so that the data is consistent. Here's a quick summary of the changes:

- The "Include Prompts" switch should now reflect the prompt settings.
- Schedules should now be saved according to the selected mechanism.
- Changes to the prompt settings updating logic:
  - After a schedule is selected, the local prompt setting is temporarily updated. This is to ensure that the schedule coordinator selects the correct mechanism (it selects based on `promptRemindersEnabled`).
  - After the scheduling completes, the prompt setting is synchronized to remote.
  - If for any reason the scheduling fails, the prompt setting is reverted to the previous state.
  - Bonus: The button is now temporarily updated to `disabled` state while the sync process is ongoing. However, this visual update is only applied when the prompt settings need to be synchronized.
- With the prompt reminders enabled, the prompt scheduler now throws `BloggingRemindersScheduler.Error.needsPermissionForPushNotifications`. This is so we can piggyback on the logic that shows `BloggingRemindersPushPromptViewController` when the user tries to schedule reminders with denied push authorization.

## To Test

### 1. "Include Prompts" switch state

- With `promptRemindersEnabled = false`, open the reminder sheet and verify that the switch is turned OFF.
- With `promptRemindersEnabled = true`, open the reminder sheet and verify that the switch is turned ON.

### 2. Scheduler mechanism switching

Note: You'll probably want to open your Simulator's `Library/Application Support` folder to ease your testing since the schedules are persisted there, i.e. `BloggingReminders.plist` and `BloggingPrompts.plist`. 

(Pro Tip: I use https://github.com/dsmelov/simsim to quickly go to my Simulator's folder. 🙂 )

#### With the prompt switch OFF:
- Select some days, and tap on the button.
  - Verify that the prompt text in the completion sheet (`"All set! You'll get reminders to blog ..."`) is correct.
  - Verify that `BloggingReminders.plist` is now filled with contents.
  - Verify that `BloggingPrompts.plist` is now empty.
- Go to My Sites menu > Site Settings > scroll to Blogging Reminders row.
  - Verify that the text displayed is correct (e.g. `Once a week at 10:00 AM`).
- Go to Notifications > tap on the gear icon > select the blog > Push notifications.
  - Verify that in the Blogging Reminders flow, the prompt text is correct.

#### With the prompt switch ON:
- Select some days, and tap on the button.
  - Verify that the prompt text in the completion sheet (`"All set! You'll get reminders to blog ..."`) is correct.
  - Verify that `BloggingReminders.plist` is now filled with contents.
  - Verify that `BloggingPrompts.plist` is now empty.
- Go to My Sites menu > Site Settings > scroll to Blogging Reminders row.
  - Verify that the text displayed is correct (e.g. `Once a week at 10:00 AM`).
- Go to Notifications > tap on the gear icon > select the blog > Push notifications.
  - Verify that in the Blogging Reminders flow, the prompt text is correct.

### 3. Push notification prompt

- Start with the prompt switch ON and no schedule set.
- Disable push notification authorization for the WordPress app.
- Go back to reminder settings sheet.
- Tap the notify me button.
- Verify that the push prompt view is shown.
- Dismiss the push prompt.
- Verify that the prompt text in Site Settings is still `Not Set`.
- Open the reminder sheet again.
- Verify that the schedules are still empty.

### 4. Clean up

- Log out from WordPress.
- Verify that both `BloggingReminders.plist` and `BloggingPrompt.plist` are now empty.

## Regression Notes
1. Potential unintended areas of impact
Blogging Reminders flow is impacted by this change, but it should be minimal since the feature is not released yet.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
The wrapper component is covered with unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
