### PR TITLE
QR Login: Restrict QR Login screens to portrait

### DIFF
--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginScanningViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginScanningViewController.swift
@@ -39,6 +39,8 @@ extension QRLoginScanningViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationController?.delegate = self
+
         errorLabel.isHidden = true
         coordinator?.start()
     }
@@ -63,6 +65,17 @@ extension QRLoginScanningViewController {
 
     @IBAction func didTapCloseButton(_ sender: Any) {
         coordinator?.didTapDismiss()
+    }
+}
+
+// MARK: - UINavigation Controller Delegate
+extension QRLoginScanningViewController: UINavigationControllerDelegate {
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        return supportedInterfaceOrientations
+    }
+
+    func navigationControllerPreferredInterfaceOrientationForPresentation(_ navigationController: UINavigationController) -> UIInterfaceOrientation {
+        return .portrait
     }
 }
 

--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
@@ -19,6 +19,8 @@ extension QRLoginVerifyAuthorizationViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        navigationController?.delegate = self
+
         coordinator?.start()
 
         applyStyles()
@@ -34,6 +36,17 @@ extension QRLoginVerifyAuthorizationViewController {
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
        return [.portrait, .portraitUpsideDown]
+    }
+}
+
+// MARK: - UINavigation Controller Delegate
+extension QRLoginVerifyAuthorizationViewController: UINavigationControllerDelegate {
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        return supportedInterfaceOrientations
+    }
+
+    func navigationControllerPreferredInterfaceOrientationForPresentation(_ navigationController: UINavigationController) -> UIInterfaceOrientation {
+        return .portrait
     }
 }
 


### PR DESCRIPTION
Ref: p5T066-3m4-p2#comment-12882

## Description
The QR login scanning screen and the QR login verify authorization screen weren't being locked in portrait mode, causing some UI issues.

## How to test
1. Turn off the portrait orientation lock
2. Follow the QR login testing instructions in p5T066-3m4-p2
3. ✅ Verify: the scanning screen is locked in portrait mode (even if the device portrait orientation lock is turned off)
4. ✅ Verify: the verify authorization screen is locked in portrait mode

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.