### PR TITLE
Follow Conversation Tooltip Improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -170,10 +170,21 @@ final class TooltipPresenter {
                 )
             }
         case .point(let targetPoint):
-            tooltipTopConstraint = tooltip.bottomAnchor.constraint(
-                equalTo: containerView.topAnchor,
-                constant: targetPoint.y + Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
-            )
+            switch tooltipOrientation() {
+            case .bottom:
+                tooltipTopConstraint = tooltip.bottomAnchor.constraint(
+                    equalTo: containerView.topAnchor,
+                    constant: targetPoint.y + Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
+                )
+            case .top:
+                tooltipTopConstraint = tooltip.bottomAnchor.constraint(
+                    equalTo: containerView.topAnchor,
+                    constant: targetPoint.y
+                    + Constants.verticalTooltipDistanceToFocus
+                    + Constants.tooltipTopConstraintAnimationOffset
+                    + tooltip.size().height
+                )
+            }
         }
 
         tooltipConstraints.append(tooltipTopConstraint!)

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -8,27 +8,61 @@ final class TooltipPresenter {
         static let horizontalBufferMargin: CGFloat = 20
         static let tooltipTopConstraintAnimationOffset: CGFloat = 8
         static let tooltipAnimationDuration: TimeInterval = 0.2
+        static let anchorBottomConstraintConstant: CGFloat = 58
+    }
+
+    enum TooltipVerticalPosition {
+        case auto
+        case above
+        case below
+    }
+
+    enum Target {
+        case view(UIView)
+        case point(CGPoint)
     }
 
     private let containerView: UIView
     private let tooltip: Tooltip
-    private let targetView: UIView
     private var primaryTooltipAction: (() -> Void)?
     private var secondaryTooltipAction: (() -> Void)?
-
+    private var anchor: TooltipAnchor?
     private var tooltipTopConstraint: NSLayoutConstraint?
+    private var anchorAction: (() -> Void)?
+    private let target: Target
+
+    private var targetMidX: CGFloat {
+        switch target {
+        case .view(let targetView):
+            return targetView.frame.midX
+        case .point(let targetPoint):
+            return targetPoint.x
+        }
+    }
+
+    private var targetMinY: CGFloat {
+        switch target {
+        case .view(let targetView):
+            return targetView.frame.minY
+        case .point(let targetPoint):
+            return targetPoint.y
+        }
+    }
+
+
+    var tooltipVerticalPosition: TooltipVerticalPosition = .auto
 
     init(containerView: UIView,
          tooltip: Tooltip,
-         targetView: UIView,
+         target: Target,
          primaryTooltipAction: (() -> Void)? = nil,
          secondaryTooltipAction: (() -> Void)? = nil
     ) {
         self.containerView = containerView
         self.tooltip = tooltip
-        self.targetView = targetView
         self.primaryTooltipAction = primaryTooltipAction
         self.secondaryTooltipAction = secondaryTooltipAction
+        self.target = target
 
         configureDismissal()
 
@@ -45,7 +79,33 @@ final class TooltipPresenter {
         )
     }
 
-    func show() {
+    func attachAnchor(withTitle title: String, onView view: UIView, anchorAction: @escaping (() -> Void)) {
+        let anchor = TooltipAnchor()
+        self.anchor = anchor
+        self.anchorAction = anchorAction
+        anchor.title = title
+        anchor.addTarget(self, action: #selector(didTapAnchor), for: .touchUpInside)
+        anchor.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(anchor)
+
+        NSLayoutConstraint.activate([
+            anchor.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            view.safeAreaLayoutGuide.bottomAnchor.constraint(
+                equalTo: anchor.bottomAnchor,
+                constant: Constants.anchorBottomConstraintConstant
+            )
+        ])
+    }
+
+    func toggleAnchorVisibility(_ isVisible: Bool) {
+        guard let anchor = anchor else {
+            return
+        }
+
+        anchor.isHidden = !isVisible
+    }
+
+    func showTooltip() {
         containerView.addSubview(tooltip)
         self.tooltip.alpha = 0
         tooltip.addArrowHead(toXPosition: arrowOffsetX(), arrowPosition: tooltipOrientation())
@@ -63,6 +123,10 @@ final class TooltipPresenter {
             tooltipTopConstraint.constant -= Constants.tooltipTopConstraintAnimationOffset
             self.containerView.layoutIfNeeded()
         }
+    }
+
+    @objc private func didTapAnchor() {
+        anchorAction?()
     }
 
     private func configureDismissal() {
@@ -91,16 +155,24 @@ final class TooltipPresenter {
             tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
         ]
 
-        switch tooltipOrientation() {
-        case .bottom:
-            tooltipTopConstraint = targetView.topAnchor.constraint(
-                equalTo: tooltip.bottomAnchor,
-                constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
-            )
-        case .top:
-            tooltipTopConstraint = tooltip.topAnchor.constraint(
-                equalTo: targetView.bottomAnchor,
-                constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
+        switch target {
+        case .view(let targetView):
+            switch tooltipOrientation() {
+            case .bottom:
+                tooltipTopConstraint = targetView.topAnchor.constraint(
+                    equalTo: tooltip.bottomAnchor,
+                    constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
+                )
+            case .top:
+                tooltipTopConstraint = tooltip.topAnchor.constraint(
+                    equalTo: targetView.bottomAnchor,
+                    constant: Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
+                )
+            }
+        case .point(let targetPoint):
+            tooltipTopConstraint = tooltip.bottomAnchor.constraint(
+                equalTo: containerView.topAnchor,
+                constant: targetPoint.y + Constants.verticalTooltipDistanceToFocus + Constants.tooltipTopConstraintAnimationOffset
             )
         }
 
@@ -110,35 +182,35 @@ final class TooltipPresenter {
 
     @objc private func resetTooltipAndShow() {
         tooltip.removeFromSuperview()
-        show()
+        showTooltip()
     }
 
     /// Calculates where the arrow needs to place in the borders of the tooltip.
-    /// This depends on the position of the `targetView` relative to `tooltip`.
+    /// This depends on the position of the target relative to `tooltip`.
     private func arrowOffsetX() -> CGFloat {
-        return targetView.frame.midX - ((containerView.bounds.width - tooltip.size().width) / 2) - extraArrowOffsetX()
+        return targetMidX - ((containerView.bounds.width - tooltip.size().width) / 2) - extraArrowOffsetX()
     }
 
-    /// If the tooltip is always vertically centered, tooltip's width may not be big enough to reach to the `targetView`
-    /// If `xxxxxxxx` is the Tooltip and `oo` is the `targetView`:
+    /// If the tooltip is always vertically centered, tooltip's width may not be big enough to reach to the target
+    /// If `xxxxxxxx` is the Tooltip and `oo` is the target:
     /// |                                               |
     /// |                xxxxxxxx                 |
     /// |                                    oo       |
     /// The tooltip needs an extra X offset to be aligned with target so that tooltip arrow points to the correct position.
-    /// Here the tooltip is pushed to the right so the arrow is pointing at the `targetView`
+    /// Here the tooltip is pushed to the right so the arrow is pointing at the target
     /// |                                               |
     /// |                           xxxxxxxx     |
     /// |                                    oo       |
-    /// It would be retracted instead of the `targetView` was at the left of the screen.
+    /// It would be retracted instead of the target was at the left of the screen.
     ///
     private func extraArrowOffsetX() -> CGFloat {
         let tooltipWidth = tooltip.size().width
         let extraPushOffset = max(
-            (targetView.frame.midX + Constants.horizontalBufferMargin) - (containerView.frame.midX + tooltipWidth / 2),
+            (targetMidX + Constants.horizontalBufferMargin) - (containerView.frame.midX + tooltipWidth / 2),
             0
         )
         let extraRetractOffset = min(
-            (targetView.frame.midX - Constants.horizontalBufferMargin) - (containerView.frame.midX - tooltipWidth / 2),
+            (targetMidX - Constants.horizontalBufferMargin) - (containerView.frame.midX - tooltipWidth / 2),
             0
         )
 
@@ -151,9 +223,16 @@ final class TooltipPresenter {
 
 
     private func tooltipOrientation() -> Tooltip.ArrowPosition {
-        if containerView.frame.midY < targetView.frame.minY {
+        switch tooltipVerticalPosition {
+        case .auto:
+            if containerView.frame.midY < targetMinY {
+                return .bottom
+            }
+            return .top
+        case .above:
             return .bottom
+        case .below:
+            return .top
         }
-        return .top
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -201,7 +201,7 @@ final class TooltipPresenter {
     /// |                                               |
     /// |                           xxxxxxxx     |
     /// |                                    oo       |
-    /// It would be retracted instead of the target was at the left of the screen.
+    /// It would be retracted instead if the target was at the left of the screen.
     ///
     private func extraArrowOffsetX() -> CGFloat {
         let tooltipWidth = tooltip.size().width


### PR DESCRIPTION
Refs pbArwn-4oo-p2

Adds support for showing tooltip on CGPoint in addition to a UIView.

To test:

Please first place the following code in the viewDidAppear of ReaderDetailViewController.
Then select a post from "Reader" and the tooltip should on the given `CGPoint`.
```Swift
        // FIXME: Remove test code!
        view.layoutIfNeeded()

        let tooltip = Tooltip()

        tooltip.title = "Follow the conversation"
        tooltip.message = "Get notified."
        tooltip.primaryButtonTitle = "Got it"
        tooltip.secondaryButtonTitle = "Learn more"

        tooltipPresenter = TooltipPresenter(
            containerView: view,
            tooltip: tooltip,
            target: .point(CGPoint(x: 100, y: 450))
        )
        tooltipPresenter?.showTooltip()
```
Also retain the tooltipPresenter to respond to orientation and system font size changes:

```Swift
       private var tooltipPresenter: TooltipPresenter?
```

## Regression Notes
1. Potential unintended areas of impact
N/A. Isolated addition that has no impact on rest of the code.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A. It is purely UI logic.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.