### PR TITLE
[RNMobile] Update "testAddGalleryBlock" test case to reflect expected content for v1 of Gallery block

### DIFF
--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -83,6 +83,6 @@ class EditorGutenbergTests: XCTestCase {
             .enterTextInTitle(text: title)
             .addParagraphBlock(withText: content)
             .addImageGallery()
-            .verifyContentStructure(blocks: 5, words: content.components(separatedBy: " ").count, characters: content.count)
+            .verifyContentStructure(blocks: 2, words: content.components(separatedBy: " ").count, characters: content.count)
     }
 }


### PR DESCRIPTION
## Description

After we re-introduced support for v1 of the Gallery block in https://github.com/WordPress/gutenberg/pull/41533, [the `testAddGalleryBlock` test case](https://github.com/wordpress-mobile/WordPress-iOS/blob/9ffcc0d8879405b7a5ed9de3f8be25e37d310b57/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift#L81-L87) within iOS' `EditorGutenbergTests` file began to fail with the following error:

```
✗ testAddGalleryBlock, XCTAssertEqual failed: ("Content Structure Blocks: 2, Words: 5, Characters: 24") is not equal to ("Content Structure Blocks: 5, Words: 5, Characters: 24") - Unexpected post structure.
```

The reason for this is that v1 is used by default when no API is mocked. Unlike v2 of the Gallery block, v1 doesn't use additional inner blocks when images are used. As additional blocks _aren't_ added to the editor when images are uploaded to v1 of the block, the number of expected blocks has changed:

* **Gallery block v2**: A Paragraph block + a Gallery block + 3 Image blocks = an expected 5 blocks.
* **Gallery block v1**: A Paragraph block + a Gallery block = an expected 2 blocks.

This PR [updates `verifyContentStructure`](https://github.com/wordpress-mobile/WordPress-iOS/blob/befdcbed0634b57ba6e68c657699e29fcbd6e9fb/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift#L86) to reflect the fact we currently only expected 2 blocks when `testAddGalleryBlock` runs.

In the future, we may seek to mock an API request and update the test case to expect v2 of the Gallery block. We're going with this simpler solution for now in order to move forward with others PRs and address the failing test.

## Testing

To test: Verify that all tests pass on this PR, with no failures.

## Regression Notes
1. Potential unintended areas of impact

I'm not aware of other areas of the code base that could be impacted by this change, though it's possible that other tests may rely on the `testAddGalleryBlock` case somehow. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Ensured all tests pass for this PR.

3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
