### PR TITLE
[UITII] Bumped ScreenObject dependency version to 0.2.1

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
-          "version": "0.2.0"
+          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
+          "revision": "3edfe86135a11d2407131af75310303c30dcb035",
+          "version": null
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
-          "version": "0.2.0"
+          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
+          "revision": "9a18de86f8db446e8e56e538588fd3158799f8be",
+          "version": null
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "3f57faf033e87dd50f111165286279eece20d1d1",
-          "version": null
+          "branch": null,
+          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
+          "version": "0.2.1"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,9 +23,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "9a18de86f8db446e8e56e538588fd3158799f8be",
-          "version": null
+          "branch": null,
+          "revision": "2d65beae47cdcaaf21703ce1b321f382fe0d0730",
+          "version": "0.2.0"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "fec717878387245f89239cd255e11e18e779785c",
+          "revision": "3f57faf033e87dd50f111165286279eece20d1d1",
           "version": null
         }
       },

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "3edfe86135a11d2407131af75310303c30dcb035",
+          "revision": "5dee6f7b8b8abfdf3f872db225b1fef6c938c4fa",
           "version": null
         }
       },

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": "UITII-reverse-waitForScreen-with-isLoaded",
-          "revision": "5dee6f7b8b8abfdf3f872db225b1fef6c938c4fa",
+          "revision": "fec717878387245f89239cd255e11e18e779785c",
           "version": null
         }
       },

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26191,8 +26191,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				branch = "UITII-reverse-waitForScreen-with-isLoaded";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26191,8 +26191,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = "UITII-reverse-waitForScreen-with-isLoaded";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26191,8 +26191,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = "UITII-reverse-waitForScreen-with-isLoaded";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
Now, once Automattic/ScreenObject/pull/11 has been merged, it's time to bump the `ScreenObject` dependency version.
No other changes to UI tests are needed in case of WPiOS.
### Test:
- You should see that now it takes ~33 minutes to run UI tests on CI, instead of ~40 min previously.