### PR TITLE
UITII-fix-testAddRemoveFeaturedImage

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -80,13 +80,14 @@ public class EditorPostSettings: ScreenObject {
     }
 
     private func isFeaturedImageLoaded() -> Bool {
+        let noImageLoadedButtonHeight = CGFloat.init(integerLiteral: 58)
         var loopCount = 0
-        while changeFeaturedImageButton.frame.height.isEqual(to: 58) && loopCount < 30 {
+        while changeFeaturedImageButton.frame.height.isEqual(to: noImageLoadedButtonHeight) && loopCount < 30 {
             sleep(1)
             loopCount += 1
         }
 
-        return changeFeaturedImageButton.frame.height.isEqual(to: 58) == false
+        return changeFeaturedImageButton.frame.height.isEqual(to: noImageLoadedButtonHeight) == false
     }
 
     /// - Note: Returns `Void` because the return screen depends on which editor the user is in.

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -71,11 +71,22 @@ public class EditorPostSettings: ScreenObject {
         let imageCount = settingsTable.images.count
         if hasImage {
             XCTAssertTrue(imageCount == 1, "Featured image not set")
+            XCTAssertTrue(isFeaturedImageLoaded(), "Featured image is not displayed")
         } else {
             XCTAssertTrue(imageCount == 0, "Featured image is set but should not be")
         }
 
         return try EditorPostSettings()
+    }
+
+    private func isFeaturedImageLoaded() -> Bool {
+        var loopCount = 0
+        while changeFeaturedImageButton.frame.height.isEqual(to: 58) && loopCount < 30 {
+            sleep(1)
+            loopCount += 1
+        }
+
+        return changeFeaturedImageButton.frame.height.isEqual(to: 58) == false
     }
 
     /// - Note: Returns `Void` because the return screen depends on which editor the user is in.

--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -80,14 +80,15 @@ public class EditorPostSettings: ScreenObject {
     }
 
     private func isFeaturedImageLoaded() -> Bool {
-        let noImageLoadedButtonHeight = CGFloat.init(integerLiteral: 58)
-        var loopCount = 0
-        while changeFeaturedImageButton.frame.height.isEqual(to: noImageLoadedButtonHeight) && loopCount < 30 {
-            sleep(1)
-            loopCount += 1
-        }
+        return waitForLoadingIconToDisappear()
+    }
 
-        return changeFeaturedImageButton.frame.height.isEqual(to: noImageLoadedButtonHeight) == false
+    private func waitForLoadingIconToDisappear() -> Bool {
+        let loadingIconDisappearedPredicate = XCTNSPredicateExpectation(
+            predicate: NSPredicate(format: "exists == false"),
+            object: changeFeaturedImageButton.images.descendants(matching: .other).element)
+
+        return XCTWaiter.wait(for: [loadingIconDisappearedPredicate], timeout: 30) == .completed
     }
 
     /// - Note: Returns `Void` because the return screen depends on which editor the user is in.


### PR DESCRIPTION
The objective of this PR is to fix `testAddRemoveFeaturedImage()`, which started [failing sometimes as seen here](https://buildkite.com/automattic/wordpress-ios/builds/8746).

### The problem
After selecting a featured image in post settings, the picture takes some time to load depending on the connection. However, the assertion we have in place for checking the image is present `XCTAssertTrue(imageCount == 1, "Featured image not set")` is not enough since it passes right after selecting image, even before the image being fully loaded. After passing this assertion, the next step in the test is to tap the image and, in the next screen, tap the `Remove` button. When the assertion passes before the image is displayed, the screen with the `Remove` button won't be displayed and the test fails due to a `timeOut`.

![image](https://user-images.githubusercontent.com/42008628/179336642-55377cee-4fd9-4d81-8255-f5dc961fab86.png)

### The solution
A new assertion was added, calling `isFeaturedImageLoaded()` which waits for the loading image to disappear. Running the test locally the image took ~8 seconds to load, a 30 seconds timeout was set.

### Testing
* The CI should be green.
* [Test PR running UI Tests 20 times without any testAddRemoveFeaturedImage() failure ](https://github.com/wordpress-mobile/WordPress-iOS/pull/19061)