### PR TITLE
Add entry for app store name to Jetpack `.po` file

### DIFF
--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -13,6 +13,11 @@ msgstr ""
 "Last-Translator: \n"
 "Language-Team: \n"
 
+#. translators: The application name in the Apple App Store. Please keep the brand names ('Jetpack' and WordPress') verbatim. Limit to 30 characters including spaces and punctuation!
+msgctxt "app_store_name"
+msgid "Jetpack"
+msgstr ""
+
 #. translators: Subtitle to be displayed below the application name in the Apple App Store. Limit to 30 characters including spaces and commas!
 msgctxt "app_store_subtitle"
 msgid "Faster, safer WordPress"


### PR DESCRIPTION
Followup to #19083 to allow the automation to send the localized app name up for translation. 

We have to do this change manually because of the known issue https://github.com/wordpress-mobile/release-toolkit/issues/172 which hasn't been addressed yet because of higher priority work in the pipeline.

## Testing

This change can be verified by creating a new branch on top of this one and running `bundle exec fastlane update_jetpack_appstore_strings`. The result should match the test I pushed with [this commit](https://github.com/wordpress-mobile/WordPress-iOS/commit/b90be740f8358cc3452fdd130b38364eebf79e59)

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
