### PR TITLE
[People Management] Fix crash on iPad

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [***] [Jetpack-only] Introducing blogging prompts. Build a writing habit and support creativity with a periodic prompt for inspiration. [#18860]
 * [**] Follow Conversation: A tooltip has been added to highlight the follow conversation feature. [#18848]
 * [*] [internal] Block Editor: Bump react-native-gesture-handler to version 2.3.2. [#18742]
+* [*] People Management: Fixed a crash that can occur when loading the People view. [#18907]
 
 20.0
 -----

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -119,6 +119,11 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
     // MARK: UITableViewDataSource
 
     override func numberOfSections(in tableView: UITableView) -> Int {
+        guard !isInitialLoad else {
+            // Until the initial load has been completed, no data should be rendered in the table.
+            return 0
+        }
+
         return resultsController.sections?.count ?? 0
     }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -136,6 +136,12 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
             fatalError()
         }
 
+        guard let sections = resultsController.sections, sections[indexPath.section].numberOfObjects > indexPath.row else {
+            DDLogError("Error: PeopleViewController table tried to render a cell that didn't exist in Core Data")
+            cell.isHidden = true
+            return cell
+        }
+
         let person = personAtIndexPath(indexPath)
         let role = self.role(person: person)
         let viewModel = PeopleCellViewModel(person: person, role: role)


### PR DESCRIPTION
Fixes #17719

Ref: p4a5px-2Pl-p2

## Description

There appears to be a race where:
1. The table view is initialized with the number of existing objects in Core Data.
2. [Core Data is wiped](https://github.com/wordpress-mobile/WordPress-iOS/blob/779d17b297caba127853df1a290a88c9039a8e60/WordPress/Classes/ViewRelated/People/PeopleViewController.swift#L176).
3. As the table view renders its cells it tries to access objects that no longer exist.

This PR adds two safeguards:
1. Until `isInitialLoad` is cleared, don't render any cells if asked.
2. If trying to render a cell using an invalid index path, return a hidden cell.

With item 1 in place I'm doubtful item 2 will occur, but it's there to be extra safe.

## Note

Interestingly I could _not_ reproduce the crash, even without these fixes, when running from the 20.1 release branch.

## Crash reproduction

To see if your device is susceptible to crashing, load WordPress 20.0.1 from the App Store and follow the testing steps expecting a crash at step 7. I've only been able to reproduce it using an iPad Pro.

### Video of crash:

https://user-images.githubusercontent.com/2092798/174352365-bc5a9d0f-96c6-40b4-8f71-b2e0de74c5dc.mp4

## Testing

All testing can be done on a .com Simple site. 

**Prerequisites:**
- iPad Pro with WPiOS in full screen
- A site with at least two Users added (a User has the role of Administrator, Editor, Author, or Contributor)
- **Important:** Only the alpha and release builds seem to crash (presumably due to faster execution). A debug build running in Simulator or on a physical device will probably not crash. [Use the alpha build from this PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/18907#issuecomment-1159210291).

**Steps:**
1. Load WPiOS in full screen mode
2. Tap People
3. Observe that the users for the site load (there should be at least two, see prerequisites)
4. Tap another view such (e.g. Sharing, Menus, Themes)
5. Tap People
6. Repeat steps 5 and 6
7. Expect no crashes

## Regression Notes
1. Potential unintended areas of impact
    - Regressions to the People view - managing users, syncing changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing on iPad and iPhone.

3. What automated tests I added (or what prevented me from doing so)
    - None. We should consider moving to an approach in the future where the view is decoupled from the data syncing.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.