### PR TITLE
Demo PR for using reverse-DNS notation for "Dismiss" localized strings

### DIFF
--- a/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
+++ b/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
@@ -154,8 +154,13 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
 
                 let title = NSLocalizedString("Failed Media Export", comment: "Error title when picked media cannot be imported into stories.")
                 let message = NSLocalizedString("Your media could not be exported. If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Error message when picked media cannot be imported into stories.")
+                let dismissTitle = NSLocalizedString(
+                    "mediaPicker.failedMediaExportAlert.dismissButton",
+                    value: "Dimiss",
+                    comment: "The title of the button to dismiss the alert shown when the picked media cannot be imported into stories."
+                )
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-                let dismiss = UIAlertAction(title: "Dismiss", style: .default) { _ in
+                let dismiss = UIAlertAction(title: dismissTitle, style: .default) { _ in
                     alert.dismiss(animated: true, completion: nil)
                 }
                 alert.addAction(dismiss)

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -516,7 +516,11 @@ extension InteractiveNotificationsManager {
             case .answerPrompt:
                 return NSLocalizedString("Answer", comment: "Verb. Opens the editor to answer the blogging prompt.")
             case .dismissPrompt:
-                return NSLocalizedString("Dismiss", comment: "Verb. Dismisses the blogging prompt notification.")
+                return NSLocalizedString(
+                    "bloggingPrompt.pushNotification.customActionDescription.dismiss",
+                    value: "Dismiss",
+                    comment: "Verb. Dismisses the blogging prompt notification."
+                )
             }
         }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -70,7 +70,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     }()
     @objc lazy var closeButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: .gridicon(.cross), style: .plain, target: self, action: #selector(WebKitViewController.close))
-        button.title = NSLocalizedString("Dismiss", comment: "Dismiss a view. Verb")
+        button.title = NSLocalizedString("webKit.button.dismiss", value: "Dismiss", comment: "Verb. Dismiss the web view screen.")
         return button
     }()
 

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -1993,9 +1993,6 @@
 "Copied block" = "Copied block";
 
 /* No comment provided by engineer. */
-"Copy block" = "Copy block";
-
-/* No comment provided by engineer. */
 "Copy file URL" = "Copy file URL";
 
 /* Copy the post url and paste anywhere in phone
@@ -5373,6 +5370,9 @@
 "Oops!" = "Oops!";
 
 /* No comment provided by engineer. */
+"Opacity" = "Opacity";
+
+/* No comment provided by engineer. */
 "OPEN" = "OPEN";
 
 /* No comment provided by engineer. */
@@ -8738,6 +8738,12 @@
 
 /* Text for related post cell preview */
 "Upgrade Focus: VideoPress For Weddings" = "Upgrade Focus: VideoPress For Weddings";
+
+/* No comment provided by engineer. */
+"Upgrade your plan to upload audio" = "Upgrade your plan to upload audio";
+
+/* No comment provided by engineer. */
+"Upgrade your plan to use video covers" = "Upgrade your plan to use video covers";
 
 /* Message displayed on a post's card when the post has failed to upload
    System notification displayed to the user when media files have failed to upload. */

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -1225,6 +1225,9 @@
 /* Label for the blogging reminders setting */
 "Blogging Reminders" = "Blogging Reminders";
 
+/* Verb. Dismisses the blogging prompt notification. */
+"bloggingPrompt.pushNotification.customActionDescription.dismiss" = "Dismiss";
+
 /* Accessibility label for bold button on formatting toolbar.
    Discoverability title for bold formatting keyboard shortcut. */
 "Bold" = "Bold";
@@ -2520,7 +2523,6 @@
    User action to dismiss featured media options.
    User action to dismiss media options.
    Verb. Button title. Tapping dismisses a prmopt.
-   Verb. Dismisses the blogging prompt notification.
    Verb. User action to dismiss error alert when failing to load media item. */
 "Dismiss" = "Dismiss";
 
@@ -4662,6 +4664,9 @@
 
 /* Downloadable/Restorable items: Media Uploads */
 "Media Uploads" = "Media Uploads";
+
+/* The title of the button to dismiss the alert shown when the picked media cannot be imported into stories. */
+"mediaPicker.failedMediaExportAlert.dismissButton" = "Dimiss";
 
 /* Medium image size. Should be the same as in core WP. */
 "Medium" = "Medium";
@@ -9281,6 +9286,9 @@
 
 /* Example Reader feed title */
 "Web News" = "Web News";
+
+/* Verb. Dismiss the web view screen. */
+"webKit.button.dismiss" = "Dismiss";
 
 /* Title of a button. A call to action to view more stats for this week */
 "Week" = "Week";


### PR DESCRIPTION
See #19028.

Notice that [the first commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/19029/commits/1f5a609f6d776e059a610f8c90094c04041c1c8f) is there only to establish a baseline for `.strings`, so that the diff in the [final commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/19029/commits/63ac6b09543c2089718a6cb322399f72b45562a6) only shows the changes due to the new "Dismiss" keys added here.