### PR TITLE
Fix Tracks event for adding domain to cart

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -743,7 +743,7 @@ import Foundation
         case .domainsDashboardAddDomainTapped:
             return "domains_dashboard_add_domain_tapped"
         case .domainsSearchSelectDomainTapped:
-            return "domains_dashboard_add_domain_tapped"
+            return "domains_dashboard_select_domain_tapped"
         case .domainsRegistrationFormViewed:
             return "domains_registration_form_viewed"
         case .domainsRegistrationFormSubmitted:


### PR DESCRIPTION
It's my understanding that the `domains_dashboard_select_domain_tapped` Tracks event should be fired when a domain is added to the cart from the "Search domains" screen. It looks like there was a typo and `domains_dashboard_add_domain_tapped` was being fired instead.

From what I can tell, this fix brings iOS in-line with Android, see code here:

https://github.com/wordpress-mobile/WordPress-Android/blob/a045c883a39f8228b1aeaa8392dd64f90517eeec/WordPress/src/main/java/org/wordpress/android/ui/domains/DomainSuggestionsViewModel.kt#L217-L225

### To test

#### Test the fix

1. Log in to the Jetpack app to manage a site
2. On the My Site tab, tap Domains 
3. Tap "Search for a domain"
4. Select a domain
5. Tap "Select domain"
6. Check that the correct event (`domains_dashboard_select_domain_tapped`) was fired
    - If you're using the Jetpack build on this PR, look in the app's Activity Log
    - If you're using Xcode, look in the Debug Console

#### Verify the bug (optional)
1. Download the latest Jetpack iOS 20.0 from Test Flight, or checkout `release/20.0`
2. Log in to the app to manage a site
3. On the My Site tab, tap Domains 
4. Tap "Search for a domain"
5. Select a domain
6. Tap "Select domain"
7. Verify that the **incorrect** event (`domains_dashboard_add_domain_tapped`) was fired
    - If you're using the Jetpack build on this PR, look in the app's Activity Log
    - If you're using Xcode, look in the Debug Console

## Regression Notes
1. Potential unintended areas of impact

This change should fix a straightforward bug. I suppose the only unintended impact would be if the new event is wrong

8. What I did to test those areas of impact (or what existing automated tests I relied on)

Just manual testing.

9. What automated tests I added (or what prevented me from doing so)

It could nice to add tests for tracks events for this feature. At the moment, I don't think it's worth it in this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
