### PR TITLE
[Site Design Revamp] Reduce recommended design thumbnail sizes

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignCategoryThumbnailSize.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignCategoryThumbnailSize.swift
@@ -5,15 +5,10 @@ enum SiteDesignCategoryThumbnailSize {
     case recommended
 
     var value: CGSize {
-        switch self {
-        case .category where UIDevice.isPad():
+        if UIDevice.isPad() {
             return .init(width: 250, height: 325)
-        case .category:
-            return .init(width: 200, height: 260)
-        case .recommended where UIDevice.isPad():
-            return .init(width: 327, height: 450)
-        case .recommended:
-            return .init(width: 350, height: 450)
         }
+
+        return .init(width: 200, height: 260)
     }
 }


### PR DESCRIPTION
Fixes #18878

| iPhone Before | iPhone After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-06-14 at 10 56 42](https://user-images.githubusercontent.com/2092798/173617129-ece43e99-5c75-470e-97b7-b7a93ca0da88.png) | ![Simulator Screen Shot - iPhone 13 - 2022-06-14 at 11 14 19](https://user-images.githubusercontent.com/2092798/173617167-1619c5bc-6f11-4916-82c2-0c4b3921cf80.png) |

| iPad Before | iPad After |
| - | - |
| ![Simulator Screen Shot - iPad (9th generation) - 2022-06-14 at 10 58 41](https://user-images.githubusercontent.com/2092798/173617301-3b11e03d-d880-4bfd-bd16-bd9eee6e349b.png) | ![Simulator Screen Shot - iPad (9th generation) - 2022-06-14 at 11 06 46](https://user-images.githubusercontent.com/2092798/173617333-aa8063fa-c94a-4211-b049-7595cbacf145.png) |

## To test:

1. Start the Site Creation flow
2. Navigate to the Site Design screen
3. Expect the thumbnails in the recommended section to match the size and quality of the other thumbnails

## Regression Notes
1. Potential unintended areas of impact
  - None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
  - Manual, visual testing.

3. What automated tests I added (or what prevented me from doing so)
  - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
