### PR TITLE
Blogging Prompts: Update prompts editor entry point strings to match Android

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -430,7 +430,7 @@ private extension DashboardPromptsCardCell {
 
         let editor = EditPostViewController(blog: blog, prompt: prompt)
         editor.modalPresentationStyle = .fullScreen
-        editor.entryPoint = .dashboard
+        editor.entryPoint = .bloggingPromptsDashboardCard
         presenterViewController?.present(editor, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -154,7 +154,8 @@ enum PostEditorEntryPoint: String {
     case unknown
     case postsList
     case dashboard
-    case bloggingPromptsFeatureIntroduction
-    case bloggingPromptsActionSheetHeader
-    case bloggingPromptsNotification
+    case bloggingPromptsFeatureIntroduction = "blogging_prompts_introduction"
+    case bloggingPromptsActionSheetHeader = "add_new_sheet_answer_prompt"
+    case bloggingPromptsNotification = "blogging_reminders_notification_answer_prompt"
+    case bloggingPromptsDashboardCard = "my_site_card_answer_prompt"
 }


### PR DESCRIPTION
See: #18472

## Description

Updates the `entry_point` strings to match Android's. Additionally, updates the prompts dashboard card entry to have a value other than `dashboard`.

## Testing

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Login if necessary
- When the prompts feature intro shows, tap on 'Try it now'
- Select a site if necessary
- When the editor opens, verify `editor_session_start` is tracked with an `entry_point` property matching `blogging_prompts_introduction`
- Dismiss the editor
- Navigate to the 'My Site' tab
- Tap on 'Answer Prompt' on the prompts dashboard card
- When the editor opens, verify `editor_session_start` is tracked with an `entry_point` property matching `my_site_card_answer_prompt`
- Dismiss the editor
- Tap on the FAB '+'
- In the prompts action sheet header, tap on 'Answer Prompt'
- When the editor opens, verify `editor_session_start` is tracked with an `entry_point` property matching `add_new_sheet_answer_prompt`
- Dismiss the editor
- Navigate to the 'My Site' tab
- Set a prompts blogging reminder in 'Menu > Site Settings > Blogging Reminders' for one minute ahead of the current time and day
- Allow push notifications if necessary
- Background the app
- Wait for the push notification and tap on it
- When the editor opens, verify `editor_session_start` is tracked with an `entry_point` property matching `blogging_reminders_notification_answer_prompt`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
