### PR TITLE
Blogging Prompts: Show prompts feature intro once when the tab controller is displayed

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -206,9 +206,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         checkAppleIDCredentialState()
 
         GutenbergSettings().performGutenbergPhase2MigrationIfNeeded()
-
-        // TODO: remove when final launching source determine.
-        WPTabBarController.sharedInstance().showBloggingPromptsFeatureIntroduction()
     }
 
     func application(_ application: UIApplication, shouldSaveApplicationState coder: NSCoder) -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/WPTabBarController+BloggingPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/WPTabBarController+BloggingPrompt.swift
@@ -38,12 +38,31 @@ extension WPTabBarController {
         bloggingPromptCoordinator.showPromptAnsweringFlow(from: viewController, promptID: promptID, blog: blog, source: source)
     }
 
+    @objc func showBloggingPromptsFeatureIntroduction() {
+        guard FeatureFlag.bloggingPrompts.enabled,
+              let blog = currentOrLastBlog(),
+              blog.isAccessibleThroughWPCom(),
+              presentedViewController == nil,
+              selectedViewController?.presentedViewController == nil,
+              !UserDefaults.standard.bool(forKey: Constants.featureIntroDisplayedUDKey)
+        else {
+            return
+        }
+
+        UserDefaults.standard.set(true, forKey: Constants.featureIntroDisplayedUDKey)
+        BloggingPromptsIntroductionPresenter().present(from: selectedViewController ?? self)
+    }
+
 }
 
 private extension WPTabBarController {
 
     var accountSites: [Blog]? {
         AccountService(managedObjectContext: ContextManager.shared.mainContext).defaultWordPressComAccount()?.visibleBlogs
+    }
+
+    struct Constants {
+        static let featureIntroDisplayedUDKey = "wp_intro_shown_blogging_prompts"
     }
 
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -94,11 +94,4 @@ extension WPTabBarController {
         tabBar.isTranslucent = false
     }
 
-    // TODO: remove when final launching source determine.
-    func showBloggingPromptsFeatureIntroduction() {
-        if FeatureFlag.bloggingPrompts.enabled {
-            BloggingPromptsIntroductionPresenter().present(from: selectedViewController ?? self)
-        }
-    }
-
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -606,6 +606,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self startWatchingQuickTours];
 
     [self trackTabAccessOnViewDidAppear];
+    [self showBloggingPromptsFeatureIntroduction];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
See: #18429

## Description

Displays prompts feature introduction screen a single time per install. Only displays in the following conditions:

- Nothing is presented by the `selectedViewController` or `WPTabBarController`
- The current blog is not self-hosted
- The user has not seen the intro view yet

## Testing

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Launch the app and sign in using a WP site
- Navigate to the dashboard
- Verify the intro screen shows when:
  - No other screen was present
  - Landing on the dashboard
- Dismiss the intro screen
- Switch sites
- Verify the intro screen does not show
- Log out and back in with the same account
- Navigate to the dashboard
- Verify the intro screen does not show

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
