### PR TITLE
Feature Highlight Tooltip follow button callback

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/FeatureHighlightStore.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/FeatureHighlightStore.swift
@@ -6,7 +6,7 @@ struct FeatureHighlightStore {
         static let followConversationTooltipCounterKey = "follow-conversation-tooltip-counter"
     }
 
-    @UserDefault(Keys.didUserDismissTooltipKey, defaultValue: true)
+    @UserDefault(Keys.didUserDismissTooltipKey, defaultValue: false)
     static var didDismissTooltip: Bool
 
     @UserDefault(Keys.followConversationTooltipCounterKey, defaultValue: 0)
@@ -14,6 +14,6 @@ struct FeatureHighlightStore {
 
     /// Tooltip will only be shown 3 times if the user never interacts with it.
     static var shouldShowTooltip: Bool {
-        followConversationTooltipCounter < 3 || !didDismissTooltip
+        followConversationTooltipCounter < 3 && !didDismissTooltip
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -131,6 +131,28 @@ final class TooltipPresenter {
         animateTooltipIn()
     }
 
+    func dismissTooltip() {
+        UIView.animate(
+            withDuration: Constants.tooltipAnimationDuration,
+            delay: 0,
+            options: .curveEaseOut
+        ) {
+            guard let tooltipTopConstraint = self.tooltipTopConstraint else {
+                return
+            }
+
+            self.tooltip.alpha = 0
+            tooltipTopConstraint.constant += Constants.tooltipTopConstraintAnimationOffset
+            self.containerView.layoutIfNeeded()
+        } completion: { isSuccess in
+            self.anchor = nil
+            self.primaryTooltipAction?()
+            self.tooltip.removeFromSuperview()
+            self.spotlightView?.removeFromSuperview()
+            NotificationCenter.default.removeObserver(self)
+        }
+    }
+
     private func animateTooltipIn() {
         UIView.animate(
             withDuration: Constants.tooltipAnimationDuration,
@@ -157,27 +179,7 @@ final class TooltipPresenter {
     }
 
     private func configureDismissal() {
-        tooltip.dismissalAction = {
-            UIView.animate(
-                withDuration: Constants.tooltipAnimationDuration,
-                delay: 0,
-                options: .curveEaseOut
-            ) {
-                guard let tooltipTopConstraint = self.tooltipTopConstraint else {
-                    return
-                }
-
-                self.tooltip.alpha = 0
-                tooltipTopConstraint.constant += Constants.tooltipTopConstraintAnimationOffset
-                self.containerView.layoutIfNeeded()
-            } completion: { isSuccess in
-                self.anchor = nil
-                self.primaryTooltipAction?()
-                self.tooltip.removeFromSuperview()
-                self.spotlightView?.removeFromSuperview()
-                NotificationCenter.default.removeObserver(self)
-            }
-        }
+        tooltip.dismissalAction = dismissTooltip
     }
 
     private func setUpTooltipConstraints() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -428,7 +428,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // of this call is accurate, the calculation returns wrong result on that case.
         // This manually delays the configuration and hacks the issue.
         // We can remove this once the culprit is out.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             if self.shouldConfigureTooltipPresenter() {
                 self.configureTooltipPresenter { [weak self] in
                     self?.scrollToTooltip()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -428,7 +428,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // of this call is accurate, the calculation returns wrong result on that case.
         // This manually delays the configuration and hacks the issue.
         // We can remove this once the culprit is out.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
             if self.shouldConfigureTooltipPresenter() {
                 self.configureTooltipPresenter { [weak self] in
                     self?.scrollToTooltip()
@@ -476,6 +476,14 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
+        commentsTableViewDelegate.followButtonTappedClosure = { [weak self] in
+            guard let tooltipPresenter = self?.tooltipPresenter else {
+                return
+            }
+
+            FeatureHighlightStore.didDismissTooltip = true
+            tooltipPresenter.dismissTooltip()
+        }
 
         commentsTableViewDelegate.updateWith(post: post,
                                              comments: approvedComments,

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -10,6 +10,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
     @IBOutlet private weak var followButton: UIButton!
     private var post: ReaderPost?
     private var readerCommentsFollowPresenter: ReaderCommentsFollowPresenter?
+    private var followButtonTappedClosure: (() ->Void)?
 
     private var totalComments = 0 {
         didSet {
@@ -34,10 +35,16 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
 
     // MARK: - Configure
 
-    func configure(post: ReaderPost, totalComments: Int, presentingViewController: UIViewController) {
+    func configure(
+        post: ReaderPost,
+        totalComments: Int,
+        presentingViewController: UIViewController,
+        followButtonTappedClosure: (() -> Void)?
+    ) {
         self.post = post
         self.totalComments = totalComments
         self.followConversationEnabled = post.commentsOpen && post.canSubscribeComments
+        self.followButtonTappedClosure = followButtonTappedClosure
 
         configureButton()
 
@@ -121,6 +128,9 @@ private extension ReaderDetailCommentsHeader {
     @objc func followButtonTapped() {
         isSubscribedComments ? readerCommentsFollowPresenter?.showNotificationSheet(sourceView: followButton) :
                                readerCommentsFollowPresenter?.handleFollowConversationButtonTapped()
+        if !isSubscribedComments {
+            followButtonTappedClosure?()
+        }
     }
 
     struct Titles {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -10,6 +10,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private var presentingViewController: UIViewController?
     private weak var buttonDelegate: BorderedButtonTableViewCellDelegate?
     private(set) var headerView: ReaderDetailCommentsHeader?
+    var followButtonTappedClosure: (() ->Void)?
 
     private var totalRows = 0
     private var hideButton = true
@@ -106,7 +107,8 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         header.configure(
             post: post,
             totalComments: totalComments,
-            presentingViewController: presentingViewController
+            presentingViewController: presentingViewController,
+            followButtonTappedClosure: followButtonTappedClosure
         )
         headerView = header
         return header


### PR DESCRIPTION
Refs pbArwn-4oo-p2

To test:
1. Enable local feature flag "Feature Highlight Tooltip".
2. Go to Reader, into any post that is not already followed.
3. Tap on anchor or scroll to Tooltip. 
4. Tap on "Follow Conversation" button
5. The tooltip and pulse indicator must be dismissed.
6. Tooltip shouldn't be shown again (either on another post or once this post is unfollowed and opened again).

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.