### PR TITLE
Upgrade `git-s3-cache` Buildkite plugin to latest version, 1.1.3

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -8,7 +8,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.2.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.6.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -5,7 +5,7 @@ common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
     - automattic/bash-cache#2.2.0
-    - automattic/git-s3-cache#v1.1.0:
+    - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.


### PR DESCRIPTION
This version includes a fix that ~~will allow our builds to use the local Git cache server in the CI VMs~~. Update: Upon looking at the logs of `trunk` CI builds, it turns out WordPress iOS never had the issue the new version fixes (unlike Pocket Casts iOS). [I thought it did during my testing](https://github.com/Automattic/git-s3-cache-buildkite-plugin/pull/11) but that was due to something else, it seems. Still, the upgrade is a useful one.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
