### PR TITLE
Remove a leading space that snuk in the Buildkite "Linter" `group` label

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -96,7 +96,7 @@ steps:
   #################
   # Linters
   #################
-  - group: " Linters"
+  - group: "Linters"
     steps:
       - label: "🧹 Lint Translations"
         command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/pull/19000#discussion_r916140310

## Testing
Nothing to test. In fact, Buildkite already removed that leading space when rendering the label 🤓

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
