### PR TITLE
Suggestions search was removing the incorrect user from search results

### DIFF
--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.swift
@@ -170,6 +170,7 @@ extension SuggestionType {
         var searchResults = searchResults
         if !suggestionsToInsert.isEmpty && suggestionIndexesToRemove.count > 0 {
             let suggestionsToInsert = suggestionsToInsert.compactMap { $0 }
+            suggestionIndexesToRemove = suggestionIndexesToRemove.sorted(by: >)
             suggestionIndexesToRemove.forEach { searchResults.remove(at: $0) }
             searchResults = suggestionsToInsert + searchResults
         }


### PR DESCRIPTION
## Description
This PR fixes a bug from another PR #18979 that was merged recently.

## Problem
In the previous PR, there was a code that removes multiple indexes from an array. Like this:
```
// `suggestionIndexesToRemove` is an array of integers.
suggestionIndexesToRemove.forEach { searchResults.remove(at: $0) }
```
This implementation is wrong. The following example illustrates the problem:

Let's assume that `suggestionIndexesToRemove` array is `[1, 3]`.

When the element at index `1` is removed, the element at index `3` is left-shifted to index `2`.  Then the element at index `3` gets removed, and that's not correct.

## Solution
Indexes should be removed from the end of the list to the beginning. In the previous example, the element at index `3` should be removed before the element at index `1`.
We can achieve this by sorting `suggestionIndexesToRemove.forEach` in descending order:
```
suggestionIndexesToRemove = suggestionIndexesToRemove.sorted(by: >)
```

We will open an upcoming PR to cover this case and other cases as well.
