### PR TITLE
[UITII] Improve removeApp reliability

### DIFF
--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -94,8 +94,13 @@ extension XCTestCase {
     }
 
     public func waitAndTap( _ element: XCUIElement) {
+        var retries = 0
+        let maxRetries = 10
         if element.waitForIsHittable(timeout: 10) {
-            element.tap()
+            while element.exists && retries < maxRetries {
+                element.tap()
+                retries += 1
+            }
         }
     }
 

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -94,7 +94,7 @@ extension XCTestCase {
     }
 
     public func waitAndTap( _ element: XCUIElement) {
-        if element.waitForExistence(timeout: 5) {
+        if element.waitForIsHittable(timeout: 10) {
             element.tap()
         }
     }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -97,7 +97,7 @@ extension XCTestCase {
         var retries = 0
         let maxRetries = 10
         if element.waitForIsHittable(timeout: 10) {
-            while element.exists && retries < maxRetries {
+            while element.isHittable && retries < maxRetries {
                 element.tap()
                 retries += 1
             }


### PR DESCRIPTION
It was noticed in CI at least two cases ([this](https://buildkite.com/automattic/wordpress-ios/builds/8995#01821ced-e440-4c3c-abc1-c537b7082b71) and [this](https://buildkite.com/automattic/wordpress-ios/builds/9047#018220f5-e0c5-4eb4-b68b-ef6ce828fcbc)) where the first UI Test passes but all the following tests fail. Checking the Xcode logs we can see that the `tearDown()` from the first test hadn't finished properly, and the simulator was displaying the `Delete "WordPress"` popup, making the `setUp()` fail for all the following tests which were failing with the message below.

| Screenshot | Error message |
| :-: | :- |
| <img src="https://user-images.githubusercontent.com/42008628/180303676-9df2f265-d8d6-4d86-a7d6-86c6145e26fc.png"> | _Failed to get launch progress for <XCUIApplicationImpl: 0x6000000ed740 org.wordpress at /usr/local/var/buildkite-agent/builds/builder/automattic/wordpress-ios/DerivedData/Build/Products/Debug-iphonesimulator/WordPress.app>: The request to open "org.wordpress" failed. The request was denied by service delegate (SBMainWorkspace) for reason: Busy ("Application "org.wordpress" is installing or uninstalling, and cannot be launched"). (Underlying Error: The operation couldn’t be completed. **Application "org.wordpress" is installing or uninstalling, and cannot be launched.**)_ |

Initially, I could think of two possible causes for this:
* ~~The button was existing but still not hittable.~~
  * Replacing the `waitForExistance()` by `waitForIsHittable` didn't solve the issue. Despite being `Hittable`, the tap just don't work sometimes. 😓 
* ~~The old iOS known issue where sometimes some buttons are just not accessible by `XCUITest`.~~
  * When reproducing the issue locally it was possible to inspect and tap the button via Xcode. 😓  

After some investigation it was identified that sometimes the tap was taking effect, possibly because of a timing issue (even though the button was already `Hittable`) since further taps do work as e expected. It was also noticed, when running locally, that the issue tends to happen in the first `tearDown()`, mainly for the `Alert` buttons (`Delete App`, `Delete`). It was not possible to identify a button property that could indicate the right moment to tap on it though.

#### Proposed solution
To avoid arbitrary waits, it was added a loop to `waitAndTap( _ element: XCUIElement)` to tap the button while it still exists. By running the tests multiple times it was noticed that, when the issue happen, it only took one extra tap to actually have the button pressed. Also, to avid getting into an infinite loop, it was limited to `10` retries.
