### PR TITLE
DO NOT MERGE: Tests A/B/n experiment implementation

### DIFF
--- a/WordPress/Classes/Utility/AB Testing/ABTest.swift
+++ b/WordPress/Classes/Utility/AB Testing/ABTest.swift
@@ -4,6 +4,7 @@ import AutomatticTracks
 // Jetpack is not supported
 enum ABTest: String, CaseIterable {
     case unknown = "unknown"
+    case abnNativeTest = "a_b_n_android_native_test"
 
     /// Returns a variation for the given experiment
     var variation: Variation {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -287,6 +287,19 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func setupView() {
         view.backgroundColor = .listBackground
         configureSegmentedControlFont()
+        
+        switch ABTest.abnNativeTest.variation {
+        case .treatment("red_background"):
+            view.backgroundColor = UIColor.red
+        case .treatment("green_background"):
+            view.backgroundColor = UIColor.green
+        case .treatment("blue_background"):
+            view.backgroundColor = UIColor.blue
+        case .control:
+            view.backgroundColor = UIColor.yellow
+        default:
+            view.backgroundColor = UIColor.black // should never be the case
+        }
     }
 
     /// This method builds a layout with the following view hierarchy:


### PR DESCRIPTION
**DO NOT MERGE**

This PR was created to verify that the client already supports A/B/n experiments (internal ref: `pbmo2S-1pZ-p2`)

To test:
1. Assign one of the variations of the ExPlat experiment `a_b_n_android_native_test` to your a8c user
2. Open the app (might need to do this twice)
3. Verify that the *My Site* screen has the background assigned from the experiment

|Control|variation: blue_background|variation: green_background|variation: red_background |
|---|---|---|---|
|![Simulator Screen Shot - iPhone 8 - 2022-06-29 at 12 06 50](https://user-images.githubusercontent.com/304044/176398943-83b86b92-e333-44f5-ae92-848c937e0b9f.png)|![Simulator Screen Shot - iPhone 8 - 2022-06-29 at 12 04 28](https://user-images.githubusercontent.com/304044/176398916-78efd9a3-e1bc-486a-8d6b-48dd5d42fb99.png)|![Simulator Screen Shot - iPhone 8 - 2022-06-29 at 12 04 55](https://user-images.githubusercontent.com/304044/176398974-fdf2bc98-a4d5-421e-a391-7350c0ff0894.png)|![Simulator Screen Shot - iPhone 8 - 2022-06-29 at 12 05 51](https://user-images.githubusercontent.com/304044/176399000-82178ed0-0a30-46e7-bc9a-81a78db86c45.png)|

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
