### PR TITLE
Fix app icon warning

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3117,7 +3117,6 @@
 		FABB1FE92602FC2C00C8785C /* TextWithAccessoryButtonCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40640045200ED30300106789 /* TextWithAccessoryButtonCell.xib */; };
 		FABB1FEA2602FC2C00C8785C /* SiteStatsDetailTableViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 98467A42221CD74D00DF51AE /* SiteStatsDetailTableViewController.storyboard */; };
 		FABB1FED2602FC2C00C8785C /* InlineEditableNameValueCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 43D74ACD20F906DD004AD934 /* InlineEditableNameValueCell.xib */; };
-		FABB1FEE2602FC2C00C8785C /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
 		FABB1FEF2602FC2C00C8785C /* MediaQuotaCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FF00889C204DFF77007CCE66 /* MediaQuotaCell.xib */; };
 		FABB1FF02602FC2C00C8785C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 931DF4D818D09A2F00540BDD /* InfoPlist.strings */; };
 		FABB1FF22602FC2C00C8785C /* ReaderSavedPostUndoCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D88106F620C0C9A8001D2F00 /* ReaderSavedPostUndoCell.xib */; };
@@ -16930,7 +16929,6 @@
 				FABB1FE92602FC2C00C8785C /* TextWithAccessoryButtonCell.xib in Resources */,
 				FABB1FEA2602FC2C00C8785C /* SiteStatsDetailTableViewController.storyboard in Resources */,
 				FABB1FED2602FC2C00C8785C /* InlineEditableNameValueCell.xib in Resources */,
-				FABB1FEE2602FC2C00C8785C /* AppImages.xcassets in Resources */,
 				FABB1FEF2602FC2C00C8785C /* MediaQuotaCell.xib in Resources */,
 				FABB1FF02602FC2C00C8785C /* InfoPlist.strings in Resources */,
 				FABB1FF22602FC2C00C8785C /* ReaderSavedPostUndoCell.xib in Resources */,


### PR DESCRIPTION
Closes #18958

The app icon for the WordPress target was added to the membership of the Jetpack app. I don't think the Jetpack app needs access to the WordPress app icon, so I've removed its membership in this PR.

Looking at the code via git blame, it looks like this the WordPress app icon has been part of Jetpack since early 2021, so this isn't a new issue.

To test:

Install both the Jetpack and the WordPress apps from this PR and verify that each has their correct app icon on the device's home screen (green for Jetpack, light blue for WordPress).

## Regression Notes
1. Potential unintended areas of impact

This PR assumes that the WordPress app icon is not used anywhere within Jetpack. If that assumption is false, this change might break some parts of the Jetpack app.

3. What I did to test those areas of impact (or what existing automated tests I relied on)

TO-DO

4. What automated tests I added (or what prevented me from doing so)

Since this affects the app icon, there are no existing tests and adding automated tests is not feasible.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
