### PR TITLE
Blogging Prompts: Fix showing future prompts and old prompt data in list view

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -9,10 +9,19 @@ class BloggingPromptsService {
     private let maxListPrompts = 11
 
     /// A UTC date formatter that ignores time information.
-    private static var dateFormatter: DateFormatter = {
+    private static var utcDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = .init(identifier: "en_US_POSIX")
         formatter.timeZone = .init(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+
+        return formatter
+    }()
+
+    /// A date formatter using the local timezone that ignores time information.
+    private static var localDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = .init(identifier: "en_US_POSIX")
         formatter.dateFormat = "yyyy-MM-dd"
 
         return formatter
@@ -22,12 +31,6 @@ class BloggingPromptsService {
     ///
     var localTodaysPrompt: BloggingPrompt? {
         loadPrompts(from: Date(), number: 1).first
-    }
-
-    /// Convenience computed variable that returns prompts for the prompts list from local store.
-    ///
-    var localListPrompts: [BloggingPrompt] {
-        loadPrompts(from: listStartDate, number: maxListPrompts)
     }
 
     /// Convenience computed variable that returns prompt settings from the local store.
@@ -40,15 +43,17 @@ class BloggingPromptsService {
     /// When no parameters are specified, this method will attempt to return prompts from ten days ago and two weeks ahead.
     ///
     /// - Parameters:
-    ///   - date: When specified, only prompts from the specified date will be returned. Defaults to 10 days ago.
+    ///   - startDate: When specified, only prompts after the specified date will be returned. Defaults to 10 days ago.
+    ///   - endDate: When specified, only prompts before the specified date will be returned.
     ///   - number: The amount of prompts to return. Defaults to 25 when unspecified (10 days back, today, 14 days ahead).
     ///   - success: Closure to be called when the fetch process succeeded.
     ///   - failure: Closure to be called when the fetch process failed.
-    func fetchPrompts(from date: Date? = nil,
+    func fetchPrompts(from startDate: Date? = nil,
+                      to endDate: Date? = nil,
                       number: Int = 25,
                       success: @escaping ([BloggingPrompt]) -> Void,
                       failure: @escaping (Error?) -> Void) {
-        let fromDate = date ?? defaultStartDate
+        let fromDate = startDate ?? defaultStartDate
         remote.fetchPrompts(for: siteID, number: number, fromDate: fromDate) { result in
             switch result {
             case .success(let remotePrompts):
@@ -58,8 +63,7 @@ class BloggingPromptsService {
                         return
                     }
 
-                    success(self.loadPrompts(from: fromDate, number: number))
-
+                    success(self.loadPrompts(from: fromDate, to: endDate, number: number))
                 }
             case .failure(let error):
                 failure(error)
@@ -103,25 +107,7 @@ class BloggingPromptsService {
     ///   - failure: Closure to be called when the fetch process failed.
     func fetchListPrompts(success: @escaping ([BloggingPrompt]) -> Void,
                           failure: @escaping (Error?) -> Void) {
-        fetchPrompts(from: listStartDate, number: maxListPrompts, success: success, failure: failure)
-    }
-
-    /// Convenience method to obtain the blogging prompts for the prompts list,
-    /// either from local cache or remote.
-    ///
-    /// - Parameters:
-    ///   - success: Closure to be called when the fetch process succeeded.
-    ///   - failure: Closure to be called when the fetch process failed.
-    func listPrompts(success: @escaping ([BloggingPrompt]) -> Void,
-                     failure: @escaping (Error?) -> Void) {
-
-        // If there aren't maxListPrompts cached, need to fetch more.
-        guard localListPrompts.count < maxListPrompts else {
-            success(localListPrompts)
-            return
-        }
-
-        fetchListPrompts(success: success, failure: failure)
+        fetchPrompts(from: listStartDate, to: Date(), number: maxListPrompts, success: success, failure: failure)
     }
 
     /// Loads a single prompt with the given `promptID`.
@@ -234,33 +220,46 @@ private extension BloggingPromptsService {
     }
 
     var listStartDate: Date {
-        calendar.date(byAdding: .day, value: -(maxListPrompts - 2), to: Date()) ?? Date()
+        calendar.date(byAdding: .day, value: -(maxListPrompts - 1), to: Date()) ?? Date()
     }
 
-    /// Converts the given date to UTC and ignores the time information.
-    /// Example: Given `2022-05-01 03:00:00 UTC-5`, this should return `2022-05-01 00:00:00 UTC`.
+    /// Converts the given date to UTC preserving the date and ignores the time information.
+    /// Examples:
+    ///   Given `2022-05-01 23:00:00 UTC-4` (`2022-05-02 03:00:00 UTC`), this should return `2022-05-01 00:00:00 UTC`.
+    ///
+    ///   Given `2022-05-02 05:00:00 UTC+9` (`2022-05-01 20:00:00 UTC`), this should return `2022-05-02 00:00:00 UTC`.
     ///
     /// - Parameter date: The date to convert.
     /// - Returns: The UTC date without the time information.
-    func utcDateIgnoringTime(from date: Date) -> Date? {
-        let utcDateString = Self.dateFormatter.string(from: date)
-        return Self.dateFormatter.date(from: utcDateString)
+    func utcDateIgnoringTime(from date: Date?) -> Date? {
+        guard let date = date else {
+            return nil
+        }
+        let dateString = Self.localDateFormatter.string(from: date)
+        return Self.utcDateFormatter.date(from: dateString)
     }
 
     /// Loads local prompts based on the given parameters.
     ///
     /// - Parameters:
-    ///   - date: When specified, only prompts from the specified date will be returned.
+    ///   - startDate: Only prompts after the specified date will be returned.
+    ///   - endDate: When specified, only prompts before the specified date will be returned.
     ///   - number: The amount of prompts to return.
-    /// - Returns: An array of `BloggingPrompt` objects sorted descending by date.
-    func loadPrompts(from date: Date, number: Int) -> [BloggingPrompt] {
-        guard let utcDate = utcDateIgnoringTime(from: date) else {
-            DDLogError("Error converting date to UTC: \(date)")
+    /// - Returns: An array of `BloggingPrompt` objects sorted ascending by date.
+    func loadPrompts(from startDate: Date, to endDate: Date? = nil, number: Int) -> [BloggingPrompt] {
+        guard let utcStartDate = utcDateIgnoringTime(from: startDate) else {
+            DDLogError("Error converting date to UTC: \(startDate)")
             return []
         }
 
         let fetchRequest = BloggingPrompt.fetchRequest()
-        fetchRequest.predicate = .init(format: "\(#keyPath(BloggingPrompt.siteID)) = %@ AND \(#keyPath(BloggingPrompt.date)) >= %@", siteID, utcDate as NSDate)
+        if let utcEndDate = utcDateIgnoringTime(from: endDate) {
+            let format = "\(#keyPath(BloggingPrompt.siteID)) = %@ AND \(#keyPath(BloggingPrompt.date)) >= %@ AND \(#keyPath(BloggingPrompt.date)) <= %@"
+            fetchRequest.predicate = NSPredicate(format: format, siteID, utcStartDate as NSDate, utcEndDate as NSDate)
+        } else {
+            let format = "\(#keyPath(BloggingPrompt.siteID)) = %@ AND \(#keyPath(BloggingPrompt.date)) >= %@"
+            fetchRequest.predicate = NSPredicate(format: format, siteID, utcStartDate as NSDate)
+        }
         fetchRequest.fetchLimit = number
         fetchRequest.sortDescriptors = [.init(key: #keyPath(BloggingPrompt.date), ascending: true)]
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -115,7 +115,7 @@ private extension BloggingPromptsViewController {
 
         isLoading = true
 
-        bloggingPromptsService.listPrompts(success: { [weak self] (prompts) in
+        bloggingPromptsService.fetchListPrompts(success: { [weak self] (prompts) in
             self?.isLoading = false
             self?.prompts = prompts.sorted(by: { $0.date.compare($1.date) == .orderedDescending })
         }, failure: { [weak self] (error) in


### PR DESCRIPTION
Fixes: #18805

## Description

Fixes displaying future prompts to the user and the prompt data being stale on the list view. These are fixed by doing:

- Adding an end date to the `loadPrompts` function so that it does not fetch future prompts
- Fixing an issue with a date conversion between the user's local timezone and UTC.
  - An example: If the users time was `2022-05-01 23:00:00 UTC-4` this becomes the date object with `2022-05-02 03:00:00 UTC` and the UTC date conversion function would return `2022-05-02 00:00:00 UTC` which is the wrong day for the user. The conversion now takes into account the user's local timezone.
- Removes using cached prompts when loading the list view. It now always fetches the prompts.

## Screenshots

**These are from June 1st, 2022.**

| Before | After |
|--------|------|
| ![Simulator Screen Shot - iPhone 11 - 2022-06-01 at 12 55 06](https://user-images.githubusercontent.com/2454408/171469839-becd74d5-f86a-4a3d-ae5f-4900d2a51acd.png) | ![Simulator Screen Shot - iPhone 11 - 2022-06-01 at 12 43 50](https://user-images.githubusercontent.com/2454408/171469857-02a2f2c2-91a0-49df-bda8-9dad4d002819.png) |
## Testing

### Testing showing future prompts

- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Change your computer timezone to a negative UTC (I used Hilo, Hawaii GMT-10)
- Wait until the simulator syncs with your computer's time
- Launch the app and sign in if necessary
- Navigate to the 'My Site' tab
- On the prompts dashboard card, tap on the menu '...'
- Tap on 'View more prompts'
- Verify:
  - No future prompts are shown
  - The list consists of the current day's prompt and 10 days of previous prompts (total of 11). This could be potentially less if there were no prompts for some days.
- Close the app and change your computer's timezone to a positive UTC (I used Wellington, New Zealand GMT+12)
- Wait until the simulator syncs with your computer's time
- Launch the app again and repeat the above steps

### Testing old prompt data

- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Launch the app and sign in if necessary
- Navigate to the 'My Site' tab
- On the prompts dashboard card, tap on the menu '...'
- Tap on 'View more prompts'
- Verify a network call is made to fetch prompts from the current day minus 10 (Ex: Today is June 1, 2022, it should fetch from May 22, 2022)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
