### PR TITLE
Quick Start: New Visuals v2 with fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -75,6 +75,17 @@ class BlogDashboardCardFrameView: UIView {
         return button
     }()
 
+    /// Button container stack view anchored to the top right corner of the view.
+    /// Displayed only when the header view is hidden.
+    private lazy var buttonContainerStackView: UIStackView = {
+        let containerStackView = UIStackView()
+        containerStackView.translatesAutoresizingMaskIntoConstraints = false
+        containerStackView.axis = .horizontal
+        return containerStackView
+    }()
+
+    private var mainStackViewTrailingConstraint: NSLayoutConstraint?
+
     weak var currentView: UIView?
 
     /// The title at the header
@@ -147,22 +158,51 @@ class BlogDashboardCardFrameView: UIView {
     /// Hide the header
     func hideHeader() {
         headerStackView.isHidden = true
+        buttonContainerStackView.isHidden = false
+
+        if !ellipsisButton.isHidden || !chevronImageView.isHidden {
+            mainStackViewTrailingConstraint?.constant = -Constants.mainStackViewTrailingPadding
+        }
     }
 
     /// Hide the header
     func showHeader() {
         headerStackView.isHidden = false
+        buttonContainerStackView.isHidden = true
+
+        mainStackViewTrailingConstraint?.constant = 0
     }
 
     private func configureStackViews() {
         addSubview(mainStackView)
-        pinSubviewToAllEdges(mainStackView, insets: UIEdgeInsets(top: 0, left: 0, bottom: Constants.bottomPadding, right: 0))
+
+        let trailingConstraint = mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+        mainStackViewTrailingConstraint = trailingConstraint
+
+        NSLayoutConstraint.activate([
+            mainStackView.topAnchor.constraint(equalTo: topAnchor),
+            mainStackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Constants.bottomPadding),
+            mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            trailingConstraint
+        ])
 
         mainStackView.addArrangedSubview(headerStackView)
 
         headerStackView.addArrangedSubviews([
             iconImageView,
             titleLabel,
+            chevronImageView,
+            ellipsisButton
+        ])
+
+        addSubview(buttonContainerStackView)
+
+        NSLayoutConstraint.activate([
+            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.buttonContainerStackViewPadding),
+            buttonContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.buttonContainerStackViewPadding)
+        ])
+
+        buttonContainerStackView.addArrangedSubviews([
             chevronImageView,
             ellipsisButton
         ])
@@ -236,6 +276,8 @@ class BlogDashboardCardFrameView: UIView {
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
         static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        static let buttonContainerStackViewPadding: CGFloat = 8
+        static let mainStackViewTrailingPadding: CGFloat = 32
     }
 
     private enum Strings {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -174,6 +174,11 @@ class BlogDashboardCardFrameView: UIView {
     }
 
     private func configureStackViews() {
+        configureMainStackView()
+        configureButtonContainerStackView()
+    }
+
+    private func configureMainStackView() {
         addSubview(mainStackView)
 
         let trailingConstraint = mainStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
@@ -194,7 +199,9 @@ class BlogDashboardCardFrameView: UIView {
             chevronImageView,
             ellipsisButton
         ])
+    }
 
+    private func configureButtonContainerStackView() {
         addSubview(buttonContainerStackView)
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -77,7 +77,7 @@ class BlogDashboardCardFrameView: UIView {
 
     /// Button container stack view anchored to the top right corner of the view.
     /// Displayed only when the header view is hidden.
-    private lazy var buttonContainerStackView: UIStackView = {
+    private(set) lazy var buttonContainerStackView: UIStackView = {
         let containerStackView = UIStackView()
         containerStackView.translatesAutoresizingMaskIntoConstraints = false
         containerStackView.axis = .horizontal

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -137,7 +137,7 @@ class BlogDashboardCardFrameView: UIView {
 
         layer.cornerRadius = Constants.cornerRadius
 
-        configureStackViews()
+        configureMainStackView()
     }
 
     required init?(coder: NSCoder) {
@@ -173,11 +173,6 @@ class BlogDashboardCardFrameView: UIView {
         mainStackViewTrailingConstraint?.constant = 0
     }
 
-    private func configureStackViews() {
-        configureMainStackView()
-        configureButtonContainerStackView()
-    }
-
     private func configureMainStackView() {
         addSubview(mainStackView)
 
@@ -201,7 +196,7 @@ class BlogDashboardCardFrameView: UIView {
         ])
     }
 
-    private func configureButtonContainerStackView() {
+    func configureButtonContainerStackView() {
         addSubview(buttonContainerStackView)
 
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -13,7 +13,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
                   let blog = self?.blog else {
                 return
             }
-            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.ellipsisButton.frame)
+            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.buttonContainerStackView.frame)
         }
         return frameView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -7,7 +7,6 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
 
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
-        frameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.onEllipsisButtonTap = { [weak self] in
             guard let viewController = self?.viewController,
@@ -62,6 +61,7 @@ extension DashboardQuickStartCardCell {
         contentView.pinSubviewToAllEdges(cardFrameView, priority: Metrics.constraintPriority)
 
         cardFrameView.add(subview: tourStateView)
+        cardFrameView.hideHeader()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -8,13 +8,6 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        frameView.onEllipsisButtonTap = { [weak self] in
-            guard let viewController = self?.viewController,
-                  let blog = self?.blog else {
-                return
-            }
-            viewController.removeQuickStart(from: blog, sourceView: frameView, sourceRect: frameView.buttonContainerStackView.frame)
-        }
         return frameView
     }()
 
@@ -40,7 +33,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         self.viewController = viewController
         self.blog = blog
 
-        cardFrameView.title = Strings.title(for: blog.quickStartType)
+        configureCardFrameView(for: blog)
 
         let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .dashboardCardItemTapped, properties:["type": DashboardCard.quickStart.rawValue])
 
@@ -49,6 +42,38 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
         BlogDashboardAnalytics.shared.track(.dashboardCardShown,
                           properties: ["type": DashboardCard.quickStart.rawValue],
                           blog: blog)
+    }
+
+    private func configureCardFrameView(for blog: Blog) {
+        switch blog.quickStartType {
+
+        case .newSite:
+            cardFrameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
+            configureOnEllipsisButtonTap(sourceRect: cardFrameView.ellipsisButton.frame)
+            cardFrameView.showHeader()
+
+        case .existingSite:
+            cardFrameView.configureButtonContainerStackView()
+            configureOnEllipsisButtonTap(sourceRect: cardFrameView.buttonContainerStackView.frame)
+            cardFrameView.hideHeader()
+
+        default:
+            break
+
+        }
+
+        cardFrameView.title = Strings.title(for: blog.quickStartType)
+    }
+
+    private func configureOnEllipsisButtonTap(sourceRect: CGRect) {
+        cardFrameView.onEllipsisButtonTap = { [weak self] in
+            guard let self = self,
+                  let viewController = self.viewController,
+                  let blog = self.blog else {
+                return
+            }
+            viewController.removeQuickStart(from: blog, sourceView: self.cardFrameView, sourceRect: sourceRect)
+        }
     }
 }
 
@@ -61,7 +86,6 @@ extension DashboardQuickStartCardCell {
         contentView.pinSubviewToAllEdges(cardFrameView, priority: Metrics.constraintPriority)
 
         cardFrameView.add(subview: tourStateView)
-        cardFrameView.hideHeader()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -47,6 +47,9 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
     private func configureCardFrameView(for blog: Blog) {
         switch blog.quickStartType {
 
+        case .undefined:
+            fallthrough
+
         case .newSite:
             cardFrameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
             configureOnEllipsisButtonTap(sourceRect: cardFrameView.ellipsisButton.frame)
@@ -56,9 +59,6 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
             cardFrameView.configureButtonContainerStackView()
             configureOnEllipsisButtonTap(sourceRect: cardFrameView.buttonContainerStackView.frame)
             cardFrameView.hideHeader()
-
-        default:
-            break
 
         }
 
@@ -98,9 +98,11 @@ extension DashboardQuickStartCardCell {
 
         static func title(for quickStartType: QuickStartType) -> String? {
             switch quickStartType {
+            case .undefined:
+                fallthrough
             case .newSite:
                 return nextSteps
-            default:
+            case .existingSite:
                 return nil
             }
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/NewQuickStartChecklistView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/NewQuickStartChecklistView.swift
@@ -221,7 +221,7 @@ extension NewQuickStartChecklistView {
 extension NewQuickStartChecklistView {
 
     private enum Metrics {
-        static let mainStackViewInsets = UIEdgeInsets(top: 0, left: 16, bottom: 8, right: 24).flippedForRightToLeft
+        static let mainStackViewInsets = UIEdgeInsets(top: 16, left: 16, bottom: 8, right: 16).flippedForRightToLeft
         static let verticalStackViewWidthMultiplier = 3.0 / 5.0
         static let verticalStackViewSpacingPortrait = 12.0
         static let verticalStackViewSpacingLandscape = 16.0

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -22,6 +22,6 @@ import UIKit
     }
 
     private enum Metrics {
-        static let margins = UIEdgeInsets(top: 16, left: 8, bottom: 8, right: 8)
+        static let margins = UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 8)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -25,7 +25,7 @@ import UIKit
         static func margins(for quickStartType: QuickStartType) -> UIEdgeInsets {
             switch quickStartType {
             case .undefined:
-                return .zero
+                fallthrough
             case .newSite:
                 return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
             case .existingSite:

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartCell.swift
@@ -10,7 +10,7 @@ import UIKit
 
     @objc func configure(blog: Blog, viewController: BlogDetailsViewController) {
         contentView.addSubview(tourStateView)
-        contentView.pinSubviewToAllEdges(tourStateView, insets: Metrics.margins)
+        contentView.pinSubviewToAllEdges(tourStateView, insets: Metrics.margins(for: blog.quickStartType))
 
         selectionStyle = .none
 
@@ -22,6 +22,16 @@ import UIKit
     }
 
     private enum Metrics {
-        static let margins = UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 8)
+        static func margins(for quickStartType: QuickStartType) -> UIEdgeInsets {
+            switch quickStartType {
+            case .undefined:
+                return .zero
+            case .newSite:
+                return UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+            case .existingSite:
+                return UIEdgeInsets(top: 0, left: 8, bottom: 8, right: 8)
+            }
+
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartChecklistHeader.xib
@@ -5,7 +5,6 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -30,7 +29,6 @@
                 </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
-            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="eef-Zj-N7X" secondAttribute="bottom" id="GNl-cm-DIY"/>
                 <constraint firstItem="eef-Zj-N7X" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="Wxm-C7-bR4"/>
@@ -47,9 +45,4 @@
             <point key="canvasLocation" x="139" y="109"/>
         </view>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>


### PR DESCRIPTION
## Context
- In https://github.com/wordpress-mobile/WordPress-iOS/pull/18856 we reverted https://github.com/wordpress-mobile/WordPress-iOS/pull/18747, as we didn't have enough time to investigate / fix the root issue for some UI issues found during the CfT for WPiOS 20.0 
- This PR adds back the changes we made in https://github.com/wordpress-mobile/WordPress-iOS/pull/18747 and also fixes the issues mentioned on the CfT
  - Incorrect chevron icon aspect ratio (ref: p5T066-3gF-p2#comment-12523)
  - Ellipsis icon being displayed for the old tours (ref: p5T066-3gF-p2#comment-12533

## How to test


### With Menu as default

1. Run the app
2. Enable QS for existing site
3. ✅ Check that it appears correctly and it can be dismissed
4. Enable QS for new site
4. ✅ Check that it appears correctly and it can be dismissed 

### With Home as default

1. Run the app
2. Enable QS for existing site
3. ✅ Check that it appears correctly and it can be dismissed
4. Enable QS for new site
4. ✅ Check that it appears correctly and it can be dismissed
5. ✅ Check that the chevron icon on card appears correctly

Tab | QS for New Site | QS for Existing Site
-- | -- | --
Home | <img src="https://user-images.githubusercontent.com/6711616/174100630-8334e4e3-fa49-4a77-b11d-a73432a4ad7a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/174100685-cdc2bea2-984a-4d37-b227-2657a00695ee.png" width=200>
Menu | <img src="https://user-images.githubusercontent.com/6711616/174100728-d6656a66-f1b0-470b-87b7-80459cf5cbc2.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/174100777-c5ad6ee2-5664-418b-8796-9879b1eadae6.png" width=200>


## Regression Notes
1. Potential unintended areas of impact
- Quick Start cards on dashboard / menu

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested manually

3. What automated tests I added (or what prevented me from doing so)
- N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.