### PR TITLE
[Tooling] Fix cache rebuild job

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -27,8 +27,7 @@ steps:
     command: |
       echo "--- :rubygems: Setting up Gems"
       # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      BUNDLER_VERSION=$(grep -A1 'BUNDLED WITH' Gemfile.lock | tail -n1)
-      gem install bundler:"${BUNDLER_VERSION}"
+      gem install bundler
 
       install_gems
 

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -27,7 +27,8 @@ steps:
     command: |
       echo "--- :rubygems: Setting up Gems"
       # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler:2.3.6
+      BUNDLER_VERSION=$(grep -A1 'BUNDLED WITH' Gemfile.lock | tail -n1)
+      gem install bundler:"${BUNDLER_VERSION}"
 
       install_gems
 


### PR DESCRIPTION
## Why?

The `cache-builder.yml` pipeline, which is triggered by a scheduled job every night to rebuild our caches for CocoaPods and Git, have been failing for more than a week due to a bundler version issue.

This failure is due to the same issue we've been observing in https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16, with a mismatching version of `bundler`.

## How?

Instead of updating the version of bundler to be installed in the `gem install bundler:$VERSION` command, I just replaced it to install the latest `bundler` (i.e. without specifying a version explicitly), like we do [in other pipelines](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/.buildkite/commands/build-for-testing.sh#L4-L5).

🤔   I'm starting to [wonder if we shouldn't just include that call to `gem install bundler` directly into `install_gems` to fix it everyone once and for all](https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16#issuecomment-1164105306)?

## To Test

I've manually triggered a build of the updated pipeline [here](https://buildkite.com/automattic/wordpress-ios/builds/8517) — using the "New Build" button on the Buildkite UI, choosing this branch, and specifying `PIPELINE="cache-builder.yml"` as part of the env vars under "Options".

If that build ends up green, we can consider this PR fixes the issue as expected.