### PR TITLE
Build Warnings: Fix the last of missing nullability warnings

### DIFF
--- a/WordPress/Classes/Categories/NSObject+Helpers.h
+++ b/WordPress/Classes/Categories/NSObject+Helpers.h
@@ -1,10 +1,12 @@
 #import <Foundation/Foundation.h>
 
-
+NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject (Helpers)
 
-+ (nonnull NSString *)classNameWithoutNamespaces;
++ (NSString *)classNameWithoutNamespaces;
 
 - (void)debounce:(SEL)selector afterDelay:(NSTimeInterval)timeInterval;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -128,4 +128,3 @@
 #import <WordPressShared/WPTableViewCell.h>
 #import <WordPressShared/WPAnalytics.h>
 #import <WordPressUI/UIImage+Util.h>
-#import <React/RCTAnimatedImage.h>


### PR DESCRIPTION
## Description
- Fixes one last build warning inside our project
- Removes an unneeded import for `RCTAnimatedImage` that was causing warnings from React-Core to surface in our project.

## Testing Instructions

No testing is required.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.