### PR TITLE
Stats Revamp: Update copy

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureDescriptionView.swift
@@ -40,34 +40,14 @@ private extension StatsRevampV2FeatureDescriptionView {
         noteTextView.layer.cornerRadius = Style.noteCornerRadius
         noteTextView.layer.borderColor = Style.noteBorderColor
         noteTextView.textContainerInset = Style.noteInsets
-        configureNoteText()
-    }
-
-    func configureNoteText() {
-        let attributedString = NSMutableAttributedString()
-
-        // These attributed string styles cannot be stored statically (i.e. in the Style enum).
-        // They must be dynamic to resize correctly when the text size changes.
-
-        attributedString.append(.init(string: Strings.noteLabel,
-                                      attributes: [.foregroundColor: Style.textColor,
-                                                   .font: UIFont.preferredFont(forTextStyle: .caption1).bold()]))
-
-        attributedString.append(.init(string: " " + Strings.noteText,
-                                      attributes: [.foregroundColor: Style.textColor,
-                                                   .font: UIFont.preferredFont(forTextStyle: .caption1)]))
-
-        noteTextView.attributedText = attributedString
-
-        noteTextView.accessibilityElementsHidden = true
-        noteAccessibilityLabel.accessibilityLabel = Strings.noteTextAccessibilityLabel
+        noteTextView.font = UIFont.preferredFont(forTextStyle: .caption1)
+        noteTextView.textColor = Style.textColor
+        noteTextView.text = Strings.noteText
     }
 
     enum Strings {
-        static let featureDescription: String = NSLocalizedString("Insights help you understand how your content resonates with your audience with an overview of how it is performing and guidance to your next steps.", comment: "Description of updated Stats Insights displayed in the Feature Introduction view.")
-        static let noteLabel: String = NSLocalizedString("Note:", comment: "Label for the note displayed in the Feature Introduction view.")
-        static let noteText: String = NSLocalizedString("You can learn more about Insights at any time in My Site > Stats > Insights", comment: "Note displayed in the Feature Introduction view for the updated Stats Insights feature.")
-        static let noteTextAccessibilityLabel: String = NSLocalizedString("You can learn more about Insights at any time in My Site, Stats, Insights.", comment: "Accessibility hint for Note displayed in the Feature Introduction view for the updated Stats Insights feature.")
+        static let featureDescription: String = NSLocalizedString("Insights help you understand how your content is performing and what’s resonating with your audience.", comment: "Description of updated Stats Insights displayed in the Feature Introduction view.")
+        static let noteText: String = NSLocalizedString("Learn more in My Site > Stats > Insights.", comment: "Note displayed in the Feature Introduction view for the updated Stats Insights feature.")
     }
 
     enum Style {

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
@@ -10,7 +10,7 @@ class StatsRevampV2FeatureIntroduction: FeatureIntroductionViewController {
 
         let headerImage = UIImage(named: HeaderStyle.imageName)?.withTintColor(.clear)
 
-        super.init(headerTitle: HeaderStrings.title, headerSubtitle: "", headerImage: headerImage, featureDescriptionView: featureDescriptionView, primaryButtonTitle: ButtonStrings.showMe, secondaryButtonTitle: nil)
+        super.init(headerTitle: HeaderStrings.title, headerSubtitle: "", headerImage: headerImage, featureDescriptionView: featureDescriptionView, primaryButtonTitle: ButtonStrings.showMe, secondaryButtonTitle: ButtonStrings.remindMe)
 
         featureIntroductionDelegate = self
     }
@@ -30,6 +30,10 @@ class StatsRevampV2FeatureIntroduction: FeatureIntroductionViewController {
 extension StatsRevampV2FeatureIntroduction: FeatureIntroductionDelegate {
     func primaryActionSelected() {
         presenter?.primaryButtonSelected()
+    }
+
+    func secondaryActionSelected() {
+        presenter?.secondaryButtonSelected()
     }
 }
 
@@ -61,6 +65,7 @@ private extension StatsRevampV2FeatureIntroduction {
 
     enum ButtonStrings {
         static let showMe = NSLocalizedString("Try it now", comment: "Button title to take user to the new Stats Insights screen.")
+        static let remindMe = NSLocalizedString("Remind me later", comment: "Button title dismiss the Stats Insights feature announcement screen.")
     }
 
     enum HeaderStrings {

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2IntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2IntroductionPresenter.swift
@@ -24,4 +24,6 @@ class StatsRevampV2IntroductionPresenter: NSObject {
     // MARK: - Action Handling
 
     func primaryButtonSelected() { }
+
+    func secondaryButtonSelected() { }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -621,7 +621,7 @@ private extension SiteStatsInsightsViewModel {
     func createFollowerTotalInsightsRow() -> StatsTotalInsightsData {
         var data =  StatsTotalInsightsData.followersCount(insightsStore: insightsStore)
         if data.count < Constants.followersGuideLimit {
-            let guideText = NSLocalizedString("You can try leaving a comment as a gesture to encourage blog engagement in return to gain more followers.",
+            let guideText = NSLocalizedString("Commenting on other blogs is a great way to build attention and followers for your new site.",
                                               comment: "A tip displayed to the user in the stats section to help them gain more followers.")
             data.guideText = NSAttributedString(string: guideText)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -261,7 +261,7 @@ class StatsLatestPostSummaryInsightsCell: StatsBaseCell, LatestPostSummaryConfig
     }
 
     private enum TextContent {
-        static let noData = NSLocalizedString("stats.insights.latestPostSummary.noData", value: "You haven't published any posts yet. Check back later once you've published your first post!", comment: "Prompt shown in the 'Latest Post Summary' stats card if a user hasn't yet published anything.")
+        static let noData = NSLocalizedString("stats.insights.latestPostSummary.noData", value: "Check back when you’ve published your first post!", comment: "Prompt shown in the 'Latest Post Summary' stats card if a user hasn't yet published anything.")
         static let createPost = NSLocalizedString("stats.insights.latestPostSummary.createPost", value: "Create Post", comment: "Title of button shown in Stats prompting the user to create a post on their site.")
         static let publishDate = NSLocalizedString("stats.insights.latestPostSummary.publishDate", value: "Published %@", comment: "Publish date of a post displayed in Stats. Placeholder will be replaced with a localized relative time, e.g. 2 days ago")
         static let views = NSLocalizedString("stats.insights.latestPostSummary.views", value: "Views", comment: "Title for Views count in Latest Post Summary stats card.")

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -93,7 +93,7 @@ struct StatsTotalInsightsData {
     private enum TextContent {
         static let likesTotalGuideTextSingular = NSLocalizedString("Your latest post <a href=\"\">%@</a> has received <strong>one</strong> like.", comment: "A hint shown to the user in stats informing the user that one of their posts has received a like. The %@ placeholder will be replaced with the title of a post, and the HTML tags should remain intact.")
         static let likesTotalGuideTextPlural = NSLocalizedString("Your latest post <a href=\"\">%@</a> has received <strong>%d</strong> likes.", comment: "A hint shown to the user in stats informing the user how many likes one of their posts has received. The %@ placeholder will be replaced with the title of a post, the %d with the number of likes, and the HTML tags should remain intact.")
-        static let commentsTotalGuideText = NSLocalizedString("View your top contributors by tapping \"Week\".", comment: "A hint shown to the user in stats telling them how to navigate to the Comments detail view.")
+        static let commentsTotalGuideText = NSLocalizedString("Tap \"Week\" to see your top commenters.", comment: "A hint shown to the user in stats telling them how to navigate to the Comments detail view.")
     }
 }
 

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -7321,7 +7321,7 @@
 "stats.insights.latestPostSummary.likes" = "Likes";
 
 /* Prompt shown in the 'Latest Post Summary' stats card if a user hasn't yet published anything. */
-"stats.insights.latestPostSummary.noData" = "You haven't published any posts yet. Check back later once you've published your first post!";
+"stats.insights.latestPostSummary.noData" = "Check back when you’ve published your first post!";
 
 /* Publish date of a post displayed in Stats. Placeholder will be replaced with a localized relative time, e.g. 2 days ago */
 "stats.insights.latestPostSummary.publishDate" = "Published %@";


### PR DESCRIPTION
This PR updates some of the text used in the stats revamp, as per the document shared on Slack.

|   |   |   |   |
|---|---|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 17 05 42](https://user-images.githubusercontent.com/4780/175092647-d5a7bf0a-4bf1-4b10-86b4-d8aea8aec861.png) | <img alt="Screenshot 2022-06-22 at 17 04 44" src="https://user-images.githubusercontent.com/4780/175092672-2353ac52-c240-4c76-9b0f-616f679424c2.png"> |  <img alt="Screenshot 2022-06-22 at 17 04 40" src="https://user-images.githubusercontent.com/4780/175092676-abe44087-b472-432f-994c-fb785e63aa1e.png"> | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-22 at 17 46 41](https://user-images.githubusercontent.com/4780/175093039-2a4a0523-ec39-4e51-b230-c90dc24d44bc.png) |

**To test**

* Build and run
* Verify the strings shown above
* To access the feature announcement, you can: 
   * Add `@objc public` to `showStatsRevampV2FeatureIntroduction()` in `WPTabBarController+Swift`
   * In `viewDidAppear` of `WPTabBarController`, replace the call to `showBloggingPromptsFeatureIntroduction` with `showStatsRevampV2FeatureIntroduction`
   * Build and run

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
