### PR TITLE
Blogging Prompts: Add "Learn more" to prompts dashboard card

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -367,6 +367,7 @@ import Foundation
     case promptsDashboardCardMenuViewMore
     case promptsDashboardCardMenuSkip
     case promptsDashboardCardMenuRemove
+    case promptsDashboardCardMenuLearnMore
     case promptsListViewed
     case promptsReminderSettingsIncludeSwitch
     case promptsReminderSettingsHelp
@@ -994,6 +995,8 @@ import Foundation
             return "blogging_prompts_my_site_card_menu_skip_this_prompt_tapped"
         case .promptsDashboardCardMenuRemove:
             return "blogging_prompts_my_site_card_menu_remove_from_dashboard_tapped"
+        case .promptsDashboardCardMenuLearnMore:
+            return "blogging_prompts_my_site_card_menu_learn_more_tapped"
         case .promptsListViewed:
             return "blogging_prompts_prompts_list_viewed"
         case .promptsReminderSettingsIncludeSwitch:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -286,10 +286,10 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         ]
 
         if removeFromDashboardEnabled {
-            return [defaultItems, [.remove(removeMenuTapped)]]
+            return [defaultItems, [.learnMore(learnMoreTapped), .remove(removeMenuTapped)]]
         }
 
-        return [defaultItems]
+        return [defaultItems, [.learnMore(learnMoreTapped)]]
     }
 
     @available(iOS 15.0, *)
@@ -458,6 +458,11 @@ private extension DashboardPromptsCardCell {
         // TODO.
     }
 
+    func learnMoreTapped() {
+        WPAnalytics.track(.promptsDashboardCardMenuLearnMore)
+        presenterViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
+    }
+
     // Fallback context menu implementation for iOS 13.
     func showMenuSheet() {
         guard let presenterViewController = presenterViewController else {
@@ -519,6 +524,7 @@ private extension DashboardPromptsCardCell {
         case viewMore(_ handler: () -> Void)
         case skip(_ handler: () -> Void)
         case remove(_ handler: () -> Void)
+        case learnMore(_ handler: () -> Void)
 
         var title: String {
             switch self {
@@ -528,6 +534,8 @@ private extension DashboardPromptsCardCell {
                 return NSLocalizedString("Skip this prompt", comment: "Menu title to skip today's prompt.")
             case .remove:
                 return NSLocalizedString("Remove from dashboard", comment: "Destructive menu title to remove the prompt card from the dashboard.")
+            case .learnMore:
+                return NSLocalizedString("Learn more", comment: "Menu title to show the prompts feature introduction modal.")
             }
         }
 
@@ -539,6 +547,8 @@ private extension DashboardPromptsCardCell {
                 return .init(systemName: "xmark.circle")
             case .remove:
                 return .init(systemName: "minus.circle")
+            case .learnMore:
+                return .init(systemName: "info.circle")
             }
         }
 
@@ -554,20 +564,27 @@ private extension DashboardPromptsCardCell {
         var toAction: UIAction {
             switch self {
             case .viewMore(let handler),
-                    .skip(let handler),
-                    .remove(let handler):
-                return .init(title: title, image: image, attributes: menuAttributes, handler: { _ in
+                 .skip(let handler),
+                 .remove(let handler),
+                 .learnMore(let handler):
+                return UIAction(title: title, image: image, attributes: menuAttributes) { _ in
                     handler()
-                })
+                }
             }
         }
 
         var toMenuSheetItem: MenuSheetViewController.MenuItem {
             switch self {
             case .viewMore(let handler),
-                    .skip(let handler),
-                    .remove(let handler):
-                return .init(title: title, image: image, destructive: menuAttributes.contains(.destructive), handler: handler)
+                 .skip(let handler),
+                 .remove(let handler),
+                 .learnMore(let handler):
+                return MenuSheetViewController.MenuItem(
+                        title: title,
+                        image: image,
+                        destructive: menuAttributes.contains(.destructive),
+                        handler: handler
+                )
             }
         }
     }


### PR DESCRIPTION
Resolves: #18788

## Description

Adds a "Learn more" option to the context menu in the prompts dashboard card. When tapped, it presents the feature introduction modal.

## Testing

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Launch the app and sign in if necessary
- Navigate to the 'My Site' tab
- On the prompts dashboard card, tap on the context menu '...'
- Verify a "Learn more" option is present and separated from other items
- Tap on the "Learn more" item
- Verify:
  - A tap analytic is sent `blogging_prompts_my_site_card_menu_learn_more_tapped`
  - The feature introduction modal is presented
- Repeat above steps on either iOS 14 or iOS 13 (iOS 15 uses the new context menu)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
