### PR TITLE
Blogging Prompts: Add info button to prompts bottom sheet header view

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -359,6 +359,7 @@ import Foundation
 
     // Blogging Prompts
     case promptsBottomSheetAnswerPrompt
+    case promptsBottomSheetHelp
     case promptsIntroductionModalViewed
     case promptsIntroductionModalDismissed
     case promptsIntroductionModalTryItNow
@@ -981,6 +982,8 @@ import Foundation
         // Blogging Prompts
         case .promptsBottomSheetAnswerPrompt:
             return "my_site_create_sheet_answer_prompt_tapped"
+        case .promptsBottomSheetHelp:
+            return "my_site_create_sheet_prompt_help_tapped"
         case .promptsIntroductionModalViewed:
             return "blogging_prompts_introduction_modal_viewed"
         case .promptsIntroductionModalDismissed:

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -4,6 +4,7 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var containerStackView: UIStackView!
     @IBOutlet private weak var titleStackView: UIStackView!
     @IBOutlet private weak var titleLabel: UILabel!
+    @IBOutlet private weak var infoButton: UIButton!
     @IBOutlet private weak var promptLabel: UILabel!
     @IBOutlet private weak var attributionStackView: UIStackView!
     @IBOutlet private weak var attributionImage: UIImageView!
@@ -15,6 +16,7 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var dividerView: UIView!
 
     var answerPromptHandler: (() -> Void)?
+    var infoButtonHandler: (() -> Void)?
 
     // This provides a quick way to toggle the shareButton.
     // Since it probably will not be included in Blogging Prompts V1,
@@ -31,7 +33,6 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
         promptsHeaderView.configure(prompt)
         return promptsHeaderView
     }
-
 }
 
 // MARK: - Private methods
@@ -56,6 +57,7 @@ private extension BloggingPromptsHeaderView {
 
     func configureStrings() {
         titleLabel.text = Strings.title
+        infoButton.accessibilityLabel = Strings.infoButtonAccessibilityLabel
         answerPromptButton.titleLabel?.text = Strings.answerButtonTitle
         answeredLabel.text = Strings.answeredLabelTitle
         shareButton.titleLabel?.text = Strings.shareButtonTitle
@@ -64,6 +66,8 @@ private extension BloggingPromptsHeaderView {
     func configureStyles() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
         titleLabel.adjustsFontForContentSizeCategory = true
+        infoButton.setImage(.gridicon(.helpOutline), for: .normal)
+        infoButton.tintColor = .listSmallIcon
         promptLabel.font = WPStyleGuide.BloggingPrompts.promptContentFont
         promptLabel.adjustsFontForContentSizeCategory = true
         answerPromptButton.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
@@ -126,6 +130,10 @@ private extension BloggingPromptsHeaderView {
     @IBAction func shareTapped(_ sender: Any) {
         // TODO
     }
+    
+    @IBAction func infoButtonTapped(_ sender: Any) {
+        infoButtonHandler?()
+    }
 
     // MARK: - Constants
 
@@ -143,6 +151,7 @@ private extension BloggingPromptsHeaderView {
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button in the create new bottom action sheet.")
         static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")
         static let shareButtonTitle = NSLocalizedString("Share", comment: "Title for a button that allows the user to share their answer to the prompt.")
+        static let infoButtonAccessibilityLabel = NSLocalizedString("Learn more about prompts", comment: "Accessibility label for the blogging prompts info button on the prompts header view.")
     }
 
 }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -130,7 +130,7 @@ private extension BloggingPromptsHeaderView {
     @IBAction func shareTapped(_ sender: Any) {
         // TODO
     }
-    
+
     @IBAction func infoButtonTapped(_ sender: Any) {
         infoButtonHandler?()
     }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,7 +18,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="349" height="110"/>
                     <subviews>
                         <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="5" translatesAutoresizingMaskIntoConstraints="NO" id="stO-XN-YJp">
-                            <rect key="frame" x="131" y="0.0" width="87.5" height="24"/>
+                            <rect key="frame" x="120.5" y="0.0" width="108.5" height="24"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="icon-lightbulb-outline" translatesAutoresizingMaskIntoConstraints="NO" id="AiS-VC-l3e">
                                     <rect key="frame" x="0.0" y="3" width="18" height="18"/>
@@ -36,6 +36,18 @@
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
                                 </label>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yaj-Vs-dvt">
+                                    <rect key="frame" x="92.5" y="4" width="16" height="16"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="16" id="JvC-wK-Zk2"/>
+                                        <constraint firstAttribute="height" constant="16" id="U0R-PT-l08"/>
+                                    </constraints>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal" image="help-outline"/>
+                                    <connections>
+                                        <action selector="infoButtonTapped:" destination="iN0-l3-epB" eventType="touchUpInside" id="dqn-4o-lCn"/>
+                                    </connections>
+                                </button>
                             </subviews>
                         </stackView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Cast the movie of your life." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Rye-vB-0gG">
@@ -132,6 +144,7 @@
                 <outlet property="attributionStackView" destination="Gef-vX-Eh7" id="vqC-5V-Z1L"/>
                 <outlet property="containerStackView" destination="HBh-15-Hby" id="ce7-Wx-TUC"/>
                 <outlet property="dividerView" destination="9KN-UC-IRC" id="Wnd-hZ-yio"/>
+                <outlet property="infoButton" destination="Yaj-Vs-dvt" id="4lv-r9-dhN"/>
                 <outlet property="promptLabel" destination="Rye-vB-0gG" id="VoE-0W-soe"/>
                 <outlet property="shareButton" destination="deu-kl-qJY" id="4ur-ok-U6p"/>
                 <outlet property="titleLabel" destination="BJN-uB-YYG" id="zxX-90-kDD"/>
@@ -141,6 +154,7 @@
         </view>
     </objects>
     <resources>
+        <image name="help-outline" width="24" height="24"/>
         <image name="icon-lightbulb-outline" width="24" height="24"/>
         <systemColor name="separatorColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.28999999999999998" colorSpace="custom" customColorSpace="sRGB"/>

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -341,7 +341,7 @@ private extension CreateButtonCoordinator {
                 self?.viewController?.present(editor, animated: true)
             }
         }
-        
+
         promptsHeaderView.infoButtonHandler = { [weak self] in
             self?.viewController?.presentedViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
         }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -343,6 +343,7 @@ private extension CreateButtonCoordinator {
         }
 
         promptsHeaderView.infoButtonHandler = { [weak self] in
+            WPAnalytics.track(.promptsBottomSheetHelp)
             self?.viewController?.presentedViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
         }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -341,6 +341,10 @@ private extension CreateButtonCoordinator {
                 self?.viewController?.present(editor, animated: true)
             }
         }
+        
+        promptsHeaderView.infoButtonHandler = { [weak self] in
+            self?.viewController?.presentedViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
+        }
 
         return promptsHeaderView
     }


### PR DESCRIPTION
See: #18429

## Description

Adds the '?' prompts info button to the action sheet header view.

![Screen Shot 2022-06-08 at 4 50 17 PM](https://user-images.githubusercontent.com/2454408/172715325-66a3db52-4274-41ee-bb53-174b627d2b15.png)

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Login if necessary
- Navigate to the 'My Site' dashboard
- Tap on the FAB '+'
- Verify there is a '?' button next to the title
- Tap on the '?' button
- Verify the informational prompts modal is presented

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
