### PR TITLE
Disable time-wasting Fastlane checks when building from CI

### DIFF
--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -20,6 +20,6 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_app_center
+bundle exec fastlane build_and_upload_app_center \
   skip_confirm:true \
   skip_prechecks:true

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -20,4 +20,6 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_app_center skip_confirm:true
+bundle exec fastlane build_and_upload_app_center
+  skip_confirm:true \
+  skip_prechecks:true

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -22,5 +22,6 @@ bundle exec fastlane run configure_apply
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_app_store_connect \
   skip_confirm:true \
+  skip_prechecks:true \
   create_release:true \
   beta_release:${1:-true} # use first call param, default to true for safety

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,21 +14,22 @@ common_params:
 
 steps:
 
-  - label: "🛠 WordPress Release Build (App Store Connect)"
+  - label: ":wordpress::testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 WordPress Release Build (App Center)"
+  # There is no App Center emojiy
+  - label: ":wordpress::hockeyapp: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 Jetpack Release Build (App Store Connect)"
+  - label: ":jetpack::testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
     env: *common_env
     plugins: *common_plugins


### PR DESCRIPTION
This could result in up to 20 minutes of extra CI time when building the WordPress iOS app.

See for example [this build](https://buildkite.com/automattic/wordpress-ios/builds/8823#0181e9c5-aa9f-4b9f-9f4d-7426c452f24a) where the `ios_build_prechecks` and `ios_build_preflight` sequence
starts [at 20:27:59](https://buildkite.com/automattic/wordpress-ios/builds/8823#0181e9c5-aa9f-4b9f-9f4d-7426c452f24a/1057-1078) and finishes [at 20:48:26](https://buildkite.com/automattic/wordpress-ios/builds/8823#0181e9c5-aa9f-4b9f-9f4d-7426c452f24a/1057-1244), 20 minutes later.

<img width="1170" alt="Screen Shot 2022-07-13 at 3 27 55 pm" src="https://user-images.githubusercontent.com/1218433/178657599-f4a2bca7-8d7f-4690-9b98-56bd21b37a6c.png">

<img width="1164" alt="image" src="https://user-images.githubusercontent.com/1218433/178657567-a98672b9-615c-4bd1-ac28-bba7e36c33ab.png">

I considered removing the call to `ios_build_preflight` altogether, but maybe there's value in having them in those rare circumstances when we run builds locally? I might open an issue to discuss this option further, but in the meantime disabling them for CI, where all those operations are already done anyways, is enough to speed up the release builds.

Here's a link to the source for `ios_build_prechecks`: https://github.com/wordpress-mobile/release-toolkit/blob/801fecfb0ed472afe70601ef75b5b523e9fed270/lib/fastlane/plugin/wpmreleasetoolkit/actions/ios/ios_build_preflight.rb#L6-L37 to check what it does, which is

- Remove `DerivedData`
- Check `convert` and `gs`, from ImageMagick and GhostScript respectively, are present (this is only relevant for builds that update the icon, like the App Center ones)
- Removes the CocoaPods cache – This step was the time sucker, as it destroyed all the work we put into caching the pods 🤦‍♂️ 
- Run `pod install` via Fastlane

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
