### PR TITLE
Add Jetpack powered badge to reader detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -18,7 +18,6 @@ class BorderedButtonTableViewCell: UITableViewCell {
 
     weak var delegate: BorderedButtonTableViewCellDelegate?
 
-    //private var button = UIButton()
     private var buttonTitle = String()
     private var buttonInsets = Defaults.buttonInsets
     private var titleFont = Defaults.titleFont

--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -18,7 +18,7 @@ class BorderedButtonTableViewCell: UITableViewCell {
 
     weak var delegate: BorderedButtonTableViewCellDelegate?
 
-    private var button = UIButton()
+    //private var button = UIButton()
     private var buttonTitle = String()
     private var buttonInsets = Defaults.buttonInsets
     private var titleFont = Defaults.titleFont
@@ -64,6 +64,41 @@ class BorderedButtonTableViewCell: UITableViewCell {
         return view
     }()
 
+    private lazy var button: UIButton = {
+        let button = UIButton()
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(buttonTitle, for: .normal)
+
+        button.setTitleColor(normalColor, for: .normal)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+
+        button.titleLabel?.font = titleFont
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+        return button
+    }()
+
+    private lazy var jetpackBadge: JetpackButton = {
+        let button = JetpackButton(style: .badge)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var jetpackBadgeView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(jetpackBadge)
+        return view
+    }()
+
+    private lazy var mainStackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [button, jetpackBadgeView])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        return stackView
+    }()
+
     // MARK: - Configure
 
     func configure(buttonTitle: String,
@@ -99,23 +134,12 @@ private extension BorderedButtonTableViewCell {
         accessibilityTraits = .button
 
         configureButton()
-        contentView.addSubview(button)
-        contentView.pinSubviewToAllEdges(button, insets: buttonInsets)
+        configureJetpackBadge()
+        contentView.addSubview(mainStackView)
+        contentView.pinSubviewToAllEdges(mainStackView, insets: buttonInsets)
     }
 
     func configureButton() {
-        let button = UIButton()
-
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(buttonTitle, for: .normal)
-
-        button.setTitleColor(normalColor, for: .normal)
-        button.setTitleColor(highlightedColor, for: .highlighted)
-
-        button.titleLabel?.font = titleFont
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.numberOfLines = 0
-
         // Add constraints to the title label, so the button can contain it properly in multi-line cases.
         if let label = button.titleLabel {
             button.pinSubviewToAllEdgeMargins(label)
@@ -124,9 +148,19 @@ private extension BorderedButtonTableViewCell {
         button.on(.touchUpInside) { [weak self] _ in
             self?.delegate?.buttonTapped()
         }
-
-        self.button = button
         updateButtonBorderColors()
+    }
+
+    func configureJetpackBadge() {
+        guard JetpackBrandingVisibility.all.enabled else {
+            jetpackBadgeView.isHidden = true
+            return
+        }
+        NSLayoutConstraint.activate([
+            jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Defaults.jetpackBadgeTopInset),
+            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor),
+            jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
+        ])
     }
 
     func updateButtonBorderColors() {
@@ -139,6 +173,7 @@ private extension BorderedButtonTableViewCell {
         static let titleFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         static let normalColor: UIColor = .text
         static let highlightedColor: UIColor = .textInverted
+        static let jetpackBadgeTopInset: CGFloat = 30
     }
 
     func toggleLoading(_ loading: Bool) {

--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -157,7 +157,7 @@ private extension BorderedButtonTableViewCell {
         }
         NSLayoutConstraint.activate([
             jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Defaults.jetpackBadgeTopInset),
-            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: Defaults.jetpackBadgeBottomInset),
+            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: -Defaults.jetpackBadgeBottomInset),
             jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
         ])
     }

--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -157,7 +157,7 @@ private extension BorderedButtonTableViewCell {
         }
         NSLayoutConstraint.activate([
             jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Defaults.jetpackBadgeTopInset),
-            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor),
+            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: Defaults.jetpackBadgeBottomInset),
             jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
         ])
     }
@@ -173,6 +173,7 @@ private extension BorderedButtonTableViewCell {
         static let normalColor: UIColor = .text
         static let highlightedColor: UIColor = .textInverted
         static let jetpackBadgeTopInset: CGFloat = 30
+        static let jetpackBadgeBottomInset: CGFloat = 6
     }
 
     func toggleLoading(_ loading: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
@@ -15,8 +15,6 @@ class ReaderDetailNoCommentCell: UITableViewCell, NibReusable {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(jetpackBadge)
-
-
         return view
     }()
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
@@ -30,9 +30,10 @@ class ReaderDetailNoCommentCell: UITableViewCell, NibReusable {
         stackView.addArrangedSubview(jetpackBadgeView)
         NSLayoutConstraint.activate([
             jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Self.jetpackBadgeTopInset),
-            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor),
+            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: -Self.jetpackBadgeBottomInset),
             jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
         ])
     }
     static let jetpackBadgeTopInset: CGFloat = 30
+    static let jetpackBadgeBottomInset: CGFloat = 6
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
@@ -3,11 +3,38 @@ import UIKit
 class ReaderDetailNoCommentCell: UITableViewCell, NibReusable {
 
     @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var stackView: UIStackView!
+
+    private lazy var jetpackBadge: JetpackButton = {
+        let button = JetpackButton(style: .badge)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var jetpackBadgeView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(jetpackBadge)
+
+
+        return view
+    }()
 
     override func awakeFromNib() {
         super.awakeFromNib()
         contentView.backgroundColor = .basicBackground
         titleLabel.textColor = .textSubtle
-    }
 
+        guard JetpackBrandingVisibility.all.enabled else {
+            return
+        }
+
+        stackView.addArrangedSubview(jetpackBadgeView)
+        NSLayoutConstraint.activate([
+            jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Self.jetpackBadgeTopInset),
+            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor),
+            jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
+        ])
+    }
+    static let jetpackBadgeTopInset: CGFloat = 30
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,22 +14,28 @@
             <rect key="frame" x="0.0" y="0.0" width="394" height="69"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
+                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="2QT-rx-5QY">
                     <rect key="frame" x="0.0" y="20" width="394" height="49"/>
-                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                    <nil key="highlightedColor"/>
-                </label>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
+                            <rect key="frame" x="0.0" y="0.0" width="394" height="49"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                            <nil key="highlightedColor"/>
+                        </label>
+                    </subviews>
+                </stackView>
             </subviews>
             <viewLayoutGuide key="safeArea" id="epR-21-48u"/>
             <constraints>
-                <constraint firstItem="QfN-CJ-PfS" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="6FS-1m-LFu"/>
-                <constraint firstAttribute="bottom" secondItem="QfN-CJ-PfS" secondAttribute="bottom" id="RVn-Cf-JSe"/>
-                <constraint firstItem="QfN-CJ-PfS" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="VQC-4P-3s7"/>
-                <constraint firstAttribute="trailing" secondItem="QfN-CJ-PfS" secondAttribute="trailing" id="zK3-Y8-YOU"/>
+                <constraint firstAttribute="bottom" secondItem="2QT-rx-5QY" secondAttribute="bottom" id="J3a-ZZ-uTs"/>
+                <constraint firstItem="2QT-rx-5QY" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="SL3-dA-OT9"/>
+                <constraint firstAttribute="trailing" secondItem="2QT-rx-5QY" secondAttribute="trailing" id="Xdc-CV-v1t"/>
+                <constraint firstItem="2QT-rx-5QY" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="b6k-Ll-Rge"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
+                <outlet property="stackView" destination="2QT-rx-5QY" id="vok-VW-wI4"/>
                 <outlet property="titleLabel" destination="QfN-CJ-PfS" id="GBW-w4-V0a"/>
             </connections>
             <point key="canvasLocation" x="36.231884057971016" y="81.361607142857139"/>


### PR DESCRIPTION
Fixes #NA

This PR adds the "Jetpack powered" badge to a reader article, in the comments section

with comments | without comments
-- | --
<img height=500 src=https://user-images.githubusercontent.com/34376330/180567621-5bac59f8-01db-4e53-95af-67df2bd69fab.png> | <img height=500 src=https://user-images.githubusercontent.com/34376330/180567603-fcb12a6f-e091-4914-9cf1-d9e286ecb0f2.png>


To test:
- Build run the WordPress target on this branch
- Go to reader and select any article
- Scroll down to Comments and make sure the Jetpack badge appears
- Rebuild the Jetpack target and make sure the badge does not appear


## Regression Notes
1. Potential unintended areas of impact
Reader detail

2. What I did to test those areas of impact (or what existing automated tests I relied on)
test on simulator and device

3. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
