### PR TITLE
[Site Design Revamp] Reset header on rotation

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -42,6 +42,10 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         true
     }
 
+    override var alwaysResetHeaderOnRotation: Bool {
+        true
+    }
+
     private lazy var helperView: UIView = {
         let view = UIView(frame: Metrics.helperFrame)
         view.addSubview(helperStackView)


### PR DESCRIPTION
Fixes #18707

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-06-02 at 13 04 08](https://user-images.githubusercontent.com/2092798/171684928-36bc8528-fd87-4ec3-9c18-8f7772bd453e.png) | ![Simulator Screen Shot - iPhone 13 - 2022-06-02 at 13 03 13](https://user-images.githubusercontent.com/2092798/171684895-3fe52ee9-ff10-435c-bbdd-c291ef84fa4b.png) |

### Note:

Though this fixes the gap, the header tends to "pop" into place which isn't preferred. Ultimately I think it's a better problem to have than the gap.

## Testing
1. Start the Site Creation flow in portrait orientation
2. Navigate to the Site Design screen
3. Rotate to landscape
4. Expect there to be no gap at the top
5. Rotate back to portrait
6. Expect there to be no regressions

## Regression Notes
1. Potential unintended areas of impact
  - Layout of designs when rotating the Site Design screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manually tested the steps above

3. What automated tests I added (or what prevented me from doing so)
  - None, as these are UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
