### PR TITLE
Tooltip presenter offset improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -62,7 +62,12 @@ final class TooltipPresenter {
     }
 
     private var spotlightVerticalBuffer: CGFloat {
-        totalVerticalBuffer + Constants.spotlightViewBufferHeight
+        switch tooltipOrientation() {
+        case .top:
+            return totalVerticalBuffer - Constants.spotlightViewBufferHeight
+        case .bottom:
+            return totalVerticalBuffer + Constants.spotlightViewBufferHeight
+        }
     }
 
     init(containerView: UIView,
@@ -247,7 +252,7 @@ final class TooltipPresenter {
 
         var constraints = [
             spotlightView.leadingAnchor.constraint(
-                equalTo: containerView.safeAreaLayoutGuide.leadingAnchor,
+                equalTo: containerView.leadingAnchor,
                 constant: arrowOffsetX() + tooltip.frame.minX - Constants.spotlightViewRadius
             )
         ]
@@ -256,27 +261,44 @@ final class TooltipPresenter {
 
         switch target {
         case .view(let targetView):
+            verticalConstraint = spotlightVerticalConstraint(spotlightView, targetView: targetView)
+        case .point(let targetPoint):
+            verticalConstraint = spotlightVerticalConstraint(spotlightView, targetPoint: targetPoint)
+        }
+
+        constraints.append(verticalConstraint)
+
+        return constraints
+    }
+
+    private func spotlightVerticalConstraint(
+        _ spotlightView: QuickStartSpotlightView,
+        targetView: UIView) -> NSLayoutConstraint {
             switch tooltipOrientation() {
             case .bottom:
-                verticalConstraint = targetView.topAnchor.constraint(
-                    equalTo: spotlightView.bottomAnchor,
+                return spotlightView.topAnchor.constraint(
+                    equalTo: targetView.topAnchor,
                     constant: spotlightVerticalBuffer
                 )
             case .top:
-                verticalConstraint = spotlightView.topAnchor.constraint(
+                return spotlightView.topAnchor.constraint(
                     equalTo: targetView.bottomAnchor,
                     constant: spotlightVerticalBuffer
                 )
             }
-        case .point(let targetPoint):
+        }
+
+    private func spotlightVerticalConstraint(
+        _ spotlightView: QuickStartSpotlightView,
+        targetPoint: (() -> CGPoint)) -> NSLayoutConstraint {
             switch tooltipOrientation() {
             case .bottom:
-                verticalConstraint = spotlightView.bottomAnchor.constraint(
+                return spotlightView.bottomAnchor.constraint(
                     equalTo: containerView.topAnchor,
                     constant: targetPoint().y + spotlightVerticalBuffer
                 )
             case .top:
-                verticalConstraint = spotlightView.bottomAnchor.constraint(
+                return spotlightView.bottomAnchor.constraint(
                     equalTo: containerView.topAnchor,
                     constant: targetPoint().y
                     + spotlightVerticalBuffer
@@ -285,10 +307,6 @@ final class TooltipPresenter {
             }
         }
 
-        constraints.append(verticalConstraint)
-
-        return constraints
-    }
 
     @objc private func resetTooltipAndShow() {
         UIView.animate(

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -194,7 +194,7 @@ final class TooltipPresenter {
             tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
         ]
 
-        let verticalExtraSpotlightOffset = 14
+        let verticalExtraSpotlightOffset: CGFloat = 14
 
         switch target {
         case .view(let targetView):

--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -62,10 +62,10 @@ final class TooltipPresenter {
     }
 
     private var spotlightVerticalBuffer: CGFloat {
-        switch tooltipOrientation() {
-        case .top:
-            return totalVerticalBuffer - Constants.spotlightViewBufferHeight
-        case .bottom:
+        switch target {
+        case .view:
+            return totalVerticalBuffer
+        case .point:
             return totalVerticalBuffer + Constants.spotlightViewBufferHeight
         }
     }
@@ -194,18 +194,20 @@ final class TooltipPresenter {
             tooltip.centerXAnchor.constraint(equalTo: containerView.centerXAnchor, constant: extraArrowOffsetX())
         ]
 
+        let verticalExtraSpotlightOffset = 14
+
         switch target {
         case .view(let targetView):
             switch tooltipOrientation() {
             case .bottom:
                 tooltipTopConstraint = targetView.topAnchor.constraint(
                     equalTo: tooltip.bottomAnchor,
-                    constant: totalVerticalBuffer
+                    constant: spotlightVerticalBuffer + verticalExtraSpotlightOffset
                 )
             case .top:
                 tooltipTopConstraint = tooltip.topAnchor.constraint(
                     equalTo: targetView.bottomAnchor,
-                    constant: totalVerticalBuffer
+                    constant: spotlightVerticalBuffer + verticalExtraSpotlightOffset
                 )
             }
         case .point(let targetPoint):
@@ -216,11 +218,10 @@ final class TooltipPresenter {
                     constant: targetPoint().y + totalVerticalBuffer
                 )
             case .top:
-                tooltipTopConstraint = tooltip.bottomAnchor.constraint(
+                tooltipTopConstraint = tooltip.topAnchor.constraint(
                     equalTo: containerView.topAnchor,
                     constant: targetPoint().y
-                    + totalVerticalBuffer
-                    + tooltip.size().height
+                    + spotlightVerticalBuffer + verticalExtraSpotlightOffset
                 )
             }
         }
@@ -276,14 +277,14 @@ final class TooltipPresenter {
         targetView: UIView) -> NSLayoutConstraint {
             switch tooltipOrientation() {
             case .bottom:
-                return spotlightView.topAnchor.constraint(
-                    equalTo: targetView.topAnchor,
+                return targetView.topAnchor.constraint(
+                    equalTo: spotlightView.topAnchor,
                     constant: spotlightVerticalBuffer
                 )
             case .top:
-                return spotlightView.topAnchor.constraint(
-                    equalTo: targetView.bottomAnchor,
-                    constant: spotlightVerticalBuffer
+                return targetView.bottomAnchor.constraint(
+                    equalTo: spotlightView.topAnchor,
+                    constant: Constants.spotlightViewRadius
                 )
             }
         }
@@ -295,14 +296,14 @@ final class TooltipPresenter {
             case .bottom:
                 return spotlightView.bottomAnchor.constraint(
                     equalTo: containerView.topAnchor,
-                    constant: targetPoint().y + spotlightVerticalBuffer
-                )
-            case .top:
-                return spotlightView.bottomAnchor.constraint(
-                    equalTo: containerView.topAnchor,
                     constant: targetPoint().y
                     + spotlightVerticalBuffer
-                    + tooltip.size().height
+                )
+            case .top:
+                return spotlightView.topAnchor.constraint(
+                    equalTo: containerView.topAnchor,
+                    constant: targetPoint().y
+                    + totalVerticalBuffer
                 )
             }
         }


### PR DESCRIPTION
This PR adjusts the spotlight and tooltip offsets for the 4 possible cases: Below a `targetView`, above a `targetView`, below a `targetPoint` and above a `targetPoint`. Now they are displayed with uniform offsets.

To test:
Add the following snippet to `viewDidAppear` in `ReaderDetailViewController`. Keep in mind that `viewDidAppear` will be invoked on various cases so it could cause the tooltip to be displayed more than once. That's irrelevant to our test though.

```Swift
        let dummySquare = UIView()
        dummySquare.backgroundColor = .magenta
        dummySquare.translatesAutoresizingMaskIntoConstraints = false
        dummySquare.layer.cornerRadius = 4
        view.addSubview(dummySquare)
        NSLayoutConstraint.activate([
            dummySquare.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 270),
            dummySquare.topAnchor.constraint(equalTo: view.topAnchor, constant: 280),
            dummySquare.heightAnchor.constraint(equalToConstant: 35),
            dummySquare.widthAnchor.constraint(equalToConstant: 35)
        ])

        let tooltip = Tooltip()
        tooltip.title = "What a beautiful Tooltip!"
        tooltip.message = "Tooltip is a way of life, a way of thinking..."
        tooltip.primaryButtonTitle = "I understand"

        _tooltipPresenter = TooltipPresenter(
            containerView: view,
            tooltip: tooltip,
            target: .view(dummySquare),
            shouldShowSpotlightView: true
        )

        _tooltipPresenter?.tooltipVerticalPosition = .above

        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
            self._tooltipPresenter?.showTooltip()
        }

        featureHighlightStore.didDismissTooltip = false
        featureHighlightStore.followConversationTooltipCounter = 0

```
Also retain the presenter as:
```Swift
    var _tooltipPresenter: TooltipPresenter?
```
Please do search for `tooltipVerticalPosition = .above` in the same file (there should be 2 matches including the one from above snippet) and alternate the enum cases between `above` and `below` to test all cases. This will change the placing of the tooltip.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
