### PR TITLE
[Jetpack] Add Jetpack banner to People view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1450,7 +1450,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showPeople
 {
-    PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
+    PeopleViewController *peopleVC = [PeopleViewController controllerWithBlog:self.blog];
+    JetpackBannerWrapperViewController *controller = [[JetpackBannerWrapperViewController alloc] initWithChildVC:peopleVC];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -1,0 +1,32 @@
+import Foundation
+import UIKit
+
+@objc class JetpackBannerWrapperViewController: UIViewController {
+    var childVC: UIViewController?
+
+    @objc convenience init(childVC: UIViewController) {
+        self.init()
+        self.childVC = childVC
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+
+        view.addSubview(stackView)
+        view.pinSubviewToAllEdges(stackView)
+
+        if let childVC = childVC {
+            addChild(childVC)
+            stackView.addArrangedSubview(childVC.view)
+            childVC.didMove(toParent: self)
+        }
+
+        let jetpackBannerView = JetpackBannerView()
+        stackView.addArrangedSubview(jetpackBannerView)
+        jetpackBannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 
 @objc class JetpackBannerWrapperViewController: UIViewController {
-    var childVC: UIViewController?
+    private var childVC: UIViewController?
 
     @objc convenience init(childVC: UIViewController) {
         self.init()

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -13,20 +13,41 @@ import UIKit
         super.viewDidLoad()
 
         let stackView = UIStackView()
+        configureStackView(stackView)
+        configureChildVC(stackView)
+        configureJetpackBanner(stackView)
+    }
+
+    private func configureStackView(_ stackView: UIStackView) {
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
 
         view.addSubview(stackView)
         view.pinSubviewToAllEdges(stackView)
+    }
 
-        if let childVC = childVC {
-            addChild(childVC)
-            stackView.addArrangedSubview(childVC.view)
-            childVC.didMove(toParent: self)
-        }
+    private func configureChildVC(_ stackView: UIStackView) {
+        guard let childVC = childVC else { return }
+
+        addChild(childVC)
+        stackView.addArrangedSubview(childVC.view)
+        childVC.didMove(toParent: self)
+    }
+
+    private func configureJetpackBanner(_ stackView: UIStackView) {
+        guard shouldShowBanner() else { return }
 
         let jetpackBannerView = JetpackBannerView()
         stackView.addArrangedSubview(jetpackBannerView)
         jetpackBannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
+
+        if let childVC = childVC as? JPScrollViewDelegate {
+            childVC.addTranslationObserver(jetpackBannerView)
+        }
+    }
+
+    /// Note: This could be improved to be delegated to the wrapped view.
+    private func shouldShowBanner() -> Bool {
+        return JetpackBrandingVisibility.all.enabled
     }
 }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -563,11 +563,11 @@ private extension PeopleViewController {
     }
 
     func setupView() {
-        title = NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
+        parent?.title = NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
 
         extendedLayoutIncludesOpaqueBars = true
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
+        parent?.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -1,3 +1,4 @@
+import Combine
 import UIKit
 
 import CocoaLumberjack
@@ -101,6 +102,9 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         frc.delegate = self
         return frc
     }()
+
+    /// Used by JPScrollViewDelegate to send scroll position
+    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
 
     /// Filtering Tab Bar
     ///
@@ -599,5 +603,13 @@ extension PeopleViewController {
             return
         }
         WPAnalytics.track(.peopleFilterChanged, properties: [:], blog: blog)
+    }
+}
+
+// MARK: - Jetpack banner delegate
+
+extension PeopleViewController: JPScrollViewDelegate {
+    public override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2257,6 +2257,8 @@
 		C373D6E728045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6E828045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */; };
+		C3835559288B02B00062E402 /* JetpackBannerWrapperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */; };
+		C383555A288B02B00062E402 /* JetpackBannerWrapperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */; };
 		C387B7A22638D66F00BDEF86 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C38C5D8127F61D2C002F517E /* MenuItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38C5D8027F61D2C002F517E /* MenuItemTests.swift */; };
 		C395FB232821FE4400AE7C11 /* SiteDesignSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */; };
@@ -7150,6 +7152,7 @@
 		C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationStep.swift; sourceTree = "<group>"; };
 		C373D6E628045281008F8C26 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
 		C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentDataTests.swift; sourceTree = "<group>"; };
+		C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerWrapperViewController.swift; sourceTree = "<group>"; };
 		C38C5D8027F61D2C002F517E /* MenuItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = MenuItemTests.swift; path = Menus/MenuItemTests.swift; sourceTree = "<group>"; };
 		C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSection.swift; sourceTree = "<group>"; };
 		C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSiteDesign+Thumbnail.swift"; sourceTree = "<group>"; };
@@ -10099,6 +10102,7 @@
 			isa = PBXGroup;
 			children = (
 				B0CD27CE286F8858009500BF /* JetpackBannerView.swift */,
+				C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */,
 				3FAE0651287C8FC500F46508 /* JPScrollViewDelegate.swift */,
 			);
 			path = Banner;
@@ -18248,6 +18252,7 @@
 				981C986821B9BDF300A7C0C8 /* PostingActivityViewController.swift in Sources */,
 				FAD2538F26116A1600EDAF88 /* AppStyleGuide.swift in Sources */,
 				17F67C56203D81430072001E /* PostCardStatusViewModel.swift in Sources */,
+				C3835559288B02B00062E402 /* JetpackBannerWrapperViewController.swift in Sources */,
 				E63BBC961C5168BE00598BE8 /* SharingAuthorizationHelper.m in Sources */,
 				98880A4A22B2E5E400464538 /* TwoColumnCell.swift in Sources */,
 				ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */,
@@ -20747,6 +20752,7 @@
 				FABB215D2602FC2C00C8785C /* ValueTransformers.swift in Sources */,
 				FABB215E2602FC2C00C8785C /* ABTest.swift in Sources */,
 				FABB215F2602FC2C00C8785C /* ContextManager+ErrorHandling.swift in Sources */,
+				C383555A288B02B00062E402 /* JetpackBannerWrapperViewController.swift in Sources */,
 				FABB21602602FC2C00C8785C /* EmptyActionView.swift in Sources */,
 				FABB21612602FC2C00C8785C /* ReaderShowAttributionAction.swift in Sources */,
 				FABB21622602FC2C00C8785C /* LinkSettingsViewController.swift in Sources */,


### PR DESCRIPTION
## Description

**This PR:**
- Introduces a container view controller for adding the Jetpack banner to existing view controllers
- Wraps the People view

**Current limitations:**
- The banner will be obscured by any subsequent view controller pushes from the contained view, so subviews aren't supported.
- The wrapping view controller is currently deciding whether the banner is shown. In the future that could be delegated to the view itself. This is only for visibility, scroll events work as expected.

## Testing

**Note:** The People view is only available when signed into a .com account (e.g. sites hosted by WordPress.com or a Jetpack connected self-hosted site)

1. Open the WordPress app 
2. Tap People
3. Expect to see the "Jetpack powered" banner at the bottom for each tab
4. Tap an existing user
5. Expect **not** to see the banner at this time
6. Tap the "+" at the top right to invite a new user
7. Expect **not** to see the banner at this time

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 14 31 28](https://user-images.githubusercontent.com/2092798/180502120-4c6634b5-98ec-4622-9284-7fc27c9bce6e.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 14 28 20](https://user-images.githubusercontent.com/2092798/180502147-20971abc-80e5-42b9-bd6c-3906fb880f2a.png) |

### Items to test

- Managing People for the site
- Large accessibility sizes
- Dark mode
- Landscape orientation
- iPad
- Banner should not appear in Jetpack app
- Banner should not appear when the feature flag is disabled

## Regression Notes
1. Potential unintended areas of impact
    - People view functionality - managing users, inviting new ones

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
