### PR TITLE
Blogging Prompts: Fix caching issue with today's prompt for the prompts dashboard card

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -51,22 +51,22 @@ class BloggingPromptsService {
     func fetchPrompts(from startDate: Date? = nil,
                       to endDate: Date? = nil,
                       number: Int = 25,
-                      success: @escaping ([BloggingPrompt]) -> Void,
-                      failure: @escaping (Error?) -> Void) {
+                      success: (([BloggingPrompt]) -> Void)? = nil,
+                      failure: ((Error?) -> Void)? = nil) {
         let fromDate = startDate ?? defaultStartDate
         remote.fetchPrompts(for: siteID, number: number, fromDate: fromDate) { result in
             switch result {
             case .success(let remotePrompts):
                 self.upsert(with: remotePrompts) { innerResult in
                     if case .failure(let error) = innerResult {
-                        failure(error)
+                        failure?(error)
                         return
                     }
 
-                    success(self.loadPrompts(from: fromDate, to: endDate, number: number))
+                    success?(self.loadPrompts(from: fromDate, to: endDate, number: number))
                 }
             case .failure(let error):
-                failure(error)
+                failure?(error)
             }
         }
     }
@@ -76,10 +76,10 @@ class BloggingPromptsService {
     /// - Parameters:
     ///   - success: Closure to be called when the fetch process succeeded.
     ///   - failure: Closure to be called when the fetch process failed.
-    func fetchTodaysPrompt(success: @escaping (BloggingPrompt?) -> Void,
-                           failure: @escaping (Error?) -> Void) {
+    func fetchTodaysPrompt(success: ((BloggingPrompt?) -> Void)? = nil,
+                           failure: ((Error?) -> Void)? = nil) {
         fetchPrompts(from: Date(), number: 1, success: { (prompts) in
-            success(prompts.first)
+            success?(prompts.first)
         }, failure: failure)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -310,6 +310,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupViews()
+        observeManagedObjectsChange()
     }
 
     required init?(coder: NSCoder) {
@@ -398,6 +399,30 @@ private extension DashboardPromptsCardCell {
         }
 
         containerStackView.addArrangedSubview((isAnswered ? answeredStateView : answerButton))
+        presenterViewController?.collectionView.collectionViewLayout.invalidateLayout()
+    }
+
+    // MARK: - Managed object observer
+
+    func observeManagedObjectsChange() {
+        NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleObjectsChange),
+                name: .NSManagedObjectContextObjectsDidChange,
+                object: ContextManager.shared.mainContext
+        )
+    }
+
+    @objc func handleObjectsChange(_ notification: Foundation.Notification) {
+        guard let prompt = prompt else {
+            return
+        }
+        let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject> ?? Set()
+        let refreshed = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject> ?? Set()
+
+        if updated.contains(prompt) || refreshed.contains(prompt) {
+            refreshStackView()
+        }
     }
 
     // MARK: Prompt Fetching


### PR DESCRIPTION
See: #18429

## Description

Adds:
- Fetching to various places in order to fix the current day's prompt showing outdated info
- An observer on the prompts managed object changing to update the dashboard card UI

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Login if necessary and select a personal public blog
- Navigate to the 'My Site' dashboard
- On the prompts dashboard card tap on 'Answer Prompt'
- Publish the post
- Wait for the 'Post published' notification on the dashboard
- Verify a network call is made to fetch the current day's prompt and that it shows as 'Answered'
- Tap on 'Posts'
- Delete the prompt post you published
- Navigate back to the dashboard
- Verify it shows the prompt as unanswered (**Note:** Sometimes the backend takes a little to update so this might not show if done too quickly. Navigating to another page and back _should_ update the prompt again.)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
