### PR TITLE
Add apps.wordpress.com to the Jetpack app associated domains

### DIFF
--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -7,6 +7,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -11,6 +11,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>webcredentials:wordpress.com</string>
+		<string>applinks:apps.wordpress.com</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
### Description
This changes the the associated domains file for all Jetpack targets to allow apps.wordpress.com links to redirect to Jetpack app.

### Screenshot
<img src="https://user-images.githubusercontent.com/793774/175326285-c123e156-0dfd-44d9-a7f6-8ffcb82a7121.PNG" width="160" />

### To test:
- Scan the QR Code below using the [QR Code scanner in iOS](https://support.apple.com/en-us/HT208843):

<img width="160" alt="Screen Shot 2022-06-23 at 10 35 40 AM" src="https://user-images.githubusercontent.com/793774/175325333-e0ba0ee0-bdef-427f-b001-9b3d76ac98a0.png">

- Verify you are asked to open it with the Jetpack app, nothing will happen if you open it in the app right now

### Regression Notes
1. Potential unintended areas of impact
Deep links

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
Impossible to add automated tested

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
