### PR TITLE
Add JP Banner to MySite->Activity

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -1,7 +1,9 @@
 import UIKit
+import Combine
 
 class JetpackActivityLogViewController: BaseActivityListViewController {
     private let jetpackBannerView = JetpackBannerView()
+    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
 
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         let activityListConfiguration = ActivityListConfiguration(
@@ -37,14 +39,18 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
     }
 
     private func configureBanner() {
-        jetpackBannerView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(jetpackBannerView)
+        containerStackView.addArrangedSubview(jetpackBannerView)
 
         NSLayoutConstraint.activate([
-            jetpackBannerView.heightAnchor.constraint(equalToConstant: 50),
-            jetpackBannerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-            jetpackBannerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            jetpackBannerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+            jetpackBannerView.heightAnchor.constraint(equalToConstant: 50)
         ])
+        addTranslationObserver(jetpackBannerView)
+    }
+}
+
+extension JetpackActivityLogViewController: JPScrollViewDelegate {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        super.scrollViewDidScroll(scrollView)
+        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -1,6 +1,8 @@
 import UIKit
 
 class JetpackActivityLogViewController: BaseActivityListViewController {
+    private let jetpackBannerView = JetpackBannerView()
+
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         let activityListConfiguration = ActivityListConfiguration(
             identifier: "activity_log",
@@ -17,6 +19,7 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         )
 
         super.init(site: site, store: store, configuration: activityListConfiguration, isFreeWPCom: isFreeWPCom)
+        configureBanner()
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -31,5 +34,17 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         extendedLayoutIncludesOpaqueBars = true
 
         WPAnalytics.track(.activityLogViewed)
+    }
+
+    private func configureBanner() {
+        jetpackBannerView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(jetpackBannerView)
+
+        NSLayoutConstraint.activate([
+            jetpackBannerView.heightAnchor.constraint(equalToConstant: 50),
+            jetpackBannerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            jetpackBannerView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            jetpackBannerView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -45,7 +45,7 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         containerStackView.addArrangedSubview(jetpackBannerView)
 
         NSLayoutConstraint.activate([
-            jetpackBannerView.heightAnchor.constraint(equalToConstant: 50)
+            jetpackBannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight)
         ])
         addTranslationObserver(jetpackBannerView)
     }

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -21,7 +21,10 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         )
 
         super.init(site: site, store: store, configuration: activityListConfiguration, isFreeWPCom: isFreeWPCom)
-        configureBanner()
+
+        if FeatureFlag.jetpackPowered.enabled && !AppConfiguration.isJetpack {
+            configureBanner()
+        }
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -47,9 +47,9 @@ extension JetpackBannerView: Subscriber {
             return .unlimited
         }
 
-        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseIn], animations: { [weak self] in
-            self?.isHidden = isHidden
-            self?.superview?.layoutIfNeeded()
+        UIView.animate(withDuration: 0.3, delay: 0, options: [.curveEaseIn], animations: {
+            self.isHidden = isHidden
+            self.superview?.layoutIfNeeded()
         }, completion: nil)
         return .unlimited
     }


### PR DESCRIPTION
Fixes #NA

Adds jetpack banner to Activity screen. It also animates in and out with scroll.

There's a little odd behavior at the bottom of the screen. The footer (although it seems to be a header in code) that goes "Since you're on a free plan..." beneath the tableview goes above the banner somehow. It is part of the tableview but there's some strange implementation there that seems to be intended. I am unsure if we can let this fly or we need to alter somethings. Let me know what you think please.

To test:
1. Go to My Site -> Activity
2. Make sure the "Jetpack powered" banner hides when scrolling down, and shows when scrolling up (see animation above)

## Regression Notes
1. Potential unintended areas of impact
Some scroll anomalies could occur.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manuel testing in portrait/landscape modes.

3. What automated tests I added (or what prevented me from doing so)
Not very straight forward to test.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

https://user-images.githubusercontent.com/15968946/179792867-0bf0b2e0-4def-49e1-b2a6-845e422df6b7.mp4