### PR TITLE
Revert: Quick Start card new visuals

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -174,11 +174,6 @@ class BlogDashboardCardFrameView: UIView {
     }
 
     private func configureStackViews() {
-        configureMainStackView()
-        configureButtonContainerStackView()
-    }
-
-    private func configureMainStackView() {
         addSubview(mainStackView)
 
         let trailingConstraint = mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
@@ -199,9 +194,7 @@ class BlogDashboardCardFrameView: UIView {
             chevronImageView,
             ellipsisButton
         ])
-    }
 
-    private func configureButtonContainerStackView() {
         addSubview(buttonContainerStackView)
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -77,7 +77,7 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Button container stack view anchored to the top right corner of the view.
     /// Displayed only when the header view is hidden.
-    private(set) lazy var buttonContainerStackView: UIStackView = {
+    private lazy var buttonContainerStackView: UIStackView = {
         let containerStackView = UIStackView()
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         containerStackView.axis = .horizontal

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -75,17 +75,6 @@ class BlogDashboardCardFrameView: UIView {
         return button
     }()
 
-    /// Button container stack view anchored to the top right corner of the view.
-    /// Displayed only when the header view is hidden.
-    private lazy var buttonContainerStackView: UIStackView = {
-        let containerStackView = UIStackView()
-        containerStackView.translatesAutoresizingMaskIntoConstraints = false
-        containerStackView.axis = .horizontal
-        return containerStackView
-    }()
-
-    private var mainStackViewTrailingConstraint: NSLayoutConstraint?
-
     weak var currentView: UIView?
 
     /// The title at the header
@@ -158,51 +147,22 @@ class BlogDashboardCardFrameView: UIView {
     /// Hide the header
     func hideHeader() {
         headerStackView.isHidden = true
-        buttonContainerStackView.isHidden = false
-
-        if !ellipsisButton.isHidden || !chevronImageView.isHidden {
-            mainStackViewTrailingConstraint?.constant = -Constants.mainStackViewTrailingPadding
-        }
     }
 
     /// Hide the header
     func showHeader() {
         headerStackView.isHidden = false
-        buttonContainerStackView.isHidden = true
-
-        mainStackViewTrailingConstraint?.constant = 0
     }
 
     private func configureStackViews() {
         addSubview(mainStackView)
-
-        let trailingConstraint = mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
-        mainStackViewTrailingConstraint = trailingConstraint
-
-        NSLayoutConstraint.activate([
-            mainStackView.topAnchor.constraint(equalTo: topAnchor),
-            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.bottomPadding),
-            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            trailingConstraint
-        ])
+        pinSubviewToAllEdges(mainStackView, insets: UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPadding, right: 0))
 
         mainStackView.addArrangedSubview(headerStackView)
 
         headerStackView.addArrangedSubviews([
             iconImageView,
             titleLabel,
-            chevronImageView,
-            ellipsisButton
-        ])
-
-        addSubview(buttonContainerStackView)
-
-        NSLayoutConstraint.activate([
-            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.buttonContainerStackViewPadding),
-            buttonContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.buttonContainerStackViewPadding)
-        ])
-
-        buttonContainerStackView.addArrangedSubviews([
             chevronImageView,
             ellipsisButton
         ])
@@ -276,8 +236,6 @@ class BlogDashboardCardFrameView: UIView {
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
-        static let buttonContainerStackViewPadding: CGFloat = 8
-        static let mainStackViewTrailingPadding: CGFloat = 32
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -7,6 +7,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
 
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
+        frameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.onEllipsisButtonTap = { [weak self] in
             guard let viewController = self?.viewController,
@@ -61,7 +62,6 @@ extension DashboardQuickStartCardCell {
         contentView.pinSubviewToAllEdges(cardFrameView, priority: Metrics.constraintPriority)
 
         cardFrameView.add(subview: tourStateView)
-        cardFrameView.hideHeader()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -13,7 +13,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                   let blog = self?.blog else {
                 return
             }
-            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.buttonContainerStackView.frame)
+            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButton.frame)
         }
         return frameView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/NewQuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/NewQuickStartChecklistView.swift
@@ -221,7 +221,7 @@ extension NewQuickStartChecklistView {
 extension NewQuickStartChecklistView {
 
     private enum Metrics {
-        static let mainStackViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16).flippedForRightToLeft
+        static let mainStackViewInsets = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 24).flippedForRightToLeft
         static let verticalStackViewWidthMultiplier = 3.0 / 5.0
         static let verticalStackViewSpacingPortrait = 12.0
         static let verticalStackViewSpacingLandscape = 16.0

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -22,6 +22,6 @@ import UIKit
     }
 
     private enum Metrics {
-        static let margins = UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 8)
+        static let margins = UIEdgeInsets(top: 16, left: 8, bottom: 8, right: 8)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,6 +30,7 @@
                 </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="eef-Zj-N7X" secondAttribute="bottom" id="GNl-cm-DIY"/>
                 <constraint firstItem="eef-Zj-N7X" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="Wxm-C7-bR4"/>
@@ -45,4 +47,9 @@
             <point key="canvasLocation" x="139" y="109"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
We have identified an issue with the Quick Start cards with a refined visual and due to the lack of time to properly fix it, we're reverting it.

### To test:

With Menu as default:

1. Run the app
2. Enable QS for existing site
3. ✅ Check that it appears correctly and it can be dismissed
4. Enable QS for new site
4. ✅ Check that it appears correctly and it can be dismissed5. 

With Home as default:

1. Run the app
2. Enable QS for existing site
3. ✅ Check that it appears correctly and it can be dismissed
4. Enable QS for new site
4. ✅ Check that it appears correctly and it can be dismissed
5. ✅ Check that the chevron icon on card appears correctly


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
