### PR TITLE
Fix screenshot UI test  for JetpackScreenshotGeneration target

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -350,9 +350,9 @@ end
 ## ===================
 ##
 def wordpress_mocks
-  # pod 'WordPressMocks', '~> 0.0.15'
+  pod 'WordPressMocks', '~> 0.0.16'
   # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :commit => ''
-  pod 'WordPressMocks', git: 'https://github.com/wordpress-mobile/WordPressMocks.git', branch: 'fix/jetpack-screenshot-generation'
+  # pod 'WordPressMocks', git: 'https://github.com/wordpress-mobile/WordPressMocks.git', branch: 'fix/jetpack-screenshot-generation'
   # pod 'WordPressMocks', :path => '../WordPressMocks'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -350,9 +350,9 @@ end
 ## ===================
 ##
 def wordpress_mocks
-  pod 'WordPressMocks', '~> 0.0.15'
+  # pod 'WordPressMocks', '~> 0.0.15'
   # pod 'WordPressMocks', :git => 'https://github.com/wordpress-mobile/WordPressMocks.git', :commit => ''
-  # pod 'WordPressMocks', git: 'https://github.com/wordpress-mobile/WordPressMocks.git', branch: 'add-organization-id-to-me-sites'
+  pod 'WordPressMocks', git: 'https://github.com/wordpress-mobile/WordPressMocks.git', branch: 'fix/jetpack-screenshot-generation'
   # pod 'WordPressMocks', :path => '../WordPressMocks'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -588,7 +588,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.55.0)
-  - WordPressMocks (from `https://github.com/wordpress-mobile/WordPressMocks.git`, branch `fix/jetpack-screenshot-generation`)
+  - WordPressMocks (~> 0.0.16)
   - WordPressShared (~> 1.18.0)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.4)
@@ -636,6 +636,7 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
+    - WordPressMocks
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -747,9 +748,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.78.1
-  WordPressMocks:
-    :branch: fix/jetpack-screenshot-generation
-    :git: https://github.com/wordpress-mobile/WordPressMocks.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.78.1/third-party-podspecs/Yoga.podspec.json
 
@@ -765,9 +763,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.78.1
-  WordPressMocks:
-    :commit: a0f3d0e39ac509cb4be16345c229bdfa581f3fc5
-    :git: https://github.com/wordpress-mobile/WordPressMocks.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -868,6 +863,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 8c9c48383fc5201c7e5e1994d673d31512ded27d
+PODFILE CHECKSUM: 87c70090c27fd39b8403e83f381c4a9ab9bdca5b
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -766,7 +766,7 @@ CHECKOUT OPTIONS:
     :submodules: true
     :tag: v1.78.1
   WordPressMocks:
-    :commit: f359aa4e92a675d30fb50eabaf2870f9eb4d554d
+    :commit: a0f3d0e39ac509cb4be16345c229bdfa581f3fc5
     :git: https://github.com/wordpress-mobile/WordPressMocks.git
 
 SPEC CHECKSUMS:

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -491,7 +491,7 @@ PODS:
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 1.15-beta)
     - wpxmlrpc (~> 0.9)
-  - WordPressMocks (0.0.15)
+  - WordPressMocks (0.0.16)
   - WordPressShared (1.18.0):
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
@@ -588,7 +588,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 2.0.0)
   - WordPressKit (~> 4.55.0)
-  - WordPressMocks (~> 0.0.15)
+  - WordPressMocks (from `https://github.com/wordpress-mobile/WordPressMocks.git`, branch `fix/jetpack-screenshot-generation`)
   - WordPressShared (~> 1.18.0)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.4)
@@ -636,7 +636,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressMocks
     - WordPressShared
     - WordPressUI
     - WPMediaPicker
@@ -748,6 +747,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.78.1
+  WordPressMocks:
+    :branch: fix/jetpack-screenshot-generation
+    :git: https://github.com/wordpress-mobile/WordPressMocks.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.78.1/third-party-podspecs/Yoga.podspec.json
 
@@ -763,6 +765,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.78.1
+  WordPressMocks:
+    :commit: f359aa4e92a675d30fb50eabaf2870f9eb4d554d
+    :git: https://github.com/wordpress-mobile/WordPressMocks.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -848,7 +853,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
   WordPressKit: eb0949165ec479f2ec1c205f141fd62c72c5047a
-  WordPressMocks: 6b52b0764d9939408151367dd9c6e8a910877f4d
+  WordPressMocks: de50fe5968a98fa05db1fb1f9a1a23c3d288b58c
   WordPressShared: e5a479220643f46dc4d7726ef8dd45f18bf0c53b
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 9533160e5587939876aeeb1461a441a4e5dc4c4d
@@ -863,6 +868,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 1df6eb961a870ad20226cb5cf90605b232cfc515
+PODFILE CHECKSUM: 8c9c48383fc5201c7e5e1994d673d31512ded27d
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -398,6 +398,9 @@ extension BaseActivityListViewController: ActivityPresenter {
         alertController.addDefaultActionWithTitle(backupTitle, handler: { _ in
             self.present(UINavigationController(rootViewController: backupOptionsVC), animated: true)
         })
+        if let backupAction = alertController.actions.last {
+            backupAction.accessibilityIdentifier = "jetpack-download-backup-button"
+        }
 
         let cancelTitle = NSLocalizedString("Cancel", comment: "Title for cancel action. Dismisses the action sheet.")
         alertController.addCancelActionWithTitle(cancelTitle)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -169,6 +169,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         let closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
         closeButton.layer.cornerRadius = 15
         closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Dismisses the current screen")
+        closeButton.accessibilityIdentifier = "close-button"
         closeButton.setImage(UIImage.gridicon(.crossSmall), for: .normal)
         closeButton.addTarget(target, action: action, for: .touchUpInside)
 

--- a/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Jetpack/JetpackBackupScreen.swift
@@ -8,7 +8,7 @@ public class JetpackBackupScreen: ScreenObject {
     }
 
     var ellipsisButton: XCUIElement { ellipsisButtonGetter(app) }
-    var downloadBackupButton: XCUIElement { app.sheets.buttons.element(boundBy: 1) }
+    var downloadBackupButton: XCUIElement { app.sheets.buttons["jetpack-download-backup-button"] }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(

--- a/WordPress/UITestsFoundation/Screens/Login/FeatureIntroductionScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/FeatureIntroductionScreen.swift
@@ -1,0 +1,28 @@
+import ScreenObject
+import XCTest
+
+public class FeatureIntroductionScreen: ScreenObject {
+    private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["close-button"]
+    }
+
+    var closeButton: XCUIElement { closeButtonGetter(app) }
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [closeButtonGetter],
+            app: app,
+            waitTimeout: 7
+        )
+    }
+
+    public func dismiss() throws -> MySiteScreen {
+        closeButton.tap()
+
+        return try MySiteScreen()
+    }
+
+    static func isLoaded() -> Bool {
+        (try? FeatureIntroductionScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -23,6 +23,7 @@ public class LoginEpilogueScreen: ScreenObject {
 
         try dismissQuickStartPromptIfNeeded()
         try dismissOnboardingQuestionsPromptIfNeeded()
+        try dismissFeatureIntroductionIfNeeded()
         return try MySiteScreen()
     }
 
@@ -75,6 +76,15 @@ public class LoginEpilogueScreen: ScreenObject {
 
             Logger.log(message: "Dismissing onboarding questions prompt...", event: .i)
             _ = try OnboardingQuestionsPromptScreen().selectSkip()
+        }
+    }
+
+    private func dismissFeatureIntroductionIfNeeded() throws {
+        try XCTContext.runActivity(named: "Dismiss feature introduction screen if needed.") { _ in
+            guard FeatureIntroductionScreen.isLoaded() else { return }
+
+            Logger.log(message: "Dismissing feature introduction screen...", event: .i)
+            _ = try FeatureIntroductionScreen().dismiss()
         }
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3047,6 +3047,7 @@
 		FA8E2FE627C6AE4500DA0982 /* QuickStartChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA8E2FE427C6AE4500DA0982 /* QuickStartChecklistView.swift */; };
 		FA90EFEF262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */; };
 		FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */; };
+		FA9276AD286C951200C323BB /* FeatureIntroductionScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA9276AC286C951200C323BB /* FeatureIntroductionScreen.swift */; };
 		FA98A24D2832A5E9003B9233 /* NewQuickStartChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98A24C2832A5E9003B9233 /* NewQuickStartChecklistView.swift */; };
 		FA98A24E2832A5E9003B9233 /* NewQuickStartChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98A24C2832A5E9003B9233 /* NewQuickStartChecklistView.swift */; };
 		FA98A2502833F1DC003B9233 /* QuickStartChecklistConfigurable.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA98A24F2833F1DC003B9233 /* QuickStartChecklistConfigurable.swift */; };
@@ -7966,6 +7967,7 @@
 		FA8E2FDF27C6377000DA0982 /* DashboardQuickStartCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardQuickStartCardCell.swift; sourceTree = "<group>"; };
 		FA8E2FE427C6AE4500DA0982 /* QuickStartChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistView.swift; sourceTree = "<group>"; };
 		FA90EFEE262E74210055AB22 /* JetpackWebViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = JetpackWebViewControllerFactory.swift; path = Classes/Services/JetpackWebViewControllerFactory.swift; sourceTree = SOURCE_ROOT; };
+		FA9276AC286C951200C323BB /* FeatureIntroductionScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureIntroductionScreen.swift; sourceTree = "<group>"; };
 		FA978DDA26CEB37E009FB14F /* WordPress 132.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 132.xcdatamodel"; sourceTree = "<group>"; };
 		FA98A24C2832A5E9003B9233 /* NewQuickStartChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewQuickStartChecklistView.swift; sourceTree = "<group>"; };
 		FA98A24F2833F1DC003B9233 /* QuickStartChecklistConfigurable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistConfigurable.swift; sourceTree = "<group>"; };
@@ -13907,6 +13909,7 @@
 				BE6DD32B1FD6782A00E55192 /* LoginEpilogueScreen.swift */,
 				FA612DDE274E9F730002B03A /* QuickStartPromptScreen.swift */,
 				C7B7CC7228134347007B9807 /* OnboardingQuestionsPromptScreen.swift */,
+				FA9276AC286C951200C323BB /* FeatureIntroductionScreen.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -19731,6 +19734,7 @@
 				EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */,
 				3F2F855626FAF227000FCDA5 /* LoginEmailScreen.swift in Sources */,
 				3FE39A3926F837E1006E2B3A /* ActivityLogScreen.swift in Sources */,
+				FA9276AD286C951200C323BB /* FeatureIntroductionScreen.swift in Sources */,
 				3F2F855B26FAF227000FCDA5 /* LoginPasswordScreen.swift in Sources */,
 				3F2F854A26FAF132000FCDA5 /* FeaturedImageScreen.swift in Sources */,
 				3F762E9B26784D2A0088CD45 /* XCUIElement+Utils.swift in Sources */,


### PR DESCRIPTION
Part of #18960 
WPMocks PR: https://github.com/wordpress-mobile/WordPressMocks/pull/42

## Description
This PR fixes several issues in the `testGenerateScreenshots()` UI test for the `JetpackScreenshotGeneration` target
- Dismisses the Feature Intro modal if needed 4c138d7
- Fixes switching sites fcfac7c
- Fixes navigating to the Backup Options screen 106fb4a

## Notes
- While this PR makes the screenshot UI test pass, we still need to fix the stats graph not displaying properly. This will be addressed in a separate PR
- Once the WPMocks PR is merged and a new version is released, I'll update the `Podfile` to point to the latest released version

## How to test
1. Run `rake mocks`
2. Delete the existing Jetpack app
3. Switch to the `JetpackScreenshotGeneration` target
4. Run the UI test
5. ✅ The UI test should succeed
6. Run the UI test again
7. ✅ The UI test should succeed

## Regression Notes
1. Potential unintended areas of impact
- `WordPressScreenshotGeneration` UI test

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Ran the UI test for the `WordPressScreenshotGeneration` target and made sure the UI test succeeds

3. What automated tests I added (or what prevented me from doing so)
- `testGenerateScreenshots()`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
