### PR TITLE
StatsTotalInsightsCell: Ensure latest post text is formatted

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -66,7 +66,7 @@ struct StatsTotalInsightsData {
 
             let formattedText: String
             if summary.likesCount == Constants.singularLikeCount {
-                formattedText = TextContent.likesTotalGuideTextSingular
+                formattedText = String(format: TextContent.likesTotalGuideTextSingular, summary.title)
             } else {
                 formattedText = String(format: TextContent.likesTotalGuideTextPlural, summary.title, summary.likesCount)
             }


### PR DESCRIPTION
Fixes #18982. This PR ensures the singular version of the Latest Post guide text in StatsTotalInsightsCell is formatted.

![latest-post-1](https://user-images.githubusercontent.com/4780/177206083-058caea9-9c8b-4502-afaf-0dca5b3a75c4.png)

**To test**

Follow the steps from the original PR. You'll need to find a site where the latest post has one like to test the singular version:

- Open the My Site tab
- Do either of the following:
   - On the Home tab, tap the Stats button
   - On the Menu tab, tap the Stats list item
- On the Insights tab, locate the LIkes Total card (if it's not added, add it via the gear icon)
- On the Likes Total card, ensure that the guide text doesn't show any placeholders

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
