### PR TITLE
Blogging Prompts: Add 'Undo' notification when skipping a prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressShared
 import WordPressUI
+import WordPressFlux
 
 class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
@@ -475,6 +476,11 @@ private extension DashboardPromptsCardCell {
         WPAnalytics.track(.promptsDashboardCardMenuSkip)
         saveSkippedPromptForSite()
         presenterViewController?.reloadCardsLocally()
+        let notice = Notice(title: Strings.promptSkippedTitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { [weak self] _ in
+            self?.clearSkippedPromptForSite()
+            self?.presenterViewController?.reloadCardsLocally()
+        }
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
     }
 
     func removeMenuTapped() {
@@ -521,6 +527,8 @@ private extension DashboardPromptsCardCell {
         static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users "
                                                               + "that answered the blogging prompt.")
         static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
+        static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
+        static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")
     }
 
     struct Style {


### PR DESCRIPTION
Resolves: #18899

## Description

Adds an undo notification when skipping a prompt.

## Testing

To test:

- Use the Jetpack app
- Login if necessary and navigate to the 'My Site' tab
- On the prompts dashboard card, tap on the context menu `...`
- Tap on `Skip this prompt`
- Verify a notification appears with the correct title and button text
  - **Title:** Prompt skipped
  - **Button title:** Undo
- Tap on `Undo`
- Verify the prompts dashboard card is displayed again

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
