### PR TITLE
Use `only_rules` syntax in SwiftLint config file

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,7 @@ excluded:
   - vendor
 
 # Rules
-whitelist_rules:
+only_rules:
   # Colons should be next to the identifier when specifying a type.
   - colon
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,8 +42,8 @@ only_rules:
 
 # Rules configuration
 
-control_statement: 
-  severity: error 
+control_statement:
+  severity: error
 
 custom_rules:
 


### PR DESCRIPTION
I noticed this while experimenting with SwiftLint in other repositories.

SwiftLint itself gives a warning about the `whitelist_rules` syntax.

## Testing

On `trunk` running `swiftlint` from the Terminal generates a warning:

![image](https://user-images.githubusercontent.com/1218433/172285956-a1aa7539-4737-4ecc-b82b-a7b1b8097966.png)


On this branch, it doesn't:

![image](https://user-images.githubusercontent.com/1218433/172285965-0099b276-f745-4fdf-8adb-fbd1d8b97aaa.png)


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**