### PR TITLE
Blogging Prompts: Add `dailyprompt` tag to blogging prompt posts

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -7,6 +7,16 @@ extension Post {
 
         content = prompt.content
         bloggingPromptID = String(prompt.promptID)
+
+        if let currentTags = tags {
+            tags = "\(currentTags), \(Strings.promptTag)"
+        } else {
+            tags = Strings.promptTag
+        }
+    }
+
+    private struct Strings {
+        static let promptTag = "dailyprompt"
     }
 
 }


### PR DESCRIPTION
See: #18429

## Description

Adds a `dailyprompt` tag to blogging prompt posts.

## Testing

- Enable `bloggingPrompts` feature flag
- Login if necessary and navigate to 'My Site' tab

**Prompts dashboard card:**
- On the prompts card, tap on 'Answer Prompt'
- On the post editor, tap on the menu in the top right '...'
- Tap on 'Preview'
- Verify a `dailyprompt` tag exists on the post
- Close the editor

**Prompts compact header view:**
- Tap on the FAB '+'
- On the action sheet compact card, tap on 'Answer Prompt'
- On the post editor, tap on the menu in the top right '...'
- Tap on 'Preview'
- Verify a `dailyprompt` tag exists on the post
- Close the editor

**Normal post:**
- Tap on the FAB '+'
- Tap on 'Blog post'
- On the post editor, tap on the menu in the top right '...'
- Tap on 'Preview'
- Verify `dailyprompt` tag does **not** exist on the post

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
