### PR TITLE
Refactoring PostListViewController: Rename VM functions & extract strings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListStringStore.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListStringStore.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum PostListStringStore {
+    enum PostRestoredPrompt {
+        static func message(filter: PostListFilter) -> String {
+            switch filter.filterType {
+            case .published:
+                return NSLocalizedString(
+                    "Post Restored to Published",
+                    comment: "Prompts the user that a restored post was moved to the published list."
+                )
+            case .scheduled:
+                return NSLocalizedString(
+                    "Post Restored to Scheduled",
+                    comment: "Prompts the user that a restored post was moved to the scheduled list."
+                )
+            default:
+                return NSLocalizedString(
+                    "Post Restored to Drafts",
+                    comment: "Prompts the user that a restored post was moved to the drafts list."
+                )
+            }
+        }
+
+        static func cancelText() -> String {
+            NSLocalizedString(
+                "OK",
+                comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt."
+            )
+        }
+    }
+
+//    enum
+}

--- a/WordPress/Classes/ViewRelated/Post/PostListStringStore.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListStringStore.swift
@@ -30,5 +30,73 @@ enum PostListStringStore {
         }
     }
 
-//    enum
+    enum NoResults {
+        static let noConnectionTitle = NSLocalizedString(
+            "Unable to load posts right now.",
+            comment: "Title for No results full page screen displayedfrom post list when there is no connection"
+        )
+
+        static let buttonTitle = NSLocalizedString("Create Post", comment: "Button title, encourages users to create post on their blog.")
+
+        static let noConnectionSubtitle = NSLocalizedString(
+            "Check your network connection and try again. Or draft a post.",
+            comment: "Subtitle for No results full page screen displayed from post list when there is no connection"
+        )
+
+        static let searchPosts = NSLocalizedString("Search posts", comment: "Text displayed when the search controller will be presented")
+
+        static func noResultsTitle(filterType: PostListFilter.Status, isSyncing: Bool, isSearching: Bool) -> String {
+            if isSyncing {
+                return NSLocalizedString(
+                    "Fetching posts...",
+                    comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts."
+                )
+            }
+
+            if isSearching {
+                return NSLocalizedString(
+                    "No posts matching your search",
+                    comment: "Displayed when the user is searching the posts list and there are no matching posts"
+                )
+            }
+
+            return filteredTitle(
+                filterType: filterType
+            )
+        }
+
+        static func noResultsButtonTitle(filterType: PostListFilter.Status, isSyncing: Bool, isSearching: Bool) -> String? {
+            if isSyncing || isSearching {
+                return nil
+            }
+
+            let filterType = filterType
+            return filterType == .trashed ? nil : PostListStringStore.NoResults.buttonTitle
+        }
+
+        private static func filteredTitle(filterType: PostListFilter.Status) -> String {
+            switch filterType {
+            case .draft:
+                return NSLocalizedString(
+                    "You don't have any draft posts",
+                    comment: "Displayed when the user views drafts in the posts list and there are no posts"
+                )
+            case .scheduled:
+                return NSLocalizedString(
+                    "You don't have any scheduled posts",
+                    comment: "Displayed when the user views scheduled posts in the posts list and there are no posts"
+                )
+            case .trashed:
+                return NSLocalizedString(
+                    "You don't have any trashed posts",
+                    comment: "Displayed when the user views trashed in the posts list and there are no posts"
+                )
+            case .published:
+                return NSLocalizedString(
+                    "You haven't published any posts yet",
+                    comment: "Displayed when the user views published posts in the posts list and there are no posts"
+                )
+            }
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -666,23 +666,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     override func promptThatPostRestoredToFilter(_ filter: PostListFilter) {
-        var message = NSLocalizedString("Post Restored to Drafts", comment: "Prompts the user that a restored post was moved to the drafts list.")
-
-        switch filter.filterType {
-        case .published:
-            message = NSLocalizedString("Post Restored to Published", comment: "Prompts the user that a restored post was moved to the published list.")
-            break
-        case .scheduled:
-            message = NSLocalizedString("Post Restored to Scheduled", comment: "Prompts the user that a restored post was moved to the scheduled list.")
-            break
-        default:
-            break
-        }
-
-        let alertCancel = NSLocalizedString("OK", comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt.")
-
-        let alertController = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        let alertController = UIAlertController(
+            title: nil,
+            message: PostListStringStore.PostRestoredPrompt.message(filter: filter), preferredStyle: .alert
+        )
+        alertController.addCancelActionWithTitle(PostListStringStore.PostRestoredPrompt.cancelText(), handler: nil)
         alertController.presentFromRootViewController()
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -817,76 +817,52 @@ private extension PostListViewController {
     func handleRefreshNoResultsViewController(_ noResultsViewController: NoResultsViewController) {
 
         guard connectionAvailable() else {
-            noResultsViewController.configure(title: "", noConnectionTitle: NoResultsText.noConnectionTitle, buttonTitle: NoResultsText.buttonTitle, subtitle: nil, noConnectionSubtitle: NoResultsText.noConnectionSubtitle, attributedSubtitle: nil, attributedSubtitleConfiguration: nil, image: nil, subtitleImage: nil, accessoryView: nil)
+            noResultsViewController.configure(
+                title: "",
+                noConnectionTitle: PostListStringStore.NoResults.noConnectionTitle,
+                buttonTitle: PostListStringStore.NoResults.buttonTitle,
+                subtitle: nil,
+                noConnectionSubtitle: PostListStringStore.NoResults.noConnectionSubtitle,
+                attributedSubtitle: nil,
+                attributedSubtitleConfiguration: nil,
+                image: nil,
+                subtitleImage: nil,
+                accessoryView: nil
+            )
             return
         }
 
+        let filterType = filterSettings.currentPostListFilter().filterType
+        let isSyncing = syncHelper.isSyncing == true
+        let noResultsTitle = PostListStringStore.NoResults.noResultsTitle(
+            filterType: filterType,
+            isSyncing: isSyncing,
+            isSearching: isSearching()
+        )
+
         if searchController.isActive {
             if currentSearchTerm()?.count == 0 {
-                noResultsViewController.configureForNoSearchResults(title: NoResultsText.searchPosts)
+                noResultsViewController.configureForNoSearchResults(title: PostListStringStore.NoResults.searchPosts)
             } else {
-                noResultsViewController.configureForNoSearchResults(title: noResultsTitle())
+                noResultsViewController.configureForNoSearchResults(title: noResultsTitle)
             }
         } else {
             let accessoryView = syncHelper.isSyncing ? NoResultsViewController.loadingAccessoryView() : nil
 
-            noResultsViewController.configure(title: noResultsTitle(),
-                                              buttonTitle: noResultsButtonTitle(),
-                                              image: noResultsImageName,
-                                              accessoryView: accessoryView)
+            noResultsViewController.configure(
+                title: noResultsTitle,
+                buttonTitle: PostListStringStore.NoResults.noResultsButtonTitle(
+                    filterType: filterType,
+                    isSyncing: isSyncing,
+                    isSearching: isSearching()
+                ),
+                image: noResultsImageName,
+                accessoryView: accessoryView)
         }
     }
 
     var noResultsImageName: String {
         return "posts-no-results"
-    }
-
-    func noResultsButtonTitle() -> String? {
-        if syncHelper.isSyncing == true || isSearching() {
-            return nil
-        }
-
-        let filterType = filterSettings.currentPostListFilter().filterType
-        return filterType == .trashed ? nil : NoResultsText.buttonTitle
-    }
-
-    func noResultsTitle() -> String {
-        if syncHelper.isSyncing == true {
-            return NoResultsText.fetchingTitle
-        }
-
-        if isSearching() {
-            return NoResultsText.noMatchesTitle
-        }
-
-        return noResultsFilteredTitle()
-    }
-
-    func noResultsFilteredTitle() -> String {
-        let filterType = filterSettings.currentPostListFilter().filterType
-        switch filterType {
-        case .draft:
-            return NoResultsText.noDraftsTitle
-        case .scheduled:
-            return NoResultsText.noScheduledTitle
-        case .trashed:
-            return NoResultsText.noTrashedTitle
-        case .published:
-            return NoResultsText.noPublishedTitle
-        }
-    }
-
-    struct NoResultsText {
-        static let buttonTitle = NSLocalizedString("Create Post", comment: "Button title, encourages users to create post on their blog.")
-        static let fetchingTitle = NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
-        static let noMatchesTitle = NSLocalizedString("No posts matching your search", comment: "Displayed when the user is searching the posts list and there are no matching posts")
-        static let noDraftsTitle = NSLocalizedString("You don't have any draft posts", comment: "Displayed when the user views drafts in the posts list and there are no posts")
-        static let noScheduledTitle = NSLocalizedString("You don't have any scheduled posts", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
-        static let noTrashedTitle = NSLocalizedString("You don't have any trashed posts", comment: "Displayed when the user views trashed in the posts list and there are no posts")
-        static let noPublishedTitle = NSLocalizedString("You haven't published any posts yet", comment: "Displayed when the user views published posts in the posts list and there are no posts")
-        static let noConnectionTitle: String = NSLocalizedString("Unable to load posts right now.", comment: "Title for No results full page screen displayedfrom post list when there is no connection")
-        static let noConnectionSubtitle: String = NSLocalizedString("Check your network connection and try again. Or draft a post.", comment: "Subtitle for No results full page screen displayed from post list when there is no connection")
-        static let searchPosts = NSLocalizedString("Search posts", comment: "Text displayed when the search controller will be presented")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -573,7 +573,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
             return
         }
 
-        viewModel?.edit(post)
+        viewModel?.didTapEdit(on: post)
     }
 
     @objc func tableView(_ tableView: UITableView, cellForRowAtIndexPath indexPath: IndexPath) -> UITableViewCell {
@@ -677,7 +677,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     // MARK: - InteractivePostViewDelegate
 
     func edit(_ post: AbstractPost) {
-        viewModel?.edit(post)
+        viewModel?.didTapEdit(on: post)
     }
 
     func view(_ post: AbstractPost) {
@@ -685,7 +685,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func stats(for post: AbstractPost) {
-        viewModel?.stats(for: post)
+        viewModel?.didTapStats(on: post)
     }
 
     func duplicate(_ post: AbstractPost) {
@@ -707,7 +707,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func trash(_ post: AbstractPost) {
-        viewModel?.trash(post)
+        viewModel?.didTapTrash(on: post)
     }
 
     func restore(_ post: AbstractPost) {
@@ -723,11 +723,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func retry(_ post: AbstractPost) {
-        viewModel?.retry(post)
+        viewModel?.didTapRetry(on: post)
     }
 
     func cancelAutoUpload(_ post: AbstractPost) {
-        viewModel?.cancelAutoUpload(post)
+        viewModel?.didTapCancelAutoUpload(on: post)
     }
 
     func share(_ apost: AbstractPost, fromView view: UIView) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -735,11 +735,11 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func retry(_ post: AbstractPost) {
-        PostCoordinator.shared.save(post)
+        viewModel?.retry(post)
     }
 
     func cancelAutoUpload(_ post: AbstractPost) {
-        PostCoordinator.shared.cancelAutoUploadOf(post)
+        viewModel?.cancelAutoUpload(post)
     }
 
     func share(_ apost: AbstractPost, fromView view: UIView) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewModel.swift
@@ -63,10 +63,6 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
         editingPostUploadSuccess?(post)
     }
 
-    func view(_ post: AbstractPost) {
-
-    }
-
     func stats(for post: AbstractPost) {
         reachabilityUtility.performActionIfConnectionAvailable {
             viewStatsForPost(post)
@@ -100,12 +96,12 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
         statsConfigured?(postID, apost.titleForDisplay(), postURL)
     }
 
-    func duplicate(_ post: AbstractPost) {
+    func trash(_ post: AbstractPost) {
 
     }
 
-    func publish(_ post: AbstractPost) {
-
+    func retry(_ post: AbstractPost) {
+        PostCoordinator.shared.save(post)
     }
 
     func trash(_ post: AbstractPost) {
@@ -144,6 +140,27 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
                 delete: deleteText
             )
         )
+    func cancelAutoUpload(_ post: AbstractPost) {
+        PostCoordinator.shared.cancelAutoUploadOf(post)
+    }
+
+    func share(_ post: AbstractPost, fromView view: UIView) {
+        // UI coupled. It should be removed from the protocol.
+    }
+
+    // Functions below need to be extracted from `AbstractPostListViewController`.
+    // If a `AbstractPostListViewModel` is created, this class can subclass that and
+    // call super's functions in these.
+    func view(_ post: AbstractPost) {
+
+    }
+
+    func duplicate(_ post: AbstractPost) {
+
+    }
+
+    func publish(_ post: AbstractPost) {
+
     }
 
     func restore(_ post: AbstractPost) {
@@ -151,18 +168,6 @@ final class PostListViewModel: PostListViewModelInputs, PostListViewModelOutputs
     }
 
     func draft(_ post: AbstractPost) {
-
-    }
-
-    func retry(_ post: AbstractPost) {
-
-    }
-
-    func cancelAutoUpload(_ post: AbstractPost) {
-
-    }
-
-    func share(_ post: AbstractPost, fromView view: UIView) {
 
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		086F2482284F52DD00032F39 /* TooltipAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081E4B4B281C019A0085E89C /* TooltipAnchor.swift */; };
 		086F2483284F52DF00032F39 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D553652821286300AA1E8D /* Tooltip.swift */; };
 		086F2484284F52E100032F39 /* FeatureHighlightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084A07052848E1820054508A /* FeatureHighlightStore.swift */; };
+		08746DB228730B6E000FAF51 /* PostListStringStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08746DB128730B6E000FAF51 /* PostListStringStore.swift */; };
+		08746DB328730B6E000FAF51 /* PostListStringStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08746DB128730B6E000FAF51 /* PostListStringStore.swift */; };
 		0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0879FC151E9301DD00E1EFC8 /* MediaTests.swift */; };
 		087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */; };
 		0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */; };
@@ -5035,6 +5037,7 @@
 		086C4D0F1E81F9240011D960 /* Media+Blog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Media+Blog.swift"; sourceTree = "<group>"; };
 		086E1FDE1BBB35D2002D86CA /* MenusViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusViewController.h; sourceTree = "<group>"; };
 		086E1FDF1BBB35D2002D86CA /* MenusViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusViewController.m; sourceTree = "<group>"; };
+		08746DB128730B6E000FAF51 /* PostListStringStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostListStringStore.swift; sourceTree = "<group>"; };
 		0879FC151E9301DD00E1EFC8 /* MediaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTests.swift; sourceTree = "<group>"; };
 		087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailService.swift; sourceTree = "<group>"; };
 		0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLIncrementalFilenameTests.swift; sourceTree = "<group>"; };
@@ -10769,6 +10772,7 @@
 				590E873A1CB8205700D1B734 /* PostListViewController.swift */,
 				08A50DEC286C80F5003B0195 /* PostListViewModel.swift */,
 				089EE55F286F016C001294B5 /* PostListReachabilityUtility.swift */,
+				08746DB128730B6E000FAF51 /* PostListStringStore.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -18455,6 +18459,7 @@
 				7E846FF320FD37BD00881F5A /* ActivityCommentRange.swift in Sources */,
 				1E672D95257663CE00421F13 /* GutenbergAudioUploadProcessor.swift in Sources */,
 				9AA0ADB1235F11700027AB5D /* AsyncOperation.swift in Sources */,
+				08746DB228730B6E000FAF51 /* PostListStringStore.swift in Sources */,
 				C73868C525C9F9820072532C /* JetpackScanThreatSectionGrouping.swift in Sources */,
 				FF8791BB1FBAF4B500AD86E6 /* MediaService+Swift.swift in Sources */,
 				D8212CB920AA77AD008E8AE8 /* ReaderActionHelpers.swift in Sources */,
@@ -21146,6 +21151,7 @@
 				FABB22EB2602FC2C00C8785C /* MediaAssetExporter.swift in Sources */,
 				FABB22EC2602FC2C00C8785C /* SharingButtonsViewController.swift in Sources */,
 				FABB22ED2602FC2C00C8785C /* EditorFactory.swift in Sources */,
+				08746DB328730B6E000FAF51 /* PostListStringStore.swift in Sources */,
 				FABB22EE2602FC2C00C8785C /* NotificationSiteSubscriptionViewController.swift in Sources */,
 				FABB22EF2602FC2C00C8785C /* PostingActivityDay.swift in Sources */,
 				C7A09A4B28401B7B003096ED /* QRLoginService.swift in Sources */,


### PR DESCRIPTION
Extracts the strings from VC and renames the VM functions to better follow VC-VM mentality.

To Test:
This does not modify any functionality but rather move things around. We can do a proper, full testing after this PR when we merge the feature branch to trunk. I think a code review should suffice for this one.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
