### PR TITLE
Missing @ and + signs from suggestions list

### DIFF
--- a/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/SuggestionViewModel.swift
@@ -2,20 +2,24 @@ import Foundation
 
 @objc final class SuggestionViewModel: NSObject {
 
-    @objc let title: String?
+    @objc private(set) var title: String?
+
     @objc let subtitle: String?
     @objc let imageURL: URL?
 
     init(suggestion: UserSuggestion) {
-        self.title = suggestion.username
+        if let username = suggestion.username {
+            self.title = "\(SuggestionType.mention.trigger)\(username)"
+        }
         self.subtitle = suggestion.displayName
         self.imageURL = suggestion.imageURL
     }
 
     init(suggestion: SiteSuggestion) {
-        self.title = suggestion.subdomain
+        if let subdomain = suggestion.subdomain {
+            self.title = "\(SuggestionType.xpost.trigger)\(subdomain)"
+        }
         self.subtitle = suggestion.title
         self.imageURL = suggestion.blavatarURL
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -327,8 +327,9 @@ CGFloat const STVSeparatorHeight = 1.f;
 {
     SuggestionViewModel *suggestion = [self.viewModel.items objectAtIndex:indexPath.row];
     NSString *currentSearchText = [self.viewModel.searchText substringFromIndex:1];
+    NSString *suggestionTitle = [suggestion.title substringFromIndex:1];
     if ([self.suggestionsDelegate respondsToSelector:@selector(suggestionsTableView:didSelectSuggestion:forSearchText:)]) {
-        [self.suggestionsDelegate suggestionsTableView:self didSelectSuggestion:suggestion.title forSearchText:currentSearchText];
+        [self.suggestionsDelegate suggestionsTableView:self didSelectSuggestion:suggestionTitle forSearchText:currentSearchText];
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2928,6 +2928,8 @@
 		F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
 		F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */; };
+		F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */; };
+		F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */; };
 		F504D2B025D60C5900A2764C /* StoryPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AA25D60C5900A2764C /* StoryPoster.swift */; };
 		F504D2B125D60C5900A2764C /* StoryMediaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AB25D60C5900A2764C /* StoryMediaLoader.swift */; };
 		F504D43725D717EF00A2764C /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
@@ -7875,6 +7877,8 @@
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModelTests.swift; sourceTree = "<group>"; };
+		F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTableViewTests.swift; sourceTree = "<group>"; };
+		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
 		F504D2AA25D60C5900A2764C /* StoryPoster.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryPoster.swift; sourceTree = "<group>"; };
 		F504D2AB25D60C5900A2764C /* StoryMediaLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryMediaLoader.swift; sourceTree = "<group>"; };
 		F50B0E7A246212B8006601DD /* NoticeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
@@ -15273,6 +15277,8 @@
 				F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */,
 				F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */,
 				F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */,
+				F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */,
+				F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */,
 			);
 			path = Mention;
 			sourceTree = "<group>";
@@ -20295,6 +20301,7 @@
 				C738CB1128626606001BE107 /* QRLoginVerifyCoordinatorTests.swift in Sources */,
 				FF0B2567237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift in Sources */,
 				FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */,
+				F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
 				8B2D4F5527ECE376009B085C /* BlogDashboardPostsParserTests.swift in Sources */,
@@ -20464,6 +20471,7 @@
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				B5882C471D5297D1008E0EAA /* NotificationTests.swift in Sources */,
 				DC2CA0852837B9080037E17E /* SiteStatsInsightsDetailsViewModelTests.swift in Sources */,
+				F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */,
 				B532ACD31DC3AE1200FFFA57 /* OHHTTPStubs+Helpers.swift in Sources */,
 				E11DF3E420C97F0A00C0B07C /* NotificationCenterObserveOnceTests.swift in Sources */,
 				5960967F1CF7959300848496 /* PostTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2927,6 +2927,7 @@
 		F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */; };
 		F44FB6CD287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */; };
 		F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */ = {isa = PBXBuildFile; fileRef = F44FB6D02878A1020001E3CE /* user-suggestions.json */; };
+		F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */; };
 		F504D2B025D60C5900A2764C /* StoryPoster.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AA25D60C5900A2764C /* StoryPoster.swift */; };
 		F504D2B125D60C5900A2764C /* StoryMediaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = F504D2AB25D60C5900A2764C /* StoryMediaLoader.swift */; };
 		F504D43725D717EF00A2764C /* PostEditor+BlogPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91DCE84321A6A7840062F134 /* PostEditor+BlogPicker.swift */; };
@@ -7873,6 +7874,7 @@
 		F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewMockDelegate.swift; sourceTree = "<group>"; };
 		F44FB6D02878A1020001E3CE /* user-suggestions.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "user-suggestions.json"; sourceTree = "<group>"; };
 		F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressShareExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModelTests.swift; sourceTree = "<group>"; };
 		F504D2AA25D60C5900A2764C /* StoryPoster.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryPoster.swift; sourceTree = "<group>"; };
 		F504D2AB25D60C5900A2764C /* StoryMediaLoader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoryMediaLoader.swift; sourceTree = "<group>"; };
 		F50B0E7A246212B8006601DD /* NoticeAnimator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeAnimator.swift; sourceTree = "<group>"; };
@@ -15270,6 +15272,7 @@
 			children = (
 				F44FB6CA287895AF0001E3CE /* SuggestionsListViewModelTests.swift */,
 				F44FB6CC287897F90001E3CE /* SuggestionsTableViewMockDelegate.swift */,
+				F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */,
 			);
 			path = Mention;
 			sourceTree = "<group>";
@@ -20522,6 +20525,7 @@
 				400A2C972217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift in Sources */,
 				DC8F61FC2703321F0087AC5D /* TimeZoneFormatterTests.swift in Sources */,
 				E180BD4E1FB4681E00D0D781 /* MockCookieJar.swift in Sources */,
+				F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */,
 				D81C2F6A20F8B449002AE1F1 /* NotificationActionParserTest.swift in Sources */,
 				F15D1FBA265C41A900854EE5 /* BloggingRemindersStoreTests.swift in Sources */,
 				E1E4CE0D177439D100430844 /* WPAvatarSourceTest.m in Sources */,

--- a/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+@testable import WordPress
+import XCTest
+
+final class SuggestionTableViewTests: CoreDataTestCase {
+
+    private var view: SuggestionsTableView!
+    private var delegate: SuggestionsTableViewDelegateMock!
+    private var viewModel: SuggestionsListViewModelType {
+        return view.viewModel
+    }
+
+    override func setUpWithError() throws {
+        let blog = Blog(context: mainContext)
+        let viewModel = SuggestionsListViewModel(blog: blog)
+        viewModel.context = mainContext
+        viewModel.userSuggestionService = SuggestionServiceMock(context: mainContext)
+        viewModel.siteSuggestionService = SiteSuggestionServiceMock(context: mainContext)
+        self.delegate = SuggestionsTableViewDelegateMock()
+        self.view = SuggestionsTableView(viewModel: viewModel, delegate: delegate)
+    }
+
+    // MARK: - Test Row Selection
+
+    /// Tests that selecting a user suggestion row pass the right params to view's delegate
+    func testUserSuggestionRowSelected() {
+        // Given
+        let word = "@"
+        let position = 0
+        self.viewModel.suggestionType = .mention
+
+        // When
+        self.viewModel.reloadData()
+        self.view.showSuggestions(forWord: word)
+        self.view.selectSuggestion(atPosition: position)
+
+        // Then
+        XCTAssertEqual(delegate.selectedSuggestion, "ghaskayne0")
+        XCTAssertEqual(delegate.searchText, "")
+    }
+
+    /// Tests that selecting a site suggestion row pass the right params to view's delegate
+    func testSiteSuggestionRowSelected() {
+        // Given
+        let word = "+"
+        let position = 0
+        self.viewModel.suggestionType = .xpost
+
+        // When
+        self.viewModel.reloadData()
+        self.view.showSuggestions(forWord: word)
+        self.view.selectSuggestion(atPosition: position)
+
+        // Then
+        XCTAssertEqual(delegate.selectedSuggestion, "pen.io")
+        XCTAssertEqual(delegate.searchText, "")
+    }
+}

--- a/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionTableViewTests.swift
@@ -1,7 +1,7 @@
 import Foundation
+import XCTest
 
 @testable import WordPress
-import XCTest
 
 final class SuggestionTableViewTests: CoreDataTestCase {
 

--- a/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import WordPress
 
-//final class SuggestionViewModelTests: CoreDataTestCase {
+final class SuggestionViewModelTests: CoreDataTestCase {
 
     /// Tests that the user suggestion view model properties are properly formatted.
     func testUserSuggestionViewModel() throws {

--- a/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionViewModelTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import XCTest
+
+@testable import WordPress
+
+//final class SuggestionViewModelTests: CoreDataTestCase {
+
+    /// Tests that the user suggestion view model properties are properly formatted.
+    func testUserSuggestionViewModel() throws {
+        // Given
+        let dictionary: [String: Any] = [
+            "ID": 1 as UInt,
+            "user_login": "ghaskayne0",
+            "display_name": "Geoffrey Haskayne",
+            "image_URL": "https://fakeimg.pl/250x100"
+        ]
+        let model = try XCTUnwrap(UserSuggestion(dictionary: dictionary, context: mainContext))
+
+        // When
+        let viewModel = SuggestionViewModel(suggestion: model)
+
+        // Then
+        XCTAssertEqual(viewModel.title, "@ghaskayne0")
+        XCTAssertEqual(viewModel.subtitle, "Geoffrey Haskayne")
+        XCTAssertEqual(viewModel.imageURL, URL(string: "https://fakeimg.pl/250x100"))
+    }
+
+    /// Tests that the site suggestion view model properties are properly formatted.
+    func testSiteSuggestionViewModel() throws {
+        // Given
+        let decoder = JSONDecoder()
+        decoder.userInfo[CodingUserInfoKey.managedObjectContext] = mainContext
+        let dictionary: [String: Any] = [
+            "title": "Pied Piper",
+            "siteurl": "https://businessweek.com",
+            "subdomain": "piedpiper",
+            "blavatar": "https://fakeimg.pl/250x100"
+        ]
+        let data = try JSONSerialization.data(withJSONObject: dictionary, options: [])
+        let model = try decoder.decode(SiteSuggestion.self, from: data)
+
+        // When
+        let viewModel = SuggestionViewModel(suggestion: model)
+
+        // Then
+        XCTAssertEqual(viewModel.title, "+piedpiper")
+        XCTAssertEqual(viewModel.subtitle, "Pied Piper")
+        XCTAssertEqual(viewModel.imageURL, URL(string: "https://fakeimg.pl/250x100"))
+    }
+}

--- a/WordPress/WordPressTest/Mention/SuggestionsTableViewDelegateMock.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionsTableViewDelegateMock.swift
@@ -11,5 +11,4 @@ final class SuggestionsTableViewDelegateMock: NSObject, SuggestionsTableViewDele
         self.selectedSuggestion = suggestion
         self.searchText = text
     }
-
 }

--- a/WordPress/WordPressTest/Mention/SuggestionsTableViewDelegateMock.swift
+++ b/WordPress/WordPressTest/Mention/SuggestionsTableViewDelegateMock.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+@testable import WordPress
+
+final class SuggestionsTableViewDelegateMock: NSObject, SuggestionsTableViewDelegate {
+
+    private(set) var selectedSuggestion: String?
+    private(set) var searchText: String?
+
+    func suggestionsTableView(_ suggestionsTableView: SuggestionsTableView, didSelectSuggestion suggestion: String?, forSearchText text: String) {
+        self.selectedSuggestion = suggestion
+        self.searchText = text
+    }
+
+}


### PR DESCRIPTION
## Issue
Fixes a bug in #19030

## Description
This PR fixes an issue where the `@` and `+` were missing from the suggestion titles. It also adds Unit Tests to cover this issue.

## Problem
The `@` and `+` signs are missing from the suggestions list.

![CleanShot 2022-07-22 at 15 45 31@2x](https://user-images.githubusercontent.com/9609223/180464500-76efbea4-b7b0-4330-bb01-e801fe0d8e71.png)

## Expected
The suggestion title should start with `@` or `+` signs.

![CleanShot 2022-07-22 at 15 50 34@2x](https://user-images.githubusercontent.com/9609223/180465515-958cd584-3a4c-437c-be7d-ff446ca23dd3.png)

## Steps to reproduce
1. Locate any text input where you can insert user mention or site mention. For example: "My Site" tab > "Plus" button > "Blog post" button.
2. Insert @-mention. You should see a list of user suggestions, but the suggestions titles are not prefixed with `@` sign.  
3. Insert +-mention. You should see a list of site suggestions, but the suggestions titles are not prefixed with `+` sign.

##### Tested on Simulator, iOS 15.5, WPiOS 20.4 (5a5e30c276a354f7ef52c399b6c5643a91122c5b)