### PR TITLE
[Site Design Revamp] Reset the scroll position every time site designs are shown

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -13,9 +13,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
 
     private var sections: [SiteDesignSection] = [] {
         didSet {
-            if oldValue.isEmpty {
-                scrollableView.setContentOffset(.zero, animated: false)
-            }
+            tableView.scrollToTop(animated: false)
             contentSizeWillChange()
             tableView.reloadData()
         }


### PR DESCRIPTION
Fixes #18794

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/2092798/171281933-b40f6885-5566-4416-a272-00e67ad8de89.mp4" /> | <video src="https://user-images.githubusercontent.com/2092798/171281978-2a05577e-af12-48c1-8bbf-56ada932a197.mp4" /> |

## Testing:
1. Start the Site Creation flow
2. Navigate to the Site Design picker screen
3. Scroll down vertically
4. Scroll horizontally to the end in any category with multiple designs
5. Tap "Topic" at the top left to navigate back to the Site Intent screen
6. Select a vertical or tap "Skip"
7. Expect the Site Design picker screen to be scrolled to the top
8. Expect all categories with multiple designs to be horizontally scrolled to their start

## Regression Notes
1. Potential unintended areas of impact
  - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manually tested steps above

3. What automated tests I added (or what prevented me from doing so)
  - None as these are visual changes

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
