### PR TITLE
Rename `test_plan_path` to `xctestrun_path` to reflect its contents

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -62,11 +62,11 @@ platform :ios do
     # Find the referenced .xctestrun file based on its name
     build_products_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products')
 
-    test_plan_path = Dir.glob(File.join(build_products_path, '*.xctestrun')).select do |path|
+    xctestrun_path = Dir.glob(File.join(build_products_path, '*.xctestrun')).select do |path|
       path.include?(options[:name])
     end.first
 
-    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}") if test_plan_path.nil? || !File.exist?((test_plan_path))
+    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     run_tests(
       workspace: WORKSPACE_PATH,
@@ -75,7 +75,7 @@ platform :ios do
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,
       test_without_building: true,
-      xctestrun: test_plan_path,
+      xctestrun: xctestrun_path,
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
       reset_simulator: true,
       result_bundle: true


### PR DESCRIPTION
I noticed this inconsistency while working on https://github.com/wordpress-mobile/WordPress-iOS/pull/18872. Addressing it here to avoid noise in that PR.

Notice this PR base branch for ease of review, and the lack of auto-merge, since the whole point is not to crowd the diff 😄 

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
