### PR TITLE
Fixes an issue when navigating to Stats on iPad from onboarding questions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+OnboardingPrompt.swift
@@ -17,7 +17,7 @@ extension MySiteViewController {
         case .stats:
             // Show the stats view for the current blog
             if let blog = blog {
-                StatsViewController.show(for: blog, from: self)
+                WPTabBarController.sharedInstance().mySitesCoordinator.showStats(for: blog, timePeriod: .insights)
             }
         case .writing:
             // Open the editor


### PR DESCRIPTION
Fixes #18985. This PR updates the onboarding prompts Stats navigation to use the newer navigation method that has been fixed to handle the home screen Dashboard.

**To test**

* Build and run on iPad (also verify on iPhone afterwards)
* Either fresh install, or log out if you are already logged in
* Log in, and on the final onboarding step choose "Checking Stats"
* You should be taken to the My Sites screen, with the menu shown in the left pane and Stats shown in the right
* On iPhone, you should just be taken to Stats, and be able to navigate back up the stack to My Sites.

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
