### PR TITLE
Stats Widget: Open Stats view when tapping the widget after the app was quit

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -71,7 +71,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
     }
 
     private func setTimePeriodForStatsURLIfPossible(_ url: URL) {
-        guard let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else {
             return
         }
 
@@ -81,6 +81,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
            let action = match.action as? StatsRoute,
            let timePeriod = action.timePeriod {
             // Initializing a StatsPeriodType to ensure we have a valid period
+            let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
             UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -138,6 +138,10 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 @protocol ScenePresenter;
 
+@protocol BlogDetailsPresentationDelegate
+- (void)presentBlogDetailsViewController:(UIViewController * __nonnull)viewController;
+@end
+
 @interface BlogDetailsViewController : UIViewController <UIViewControllerRestoration, UIViewControllerTransitioningDelegate> {
     
 }
@@ -147,6 +151,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 @property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;
 @property (nonatomic, strong, readwrite) UITableView * _Nonnull tableView;
 @property (nonatomic) BOOL shouldScrollToViewSite;
+@property (nonatomic, weak, nullable) id<BlogDetailsPresentationDelegate> presentationDelegate;
 
 - (id _Nonnull)initWithMeScenePresenter:(id<ScenePresenter> _Nonnull)meScenePresenter;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1413,7 +1413,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedComments fromSource:source];
     CommentsViewController *controller = [CommentsViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1423,7 +1423,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedPosts fromSource:source];
     PostListViewController *controller = [PostListViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1433,7 +1433,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedPages fromSource:source];
     PageListViewController *controller = [PageListViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementPages];
 }
@@ -1443,7 +1443,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedMediaLibrary fromSource:source];
     MediaLibraryViewController *controller = [[MediaLibraryViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementMediaScreen];
 }
@@ -1452,7 +1452,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1462,7 +1462,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatOpenedPluginDirectory withBlog:self.blog];
     PluginDirectoryViewController *controller = [self makePluginDirectoryViewControllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1472,7 +1472,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedPlans fromSource:source];
     PlanListViewController *controller = [[PlanListViewController alloc] initWithStyle:UITableViewStyleGrouped];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementPlans];
 }
@@ -1482,7 +1482,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [self trackEvent:WPAnalyticsStatOpenedSiteSettings fromSource:source];
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1495,14 +1495,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     UIViewController *controller = [self makeDomainsDashboardViewController];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 }
 
 -(void)showJetpackSettings
 {
     JetpackSettingsViewController *controller = [[JetpackSettingsViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 }
 
 - (void)showSharingFromSource:(BlogDetailsNavigationSource)source
@@ -1518,7 +1518,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [self trackEvent:WPAnalyticsStatOpenedSharingManagement fromSource:source];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementSharing];
 }
@@ -1538,7 +1538,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (self.splitViewController.isCollapsed) {
         [self.navigationController pushViewController:statsView animated:YES];
     } else {
-        [self showDetailViewController:statsView sender:self];
+        [self.presentationDelegate presentBlogDetailsViewController:statsView];
     }
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementStats];
@@ -1549,14 +1549,14 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     BlogDashboardViewController *controller = [[BlogDashboardViewController alloc] initWithBlog:self.blog embeddedInScrollView:NO];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     controller.extendedLayoutIncludesOpaqueBars = YES;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 }
 
 - (void)showActivity
 {
     JetpackActivityLogViewController *controller = [[JetpackActivityLogViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1565,7 +1565,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     JetpackScanViewController *controller = [[JetpackScanViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
@@ -1574,7 +1574,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     BackupListViewController *controller = [[BackupListViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:controller sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:controller];
 }
 
 - (void)showThemes
@@ -1585,7 +1585,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [self startAlertTimer];
     };
     viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:viewController sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:viewController];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementThemes];
 }
@@ -1595,7 +1595,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [WPAppAnalytics track:WPAnalyticsStatMenusAccessed withBlog:self.blog];
     MenusViewController *viewController = [MenusViewController controllerWithBlog:self.blog];
     viewController.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    [self showDetailViewController:viewController sender:self];
+    [self.presentationDelegate presentBlogDetailsViewController:viewController];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -136,7 +136,11 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private(set) var sitePickerViewController: SitePickerViewController?
-    private(set) var blogDetailsViewController: BlogDetailsViewController?
+    private(set) var blogDetailsViewController: BlogDetailsViewController? {
+        didSet {
+            blogDetailsViewController?.presentationDelegate = self
+        }
+    }
     private(set) var blogDashboardViewController: BlogDashboardViewController?
 
     /// When we display a no results view, we'll do so in a scrollview so that
@@ -716,15 +720,6 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         removeChildFromStackView(blogDetailsViewController)
     }
 
-    /// Shows the specified `BlogDetailsSubsection` for a `Blog`.
-    ///
-    /// - Parameters:
-    ///         - subsection: The specific subsection to show.
-    ///
-    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
-        blogDetailsViewController?.showDetailView(for: subsection)
-    }
-
     /// Shows a `BlogDetailsViewController` for the specified `Blog`.  If the VC doesn't exist, this method also takes care
     /// of creating it.
     ///
@@ -942,14 +937,6 @@ extension MySiteViewController: WPSplitViewControllerDetailProvider {
     }
 }
 
-// MARK: - My site detail views
-extension MySiteViewController {
-
-    func showDetailView(for section: BlogDetailsSubsection) {
-        blogDetailsViewController?.showDetailView(for: section)
-    }
-}
-
 // MARK: - UIViewControllerTransitioningDelegate
 //
 extension MySiteViewController: UIViewControllerTransitioningDelegate {
@@ -967,5 +954,30 @@ extension MySiteViewController: UIViewControllerTransitioningDelegate {
 extension MySiteViewController {
     func startAlertTimer() {
         blogDetailsViewController?.startAlertTimer()
+    }
+}
+
+// MARK: - Presentation
+/// Supporting presentation of BlogDetailsSubsection from both BlogDashboard and BlogDetails
+extension MySiteViewController: BlogDetailsPresentationDelegate {
+
+    /// Shows the specified `BlogDetailsSubsection` for a `Blog`.
+    ///
+    /// - Parameters:
+    ///         - subsection: The specific subsection to show.
+    ///
+    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
+        blogDetailsViewController?.showDetailView(for: subsection)
+    }
+
+    func presentBlogDetailsViewController(_ viewController: UIViewController) {
+        switch currentSection {
+        case .dashboard:
+            blogDashboardViewController?.showDetailViewController(viewController, sender: blogDashboardViewController)
+        case .siteMenu:
+            blogDetailsViewController?.showDetailViewController(viewController, sender: blogDetailsViewController)
+        case .none:
+            return
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -52,10 +52,9 @@ fileprivate extension StatsPeriodType {
 
 class SiteStatsDashboardViewController: UIViewController {
 
-    static var lastSelectedStatsPeriodTypeKey: String? {
-        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else {
-            return nil
-        }
+    // MARK: - Keys
+
+    static func lastSelectedStatsPeriodTypeKey(forSiteID siteID: Int) -> String {
         return "LastSelectedStatsPeriodType-\(siteID)"
     }
 
@@ -180,19 +179,19 @@ private extension SiteStatsDashboardViewController {
 private extension SiteStatsDashboardViewController {
 
     func saveSelectedPeriodToUserDefaults() {
-
-        guard let key = Self.lastSelectedStatsPeriodTypeKey,
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue,
               !insightsTableViewController.isGrowAudienceShowing else {
             return
         }
 
+        let key = Self.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
         UserDefaults.standard.set(currentSelectedPeriod.rawValue, forKey: key)
     }
 
     func getSelectedPeriodFromUserDefaults() -> StatsPeriodType {
 
-        guard let key = Self.lastSelectedStatsPeriodTypeKey,
-              let periodType = StatsPeriodType(rawValue: UserDefaults.standard.integer(forKey: key)) else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue,
+              let periodType = StatsPeriodType(rawValue: UserDefaults.standard.integer(forKey: Self.lastSelectedStatsPeriodTypeKey(forSiteID: siteID))) else {
             return .insights
         }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -129,11 +129,10 @@ class MySitesCoordinator: NSObject {
             UserDefaults.standard.set(date, forKey: SiteStatsDashboardViewController.lastSelectedStatsDateKey)
         }
 
-        guard let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey else {
-            return
+        if let siteID = blog.dotComID?.intValue {
+            let key = SiteStatsDashboardViewController.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
+            UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
         }
-
-        UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
 
         mySiteViewController.showDetailView(for: .stats)
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -134,7 +134,7 @@ class MySitesCoordinator: NSObject {
             UserDefaults.standard.set(timePeriod.rawValue, forKey: key)
         }
 
-        mySiteViewController.showDetailView(for: .stats)
+        mySiteViewController.showBlogDetailsSubsection(.stats)
     }
 
     func showActivityLog(for blog: Blog) {


### PR DESCRIPTION
## Issue

Closes #18452 

## Description

### Issue

When Stats widget is configured and then the app is closed, tapping on the widget does not open Stats view. Tapping on the widget opens Stats view only after we first open Stats view manually in the app.

### Additional issue found while testing

[When tapping Stats widget, navigation doesn't work if Initial Screen is set to "Home"](https://github.com/wordpress-mobile/WordPress-iOS/pull/18837#issuecomment-1157561284)

### Rootcause

1. The issue happens because `showStats(..)` method in `MySitesCoordinator` exits early if `lastSelectedStatsPeriodTypeKey` doesn't have value. 
2. `lastSelectedStatsPeriodTypeKey` depends on `SiteStatsInformation.sharedInstance.siteID`. `SiteStatsInformation`values are only set when `StatsViewController` is initialized. That's why  `SiteStatsInformation.sharedInstance.siteID` is nil after quiting and reopening the app.
3. The bug is a regression from [Empty Stats: Stay on insights tab if Grow Audience card is showing](https://github.com/wordpress-mobile/WordPress-iOS/pull/17332)

### Solution

1. Make callers of `lastSelectedStatsPeriodTypeKey` pass `postID` to make it usable in context where `SiteStatsInformation` is not initialized yet.
2.  Use `blog.dotComID` in `MySitesCoordinator` when getting `lastSelectedStatsPeriodTypeKey`.

### Other Considerations

- Use `NavigationAction.defaultBlog()?` or a similar default `Blog` instance for returning a `lastSelectedStatsPeriodTypeKey`. I chose to pass siteID since we already had a `Blog` passed to a `showStats(..)` method. 
- Don't use `guard let` and don't return if `lastSelectedStatsPeriodTypeKey` doesn't exist. If we do this, stats page would open but the correct time tab wouldn't be chosen. 
- Preload `SiteStatsInformation` when site is selected. That would be a more significant change and since this is a regression I made a decision to return the code to a previous state.

## Testing instructions

1. Make sure a site is selected in WordPress app
2. Open Stats view
3. Put the app in the background
4. Add Today, This Week and All Time Widget
5. Confirm that tapping on widgets open corresponding Today, This Week and Insights Stat views
6. Force quit the app in the app switcher
7. Tap on Today widget
8. Confirm that the Stats view is opened with the corresponding Today view
9. Repeat steps 6-8 for This Week and All Time Widgets. 

## Regression Notes

1. Potential unintended areas of impact

- Breaking functionality of https://github.com/wordpress-mobile/WordPress-iOS/pull/17332
- The other possibility of some unintended consequences if there're valid cases where `blog.dotComID` **should** be different from `SiteStatsInformation.sharedInstance.siteID` but I couldn't find the reason why it should be.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

- Perfomed tests described in https://github.com/wordpress-mobile/WordPress-iOS/pull/17332
- Didn't rely on any automated tests

3. What automated tests I added (or what prevented me from doing so)

I considered adding `MySitesCoordinatorTests` since there're tests for other types of coordinators but since this is my first PR I want to make and early PR and consult before doing so. 

## Images and Gif

![issue-18452](https://user-images.githubusercontent.com/4062343/172412049-8670db0d-a5d3-490a-b687-64c5ae4fd41e.gif)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
