### PR TITLE
Stats: Add tappable actions to views & visitors and Likes Guide

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsNudgeView.swift
@@ -21,26 +21,18 @@ final class DashboardStatsNudgeView: UIView {
 
     // MARK: - Init
 
-    convenience init(title: String, hint: String) {
+    convenience init(title: String, hint: String?, insets: UIEdgeInsets = Constants.margins) {
         self.init(frame: .zero)
 
+        setup(insets: insets)
         setTitle(title: title, hint: hint)
-    }
-
-    override init(frame: CGRect) {
-        super.init(frame: frame)
-        setup()
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("Not implemented")
     }
 
     // MARK: - View setup
 
-    private func setup() {
+    private func setup(insets: UIEdgeInsets) {
         addSubview(titleLabel)
-        pinSubviewToAllEdges(titleLabel, insets: Constants.margins)
+        pinSubviewToAllEdges(titleLabel, insets: insets)
 
         prepareForVoiceOver()
     }
@@ -49,14 +41,15 @@ final class DashboardStatsNudgeView: UIView {
         onTap?()
     }
 
-    private func setTitle(title: String, hint: String) {
+    private func setTitle(title: String, hint: String?) {
         let externalAttachment = NSTextAttachment(image: UIImage.gridicon(.external, size: Constants.iconSize).withTintColor(.primary))
         externalAttachment.bounds = Constants.iconBounds
 
         let attachmentString = NSAttributedString(attachment: externalAttachment)
 
         let titleString = NSMutableAttributedString(string: "\(title) \u{FEFF}")
-        if let subStringRange = title.nsRange(of: hint) {
+        if let hint = hint,
+           let subStringRange = title.nsRange(of: hint) {
             titleString.addAttributes([
                 .foregroundColor: UIColor.primary,
                 .font: WPStyleGuide.fontForTextStyle(.subheadline).bold()

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -9,6 +9,9 @@ struct StatsTotalInsightsData {
     var sparklineData: [Int]? = nil
     var guideText: NSAttributedString? = nil
 
+    // Used to allow a URL to be displayed in response to a guide being tapped
+    var guideURL: URL? = nil
+
     public static func followersCount(insightsStore: StatsInsightsStore) -> StatsTotalInsightsData {
         return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount())
     }
@@ -33,8 +36,9 @@ struct StatsTotalInsightsData {
         let sparklineData: [Int] = makeSparklineData(countKey: countKey, splitSummaryTimeIntervalData: splitSummaryTimeIntervalData)
         let data = SiteStatsInsightsViewModel.intervalData(periodSummary, summaryType: statsSummaryType)
         let guideText = makeTotalInsightsGuideText(insightsStore: insightsStore, statsSummaryType: statsSummaryType)
+        let guideURL: URL? = statsSummaryType == .likes ? insightsStore.getLastPostInsight()?.url : nil
 
-        return StatsTotalInsightsData(count: data.count, difference: data.difference, percentage: data.percentage, sparklineData: sparklineData, guideText: guideText)
+        return StatsTotalInsightsData(count: data.count, difference: data.difference, percentage: data.percentage, sparklineData: sparklineData, guideText: guideText, guideURL: guideURL)
     }
 
     static func makeSparklineData(countKey: KeyPath<StatsSummaryData, Int>, splitSummaryTimeIntervalData: [StatsSummaryTimeIntervalDataAsAWeek]) -> [Int] {
@@ -100,6 +104,7 @@ struct StatsTotalInsightsData {
 class StatsTotalInsightsCell: StatsBaseCell {
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private var lastPostInsight: StatsLastPostInsight?
+    private var guideURL: URL? = nil
 
     private let outerStackView = UIStackView()
     private let topInnerStackView = UIStackView()
@@ -172,6 +177,9 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         guideViewLabel.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
         guideView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+
+        let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(guideTapped))
+        guideView.addGestureRecognizer(gestureRecognizer)
     }
 
     private func configureLabels() {
@@ -207,7 +215,9 @@ class StatsTotalInsightsCell: StatsBaseCell {
         guideView.pinSubviewToAllEdges(guideViewLabel, insets: UIEdgeInsets(allEdges: 16.0), priority: .required)
     }
 
-    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, guideText: NSAttributedString? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, guideText: NSAttributedString? = nil, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+        self.guideURL = guideURL
+
         self.statSection = statSection
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
@@ -217,25 +227,32 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         countLabel.text = count.abbreviatedString()
 
+        updateGuideView(withGuideText: guideText)
+        updateComparisonLabel(withCount: count, difference: difference, percentage: percentage)
+    }
+
+    private func updateGuideView(withGuideText guideText: NSAttributedString?) {
         if let guideText = guideText,
            guideText.string.isEmpty == false {
             outerStackView.addArrangedSubview(guideView)
 
             guideViewLabel.attributedText = addTipEmojiToGuide(guideText)
-            // Setting this hear appears to help with updating the layout (found via a tip on Stack Overflow)
+            // Setting this here appears to help with updating the layout
             guideViewLabel.lineBreakMode = .byWordWrapping
             invalidateIntrinsicContentSize()
 
         } else if guideView.superview != nil {
             guideView.removeFromSuperview()
         }
+    }
 
+    private func updateComparisonLabel(withCount count: Int, difference: Int?, percentage: Int?) {
         guard let difference = difference,
               let percentage = percentage,
               difference != 0 || count > 0 else {
-                  comparisonLabel.isHidden = true
-                  return
-              }
+            comparisonLabel.isHidden = true
+            return
+        }
 
         comparisonLabel.isHidden = false
         let differencePrefix = difference < 0 ? "" : "+"
@@ -297,6 +314,12 @@ class StatsTotalInsightsCell: StatsBaseCell {
         mutableString.addAttributes(highlightAttributes, range: nsRange)
 
         return NSAttributedString(attributedString: mutableString)
+    }
+
+    @objc private func guideTapped() {
+        if let guideURL = guideURL {
+            siteStatsInsightsDelegate?.displayWebViewWithURL?(guideURL)
+        }
     }
 
     private enum Metrics {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -100,9 +100,10 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
     @IBOutlet weak var legendPreviousLabel: UILabel!
     @IBOutlet weak var previousLabel: UILabel!
     @IBOutlet weak var previousData: UILabel!
-    @IBOutlet weak var differenceLabel: UILabel!
+    @IBOutlet var differenceLabel: UILabel!
     @IBOutlet weak var chartContainerView: UIView!
     @IBOutlet weak var segmentedControl: UISegmentedControl!
+    @IBOutlet weak var bottomStackView: UIStackView!
 
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private typealias Style = WPStyleGuide.Stats
@@ -115,6 +116,16 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
 
     private var period: StatsPeriodUnit?
     private var xAxisDates: [Date] = []
+
+    fileprivate lazy var tipView: DashboardStatsNudgeView = {
+        let tipView = DashboardStatsNudgeView(title: Constants.topTipsText, hint: nil, insets: .zero)
+        tipView.onTap = { [weak self] in
+            if let url = URL(string: Constants.topTipsURLString) {
+                self?.siteStatsInsightsDelegate?.displayWebViewWithURL?(url)
+            }
+        }
+        return tipView
+    }()
 
     // MARK: - Configure
 
@@ -206,6 +217,14 @@ private extension ViewsVisitorsLineChartCell {
         previousData.text = segmentData.segmentPrevData.abbreviatedString(forHeroNumber: true)
 
         differenceLabel.attributedText = segmentData.attributedDifferenceText
+
+        if segmentData.segmentData == 0 && segmentData.segmentPrevData == 0 {
+            differenceLabel.removeFromSuperview()
+            bottomStackView.addArrangedSubview(tipView)
+        } else {
+            tipView.removeFromSuperview()
+            bottomStackView.addArrangedSubview(differenceLabel)
+        }
     }
 
     // MARK: Chart support
@@ -255,6 +274,11 @@ private extension ViewsVisitorsLineChartCell {
         } else {
             WPAppAnalytics.track(event, withProperties: properties)
         }
+    }
+
+    enum Constants {
+        static let topTipsText = NSLocalizedString("Check out our top tips to increase your views and traffic", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
+        static let topTipsURLString = "https://wordpress.com/support/getting-more-views-and-traffic/"
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -113,12 +113,17 @@
                             <constraint firstAttribute="height" constant="190" id="rjY-cD-mbj"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your last week's views are +8(36%) higher than the previous week." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0W-0V-Nuo" userLabel="Difference Label">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Quw-Zj-bJ3">
                         <rect key="frame" x="16" y="303" width="453" height="17"/>
-                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                        <color key="textColor" systemColor="secondaryLabelColor"/>
-                        <nil key="highlightedColor"/>
-                    </label>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Your last week's views are +8(36%) higher than the previous week." lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h0W-0V-Nuo" userLabel="Difference Label">
+                                <rect key="frame" x="0.0" y="0.0" width="453" height="17"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <color key="textColor" systemColor="secondaryLabelColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                    </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalCentering" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Tfh-Lq-o9J" userLabel="Segmented Bar Stack View">
                         <rect key="frame" x="0.0" y="336" width="485" height="31"/>
                         <subviews>
@@ -136,23 +141,24 @@
                     </stackView>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="h0W-0V-Nuo" secondAttribute="trailing" constant="16" id="6fh-P0-moZ"/>
+                    <constraint firstAttribute="trailing" secondItem="Quw-Zj-bJ3" secondAttribute="trailing" constant="16" id="10E-ce-he1"/>
+                    <constraint firstItem="Tfh-Lq-o9J" firstAttribute="top" secondItem="Quw-Zj-bJ3" secondAttribute="bottom" constant="16" id="5Es-9g-Xx5"/>
                     <constraint firstAttribute="trailing" secondItem="Tfh-Lq-o9J" secondAttribute="trailing" id="91Q-a7-m1X"/>
+                    <constraint firstItem="Quw-Zj-bJ3" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Epu-xD-Car"/>
                     <constraint firstItem="4jQ-Ow-Etk" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="Fis-ig-izK"/>
                     <constraint firstItem="x1C-Id-ZI7" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="JK8-PX-X8b"/>
                     <constraint firstItem="4jQ-Ow-Etk" firstAttribute="top" secondItem="x1C-Id-ZI7" secondAttribute="bottom" constant="16" id="LFJ-OH-F5u"/>
-                    <constraint firstItem="h0W-0V-Nuo" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="16" id="T0j-jQ-INl"/>
                     <constraint firstAttribute="trailing" secondItem="x1C-Id-ZI7" secondAttribute="trailing" constant="16" id="VKz-kh-bGa"/>
                     <constraint firstItem="Tfh-Lq-o9J" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="YYL-LK-vKy"/>
                     <constraint firstAttribute="bottom" secondItem="Tfh-Lq-o9J" secondAttribute="bottom" constant="20" symbolic="YES" id="h4i-hl-Sq1"/>
-                    <constraint firstItem="h0W-0V-Nuo" firstAttribute="top" secondItem="4jQ-Ow-Etk" secondAttribute="bottom" constant="16" id="kLP-Da-bDV"/>
                     <constraint firstAttribute="trailing" secondItem="4jQ-Ow-Etk" secondAttribute="trailing" constant="16" id="lco-zt-ZS4"/>
                     <constraint firstItem="x1C-Id-ZI7" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="qwW-fg-Wis"/>
-                    <constraint firstItem="Tfh-Lq-o9J" firstAttribute="top" secondItem="h0W-0V-Nuo" secondAttribute="bottom" constant="16" id="ush-xJ-9sB"/>
+                    <constraint firstItem="Quw-Zj-bJ3" firstAttribute="top" secondItem="4jQ-Ow-Etk" secondAttribute="bottom" constant="16" id="yiC-lc-TD5"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>
+                <outlet property="bottomStackView" destination="Quw-Zj-bJ3" id="ncc-xx-RvN"/>
                 <outlet property="chartContainerView" destination="4jQ-Ow-Etk" id="snp-Cx-isi"/>
                 <outlet property="differenceLabel" destination="h0W-0V-Nuo" id="kMx-jD-0EQ"/>
                 <outlet property="labelsStackView" destination="x1C-Id-ZI7" id="trE-fV-b3c"/>

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -336,7 +336,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, guideText: dataRow.guideText, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, guideText: dataRow.guideText, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 


### PR DESCRIPTION
This PR adds a tappable 'no data' action to the View & Visitors chart, and hooks up the Latest Post link in the Likes Total guide:

|    |    |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 21 53 03](https://user-images.githubusercontent.com/4780/175424332-afbc50e3-7a3e-46eb-b126-c462ccc1092a.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 10 54 18](https://user-images.githubusercontent.com/4780/175424352-5518c6dc-46a5-4bd1-a900-2b11e6bb2c7c.png) |

**To test**

* Enable the stats feature flags and build and run
* In Stats > Insights...
* Navigate to a site with no views. Ensure you see the 'top tips' view shown above, and that you can tap it to display a web view.
* Navigate to a site with some views. Ensure the top tips view is not shown and you see the standard comparison text at the bottom of the views & visitors graph.
* Navigate to a site with a published post. On the Likes Total cell, ensure you can tap the guide to display a web view with the latest post in it.

## Regression Notes
1. Potential unintended areas of impact

I made a tweak to the 'dashboard nudge view' which is used in the Dashboard stats card. You can verify this still looks and works correctly by viewing the dashboard for a site with no views:

<img width="377" alt="image" src="https://user-images.githubusercontent.com/4780/175424851-07f2ed6e-45ce-4f49-a977-549e1c31072f.png">


2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested.

3. What automated tests I added (or what prevented me from doing so)4. 
-

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
