### PR TITLE
Blogging Prompts: Fix warning when saving settings in `BloggingPromptsService`

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -154,8 +154,10 @@ class BloggingPromptsService {
         remote.fetchSettings(for: siteID) { result in
             switch result {
             case .success(let remoteSettings):
-                self.saveSettings(remoteSettings,
-                        completion: self.loadSettingsCompletion(success: success, failure: failure))
+                self.saveSettings(remoteSettings) {
+                    let settings = self.loadSettings(context: self.contextManager.mainContext)
+                    success(settings)
+                }
             case .failure(let error):
                 failure(error)
             }
@@ -179,9 +181,10 @@ class BloggingPromptsService {
                     success(nil)
                     return
                 }
-
-                self.saveSettings(updatedSettings,
-                        completion: self.loadSettingsCompletion(success: success, failure: failure))
+                self.saveSettings(updatedSettings) {
+                    let settings = self.loadSettings(context: self.contextManager.mainContext)
+                    success(settings)
+                }
             case .failure(let error):
                 failure(error)
             }
@@ -327,22 +330,16 @@ private extension BloggingPromptsService {
     ///
     /// - Parameters:
     ///   - remoteSettings: The blogging prompt settings from the remote.
-    ///   - completion: Closure to be called on completion. Result object with `Void` on success and an `Error` on failure.
-    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping (Result<Void, Error>) -> Void) {
+    ///   - completion: Closure to be called on completion.
+    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping () -> Void) {
         let derivedContext = contextManager.newDerivedContext()
         derivedContext.perform {
-            do {
-                let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
-                settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
+            let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
+            settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
 
-                self.contextManager.save(derivedContext) {
-                    DispatchQueue.main.async {
-                        completion(.success(()))
-                    }
-                }
-            } catch let error {
+            self.contextManager.save(derivedContext) {
                 DispatchQueue.main.async {
-                    completion(.failure(error))
+                    completion()
                 }
             }
         }
@@ -353,25 +350,6 @@ private extension BloggingPromptsService {
         fetchRequest.predicate = NSPredicate(format: "\(#keyPath(BloggingPromptSettings.siteID)) = %@", siteID)
         fetchRequest.fetchLimit = 1
         return (try? context.fetch(fetchRequest))?.first
-    }
-
-    /// A completion closure that will load the settings on success and calls the failure closure on an error.
-    ///
-    /// - Parameters:
-    ///   - success: Closure to be called on success with an optional `BloggingPromptSettings` object.
-    ///   - failure: Closure to be called on failure with an optional `Error` object.
-    /// - Returns: A closure which takes a `Result<Void, Error>` input
-    func loadSettingsCompletion(success: @escaping (BloggingPromptSettings?) -> Void,
-                                failure: @escaping (Error?) -> Void) -> (Result<Void, Error>) -> Void {
-        return { result in
-            switch result {
-            case .success:
-                let settings = self.loadSettings(context: self.contextManager.mainContext)
-                success(settings)
-            case .failure(let error):
-                failure(error)
-            }
-        }
     }
 
 }


### PR DESCRIPTION
See: #18549

## Description

Fixes a warning in `BloggingPromptsService` about the `catch` block being unreachable.

## Testing

To test:
- Build and verify the warning is gone
- Enable `bloggingPrompts` feature flag
- Navigate to Menu > Site Settings > Blogging Reminders
- Set a schedule if one doesn't exist already with prompts on
- Tap 'Notify me'/'Update'
- Verify settings are still properly saved

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
