### PR TITLE
Stats revamp: Set Insights margins to readable width

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -70,6 +70,10 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
         tableView.estimatedRowHeight = 500
         tableView.rowHeight = UITableView.automaticDimension
 
+        if FeatureFlag.statsNewAppearance.enabled {
+            tableView.cellLayoutMarginsFollowReadableWidth = true
+        }
+
         displayEmptyViewIfNecessary()
     }
 


### PR DESCRIPTION
A small tweak to set the margins of the Insights tableview to follow the readable width guide.

| Before | After |
|---|---|
| ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-06-24 at 20 18 04](https://user-images.githubusercontent.com/4780/175655304-88adcd91-b29e-4f71-bec3-0144e2f44a09.png) | ![Simulator Screen Shot - iPad Pro (11-inch) (3rd generation) - 2022-06-24 at 20 15 46](https://user-images.githubusercontent.com/4780/175655321-3d80d685-032c-45e3-98ec-73104ff853d2.png) |

**To test**

* Enable both the stats feature flags
* Build and run on iPad
* Navigate to Stats > Insights
* Check that the cells are inset as in the screenshot above

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
