### PR TITLE
Blogging Prompts: Update prompts reminder analytics to match Android

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -365,6 +365,9 @@ import Foundation
     case promptsDashboardCardMenuSkip
     case promptsDashboardCardMenuRemove
     case promptsListViewed
+    case promptsReminderSettingsIncludeSwitch
+    case promptsReminderSettingsHelp
+
 
     /// A String that represents the event
     var value: String {
@@ -983,6 +986,10 @@ import Foundation
             return "blogging_prompts_my_site_card_menu_remove_from_dashboard_tapped"
         case .promptsListViewed:
             return "blogging_prompts_prompts_list_viewed"
+        case .promptsReminderSettingsIncludeSwitch:
+            return "blogging_reminders_include_prompt_tapped"
+        case .promptsReminderSettingsHelp:
+            return "blogging_reminders_include_prompt_help_tapped"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -324,15 +324,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
     }
 
     @objc private func bloggingPromptsInfoButtonTapped() {
-        tracker.buttonPressed(button: .bloggingPromptsInfo, screen: .dayPicker)
+        WPAnalytics.track(.promptsReminderSettingsHelp)
 
         present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
     }
 
     @objc private func bloggingPromptsSwitchChanged(_ sender: UISwitch) {
-        tracker.switchPressed(control: .bloggingPrompts,
-                              state: sender.isOn ? .enabled : .disabled,
-                              screen: .dayPicker)
+        WPAnalytics.track(.promptsReminderSettingsIncludeSwitch, properties: ["enabled": String(sender.isOn)])
     }
 
     /// Schedules the reminders and shows a VC that requests PN authorization, if necessary.

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersTracker.swift
@@ -25,7 +25,6 @@ class BloggingRemindersTracker {
         // Misc UI events
         case buttonPressed = "blogging_reminders_button_pressed"
         case screenShown = "blogging_reminders_screen_shown"
-        case switchPressed = "blogging_reminders_switch_pressed"
     }
 
     enum FlowStartSource: String {
@@ -33,7 +32,7 @@ class BloggingRemindersTracker {
         case blogSettings = "blog_settings"
         case notificationSettings = "notification_settings"
         case statsInsights = "stats_insights"
-        case bloggingPromptsFeatureIntroduction = "blogging_prompts_feature_introduction"
+        case bloggingPromptsFeatureIntroduction = "blogging_prompts_onboarding"
     }
 
     enum FlowDismissSource: String {
@@ -54,16 +53,6 @@ class BloggingRemindersTracker {
         case `continue`
         case dismiss
         case notificationSettings
-        case bloggingPromptsInfo
-    }
-
-    enum Switch: String {
-        case bloggingPrompts
-    }
-
-    enum State: String {
-        case disabled
-        case enabled
     }
 
     enum Property: String {
@@ -72,7 +61,6 @@ class BloggingRemindersTracker {
         case source = "source"
         case screen = "screen"
         case selectedTime = "selected_time"
-        case `switch` = "switch"
         case state = "state"
     }
 
@@ -99,16 +87,6 @@ class BloggingRemindersTracker {
         ]
 
         track(event(.buttonPressed, properties: properties))
-    }
-
-    func switchPressed(control: Switch, state: State, screen: Screen) {
-        let properties = [
-            Property.switch.rawValue: control.rawValue,
-            Property.state.rawValue: state.rawValue,
-            Property.screen.rawValue: screen.rawValue,
-        ]
-
-        track(event(.switchPressed, properties: properties))
     }
 
     func flowCompleted() {


### PR DESCRIPTION
See: #18472

## Description

Updates some analytics in the reminders flow to match Android.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- On the feature intro screen, tap 'Remind me'
- Verify the `source` property is `blogging_prompts_onboarding`
- Flip the include switch on and off
- Verify `blogging_reminders_include_prompt_tapped` fired with properties `["enabled": "true"]` & `["enabled": "false"]`
- Tap on the help button '?' next to "Include prompt"
- Verify `blogging_reminders_include_prompt_help_tapped` is sent

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
