### PR TITLE
Fix unsatisfiable constraints in Editor and Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -31,7 +31,11 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
         return GutenbergSettings()
     }()
 
-    let ghostView = GutenGhostView()
+    lazy var ghostView: GutenGhostView = {
+        let view = GutenGhostView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
 
     private var storyEditor: StoryEditor?
 
@@ -554,10 +558,8 @@ extension GutenbergViewController {
         gutenberg.rootView.backgroundColor = .basicBackground
         view.addSubview(gutenberg.rootView)
 
-        view.leftAnchor.constraint(equalTo: gutenberg.rootView.leftAnchor).isActive = true
-        view.rightAnchor.constraint(equalTo: gutenberg.rootView.rightAnchor).isActive = true
-        view.topAnchor.constraint(equalTo: gutenberg.rootView.topAnchor).isActive = true
-        view.bottomAnchor.constraint(equalTo: gutenberg.rootView.bottomAnchor).isActive = true
+        view.pinSubviewToAllEdges(gutenberg.rootView)
+        gutenberg.rootView.pinSubviewToAllEdges(ghostView)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteStreamHeader.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -34,7 +35,7 @@
                 </label>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jvF-YL-IV0">
                     <rect key="frame" x="132" y="76.666666666666671" width="30" height="34"/>
-                    <color key="tintColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <color key="tintColor" systemColor="systemBackgroundColor"/>
                     <connections>
                         <action selector="didTapFollowButton:" destination="QDT-3t-9yR" eventType="touchUpInside" id="dRK-lH-Zga"/>
                     </connections>
@@ -52,8 +53,8 @@
                     <nil key="highlightedColor"/>
                 </label>
             </subviews>
-            <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-            <color key="tintColor" systemColor="linkColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+            <color key="tintColor" systemColor="linkColor"/>
             <constraints>
                 <constraint firstItem="mi7-dO-TOF" firstAttribute="top" secondItem="JHO-IY-cyK" secondAttribute="bottom" constant="16" id="5pv-Dj-zWG"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leadingMargin" id="AIG-RK-eJh"/>
@@ -66,9 +67,9 @@
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="mi7-dO-TOF" secondAttribute="bottom" constant="16" id="Zc9-ns-Y8r"/>
                 <constraint firstItem="JHO-IY-cyK" firstAttribute="leading" secondItem="fq2-Xh-dYx" secondAttribute="leading" id="bkn-wr-ADc"/>
                 <constraint firstAttribute="trailingMargin" secondItem="mi7-dO-TOF" secondAttribute="trailing" id="blt-Tr-kwH"/>
-                <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="leading" id="eAG-pR-tpk"/>
+                <constraint firstItem="mi7-dO-TOF" firstAttribute="leading" secondItem="QDT-3t-9yR" secondAttribute="leading" priority="999" constant="16" id="eAG-pR-tpk"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="leading" secondItem="QqV-yA-rBc" secondAttribute="leading" id="nuq-AR-loX"/>
-                <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" constant="16" id="qUa-8H-hSo"/>
+                <constraint firstAttribute="trailing" secondItem="QqV-yA-rBc" secondAttribute="trailingMargin" priority="999" constant="16" id="qUa-8H-hSo"/>
                 <constraint firstItem="w1n-O9-Da1" firstAttribute="top" secondItem="QDT-3t-9yR" secondAttribute="top" constant="16" id="ssc-l7-h6V"/>
                 <constraint firstItem="QqV-yA-rBc" firstAttribute="leading" secondItem="w1n-O9-Da1" secondAttribute="trailing" constant="20" id="uve-ck-hpx"/>
                 <constraint firstItem="jvF-YL-IV0" firstAttribute="top" secondItem="fq2-Xh-dYx" secondAttribute="bottom" constant="16" id="why-cC-543"/>
@@ -86,4 +87,15 @@
             <point key="canvasLocation" x="-108" y="-82"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="secondarySystemGroupedBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -548,6 +548,7 @@ import WordPressFlux
         let topConstraint = header.topAnchor.constraint(equalTo: tableView.topAnchor)
         let headerWidthConstraint = header.widthAnchor.constraint(equalTo: tableView.widthAnchor)
         headerWidthConstraint.priority = UILayoutPriority(999)
+        centerConstraint.priority = UILayoutPriority(999)
 
         NSLayoutConstraint.activate([
             centerConstraint,


### PR DESCRIPTION
Part of #18098

## Description
This resolves a couple of unsatisfiable constraints errors:
- Issue in Editor
    - This was triggered whenever we open the editor. It was caused by the laying out of the ghost view.
    - Fixed by setting `translatesAutoresizingMaskIntoConstraints` of the ghost view to false and adding manual constraints.
- Issue in Reader Site Stream
    - This was triggered by a conflict of constraints while laying out the table's header view. 
    - Fixed by setting the priority of some constraints to `999`
    
All fixes do not introduce any visible changes.

## Testing Instructions

1. Open the editor by creating a new post
2. Make sure the ghost view is displayed correctly
3. Close the editor
4. Navigate to the Reader
5. Tap on the site name from any post
6. Make sure the header in the site stream view is displayed correctly

## Regression Notes
1. Potential unintended areas of impact
UI of the components touched

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Testing manually all affected areas.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
