### PR TITLE
Move lint translations and RuboCop in a `group` step in Buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -94,30 +94,27 @@ steps:
               context: "UI Tests (iPad)"
 
   #################
-  # Lint Translations
+  # Linters
   #################
-  - label: "🧹 Lint Translations"
-    command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-    plugins:
-      - docker#v3.8.0:
-          image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-    agents:
-      queue: "default"
-    notify:
-      - github_commit_status:
-          context: "Lint Translations"
-
-  #################
-  # Lint Ruby Tooling
-  #################
-  #
-  # TODO: This ought to be run on a Docker or Ubuntu agent as there's nothing that requires macOS.
-  # It's currently in the stock setup because... it was faster to build a proof of concept for it this way;
-  # I don't know how to pass the `DANGER_GITHUB_API_TOKEN` secret that we need to a Docker agent.
-  #
-  # This step uses Danger to run RuboCop, but it's "agnostic" about it.
-  # That is, it outwardly only mentions RuboCop, not Danger
-  - label: ":rubocop: Lint Ruby Tooling"
-    command: .buildkite/commands/rubocop-via-danger.sh
-    env: *common_env
-    plugins: *common_plugins
+  - group: " Linters"
+    steps:
+      - label: "🧹 Lint Translations"
+        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
+        plugins:
+          - docker#v3.8.0:
+              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+        agents:
+          queue: "default"
+        notify:
+          - github_commit_status:
+              context: "Lint Translations"
+      # TODO: This ought to be run on a Docker or Ubuntu agent as there's nothing that requires macOS.
+      # It's currently in the stock setup because... it was faster to build a proof of concept for it this way;
+      # I don't know how to pass the `DANGER_GITHUB_API_TOKEN` secret that we need to a Docker agent.
+      #
+      # This step uses Danger to run RuboCop, but it's "agnostic" about it.
+      # That is, it outwardly only mentions RuboCop, not Danger
+      - label: ":rubocop: Lint Ruby Tooling"
+        command: .buildkite/commands/rubocop-via-danger.sh
+        env: *common_env
+        plugins: *common_plugins


### PR DESCRIPTION
💅

![image](https://user-images.githubusercontent.com/1218433/177673789-f5ae4b2c-9109-4ded-b9eb-8ddcba4cdaf4.png)

![image](https://user-images.githubusercontent.com/1218433/177673800-804c5c3b-d59e-4373-905c-2e543e242f1a.png)

<img width="956" alt="image" src="https://user-images.githubusercontent.com/1218433/177696839-99cf2037-8d3e-4c32-b33d-064a265902fd.png">


If CI is green, we can merge this.


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
