### PR TITLE
Adds "Jetpack powered" feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -31,6 +31,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case qrLogin
     case betaSiteDesigns
     case featureHighlightTooltip
+    case jetpackPowered
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -100,6 +101,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .betaSiteDesigns:
             return false
         case .featureHighlightTooltip:
+            return true
+        case .jetpackPowered:
             return true
         }
     }
@@ -189,6 +192,8 @@ extension FeatureFlag {
             return "Fetch Beta Site Designs"
         case .featureHighlightTooltip:
             return "Feature Highlight Tooltip"
+        case .jetpackPowered:
+            return "Jetpack powered banners and badges"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -159,7 +159,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
     }
 
     private func setupJetpackBadge() {
-        guard AppConfiguration.isWordPress else {
+        guard AppConfiguration.isWordPress, FeatureFlag.jetpackPowered.enabled else {
             return
         }
         jetpackBadgeView.isHidden = false

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -604,7 +604,7 @@ private extension NotificationsViewController {
     }
 
     func configureJetpackBanner() {
-        jetpackBannerView.isHidden = AppConfiguration.isJetpack
+        jetpackBannerView.isHidden = AppConfiguration.isJetpack || !FeatureFlag.jetpackPowered.enabled
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -83,13 +83,13 @@ class SiteStatsDashboardViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureJetpackBanner()
         configureInsightsTableView()
         setupFilterBar()
         restoreSelectedDateFromUserDefaults()
         restoreSelectedPeriodFromUserDefaults()
         addWillEnterForegroundObserver()
         configureNavBar()
-        configureJetpackBanner()
         view.accessibilityIdentifier = "stats-dashboard"
     }
 
@@ -102,11 +102,7 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     func configureJetpackBanner() {
-        if AppConfiguration.isJetpack {
-            // When the banner is removed (along with its constraints), the view above it
-            // will grow to occupy the space. This is because the view above it has a
-            // lower-priority constraint from its bottom edge to the bottom edge of the
-            // screen.
+        if AppConfiguration.isJetpack || !FeatureFlag.jetpackPowered.enabled {
             jetpackBannerView.removeFromSuperview()
         }
     }


### PR DESCRIPTION
Fixes #NA

This PR adds a feature flag for the "Jetpack powered" elements.
**Note: the flag is set to true by default, since we already released some components**

To test:
- Build/run this branch and make sure the "Jetpack powered" components appear properly (Badge in activity log detail, banner in Stats and Notifications)
- Set the `jetpackPowered` feature flag to `false`
- Re-run the branch and make sure the above components do not appear in the app

## Regression Notes
1. Potential unintended areas of impact
none

2. What I did to test those areas of impact (or what existing automated tests I relied on)
na

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
