### PR TITLE
Blogging Prompts: Add check to prompts header to only display for WP sites

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -325,6 +325,7 @@ private extension CreateButtonCoordinator {
     private func createPromptHeaderView() -> BloggingPromptsHeaderView? {
         guard FeatureFlag.bloggingPrompts.enabled,
               let blog = blog,
+              blog.isAccessibleThroughWPCom(),
               let prompt = prompt else {
             return nil
         }


### PR DESCRIPTION
See: #18429

## Description

Hides the prompts action sheet header view on self-hosted sites.

## Testing

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Launch the app and sign in if necessary
- Select a WP hosted site
- Navigate to the 'My Site' tab
- Tap on the floating action button '+'
- Verify the prompts header is still shown
- Switch to a self-hosted site or mock the return of that bool
- Tap on the floating action button '+'
- Verify the prompts header is hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
