### PR TITLE
[Jetpack] Revert Jetpack banner on People view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1450,8 +1450,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showPeople
 {
-    PeopleViewController *peopleVC = [PeopleViewController controllerWithBlog:self.blog];
-    JetpackBannerWrapperViewController *controller = [[JetpackBannerWrapperViewController alloc] initWithChildVC:peopleVC];
+    PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -1,4 +1,3 @@
-import Combine
 import UIKit
 
 import CocoaLumberjack
@@ -102,9 +101,6 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         frc.delegate = self
         return frc
     }()
-
-    /// Used by JPScrollViewDelegate to send scroll position
-    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
 
     /// Filtering Tab Bar
     ///
@@ -563,11 +559,11 @@ private extension PeopleViewController {
     }
 
     func setupView() {
-        parent?.title = NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
+        title = NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
 
         extendedLayoutIncludesOpaqueBars = true
 
-        parent?.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
+        navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
                                                             target: self,
                                                             action: #selector(invitePersonWasPressed))
 
@@ -603,13 +599,5 @@ extension PeopleViewController {
             return
         }
         WPAnalytics.track(.peopleFilterChanged, properties: [:], blog: blog)
-    }
-}
-
-// MARK: - Jetpack banner delegate
-
-extension PeopleViewController: JPScrollViewDelegate {
-    public override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
     }
 }


### PR DESCRIPTION
This PR reverts the People view specific changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/19103.

To test:
- The People view should be reverted
- The Sharing view should not be affected and the banner should appear (tested from https://github.com/wordpress-mobile/WordPress-iOS/pull/19106 should pass)

## Regression Notes
1. Potential unintended areas of impact
    - Functionality of People view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
