### PR TITLE
Build Warnings: Various Swift compiler warnings

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -123,8 +123,8 @@ class WeeklyRoundupDataProvider {
     private func filterBest(_ count: Int, minimumViewsCount: Int = 5, from blogStats: SiteStats) -> SiteStats {
         let filteredAndSorted = blogStats.filter { (site, stats) in
             stats.viewsCount >= minimumViewsCount
-        }.sorted { (first: (blog: Blog, stats: StatsSummaryData), second: (blog: Blog, stats: StatsSummaryData)) in
-            first.stats.viewsCount >= second.stats.viewsCount
+        }.sorted { (first: (_, value: StatsSummaryData), second: (_, value: StatsSummaryData)) in
+            first.value.viewsCount >= second.value.viewsCount
         }
 
         return filteredAndSorted

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/UnknownEditorViewController.swift
@@ -9,14 +9,14 @@ class UnknownEditorViewController: UIViewController {
 
     /// Save Bar Button
     ///
-    fileprivate(set) var saveButton: UIBarButtonItem = {
+    fileprivate(set) lazy var saveButton: UIBarButtonItem = {
         let saveTitle = NSLocalizedString("Save", comment: "Save Action")
         return UIBarButtonItem(title: saveTitle, style: .plain, target: self, action: #selector(saveWasPressed))
     }()
 
     /// Cancel Bar Button
     ///
-    fileprivate(set) var cancelButton: UIBarButtonItem = {
+    fileprivate(set) lazy var cancelButton: UIBarButtonItem = {
         let cancelTitle = NSLocalizedString("Cancel", comment: "Cancel Action")
         return UIBarButtonItem(title: cancelTitle, style: .plain, target: self, action: #selector(cancelWasPressed))
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowCompletionViewController.swift
@@ -55,7 +55,7 @@ class BloggingRemindersFlowCompletionViewController: UIViewController {
         return label
     }()
 
-    private let doneButton: UIButton = {
+    private lazy var doneButton: UIButton = {
         let button = FancyButton()
         button.isPrimary = true
         button.setTitle(TextContent.doneButtonTitle, for: .normal)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -42,7 +42,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         return label
     }()
 
-    private let getStartedButton: UIButton = {
+    private lazy var getStartedButton: UIButton = {
         let button = FancyButton()
         button.isPrimary = true
         button.setTitle(TextContent.introButtonTitle, for: .normal)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -52,7 +52,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         return label
     }()
 
-    private let button: UIButton = {
+    private lazy var button: UIButton = {
         let button = FancyButton()
         button.isPrimary = true
         button.addTarget(self, action: #selector(notifyMeButtonTapped), for: .touchUpInside)

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersPushPromptViewController.swift
@@ -57,7 +57,7 @@ class BloggingRemindersPushPromptViewController: UIViewController {
         return label
     }()
 
-    private let turnOnNotificationsButton: UIButton = {
+    private lazy var turnOnNotificationsButton: UIButton = {
         let button = FancyButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.isPrimary = true
@@ -67,7 +67,7 @@ class BloggingRemindersPushPromptViewController: UIViewController {
         return button
     }()
 
-    private let dismissButton: UIButton = {
+    private lazy var dismissButton: UIButton = {
         let button = UIButton(type: .custom)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setImage(.gridicon(.cross), for: .normal)

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -398,14 +398,16 @@ import WordPressShared
         var rows = [SharingButtonsRow]()
 
         let row = SharingSwitchRow()
-        row.configureCell = {[unowned self] (cell: UITableViewCell) in
+        row.configureCell = {[weak self] (cell: UITableViewCell) in
+            guard let self = self else { return }
             if let switchCell = cell as? SwitchTableViewCell {
                 cell.editingAccessoryView = cell.accessoryView
                 cell.editingAccessoryType = cell.accessoryType
                 switchCell.textLabel?.text = NSLocalizedString("Edit sharing buttons", comment: "Title for the edit sharing buttons section")
                 switchCell.on = self.buttonsSection.editing
-                switchCell.onChange = { newValue in
-                    WPAnalytics.track(.sharingButtonsEditSharingButtonsToggled, properties: ["checked": newValue as Any], blog: blog)
+                switchCell.onChange = { [weak self] newValue in
+                    guard let self = self else { return }
+                    WPAnalytics.track(.sharingButtonsEditSharingButtonsToggled, properties: ["checked": newValue as Any], blog: self.blog)
                     self.buttonsSection.editing = !self.buttonsSection.editing
                     self.updateButtonOrderAfterEditing()
                     self.reloadButtons()
@@ -441,17 +443,19 @@ import WordPressShared
         var rows = [SharingButtonsRow]()
 
         let row = SharingSwitchRow()
-        row.configureCell = {[unowned self] (cell: UITableViewCell) in
+        row.configureCell = {[weak self] (cell: UITableViewCell) in
+            guard let self = self else { return }
             if let switchCell = cell as? SwitchTableViewCell {
                 cell.editingAccessoryView = cell.accessoryView
                 cell.editingAccessoryType = cell.accessoryType
                 switchCell.textLabel?.text = NSLocalizedString("Edit \"More\" button", comment: "Title for the edit more button section")
                 switchCell.on = self.moreSection.editing
-                switchCell.onChange = { newValue in
-                    WPAnalytics.track(.sharingButtonsEditMoreButtonToggled, properties: ["checked": newValue as Any], blog: blog)
+                switchCell.onChange = { [weak self] newValue in
+                    guard let self = self else { return }
+                    WPAnalytics.track(.sharingButtonsEditMoreButtonToggled, properties: ["checked": newValue as Any], blog: self.blog)
                     self.updateButtonOrderAfterEditing()
                     self.moreSection.editing = !self.moreSection.editing
-                   self.reloadButtons()
+                    self.reloadButtons()
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteIconPickerView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteIconPickerView.swift
@@ -120,7 +120,7 @@ struct SiteIconPickerView: View {
         Group {
             let columnCount = SiteIconPickerView.allEmoji.count / Metrics.emojiRowCount
 
-            ForEach((0..<columnCount)) { index in
+            ForEach(0..<columnCount, id: \.self) { index in
                 let startIndex = index * Metrics.emojiRowCount
                 let endIndex = min(startIndex + Metrics.emojiRowCount, SiteIconPickerView.allEmoji.count)
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -9,7 +9,7 @@ class StatsBaseCell: UITableViewCell {
         return label
     }()
 
-    private let showDetailsButton: UIButton = {
+    private lazy var showDetailsButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = true
         button.addTarget(self, action: #selector(detailsButtonTapped), for: .touchUpInside)

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -181,15 +181,16 @@ private extension SupportTableViewController {
     }
 
     func contactUsSelected() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [weak self] row in
+            guard let self = self else { return }
             self.tableView.deselectSelectedRowWithAnimation(true)
             if ZendeskUtils.zendeskEnabled {
                 guard let controllerToShowFrom = self.controllerToShowFrom() else {
                     return
                 }
-                ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: controllerToShowFrom, with: self.sourceTag) { identityUpdated in
+                ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: controllerToShowFrom, with: self.sourceTag) { [weak self] identityUpdated in
                     if identityUpdated {
-                        reloadViewModel()
+                        self?.reloadViewModel()
                     }
                 }
             } else {
@@ -202,16 +203,17 @@ private extension SupportTableViewController {
     }
 
     func myTicketsSelected() -> ImmuTableAction {
-        return { [unowned self] row in
+        return { [weak self] row in
+            guard let self = self else { return }
             ZendeskUtils.pushNotificationRead()
             self.tableView.deselectSelectedRowWithAnimation(true)
 
             guard let controllerToShowFrom = self.controllerToShowFrom() else {
                 return
             }
-            ZendeskUtils.sharedInstance.showTicketListIfPossible(from: controllerToShowFrom, with: self.sourceTag) { identityUpdated in
+            ZendeskUtils.sharedInstance.showTicketListIfPossible(from: controllerToShowFrom, with: self.sourceTag) { [weak self] identityUpdated in
                 if identityUpdated {
-                    reloadViewModel()
+                    self?.reloadViewModel()
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -64,7 +64,7 @@ class ActionSheetViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private var gripButton: UIButton = {
+    private lazy var gripButton: UIButton = {
         let button = GripButton()
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(buttonPressed), for: .touchUpInside)


### PR DESCRIPTION
## Description
Fixes the remaining Xcode Warnings
- 0590e9ae838f30c1e4ffdc95a66baba696ab5c49: Fixes a warning caused by referencing `self` while initializing a `let` variable. The warning was due to `self` not being ready. Fixed by using lazy vars instead. ([Reference](https://stackoverflow.com/a/71564652))
- b245bd2360d696109ccc15e98fe4a6859528c37a: Fixes a SwiftUI warning caused by passing `ForEach` a non-constant Range. Fixed by using the initializer that takes `id:` as well as a range. ([Reference](https://twitter.com/lostmoa_nz/status/1256152748447330304?lang=en))
- d3717164ef506f20f692189125014ac19d417e05: Fixes a tuple labels mismatch warning. Fixed by renaming the labels to match dictionary tuple.
- d8895fc0a64e01f1e061b62bbb008f313d2241eb: Fixes multiple warnings caused by nested closures that capture `self`. Fixed by using weak self instead of unowned and adding capture list for the inner closure to capture a weak reference to the strong self in the outer closure. 

## Testing Instructions

No testing is needed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.