### PR TITLE
Run RuboCop in CI via Danger

### DIFF
--- a/.buildkite/commands/rubocop-via-danger.sh
+++ b/.buildkite/commands/rubocop-via-danger.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -eu
+
+# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
+echo "--- :rubygems: Fixing Ruby Setup"
+gem install bundler
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :rubocop: Run Rubocop via Danger"
+bundle exec danger --fail-on-errors=true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -107,3 +107,17 @@ steps:
       - github_commit_status:
           context: "Lint Translations"
 
+  #################
+  # Lint Ruby Tooling
+  #################
+  #
+  # TODO: This ought to be run on a Docker or Ubuntu agent as there's nothing that requires macOS.
+  # It's currently in the stock setup because... it was faster to build a proof of concept for it this way;
+  # I don't know how to pass the `DANGER_GITHUB_API_TOKEN` secret that we need to a Docker agent.
+  #
+  # This step uses Danger to run RuboCop, but it's "agnostic" about it.
+  # That is, it outwardly only mentions RuboCop, not Danger
+  - label: ":rubocop: Lint Ruby Tooling"
+    command: .buildkite/commands/rubocop-via-danger.sh
+    env: *common_env
+    plugins: *common_plugins

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+github.dismiss_out_of_range_messages
+rubocop.lint inline_comment: true, fail_on_inline_comment: true

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gem 'cocoapods', '~> 1.11'
 gem 'commonmarker'
+gem 'danger', '~> 8.6'
+gem 'danger-rubocop', '~> 0.10'
 gem 'dotenv'
 gem 'fastlane', '~> 2.174'
 gem 'octokit', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -394,4 +394,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.15
+   2.3.17

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,10 @@ GEM
       sawyer (>= 0.6)
     chroma (0.2.0)
     claide (1.1.0)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
     cocoapods (1.11.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
@@ -82,6 +86,24 @@ GEM
     commonmarker (0.21.2)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.10)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (8.6.1)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (>= 0.9.0, < 2.0)
+      faraday-http-cache (~> 2.0)
+      git (~> 1.7)
+      kramdown (~> 2.3)
+      kramdown-parser-gfm (~> 1.0)
+      no_proxy_fix
+      octokit (~> 4.7)
+      terminal-table (>= 1, < 4)
+    danger-rubocop (0.10.0)
+      danger
+      rubocop (~> 1.0)
     declarative (0.0.20)
     diffy (3.4.0)
     digest-crc (0.6.4)
@@ -112,6 +134,8 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
+    faraday-http-cache (2.4.0)
+      faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.3)
       multipart-post (>= 1.2, < 3)
@@ -234,6 +258,10 @@ GEM
       oj (~> 3)
       optimist (~> 3)
     jwt (2.3.0)
+    kramdown (2.4.0)
+      rexml
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     memoist (0.16.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
@@ -246,6 +274,7 @@ GEM
     nap (1.1.0)
     naturally (2.2.1)
     netrc (0.11.0)
+    no_proxy_fix (0.1.2)
     nokogiri (1.13.6)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
@@ -253,6 +282,7 @@ GEM
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     oj (3.13.13)
+    open4 (1.3.4)
     optimist (3.0.1)
     options (2.3.2)
     optparse (0.1.1)
@@ -349,6 +379,8 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.11)
   commonmarker
+  danger (~> 8.6)
+  danger-rubocop (~> 0.10)
   dotenv
   fastlane (~> 2.174)
   fastlane-plugin-appcenter (~> 1.8)
@@ -362,4 +394,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.9
+   2.3.15

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ require 'yaml'
 require 'digest'
 
 SWIFTLINT_VERSION = '0.47.1'
-RUBY_REPO_VERSION = File.read('./.ruby-version').strip
+RUBY_REPO_VERSION = File.read('./.ruby-version').rstrip
 XCODE_WORKSPACE = 'WordPress.xcworkspace'
 XCODE_SCHEME = 'WordPress'
 XCODE_CONFIGURATION = 'Debug'

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -351,8 +351,6 @@ platform :ios do
   end
   # rubocop:enable Metrics/AbcSize
 
-
-
   # Uploads the localized metadata for WordPress and Jetpack (from `fastlane/{metadata,jetpack_metadata}/`) to App Store Connect
   #
   # @option [Boolean] with_screenshots (default: false) If true, will also upload the latest screenshot files to ASC


### PR DESCRIPTION
_What it says in the title_ 😅 

You can see this in action [here](https://github.com/wordpress-mobile/WordPress-iOS/pull/18846):

<img width="884" alt="image" src="https://user-images.githubusercontent.com/1218433/172834337-b91c2c95-ba03-464b-aa07-af1d9e4abcd2.png">


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
