### PR TITLE
Stats Revamp: Add donut chart to referrers detail card

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
@@ -90,8 +90,8 @@ class DonutChartView: UIView {
             chartContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             chartContainer.topAnchor.constraint(equalTo: topAnchor),
 
-            legendStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            legendStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            legendStackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
+            legendStackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             legendStackView.topAnchor.constraint(equalTo: chartContainer.bottomAnchor, constant: Constants.chartToLegendSpacing),
             legendStackView.bottomAnchor.constraint(equalTo: bottomAnchor),
 
@@ -141,6 +141,10 @@ class DonutChartView: UIView {
         var currentTotal: Float = 0.0
 
         for segment in segments {
+            if segment.value == 0 {
+                continue
+            }
+
             let segmentLayer = makeSegmentLayer()
             segmentLayer.strokeColor = segment.color.cgColor
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -227,7 +227,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                    let referrers = periodStore.getTopReferrers() {
                     let referrersData = referrersRowData()
                     let chartViewModel = StatsReferrersChartViewModel(referrers: referrers)
-                    let chartView = chartViewModel.makeReferrersChartView()
+                    let chartView: UIView? = referrers.totalReferrerViewsCount > 0 ?  chartViewModel.makeReferrersChartView() : nil
 
                     // Views Visitors
                     rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -223,18 +223,25 @@ class SiteStatsInsightsDetailsViewModel: Observable {
             return periodImmuTable(for: periodStore.topReferrersStatus) { status in
                 var rows = [ImmuTableRow]()
 
-                if let periodSummary = periodStore.getSummary() {
+                if let periodSummary = periodStore.getSummary(),
+                   let referrers = periodStore.getTopReferrers() {
+                    let referrersData = referrersRowData()
+                    let chartViewModel = StatsReferrersChartViewModel(referrers: referrers)
+                    let chartView = chartViewModel.makeReferrersChartView()
+
                     // Views Visitors
                     rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!,
                             statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
 
                     // Referrers
-                    rows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
-                            dataSubtitle: StatSection.periodReferrers.dataSubtitle,
-                            dataRows: referrersRowData(),
-                            statSection: StatSection.periodReferrers,
-                            siteStatsPeriodDelegate: nil, //TODO - look at if I need to be not null
-                            siteStatsReferrerDelegate: nil))
+                    var referrersRow = TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                                                               dataSubtitle: StatSection.periodReferrers.dataSubtitle,
+                                                               dataRows: referrersData,
+                                                               statSection: StatSection.periodReferrers,
+                                                               siteStatsPeriodDelegate: nil, //TODO - look at if I need to be not null
+                                                               siteStatsReferrerDelegate: nil)
+                    referrersRow.topAccessoryView = chartView
+                    rows.append(referrersRow)
 
 
                     // Countries

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -56,7 +56,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
             case .insightsViewsVisitors:
                 self.selectedPeriod = .week
 
-                var date = selectedDate ?? StatsDataHelper.currentDateForSite()
+                let date = selectedDate ?? StatsDataHelper.currentDateForSite()
                 periodStore.actionDispatcher.dispatch(PeriodAction.refreshPeriodOverviewData(date: date,
                         period: StatsPeriodUnit.day,
                         forceRefresh: false))

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+struct StatsReferrersChartViewModel {
+    let referrers: StatsTopReferrersTimeIntervalData
+
+    func makeReferrersChartView() -> UIView {
+        // The referrers chart currently shows 3 segments. If available, it will show:
+        // - WordPress.com Reader
+        // - Search
+        // - Other
+        // Unfortunately due to the results returned by the API this just has to be checked
+        // based on the title of the group, so it's really only possible for English-speaking users.
+        // When we can't find a WordPress.com Reader or Search Engines group, we'll just use the top
+        // two groups with the highest referrers count.
+
+        var topReferrers: [StatsReferrer] = []
+        var allReferrers = referrers.referrers
+
+        // First, find the WordPress.com and Search groups if we can
+        if let wpIndex = allReferrers.firstIndex(where: { $0.title.contains(Constants.wpComReferrerGroupTitle) }) {
+            topReferrers.append(allReferrers[wpIndex])
+            allReferrers.remove(at: wpIndex)
+        }
+
+        if let searchIndex = allReferrers.firstIndex(where: { $0.title.contains(Constants.searchEnginesReferrerGroupTitle) }) {
+            topReferrers.append(allReferrers[searchIndex])
+            allReferrers.remove(at: searchIndex)
+        }
+
+        // Then add groups from the top of the list to make up our target group count
+        while topReferrers.count < (Constants.referrersMaxGroupCount-1) && allReferrers.count > 0 {
+            topReferrers.append(allReferrers.removeFirst())
+        }
+
+        // Create segments for each referrer
+        var segments = topReferrers.enumerated().map({ index, item in
+            return DonutChartView.Segment(
+                title: Constants.referrersTitlesMap[item.title] ?? item.title,
+                value: Float(item.viewsCount),
+                color: Constants.referrersSegmentColors[index]
+            )
+        })
+
+        // Create a segment for all remaining referrers – "Other"
+        let otherCount = allReferrers.map({ $0.viewsCount }).reduce(0, +) + referrers.otherReferrerViewsCount
+        let otherSegment = DonutChartView.Segment(
+            title: Constants.otherReferrerGroupTitle,
+            value: Float(otherCount),
+            color: Constants.referrersSegmentColors.last!
+        )
+        segments.append(otherSegment)
+
+        let chartView = DonutChartView()
+        chartView.configure(title: Constants.chartTitle, totalCount: Float(referrers.totalReferrerViewsCount), segments: segments)
+        chartView.translatesAutoresizingMaskIntoConstraints = false
+        chartView.heightAnchor.constraint(equalToConstant: Constants.chartHeight).isActive = true
+        return chartView
+    }
+
+    private enum Constants {
+        // Referrers
+        // These first two titles are not localized as they're used for string matching against the API response.
+        static let wpComReferrerGroupTitle = "WordPress.com Reader"
+        static let searchEnginesReferrerGroupTitle = "Search Engines"
+        static let otherReferrerGroupTitle = NSLocalizedString("Other", comment: "Title of Stats section that shows referrer traffic from other sources.")
+        static let chartTitle = NSLocalizedString("Views", comment: "Title for chart showing site views from various referrer sources.")
+
+        static let referrersMaxGroupCount = 3
+        static let referrersSegmentColors: [UIColor] = [
+            .muriel(color: .primary, .shade80),
+            .muriel(color: .primary, .shade50),
+            .muriel(color: .primary, .shade5)
+        ]
+
+        static let referrersTitlesMap = [
+            "WordPress.com Reader":  "WordPress",
+            "Search Engines": NSLocalizedString("Search", comment: "Title of Stats section that shows search engine referrer traffic.")
+        ]
+
+        static let chartHeight: CGFloat = 231.0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
@@ -73,7 +73,7 @@ struct StatsReferrersChartViewModel {
         ]
 
         static let referrersTitlesMap = [
-            "WordPress.com Reader":  "WordPress",
+            "WordPress.com Reader": "WordPress",
             "Search Engines": NSLocalizedString("Search", comment: "Title of Stats section that shows search engine referrer traffic.")
         ]
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -15,8 +15,6 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
-    @IBOutlet weak var subtitlesStackViewTopConstraint: NSLayoutConstraint!
-    @IBOutlet weak var rowsStackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
     private var originalSubtitleStackViewTopConstant: CGFloat = 0
@@ -33,13 +31,6 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
     private weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     private weak var postStatsDelegate: PostStatsDelegate?
     private typealias Style = WPStyleGuide.Stats
-
-    override func awakeFromNib() {
-        super.awakeFromNib()
-
-        subtitlesStackViewHeightConstraint = subtitleStackView.heightAnchor.constraint(equalToConstant: 0)
-        originalSubtitleStackViewTopConstant = subtitlesStackViewTopConstraint.constant
-    }
 
     // MARK: - Configure
 
@@ -136,14 +127,8 @@ private extension TopTotalsCell {
 
     private func updateSubtitleConstraints(showSubtitles: Bool) {
         if showSubtitles {
-            rowsStackViewTopConstraint.constant = originalSubtitleStackViewTopConstant
-            subtitlesStackViewTopConstraint.constant = originalSubtitleStackViewTopConstant
-            subtitlesStackViewHeightConstraint?.isActive = false
             subtitleStackView.isHidden = false
         } else {
-            rowsStackViewTopConstraint.constant = 0
-            subtitlesStackViewTopConstraint.constant = 0
-            subtitlesStackViewHeightConstraint?.isActive = true
             subtitleStackView.isHidden = true
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -11,14 +11,24 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
 
     // MARK: - Properties
 
+    @IBOutlet weak var outerStackView: UIStackView!
     @IBOutlet weak var subtitleStackView: UIStackView!
     @IBOutlet weak var rowsStackView: UIStackView!
     @IBOutlet weak var itemSubtitleLabel: UILabel!
     @IBOutlet weak var dataSubtitleLabel: UILabel!
     @IBOutlet weak var topSeparatorLine: UIView!
     @IBOutlet weak var bottomSeparatorLine: UIView!
-    private var originalSubtitleStackViewTopConstant: CGFloat = 0
-    private var subtitlesStackViewHeightConstraint: NSLayoutConstraint? = nil
+    private var topAccessoryView: UIView? = nil {
+        didSet {
+            oldValue?.removeFromSuperview()
+
+            if let topAccessoryView = topAccessoryView {
+                outerStackView.insertArrangedSubview(topAccessoryView, at: 0)
+                topAccessoryView.layoutMargins = subtitleStackView.layoutMargins
+                outerStackView.setCustomSpacing(Metrics.topAccessoryViewSpacing, after: topAccessoryView)
+            }
+        }
+    }
 
     private var forDetails = false
     private var limitRowsDisplayed = true
@@ -43,6 +53,7 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
                    siteStatsReferrerDelegate: SiteStatsReferrerDelegate? = nil,
                    siteStatsDetailsDelegate: SiteStatsDetailsDelegate? = nil,
                    postStatsDelegate: PostStatsDelegate? = nil,
+                   topAccessoryView: UIView? = nil,
                    limitRowsDisplayed: Bool = true,
                    forDetails: Bool = false) {
         itemSubtitleLabel.text = itemSubtitle
@@ -55,6 +66,7 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
         self.siteStatsReferrerDelegate = siteStatsReferrerDelegate
         self.siteStatsDetailsDelegate = siteStatsDetailsDelegate
         self.postStatsDelegate = postStatsDelegate
+        self.topAccessoryView = topAccessoryView
         self.limitRowsDisplayed = limitRowsDisplayed
         self.forDetails = forDetails
 
@@ -92,6 +104,10 @@ class TopTotalsCell: StatsBaseCell, NibLoadable {
         }
 
         removeRowsFromStackView(rowsStackView)
+    }
+
+    private enum Metrics {
+        static let topAccessoryViewSpacing: CGFloat = 32.0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
@@ -82,6 +82,7 @@
                 <outlet property="bottomSeparatorLine" destination="9px-XX-eCP" id="jWU-xt-Cru"/>
                 <outlet property="dataSubtitleLabel" destination="DfF-g0-7Iu" id="JdZ-nM-kKj"/>
                 <outlet property="itemSubtitleLabel" destination="vbE-CG-voj" id="eZl-wI-KfG"/>
+                <outlet property="outerStackView" destination="Odo-Xd-cYF" id="WQ4-Ed-f0y"/>
                 <outlet property="rowsStackView" destination="w2N-OJ-hIR" id="5DU-xj-fcC"/>
                 <outlet property="subtitleStackView" destination="Tyj-5B-MLc" id="Ddg-AW-G7w"/>
                 <outlet property="topConstraint" destination="tsc-9l-RqU" id="AVy-aN-qDf"/>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.xib
@@ -17,28 +17,37 @@
                 <rect key="frame" x="0.0" y="0.0" width="323" height="200"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
-                        <rect key="frame" x="16" y="7" width="291" height="14.5"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="Odo-Xd-cYF">
+                        <rect key="frame" x="0.0" y="7" width="323" height="193"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
-                                <rect key="frame" x="0.0" y="0.0" width="145.5" height="14.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
-                                <rect key="frame" x="145.5" y="0.0" width="145.5" height="14.5"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="Tyj-5B-MLc" userLabel="Subtitles Stack View">
+                                <rect key="frame" x="0.0" y="0.0" width="323" height="14.5"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vbE-CG-voj">
+                                        <rect key="frame" x="16" y="0.0" width="145.5" height="14.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DfF-g0-7Iu">
+                                        <rect key="frame" x="161.5" y="0.0" width="145.5" height="14.5"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="vbE-CG-voj" secondAttribute="bottom" id="t2i-mf-5XT"/>
+                                </constraints>
+                                <edgeInsets key="layoutMargins" top="0.0" left="16" bottom="0.0" right="16"/>
+                            </stackView>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
+                                <rect key="frame" x="0.0" y="21.5" width="323" height="171.5"/>
+                            </stackView>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="bottom" secondItem="vbE-CG-voj" secondAttribute="bottom" id="t2i-mf-5XT"/>
+                            <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="Odo-Xd-cYF" secondAttribute="leading" id="HeQ-5k-tel"/>
                         </constraints>
-                    </stackView>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="w2N-OJ-hIR">
-                        <rect key="frame" x="0.0" y="28.5" width="323" height="171.5"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cBd-Ut-Uch" userLabel="Top Seperator Line">
                         <rect key="frame" x="0.0" y="0.0" width="323" height="0.5"/>
@@ -56,19 +65,16 @@
                     </view>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="Tyj-5B-MLc" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="04p-Eh-3C7"/>
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="3tF-WR-xtY"/>
-                    <constraint firstItem="Tyj-5B-MLc" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="3w8-O5-egA"/>
-                    <constraint firstAttribute="bottom" secondItem="w2N-OJ-hIR" secondAttribute="bottom" id="42h-SA-4TJ"/>
-                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="HgO-4i-Tfs"/>
-                    <constraint firstAttribute="trailing" secondItem="w2N-OJ-hIR" secondAttribute="trailing" id="J0K-LT-LLo"/>
+                    <constraint firstItem="Odo-Xd-cYF" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="7vH-Bx-r9n"/>
                     <constraint firstItem="cBd-Ut-Uch" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="MkM-w2-NRz"/>
+                    <constraint firstAttribute="bottom" secondItem="Odo-Xd-cYF" secondAttribute="bottom" id="MvA-em-4UC"/>
                     <constraint firstAttribute="trailing" secondItem="9px-XX-eCP" secondAttribute="trailing" id="WsP-Kk-luU"/>
-                    <constraint firstAttribute="trailing" secondItem="Tyj-5B-MLc" secondAttribute="trailing" constant="16" id="XOL-9m-28D"/>
                     <constraint firstAttribute="trailing" secondItem="cBd-Ut-Uch" secondAttribute="trailing" id="bwo-8W-tHL"/>
                     <constraint firstAttribute="bottom" secondItem="9px-XX-eCP" secondAttribute="bottom" id="e26-py-r2V"/>
+                    <constraint firstAttribute="trailing" secondItem="Odo-Xd-cYF" secondAttribute="trailing" id="q0P-6f-H1W"/>
                     <constraint firstItem="9px-XX-eCP" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="qfo-Hn-1HP"/>
-                    <constraint firstItem="w2N-OJ-hIR" firstAttribute="top" secondItem="Tyj-5B-MLc" secondAttribute="bottom" constant="7" id="w86-Wi-KtN"/>
+                    <constraint firstItem="Odo-Xd-cYF" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="7" id="tsc-9l-RqU"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
@@ -77,10 +83,8 @@
                 <outlet property="dataSubtitleLabel" destination="DfF-g0-7Iu" id="JdZ-nM-kKj"/>
                 <outlet property="itemSubtitleLabel" destination="vbE-CG-voj" id="eZl-wI-KfG"/>
                 <outlet property="rowsStackView" destination="w2N-OJ-hIR" id="5DU-xj-fcC"/>
-                <outlet property="rowsStackViewTopConstraint" destination="w86-Wi-KtN" id="uyG-4u-hdw"/>
                 <outlet property="subtitleStackView" destination="Tyj-5B-MLc" id="Ddg-AW-G7w"/>
-                <outlet property="subtitlesStackViewTopConstraint" destination="3w8-O5-egA" id="Qsd-dr-iv9"/>
-                <outlet property="topConstraint" destination="3w8-O5-egA" id="aqp-6y-dwu"/>
+                <outlet property="topConstraint" destination="tsc-9l-RqU" id="AVy-aN-qDf"/>
                 <outlet property="topSeparatorLine" destination="cBd-Ut-Uch" id="C1i-Zd-yPU"/>
             </connections>
             <point key="canvasLocation" x="55.200000000000003" y="17.991004497751124"/>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -438,6 +438,7 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
     var statSection: StatSection?
     weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     weak var siteStatsReferrerDelegate: SiteStatsReferrerDelegate?
+    var topAccessoryView: UIView? = nil
     let action: ImmuTableAction? = nil
 
     func configureCell(_ cell: UITableViewCell) {
@@ -451,7 +452,8 @@ struct TopTotalsPeriodStatsRow: ImmuTableRow {
                        dataRows: dataRows,
                        statSection: statSection,
                        siteStatsPeriodDelegate: siteStatsPeriodDelegate,
-                       siteStatsReferrerDelegate: siteStatsReferrerDelegate)
+                       siteStatsReferrerDelegate: siteStatsReferrerDelegate,
+                       topAccessoryView: topAccessoryView)
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -293,6 +293,8 @@
 		1761F18C26209AEE000815EF /* hot-pink-icon-app-60x60@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1761F16E26209AEE000815EF /* hot-pink-icon-app-60x60@3x.png */; };
 		1761F18D26209AEE000815EF /* hot-pink-icon-app-76x76.png in Resources */ = {isa = PBXBuildFile; fileRef = 1761F16F26209AEE000815EF /* hot-pink-icon-app-76x76.png */; };
 		1761F18E26209AEE000815EF /* hot-pink-icon-app-76x76@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 1761F17026209AEE000815EF /* hot-pink-icon-app-76x76@2x.png */; };
+		1762B6DC2845510400F270A5 /* StatsReferrersChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1762B6DB2845510400F270A5 /* StatsReferrersChartViewModel.swift */; };
+		1762B6DD2845510400F270A5 /* StatsReferrersChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1762B6DB2845510400F270A5 /* StatsReferrersChartViewModel.swift */; };
 		1767494E1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */; };
 		176BA53B268266E70025E4A3 /* BlogService+Reminders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176BA53A268266DE0025E4A3 /* BlogService+Reminders.swift */; };
 		176BA53C268266E70025E4A3 /* BlogService+Reminders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176BA53A268266DE0025E4A3 /* BlogService+Reminders.swift */; };
@@ -5184,6 +5186,7 @@
 		1761F16E26209AEE000815EF /* hot-pink-icon-app-60x60@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "hot-pink-icon-app-60x60@3x.png"; sourceTree = "<group>"; };
 		1761F16F26209AEE000815EF /* hot-pink-icon-app-76x76.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "hot-pink-icon-app-76x76.png"; sourceTree = "<group>"; };
 		1761F17026209AEE000815EF /* hot-pink-icon-app-76x76@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "hot-pink-icon-app-76x76@2x.png"; sourceTree = "<group>"; };
+		1762B6DB2845510400F270A5 /* StatsReferrersChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsReferrersChartViewModel.swift; sourceTree = "<group>"; };
 		1767494D1D3633A000B8D1D1 /* ThemeBrowserSearchHeaderView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThemeBrowserSearchHeaderView.swift; sourceTree = "<group>"; };
 		176BA53A268266DE0025E4A3 /* BlogService+Reminders.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "BlogService+Reminders.swift"; sourceTree = "<group>"; };
 		176BB87E20D0068500751DCE /* FancyAlertViewController+SavedPosts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+SavedPosts.swift"; sourceTree = "<group>"; };
@@ -12238,6 +12241,7 @@
 				DCCDF75D283BF02D00AA347E /* SiteStatsInsightsDetailsViewModel.swift */,
 				987535612282682D001661B4 /* DetailDataCell.swift */,
 				987535622282682D001661B4 /* DetailDataCell.xib */,
+				1762B6DB2845510400F270A5 /* StatsReferrersChartViewModel.swift */,
 			);
 			path = "Stats Detail";
 			sourceTree = "<group>";
@@ -18889,6 +18893,7 @@
 				FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */,
 				E142007A1C117A3B00B3B115 /* ManagedAccountSettings+CoreDataProperties.swift in Sources */,
 				B535209D1AF7EB9F00B33BA8 /* PushAuthenticationService.swift in Sources */,
+				1762B6DC2845510400F270A5 /* StatsReferrersChartViewModel.swift in Sources */,
 				B57273611B66CCEF000D1C4F /* AlertView.swift in Sources */,
 				3F851428260D1EA300A4B938 /* CircledIcon.swift in Sources */,
 				3101866B1A373B01008F7DF6 /* WPTabBarController.m in Sources */,
@@ -20689,6 +20694,7 @@
 				FABB22672602FC2C00C8785C /* CommentsViewController+Filters.swift in Sources */,
 				FABB22682602FC2C00C8785C /* AddressCell.swift in Sources */,
 				FABB22692602FC2C00C8785C /* URL+LinkNormalization.swift in Sources */,
+				1762B6DD2845510400F270A5 /* StatsReferrersChartViewModel.swift in Sources */,
 				FABB226A2602FC2C00C8785C /* ReaderTopicService+SiteInfo.swift in Sources */,
 				FABB226B2602FC2C00C8785C /* WordPressSupportSourceTag+Helpers.swift in Sources */,
 				FABB226C2602FC2C00C8785C /* ParentPageSettingsViewController.swift in Sources */,


### PR DESCRIPTION
Fixes #18780. This PR adds the donut chart component to the referrers detail card:

|   |   |   |
|---|---|---|
| <img src="https://user-images.githubusercontent.com/4780/171179599-4a700b87-7afc-4536-9dc4-6eefda190acc.png"> | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-31 at 14 10 54](https://user-images.githubusercontent.com/4780/171190176-a9b86646-9213-4cf7-b883-6e59f4d185ae.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-05-31 at 14 02 49](https://user-images.githubusercontent.com/4780/171190191-7ffccf4b-b58e-4cdd-8691-09307e2fd8c3.png) |

## To test

**Feature flag disabled**

* Build and run
* Navigate to Stats for a site and check Insights and Day / Week / Month / Year views for "TopTotals" cells like this:

<img width="350" alt="Screenshot 2022-05-31 at 14 52 37" src="https://user-images.githubusercontent.com/4780/171190228-f3ea9f11-55ad-402c-a62c-8075afc101a1.png">

* Ensure that they look as above, with nothing extra above the main content table.

**Feature flag enabled**

* Enable the two new Stats feature flags (LIST)
* Navigate to Stats > Insights for a site, and tap "This Week" in the top right of the views and visitors cell
* On the detail screen, ensure you can see the chart view at the top of the Referrers cell:

<img src="https://user-images.githubusercontent.com/4780/171179599-4a700b87-7afc-4536-9dc4-6eefda190acc.png" width=350>

* Test the chart on sites with a lot of visits, very few visits, and no visits at all. If there are no visits, the chart should be hidden.
* The chart should show WordPress.com Reader and Search Engines referrers if available (otherwise, the top referrers from the list) and a third "Other" category.

## Regression Notes

1. Potential unintended areas of impact

Existing TopTotalsCell with feature flag disabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Ensured the chart is only added in the new insights details view, and manually tested.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
