### PR TITLE
Feature Highlight Tooltip Tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -95,6 +95,8 @@ import Foundation
     case readerSearchHistoryCleared
     case readerArticleLinkTapped
     case readerArticleImageTapped
+    case readerFollowConversationTooltipTapped
+    case readerFollowConversationAnchorTapped
 
     // Stats - Empty Stats nudges
     case statsPublicizeNudgeShown
@@ -539,6 +541,10 @@ import Foundation
             return "reader_article_link_tapped"
         case .readerArticleImageTapped:
             return "reader_article_image_tapped"
+        case .readerFollowConversationTooltipTapped:
+            return "reader_follow_conversation_tooltip_tapped"
+        case .readerFollowConversationAnchorTapped:
+            return "reader_follow_conversation_anchor_tapped"
 
         // Stats - Empty Stats nudges
         case .statsPublicizeNudgeShown:

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -296,6 +296,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             shouldShowSpotlightView: true,
             primaryTooltipAction: {
                 FeatureHighlightStore.didDismissTooltip = true
+                WPAnalytics.trackReader(.readerFollowConversationTooltipTapped)
             }
         )
         tooltipPresenter?.tooltipVerticalPosition = .above
@@ -431,6 +432,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             if self.shouldConfigureTooltipPresenter() {
                 self.configureTooltipPresenter { [weak self] in
                     self?.scrollToTooltip()
+                    WPAnalytics.trackReader(.readerFollowConversationAnchorTapped)
                 }
             }
         }


### PR DESCRIPTION
Refs pbArwn-4oo-p2

This PR adds 2 tracks for feature highlight tooltip

To test:
1. Enable local feature flag "Feature Highlight Tooltip".
2. Go to Reader, into any post.
3. Validate `reader_follow_conversation_anchor_tapped` is triggered when anchor is tapped.
4. Validate `reader_follow_conversation_tooltip_tapped` is triggered when tooltip is tapped.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.