### PR TITLE
Blogging Prompts: Fix some UI display issues

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -259,7 +259,7 @@ private extension BloggingPromptsService {
         let fetchRequest = BloggingPrompt.fetchRequest()
         fetchRequest.predicate = .init(format: "\(#keyPath(BloggingPrompt.siteID)) = %@ AND \(#keyPath(BloggingPrompt.date)) >= %@", siteID, utcDate as NSDate)
         fetchRequest.fetchLimit = number
-        fetchRequest.sortDescriptors = [.init(key: #keyPath(BloggingPrompt.date), ascending: false)]
+        fetchRequest.sortDescriptors = [.init(key: #keyPath(BloggingPrompt.date), ascending: true)]
 
         return (try? self.contextManager.mainContext.fetch(fetchRequest)) ?? []
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -41,13 +41,13 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         }
     }
 
-    private lazy var isAnswered: Bool = {
+    private var isAnswered: Bool {
         if forExampleDisplay {
             return false
         }
 
         return prompt?.answered ?? false
-    }()
+    }
 
     private lazy var bloggingPromptsService: BloggingPromptsService? = {
         return BloggingPromptsService(blog: blog)
@@ -118,13 +118,13 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     // MARK: Middle row views
 
-    private lazy var answerCount: Int = {
+    private var answerCount: Int {
         if forExampleDisplay {
             return Constants.exampleAnswerCount
         }
 
         return Int(prompt?.answerCount ?? 0)
-    }()
+    }
 
     private var answerInfoText: String {
         let stringFormat = (answerCount == 1 ? Strings.answerInfoSingularFormat : Strings.answerInfoPluralFormat)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -15,6 +15,7 @@ class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
         formatter.setLocalizedDateFormatFromTemplate("MMM d, yyyy")
         return formatter
     }()

--- a/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
+++ b/WordPress/WordPressTest/BloggingPromptsServiceTests.swift
@@ -54,37 +54,37 @@ final class BloggingPromptsServiceTests: CoreDataTestCase {
 
             // Verify mappings for the first prompt
             let firstPrompt = prompts.first!
-            XCTAssertEqual(firstPrompt.promptID, 239)
-            XCTAssertEqual(firstPrompt.text, "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.")
-            XCTAssertEqual(firstPrompt.title, "Prompt number 1")
-            XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
-            XCTAssertEqual(firstPrompt.attribution, "dayone")
+            XCTAssertEqual(firstPrompt.promptID, 248)
+            XCTAssertEqual(firstPrompt.text, "Tell us about a time when you felt out of place.")
+            XCTAssertEqual(firstPrompt.title, "Prompt number 10")
+            XCTAssertEqual(firstPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
+            XCTAssertTrue(firstPrompt.attribution.isEmpty)
 
             let firstDateComponents = Calendar.current.dateComponents(in: Self.utcTimeZone, from: firstPrompt.date)
-            XCTAssertEqual(firstDateComponents.year!, 2022)
-            XCTAssertEqual(firstDateComponents.month!, 5)
-            XCTAssertEqual(firstDateComponents.day!, 3)
+            XCTAssertEqual(firstDateComponents.year!, 2021)
+            XCTAssertEqual(firstDateComponents.month!, 9)
+            XCTAssertEqual(firstDateComponents.day!, 12)
 
-            XCTAssertFalse(firstPrompt.answered)
-            XCTAssertEqual(firstPrompt.answerCount, 0)
-            XCTAssertTrue(firstPrompt.displayAvatarURLs.isEmpty)
+            XCTAssertTrue(firstPrompt.answered)
+            XCTAssertEqual(firstPrompt.answerCount, 1)
+            XCTAssertEqual(firstPrompt.displayAvatarURLs.count, 1)
 
             // Verify mappings for the second prompt
             let secondPrompt = prompts.last!
-            XCTAssertEqual(secondPrompt.promptID, 248)
-            XCTAssertEqual(secondPrompt.text, "Tell us about a time when you felt out of place.")
-            XCTAssertEqual(secondPrompt.title, "Prompt number 10")
-            XCTAssertEqual(secondPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Tell us about a time when you felt out of place.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
-            XCTAssertTrue(secondPrompt.attribution.isEmpty)
+            XCTAssertEqual(secondPrompt.promptID, 239)
+            XCTAssertEqual(secondPrompt.text, "Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.")
+            XCTAssertEqual(secondPrompt.title, "Prompt number 1")
+            XCTAssertEqual(secondPrompt.content, "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>Was there a toy or thing you always wanted as a child, during the holidays or on your birthday, but never received? Tell us about it.</p><cite>(courtesy of plinky.com)</cite></blockquote></figure>\n<!-- /wp:pullquote -->")
+            XCTAssertEqual(secondPrompt.attribution, "dayone")
 
             let secondDateComponents = Calendar.current.dateComponents(in: Self.utcTimeZone, from: secondPrompt.date)
-            XCTAssertEqual(secondDateComponents.year!, 2021)
-            XCTAssertEqual(secondDateComponents.month!, 9)
-            XCTAssertEqual(secondDateComponents.day!, 12)
+            XCTAssertEqual(secondDateComponents.year!, 2022)
+            XCTAssertEqual(secondDateComponents.month!, 5)
+            XCTAssertEqual(secondDateComponents.day!, 3)
 
-            XCTAssertTrue(secondPrompt.answered)
-            XCTAssertEqual(secondPrompt.answerCount, 1)
-            XCTAssertEqual(secondPrompt.displayAvatarURLs.count, 1)
+            XCTAssertFalse(secondPrompt.answered)
+            XCTAssertEqual(secondPrompt.answerCount, 0)
+            XCTAssertTrue(secondPrompt.displayAvatarURLs.isEmpty)
 
             expectation.fulfill()
 


### PR DESCRIPTION
See: #18429

## Description

- Adds a timezone to the blogging prompts list view so the display date is correct
- Prevents the dashboard card from caching some prompt values and preventing the card from updating if the prompt changes

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Launch the app and navigate to the 'My Site' tab
- Verify the prompts dashboard card still displays the same as before
- Tap on the menu '...'
- Tap on 'View more prompts'
- Verify the date displayed in the cell matches the date of the prompt

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
