### PR TITLE
Disable Stats revamp feature for Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 
 20.2
 -----
-* [***] [Jetpack-only] The Insights view in Stats has been revamped with a cleaner look and a new set of cards to make it easier than ever to see at a glance how your site's performing. [#18945]
 * [*] Preview: Post preview now resizes to account for device orientation change. [#18921]
 * [***] [Jetpack-only] Enables QR Code Login scanning from the Me menu. [#18904]
 * [*] Reverted the app icon back to Cool Blue. Users can reselect last month's icon in Me > App Settings > App Icon if they'd like. [#18934]

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -19,6 +19,6 @@ import Foundation
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = false
-    @objc static let showsStatsRevampV2: Bool = true
+    @objc static let showsStatsRevampV2: Bool = false
     @objc static let qrLoginEnabled: Bool = true
 }

--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -40,8 +40,6 @@ msgstr ""
 
 msgctxt "v20.2-whats-new"
 msgid ""
-"We updated the Insights view in your site’s Stats. See how your site is performing with a quick glance—and comparing performance to previous time periods is just a finger-tap away.\n"
-"\n"
 "Need to switch over to your browser? You can now sign in by scanning a QR code in the app’s Me menu.\n"
 "\n"
 "When you’re previewing a post, you can now switch between portrait and landscape orientation without cutting off any content. Nice.\n"

--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -40,6 +40,8 @@ msgstr ""
 
 msgctxt "v20.2-whats-new"
 msgid ""
+"We updated the Insights view in your site’s Stats. See how your site is performing with a quick glance—and comparing performance to previous time periods is just a finger-tap away.\n"
+"\n"
 "Need to switch over to your browser? You can now sign in by scanning a QR code in the app’s Me menu.\n"
 "\n"
 "When you’re previewing a post, you can now switch between portrait and landscape orientation without cutting off any content. Nice.\n"

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,5 +1,3 @@
-We updated the Insights view in your site’s Stats. See how your site is performing with a quick glance—and comparing performance to previous time periods is just a finger-tap away.
-
 Need to switch over to your browser? You can now sign in by scanning a QR code in the app’s Me menu.
 
 When you’re previewing a post, you can now switch between portrait and landscape orientation without cutting off any content. Nice.


### PR DESCRIPTION
This disables the Stats Revamp feature flag for the Jetpack app by reverting the logic made in https://github.com/wordpress-mobile/WordPress-iOS/pull/18945. We expect to re-enable it for 20.3 after fixing blocking issues.

## To test
1. Log into the Jetpack app
2. Ensure that the "Stats Insights" feature announcement is not shown
3. Open the Stats' Insights tab 
4. Ensure that the cards use the old appearance (the same as 20.1)
5. Ensure that the Views & Visitors. Likes Total, and Comments Total cards are not shown
6. Log into the WordPress app
7. Repeat steps 2 to 5

## Regression Notes
1. Potential unintended areas of impact

The Stats feature should work as it did in 20.1 in the Jetpack app.

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Smoke tested the Stats feature.

6. What automated tests I added (or what prevented me from doing so)

Since this temporarily disables the **new** Stats, so no automated tests seem applicable.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
