### PR TITLE
Remove `AMScrollingNavbar` dependency

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -190,7 +190,6 @@ abstract_target 'Apps' do
   pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
   pod 'FSInteractiveMap', git: 'https://github.com/wordpress-mobile/FSInteractiveMap.git', tag: '0.2.0'
   pod 'JTAppleCalendar', '~> 8.0.2'
-  pod 'AMScrollingNavbar', '5.6.0'
   pod 'CropViewController', '2.5.3'
 
   ## Automattic libraries

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -4,7 +4,6 @@ PODS:
     - Alamofire (~> 4.8)
   - AlamofireNetworkActivityIndicator (2.4.0):
     - Alamofire (~> 4.8)
-  - AMScrollingNavbar (5.6.0)
   - AppAuth (1.5.0):
     - AppAuth/Core (= 1.5.0)
     - AppAuth/ExternalUserAgent (= 1.5.0)
@@ -536,7 +535,6 @@ DEPENDENCIES:
   - Alamofire (= 4.8.0)
   - AlamofireImage (= 3.5.2)
   - AlamofireNetworkActivityIndicator (~> 2.4)
-  - AMScrollingNavbar (= 5.6.0)
   - AppCenter (~> 4.1)
   - AppCenter/Distribute (~> 4.1)
   - Automattic-Tracks-iOS (~> 0.11.1)
@@ -622,7 +620,6 @@ SPEC REPOS:
     - Alamofire
     - AlamofireImage
     - AlamofireNetworkActivityIndicator
-    - AMScrollingNavbar
     - AppAuth
     - AppCenter
     - Automattic-Tracks-iOS
@@ -790,7 +787,6 @@ SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
   AlamofireImage: 63cfe3baf1370be6c498149687cf6db3e3b00999
   AlamofireNetworkActivityIndicator: 9acc3de3ca6645bf0efed462396b0df13dd3e7b8
-  AMScrollingNavbar: cf0ec5a5ee659d76ba2509f630bf14fba7e16dc3
   AppAuth: 80317d99ac7ff2801a2f18ff86b48cd315ed465d
   AppCenter: b0b6f1190215b5f983c42934db718f3b46fff3c0
   Automattic-Tracks-iOS: 5cd49d3acf76c26b92b4094d34ba84e6b55e5425
@@ -888,6 +884,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 44fc949fa1ba5f153224dc6491c86dd3fe2065f0
+PODFILE CHECKSUM: 3389c6c15b6310a7af21baecb9db069fb5431077
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/WPStyleGuide+Reader.swift
@@ -1,7 +1,6 @@
 import Foundation
 import WordPressShared
 import Gridicons
-import AMScrollingNavbar
 
 /// A WPStyleGuide extension with styles and methods specific to the Reader feature.
 ///
@@ -593,11 +592,5 @@ extension WPStyleGuide {
             static let imageEdgeInsets = UIEdgeInsets(top: 1.0, left: -4.0, bottom: 0.0, right: -4.0)
             static let contentEdgeInsets = UIEdgeInsets(top: 0.0, left: 4.0, bottom: 0.0, right: 0.0)
         }
-    }
-}
-
-extension ScrollingNavigationController {
-    open override var preferredStatusBarStyle: UIStatusBarStyle {
-        return WPStyleGuide.preferredStatusBarStyle
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -12,7 +12,6 @@
 #import <WordPressShared/WPDeviceIdentification.h>
 #import "WPAppAnalytics.h"
 #import "WordPress-Swift.h"
-#import "AMScrollingNavbar-Swift.h"
 
 @import Gridicons;
 @import WordPressShared;


### PR DESCRIPTION
There were a couple of imports, but the app still builds without them so we should be safe to remove it.

One thing to note: [There was a segmentation fault in CI when building the app for testing](https://buildkite.com/automattic/wordpress-ios/builds/8868#0181fac0-ef01-44e3-82a4-60c02854cee0/2257-13168). However, the same build successfully built the Installable Builds for both Jetpack and WordPress _and_ the step succeeded when I retried it. So, I'm fairly confident the original failure was just an unlucky fluke.

I also built locally, including after purging the `DerivedData` folder and via the same Fastlane action CI uses.

_Fun fact, I actually worked with [Andrea Mazzini](https://github.com/andreamazz), the `AM` author of the library. Top bloke and great OSS contributor. Sad to see his lib go, but we gotta keep things clean_ 🧹 

## Regression Notes

1. Potential unintended areas of impact – If the app builds without the library in CI, then we should be guaranteed there is no issue removing it.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
