### PR TITLE
Insights Management: Fix an issue when deactivating all cards

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -199,6 +199,7 @@ class InsightsManagementViewController: UITableViewController {
         static let activeCardsHeader = NSLocalizedString("stats.insights.management.activeCards", value: "Active Cards", comment: "Header title indicating which Stats Insights cards the user currently has set to active.")
         static let inactiveCardsHeader = NSLocalizedString("stats.insights.management.inactiveCards", value: "Inactive Cards", comment: "Header title indicating which Stats Insights cards the user currently has disabled.")
         static let placeholderRowTitle = NSLocalizedString("stats.insights.management.selectCardsPrompt", value: "Select cards from the list below", comment: "Prompt displayed on the Stats Insights management screen telling the user to tap a row to add it to their list of active cards.")
+        static let inactivePlaceholderRowTitle = NSLocalizedString("stats.insights.management.noCardsPrompt", value: "No inactive cards remaining", comment: "Prompt displayed on the Stats Insights management screen telling the user that all Stats cards are enabled.")
 
         static let savePromptMessage = NSLocalizedString("stats.insights.management.savePrompt.message", value: "You've made changes to your active Insights cards.", comment: "Title of alert in Stats Insights management, prompting the user to save changes to their list of active Stats cards.")
         static let savePromptSaveButton = NSLocalizedString("stats.insights.management.savePrompt.saveButton", value: "Save Changes", comment: "Title of button in Stats Insights management, prompting the user to save changes to their list of active Stats cards.")
@@ -251,8 +252,8 @@ private extension InsightsManagementViewController {
     func inactiveCardsSection() -> ImmuTableSection {
         let rows = InsightsManagementViewController.allInsights.filter({ !self.insightsShown.contains($0) })
 
-        guard insightsShown.count > 0 else {
-            return ImmuTableSection(headerText: TextContent.inactiveCardsHeader, rows: [placeholderRow])
+        guard rows.count > 0 else {
+            return ImmuTableSection(headerText: TextContent.inactiveCardsHeader, rows: [inactivePlaceholderRow])
         }
 
         return ImmuTableSection(headerText: TextContent.inactiveCardsHeader,
@@ -313,6 +314,12 @@ private extension InsightsManagementViewController {
 
     var placeholderRow: ImmuTableRow {
         return AddInsightStatRow(title: TextContent.placeholderRowTitle,
+                                 enabled: false,
+                                 action: nil)
+    }
+
+    var inactivePlaceholderRow: ImmuTableRow {
+        return AddInsightStatRow(title: TextContent.inactivePlaceholderRowTitle,
                                  enabled: false,
                                  action: nil)
     }


### PR DESCRIPTION
Fixes #18981. This PR fixes an issue where all cards could disappear from the Insights Management screen if all cards are deactivated.

| All Active | All Inactive |
|---|---|
| ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-04 at 22 26 29](https://user-images.githubusercontent.com/4780/177218147-5e760fd5-0c5c-4c90-b752-77586dd7c8f0.png) | ![Simulator Screen Shot - iPhone 13 Pro - 2022-07-04 at 22 26 44](https://user-images.githubusercontent.com/4780/177218142-1446e263-1cbe-47bf-9151-86731ec430e7.png) |

**To test**

* Build and run
* Navigate to Stats > Insights, and tap the settings icon in the top right
* Try activating all cards, and then deactivating all cards. You should see the behaviour shown in the screenshots above.

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
