### PR TITLE
Add an empty configureCell method to conform to WPTableViewHandlerDelegate

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -435,6 +435,14 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     return @"relativeDateSectionIdentifier";
 }
 
+- (void)configureCell:(nonnull UITableViewCell *)cell atIndexPath:(nonnull NSIndexPath *)indexPath
+{
+    /// No implementation needed here; This method is added to remove protocol conformance warnings.
+    ///
+    /// Note that `WPTableViewHandler` will prioritize `tableView:cellForRowAtIndexPath:` when it is available.
+    /// We're not using the `configureCell` method because the handler only dequeues cell with `DefaultCellIdentifier` for this method.
+}
+
 #pragma mark - Predicate Wrangling
 
 - (void)updateFetchRequestPredicate:(CommentStatusFilter)statusFilter


### PR DESCRIPTION
Refs #18773

This removes a warning from `CommentsViewController` regarding incomplete protocol conformance.

---

⚠️ **Auto-merge is enabled!** ⚠️ 

---

## To test

- Navigate to My Sites > Comments.
- Verify that the comment cells are displayed correctly.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
