### PR TITLE
Fix jetpack branding elements in RTL

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -84,6 +84,7 @@ class JetpackButton: UIButton {
         imageEdgeInsets = Appearance.iconInsets
         contentEdgeInsets = Appearance.contentInsets
         imageView?.contentMode = .scaleAspectFit
+        flipInsetsForRightToLeftLayoutDirection()
 
         // sets the background of the jp logo to white
         if let imageView = imageView {


### PR DESCRIPTION
Fixes #NA

This PR fixes the layout of Jetpack badges and banners with RTL languages

badge | banner
-- | --
<img height=350 src=https://user-images.githubusercontent.com/34376330/180502198-6a399ecf-c1a5-44ea-ac5d-83a5050de585.png> | <img height=350 src=https://user-images.githubusercontent.com/34376330/180502206-e5a40550-cc56-432a-8d49-b4154c96aa3c.png>


To test:

- set the device to an rtl language
- build/run the WordPress target on tihis branch
- make sure the layout of badges and banners looks correct
- change the device language to a ltr language
- make sure badges and banners still look correct

## Regression Notes
1. Potential unintended areas of impact
none

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)4. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
