### PR TITLE
Stats Revamp: Date Picker 2nd Level - remove from Followers and Comments

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -94,11 +94,15 @@ private extension SiteStatsInsightsDetailsTableViewController {
             return
         }
 
-        // When section header is this year, we configure the header so it shows only year
-        if let statSection = statSection,
-              statSection == .insightsAnnualSiteStats,
-              let allAnnualInsights = insightsStore.getAllAnnual()?.allAnnualInsights,
-              let mostRecentYear = allAnnualInsights.last?.year {
+        guard let statSection = statSection else {
+            return
+        }
+
+        if statSection == .insightsFollowerTotals || statSection == .insightsCommentsTotals {
+            return
+        } else if statSection == .insightsAnnualSiteStats, // When section header is this year, we configure the header so it shows only year
+           let allAnnualInsights = insightsStore.getAllAnnual()?.allAnnualInsights,
+           let mostRecentYear = allAnnualInsights.last?.year {
             // Allow the date bar to only go up to the most recent year available.
             var dateComponents = Calendar.current.dateComponents([.year, .month, .day], from: StatsDataHelper.currentDateForSite())
             dateComponents.year = mostRecentYear
@@ -114,9 +118,7 @@ private extension SiteStatsInsightsDetailsTableViewController {
             siteStatsTableHeaderView.configure(date: selectedDate, period: StatsPeriodUnit.week, delegate: self)
         }
 
-        if let statSection = statSection {
-            siteStatsTableHeaderView.animateGhostLayers(viewModel?.storeIsFetching(statSection: statSection) == true)
-        }
+        siteStatsTableHeaderView.animateGhostLayers(viewModel?.storeIsFetching(statSection: statSection) == true)
 
         tableView.tableHeaderView = siteStatsTableHeaderView
 


### PR DESCRIPTION
This PR removes the 2nd level Date Picker from Followers and Comments 2nd level screens

Ref #18604, #18605

To test:
1. Enable both of the new stats feature flags and build and run
statsNewAppearance
statsNewInsights

1. Scroll to Followers Total and tap the upper right disclosure which should navigate you to the Followers Insights Details screen.  The Date Picker should no longer be visible at the top
2. Navigate back to the Top level Stats insights screen and repeat the same process for Comments Total card.
Navigate back to the Top level Stats insights screen and repeat the same process for other cards; the Date Picker should be available for these other screens

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
