### PR TITLE
[UITII] Remove the app after each test

### DIFF
--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -49,49 +49,4 @@ class LoginFlow {
         }
         return try TabNavComponent()
     }
-
-    // Login with WP site via Site Address.
-    static func loginIfNeeded(siteUrl: String, email: String, password: String) throws -> TabNavComponent {
-        guard TabNavComponent.isLoaded() else {
-            return try login(siteUrl: siteUrl, email: email, password: password).tabBar
-        }
-        return try TabNavComponent()
-    }
-
-    static func logoutIfNeeded() throws {
-        try XCTContext.runActivity(named: "Log out of app if currently logged in") { (activity) in
-            if TabNavComponent.isLoaded() {
-                Logger.log(message: "Logging out...", event: .i)
-                let meScreen = try TabNavComponent().goToMeScreen()
-                if meScreen.isLoggedInToWpcom() {
-                    _ = try meScreen.logoutToPrologue()
-                } else {
-                    try meScreen.dismiss().removeSelfHostedSite()
-                }
-                return
-            }
-        }
-
-        try XCTContext.runActivity(named: "Return to app prologue screen if needed") { (activity) in
-            if !PrologueScreen.isLoaded() {
-                while PasswordScreen.isLoaded() || GetStartedScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
-                    if GetStartedScreen.isLoaded() && GetStartedScreen.isEmailEntered() {
-                        try GetStartedScreen().emailTextField.clearText()
-                    }
-                    navigateBack()
-                }
-            }
-
-            // TODO: remove when unifiedAuth is permanent.
-            // Leaving here for now in case unifiedAuth is disabled.
-//            if !WelcomeScreen.isLoaded() {
-//                while LoginPasswordScreen.isLoaded() || LoginEmailScreen.isLoaded() || LinkOrPasswordScreen.isLoaded() || LoginSiteAddressScreen.isLoaded() || LoginUsernamePasswordScreen.isLoaded() || LoginCheckMagicLinkScreen.isLoaded() {
-//                    if LoginEmailScreen.isLoaded() && LoginEmailScreen.isEmailEntered() {
-//                        LoginEmailScreen().emailTextField.clearTextIfNeeded()
-//                    }
-//                    navBackButton.tap()
-//                }
-//            }
-        }
-    }
 }

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -5,8 +5,6 @@ class LoginFlow {
 
     @discardableResult
     static func login(email: String, password: String) throws -> MySiteScreen {
-        try logoutIfNeeded()
-
         return try PrologueScreen().selectContinue()
             .proceedWith(email: email)
             .proceedWith(password: password)
@@ -17,8 +15,6 @@ class LoginFlow {
     // Login with self-hosted site via Site Address.
     @discardableResult
     static func login(siteUrl: String, username: String, password: String) throws -> MySiteScreen {
-        try logoutIfNeeded()
-
         return try PrologueScreen().selectSiteAddress()
             .proceedWith(siteUrl: siteUrl)
             .proceedWith(username: username, password: password)
@@ -38,8 +34,6 @@ class LoginFlow {
     // Login with WP site via Site Address.
     @discardableResult
     static func login(siteUrl: String, email: String, password: String) throws -> MySiteScreen {
-        try logoutIfNeeded()
-
         return try PrologueScreen().selectSiteAddress()
             .proceedWithWP(siteUrl: siteUrl)
             .proceedWith(email: email)

--- a/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorAztecTests.swift
@@ -7,7 +7,7 @@ class EditorAztecTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = try EditorFlow
             .toggleBlockEditor(to: .off)
             .goBackToMySite()
@@ -17,12 +17,7 @@ class EditorAztecTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        if editorScreen != nil && !TabNavComponent.isVisible() {
-            EditorFlow.returnToMainEditorScreen()
-            editorScreen.closeEditor()
-        }
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+        removeApp()
     }
 
     // TODO: Re-enable Aztec tests but for editing an existing Aztec post.

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -17,15 +17,7 @@ class EditorGutenbergTests: XCTestCase {
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
 
-        if editorScreen == nil {
-            BlockEditorScreen.closeEditorDiscardingChanges()
-        } else if TabNavComponent.isVisible() == false {
-            editorScreen.dismissBlocksPickerIfNeeded()
-            EditorFlow.returnToMainEditorScreen()
-            editorScreen.closeEditor()
-        }
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+        removeApp()
     }
 
     let title = "Rich post title"

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -16,7 +16,6 @@ class EditorGutenbergTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/WordPressUITests/Tests/EditorGutenbergTests.swift
@@ -7,7 +7,7 @@ class EditorGutenbergTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         editorScreen = try EditorFlow
             .goToMySiteScreen()
             .tabBar.gotoBlockEditorScreen()

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -6,8 +6,6 @@ class LoginTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()
-
-        try LoginFlow.logoutIfNeeded()
     }
 
     override func tearDownWithError() throws {

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,9 +12,8 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try? MySitesScreen().closeModalIfNeeded()
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+
+        removeApp()
     }
 
     // Unified email login/out

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -12,7 +12,6 @@ class LoginTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -14,8 +14,8 @@ class MainNavigationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+
+        removeApp()
     }
 
     func testTabBarNavigation() throws {

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -14,7 +14,6 @@ class MainNavigationTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -7,7 +7,7 @@ class ReaderTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
 
-        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         readerScreen = try EditorFlow
             .goToMySiteScreen()
             .tabBar.goToReaderScreen()

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -15,7 +15,6 @@ class ReaderTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/ReaderTests.swift
+++ b/WordPress/WordPressUITests/Tests/ReaderTests.swift
@@ -15,11 +15,8 @@ class ReaderTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        if readerScreen != nil && !TabNavComponent.isVisible() {
-            readerScreen.dismissPost()
-        }
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+
+        removeApp()
     }
 
     let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -6,8 +6,6 @@ class SignupTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
         setUpTestSuite()
-
-        try LoginFlow.logoutIfNeeded()
     }
 
     override func tearDownWithError() throws {

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -12,8 +12,8 @@ class SignupTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+
+        removeApp()
     }
 
     func testEmailSignup() throws {

--- a/WordPress/WordPressUITests/Tests/SignupTests.swift
+++ b/WordPress/WordPressUITests/Tests/SignupTests.swift
@@ -12,7 +12,6 @@ class SignupTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -16,8 +16,8 @@ class StatsTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try LoginFlow.logoutIfNeeded()
-        try super.tearDownWithError()
+
+        removeApp()
     }
 
     let insightsStats: [String] = [

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -6,7 +6,7 @@ class StatsTests: XCTestCase {
 
     override func setUpWithError() throws {
         setUpTestSuite()
-        _ = try LoginFlow.loginIfNeeded(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         statsScreen = try MySiteScreen()
             .goToStatsScreen()
             .switchTo(mode: .insights)

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -16,7 +16,6 @@ class StatsTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -9,9 +9,8 @@ class SupportScreenTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-        try ContactUsScreen().dismiss().dismiss()
-        try GetStartedScreen().goBackToPrologue()
-        try LoginFlow.logoutIfNeeded()
+
+        removeApp()
     }
 
     func testContactUsCanBeLoadedDuringLogin() throws {

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -9,7 +9,6 @@ class SupportScreenTests: XCTestCase {
 
     override func tearDownWithError() throws {
         takeScreenshotOfFailedTest()
-
         removeApp()
     }
 

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -4,7 +4,6 @@ import XCTest
 class SupportScreenTests: XCTestCase {
     override func setUpWithError() throws {
         setUpTestSuite()
-        try LoginFlow.logoutIfNeeded()
     }
 
     override func tearDownWithError() throws {

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -10,7 +10,6 @@ extension XCTestCase {
         continueAfterFailure = false
 
         let app = XCUIApplication()
-        app.terminate()
         app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
         app.activate()
 

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -77,4 +77,21 @@ extension XCTestCase {
         static let category = "iOS Test"
         static let tag = "tag \(Date().toString())"
     }
+
+    public func removeApp() {
+        let app = XCUIApplication()
+        app.terminate()
+
+        let home = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        home.icons["WordPress"].press(forDuration: 1)
+        waitAndTap(home.buttons["Remove App"])
+        waitAndTap(home.alerts.buttons["Delete App"])
+        waitAndTap(home.alerts.buttons["Delete"])
+    }
+
+    public func waitAndTap( _ element: XCUIElement) {
+        if (element.waitForExistence(timeout: 5)) {
+            element.tap()
+        }
+    }
 }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -83,7 +83,7 @@ extension XCTestCase {
         app.terminate()
 
         let home = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        home.icons["WordPress"].press(forDuration: 1)
+        home.icons["WordPress"].firstMatch.press(forDuration: 1)
         waitAndTap(home.buttons["Remove App"])
         waitAndTap(home.alerts.buttons["Delete App"])
         waitAndTap(home.alerts.buttons["Delete"])

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -90,7 +90,7 @@ extension XCTestCase {
     }
 
     public func waitAndTap( _ element: XCUIElement) {
-        if (element.waitForExistence(timeout: 5)) {
+        if element.waitForExistence(timeout: 5) {
             element.tap()
         }
     }


### PR DESCRIPTION
The objective of this PR is to speed up `setUp()`/`tearDown()` and reduce unnecessary complexity of handling all possible errors so the following tests can run properly.

Uninstalling the app after each test improves test isolation as the user data is removed and allows us to always start a new test with a fresh installation, so it doesn't matter if the previous test passed or failed in an unexpected screen, if the user is logged in or not, the test will always start from the first time the application is opened. We would then be able to get rid of many checks in both `setUp()` and `tearDown()` and save execution time and maintenance effort. 


Testing:
* [Test PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19027) has changes from this PR and UI Tests running 10 times.

  [In Buildkite the initial runs for both iPhone and iPad have failures](https://buildkite.com/automattic/wordpress-ios/builds/8883#_), most likely some connection or Buildkite instability, since the executions failed even before the UI Tests being started. The rerun passed for both devices and no tests needed retry (xcode results available under _Artifacts_ tab).

  |  |  |
  | - | - |
  | <img width="300" src="https://user-images.githubusercontent.com/42008628/179788989-c5a9e4ee-2438-42bb-a74a-04846bea1884.png"> | <img width="300" alt="image" src="https://user-images.githubusercontent.com/42008628/179788534-2c0f5a2e-0d31-4712-b1f8-9a9192ae6a47.png"> |

  <img width="650" alt="image" src="https://user-images.githubusercontent.com/42008628/179790175-0c8403d9-86a3-4430-b121-17ce9e5fdaf9.png">

* [Control PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19050) has `trunk` code and UI Tests running 10 times.

## Results

[Test PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19027) and [Control PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19050) comparison indicates over 5 minutes gain in execution time for the proposed changes.

  | iPhone | iPad |
  | :-: | :-: |
  | Test \| Control | Test \| Control |
  | <img src="https://user-images.githubusercontent.com/42008628/179797117-4bf73dd6-7bf8-4e9c-94a0-2f44e061d689.png"> | <img src="https://user-images.githubusercontent.com/42008628/179797283-152322b1-07b8-42dd-94a8-2872f822f4c7.png"> |

