### PR TITLE
Stats Revamp: Comments Details Screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -110,6 +110,17 @@
         case .insightsAnnualSiteStats:
             return InsightsHeaders.annualSiteStats
         case .insightsCommentsAuthors, .insightsCommentsPosts:
+            if FeatureFlag.statsNewInsights.enabled {
+                switch self {
+                case .insightsCommentsAuthors:
+                    return InsightsHeaders.topCommenters
+                case .insightsCommentsPosts:
+                    return InsightsHeaders.posts
+                default:
+                    return InsightsHeaders.comments
+                }
+            }
+
             return InsightsHeaders.comments
         case .insightsFollowersWordPress, .insightsFollowersEmail:
             return InsightsHeaders.followers
@@ -388,7 +399,9 @@
         static let publicize = NSLocalizedString("Publicize", comment: "Insights 'Publicize' header")
         static let todaysStats = NSLocalizedString("Today", comment: "Insights 'Today' header")
         static let postingActivity = NSLocalizedString("Posting Activity", comment: "Insights 'Posting Activity' header")
+        static let posts = NSLocalizedString("Posts", comment: "Insights 'Posts' header")
         static let comments = NSLocalizedString("Comments", comment: "Insights 'Comments' header")
+        static let topCommenters = NSLocalizedString("Top Commenters", comment: "Insights 'Top Commenters' header")
         static let followers = NSLocalizedString("Followers", comment: "Insights 'Followers' header")
         static let tagsAndCategories = NSLocalizedString("Tags and Categories", comment: "Insights 'Tags and Categories' header")
         static let annualSiteStats = NSLocalizedString("This Year", comment: "Insights 'This Year' header")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -413,7 +413,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
         if FeatureFlag.statsNewInsights.enabled {
             switch statSection {
-            case .insightsViewsVisitors, .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals, .insightsLikesTotals:
+            case .insightsViewsVisitors, .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
                 segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
             default:
                 segueToDetails(statSection: statSection, selectedDate: selectedDate)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -94,6 +94,17 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     refreshPeriodOverviewData(date: date, period: StatsPeriodUnit.day, forceRefresh: false)
                     refreshPostsAndPages()
                 }
+            case .insightsCommentsTotals:
+                guard let storeQuery = queryForInsightStatSection(statSection) else {
+                    return
+                }
+
+                insightsChangeReceipt = insightsStore.onChange { [weak self] in
+                    self?.emitChange()
+                }
+                insightsReceipt = insightsStore.query(storeQuery)
+
+                refreshComments()
             default:
                 guard let storeQuery = queryForInsightStatSection(statSection) else {
                     return
@@ -158,6 +169,11 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
                 return periodStore.fetchingFailed(for: storeQueryViewsVisitors) &&
                         periodStore.fetchingFailed(for: storeQueryPostPages)
+            case .insightsCommentsTotals:
+                guard let storeQuery = queryForInsightStatSection(statSection) else {
+                    return true
+                }
+                return insightsStore.fetchingFailed(for: storeQuery)
             default:
                 guard let storeQuery = queryForInsightStatSection(statSection) else {
                     return true
@@ -183,7 +199,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
             return periodStore.isFetchingReferrers
         case .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals:
             return insightsStore.isFetchingAllFollowers
-        case .insightsCommentsAuthors, .insightsCommentsPosts:
+        case .insightsCommentsAuthors, .insightsCommentsPosts, .insightsCommentsTotals:
             return insightsStore.isFetchingComments
         case .insightsTagsAndCategories:
             return insightsStore.isFetchingTagsAndCategories
@@ -319,22 +335,22 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                         siteStatsReferrerDelegate: nil))
                 return rows
             }
-        case .insightsCommentsAuthors, .insightsCommentsPosts:
+        case .insightsCommentsAuthors, .insightsCommentsPosts, .insightsCommentsTotals:
             return insightsImmuTable(for: (.allComments, insightsStore.allCommentsInsightStatus)) {
                 var rows = [ImmuTableRow]()
-                let selectedIndex = statSection == .insightsCommentsAuthors ? 0 : 1
+                rows.append(TotalInsightStatsRow(dataRow: createCommentsTotalInsightsRow(), statSection: .insightsCommentsTotals, siteStatsInsightsDelegate: nil))
+
                 let authorsTabData = tabDataForCommentType(.insightsCommentsAuthors)
+                rows.append(TopTotalsInsightStatsRow(itemSubtitle: "",
+                        dataSubtitle: "",
+                        dataRows: authorsTabData.dataRows,
+                        siteStatsInsightsDelegate: nil))
+
                 let postsTabData = tabDataForCommentType(.insightsCommentsPosts)
-                rows.append(DetailSubtitlesTabbedHeaderRow(tabsData: [authorsTabData, postsTabData],
-                        siteStatsDetailsDelegate: detailsDelegate,
-                        showTotalCount: false,
-                        selectedIndex: selectedIndex))
-                let dataRows = statSection == .insightsCommentsAuthors ? authorsTabData.dataRows : postsTabData.dataRows
-                if dataRows.isEmpty {
-                    rows.append(StatsErrorRow(rowStatus: .success, statType: .insights))
-                } else {
-                    rows.append(contentsOf: tabbedRowsFrom(dataRows))
-                }
+                rows.append(TopTotalsInsightStatsRow(itemSubtitle: StatSection.InsightsHeaders.posts,
+                        dataSubtitle: StatSection.InsightsHeaders.comments,
+                        dataRows: postsTabData.dataRows,
+                        siteStatsInsightsDelegate: nil))
                 return rows
             }
         case .insightsTagsAndCategories:
@@ -453,6 +469,10 @@ class SiteStatsInsightsDetailsViewModel: Observable {
         return StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore, statsSummaryType: .likes)
     }
 
+    func createCommentsTotalInsightsRow() -> StatsTotalInsightsData {
+        return StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore, statsSummaryType: .comments)
+    }
+
     // MARK: - Refresh Data
 
     func refreshPeriodOverviewData(date: Date, period: StatsPeriodUnit = .week, forceRefresh: Bool = false) {
@@ -569,7 +589,7 @@ private extension SiteStatsInsightsDetailsViewModel {
         switch statSection {
         case .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals:
             return .allFollowers
-        case .insightsCommentsAuthors, .insightsCommentsPosts:
+        case .insightsCommentsAuthors, .insightsCommentsPosts, .insightsCommentsTotals:
             return .allComments
         case .insightsTagsAndCategories:
             return .allTagsAndCategories


### PR DESCRIPTION
This PR adds the Details (2nd level) Comments screen

Fixes #18604

Note:
 * Comments Total and Posts from original Insights screen never worked with DateSelector / Periods so the DateSelector doesn't work + change data and will be handled in a future PR

Implementation
<img width="222" alt="image" src="https://user-images.githubusercontent.com/88816724/174000817-43865bcf-ef74-43b3-9a2a-202fd90f8d8a.png">

Design
<img width="222" alt="image" src="https://user-images.githubusercontent.com/88816724/174000834-0a9dce46-f46e-45ef-8f08-b67d734a28a4.png">


To test:
1. Build and run + navigate to Stats Insights for a site
2. Comments Total card should not be available
3. Click around insights, period stats and ensure there are no crashes
4. Now enable both of the new stats feature flags below and build and run again
```
statsNewAppearance
statsNewInsights
```
5. From the top level Stats Insights screen add the Comments Total card if not already visible.  There should be no changes to Comments Total in the total number of comments
6. On the top level Stats Insights screen for cards Comments Total tap the right chevron which should navigate you to the details screen 
7. You should see the Comments Total card followed by the Posts card with comments count

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
