### PR TITLE
App Store Screenshots: Ensure overview chart is displayed for Stats screenshot

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_visits-month.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/stats/stats_visits-month.json
@@ -26,91 +26,106 @@
         "period",
         "views",
         "visitors",
-        "comments"
+        "comments",
+        "likes"
       ],
       "data": [
         [
           "{{now offset='-13 months' format='yyyy-MM-dd'}}",
           1443,
           678,
+          0,
           0
         ],
         [
           "{{now offset='-12 months' format='yyyy-MM-dd'}}",
           1371,
           647,
+          0,
           0
         ],
         [
           "{{now offset='-11 months' format='yyyy-MM-dd'}}",
           1444,
           678,
+          0,
           0
         ],
         [
           "{{now offset='-10 months' format='yyyy-MM-dd'}}",
           1361,
           634,
-          1
+          1,
+          0
         ],
         [
           "{{now offset='-9 months' format='yyyy-MM-dd'}}",
           1195,
           560,
+          0,
           0
         ],
         [
           "{{now offset='-8 months' format='yyyy-MM-dd'}}",
           1391,
           644,
+          0,
           0
         ],
         [
           "{{now offset='-7 months' format='yyyy-MM-dd'}}",
           1257,
           588,
+          0,
           0
         ],
         [
           "{{now offset='-6 months' format='yyyy-MM-dd'}}",
           1458,
           686,
+          0,
           0
         ],
         [
           "{{now offset='-5 months' format='yyyy-MM-dd'}}",
           1716,
           808,
+          0,
           0
         ],
         [
           "{{now offset='-4 months' format='yyyy-MM-dd'}}",
           1586,
           746,
+          0,
           0
         ],
         [
           "{{now offset='-3 months' format='yyyy-MM-dd'}}",
           1342,
           659,
+          0,
           0
         ],
         [
           "{{now offset='-2 months' format='yyyy-MM-dd'}}",
           1280,
           643,
+          0,
           0
         ],
         [
           "{{now offset='-1 months' format='yyyy-MM-dd'}}",
           1218,
           623,
+          0,
           0
         ],
         [
           "{{now format='yyyy-MM-dd'}}",
           1233,
           655,
+          0,
           0
         ]
       ]


### PR DESCRIPTION
Part of #18960 

## Description

This fixes an issue on both WPiOS and JPiOS where “an error occurred” message was being displayed in place of the overview chart during the screenshot UI tests.

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/178021110-dc3a6237-56f4-45cd-b4db-38857b4399bd.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/178021115-90a9b468-c741-4f9f-88d1-010ad311d09f.png" width=200>

## ⚠️ Note

When you turn on the Stats Revamp feature flag (i.e. by setting `showsStatsRevampV2` to `true`) and run the UI tests, we get an entirely different error where the entire Stats creen isn't loaded. So I'm guessing this has to do something with how the Stats Revamp was implemented. I'll address this in a future PR. @guarani Any idea what might be going on? 

<img src="https://user-images.githubusercontent.com/6711616/178022371-6fce89f4-e564-4f2e-820f-1151bfc15128.png" width=200>

## How to test

1. Run `rake mocks`
2. Switch to the `JetpackScreenshotGeneration` target
3. Run `testGenerateScreenshots()`
4. ✅ Verify: the overview chart is displayed for the stats screenshot

## Regression Notes
1. Potential unintended areas of impact
n/a

5. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
