### PR TITLE
Fix: Tooltip blinking when phone is tilted

### DIFF
--- a/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/TooltipPresenter.swift
@@ -70,6 +70,8 @@ final class TooltipPresenter {
         }
     }
 
+    private var previousDeviceOrientation: UIDeviceOrientation?
+
     init(containerView: UIView,
          tooltip: Tooltip,
          target: Target,
@@ -86,6 +88,7 @@ final class TooltipPresenter {
 
         configureDismissal()
 
+        previousDeviceOrientation = UIDevice.current.orientation
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(resetTooltipAndShow),
@@ -93,7 +96,7 @@ final class TooltipPresenter {
         )
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(resetTooltipAndShow),
+            selector: #selector(didDeviceOrientationChange),
             name: UIDevice.orientationDidChangeNotification,
             object: nil
         )
@@ -308,6 +311,23 @@ final class TooltipPresenter {
             }
         }
 
+    /// `orientationDidChangeNotification` is published when the device is at `faceUp` or `faceDown`
+    ///  states too. The sizing won't be affected in these cases so no need to reset the tooltip. Here we filter out changes
+    ///  to and from `faceUp` & `faceDown`.
+    @objc private func didDeviceOrientationChange() {
+        guard let previousDeviceOrientation = previousDeviceOrientation else {
+            return
+        }
+
+        self.previousDeviceOrientation = UIDevice.current.orientation
+
+        switch (previousDeviceOrientation, UIDevice.current.orientation) {
+        case (_, .faceUp), (_, .faceDown), (.faceUp, _), (.faceDown, _):
+            return
+        default:
+            resetTooltipAndShow()
+        }
+    }
 
     @objc private func resetTooltipAndShow() {
         UIView.animate(


### PR DESCRIPTION
Fixes #18938 

## To Test
1. Fresh installation on a Device.
2. Disable Orientation Lock from Control Center.
3. Go to Reader.
4. Select a post
5. Tap the New anchor
6. Tilt the phone down and up and verify the tooltip does not blink in and out. 
7. Alternate between landscape and portrait and see if tooltip and `QuickStartSpotlightView` are placed correctly (tooltip might not be visible after orientation change and the anchor may re-appear. That is the intended behavior).

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
