### PR TITLE
Show Stats Revamp feature announcement on launch

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2FeatureIntroduction.swift
@@ -8,7 +8,7 @@ class StatsRevampV2FeatureIntroduction: FeatureIntroductionViewController {
         let featureDescriptionView = StatsRevampV2FeatureDescriptionView.loadFromNib()
         featureDescriptionView.translatesAutoresizingMaskIntoConstraints = false
 
-        let headerImage = UIImage(named: HeaderStyle.imageName)?.withTintColor(.clear)
+        let headerImage = UIImage.gridicon(.statsAlt, size: HeaderStyle.iconSize).withTintColor(.clear)
 
         super.init(headerTitle: HeaderStrings.title, headerSubtitle: "", headerImage: headerImage, featureDescriptionView: featureDescriptionView, primaryButtonTitle: ButtonStrings.showMe, secondaryButtonTitle: ButtonStrings.remindMe)
 
@@ -43,6 +43,8 @@ extension StatsRevampV2FeatureIntroduction: FeatureIntroductionDelegate {
     }
 
     func closeButtonWasTapped() {
+        presenter?.dismissButtonSelected()
+
         captureAnalyticsEvent(.statsInsightsAnnouncementDismissed)
     }
 }
@@ -87,8 +89,8 @@ private extension StatsRevampV2FeatureIntroduction {
     }
 
     enum HeaderStyle {
-        static let imageName = "icon-lightbulb-outline"
-        static let startGradientColor: UIColor = .warning(.shade30)
-        static let endGradientColor: UIColor = .accent(.shade40)
+        static let iconSize = CGSize(width: 40, height: 40)
+        static let startGradientColor: UIColor = .muriel(name: .blue, .shade5)
+        static let endGradientColor: UIColor = .muriel(name: .blue, .shade50)
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2IntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Stats Revamp v2/StatsRevampV2IntroductionPresenter.swift
@@ -7,7 +7,18 @@ import UIKit
 
 class StatsRevampV2IntroductionPresenter: NSObject {
 
+    weak var presentingViewController: UIViewController? = nil
+
     // MARK: - Properties
+
+    static var hasPresented: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: Constants.statsRevampV2FeatureIntroDisplayedKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: Constants.statsRevampV2FeatureIntroDisplayedKey)
+        }
+    }
 
     private lazy var navigationController: UINavigationController = {
         let vc = StatsRevampV2FeatureIntroduction()
@@ -18,12 +29,50 @@ class StatsRevampV2IntroductionPresenter: NSObject {
     // MARK: - Present Feature Introduction
 
     func present(from presentingViewController: UIViewController) {
+        StatsRevampV2IntroductionPresenter.hasPresented = true
+        self.presentingViewController = presentingViewController
+
         presentingViewController.present(navigationController, animated: true)
     }
 
     // MARK: - Action Handling
 
-    func primaryButtonSelected() { }
+    func primaryButtonSelected() {
+        presentingViewController?.dismiss(animated: true)
 
-    func secondaryButtonSelected() { }
+        guard let blog = WPTabBarController.sharedInstance().currentOrLastBlog() else {
+            return
+        }
+
+        WPTabBarController.sharedInstance().mySitesCoordinator.showStats(for: blog, timePeriod: .insights)
+    }
+
+    // "Remind Me" prompt
+    func secondaryButtonSelected() {
+        StatsRevampV2IntroductionPresenter.hasPresented = false
+        presentingViewController?.dismiss(animated: true)
+    }
+
+    func dismissButtonSelected() {
+        presentingViewController?.dismiss(animated: true)
+    }
+
+    struct Constants {
+        static let statsRevampV2FeatureIntroDisplayedKey = "stats_revamp_v2_feature_intro_displayed"
+    }
+}
+
+extension WPTabBarController {
+    @objc public func showStatsRevampV2FeatureIntroduction() {
+        guard FeatureFlag.statsNewInsights.enabled,
+              let blog = currentOrLastBlog(),
+              blog.isAccessibleThroughWPCom(),
+              presentedViewController == nil,
+              selectedViewController?.presentedViewController == nil,
+              !StatsRevampV2IntroductionPresenter.hasPresented else {
+            return
+        }
+
+        StatsRevampV2IntroductionPresenter().present(from: selectedViewController ?? self)
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -93,11 +93,4 @@ extension WPTabBarController {
     @objc func setupColors() {
         tabBar.isTranslucent = false
     }
-
-    // TODO: temporary
-    func showStatsRevampV2FeatureIntroduction() {
-        if FeatureFlag.statsNewInsights.enabled {
-            StatsRevampV2IntroductionPresenter().present(from: selectedViewController ?? self)
-        }
-    }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -631,6 +631,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [self startWatchingQuickTours];
 
     [self trackTabAccessOnViewDidAppear];
+    [self showStatsRevampV2FeatureIntroduction];
 }
 
 - (void)viewDidLayoutSubviews


### PR DESCRIPTION
Fixes #18624. This PR shows the stats revamp feature announcement on launch.

<img src="https://user-images.githubusercontent.com/4780/175649729-254732a6-554c-431a-a9fb-1e745ceb3f66.png" width=350>

**To test**

* Enable the stats feature announcements and build and run
* If you're not already logged in, log in with a wpcom account.
* You should see the announcement shown above.
* Test each of the actions available. If you'd like to reset the logic, replace the contents of `showStatsRevampV2FeatureIntroduction` with `StatsRevampV2IntroductionPresenter.hasPresented = false`, run the app once, then restore the contents of the method and continue testing.
    * Tap the X in the top corner. The view should be dismissed. Relaunch the app and the view should not reappear.
    * Tap Remind Me. The view should be dismissed. Relaunch the app and the view should reappear.
    * Tap Try it now. The view should be dismissed and you should be taken to Insights. If you relaunch the app, the view should not reappear.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
