### PR TITLE
[Tooling] Fix issue with installing hooks in a git worktree setup

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -269,11 +269,12 @@ namespace :git do
   end
 
   def hook_target(hook)
-    ".git/hooks/#{hook}"
+    hoos_dir = %x[git rev-parse --git-path hooks].chomp
+    File.join(hoos_dir, hook)
   end
 
   def hook_source(hook)
-    "../../Scripts/hooks/#{hook}"
+    File.absolute_path(File.join(PROJECT_DIR, 'Scripts', 'hooks', hook))
   end
 
   def hook_backup(hook)

--- a/Rakefile
+++ b/Rakefile
@@ -269,8 +269,8 @@ namespace :git do
   end
 
   def hook_target(hook)
-    hoos_dir = `git rev-parse --git-path hooks`.chomp
-    File.join(hoos_dir, hook)
+    hooks_dir = `git rev-parse --git-path hooks`.chomp
+    File.join(hooks_dir, hook)
   end
 
   def hook_source(hook)

--- a/Rakefile
+++ b/Rakefile
@@ -269,7 +269,7 @@ namespace :git do
   end
 
   def hook_target(hook)
-    hoos_dir = %x[git rev-parse --git-path hooks].chomp
+    hoos_dir = `git rev-parse --git-path hooks`.chomp
     File.join(hoos_dir, hook)
   end
 


### PR DESCRIPTION
The `git:install_hooks` task assumes the git repo directory is located at '.git' and it's in the same directory as the 'Scripts' directory, which isn't true for a [git worktree](https://git-scm.com/docs/git-worktree) setup (one git repo with multiple working copies).

This PR uses `git` command to find the git hooks directory and use the absolute path of the hook scripts to install the hooks.

-------
_No regression tests are needed._

## Regression Notes
1. Potential unintended areas of impact
2. What I did to test those areas of impact (or what existing automated tests I relied on)
3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
