### PR TITLE
[Site Design Revamp] Make the Site Design screen header solid

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -164,6 +164,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         tableView.register(CategorySectionTableViewCell.nib, forCellReuseIdentifier: CategorySectionTableViewCell.cellReuseIdentifier)
         tableView.dataSource = self
         navigationItem.backButtonTitle = TextContent.backButtonTitle
+        configureHeaderStyling()
         configureCloseButton()
         configureSkipButton()
         SiteCreationAnalyticsHelper.trackSiteDesignViewed(previewMode: selectedPreviewDevice)
@@ -199,6 +200,11 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
                 self.isLoading = false
             }
         }
+    }
+
+    private func configureHeaderStyling() {
+        headerView.backgroundColor = .systemBackground
+        hideHeaderVisualEffects()
     }
 
     private func configureSkipButton() {


### PR DESCRIPTION
Fixes tweak 4 of #18677

This PR matches the top header bar and the background colors of the Site Design screen. If the before photo looks like the after photo don't worry - you probably have normal human vision.

| Before | After Light | After Dark |
| - | - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-05-31 at 15 27 10](https://user-images.githubusercontent.com/2092798/171269610-7a128c7f-764e-4965-acc1-2e322de063ac.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-31 at 15 23 55](https://user-images.githubusercontent.com/2092798/171269642-c2c6ed29-2947-4bcb-9284-d3f2e2c4a5be.png) | ![Simulator Screen Shot - iPhone 13 - 2022-05-31 at 15 24 20](https://user-images.githubusercontent.com/2092798/171269700-1ab1851e-712d-49fa-92d2-8f37d1ef0cc5.png) |


## Testing
1. Start the Site Creation flow
2. Navigate to the Site Design screen
3. Observe the background color of the header and the rest of the view

## Regression Notes
1. Potential unintended areas of impact
  - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Visually inspected the difference in light and dark modes.

3. What automated tests I added (or what prevented me from doing so)
  - None, as these are visual changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
