### PR TITLE
Send test analytics to dedicated suites for unit, UI iPhone, and UI iPad

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -6,6 +6,14 @@ IOS_VERSION=$3
 
 echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
 
+# Run this at the start to fail early if value not available
+echo '--- :test-analytics: Configuring Test Analytics'
+if [[ $DEVICE =~ ^iPhone ]]; then
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
+else
+  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
+fi
+
 echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products.tar
 tar -xf build-products.tar

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash -eu
 
+# Run this at the start to fail early if value not available
+echo '--- :test-analytics: Configuring Test Analytics'
+export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
+
 echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products.tar
 tar -xf build-products.tar

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/buildkite/test-collector-swift",
         "state": {
           "branch": null,
-          "revision": "87afcecfb58dd017d6e835ec8e88e9eaa18095ba",
-          "version": "0.1.1"
+          "revision": "77c7f492f5c1c9ca159f73d18f56bbd1186390b0",
+          "version": "0.3.0"
         }
       },
       {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26607,7 +26607,7 @@
 			repositoryURL = "https://github.com/buildkite/test-collector-swift";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.1.1;
+				minimumVersion = 0.3.0;
 			};
 		};
 		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {

--- a/WordPress/WordPressTest/WordPressUnitTests.xctestplan
+++ b/WordPress/WordPressTest/WordPressUnitTests.xctestplan
@@ -19,38 +19,7 @@
       ]
     },
     "environmentVariableEntries" : [
-      {
-        "key" : "BUILDKITE_ANALYTICS_TOKEN",
-        "value" : "$(BUILDKITE_ANALYTICS_TOKEN)"
-      },
-      {
-        "key" : "BUILDKITE_BRANCH",
-        "value" : "$(BUILDKITE_BRANCH)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_ID",
-        "value" : "$(BUILDKITE_BUILD_ID)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_NUMBER",
-        "value" : "$(BUILDKITE_BUILD_NUMBER)"
-      },
-      {
-        "key" : "BUILDKITE_BUILD_URL",
-        "value" : "$(BUILDKITE_BUILD_URL)"
-      },
-      {
-        "key" : "BUILDKITE_COMMIT",
-        "value" : "$(BUILDKITE_COMMIT)"
-      },
-      {
-        "key" : "BUILDKITE_JOB_ID",
-        "value" : "$(BUILDKITE_JOB_ID)"
-      },
-      {
-        "key" : "BUILDKITE_MESSAGE",
-        "value" : "$(BUILDKITE_MESSAGE)"
-      }
+
     ],
     "targetForVariableExpansion" : {
       "containerPath" : "container:WordPress.xcodeproj",

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -80,6 +80,8 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
+    inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+
     run_tests(
       workspace: WORKSPACE_PATH,
       scheme: 'WordPress',


### PR DESCRIPTION
Mirrors the https://github.com/woocommerce/woocommerce-ios/pull/7490 setup:

- Inject Test Analytics environment variables via Fastlane in CI, so we don't need to jump through configuration hoops via Xcode and we have a single source of truth for the values.
- From Buildkite, make user the token for the current suite is exported as `BUILDKITE_ANALYTICS_TOKEN`, so Fastlane can inject it. _I suppose this could have been done via Fastlane, too, but it felt more appropriate to manage those tokens in CI, because that's where they are available via `mobile-secrets/CI/...`_.
- Remove now redundant env var declarations in the `xctestplan` files, so we don't need to maintain duplicated versions of them.

<img width="1176" alt="image" src="https://user-images.githubusercontent.com/1218433/184812148-87093aef-1093-4ad4-a52a-124f7dcacf1d.png">

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
