### PR TITLE
Blogging Prompts: Update the display logic for prompts dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -336,18 +336,17 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     static func shouldShowCard(for blog: Blog) -> Bool {
         guard FeatureFlag.bloggingPrompts.enabled,
               let promptsService = BloggingPromptsService(blog: blog),
-              let settings = promptsService.localSettings,
-              settings.isPotentialBloggingSite,
-              settings.promptCardEnabled else {
+              let settings = promptsService.localSettings else {
             return false
         }
 
+        let shouldDisplayCard = settings.promptRemindersEnabled || settings.isPotentialBloggingSite
         guard let todaysPrompt = promptsService.localTodaysPrompt else {
             // If there is no cached prompt, it can't have been skipped. So show the card.
-            return true
+            return shouldDisplayCard
         }
 
-        return !userSkippedPrompt(todaysPrompt, for: blog)
+        return !userSkippedPrompt(todaysPrompt, for: blog) && shouldDisplayCard
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -346,12 +346,12 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         // update local prompt settings so that the coordinator uses the right scheduler.
         let resetPromptSettingsClosure = temporarilyUpdatePromptSettings()
         let promptSettingsChanged = resetPromptSettingsClosure != nil
+        button.isEnabled = false
 
-         scheduler.schedule(schedule, for: blog, time: scheduledTime) { [weak self] result in
+        scheduler.schedule(schedule, for: blog, time: scheduledTime) { [weak self] result in
             guard let self = self else {
                 return
             }
-
             switch result {
             case .success:
                 self.tracker.scheduled(schedule, time: self.scheduledTime)
@@ -360,6 +360,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                     let completion = {
                         self?.delegate?.didSetUpBloggingReminders()
                         self?.pushCompletionViewController()
+                        self?.button.isEnabled = true
                     }
 
                     // only sync prompt settings in Blogging Prompts context.
@@ -368,12 +369,8 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                         return
                     }
 
-                    // show that some process is occurring, and prevent multiple tap events.
-                    self?.button.isEnabled = false
-
                     // sync the updated settings to remote.
                     self?.syncPromptsScheduleIfNeeded {
-                        self?.button.isEnabled = true
                         completion()
                     }
                 }
@@ -383,11 +380,13 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
                 case BloggingRemindersScheduler.Error.needsPermissionForPushNotifications where showPushPrompt == true:
                     DispatchQueue.main.async { [weak self] in
                         self?.pushPushPromptViewController()
+                        self?.button.isEnabled = true
                     }
                 default:
                     // The scheduler should normally not fail unless it's because of having no push permissions.
                     // As a simple solution for now, we'll just avoid taking any action if the scheduler did fail.
                     DDLogError("Error scheduling blogging reminders: \(error)")
+                    self.button.isEnabled = true
                     break
                 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -317,7 +317,7 @@ extension SiteSettingsViewController {
         cell.editable = true
         cell.textLabel?.text = NSLocalizedString("Blogging Reminders", comment: "Label for the blogging reminders setting")
         cell.detailTextLabel?.adjustsFontSizeToFitWidth = true
-        cell.detailTextLabel?.minimumScaleFactor = 0.5
+        cell.detailTextLabel?.minimumScaleFactor = 0.75
         cell.accessoryType = .none
         cell.textValue = schedule(for: blog)
     }


### PR DESCRIPTION
See: #18429

## Description

Updates the prompts dashboard card with the following logic:

- Show for all sites if the user has prompt reminders enabled
- If reminders are disabled, show for potential blogging sites
- Hide skipped prompts

## Testing

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Launch the app and sign in if necessary
- Select a blogging site
- Navigate to the 'My Site' tab
- Navigate to Menu > Site Settings > Blogging Reminders
- If blogging prompts is enabled, disable it, set a schedule, and tap 'Notify me'/'Update'
- Navigate back to the dashboard
- Verify the dashboard card still appears
- Open the context menu '...'
- Tap on 'Skip this prompt'
- Verify the card is hidden
- Change to a non-blogging site
- Verify the dashboard card is hidden
- Navigate to Menu > Site Settings > Blogging Reminders
- Enable blogging prompts, set a schedule, and tap 'Notify me'/'Update'
- Navigate back to the dashboard
- Verify the dashboard card is shown

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
