### PR TITLE
[Tooling] Cleanup pipeline steps structure

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,33 @@ steps:
           context: "Unit Tests"
 
   #################
+  # UI Tests
+  #################
+  - group: "🔬 UI Tests"
+    steps:
+      - label: "🔬 UI Tests (iPhone)"
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "UI Tests (iPhone)"
+
+      - label: "🔬 UI Tests (iPad)"
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "UI Tests (iPad)"
+
+  #################
   # Lint Translations
   #################
   - label: "🧹 Lint Translations"
@@ -78,27 +105,3 @@ steps:
       - github_commit_status:
           context: "Lint Translations"
 
-  #################
-  # UI Tests
-  #################
-  - label: "🔬 UI Tests (iPhone)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "UI Tests (iPhone)"
-
-  - label: "🔬 UI Tests (iPad)"
-    command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "UI Tests (iPad)"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,23 +20,25 @@ steps:
   #################
   # Create Installable Builds for WP and JP
   #################
-  - label: "🛠 WordPress Installable Build"
-    command: ".buildkite/commands/installable-build-wordpress.sh"
-    env: *common_env
-    plugins: *common_plugins
-    if: "build.pull_request.id != null || build.pull_request.draft"
-    notify:
-      - github_commit_status:
-          context: "WordPress Installable Build"
+  - group: "🛠 Installable Builds"
+    steps:
+      - label: "🛠 WordPress Installable Build"
+        command: ".buildkite/commands/installable-build-wordpress.sh"
+        env: *common_env
+        plugins: *common_plugins
+        if: "build.pull_request.id != null || build.pull_request.draft"
+        notify:
+          - github_commit_status:
+              context: "WordPress Installable Build"
 
-  - label: "🛠 Jetpack Installable Build"
-    command: ".buildkite/commands/installable-build-jetpack.sh"
-    env: *common_env
-    plugins: *common_plugins
-    if: "build.pull_request.id != null || build.pull_request.draft"
-    notify:
-      - github_commit_status:
-          context: "Jetpack Installable Build"
+      - label: "🛠 Jetpack Installable Build"
+        command: ".buildkite/commands/installable-build-jetpack.sh"
+        env: *common_env
+        plugins: *common_plugins
+        if: "build.pull_request.id != null || build.pull_request.draft"
+        notify:
+          - github_commit_status:
+              context: "Jetpack Installable Build"
 
   #################
   # Build the app


### PR DESCRIPTION
This PR  restructures the `pipeline.yml` a bit in order to:

 - Move the two "UI Test" steps _before_ the "Lint Translations" step, so that they are next to the "Build for Testing" and that all the related "Run {Unit|UI} Tests" steps stay together
 - [Use a Group step](https://buildkite.com/docs/pipelines/group-step) to group the related steps together, making the list of steps shown in the Build header/summary look neater. Especially:
    - Grouped the two "Installable Build" (WP and JP) steps together
    - Grouped the two "UI Tests" (iPhone and iPad) steps together.

<img width="1159" alt="image" src="https://user-images.githubusercontent.com/216089/176295022-97a3ec58-95fc-4870-a708-1b911220712d.png">
<img width="1156" alt="image" src="https://user-images.githubusercontent.com/216089/176307580-1a40284e-6815-43af-b535-b8a54b0ecc3d.png">

> **Note** The "group" step does not create any actual _new_ step for the group itself in the pipeline, Build page or CI checks. Its only effect is on the grouping of the steps visually in the header of Buildkite's build page summary. So this should not affect the list of GitHub checks nor anything else other than that Build page header.
