### PR TITLE
[Jetpack] Remove locale from Jetpack connection URL

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -60,12 +60,11 @@ class JetpackConnectionWebViewController: UIViewController {
     }
 
     func startConnectionFlow() {
-        let locale = WordPressComLanguageDatabase().deviceLanguage.slug
         let url: URL
         if let escapedSiteURL = blog.homeURL?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
-            url = URL(string: "https://wordpress.com/jetpack/connect/\(locale)?url=\(escapedSiteURL)&mobile_redirect=\(mobileRedirectURL)&from=mobile")!
+            url = URL(string: "https://wordpress.com/jetpack/connect?url=\(escapedSiteURL)&mobile_redirect=\(mobileRedirectURL)&from=mobile")!
         } else {
-            url = URL(string: "https://wordpress.com/jetpack/connect/\(locale)?mobile_redirect=\(mobileRedirectURL)&from=mobile")!
+            url = URL(string: "https://wordpress.com/jetpack/connect?mobile_redirect=\(mobileRedirectURL)&from=mobile")!
         }
 
         let request = URLRequest(url: url)


### PR DESCRIPTION
## Description

The current Jetpack connection URL contains the locale in its path which:
- Isn't accepted by the web server and results in a blank web view
- Doesn't match [the URL that Android uses](https://github.com/wordpress-mobile/WordPress-Android/blob/241a175d8ddc58e852b206bcf9b95ce351ce839e/WordPress/src/main/java/org/wordpress/android/ui/JetpackConnectionWebViewActivity.java#L48)

After consulting with @sergeymitr in this Jetpack PR, [we believe it should be removed](https://github.com/Automattic/jetpack/pull/25099#issuecomment-1185676243).

## Testing

**Prerequisites:** Self-hosted site with Jetpack version 11.1.2 or higher. At this time it's the latest release candidate: `Version 11.1.1-2679096112-gc24efd1`

ℹ️ Internal refs for how to quickly spin up a self-hosted site running Jetpack from a specific branch:
- PCYsg-g6b-p2
- PCYsg-gD0-p2 

### Test 1 - WordPress app clean install

1. Connect the WordPress app to a self-hosted site that doesn't have Jetpack installed or activated
2. Navigate to the Stats view from My Site
3. Expect a screen with an "Install Jetpack" button - tap "Install Jetpack"
4. Expect another screen with "Install Jetpack" under the Jetpack logo and a "Continue" button - tap "Continue"
5. After a moment, expect the screen to show "Jetpack installed" with a button that says "Set up"
6. Confirm that Jetpack has been installed in WP Admin on the self-hosted site
7. _Note:_ If using the tools from the internal refs above, you'll need to activate the beta version at this point
8. In the app, tap "Set up"
9. You may briefly see a Jetpack page with "Set up Jetpack on your self-hosted WordPress" at the top
10. Expect to be prompted for .com credentials
11. Log in using .com credentials
12. ⚠️ If your account has .com sites, you may see a prompt to choose a site. Choose any site. A bug report will be created for this.
13. ⚠️ You may see a view "What would you like to focus on first?" Tap skip. A bug report will be created for this.
14. Expect to see a Jetpack page with "Completing setup" at the top and an "Approve" button
15. Tap "Approve"
16. ⚠️ You may see an error: "Error authorizing. Page is refreshing for another attempt."
17. If the page refreshes, tap "Approve" again
18. ⚠️ Instead of the Stats view loading, you may see a button that says "Enable Site Stats"
19. ⚠️ Tapping "Enable Site Stats" does nothing
20. Tap "Back" to go back to the "My Site" view
21. Tap "Stats" and observe that the stats view loads correctly

**The same flow should also succeed if started from the Notifications view rather than the Stats view. Its flow will end at step 17.**

https://user-images.githubusercontent.com/2092798/179302245-146c509f-d607-413a-a511-348fe5a97174.mp4

### Test 2 - Repeat Test 1 with the Jetpack app

## Regression Notes
1. Potential unintended areas of impact
    - Connecting Jetpack to a self-hosted site from the WordPress or Jetpack app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing above, as well as regression tests against Jetpack 11.

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.