### PR TITLE
Update the SwiftLint version used in `Rakefile` to the latest

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'English'
-SWIFTLINT_VERSION = '0.27.0'
+SWIFTLINT_VERSION = '0.47.1'
 XCODE_WORKSPACE = 'WordPress.xcworkspace'
 XCODE_SCHEME = 'WordPress'
 XCODE_CONFIGURATION = 'Debug'

--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -322,7 +322,7 @@ extension RequestAuthenticator {
     }
 }
 
-/// MARK: Navigation Validator
+// MARK: Navigation Validator
 extension RequestAuthenticator {
     /// Validates that the navigation worked as expected then provides a recommendation on if the screen should reload or not.
     func decideActionFor(response: URLResponse, cookieJar: CookieJar, completion: @escaping (WPNavigationActionType) -> Void) {

--- a/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
@@ -41,7 +41,7 @@ class TimeZoneSelectorViewModelTests: CoreDataTestCase {
         case .ready(let groups):
             // Then viewModel should be ready
             XCTAssertEqual(groups.count, timeZoneGroups.count)
-        case .error(_):
+        case .error:
             XCTFail()
         }
     }


### PR DESCRIPTION
When updating the `.swiftlint.yml` config in a7cc646331bcab81dd3da9ad510372768136ff56, it didn't occur to me that Rake is one of the ways we use SwiftLint. 🤦‍♂️

The `only_rules` option that commit introduced was not available in the SwiftLint version Rake expected.


## Testing

Checkout this branch and run `rake lint`. It should:

1) Download the latest SwiftLint
2) Produce only two warnings

```
/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift:325:1: warning: Mark Violation: MARK comment should be in valid format. e.g. '// MARK: ...' or '// MARK: - ...' (mark)
/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift:44:20: warning: Empty Enum Arguments Violation: Arguments can be omitted when matching enums with associated values if they are not used. (empty_enum_arguments)
```

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**