### PR TITLE
[People Management] Fix iPad crash in the People view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,7 @@
 * [***] [Jetpack-only] Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [#18860]
 * [**] Follow Conversation: A tooltip has been added to highlight the follow conversation feature. [#18848]
 * [*] [internal] Block Editor: Bump react-native-gesture-handler to version 2.3.2. [#18742]
-* [*] People Management: Fixed a crash that can occur when loading the People view. [#18896]
+* [*] People Management: Fixed a synchronization bug as well as a crash that can occur when loading the People view. [#18896]
 
 20.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [***] [Jetpack-only] Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [#18860]
 * [**] Follow Conversation: A tooltip has been added to highlight the follow conversation feature. [#18848]
 * [*] [internal] Block Editor: Bump react-native-gesture-handler to version 2.3.2. [#18742]
+* [*] People Management: Fixed a crash that can occur when loading the People view. [#18896]
 
 20.0
 -----

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -43,7 +43,7 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
     ///
     private var isLoadingMore = false
 
-    /// Indicates where we are doing a full refresh, which involves clearing all the data at the start.
+    /// Indicates whether we are doing a full refresh.
     /// This is used to prevent the UI from showing "No Results" between all data being cleared and populated by the API.
     ///
     private var fullRefreshInProgress = true
@@ -173,6 +173,7 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         WPAppAnalytics.track(.openedPeople, with: blog)
     }
 
+    /// Nuke all existing data and refresh it from the remote API.
     private func refreshRemoteData() {
         fullRefreshInProgress = true
         shouldLoadMore = false
@@ -188,6 +189,7 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
+    /// Re-render the table and determine if the "No Results" view should be shown or removed.
     private func refreshView() {
         tableView.reloadData()
 
@@ -375,7 +377,7 @@ private extension PeopleViewController {
 
     // MARK: Sync Helpers
 
-    private func refreshPeople(completionHandler: @escaping (() -> Void)) {
+    func refreshPeople(completionHandler: @escaping (() -> Void)) {
         resetManagedPeople()
 
         loadPeoplePage() { [weak self] (retrieved, shouldLoadMore) in

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -119,6 +119,11 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
     // MARK: UITableViewDataSource
 
     override func numberOfSections(in tableView: UITableView) -> Int {
+        guard !isInitialLoad else {
+            // Until the initial load has been completed, no data should be rendered in the table.
+            return 0
+        }
+
         return resultsController.sections?.count ?? 0
     }
 


### PR DESCRIPTION
Fixes #

## Description

**Bugfixes:**
- A race condition was removed that caused some devices to crash. The `UITableView` would try to render cells using objects from the [MOC](https://developer.apple.com/documentation/coredata/nsmanagedobjectcontext) that no longer existed. It seemed to occur only on faster devices (e.g. iPad Pro) when the `UISplitViewController` is full screen.
- Pull-to-refresh now correctly reflects when a user has been deleted remotely.
  - This [PR has been effectively reverted](https://github.com/wordpress-mobile/WordPress-iOS/pull/16532) in favor of having the latest data from the API.

**Behavioral changes:**
- With every filter change (tapping Users, Followers, Email Followers), the data is fully re-synced with the API. Although this is more resource-heavy, API pages are limited to 20 results and it helps ensure parity with web. I can't identify much value that offline caching the People view would provide, since every operation (adding, removing, changing a user's role) requires API communication.
- Pulling to refresh does a full re-sync.

## Notes

**Known issues:**
- If a user switches filters quickly this can have unintended effects on the UI due to multiple firing closures. Since they are on the same thread, the UI should resolve to the proper state.

**Future improvements to consider:**
- Instead of deleting all People in Core Data, prune the users that weren't returned on the API side.
- Debounce / prevent concurrent calls to `refreshRemoteData()`.
- Add a delay before showing the "Loading People..." view. Pulling to refresh on fast connections has a flickering effect.

## Testing

All testing can be done on a .com Simple site.

### Test 1 - iPad Pro doesn't crash

To test if your device crashes, load WordPress 20.0.1 from the App Store and follow these same steps expecting a crash at step 7.

https://user-images.githubusercontent.com/2092798/174352365-bc5a9d0f-96c6-40b4-8f71-b2e0de74c5dc.mp4

**Prerequisites:**
- iPad Pro with WPiOS in full screen
- A site with at least two Users added (a User has the role of Administrator, Editor, Author, or Contributor)
- **Important:** Only the alpha and release builds seem to crash (presumably due to faster execution). A debug build running in Simulator or on a physical device will probably not crash. [Use the alpha build from this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18896#issuecomment-1157710034).

**Steps:**
1. Load WPiOS in full screen mode
2. Tap People
3. Observe that the users for the site load (there should be at least two, see prerequisites)
4. Tap another view such (e.g. Sharing, Menus, Themes)
5. Tap People
6. Repeat steps 5 and 6
7. Expect no crashes

### Test 2 - Deleting a user remotely is reflected when the view is refreshed

**Prerequisites:**
- A site with at least two Users added (a User has the role of Administrator, Editor, Author, or Contributor)

**Steps:**
1. Load WPiOS
2. Tap People
3. Observe that the users for the site load (there should be at least two, see prerequisites)
4. In a browser as the site administrator, delete a user that was loaded in step 3
5. In WPiOS, pull to refresh the People view
6. Expect the user to be removed

## Regression tests

### Test 3 - Adding / Removing a user

This test isn't iPad specific and should be performed on an iPhone as well.

**Prerequisites:**
- Access to a site that your user is the administrator of.

**Steps:**
1. Load WPiOS
2. Tap People
3. Add a user and specify a role
4. In a browser, log into Wordpress.com and accept the invitation as the other user
5. In a browser as the site administrator, view the Users for the site and confirm the invited user now appears
6. In WPiOS pull-to-refresh the People view
7. Expect the user is added
8. Delete the user from WPiOS
9. In a browser as the site administrator, confirm the user has been deleted from the Users list

### Test 4 - Changing a user's roles

This test isn't iPad specific and should be performed on an iPhone as well.

**Prerequisites:**
- Access to a site that your user is the administrator of that has at least one other user.
**Note: .com Super Admins cannot have their roles changed.**

**Steps:**
1. Load WPiOS
2. Tap People
3. Select an existing user
4. Tap Role
5. Choose a new role
6. Expect that the UI is updated to reflect the new role
7. Expect that the role is updated on the web

### Test 5 - Pagination

This test isn't iPad specific and should be performed on an iPhone as well.

**Prerequisites:**
- A site with more than 20 users

**Steps:**
1. Load WPiOS
2. Tap People
3. Expect the first twenty users to be loaded
4. Scroll down in the list
5. Expect more users to be loaded

## Regression Notes
1. Potential unintended areas of impact
    - Anything involving user management in the People view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested the steps above with and iPhone and iPad

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
