### PR TITLE
[Site Design Revamp] Update recommended designs caption font

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -99,7 +99,7 @@ class CategorySectionTableViewCell: UITableViewCell {
         categoryTitle.font = categoryTitleFont ?? WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.headline, fontWeight: .semibold)
         categoryTitle.layer.masksToBounds = true
         categoryTitle.layer.cornerRadius = 4
-        categoryCaptionLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        categoryCaptionLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular)
         setCaption()
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.xib
@@ -19,7 +19,7 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <collectionView multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" dataMode="none" springLoaded="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mQ0-DH-hTW" customClass="AccessibleCollectionView" customModule="WordPress" customModuleProvider="target">
-                        <rect key="frame" x="0.0" y="59" width="320" height="220"/>
+                        <rect key="frame" x="0.0" y="57" width="320" height="222"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstAttribute="height" priority="999" constant="240" id="iK4-y8-V36"/>
@@ -35,8 +35,8 @@
                             <outlet property="delegate" destination="KGk-i7-Jjw" id="7er-Am-6i2"/>
                         </connections>
                     </collectionView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
-                        <rect key="frame" x="20" y="20" width="80" height="19"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="b14-QX-4ea">
+                        <rect key="frame" x="20" y="20" width="80" height="17"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ujI-Bw-5eP">
                                 <rect key="frame" x="0.0" y="0.0" width="80" height="0.0"/>
@@ -45,7 +45,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pe-2p-9as">
-                                <rect key="frame" x="0.0" y="4" width="80" height="15"/>
+                                <rect key="frame" x="0.0" y="2" width="80" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="15" id="Cne-bu-2aD"/>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="b0Y-Uh-CXP"/>


### PR DESCRIPTION
Fixes #18674

- Reduces the font size from Subhead / Semibold to Footnote / Regular [[HIG typography](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/typography/)]
- Reduces the margin between the title and the caption

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-31 at 13 40 20](https://user-images.githubusercontent.com/2092798/171254122-8ff2ecdd-db5f-49f3-a724-e739957469cf.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-31 at 14 00 04](https://user-images.githubusercontent.com/2092798/171254148-25941867-182e-463d-9479-98fa9eb3dd8e.png) |

## Testing
1. Start the Site Creation flow
2. Navigate to the Site Design picker screen
3. Observe the font size of the caption for the recommended designs section

## Regression Notes
1. Potential unintended areas of impact
  - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - None

3. What automated tests I added (or what prevented me from doing so)
  - This was purely visual.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
