### PR TITLE
[Tooling] Add Buildkite annotation on test failures (option 2)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,16 +53,23 @@ steps:
   #################
   # Run Unit Tests
   #################
-  - label: "🔬 Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "Unit Tests"
+  - group: "🔬 Unit Tests"
+    steps:
+      - label: "🔬 Run Unit Tests"
+        command: ".buildkite/commands/run-unit-tests.sh"
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "Unit Tests"
+      - wait: ~
+        continue_on_failure: true
+      - plugins:
+          - junit-annotate#v2.0.2:
+              artifacts: build/results/report.junit
 
   #################
   # Lint Translations
@@ -81,24 +88,38 @@ steps:
   #################
   # UI Tests
   #################
-  - label: "🔬 UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "UI Tests (iPhone)"
+  - group: "🔬 UI Tests (iPhone)"
+    steps:
+      - label: "🔬 Run UI Tests (iPhone)"
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "UI Tests (iPhone)"
+      - wait: ~
+        continue_on_failure: true
+      - plugins:
+          - junit-annotate#v2.0.2:
+              artifacts: build/results/report.junit
 
-  - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "UI Tests (iPad)"
+  - group: "🔬 UI Tests (iPad)"
+    steps:
+      - label: "🔬 Run UI Tests (iPad)"
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "UI Tests (iPad)"
+      - wait: ~
+        continue_on_failure: true
+      - plugins:
+          - junit-annotate#v2.0.2:
+              artifacts: build/results/report.junit

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -67,7 +67,8 @@ steps:
               context: "Unit Tests"
       - wait: ~
         continue_on_failure: true
-      - plugins:
+      - label: ":buildkite: Annotate Test Failures"
+        plugins:
           - junit-annotate#v2.0.2:
               artifacts: build/results/report.junit
 
@@ -102,7 +103,8 @@ steps:
               context: "UI Tests (iPhone)"
       - wait: ~
         continue_on_failure: true
-      - plugins:
+      - label: ":buildkite: Annotate Test Failures"
+        plugins:
           - junit-annotate#v2.0.2:
               artifacts: build/results/report.junit
 
@@ -120,6 +122,7 @@ steps:
               context: "UI Tests (iPad)"
       - wait: ~
         continue_on_failure: true
-      - plugins:
+      - label: ":buildkite: Annotate Test Failures"
+        plugins:
           - junit-annotate#v2.0.2:
               artifacts: build/results/report.junit

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,14 @@ common_params:
     # `xcode-13.4.1` note: The issue "FIXIT-13.1" addresses is still there in this image.
     # See: https://buildkite.com/automattic/wordpress-ios/builds/8187#01813c28-1c1d-4a25-95c0-0fdd6f2af399
     IMAGE_ID: xcode-13.4.1
+  # Reusable step to use the `junit-annotate` plugin after running UI or Unit tests
+  - &annotate_test_failures_step
+    label: ":buildkite: Annotate Test Failures"
+    plugins:
+      - junit-annotate#v2.0.2:
+          artifacts: build/results/report.junit
+    agents:
+      queue: "default"
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -67,10 +75,7 @@ steps:
               context: "Unit Tests"
       - wait: ~
         continue_on_failure: true
-      - label: ":buildkite: Annotate Test Failures"
-        plugins:
-          - junit-annotate#v2.0.2:
-              artifacts: build/results/report.junit
+      - *annotate_test_failures_step
 
   #################
   # Lint Translations
@@ -103,10 +108,7 @@ steps:
               context: "UI Tests (iPhone)"
       - wait: ~
         continue_on_failure: true
-      - label: ":buildkite: Annotate Test Failures"
-        plugins:
-          - junit-annotate#v2.0.2:
-              artifacts: build/results/report.junit
+      - *annotate_test_failures_step
 
   - group: "🔬 UI Tests (iPad)"
     steps:
@@ -122,7 +124,4 @@ steps:
               context: "UI Tests (iPad)"
       - wait: ~
         continue_on_failure: true
-      - label: ":buildkite: Annotate Test Failures"
-        plugins:
-          - junit-annotate#v2.0.2:
-              artifacts: build/results/report.junit
+      - *annotate_test_failures_step

--- a/WordPress/WordPressTest/Extensions/AbstractPost+fixLocalMediaURLsTests.swift
+++ b/WordPress/WordPressTest/Extensions/AbstractPost+fixLocalMediaURLsTests.swift
@@ -8,6 +8,7 @@ class AbstractPostFixLocalMediaURLsTests: CoreDataTestCase {
     private let documentDirectory = FileManager.default.urls(for: .documentDirectory, in: .allDomainsMask).first!
 
     func testUpdateLocalMediaPathsInCachesDirectory() {
+        XCTFail("This is a forced failure to test Buildkite annotations.")
         let post = PostBuilder(mainContext)
             .with(remoteStatus: .failed)
             .with(image: "test.jpeg")

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -25,6 +25,7 @@ class ReaderTests: XCTestCase {
     let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
 
     func testViewPost() {
+        XCTFail("This is a forced failure to test Buildkite annotations.")
         readerScreen.openLastPost()
         XCTAssert(readerScreen.postContentEquals(expectedPostContent))
     }


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/18952, but using another approach — namely using [Buildkite's `junit-annotate` plugin](https://github.com/buildkite-plugins/junit-annotate-buildkite-plugin).

Let's see how the outputs differ between the two approaches.

> [EDIT]: After experimenting with the 2 approaches, I'm privileging the solution from https://github.com/wordpress-mobile/WordPress-iOS/pull/18952. (I'm going to keep this PR around as draft until the other one is approved just in case people disagree and prefer the approach in that PR instead, and close this PR once the other one lands)

---

One of the downsides I already noticed is that having this as a plugin step in the pipeline makes those extra steps quite apparent in the log page. And that's even while I've used [the "Group Step" Buildkite feature](https://buildkite.com/docs/pipelines/group-step)… (And I wonder if it also means it will also report those as CI checks in PRs on GitHub?… as if we didn't have a long-enough list there 😅)

<img width="1160" alt="image" src="https://user-images.githubusercontent.com/216089/176252869-ff5f7029-cd71-4f12-a758-131191a6dc9e.png">

Another downside of this is that it needs to wait and spawn a new agent, boot and prepare the plugins and working dir, etc… _just_ to run the junit-annotate plugin.