### PR TITLE
Refactoring PostListViewController: Add ViewModel & extract edit post logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -100,6 +100,8 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     /// If set, when the post list appear it will show the tab for this status
     var initialFilterWithPostStatus: BasePost.Status?
 
+    private var viewModel: PostListViewModel?
+
     // MARK: - Convenience constructors
 
     @objc class func controllerWithBlog(_ blog: Blog) -> PostListViewController {
@@ -116,6 +118,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         let controller = PostListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         controller.initialFilterWithPostStatus = postStatus
+        controller.viewModel = PostListViewModel(blog: blog, postCoordinator: PostCoordinator.shared)
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.blogDetailNavigation)
@@ -176,7 +179,22 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         configureInitialFilterIfNeeded()
         listenForAppComingToForeground()
 
+        bindViewModel()
         createButtonCoordinator.add(to: view, trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor, bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
+    }
+
+    private func bindViewModel() {
+        bindViewModelOutputs()
+    }
+
+    private func bindViewModelOutputs() {
+        viewModel?.editingPostUploadSuccess = { post in
+            PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
+        }
+
+        viewModel?.editingPostUploadFailed = { [weak self] in
+            self?.presentAlertForPostBeingUploaded()
+        }
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {
@@ -531,7 +549,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
-        editPost(apost: post)
+        viewModel?.edit(post)
     }
 
     @objc func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
@@ -605,19 +623,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         WPAppAnalytics.track(.editorCreatedPost, withProperties: [WPAppAnalyticsKeyTapSource: "posts_view", WPAppAnalyticsKeyPostType: "post"], with: blog)
     }
 
-    private func editPost(apost: AbstractPost) {
-        guard let post = apost as? Post else {
-            return
-        }
-        guard !PostCoordinator.shared.isUploading(post: post) else {
-            presentAlertForPostBeingUploaded()
-            return
-        }
-
-        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
-        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
-    }
-
     private func editDuplicatePost(apost: AbstractPost) {
         guard let post = apost as? Post else {
             return
@@ -686,7 +691,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - InteractivePostViewDelegate
 
     func edit(_ post: AbstractPost) {
-        editPost(apost: post)
+        viewModel?.edit(post)
     }
 
     func view(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -100,7 +100,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     /// If set, when the post list appear it will show the tab for this status
     var initialFilterWithPostStatus: BasePost.Status?
 
-    private var viewModel: PostListViewModel?
+    var viewModel: PostListViewModel?
 
     // MARK: - Convenience constructors
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -109,6 +109,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         let storyBoard = UIStoryboard(name: "Posts", bundle: Bundle.main)
         let controller = storyBoard.instantiateViewController(withIdentifier: "PostListViewController") as! PostListViewController
         controller.blog = blog
+        controller.viewModel = PostListViewModel(blog: blog, postCoordinator: PostCoordinator.shared)
         controller.restorationClass = self
 
         return controller
@@ -118,7 +119,6 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         let controller = PostListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         controller.initialFilterWithPostStatus = postStatus
-        controller.viewModel = PostListViewModel(blog: blog, postCoordinator: PostCoordinator.shared)
         sourceController.navigationController?.pushViewController(controller, animated: true)
 
         QuickStartTourGuide.shared.visited(.blogDetailNavigation)

--- a/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+protocol PostListViewModelProtocol {
+    
+}
+
+/// REFACTOR IN PROGRESS: Extracting VM logic from `PostListViewController`
+final class PostListViewModel: InteractivePostViewDelegate {
+    private enum Constants {
+        enum AnalyticsProperty: String {
+            case type
+            case filter
+        }
+    }
+
+    private let blog: Blog
+
+    init(blog: Blog) {
+        self.blog = blog
+    }
+
+    lazy var filterSettings: PostListFilterSettings = {
+        return PostListFilterSettings(blog: self.blog, postType: PostServiceType.post)
+    }()
+
+    func edit(_ post: AbstractPost) {
+        guard let post = post as? Post else {
+            return
+        }
+//        guard !PostCoordinator.shared.isUploading(post: post) else {
+//            presentAlertForPostBeingUploaded()
+//            return
+//        }
+
+        WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
+//        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
+    }
+
+    func view(_ post: AbstractPost) {
+
+    }
+
+    func stats(for post: AbstractPost) {
+
+    }
+
+    func duplicate(_ post: AbstractPost) {
+
+    }
+
+    func publish(_ post: AbstractPost) {
+
+    }
+
+    func trash(_ post: AbstractPost) {
+
+    }
+
+    func restore(_ post: AbstractPost) {
+
+    }
+
+    func draft(_ post: AbstractPost) {
+
+    }
+
+    func retry(_ post: AbstractPost) {
+
+    }
+
+    func cancelAutoUpload(_ post: AbstractPost) {
+
+    }
+
+    func share(_ post: AbstractPost, fromView view: UIView) {
+
+    }
+
+    func copyLink(_ post: AbstractPost) {
+
+    }
+}
+
+private extension PostListViewModel {
+    func propertiesForAnalytics() -> [String: AnyObject] {
+        var properties = [String: AnyObject]()
+
+        properties[Constants.AnalyticsProperty.type.rawValue] = PostServiceType.post as AnyObject?
+        properties[Constants.AnalyticsProperty.filter.rawValue] = filterSettings.currentPostListFilter().title as AnyObject?
+
+        if let dotComID = blog.dotComID {
+            properties[WPAppAnalyticsKeyBlogID] = dotComID
+        }
+
+        return properties
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
@@ -2,11 +2,13 @@ import Foundation
 
 protocol PostListViewModelOutputs {
     var editingPostUploadFailed: (() -> Void)? { get set }
-    var editingPostUploadSuccess: (() -> Void)? { get set }
+    var editingPostUploadSuccess: ((Post) -> Void)? { get set }
 }
 
 /// Convert to protocol if more inputs are needed.
 typealias PostListViewModelInputs = InteractivePostViewDelegate
+
+typealias PostListViewModelType = PostListViewModelInputs & PostListViewModelOutputs
 
 /// REFACTOR IN PROGRESS: Extracting VM logic from `PostListViewController`
 final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs {
@@ -19,7 +21,7 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
 
     // MARK: - Output Closures
     var editingPostUploadFailed: (() -> Void)?
-    var editingPostUploadSuccess: (() -> Void)?
+    var editingPostUploadSuccess: ((Post) -> Void)?
 
     // MARK: - Internal State
     lazy var filterSettings: PostListFilterSettings = {
@@ -42,14 +44,13 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
             return
         }
         guard !postCoordinator.isUploading(post: post) else {
-//            presentAlertForPostBeingUploaded()
             editingPostUploadFailed?()
             return
         }
 
+        // DI Analytics & test
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
-//        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
-        editingPostUploadSuccess?()
+        editingPostUploadSuccess?(post)
     }
 
     func view(_ post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
@@ -1,11 +1,15 @@
 import Foundation
 
-protocol PostListViewModelProtocol {
-    
+protocol PostListViewModelOutputs {
+    var editingPostUploadFailed: (() -> Void)? { get set }
+    var editingPostUploadSuccess: (() -> Void)? { get set }
 }
 
+/// Convert to protocol if more inputs are needed.
+typealias PostListViewModelInputs = InteractivePostViewDelegate
+
 /// REFACTOR IN PROGRESS: Extracting VM logic from `PostListViewController`
-final class PostListViewModel: InteractivePostViewDelegate {
+final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs {
     private enum Constants {
         enum AnalyticsProperty: String {
             case type
@@ -13,27 +17,39 @@ final class PostListViewModel: InteractivePostViewDelegate {
         }
     }
 
-    private let blog: Blog
+    // MARK: - Output Closures
+    var editingPostUploadFailed: (() -> Void)?
+    var editingPostUploadSuccess: (() -> Void)?
 
-    init(blog: Blog) {
-        self.blog = blog
-    }
-
+    // MARK: - Internal State
     lazy var filterSettings: PostListFilterSettings = {
         return PostListFilterSettings(blog: self.blog, postType: PostServiceType.post)
     }()
 
+    // MARK: - Private State
+    private let blog: Blog
+    private let postCoordinator: PostCoordinator
+
+    // MARK: - Lifecycle
+    init(blog: Blog, postCoordinator: PostCoordinator) {
+        self.blog = blog
+        self.postCoordinator = postCoordinator
+    }
+
+    // MARK: - Outputs
     func edit(_ post: AbstractPost) {
         guard let post = post as? Post else {
             return
         }
-//        guard !PostCoordinator.shared.isUploading(post: post) else {
+        guard !postCoordinator.isUploading(post: post) else {
 //            presentAlertForPostBeingUploaded()
-//            return
-//        }
+            editingPostUploadFailed?()
+            return
+        }
 
         WPAppAnalytics.track(.postListEditAction, withProperties: propertiesForAnalytics(), with: post)
 //        PostListEditorPresenter.handle(post: post, in: self, entryPoint: .postsList)
+        editingPostUploadSuccess?()
     }
 
     func view(_ post: AbstractPost) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */; };
 		08A50DED286C80F5003B0195 /* PostListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A50DEC286C80F5003B0195 /* PostListViewModel.swift */; };
 		08A50DEE286C80F5003B0195 /* PostListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A50DEC286C80F5003B0195 /* PostListViewModel.swift */; };
+		08AAC954286CC22B0052790A /* PostListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08AAC953286CC22B0052790A /* PostListViewModelTests.swift */; };
 		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
 		08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
@@ -5038,6 +5039,7 @@
 		08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagServiceTests.m; sourceTree = "<group>"; };
 		08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategoryServiceTests.m; sourceTree = "<group>"; };
 		08A50DEC286C80F5003B0195 /* PostListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewModel.swift; sourceTree = "<group>"; };
+		08AAC953286CC22B0052790A /* PostListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewModelTests.swift; sourceTree = "<group>"; };
 		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
 		08AAD69E1CBEA47D002B2418 /* MenusService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusService.m; sourceTree = "<group>"; };
 		08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceTests.m; sourceTree = "<group>"; };
@@ -10547,6 +10549,7 @@
 				59ECF87A1CB7061D00E68F25 /* PostSharingControllerTests.swift */,
 				F18B43771F849F580089B817 /* PostAttachmentTests.swift */,
 				8B6BD54F24293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift */,
+				08AAC953286CC22B0052790A /* PostListViewModelTests.swift */,
 			);
 			name = Posts;
 			sourceTree = "<group>";
@@ -20309,6 +20312,7 @@
 				24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */,
 				8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */,
 				8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */,
+				08AAC954286CC22B0052790A /* PostListViewModelTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,
 				027AC5212278983F0033E56E /* DomainCreditEligibilityTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -106,6 +106,8 @@
 		088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088CC593282BEC41007B9421 /* TooltipPresenter.swift */; };
 		08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */; };
 		08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */; };
+		08A50DED286C80F5003B0195 /* PostListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A50DEC286C80F5003B0195 /* PostListViewModel.swift */; };
+		08A50DEE286C80F5003B0195 /* PostListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A50DEC286C80F5003B0195 /* PostListViewModel.swift */; };
 		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
 		08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
@@ -5035,6 +5037,7 @@
 		088CC593282BEC41007B9421 /* TooltipPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenter.swift; sourceTree = "<group>"; };
 		08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagServiceTests.m; sourceTree = "<group>"; };
 		08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategoryServiceTests.m; sourceTree = "<group>"; };
+		08A50DEC286C80F5003B0195 /* PostListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListViewModel.swift; sourceTree = "<group>"; };
 		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
 		08AAD69E1CBEA47D002B2418 /* MenusService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusService.m; sourceTree = "<group>"; };
 		08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceTests.m; sourceTree = "<group>"; };
@@ -10755,6 +10758,7 @@
 				591232681CCEAA5100B86207 /* AbstractPostListViewController.swift */,
 				590E873A1CB8205700D1B734 /* PostListViewController.swift */,
 				E684383D221F535900752258 /* LoadMoreCounter.swift */,
+				08A50DEC286C80F5003B0195 /* PostListViewModel.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -19415,6 +19419,7 @@
 				FF8DDCDF1B5DB1C10098826F /* SettingTableViewCell.m in Sources */,
 				9A3BDA0E22944F3500FBF510 /* CountriesMapView.swift in Sources */,
 				17BB26AE1E6D8321008CD031 /* MediaLibraryViewController.swift in Sources */,
+				08A50DED286C80F5003B0195 /* PostListViewModel.swift in Sources */,
 				98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				F5E1577F25DE04E200EEEDFB /* GutenbergMediaFilesUploadProcessor.swift in Sources */,
 				80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
@@ -21633,6 +21638,7 @@
 				FABB249D2602FC2C00C8785C /* JetpackScanHistoryCoordinator.swift in Sources */,
 				FABB249E2602FC2C00C8785C /* NoticeStore.swift in Sources */,
 				FABB249F2602FC2C00C8785C /* RevisionBrowserState.swift in Sources */,
+				08A50DEE286C80F5003B0195 /* PostListViewModel.swift in Sources */,
 				982DDF93263238A6002B3904 /* LikeUser+CoreDataProperties.swift in Sources */,
 				FAADE42626159AFE00BF29FE /* AppConstants.swift in Sources */,
 				C352870627FDD35C004E2E51 /* SiteNameStep.swift in Sources */,

--- a/WordPress/WordPressTest/PostListViewModelTests.swift
+++ b/WordPress/WordPressTest/PostListViewModelTests.swift
@@ -1,0 +1,51 @@
+import XCTest
+@testable import WordPress
+
+final class PostListViewModelTests: XCTestCase {
+    private let mockContextManager = ContextManagerMock()
+
+    func testFilterSettingsIsPostType() {
+        let sut = PostListViewModel(blog: makeBlog(), postCoordinator: PostCoordinator())
+        XCTAssertEqual(sut.filterSettings.postType, .post)
+    }
+
+    func testEditInvokesFailureWhenPostIsUploading() {
+        class MockPostCoordinator: PostCoordinator {
+            override func isUploading(post: AbstractPost) -> Bool {
+                true
+            }
+        }
+
+        let sut = PostListViewModel(blog: makeBlog(), postCoordinator: MockPostCoordinator())
+
+        var postFailedCounter = 0
+        sut.editingPostUploadFailed = {
+            postFailedCounter += 1
+        }
+        sut.edit(PostBuilder().build())
+
+        XCTAssertEqual(postFailedCounter, 1)
+    }
+
+    func testEditInvokesSuccessWhenPostIsUploading() {
+        class MockPostCoordinator: PostCoordinator {
+            override func isUploading(post: AbstractPost) -> Bool {
+                true
+            }
+        }
+
+        let sut = PostListViewModel(blog: makeBlog(), postCoordinator: MockPostCoordinator())
+
+        var postFailedCounter = 0
+        sut.editingPostUploadFailed = {
+            postFailedCounter += 1
+        }
+        sut.edit(PostBuilder().build())
+
+        XCTAssertEqual(postFailedCounter, 1)
+    }
+
+    func makeBlog() -> Blog {
+        return BlogBuilder(mockContextManager.mainContext).isHostedAtWPcom().build()
+    }
+}


### PR DESCRIPTION
This PR will be the first of a chain of PR's to refactor the VC. 
I started with extracting the `InteractivePostViewDelegate` as it provides the main interaction points with the screen.

It adds `PostListViewModel` & `PostListViewModelTests` and extracts `edit` logic to the VM. It is based on a feature branch to give a us a chance to test the whole screen all together in the end. I will create a PR for every action that protocol provides along with the tests.

## To Test:
1. Go to Posts Screen.
2. Edit any post and see if it updates correctly.
3. There's also the "Post being edited" case but I am unsure of how to triggered that case. Unit tests were added for it but the test do not cover VC's part of showing the alert. It looks perfectly fine to me but just a heads up.

## Regression Notes
1. Potential unintended areas of impact
3rd point in "To Test" section.
Another possibility would be if there's another instantiation of the VC apart from the static function. A quick search reveals no such instantiation.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
I added unit tests in `PostListViewModel`.

5. What automated tests I added (or what prevented me from doing so)
`PostListViewModel`
Tracking is not tested yet. `WPAppAnalytics` is not directly injectable I think. I will follow up with another PR for that and add tests for tracking too.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
