### PR TITLE
Update `ShareAppContentPresenter` tests to be synchronous

### DIFF
--- a/WordPress/Classes/ViewRelated/Sharing/ShareAppContentPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Sharing/ShareAppContentPresenter.swift
@@ -24,9 +24,7 @@ class ShareAppContentPresenter {
     /// The API used for fetching the share app link. Anonymous profile is allowed.
     private let api: WordPressComRestApi
 
-    private lazy var remote: ShareAppContentServiceRemote = {
-        ShareAppContentServiceRemote(wordPressComRestApi: api)
-    }()
+    private var remote: ShareAppContentServiceRemote
 
     /// In-memory cache. As long as the same presenter instance is used, there's no need to re-fetch the content everytime `shareContent` is called.
     private var cachedContent: RemoteShareAppContent? = nil
@@ -34,8 +32,9 @@ class ShareAppContentPresenter {
     // MARK: Initialization
 
     /// Instantiates the presenter. When the provided account is nil, the presenter will default to anonymous API.
-    init(account: WPAccount? = nil) {
+    init(remote: ShareAppContentServiceRemote? = nil, account: WPAccount? = nil) {
         self.api = account?.wordPressComRestV2Api ?? .anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
+        self.remote = remote ?? ShareAppContentServiceRemote(wordPressComRestApi: api)
     }
 
     // MARK: Public Methods


### PR DESCRIPTION
## Description

Mocks the remote API class to make the `completion` block synchronous when testing. This fixes the issue where these tests would sometimes timeout.

## Testing

To test:
- Run `ShareAppContentPresenterTests`
- Verify they pass

**Verifying production code changes**

- Run and login to the WordPress app
- Select a site if necessary and navigate to the 'My Site' tab
- Tap on your avatar in the top right
- Tap on 'Share WordPress with a friend'
- Verify the share sheet appears
- Close the sheet
- Tap on 'About WordPress'
- Tap on 'Share with Friends'
- Verify the sheet appears

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
