### PR TITLE
Use custom emojis for WordPress and Jetpack in Buildkite pipeline

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,21 +14,22 @@ common_params:
 
 steps:
 
-  - label: "🛠 WordPress Release Build (App Store Connect)"
+  - label: ":wordpress::testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 WordPress Release Build (App Center)"
+  # There is no App Center emojiy
+  - label: ":wordpress::hockeyapp: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
-  - label: "🛠 Jetpack Release Build (App Store Connect)"
+  - label: ":jetpack::testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
     env: *common_env
     plugins: *common_plugins


### PR DESCRIPTION
It sort of upsets me how the step names gets truncated in the build pipeline visualization and one can't tell which box is for App Center and which for App Store Connect.

I added a custom emoji for Jetpack in Buildkite, https://github.com/buildkite/emojis/pull/392, and now's the time to use it.

#### Before
![image](https://user-images.githubusercontent.com/1218433/179156883-47cafef0-036d-431c-9a9f-caaedede930d.png)

#### After

Tested via https://github.com/wordpress-mobile/WordPress-iOS/pull/19053.

<img width="1191" alt="image" src="https://user-images.githubusercontent.com/1218433/179159075-28f82b4d-d73b-4f70-ba21-8707b26c764f.png">

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

---

Upon looking at the result in the test branch, I'm not too happy with how it looks like 🤔 What do you think?