### PR TITLE
[Test PR] Revert fastlane to 2.206.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GEM
     ast (2.4.2)
     atomos (0.1.3)
     aws-eventstream (1.2.0)
-    aws-partitions (1.609.0)
+    aws-partitions (1.610.0)
     aws-sdk-core (3.131.3)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)
@@ -147,7 +147,7 @@ GEM
     faraday_middleware (1.2.0)
       faraday (~> 1.0)
     fastimage (2.2.6)
-    fastlane (2.208.0)
+    fastlane (2.206.0)
       CFPropertyList (>= 2.3, < 4.0.0)
       addressable (>= 2.8, < 3.0.0)
       artifactory (~> 3.0)
@@ -344,8 +344,7 @@ GEM
       CFPropertyList
       naturally
     terminal-notifier (2.0.0)
-    terminal-table (1.8.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
+    terminal-table (1.6.0)
     thread_safe (0.3.6)
     trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
@@ -360,7 +359,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unicode-display_width (1.8.0)
+    unicode-display_width (2.2.0)
     webrick (1.7.0)
     word_wrap (1.0.0)
     xcodeproj (1.22.0)


### PR DESCRIPTION
This is an attempt to fix build errors in https://github.com/wordpress-mobile/WordPress-iOS/pull/19110

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
