### PR TITLE
Blogging Prompts: Hide self-hosted sites in the site picker from the prompts intro view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -173,8 +173,8 @@ class BlogListDataSource: NSObject {
         return nil
     }
 
-    @objc var allBlogsCount: Int {
-        return allBlogs.count
+    @objc var blogsCount: Int {
+        return filteredBlogs.count
     }
 
     @objc var displayedBlogsCount: Int {
@@ -184,7 +184,7 @@ class BlogListDataSource: NSObject {
     }
 
     @objc var visibleBlogsCount: Int {
-        return allBlogs.filter({ $0.visible }).count
+        return filteredBlogs.filter({ $0.visible }).count
     }
 
     // MARK: - Internal properties
@@ -288,12 +288,12 @@ private extension BlogListDataSource {
         if let sections = cachedSections {
             return sections
         }
-        let mappedSections = mode.mapper.map(allBlogs)
+        let mappedSections = mode.mapper.map(filteredBlogs)
         cachedSections = mappedSections
         return mappedSections
     }
 
-    var allBlogs: [Blog] {
+    var filteredBlogs: [Blog] {
         guard var blogs = resultsController.fetchedObjects else {
             return []
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListDataSource.swift
@@ -86,6 +86,16 @@ class BlogListDataSource: NSObject {
     ///
     @objc var shouldShowDisclosureIndicator = true
 
+    /// If this is set to `true`, blogs that are not accessible through the WP API will be hidden
+    ///
+    @objc var shouldHideSelfHostedSites = false {
+        didSet {
+            if shouldHideSelfHostedSites != oldValue {
+                dataChanged?()
+            }
+        }
+    }
+
     // MARK: - Inputs
 
     // Pass to the LoggedInDataSource to match a specifc blog.
@@ -284,8 +294,11 @@ private extension BlogListDataSource {
     }
 
     var allBlogs: [Blog] {
-        guard let blogs = resultsController.fetchedObjects else {
+        guard var blogs = resultsController.fetchedObjects else {
             return []
+        }
+        if shouldHideSelfHostedSites {
+            blogs = blogs.filter { $0.isAccessibleThroughWPCom() }
         }
         guard let account = account else {
             return blogs

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -223,7 +223,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)maybeShowNUX
 {
-    NSInteger blogCount = self.dataSource.allBlogsCount;
+    NSInteger blogCount = self.dataSource.blogsCount;
     BOOL isLoggedIn = AccountHelper.isLoggedIn;
 
     if (blogCount > 0 && !isLoggedIn) {
@@ -238,7 +238,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)updateViewsForCurrentSiteCount
 {
-    NSUInteger count = self.dataSource.allBlogsCount;
+    NSUInteger count = self.dataSource.blogsCount;
     NSUInteger visibleSitesCount = self.dataSource.visibleBlogsCount;
     
     // Ensure No Results VC is not shown. Will be shown later if necessary.
@@ -297,7 +297,7 @@ static NSInteger HideSearchMinSites = 3;
 {
     [self instantiateNoResultsViewControllerIfNeeded];
     
-    NSUInteger count = self.dataSource.allBlogsCount;
+    NSUInteger count = self.dataSource.blogsCount;
     
     NSString *singularTitle = NSLocalizedString(@"You have 1 hidden WordPress site.", @"Message informing the user that all of their sites are currently hidden (singular)");
     
@@ -869,7 +869,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (BOOL)shouldShowAddSiteButton
 {
-    return self.dataSource.allBlogsCount > 0;
+    return self.dataSource.blogsCount > 0;
 }
 
 - (BOOL)shouldShowEditButton
@@ -926,7 +926,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)setVisible:(BOOL)visible forBlog:(Blog *)blog
 {
-    if(!visible && self.dataSource.allBlogsCount > HideAllMinSites) {
+    if(!visible && self.dataSource.blogsCount > HideAllMinSites) {
         if (self.hideCount == 0) {
             self.firstHide = [NSDate date];
         }
@@ -991,7 +991,7 @@ static NSInteger HideSearchMinSites = 3;
 
 - (void)showAddSiteAlertFrom:(id)source
 {
-    if (self.dataSource.allBlogsCount > 0 && self.dataSource.visibleBlogsCount == 0) {
+    if (self.dataSource.blogsCount > 0 && self.dataSource.visibleBlogsCount == 0) {
         [self setEditing:YES animated:YES];
     } else {
         AddSiteAlertFactory *factory = [AddSiteAlertFactory new];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.h
@@ -20,6 +20,7 @@ typedef void (^BlogSelectorDismissHandler)(void);
 @property (nonatomic, assign) BOOL displaysOnlyDefaultAccountSites;
 @property (nonatomic, assign) BOOL displaysNavigationBarWhenSearching;
 @property (nonatomic, assign) BOOL displaysCancelButton;
+@property (nonatomic, assign) BOOL shouldHideSelfHostedSites;
 @property (nonatomic, assign) BOOL dismissOnCancellation;
 @property (nonatomic, assign) BOOL dismissOnCompletion;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -104,7 +104,9 @@
 
         self.navigationItem.leftBarButtonItem = cancelButtonItem;
     }
-    
+
+    self.dataSource.shouldHideSelfHostedSites = self.shouldHideSelfHostedSites;
+
     // TableView
     [WPStyleGuide configureColorsForView:self.view andTableView:self.tableView];
     

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -24,7 +24,10 @@ class BloggingPromptsIntroductionPresenter: NSObject {
     private var selectedBlog: Blog?
 
     private lazy var accountSites: [Blog]? = {
-        return AccountService(managedObjectContext: ContextManager.shared.mainContext).defaultWordPressComAccount()?.visibleBlogs
+        return AccountService(managedObjectContext: ContextManager.shared.mainContext)
+                .defaultWordPressComAccount()?
+                .visibleBlogs
+                .filter { $0.isAccessibleThroughWPCom() }
     }()
 
     private lazy var accountHasMultipleSites: Bool = {
@@ -95,6 +98,7 @@ private extension BloggingPromptsIntroductionPresenter {
         selectorViewController.displaysOnlyDefaultAccountSites = true
         selectorViewController.dismissOnCompletion = false
         selectorViewController.dismissOnCancellation = true
+        selectorViewController.shouldHideSelfHostedSites = true
 
         let selectorNavigationController = UINavigationController(rootViewController: selectorViewController)
         self.navigationController.present(selectorNavigationController, animated: true)


### PR DESCRIPTION
See: #18429

## Description

Filters out self-hosted sites from the site picker when tapping on 'Try it now' from the prompts feature introduction view.

## Testing

**Note:** I don't have any self-hosted sites, so I manually changed the return value from `isAccessibleThroughWPCom`. It might be easier doing it this way unless you have a self-hosted site.

To test:
- Enable `bloggingPrompts` feature flag in `FeatureFlag.swift`
- Log in if necessary and navigate to the dashboard
- When the prompts feature introduction screen appears, tap on 'Try it now'
- Verify no self-hosted sites display

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
