### PR TITLE
Stats: Updates chart elements to use Blue in Jetpack

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -240,7 +240,7 @@ extension WPStyleGuide {
 
         static let positiveColor = UIColor.success
         static let negativeColor = UIColor.error
-        static let neutralColor = UIColor.primary
+        static let neutralColor = UIColor.muriel(color: MurielColor(name: .blue))
 
         static let gridiconSize = CGSize(width: 24, height: 24)
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
@@ -46,8 +46,8 @@ struct StatsFollowersChartViewModel {
 
         static let followersMaxGroupCount = 3
 
-        static let wpComColor: UIColor = .muriel(color: .primary, .shade50)
-        static let emailColor: UIColor = .muriel(color: .primary, .shade5)
+        static let wpComColor: UIColor = .muriel(name: .blue, .shade50)
+        static let emailColor: UIColor = .muriel(name: .blue, .shade5)
         static let socialColor: UIColor = .muriel(name: .orange, .shade30)
 
         static let chartHeight: CGFloat = 231.0

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
@@ -67,9 +67,9 @@ struct StatsReferrersChartViewModel {
 
         static let referrersMaxGroupCount = 3
         static let referrersSegmentColors: [UIColor] = [
-            .muriel(color: .primary, .shade80),
-            .muriel(color: .primary, .shade50),
-            .muriel(color: .primary, .shade5)
+            .muriel(name: .blue, .shade80),
+            .muriel(name: .blue, .shade50),
+            .muriel(name: .blue, .shade5)
         ]
 
         static let referrersTitlesMap = [


### PR DESCRIPTION
This PR tweaks the colours used by Stats Revamp charts to ensure they still use Blue in the Jetpack app rather than the Primary colour (which get switched to green).

|   |   |   |
|---|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-24 at 11 57 47](https://user-images.githubusercontent.com/4780/175524115-9cb485a4-a595-4338-bda5-20e2a7c1741f.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-24 at 11 57 13](https://user-images.githubusercontent.com/4780/175524124-197ceb7e-0860-4b0f-b008-843a6dab3b55.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-06-23 at 23 09 22](https://user-images.githubusercontent.com/4780/175524130-d5af47c9-971e-41f5-83a1-31dfe1faa014.png) |

**To test**

* Enable the stats revamp feature flags and build and run Jetpack
* Navigate to Stats Insights, and ensure that the following all use blue colours:
   * Sparkline graphs on Likes, Comments, Follower Totals when negative
   * Referrers donut chart (accessible from Views & Visitors)
   * Followers donut chart (accessible from Follower Totals)

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
