### PR TITLE
Quick Start: Fix task complete event misfiring

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -238,7 +238,7 @@ open class QuickStartTourGuide: NSObject {
 
     func complete(tour: QuickStartTour, for blog: Blog, postNotification: Bool = true) {
         guard let tourCount = blog.quickStartTours?.count, tourCount > 0,
-                isTourNotCompleted(tour: tour, for: blog) else {
+              isTourAvailableToComplete(tour: tour, for: blog) else {
             // Tours haven't been set up yet or were skipped.
             // Or tour to be completed has already been completed.
             // No reason to continue.
@@ -421,7 +421,7 @@ private extension QuickStartTourGuide {
     ///   - tour: tour to check
     ///   - blog: blog to check
     /// - Returns: boolean, true if the tour is not completed and is available. False otherwise
-    func isTourNotCompleted(tour: QuickStartTour, for blog: Blog) -> Bool {
+    func isTourAvailableToComplete(tour: QuickStartTour, for blog: Blog) -> Bool {
         let uncompletedTours = uncompletedTours(for: blog)
         return uncompletedTours.contains { element in
             element.key == tour.key

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -237,8 +237,11 @@ open class QuickStartTourGuide: NSObject {
     }
 
     func complete(tour: QuickStartTour, for blog: Blog, postNotification: Bool = true) {
-        guard let tourCount = blog.quickStartTours?.count, tourCount > 0 else {
-            // Tours haven't been set up yet or were skipped. No reason to continue.
+        guard let tourCount = blog.quickStartTours?.count, tourCount > 0,
+                isTourNotCompleted(tour: tour, for: blog) else {
+            // Tours haven't been set up yet or were skipped.
+            // Or tour to be completed has already been completed.
+            // No reason to continue.
             return
         }
         completed(tour: tour, for: blog, postNotification: postNotification)
@@ -401,6 +404,28 @@ private extension QuickStartTourGuide {
     func allToursCompleted(for blog: Blog) -> Bool {
         let list = QuickStartFactory.allTours(for: blog)
         return countChecklistCompleted(in: list, for: blog) >= list.count
+    }
+
+    /// Returns a list of all available tours that have not yet been completed
+    /// - Parameter blog: blog to check
+    func uncompletedTours(for blog: Blog) -> [QuickStartTour] {
+        let completedTours: [QuickStartTourState] = blog.completedQuickStartTours ?? []
+        let allTours = QuickStartFactory.allTours(for: blog)
+        let completedIDs = completedTours.map { $0.tourID }
+        let uncompletedTours = allTours.filter { !completedIDs.contains($0.key) }
+        return uncompletedTours
+    }
+
+    /// Check if the provided tour have not yet been completed and is available to complete
+    /// - Parameters:
+    ///   - tour: tour to check
+    ///   - blog: blog to check
+    /// - Returns: boolean, true if the tour is not completed and is available. False otherwise
+    func isTourNotCompleted(tour: QuickStartTour, for blog: Blog) -> Bool {
+        let uncompletedTours = uncompletedTours(for: blog)
+        return uncompletedTours.contains { element in
+            element.key == tour.key
+        }
     }
 
     func showCurrentStep() {


### PR DESCRIPTION
Fixes #18947

## Description
Fixes an issue where quick start task completed event was misfiring.

## Testing Instructions

### Misfiring

1. Enable Quick Start for existing sites
2. Finish all tasks
3. Tap on the site icon
4. Update site icon
5. Make sure that `quick_start_task_completed` is not fired
6. Create a new post and publish it
7. Make sure that `quick_start_task_completed` is not fired

### Regression

1. Enable Quick Start for new sites
2. Tap on the site icon
3. Update site icon
4. Make sure that `quick_start_task_completed` is fired and the quick start card is updated
5. Create a new post and publish it
6. Make sure that `quick_start_task_completed` is fired and the quick start card is updated

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.