### PR TITLE
[Tooling] Fix some initial issues with screenshot generation

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -85,18 +85,6 @@ class JetpackScreenshotGeneration: XCTestCase {
     }
 }
 
-extension BaseScreen {
-    @discardableResult
-    func thenTakeScreenshot(_ index: Int, named title: String) -> Self {
-        let mode = XCUIDevice.inDarkMode ? "dark" : "light"
-        let filename = "\(index)-\(mode)-\(title)"
-
-        snapshot(filename)
-
-        return self
-    }
-}
-
 extension ScreenObject {
 
     @discardableResult

--- a/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
+++ b/WordPress/WordPressScreenshotGeneration/SnapshotHelper.swift
@@ -165,7 +165,7 @@ open class Snapshot: NSObject {
             }
 
             let screenshot = XCUIScreen.main.screenshot()
-            #if os(iOS)
+            #if os(iOS) && !targetEnvironment(macCatalyst)
             let image = XCUIDevice.shared.orientation.isLandscape ?  fixLandscapeOrientation(image: screenshot.image) : screenshot.image
             #else
             let image = screenshot.image
@@ -193,16 +193,20 @@ open class Snapshot: NSObject {
     }
 
     class func fixLandscapeOrientation(image: UIImage) -> UIImage {
-        if #available(iOS 10.0, *) {
-            let format = UIGraphicsImageRendererFormat()
-            format.scale = image.scale
-            let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
-            return renderer.image { context in
-                image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-            }
-        } else {
+        #if os(watchOS)
             return image
-        }
+        #else
+            if #available(iOS 10.0, *) {
+                let format = UIGraphicsImageRendererFormat()
+                format.scale = image.scale
+                let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+                return renderer.image { context in
+                    image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+                }
+            } else {
+                return image
+            }
+        #endif
     }
 
     class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
@@ -302,4 +306,4 @@ private extension CGFloat {
 
 // Please don't remove the lines below
 // They are used to detect outdated configuration files
-// SnapshotHelperVersion [1.25]
+// SnapshotHelperVersion [1.28]

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_1.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_1.txt
@@ -1,3 +1,0 @@
-Safer.
-Faster.
-More traffic.

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_2.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_2.txt
@@ -1,2 +1,0 @@
-Bring your
-Jetpack with you.

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_3.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_3.txt
@@ -1,2 +1,0 @@
-Keep tabs on
-your site activity.

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_4.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_4.txt
@@ -1,2 +1,0 @@
-Scan for issues
-on the go.

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_5.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_5.txt
@@ -1,2 +1,0 @@
-Back up your site
-at any moment.

--- a/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_6.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-AU/app_store_screenshot_6.txt
@@ -1,2 +1,0 @@
-Site stats in your
-pocket.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_1.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_1.txt
@@ -1,3 +1,0 @@
-Safer.
-Faster.
-More traffic.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_2.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_2.txt
@@ -1,2 +1,0 @@
-Bring your
-Jetpack with you.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_3.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_3.txt
@@ -1,2 +1,0 @@
-Keep tabs on
-your site activity.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_4.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_4.txt
@@ -1,2 +1,0 @@
-Scan for issues
-on the go.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_5.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_5.txt
@@ -1,2 +1,0 @@
-Back up your site
-at any moment.

--- a/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_6.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-CA/app_store_screenshot_6.txt
@@ -1,2 +1,0 @@
-Site stats in your
-pocket.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_1.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_1.txt
@@ -1,3 +1,0 @@
-Safer.
-Faster.
-More traffic.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_2.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_2.txt
@@ -1,2 +1,0 @@
-Bring your
-Jetpack with you.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_3.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_3.txt
@@ -1,2 +1,0 @@
-Keep tabs on
-your site activity.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_4.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_4.txt
@@ -1,2 +1,0 @@
-Scan for issues
-on the go.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_5.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_5.txt
@@ -1,2 +1,0 @@
-Back up your site
-at any moment.

--- a/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_6.txt
+++ b/fastlane/appstoreres/jetpack_metadata/en-GB/app_store_screenshot_6.txt
@@ -1,2 +1,0 @@
-Site stats in your
-pocket.

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -28,7 +28,7 @@ platform :ios do
   #
   desc 'Generate localised screenshots'
   lane :screenshots do |options|
-    sh('bundle exec pod install')
+    cocoapods # pod install
     FileUtils.rm_rf(DERIVED_DATA_PATH) unless options[:skip_clean]
 
     scheme = options[:scheme] || 'WordPressScreenshotGeneration'

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -65,7 +65,7 @@ platform :ios do
       end
     end
 
-    UI.message "Generating screenshots for the following languages: #{languages}"
+    UI.message "--- Generating screenshots for the following languages: #{languages}"
 
     create_missing_simulators_for_screenshots
     [true, false].each do |dark_mode_enabled|
@@ -231,11 +231,11 @@ platform :ios do
       device_type_id = device_spec['identifier']
 
       already_exists = specs['devices'].any? { |runtime, dev_list| dev_list.any? { |dev_spec| dev_spec['deviceTypeIdentifier'] == device_type_id } }
+      step_name = "Creating simulator for device type #{device_name}"
       if already_exists
-        UI.message "A simulator for device type #{device_type_id} already exists"
+        Actions.execute_action(step_name) { UI.message "A simulator for device type #{device_type_id} already exists" }
       else
-        UI.message "Creating simulator for device type #{device_type_id}"
-        res = sh('xcrun', 'simctl', 'create', device_name, device_type_id)
+        res = sh('xcrun', 'simctl', 'create', device_name, device_type_id, step_name: step_name)
         # res.split("\n").find { |line| line.match?(/^[0-9A-F-]+$/) }&.chomp # UUID of the created simulator
       end
     end

--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -16,11 +16,20 @@ platform :ios do
   # @option [String] scheme (default: "WordPressScreenshotGeneration") The name of the scheme to use to run the screenshots
   # @option [String] output_directory (default: `${PWD}/screenhots`) The directory to generate the screenshots to
   # @option [Array<String>] language (default: the list of Mag16 locales) The subset of locales to generate the screenshots for
+  # @option [Boolean] skip_clean Skip the deletion of DerivedData before starting. Useful to speed up iterating while adjusting screenshots until we're happy with the final results, for example
+  #
+  # @note When you're working on updating the screenshots with new design, and might need to run this lane multiple time to do some
+  # trial and errors to adjust the results until you're happy with it, you might want to run this lane with the following options:
+  #
+  #   `bundle exec fastlane screenshots language:fr-FR skip_clean:true`
+  #
+  # That way, it uses incremental builds instead of clean builds (faster iterations), and only generates screenshots for one language
+  # (which is usually enough to check that the design and screens being captured look correct while iterating).
   #
   desc 'Generate localised screenshots'
   lane :screenshots do |options|
     sh('bundle exec pod install')
-    FileUtils.rm_rf(DERIVED_DATA_PATH)
+    FileUtils.rm_rf(DERIVED_DATA_PATH) unless options[:skip_clean]
 
     scheme = options[:scheme] || 'WordPressScreenshotGeneration'
 


### PR DESCRIPTION
See paaHJt-3sE-p2#state-of-wp-jp-ios for all the details

 - The `JetpackScreenshotGeneration.swift` file was still containing some `extension BaseScreen { … }`, but the `BaseScreen` type got deleted a while ago. I [had to delete](https://github.com/wordpress-mobile/WordPress-iOS/commit/c3f9f80b2d66083ba6b688e7cefae02b64421104) that `extension` to make the target compile.
 - The list of devices to run the raw screenshots on — defined in the screenshots lane in `fastlane/lanes/screenshots.rb` — were outdated: the simulator names used were no longer part of the default simulators shipped with the latest Xcode we use. So I [had to pick new ones](https://github.com/wordpress-mobile/WordPress-iOS/commit/e84a4440160e5c2976ccbfb4e36cb0f483120e46).
 - The `SnapshotHelper.swift` file provided by `fastlane` was outdated. I [had to run fastlane snapshot update to make fastlane update it](https://github.com/wordpress-mobile/WordPress-iOS/commit/759baa2f3ccb3975827a656fdfb53d3952b106b3) to a newer version compatible with the `fastlane` version we’re using nowadays.
 - I’ve also [added a `skip_clean:true` option to the screenshots lane to skip the deletion of DerivedData](https://github.com/wordpress-mobile/WordPress-iOS/commit/61ae3a9c8559e4b66144e4e7fc8da8a37a3c7d74) at the start of the lane, so that we can avoid having to do a clean build which takes forever every time we do an iterative tweaking while fixing the screenshots. That makes those little trial-and-error iterations much faster!

---

Even after fixing all the above issues and finally being able to compile and make the screenshots lane run, the UI Tests are all failing (Error code 65), because the actual screens of the app have changed a lot since last time we updated the UI Test used for screenshots — so it couldn’t find the proper `XCUIElements` it expected on screen anymore.

So this PR is not enough to make the Screenshot UI Tests run, and those will need to be updated and fixed separately. But the changes in this PR are still a way forward.