### PR TITLE
Retain horizontal scroll position for site and page designs.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 20.4
 -----
+* [*] Site Creation: Fixed a bug in the design picker where the horizontal position of designs could be reset. [#19020]
 
 
 20.3

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -5,6 +5,7 @@ protocol CategorySectionTableViewCellDelegate: AnyObject {
     func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String)
     func didDeselectItem(forCell cell: CategorySectionTableViewCell)
     func accessibilityElementDidBecomeFocused(forCell cell: CategorySectionTableViewCell)
+    func saveHorizontalScrollPosition(forCell cell: CategorySectionTableViewCell, xPosition: CGFloat)
     var selectedPreviewDevice: PreviewDeviceSelectionViewController.PreviewDevice { get }
 }
 
@@ -22,7 +23,6 @@ protocol CategorySection {
     var emoji: String? { get }
     var description: String? { get }
     var thumbnails: [Thumbnail] { get }
-    var scrollOffset: CGPoint { get set }
     var thumbnailSize: CGSize { get }
 }
 
@@ -50,7 +50,6 @@ class CategorySectionTableViewCell: UITableViewCell {
         didSet {
             thumbnails = section?.thumbnails ?? []
             categoryTitle.text = section?.title
-            collectionView.contentOffset = section?.scrollOffset ?? .zero
             setCaption()
 
             if let section = section {
@@ -84,9 +83,13 @@ class CategorySectionTableViewCell: UITableViewCell {
         }
     }
     var showsCheckMarkWhenSelected = true
+    var horizontalScrollOffset: CGFloat = .zero {
+        didSet {
+            collectionView.contentOffset.x = horizontalScrollOffset
+        }
+    }
 
     override func prepareForReuse() {
-        section?.scrollOffset = collectionView.contentOffset
         delegate = nil
         super.prepareForReuse()
         collectionView.contentOffset.x = 0
@@ -137,6 +140,10 @@ extension CategorySectionTableViewCell: UICollectionViewDelegate {
 
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
         delegate?.didDeselectItem(forCell: self)
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        delegate?.saveHorizontalScrollPosition(forCell: self, xPosition: scrollView.contentOffset.x)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLayoutPickerViewController.swift
@@ -13,7 +13,6 @@ class GutenbergLayoutSection: CategorySection {
 
     var section: PageTemplateCategory
     var layouts: [PageTemplateLayout]
-    var scrollOffset: CGPoint
     var thumbnailSize: CGSize
 
     var title: String { section.title }
@@ -26,7 +25,6 @@ class GutenbergLayoutSection: CategorySection {
         let layouts = Array(section.layouts ?? []).sorted()
         self.section = section
         self.layouts = layouts
-        self.scrollOffset = .zero
         self.thumbnailSize = thumbnailSize
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -19,6 +19,9 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
         }
     }
 
+    /// Dictionary to store horizontal scroll position of sections, keyed by category slug
+    private var sectionHorizontalOffsets: [String: CGFloat] = [:]
+
     private var isLoading: Bool = true {
         didSet {
             if isLoading {
@@ -294,18 +297,28 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         }
         cell.delegate = self
         cell.selectionStyle = UITableViewCell.SelectionStyle.none
-        cell.section = isLoading ? nil : sections[indexPath.row]
-        cell.isGhostCell = isLoading
+
         if isLoading {
+            cell.section = nil
+            cell.isGhostCell = true
             cell.ghostThumbnailSize = ghostThumbnailSize
+            cell.collectionView.allowsSelection = false
+        } else {
+            let section = sections[indexPath.row]
+            cell.section = section
+            cell.isGhostCell = false
+            cell.collectionView.allowsSelection = true
+            cell.horizontalScrollOffset = sectionHorizontalOffsets[section.categorySlug] ?? .zero
         }
+
         cell.showsCheckMarkWhenSelected = false
         cell.layer.masksToBounds = false
         cell.clipsToBounds = false
-        cell.collectionView.allowsSelection = !isLoading
         cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
         return cell
     }
+
+
 }
 
 // MARK: - CategorySectionTableViewCellDelegate
@@ -342,5 +355,13 @@ extension SiteDesignContentCollectionViewController: CategorySectionTableViewCel
     func accessibilityElementDidBecomeFocused(forCell cell: CategorySectionTableViewCell) {
         guard UIAccessibility.isVoiceOverRunning, let cellIndexPath = tableView.indexPath(for: cell) else { return }
         tableView.scrollToRow(at: cellIndexPath, at: .middle, animated: true)
+    }
+
+    func saveHorizontalScrollPosition(forCell cell: CategorySectionTableViewCell, xPosition: CGFloat) {
+        guard let cellSection = cell.section else {
+            return
+        }
+
+        sectionHorizontalOffsets[cellSection.categorySlug] = xPosition
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -14,6 +14,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     private var sections: [SiteDesignSection] = [] {
         didSet {
             tableView.scrollToTop(animated: false)
+            sectionHorizontalOffsets.removeAll()
             contentSizeWillChange()
             tableView.reloadData()
         }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -318,8 +318,6 @@ extension SiteDesignContentCollectionViewController: UITableViewDataSource {
         cell.categoryTitleFont = WPStyleGuide.serifFontForTextStyle(.title2, fontWeight: .semibold)
         return cell
     }
-
-
 }
 
 // MARK: - CategorySectionTableViewCellDelegate
@@ -362,7 +360,6 @@ extension SiteDesignContentCollectionViewController: CategorySectionTableViewCel
         guard let cellSection = cell.section else {
             return
         }
-
         sectionHorizontalOffsets[cellSection.categorySlug] = xPosition
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignSection.swift
@@ -10,7 +10,6 @@ struct SiteDesignSection: CategorySection {
     var emoji: String?
     var description: String?
     var thumbnails: [Thumbnail] { designs }
-    var scrollOffset: CGPoint = .zero
 
     var sectionType: SiteDesignSectionType = .standard
 }


### PR DESCRIPTION
Fixes #19025

## Description

This PR:
- Adds a `CategorySectionTableViewCellDelegate` protocol method `saveHorizontalScrollPosition` for saving horizontal scroll positions
- Makes it the responsibility of the `CategorySectionTableViewCellDelegate` instance to save scroll positions
- Removes UI state (`scrollOffset`) from the `CategorySection` and `GutenbergLayoutSection` types, which only pertains to the UITableView / UICollectionView and not the sections themselves

## Testing

### Site Creation

#### Horizontal scroll positions are retained
1. Start the Site Creation flow
2. Tap "Skip" on the "What's your website about?" screen
3. In the "Best for Blogging" category, scroll horizontally to the end
4. Scroll the theme selection to the bottom
5. Scroll back up to the "Best for Blogging" category
6. Observe that the horizontal scroll position has been retained
7. Run the same test with other categories

| Before | After |
| - | - |
| <video src="https://user-images.githubusercontent.com/2092798/178319626-75462a1c-0926-49c9-b7ae-25835be75765.MP4" /> | <video src="https://user-images.githubusercontent.com/2092798/178319887-0ea3d70d-7b09-4ff4-8a11-942ffeba0c95.MP4" /> |

#### Horizontal and vertical scroll positions are reset when navigating forwards or backwards
1. Start the Site Creation flow
2. Tap "Skip" on the "What's your website about?" screen
3. In multiple categories, scroll horizontally to random positions
4. Tap the "Back" button at the top left to navigate backwards
5. Tap "Skip" (or choose a vertical" on the "What's your website about?" screen to navigate forwards
6. Expect that all scroll positions are reset: The vertical position is at the top, all categories are scrolled horizontally to the beginning
7. Repeat steps 1-3
9. Tap the "Skip" button at the top right to navigate forwards
10. Tap the "Back" button at the top left to navigate backwards
11. Expect that all scroll positions are reset: The vertical position is at the top, all categories are scrolled horizontally to the beginning*

***Note**: As a future enhancement we should consider retaining the position of the design chosen when pressing "Back".

### Page Creation

1. Start the Page Creation flow by tapping the FAB button and choosing "Site page"
2. In the "Blog" category, scroll horizontally to the end
3. Scroll the layout selection to the bottom
4. Scroll back up to the "Blog" category
13. Observe that the horizontal scroll position has been retained
14. Run the same test with other categories
15. Filtering categories should not affect horizontal scroll positions

## Regression Notes
1. Potential unintended areas of impact
    - Scroll positions of site designs and page layouts

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested steps above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
