### PR TITLE
Blogging Prompts: Allow feature intro screen without site picker

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -492,7 +492,10 @@ private extension DashboardPromptsCardCell {
 
     func learnMoreTapped() {
         WPAnalytics.track(.promptsDashboardCardMenuLearnMore)
-        presenterViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
+        guard let presenterViewController = presenterViewController else {
+            return
+        }
+        BloggingPromptsIntroductionPresenter(interactionType: .actionable(blog: blog)).present(from: presenterViewController)
     }
 
     // Fallback context menu implementation for iOS 13.

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/WPTabBarController+BloggingPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/WPTabBarController+BloggingPrompt.swift
@@ -38,21 +38,6 @@ extension WPTabBarController {
         bloggingPromptCoordinator.showPromptAnsweringFlow(from: viewController, promptID: promptID, blog: blog, source: source)
     }
 
-    @objc func showBloggingPromptsFeatureIntroduction() {
-        guard FeatureFlag.bloggingPrompts.enabled,
-              let blog = currentOrLastBlog(),
-              blog.isAccessibleThroughWPCom(),
-              presentedViewController == nil,
-              selectedViewController?.presentedViewController == nil,
-              !UserDefaults.standard.bool(forKey: Constants.featureIntroDisplayedUDKey)
-        else {
-            return
-        }
-
-        UserDefaults.standard.set(true, forKey: Constants.featureIntroDisplayedUDKey)
-        BloggingPromptsIntroductionPresenter().present(from: selectedViewController ?? self)
-    }
-
 }
 
 private extension WPTabBarController {

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureIntroduction.swift
@@ -9,8 +9,9 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
     private var interactionType: BloggingPromptsFeatureIntroduction.InteractionType
 
     enum InteractionType {
-        // Two buttons are displayed, both perform an action.
-        case actionable
+        // Two buttons are displayed, both perform an action. Shows a site picker
+        // if `blog` is `nil` and user has multiple sites.
+        case actionable(blog: Blog?)
         // One button is displayed, which only dismisses the view.
         case informational
 
@@ -82,7 +83,7 @@ class BloggingPromptsFeatureIntroduction: FeatureIntroductionViewController {
 extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
 
     func primaryActionSelected() {
-        guard interactionType == .actionable else {
+        guard case .actionable = interactionType else {
             WPAnalytics.track(.promptsIntroductionModalGotIt)
             super.closeButtonTapped()
             return
@@ -93,7 +94,7 @@ extension BloggingPromptsFeatureIntroduction: FeatureIntroductionDelegate {
     }
 
     func secondaryActionSelected() {
-        guard interactionType == .actionable else {
+        guard case .actionable = interactionType else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -12,7 +12,7 @@ class BloggingPromptsIntroductionPresenter: NSObject {
     // MARK: - Properties
 
     private var presentingViewController: UIViewController?
-    private var interactionType: BloggingPromptsFeatureIntroduction.InteractionType = .actionable
+    private var interactionType: BloggingPromptsFeatureIntroduction.InteractionType
 
     private lazy var navigationController: UINavigationController = {
         let vc = BloggingPromptsFeatureIntroduction(interactionType: interactionType)
@@ -41,6 +41,16 @@ class BloggingPromptsIntroductionPresenter: NSObject {
     private lazy var bloggingPromptsService: BloggingPromptsService? = {
         return BloggingPromptsService(blog: blogToUse())
     }()
+
+    // MARK: - Init
+
+    init(interactionType: BloggingPromptsFeatureIntroduction.InteractionType = .actionable(blog: nil)) {
+        self.interactionType = interactionType
+        if case .actionable(let blog) = interactionType {
+            selectedBlog = blog
+        }
+        super.init()
+    }
 
     // MARK: - Present Feature Introduction
 
@@ -76,7 +86,7 @@ class BloggingPromptsIntroductionPresenter: NSObject {
 private extension BloggingPromptsIntroductionPresenter {
 
     func showSiteSelectorIfNeeded(completion: @escaping () -> Void) {
-        guard accountHasMultipleSites else {
+        guard accountHasMultipleSites, selectedBlog == nil else {
             completion()
             return
         }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -344,7 +344,10 @@ private extension CreateButtonCoordinator {
 
         promptsHeaderView.infoButtonHandler = { [weak self] in
             WPAnalytics.track(.promptsBottomSheetHelp)
-            self?.viewController?.presentedViewController?.present(BloggingPromptsFeatureIntroduction.navigationController(interactionType: .informational), animated: true)
+            guard let presentedViewController = self?.viewController?.presentedViewController else {
+                return
+            }
+            BloggingPromptsIntroductionPresenter(interactionType: .actionable(blog: blog)).present(from: presentedViewController)
         }
 
         return promptsHeaderView

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -631,7 +631,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self startWatchingQuickTours];
 
     [self trackTabAccessOnViewDidAppear];
-    [self showBloggingPromptsFeatureIntroduction];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
## Description

Makes the following changes:

- Allows the prompts feature introduction screen to be presented without needing a site picker. This was due to some feedback from the beta testing.
- Update the 'Learn more' action in the prompts dashboard card to show the actionable feature intro screen for the current blog
- Update the '?' action in the prompts compact card to show the actionable feature intro screen for the current blog

## Testing

To test:

- Fresh install of the Jetpack app
- Login and select a site
- On the feature introduction screen that pops up, verify:
  - Site picker appears when you tap on 'Try it now'
  - Site picker appears when you tap on 'Remind me'
- Dismiss the feature intro screen
- On the prompts dashboard card, tap on the context menu '...'
- Tap on 'Learn more'
- Verify:
  - Feature intro screen appears with two actions 'Try it now' & 'Remind me'
  - Tapping on either does **NOT** bring up a site picker
- Navigate back to the 'My Site' tab if necessary
- Tap on the floating action button '+'
- On the prompts header, tap on the '?'
- Verify:
  - Feature intro screen appears with two actions 'Try it now' & 'Remind me'
  - Tapping on either does **NOT** bring up a site picker
- Navigate back to the 'My Site' tab if necessary
- Go to the blogging reminders screen (Menu > Site Settings > Blogging Reminders)
- Tap on the '?' next to 'Include prompt'
- Verify:
  - Feature intro screen appears with a single action 'Got it'

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
