### PR TITLE
Enable Stats revamp feature flag for Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 20.2
 -----
+* [***] [Jetpack-only] The Insights view in Stats has been revamped with a cleaner look and a new set of cards to make it easier than ever to see at a glance how your site's performing. [#18945]
 * [*] Preview: Post preview now resizes to account for device orientation change. [#18921]
 * [***] [Jetpack-only] Enables QR Code Login scanning from the Me menu. [#18904]
 * [*] Reverted the app icon back to Cool Blue. Users can reselect last month's icon in Me > App Settings > App Icon if they'd like. [#18934]

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -19,5 +19,6 @@ import Foundation
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
+    @objc static let showsStatsRevampV2: Bool = false
     @objc static let qrLoginEnabled: Bool = false
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -88,9 +88,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .landInTheEditor:
             return false
         case .statsNewAppearance:
-            return false
+            return AppConfiguration.showsStatsRevampV2
         case .statsNewInsights:
-            return false
+            return AppConfiguration.showsStatsRevampV2
         case .siteName:
             return false
         case .quickStartForExistingUsers:

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -19,5 +19,6 @@ import Foundation
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = false
+    @objc static let showsStatsRevampV2: Bool = true
     @objc static let qrLoginEnabled: Bool = true
 }


### PR DESCRIPTION
This PR enables the Stats Revamp feature flag for the Jetpack app.

**To test**

* Build and run the WordPress app. 
* Navigate to Stats > Insights and ensure you see the old stats appearance:

<img src="https://user-images.githubusercontent.com/4780/175663457-48ff6e0b-123e-4132-90cb-2a22f8b68f78.png" width=350>

* Build and run the Jetpack app
* Navigate to Stats > Insights and ensure you see the new stats appearance:

<img src="https://user-images.githubusercontent.com/4780/175663564-3d966197-83ac-4819-bcf4-acd6ca2b9c27.png" width=350>

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
