### PR TITLE
Editor: Reset search query when media picker is dismissed

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 20.3
 -----
-
+* [*] Block Editor: Fixed an issue where the media picker search query was being retained after dismissing the picker and opening it again. [#18980]
 
 20.2
 -----

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -132,6 +132,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
+        mediaLibraryDataSource.searchCancelled()
         context.dismiss(animated: true, completion: { self.invokeMediaPickerCallback(asset: nil) })
     }
 


### PR DESCRIPTION
Part of #18840 

## Description
Fixes an issue in the editor where the search query was being retained even after dismissing the media picker.

## Testing Instructions

1. Create a new blog post
2. Add an Image block
3. Click `ADD IMAGE`
4. Click `WordPress Media Library`
5. Search for some string that will not return any results
6. Click `Cancel` button in Navigation bar
7. Click `ADD IMAGE`
8. Click `WordPress Media Library`
9. Make sure that all the available images are displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.