### PR TITLE
Blogging Prompts: Add `prompt_id` property to the post published analytic

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -295,6 +295,10 @@ extension PublishingEditor {
             properties[WPAnalyticsStatEditorPublishedPostPropertyPhoto] = post.hasPhoto()
             properties[WPAnalyticsStatEditorPublishedPostPropertyTag] = post.hasTags()
             properties[WPAnalyticsStatEditorPublishedPostPropertyVideo] = post.hasVideo()
+
+            if let post = post as? Post, let promptId = post.bloggingPromptID {
+                properties["prompt_id"] = promptId
+            }
         }
 
         WPAppAnalytics.track(stat, withProperties: properties, with: post)


### PR DESCRIPTION
See: #18472

## Description

Adds a `prompt_id` property to the post published analytic.

## Testing

To test:
- Enable `bloggingPrompts` feature flag
- Login if necessary and navigate to the 'My Site' tab
- On the prompts dashboard card, tap on 'Answer Prompt'
- Publish the post
- Verify the analytic event `editor_post_published` contains the `prompt_id` property
- Tap on the FAB '+'
- Tap on 'Blog Post'
- Publish a post
- Verify the analytic event `editor_post_published` does not contain the `prompt_id` property

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
