### PR TITLE
Remove crufty logs from Git hooks output

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,7 @@ excluded:
   - Pods
   - Scripts
   - vendor
+  - DerivedData
 
 # Rules
 only_rules:

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ namespace :dependencies do
 
   namespace :bundle do
     task :check do
-      sh 'bundle check --path=${BUNDLE_PATH:-vendor/bundle} > /dev/null', verbose: false do |ok, _res|
+      sh 'bundle check > /dev/null', verbose: false do |ok, _res|
         next if ok
 
         # bundle check exits with a non zero code if install is needed

--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,7 @@ namespace :dependencies do
     task :apply do
       next unless Dir.exist?(File.join(Dir.home, '.mobile-secrets/.git')) || ENV.key?('CONFIGURE_ENCRYPTION_KEY')
 
-     # The string is indented all the way to the left to avoid padding when printed in the terminal 
+      # The string is indented all the way to the left to avoid padding when printed in the terminal
       command = %(
 FASTLANE_SKIP_UPDATE_CHECK=1 \
 FASTLANE_HIDE_CHANGELOG=1 \

--- a/Rakefile
+++ b/Rakefile
@@ -87,17 +87,18 @@ namespace :dependencies do
     task :apply do
       next unless Dir.exist?(File.join(Dir.home, '.mobile-secrets/.git')) || ENV.key?('CONFIGURE_ENCRYPTION_KEY')
 
-      command_compontents = %w[
-        FASTLANE_SKIP_UPDATE_CHECK=1
-        FASTLANE_HIDE_CHANGELOG=1
-        FASTLANE_HIDE_PLUGINS_TABLE=1
-        FASTLANE_ENV_PRINTER=1
-        FASTLANE_SKIP_ACTION_SUMMARY=1
-        FASTLANE_HIDE_TIMESTAMP=1
-        bundle exec fastlane run configure_apply force:true
-      ]
+     # The string is indented all the way to the left to avoid padding when printed in the terminal 
+      command = %(
+FASTLANE_SKIP_UPDATE_CHECK=1 \
+FASTLANE_HIDE_CHANGELOG=1 \
+FASTLANE_HIDE_PLUGINS_TABLE=1 \
+FASTLANE_ENV_PRINTER=1 \
+FASTLANE_SKIP_ACTION_SUMMARY=1 \
+FASTLANE_HIDE_TIMESTAMP=1 \
+bundle exec fastlane run configure_apply force:true
+      )
 
-      sh(command_compontents.join(' '))
+      sh(command)
     end
   end
 

--- a/Rakefile
+++ b/Rakefile
@@ -87,7 +87,17 @@ namespace :dependencies do
     task :apply do
       next unless Dir.exist?(File.join(Dir.home, '.mobile-secrets/.git')) || ENV.key?('CONFIGURE_ENCRYPTION_KEY')
 
-      sh('FASTLANE_SKIP_UPDATE_CHECK=1 FASTLANE_ENV_PRINTER=1 bundle exec fastlane run configure_apply force:true')
+      command_compontents = %w[
+        FASTLANE_SKIP_UPDATE_CHECK=1
+        FASTLANE_HIDE_CHANGELOG=1
+        FASTLANE_HIDE_PLUGINS_TABLE=1
+        FASTLANE_ENV_PRINTER=1
+        FASTLANE_SKIP_ACTION_SUMMARY=1
+        FASTLANE_HIDE_TIMESTAMP=1
+        bundle exec fastlane run configure_apply force:true
+      ]
+
+      sh(command_compontents.join(' '))
     end
   end
 


### PR DESCRIPTION
I'll admit I never used the hooks from our repo. 😳  I set them up the first time after reviewing @crazytonyli's PR #19078 .

After doing so, I got annoyed by all the noise they generated. This PR addresses part of it, but I'm sure there's more we could do.

### Before / After when checking out branches:

<img width="1580" alt="image" src="https://user-images.githubusercontent.com/1218433/180140919-39a70825-110a-4faf-83f4-73f15b981e85.png">


### Check that all hooks still work

<img width="1595" alt="image" src="https://user-images.githubusercontent.com/1218433/180140817-7b7a6025-5c91-4551-be60-48e61d25ac0b.png">

---

## Regression Notes

1. Potential unintended areas of impact – The Git hooks, but how many people use them? Maybe not many or surely someone would have complained about all the noise in the terminal by now, right?
2. What I did to test those areas of impact (or what existing automated tests I relied on) – Manually run `rake git:...`, see above
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
