### PR TITLE
Stats Revamp: Top Followers card styling + card resizing fix

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -171,7 +171,8 @@ extension WPStyleGuide {
 
         static func configureFilterTabBar(_ filterTabBar: FilterTabBar,
                                           forTabbedCard: Bool = false,
-                                          forOverviewCard: Bool = false) {
+                                          forOverviewCard: Bool = false,
+                                          forNewInsightsCard: Bool = false) {
             WPStyleGuide.configureFilterTabBar(filterTabBar)
 
             // For FilterTabBar on TabbedTotalsCell
@@ -186,6 +187,15 @@ extension WPStyleGuide {
                 filterTabBar.tabSizingStyle = .equalWidths
                 filterTabBar.tintColor = defaultFilterTintColor
                 filterTabBar.selectedTitleColor = tabbedCardFilterSelectedTitleColor
+            }
+
+            // For FilterTabBar on StatsInsights
+            if forNewInsightsCard {
+                filterTabBar.tabSizingStyle = .fitting
+                filterTabBar.tintColor = UIColor.text
+                filterTabBar.selectedTitleColor = UIColor.text
+                filterTabBar.backgroundColor = .listForeground
+                filterTabBar.deselectedTabColor = UIColor(light: .neutral(.shade20), dark: .neutral(.shade50))
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -790,7 +790,7 @@ private extension SiteStatsInsightsViewModel {
                                                tabDataForFollowerType(.insightsFollowersEmail)],
                                     statSection: .insightsFollowersWordPress,
                                     siteStatsInsightsDelegate: siteStatsInsightsDelegate,
-                                    showTotalCount: true)
+                                    showTotalCount: FeatureFlag.statsNewAppearance.enabled ? false : true)
     }
 
     func tabDataForFollowerType(_ followerType: StatSection) -> TabData {
@@ -819,8 +819,8 @@ private extension SiteStatsInsightsViewModel {
         }
 
         return TabData(tabTitle: tabTitle,
-                       itemSubtitle: followerType.itemSubtitle,
-                       dataSubtitle: followerType.dataSubtitle,
+                       itemSubtitle: FeatureFlag.statsNewAppearance.enabled ? "" : followerType.itemSubtitle,
+                       dataSubtitle: FeatureFlag.statsNewAppearance.enabled ? "" : followerType.dataSubtitle,
                        totalCount: totalCount,
                        dataRows: followersData ?? [])
     }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -96,7 +96,11 @@ class TabbedTotalsCell: StatsBaseCell, NibLoadable {
 private extension TabbedTotalsCell {
 
     func setupFilterBar(selectedIndex: Int) {
-        WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)
+        if FeatureFlag.statsNewAppearance.enabled && (statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail) {
+            WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forNewInsightsCard: true)
+        } else {
+            WPStyleGuide.Stats.configureFilterTabBar(filterTabBar, forTabbedCard: true)
+        }
         filterTabBar.items = tabsData
         filterTabBar.setSelectedIndex(selectedIndex)
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -231,7 +231,6 @@ private extension SiteStatsInsightsDetailsTableViewController {
 
     func applyTableUpdates() {
         tableView.performBatchUpdates({
-            updateStatSectionForFilterChange()
         })
     }
 
@@ -267,7 +266,7 @@ private extension SiteStatsInsightsDetailsTableViewController {
 extension SiteStatsInsightsDetailsTableViewController: SiteStatsDetailsDelegate {
 
     func tabbedTotalsCellUpdated() {
-        updateStatSectionForFilterChange()
+        applyTableUpdates()
     }
 
     func displayWebViewWithURL(_ url: URL) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -342,7 +342,8 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                                                             tabDataForFollowerType(.insightsFollowersEmail)],
                         statSection: .insightsFollowersWordPress,
                         siteStatsInsightsDelegate: nil,
-                        showTotalCount: true))
+                        siteStatsDetailsDelegate: detailsDelegate,
+                        showTotalCount: false))
                 return rows
             }
         case .insightsLikesTotals:
@@ -698,8 +699,8 @@ private extension SiteStatsInsightsDetailsViewModel {
         }
 
         return TabData(tabTitle: tabTitle,
-                itemSubtitle: followerType.itemSubtitle,
-                dataSubtitle: followerType.dataSubtitle,
+                itemSubtitle: "",
+                dataSubtitle: "",
                 totalCount: totalCount,
                 dataRows: followersData)
     }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -9,6 +9,7 @@ class ViewMoreRow: UIView, NibLoadable, Accessible {
     // MARK: - Properties
 
     @IBOutlet weak var viewMoreLabel: UILabel!
+    @IBOutlet weak var disclosureImageView: UIImageView!
 
     private var statSection: StatSection?
     private weak var delegate: ViewMoreRowDelegate?
@@ -38,6 +39,9 @@ private extension ViewMoreRow {
         backgroundColor = .listForeground
         viewMoreLabel.text = NSLocalizedString("View more", comment: "Label for viewing more stats.")
         viewMoreLabel.textColor = WPStyleGuide.Stats.actionTextColor
+        if FeatureFlag.statsNewAppearance.enabled && (statSection == .insightsFollowersWordPress || statSection == .insightsFollowersEmail) {
+            disclosureImageView.isHidden = true
+        }
     }
 
     @IBAction func didTapViewMoreButton(_ sender: UIButton) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -41,7 +41,7 @@
                         <constraint firstItem="Umw-QX-aI2" firstAttribute="leading" secondItem="N97-9D-WNI" secondAttribute="leading" constant="16" id="wMp-ZA-nkO"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N3F-KZ-xRt" userLabel="View More Button">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="N3F-KZ-xRt" userLabel="View More Button">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <connections>
@@ -49,6 +49,7 @@
                     </connections>
                 </button>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="N3F-KZ-xRt" firstAttribute="leading" secondItem="N97-9D-WNI" secondAttribute="leading" id="0nP-FU-mOy"/>
@@ -61,8 +62,8 @@
                 <constraint firstItem="N97-9D-WNI" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="wVz-9r-Pr4"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <connections>
+                <outlet property="disclosureImageView" destination="gbG-Q7-nUb" id="stz-jY-mOy"/>
                 <outlet property="viewMoreLabel" destination="Umw-QX-aI2" id="ZdF-R6-GQb"/>
             </connections>
             <point key="canvasLocation" x="-476" y="-27.886056971514247"/>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -224,6 +224,7 @@ struct TabbedTotalsStatsRow: ImmuTableRow {
     let tabsData: [TabData]
     let statSection: StatSection
     weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    weak var siteStatsDetailsDelegate: SiteStatsDetailsDelegate?
     let showTotalCount: Bool
     let action: ImmuTableAction? = nil
 
@@ -236,6 +237,7 @@ struct TabbedTotalsStatsRow: ImmuTableRow {
         cell.configure(tabsData: tabsData,
                        statSection: statSection,
                        siteStatsInsightsDelegate: siteStatsInsightsDelegate,
+                       siteStatsDetailsDelegate: siteStatsDetailsDelegate,
                        showTotalCount: showTotalCount)
     }
 }


### PR DESCRIPTION
This PR updates the for styling for the top followers card

Implementation:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/88816724/175363647-e4ac44f3-7455-4f81-9caf-cdd1d583308a.png">

Design:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/88816724/175363880-6611abdb-583d-41e4-a317-e5f0aba337fe.png">


Ref #18602

Note:
* Follow button has not been implemented and will be done in a later PR

To test:
1. Build and run + navigate to Stats Insights for a site
2. Followers Total card should not be available and Followers Card should look and behave same as AppStore version
3. Clicking View more on the Followers card should take you to the same screen as in current appstore version
4. Click around insights, period stats and ensure there are no crashes
5. Now enable both of the new stats feature flags and build and run again
statsNewAppearance
statsNewInsights

1. On the stats Insights screen the followers card should now have new styling
2. Tap the "View More" at the bottom of the followers card. The followers card in the 2nd level should also have the same new styling
3. Tap between the 'Wordpress' and 'Email' tabs and confirm that the Followers card now resizes correctly if there is no data 


## Regression Notes
1. Potential unintended areas of impact
Current App Store insights followers card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
