### PR TITLE
Stats Revamp: UI and copy cleanup

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -25,7 +25,7 @@ class SiteStatsImmuTableRows {
                 segmentData: visitorsData.count,
                 segmentPrevData: visitorsData.prevCount,
                 difference: visitorsData.difference,
-                differenceText: viewsData.difference < 0 ? Constants.viewsLower : Constants.viewsHigher,
+                differenceText: visitorsData.difference < 0 ? Constants.visitorsLower : Constants.visitorsHigher,
                 date: periodDate,
                 period: StatsPeriodUnit.week,
                 analyticsStat: .statsOverviewTypeTappedViews,

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -13,7 +13,7 @@ class SiteStatsImmuTableRows {
                 segmentData: viewsData.count,
                 segmentPrevData: viewsData.prevCount,
                 difference: viewsData.difference,
-                differenceText: viewsData.difference < 0 ? Constants.viewsLower : Constants.viewsHigher,
+                differenceText: viewsDifferenceText(with: viewsData.count, difference: viewsData.difference),
                 date: periodDate,
                 period: StatsPeriodUnit.week,
                 analyticsStat: .statsOverviewTypeTappedViews,
@@ -25,7 +25,7 @@ class SiteStatsImmuTableRows {
                 segmentData: visitorsData.count,
                 segmentPrevData: visitorsData.prevCount,
                 difference: visitorsData.difference,
-                differenceText: visitorsData.difference < 0 ? Constants.visitorsLower : Constants.visitorsHigher,
+                differenceText: visitorsDifferenceText(with: visitorsData.count, difference: visitorsData.difference),
                 date: periodDate,
                 period: StatsPeriodUnit.week,
                 analyticsStat: .statsOverviewTypeTappedViews,
@@ -69,10 +69,28 @@ class SiteStatsImmuTableRows {
         return tableRows
     }
 
+    private static func viewsDifferenceText(with count: Int, difference: Int) -> String {
+        if difference == 0 && count != 0 {
+            return Constants.viewsNoDifference
+        }
+
+        return difference < 0 ? Constants.viewsLower : Constants.viewsHigher
+    }
+
+    private static func visitorsDifferenceText(with count: Int, difference: Int) -> String {
+        if difference == 0 && count != 0 {
+            return Constants.visitorsNoDifference
+        }
+
+        return difference < 0 ? Constants.visitorsLower : Constants.visitorsHigher
+    }
+
     enum Constants {
         static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
         static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
         static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
         static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
+        static let viewsNoDifference = NSLocalizedString("Your views this week are the same as the previous week.\n", comment: "Stats insights label shown when the user's view count is the same as the previous week.")
+        static let visitorsNoDifference = NSLocalizedString("Your visitors this week are the same as the previous week.\n", comment: "Stats insights label shown when the user's visitor count is the same as the previous week.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -109,7 +109,7 @@ class StatsBaseCell: UITableViewCell {
             showDetailsButton.isHidden = false
 
             switch statSection {
-            case .insightsViewsVisitors:
+            case .insightsViewsVisitors, .insightsLikesTotals, .insightsCommentsTotals:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleThisWeek, for: .normal)
             case .insightsFollowerTotals:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleViewMore, for: .normal)
@@ -159,12 +159,12 @@ class StatsBaseCell: UITableViewCell {
     enum Metrics {
         static let padding: CGFloat = 16.0
         static let stackSpacing: CGFloat = 8.0
-        static let buttonTitleInsets = UIEdgeInsets(top: 0, left: -12.0, bottom: 0, right: 12.0)
-        static let rtlButtonTitleInsets = UIEdgeInsets(top: 0, left: 12.0, bottom: 0, right: -12.0)
+        static let buttonTitleInsets = UIEdgeInsets(top: 0, left: -8.0, bottom: 0, right: 8.0)
+        static let rtlButtonTitleInsets = UIEdgeInsets(top: 0, left: 8.0, bottom: 0, right: -8.0)
     }
 
     private enum LocalizedText {
-        static let buttonTitleThisWeek = NSLocalizedString("This week", comment: "Title of a button. A call to action to view more stats for this week")
+        static let buttonTitleThisWeek = NSLocalizedString("Week", comment: "Title of a button. A call to action to view more stats for this week")
         static let buttonTitleViewMore = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         static let buttonAccessibilityHint = NSLocalizedString("Tap to view more stats for this week", comment: "VoiceOver accessibility hint, informing the user the button can be used to access more stats about this week")
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -231,17 +231,26 @@ class StatsTotalInsightsCell: StatsBaseCell {
         }
 
         guard let difference = difference,
-              let percentage = percentage else {
+              let percentage = percentage,
+              difference > 0 || count > 0 else {
                   comparisonLabel.isHidden = true
                   return
               }
 
-        let differenceText = difference > 0 ? TextContent.differenceHigher : TextContent.differenceLower
-        let differencePrefix = difference < 0 ? "" : "+"
-        let formattedText = String(format: differenceText, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
-
         comparisonLabel.isHidden = false
-        comparisonLabel.attributedText = attributedDifferenceString(formattedText, highlightAttributes: [.foregroundColor: differenceTextColor(for: difference)])
+        let differencePrefix = difference < 0 ? "" : "+"
+
+        let differenceText: String = {
+            if difference > 0 {
+                return String(format: TextContent.differenceHigher, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
+            } else if difference < 0 {
+                return String(format: TextContent.differenceLower, differencePrefix, difference.abbreviatedString(), percentage.abbreviatedString())
+            } else {
+                return TextContent.differenceSame
+            }
+        }()
+
+        comparisonLabel.attributedText = attributedDifferenceString(differenceText, highlightAttributes: [.foregroundColor: differenceTextColor(for: difference)])
     }
 
     private func addTipEmojiToGuide(_ guideText: NSAttributedString) -> NSAttributedString {
@@ -269,13 +278,13 @@ class StatsTotalInsightsCell: StatsBaseCell {
         return difference < 0 ? WPStyleGuide.Stats.neutralColor : WPStyleGuide.Stats.positiveColor
     }
 
-    private func attributedDifferenceString(_ string: String, highlightAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString? {
+    private func attributedDifferenceString(_ string: String, highlightAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
         let defaultAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .subheadline), NSAttributedString.Key.foregroundColor: UIColor.textSubtle]
 
         guard let firstIndex = string.firstIndex(of: TextContent.differenceDelimiter),
               let lastIndex = string.lastIndex(of: TextContent.differenceDelimiter),
               firstIndex != lastIndex else {
-                  return nil
+                  return NSAttributedString(string: string, attributes: defaultAttributes)
               }
 
         let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
@@ -300,5 +309,6 @@ class StatsTotalInsightsCell: StatsBaseCell {
         static let differenceDelimiter = Character("*")
         static let differenceHigher = NSLocalizedString("*%@%@ (%@%%)* higher than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
         static let differenceLower = NSLocalizedString("*%@%@ (%@%%)* lower than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
+        static let differenceSame = NSLocalizedString("The same as the previous week", comment: "Label shown in Stats Insights when a metric is showing the same level as the previous week")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -232,7 +232,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         guard let difference = difference,
               let percentage = percentage,
-              difference > 0 || count > 0 else {
+              difference != 0 || count > 0 else {
                   comparisonLabel.isHidden = true
                   return
               }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -28,15 +28,26 @@ struct StatsSegmentedControlData {
         self.accessibilityHint = accessibilityHint
     }
 
-    var attributedDifference: NSAttributedString? {
+    var attributedDifferenceText: NSAttributedString? {
+        guard difference != 0 || segmentData > 0 else {
+            // No comparison shown if there's no change and 0 data
+            return nil
+        }
+
+        let defaultAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .subheadline), NSAttributedString.Key.foregroundColor: UIColor.textSubtle]
+
+        if difference == 0 && segmentData != 0 {
+            return NSAttributedString(string: differenceText, attributes: defaultAttributes)
+        }
+
         let differenceText = String(format: differenceText, differenceLabel)
-        let attributedString = NSMutableAttributedString(string: differenceText)
+        let attributedString = NSMutableAttributedString(string: differenceText, attributes: defaultAttributes)
 
         let str = attributedString.string as NSString
         let range = str.range(of: differenceLabel)
 
         attributedString.addAttributes([.foregroundColor: differenceTextColor,
-                                        .font: UIFont.preferredFont(forTextStyle: .body).bold()],
+                                        .font: UIFont.preferredFont(forTextStyle: .subheadline).bold()],
                 range: NSRange(location: range.location, length: differenceLabel.count))
 
         return attributedString
@@ -68,6 +79,13 @@ struct StatsSegmentedControlData {
 
     var accessibilityValue: String? {
         return segmentDataStub != nil ? "" : "\(segmentData)"
+    }
+
+    enum Constants {
+        static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
+        static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
+        static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
+        static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
     }
 }
 
@@ -187,7 +205,7 @@ private extension ViewsVisitorsLineChartCell {
         latestData.text = segmentData.segmentData.abbreviatedString(forHeroNumber: true)
         previousData.text = segmentData.segmentPrevData.abbreviatedString(forHeroNumber: true)
 
-        differenceLabel.attributedText = segmentData.attributedDifference
+        differenceLabel.attributedText = segmentData.attributedDifferenceText
     }
 
     // MARK: Chart support


### PR DESCRIPTION
This PR tweaks some UI elements to bring them closer in line with the designs:

- The totals cards now all have the title "Week", except for Followers which uses View More
- Fixes a bug where the views and visitors card was always using 'views' in the comparison text (and views data)
- If there is previous data but 0 change, the difference text for totals cells and views & visitors now mentions this ('the same as the previous week')

**To test**

- Enable the stats feature flags
- Build and run
- Ensure that

No difference labels are visible on views & visitors or totals cards if there is 0 previous data and 0 change:

|   |   |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 13 08 58](https://user-images.githubusercontent.com/4780/175317741-df7ea6ac-ef3f-4fa3-8e77-29b75b4f4fe7.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 13 08 51](https://user-images.githubusercontent.com/4780/175317771-8a637f78-0c07-4d39-84b2-d815a9337a08.png) |

If there is > 0 previous data, and this week's data is the same (you may just want to hardcode this to test), the Totals cells should show that the data is the same as the previous week:

![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 13 07 44](https://user-images.githubusercontent.com/4780/175317951-3cbcff08-1dd8-4c9c-9623-664e1362b3d2.png)

The same for views and visitors:

![Uploading Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 13.07.40.png…]()

- Finally, ensure that the Views and Visitors views (toggled on the segmented control) show different text and the correct data

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
