### PR TITLE
Use `fix-cache-key-comparison` `git-s3-cache` plugin branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.6.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#fix-cache-key-comparison:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.6.0
-    - automattic/git-s3-cache#fix-cache-key-comparison:
+    - automattic/git-s3-cache#shellcheck-plus-fix:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.


### PR DESCRIPTION
This is to test
https://github.com/Automattic/git-s3-cache-buildkite-plugin/pull/6 in
the context of a repo that did not exhibit the issue the PR aims to fix.

See also
https://github.com/Automattic/git-s3-cache-buildkite-plugin/pull/6#pullrequestreview-1038735114
