### PR TITLE
Blogging Prompts: Hide 'create' and 'next' cards when prompts card is displayed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -46,16 +46,10 @@ enum DashboardCard: String, CaseIterable {
         switch self {
         case .quickStart:
             return QuickStartTourGuide.quickStartEnabled(for: blog) && mySiteSettings.defaultSection == .dashboard
-        case .draftPosts:
-            fallthrough
-        case .scheduledPosts:
-            fallthrough
-        case .nextPost:
-            fallthrough
-        case .createPost:
-            fallthrough
-        case .todaysStats:
-            return self.shouldShowRemoteCard(apiResponse: apiResponse)
+        case .draftPosts, .scheduledPosts, .todaysStats:
+            return shouldShowRemoteCard(apiResponse: apiResponse)
+        case .nextPost, .createPost:
+            return !DashboardPromptsCardCell.shouldShowCard(for: blog) && shouldShowRemoteCard(apiResponse: apiResponse)
         case .prompts:
             return DashboardPromptsCardCell.shouldShowCard(for: blog)
         case .ghost:


### PR DESCRIPTION
Resolves: #18901

## Description

Hides the "create new" and "next" cards when the prompts dashboard card is displayed.

## Testing

To test:

- Use the Jetpack app
- Login if necessary and navigate to the 'My Site' tab
- Verify the create new/next dashboard cards are hidden if the prompts card is visible
- Select a site which previously had one of the cards
- On the prompts card, open the context menu `...`
- Tap on `Skip this prompt`
- Verify the card appears again after the prompts card is hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
