### PR TITLE
Remove "(missing)" build targets from multiple scheme

### DIFF
--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Alpha.xcscheme
@@ -52,36 +52,6 @@
                </Test>
             </SkippedTests>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "931CFFD01EBCB016005E6BB4"
-               BuildableName = "WordPressComStatsiOSTests.xctest"
-               BlueprintName = "WordPressComStatsiOSTests"
-               ReferencedContainer = "container:../WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9368C7831EC5EF1B0092CE8E"
-               BuildableName = "WordPressKitTests.xctest"
-               BlueprintName = "WordPressKitTests"
-               ReferencedContainer = "container:../WordPressKit/WordPressKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "829DD1461EC9EED200AB8C12"
-               BuildableName = "WordPressSharedTests.xctest"
-               BlueprintName = "WordPressSharedTests"
-               ReferencedContainer = "container:../WordPressShared/WordPressShared.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress Internal.xcscheme
@@ -52,16 +52,6 @@
                </Test>
             </SkippedTests>
          </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "931CFFD01EBCB016005E6BB4"
-               BuildableName = "WordPressComStatsiOSTests.xctest"
-               BlueprintName = "WordPressComStatsiOSTests"
-               ReferencedContainer = "container:WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPress.xcscheme
@@ -20,20 +20,6 @@
                ReferencedContainer = "container:WordPress.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "829DD1461EC9EED200AB8C12"
-               BuildableName = "WordPressSharedTests.xctest"
-               BlueprintName = "WordPressSharedTests"
-               ReferencedContainer = "container:../WordPressShared/WordPressShared.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -68,56 +54,6 @@
                BuildableName = "WordPressTest.xctest"
                BlueprintName = "WordPressTest"
                ReferencedContainer = "container:WordPress.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "931CFFD01EBCB016005E6BB4"
-               BuildableName = "WordPressComStatsiOSTests.xctest"
-               BlueprintName = "WordPressComStatsiOSTests"
-               ReferencedContainer = "container:../WordPressComStatsiOS/WordPressComStatsiOS.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "829DD1461EC9EED200AB8C12"
-               BuildableName = "WordPressSharedTests.xctest"
-               BlueprintName = "WordPressSharedTests"
-               ReferencedContainer = "container:../WordPressShared/WordPressShared.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9368C7831EC5EF1B0092CE8E"
-               BuildableName = "WordPressKitTests.xctest"
-               BlueprintName = "WordPressKitTests"
-               ReferencedContainer = "container:../WordPressKit/WordPressKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B59DCB64202B146D00BEBD8A"
-               BuildableName = "WordPressUIKitTests.xctest"
-               BlueprintName = "WordPressUIKitTests"
-               ReferencedContainer = "container:../WordPressUIKit/WordPressUIKit.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "B5ED78FC207E976500A8FD8C"
-               BuildableName = "WordPressAuthenticatorTests.xctest"
-               BlueprintName = "WordPressAuthenticatorTests"
-               ReferencedContainer = "container:../WordPressAuthenticator/WordPressAuthenticator.xcodeproj">
             </BuildableReference>
          </TestableReference>
       </Testables>


### PR DESCRIPTION
Here's what this means for the WordPress scheme:

<table>
<tr>
	<td>Before</td>
	<td>After</td>
</tr>
<tr>
	<td><img width="931" alt="Screen Shot 2022-06-21 at 7 33 11 pm" src="https://user-images.githubusercontent.com/1218433/174771968-75b46098-0493-486f-ae3f-f552a79505b2.png"></td>
	<td><img width="922" alt="Screen Shot 2022-06-21 at 7 50 56 pm" src="https://user-images.githubusercontent.com/1218433/174772075-deaf47fc-664a-45aa-9173-19c5565939f9.png"></td>
</tr>
</table>

## Testing
Nothing to test because none of those build targets were there to begin with.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
