### PR TITLE
Replace `safe_load` with `load_file` for `Podfile.lock` in `Rakefile`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -695,7 +695,7 @@ def pod(args)
 end
 
 def lockfile_hash
-  YAML.safe_load(File.read('Podfile.lock'))
+  YAML.load_file('Podfile.lock')
 end
 
 def lockfiles_match?


### PR DESCRIPTION
The automated RuboCop violation fixing from 41066ae4c01a16702e7d7e62c29e4bc6942c35a7 introduced `safe_load` by replacing `load`.

Unfortunately, because of the way `Podfile.lock` is formatted (namely it includes types that would deserialize from YAML as `Symbol`) `safe_load` raises.

There is a way to update `safe_load` to successfully load `Podfile.lock`:

```ruby
YAML.safe_load(File.read('Podfile.lock'), [Symbol])
```

However, I think in this instance using `load_file` is more appropriate. We are reading from a file, after all. Also, `Podfile.lock` is a file generated by a trusted 3rd party, CocoaPods, and we can be relatively sure it will be a valid YAML.

Also worth mentioning that we have another usage of `load_file` to load `Podfile.lock` at line 118: https://github.com/wordpress-mobile/WordPress-iOS/blob/2185a1e1c2cdaa0b089e93ba75b315e058f360ce/Rakefile#L118

It would be appropriate to consolidate the two, but I wanted to keep this commit focused on fixing the `Rakefile` execution crash.

## Testing

Run `bundle exec rake dependencies` and/or `bundle exec rake xcode` and verify they succeed.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
