### PR TITLE
[Site Design Revamp] Remove selection border on dismissal of preview

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -317,14 +317,16 @@ extension SiteDesignContentCollectionViewController: CategorySectionTableViewCel
             sectionType: sectionType,
             onDismissWithDeviceSelected: { [weak self] device in
                 self?.previewViewSelectedPreviewDevice = device
-                cell.deselectItems()
             },
             completion: completion
         )
 
         let navController = GutenbergLightNavigationController(rootViewController: previewVC)
         navController.modalPresentationStyle = .pageSheet
-        navigationController?.present(navController, animated: true)
+        navigationController?.present(navController, animated: true) {
+            // deselect so no border is shown on dismissal of the preview
+            cell.deselectItems()
+        }
     }
 
     func didDeselectItem(forCell cell: CategorySectionTableViewCell) {}


### PR DESCRIPTION
Fixes tweak 3 of #18677.

This PR prevents the thumbnail selection border from being shown when a preview is dismissed. The border is retained when the user initially selects a design so that user feedback is provided.

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/2092798/171264238-4239959d-1dad-47bb-ab8f-af5fcaf7737d.mp4" /> | <video src="https://user-images.githubusercontent.com/2092798/171264341-cd2cc711-0824-49af-8414-b318c1d1cb21.mp4" /> |

## Testing
1. Start the Site Creation flow
2. Navigate to the Site Design picker screen
3. Tap a design and observe the selection border
4. Dismiss the design
5. Observe no selection border is shown

## Regression Notes
1. Potential unintended areas of impact
  - None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Tested VoiceOver and found no regressions.

3. What automated tests I added (or what prevented me from doing so)
  - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
