### PR TITLE
Blogging Prompts: Add left and right margins to prompts title in dashboard card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -91,6 +91,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         stackView.alignment = .center
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.spacing = Constants.spacing
+        stackView.layoutMargins = Constants.containerMargins
+        stackView.isLayoutMarginsRelativeArrangement = true
         return stackView
     }()
 
@@ -111,8 +113,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(promptLabel)
-        let insets = UIEdgeInsets(top: Constants.spacing, left: Constants.titleMarginSpacing, bottom: 0, right: Constants.titleMarginSpacing)
-        view.pinSubviewToAllEdges(promptLabel, insets: insets)
+        view.pinSubviewToAllEdges(promptLabel, insets: UIEdgeInsets(top: Constants.spacing, left: 0, bottom: 0, right: 0))
 
         return view
     }()
@@ -536,7 +537,7 @@ private extension DashboardPromptsCardCell {
         static let spacing: CGFloat = 12
         static let answeredButtonsSpacing: CGFloat = 16
         static let answerInfoViewSpacing: CGFloat = 6
-        static let titleMarginSpacing: CGFloat = 16
+        static let containerMargins = UIEdgeInsets(top: 0, left: 16, bottom: 0, right: 16)
         static let maxAvatarCount = 3
         static let exampleAnswerCount = 19
         static let cardIconSize = CGSize(width: 18, height: 18)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -111,7 +111,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(promptLabel)
-        view.pinSubviewToAllEdges(promptLabel, insets: .init(top: Constants.spacing, left: 0, bottom: 0, right: 0))
+        let insets = UIEdgeInsets(top: Constants.spacing, left: Constants.titleMarginSpacing, bottom: 0, right: Constants.titleMarginSpacing)
+        view.pinSubviewToAllEdges(promptLabel, insets: insets)
 
         return view
     }()
@@ -535,6 +536,7 @@ private extension DashboardPromptsCardCell {
         static let spacing: CGFloat = 12
         static let answeredButtonsSpacing: CGFloat = 16
         static let answerInfoViewSpacing: CGFloat = 6
+        static let titleMarginSpacing: CGFloat = 16
         static let maxAvatarCount = 3
         static let exampleAnswerCount = 19
         static let cardIconSize = CGSize(width: 18, height: 18)


### PR DESCRIPTION
## Description

Adds some margins to the left and right sides of the prompt's label on the dashboard card.

## Testing

To test:

- Use the Jetpack app
- Login if necessary and navigate to the 'My Site' tab
- Verify the margins on the card

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
