### PR TITLE
Remove `@objc` from `InteractivePostView` and related delegates

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/InteractivePostView.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc protocol InteractivePostView {
+protocol InteractivePostView {
     func setInteractionDelegate(_ delegate: InteractivePostViewDelegate)
-    @objc optional func setActionSheetDelegate(_ delegate: PostActionSheetDelegate)
+    func setActionSheetDelegate(_ delegate: PostActionSheetDelegate)
 }

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-@objc protocol InteractivePostViewDelegate {
+protocol InteractivePostViewDelegate: AnyObject {
     func edit(_ post: AbstractPost)
     func view(_ post: AbstractPost)
     func stats(for post: AbstractPost)

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -1,7 +1,7 @@
 import Foundation
 import AutomatticTracks
 
-@objc protocol PostActionSheetDelegate {
+protocol PostActionSheetDelegate: AnyObject {
     func showActionSheet(_ postCardStatusViewModel: PostCardStatusViewModel, from view: UIView)
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCompactCell.swift
@@ -196,7 +196,7 @@ class PostCompactCell: UITableViewCell, ConfigurablePostView {
 
 extension PostCompactCell: InteractivePostView {
     func setInteractionDelegate(_ delegate: InteractivePostViewDelegate) {
-
+        // Do nothing, since this cell doesn't support actions in `InteractivePostViewDelegate`.
     }
 
     func setActionSheetDelegate(_ delegate: PostActionSheetDelegate) {

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -559,7 +559,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         }
 
         interactivePostView.setInteractionDelegate(self)
-        interactivePostView.setActionSheetDelegate?(self)
+        interactivePostView.setActionSheetDelegate(self)
 
         configurablePostView.configure(with: post)
 

--- a/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/RestorePostTableViewCell.swift
@@ -76,6 +76,10 @@ class RestorePostTableViewCell: UITableViewCell, ConfigurablePostView, Interacti
         self.delegate = delegate
     }
 
+    func setActionSheetDelegate(_ delegate: PostActionSheetDelegate) {
+        // Do nothing, since this cell doesn't have an action to present an action sheet.
+    }
+
     private enum Constants {
         static let defaultMargin: CGFloat = 16
         static let compactMargin: CGFloat = 0


### PR DESCRIPTION
## Issue
<img width="796" alt="duplicate-conflict" src="https://user-images.githubusercontent.com/1101828/179652783-6dcb9717-c84b-4ae2-93db-765c80b68308.png">

A new API [`UIReponder.duplicate(_:)`](https://developer.apple.com/documentation/uikit/uiresponderstandardeditactions/3967529-duplicate?changes=latest_minor), which is introduced in iOS 16 UIKit, caused a conflict with our own [`InteractivePostViewDelegate.duplicate(_:)`](https://github.com/wordpress-mobile/WordPress-iOS/blob/e0e72e4dbe912d390173dd111643aea2297d9b3f/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift#L7).

## Changes

We could simpliy rename our `duplicate(_:)` function, but I found out that `InteractivePostViewDelegate`(along with a couple other types changed in this PR) isn't actually used in Objective-C code, nor invoked from Objective-C runtime(no result when I searched for all the selectors defined in the delegate). So, I thought I'll remove the `@objc` declaration, to prevent a similar conflict from happening again.

## Regression Notes
1. Potential unintended areas of impact
I can't think of any

2. What I did to test those areas of impact (or what existing automated tests I relied on)
In My Sites -> Posts, I tapped the actions in the post cell, including actions in "More", they all work as expected.

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
   _This isn't a unit-test-able change._
- [x] I have considered adding accessibility improvements for my changes.
   _N/A_
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
   _N/A_
