### PR TITLE
[Jetpack] Add Jetpack banner to Sharing view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1514,7 +1514,8 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         controller = [[SharingButtonsViewController alloc] initWithBlog:self.blog];
 
     } else {
-        controller = [[SharingViewController alloc] initWithBlog:self.blog delegate: nil];
+        SharingViewController *sharingVC = [[SharingViewController alloc] initWithBlog:self.blog delegate:nil];
+        controller = [[JetpackBannerWrapperViewController alloc] initWithChildVC: sharingVC];
     }
 
     [self trackEvent:WPAnalyticsStatOpenedSharingManagement fromSource:source];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -44,12 +44,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     [super viewDidLoad];
 
-    self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
+    self.parentViewController.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
     
     self.extendedLayoutIncludesOpaqueBars = YES;
     
     if (self.isModal) {
-        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+        self.parentViewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                                target:self
                                                                                                action:@selector(doneButtonTapped)];
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -48,6 +48,11 @@ import UIKit
 
     /// Note: This could be improved to be delegated to the wrapped view.
     private func shouldShowBanner() -> Bool {
+        /// Presenting as a modal currently isn't supported due to Safe Area overlap
+        guard !isModal() else {
+            return false
+        }
+
         return JetpackBrandingVisibility.all.enabled
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -473,8 +473,11 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
-        let controller: UIViewController = SharingViewController(blog: blog, delegate: self)
+        guard let sharingVC = SharingViewController(blog: blog, delegate: self) else {
+            return
+        }
 
+        let controller: UIViewController = JetpackBannerWrapperViewController(childVC: sharingVC)
         let navigationController = UINavigationController(rootViewController: controller)
 
         present(navigationController, animated: true)


### PR DESCRIPTION
## Description

This PR adds the Jetpack banner to the Sharing view.

**It does not:**
- Show the banner when the Sharing view is presented as a modal due to overlapping of the Safe Area
    - My Site -> Stats -> Enable post sharing
- Respond to scroll events
- Show the banner on any subviews

## Testing

**Note:** The People view is only available when signed into a .com account (e.g. sites hosted by WordPress.com or a Jetpack connected self-hosted site)

1. Open the WordPress app
2. Tap Sharing
3. Expect to see the "Jetpack powered" banner at the bottom
4. Tap a social media service
5. Expect to **not** see the banner
6. Go back and tap "Manage" under "Sharing buttons"
7. Expect to **not** see the banner

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 15 53 11](https://user-images.githubusercontent.com/2092798/180517455-1fbe2f1c-5560-40ae-b4bf-85018b9727da.png) | ![Simulator Screen Shot - iPhone 13 - 2022-07-22 at 15 51 30](https://user-images.githubusercontent.com/2092798/180517469-c6172526-4a04-4393-b86c-012dfaef3118.png) |

### Items to test
- Managing People for the site
- Large accessibility sizes
- Dark mode
- Landscape orientation
- iPad
- Banner should not appear in Jetpack app
- Banner should not appear when the feature flag is disabled

## Regression Notes
1. Potential unintended areas of impact
    - Sharing view functionality

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
