### PR TITLE
Stats Revamp: Tracks ViewsVisitors, ViewMore, GrowAudience, TotalLikesGuide, Feature announcement

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -117,6 +117,14 @@ import Foundation
     case statsCustomizeInsightsShown
     case statsInsightsManagementSaved
     case statsInsightsManagementDismissed
+    case statsInsightsViewMore
+    case statsInsightsViewsVisitorsToggled
+    case statsInsightsViewsGrowAudienceDismissed
+    case statsInsightsViewsGrowAudienceConfirmed
+    case statsInsightsAnnouncementShown
+    case statsInsightsAnnouncementConfirmed
+    case statsInsightsAnnouncementDismissed
+    case statsInsightsTotalLikesGuideTapped
 
     // What's New - Feature announcements
     case featureAnnouncementShown
@@ -599,6 +607,22 @@ import Foundation
             return "stats_insights_management_saved"
         case .statsInsightsManagementDismissed:
             return "stats_insights_management_dismissed"
+        case .statsInsightsViewMore:
+            return "stats_insights_view_more"
+        case .statsInsightsViewsVisitorsToggled:
+            return "stats_insights_views_visitors_toggled"
+        case .statsInsightsViewsGrowAudienceDismissed:
+            return "stats_insights_views_grow_audience_dismissed"
+        case .statsInsightsViewsGrowAudienceConfirmed:
+            return "stats_insights_views_grow_audience_confirmed"
+        case .statsInsightsAnnouncementShown:
+            return "stats_insights_announcement_shown"
+        case .statsInsightsAnnouncementConfirmed:
+            return "stats_insights_announcement_confirmed"
+        case .statsInsightsAnnouncementDismissed:
+            return "stats_insights_announcement_dismissed"
+        case .statsInsightsTotalLikesGuideTapped:
+            return "stats_insights_total_likes_guide_tapped"
 
         // What's New - Feature announcements
         case .featureAnnouncementShown:

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -3,6 +3,7 @@ import UIKit
 @objc protocol FeatureIntroductionDelegate: AnyObject {
     func primaryActionSelected()
     @objc optional func secondaryActionSelected()
+    @objc optional func closeButtonWasTapped()
 }
 
 /// This is used to display a modal with information about a new feature.
@@ -93,6 +94,7 @@ class FeatureIntroductionViewController: CollapsableHeaderViewController {
     }
 
     @IBAction func closeButtonTapped() {
+        featureIntroductionDelegate?.closeButtonWasTapped?()
         dismiss(animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
@@ -24,16 +24,26 @@ class StatsRevampV2FeatureIntroduction: FeatureIntroductionViewController {
 
         // Add the gradient after the image has been added to the view so the gradient is the correct size.
         addHeaderImageGradient()
+
+        captureAnalyticsEvent(.statsInsightsAnnouncementShown)
     }
 }
 
 extension StatsRevampV2FeatureIntroduction: FeatureIntroductionDelegate {
     func primaryActionSelected() {
         presenter?.primaryButtonSelected()
+
+        captureAnalyticsEvent(.statsInsightsAnnouncementConfirmed)
     }
 
     func secondaryActionSelected() {
         presenter?.secondaryButtonSelected()
+
+        captureAnalyticsEvent(.statsInsightsAnnouncementDismissed)
+    }
+
+    func closeButtonWasTapped() {
+        captureAnalyticsEvent(.statsInsightsAnnouncementDismissed)
     }
 }
 
@@ -61,6 +71,10 @@ private extension StatsRevampV2FeatureIntroduction {
 
         // Add the gradient as a sublayer to the imageView's layer.
         headerImageView.layer.addSublayer(gradient)
+    }
+
+    private func captureAnalyticsEvent(_ event: WPAnalyticsEvent) {
+        WPAnalytics.track(event)
     }
 
     enum ButtonStrings {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -364,6 +364,21 @@
         }
     }
 
+    var analyticsProperty: String {
+        switch self {
+        case .insightsViewsVisitors:
+            return "views_and_visitors"
+        case .insightsFollowerTotals:
+            return "total_followers"
+        case .insightsLikesTotals:
+            return "total_likes"
+        case .insightsCommentsTotals:
+            return "total_comments"
+        default:
+            return ""
+        }
+    }
+
     // MARK: - Image Size Accessor
 
     static let defaultImageSize = CGFloat(24)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -143,8 +143,13 @@ class StatsBaseCell: UITableViewCell {
         let legacyEvent: WPAnalyticsStat = .statsViewAllAccessed
         captureAnalyticsEvent(legacyEvent)
 
-        if let modernEvent = statSection.analyticsViewMoreEvent {
-            captureAnalyticsEvent(modernEvent)
+        switch statSection {
+        case .insightsViewsVisitors, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
+            captureAnalyticsEvent(.statsInsightsViewMore, statSection: statSection)
+        default:
+            if let modernEvent = statSection.analyticsViewMoreEvent {
+                captureAnalyticsEvent(modernEvent)
+            }
         }
     }
 
@@ -153,6 +158,17 @@ class StatsBaseCell: UITableViewCell {
             WPAppAnalytics.track(event, withBlogID: blogIdentifier)
         } else {
             WPAppAnalytics.track(event)
+        }
+    }
+
+    private func captureAnalyticsEvent(_ event: WPAnalyticsEvent, statSection: StatSection) {
+        let properties: [String: String] = ["type": statSection.analyticsProperty]
+
+        if let blogId = SiteStatsInformation.sharedInstance.siteID,
+           let blog = Blog.lookup(withID: blogId, in: ContextManager.sharedInstance().mainContext) {
+            WPAnalytics.track(event, properties: properties, blog: blog)
+        } else {
+            WPAnalytics.track(event, properties: properties)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -320,6 +320,21 @@ class StatsTotalInsightsCell: StatsBaseCell {
         if let guideURL = guideURL {
             siteStatsInsightsDelegate?.displayWebViewWithURL?(guideURL)
         }
+
+        guard let statSection = statSection else {
+            return
+        }
+
+        switch statSection {
+        case .insightsLikesTotals:
+            captureAnalyticsEvent(.statsInsightsTotalLikesGuideTapped)
+        default:
+            break
+        }
+    }
+
+    private func captureAnalyticsEvent(_ event: WPAnalyticsEvent) {
+        WPAnalytics.track(event)
     }
 
     private enum Metrics {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -159,9 +159,8 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
     }
 
     @IBAction func selectedSegmentDidChange(_ sender: Any) {
-        if let event = segmentsData[segmentedControl.selectedSegmentIndex].analyticsStat {
-            captureAnalyticsEvent(event)
-        }
+        let selectedSegmentIndex = segmentedControl.selectedSegmentIndex
+        captureAnalyticsEvent(selectedSegmentIndex)
 
         configureChartView()
         updateLabels()
@@ -266,13 +265,16 @@ private extension ViewsVisitorsLineChartCell {
 
     // MARK: - Analytics support
 
-    func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
-        let properties: [AnyHashable: Any] = [StatsPeriodUnit.analyticsPeriodKey: period?.description as Any]
+    func captureAnalyticsEvent(_ selectedSegmentIndex: Int) {
+        let statsInsightsFilterDimension: StatsInsightsFilterDimension = selectedSegmentIndex == 0 ? .views : .visitors
 
-        if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
-            WPAppAnalytics.track(event, withProperties: properties, withBlogID: blogIdentifier)
+        let properties: [String: String] = ["value": statsInsightsFilterDimension.analyticsProperty]
+
+        if let blogId = SiteStatsInformation.sharedInstance.siteID,
+           let blog = Blog.lookup(withID: blogId, in: ContextManager.sharedInstance().mainContext) {
+            WPAnalytics.track(.statsInsightsViewsVisitorsToggled, properties: properties, blog: blog)
         } else {
-            WPAppAnalytics.track(event, withProperties: properties)
+            WPAnalytics.track(.statsInsightsViewsVisitorsToggled, properties: properties)
         }
     }
 
@@ -280,5 +282,4 @@ private extension ViewsVisitorsLineChartCell {
         static let topTipsText = NSLocalizedString("Check out our top tips to increase your views and traffic", comment: "Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped.")
         static let topTipsURLString = "https://wordpress.com/support/getting-more-views-and-traffic/"
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -120,6 +120,8 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         guard let hintType = hintType else {
             return
         }
+        captureAnalyticsEvent(.statsInsightsViewsGrowAudienceDismissed)
+
         insightsDelegate?.growAudienceDismissButtonTapped?(hintType)
     }
 
@@ -127,6 +129,8 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         guard let hintType = hintType else {
             return
         }
+
+        captureAnalyticsEvent(.statsInsightsViewsGrowAudienceConfirmed)
 
         switch hintType {
         case .social:
@@ -136,7 +140,15 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         case .readerDiscover:
             insightsDelegate?.growAudienceReaderDiscoverButtonTapped?()
         }
+    }
 
+    func captureAnalyticsEvent(_ event: WPAnalyticsEvent) {
+        if let blogId = SiteStatsInformation.sharedInstance.siteID,
+           let blog = Blog.lookup(withID: blogId, in: ContextManager.sharedInstance().mainContext) {
+            WPAnalytics.track(event, properties: [:], blog: blog)
+        } else {
+            WPAnalytics.track(event, properties: [:])
+        }
     }
 
     // MARK: - Localization

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -120,8 +120,6 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         guard let hintType = hintType else {
             return
         }
-        captureAnalyticsEvent(.statsInsightsViewsGrowAudienceDismissed)
-
         insightsDelegate?.growAudienceDismissButtonTapped?(hintType)
     }
 
@@ -129,8 +127,6 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         guard let hintType = hintType else {
             return
         }
-
-        captureAnalyticsEvent(.statsInsightsViewsGrowAudienceConfirmed)
 
         switch hintType {
         case .social:
@@ -140,15 +136,7 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         case .readerDiscover:
             insightsDelegate?.growAudienceReaderDiscoverButtonTapped?()
         }
-    }
 
-    func captureAnalyticsEvent(_ event: WPAnalyticsEvent) {
-        if let blogId = SiteStatsInformation.sharedInstance.siteID,
-           let blog = Blog.lookup(withID: blogId, in: ContextManager.sharedInstance().mainContext) {
-            WPAnalytics.track(event, properties: [:], blog: blog)
-        } else {
-            WPAnalytics.track(event, properties: [:])
-        }
     }
 
     // MARK: - Localization


### PR DESCRIPTION
This PR adds Tracks Events for:
* Toggling the Views & Visitors chart between Views and Visitors
* When tapping the upper right disclosure of the new Stats revamp cards for Views & Visitors, Follower Totals, Likes Totals, Comments Totals
* Grow Audience and confirming or dismissing the card
* Tapping the last post link in the Total Likes card
* Stats Insights New Feature Announcement (shown, confirmed and dismissed)

Ref #18926

### To test:

1. Enable the new Stats FeatureFlags

### Views & Visitors
1. Toggle Views / Visitors segmented control from main insights screen.
	For visitors you should see:
		Tracked: `stats_insights_views_visitors_toggled <blog_id: XXX, default_tab_experiment: site_menu, site_type: blog, value: visitors>`
	
	For views you should see:
		Tracked: `stats_insights_views_visitors_toggled <blog_id: XXX, default_tab_experiment: site_menu, site_type: blog, value: views>`

2. Tap This week on Views & Visitors to navigate to the Insights Details screen and Repeat Step 2 

### View More

1. Navigate back to the main insights screen
2. Tap the upper right Disclosures for Views & Visitors, Follower Totals, Likes Totals, Comments Totals
	
	You should see the following track event with type = the card type
	Tracked: `stats_insights_view_more <blog_id: XXX, default_tab_experiment: site_menu, site_type: blog, type: views_and_visitors>`

### Grow Audience
1. Navigate to a site where the Grow Audience card will be displayed
2. On the Grow Audience card, tap the lower right button for example "Discover blogs to follow"

	You should see the track event: `stats_insights_views_grow_audience_confirmed`
3. On the Grow Audience card tap dismiss
	
	You shuld see the track event: `stats_insights_views_grow_audience_dismissed`

### Stats Total Likes Guide tapped
1. Navigate back to the main insights screen
2. Scroll to the Total Likes card
3. Tap the total guides link and you should see the event `stats_insights_total_likes_guide_tapped`

Stats Insights Feature announcement
1. Enable the Stats Insights Feature announcement

• Add `@objc public` to `showStatsRevampV2FeatureIntroduction()` in `WPTabBarController+Swift`
• In `viewDidAppear` of `WPTabBarController`, replace the call to `showBloggingPromptsFeatureIntroduction` with `showStatsRevampV2FeatureIntroduction`

Build and Run
	a. Tapping on "Try it now" you should see the event `stats_insights_announcement_confirmed`
	b. Tapping on "Remind me later" you should see `stats_insights_announcement_dismissed`
	c. Tapping on X upper right you should see `stats_insights_announcement_dismissed`

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
