### PR TITLE
[Jetpack] Remove duplicate Jetpack badges in Reader detail view

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -18,6 +18,7 @@ class BorderedButtonTableViewCell: UITableViewCell {
 
     weak var delegate: BorderedButtonTableViewCellDelegate?
 
+    private var button = UIButton()
     private var buttonTitle = String()
     private var buttonInsets = Defaults.buttonInsets
     private var titleFont = Defaults.titleFont
@@ -63,41 +64,6 @@ class BorderedButtonTableViewCell: UITableViewCell {
         return view
     }()
 
-    private lazy var button: UIButton = {
-        let button = UIButton()
-
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(buttonTitle, for: .normal)
-
-        button.setTitleColor(normalColor, for: .normal)
-        button.setTitleColor(highlightedColor, for: .highlighted)
-
-        button.titleLabel?.font = titleFont
-        button.titleLabel?.textAlignment = .center
-        button.titleLabel?.numberOfLines = 0
-        return button
-    }()
-
-    private lazy var jetpackBadge: JetpackButton = {
-        let button = JetpackButton(style: .badge)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-
-    private lazy var jetpackBadgeView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(jetpackBadge)
-        return view
-    }()
-
-    private lazy var mainStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [button, jetpackBadgeView])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.axis = .vertical
-        return stackView
-    }()
-
     // MARK: - Configure
 
     func configure(buttonTitle: String,
@@ -133,12 +99,23 @@ private extension BorderedButtonTableViewCell {
         accessibilityTraits = .button
 
         configureButton()
-        configureJetpackBadge()
-        contentView.addSubview(mainStackView)
-        contentView.pinSubviewToAllEdges(mainStackView, insets: buttonInsets)
+        contentView.addSubview(button)
+        contentView.pinSubviewToAllEdges(button, insets: buttonInsets)
     }
 
     func configureButton() {
+        let button = UIButton()
+
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(buttonTitle, for: .normal)
+
+        button.setTitleColor(normalColor, for: .normal)
+        button.setTitleColor(highlightedColor, for: .highlighted)
+
+        button.titleLabel?.font = titleFont
+        button.titleLabel?.textAlignment = .center
+        button.titleLabel?.numberOfLines = 0
+
         // Add constraints to the title label, so the button can contain it properly in multi-line cases.
         if let label = button.titleLabel {
             button.pinSubviewToAllEdgeMargins(label)
@@ -147,19 +124,9 @@ private extension BorderedButtonTableViewCell {
         button.on(.touchUpInside) { [weak self] _ in
             self?.delegate?.buttonTapped()
         }
-        updateButtonBorderColors()
-    }
 
-    func configureJetpackBadge() {
-        guard JetpackBrandingVisibility.all.enabled else {
-            jetpackBadgeView.isHidden = true
-            return
-        }
-        NSLayoutConstraint.activate([
-            jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Defaults.jetpackBadgeTopInset),
-            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: -Defaults.jetpackBadgeBottomInset),
-            jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
-        ])
+        self.button = button
+        updateButtonBorderColors()
     }
 
     func updateButtonBorderColors() {
@@ -172,8 +139,6 @@ private extension BorderedButtonTableViewCell {
         static let titleFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         static let normalColor: UIColor = .text
         static let highlightedColor: UIColor = .textInverted
-        static let jetpackBadgeTopInset: CGFloat = 30
-        static let jetpackBadgeBottomInset: CGFloat = 6
     }
 
     func toggleLoading(_ loading: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -119,7 +119,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         guard section == 0, JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView(bottomPadding: 10)
+        return JetpackButton.makeBadgeView(bottomPadding: Constants.jetpackBadgeBottomPadding)
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
@@ -158,5 +158,6 @@ private extension ReaderDetailCommentsTableViewDelegate {
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
         static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
+        static let jetpackBadgeBottomPadding: CGFloat = 10
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -114,11 +114,29 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         return header
     }
 
+    func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard section == 0, JetpackBrandingVisibility.all.enabled else {
+            return nil
+        }
+        return JetpackButton.makeBadgeView(bottomPadding: 10)
+    }
+
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         return ReaderDetailCommentsHeader.estimatedHeight
     }
 
+    func tableView(_ tableView: UITableView, estimatedHeightForFooterInSection section: Int) -> CGFloat {
+        return ReaderDetailCommentsHeader.estimatedHeight
+    }
+
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return UITableView.automaticDimension
+    }
+
+    func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        guard section == 0, JetpackBrandingVisibility.all.enabled else {
+            return 0
+        }
         return UITableView.automaticDimension
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -115,6 +115,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     }
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        /// We used this method to show the Jetpack badge rather than setting `tableFooterView` because it scaled better with Dynamic type.
         guard section == 0, JetpackBrandingVisibility.all.enabled else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.swift
@@ -3,37 +3,11 @@ import UIKit
 class ReaderDetailNoCommentCell: UITableViewCell, NibReusable {
 
     @IBOutlet weak var titleLabel: UILabel!
-    @IBOutlet weak var stackView: UIStackView!
-
-    private lazy var jetpackBadge: JetpackButton = {
-        let button = JetpackButton(style: .badge)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        return button
-    }()
-
-    private lazy var jetpackBadgeView: UIView = {
-        let view = UIView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(jetpackBadge)
-        return view
-    }()
 
     override func awakeFromNib() {
         super.awakeFromNib()
         contentView.backgroundColor = .basicBackground
         titleLabel.textColor = .textSubtle
-
-        guard JetpackBrandingVisibility.all.enabled else {
-            return
-        }
-
-        stackView.addArrangedSubview(jetpackBadgeView)
-        NSLayoutConstraint.activate([
-            jetpackBadge.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Self.jetpackBadgeTopInset),
-            jetpackBadge.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor, constant: -Self.jetpackBadgeBottomInset),
-            jetpackBadge.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor)
-        ])
     }
-    static let jetpackBadgeTopInset: CGFloat = 30
-    static let jetpackBadgeBottomInset: CGFloat = 6
+
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailNoCommentCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -14,28 +14,22 @@
             <rect key="frame" x="0.0" y="0.0" width="394" height="69"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="2QT-rx-5QY">
+                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
                     <rect key="frame" x="0.0" y="20" width="394" height="49"/>
-                    <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No comments yet" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QfN-CJ-PfS">
-                            <rect key="frame" x="0.0" y="0.0" width="394" height="49"/>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                            <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                            <nil key="highlightedColor"/>
-                        </label>
-                    </subviews>
-                </stackView>
+                    <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <viewLayoutGuide key="safeArea" id="epR-21-48u"/>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="2QT-rx-5QY" secondAttribute="bottom" id="J3a-ZZ-uTs"/>
-                <constraint firstItem="2QT-rx-5QY" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="SL3-dA-OT9"/>
-                <constraint firstAttribute="trailing" secondItem="2QT-rx-5QY" secondAttribute="trailing" id="Xdc-CV-v1t"/>
-                <constraint firstItem="2QT-rx-5QY" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="b6k-Ll-Rge"/>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="top" secondItem="kPA-oR-TOp" secondAttribute="top" constant="20" id="6FS-1m-LFu"/>
+                <constraint firstAttribute="bottom" secondItem="QfN-CJ-PfS" secondAttribute="bottom" id="RVn-Cf-JSe"/>
+                <constraint firstItem="QfN-CJ-PfS" firstAttribute="leading" secondItem="kPA-oR-TOp" secondAttribute="leading" id="VQC-4P-3s7"/>
+                <constraint firstAttribute="trailing" secondItem="QfN-CJ-PfS" secondAttribute="trailing" id="zK3-Y8-YOU"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="stackView" destination="2QT-rx-5QY" id="vok-VW-wI4"/>
                 <outlet property="titleLabel" destination="QfN-CJ-PfS" id="GBW-w4-V0a"/>
             </connections>
             <point key="canvasLocation" x="36.231884057971016" y="81.361607142857139"/>


### PR DESCRIPTION
Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19108

## Description

This PR fixes an issue where duplicate badges would be shown when there were no comments for a site that had comments enabled.

### Technical notes
- The first two commits of this PR roll back the changes to `BorderedButtonTableViewCell.swift`, `ReaderDetailNoCommentCell.swift`, and `ReaderDetailNoCommentCell.xib` to their state before https://github.com/wordpress-mobile/WordPress-iOS/pull/19108
- `func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView?` was used over [`tableFooterView`](https://developer.apple.com/documentation/uikit/uitableview/1614976-tablefooterview) because it seemed to support Dynamic Type resizing better

## Testing

**Note:** For these test cases, follow twstokes.wordpress.com in Reader

### Test Post 1

| Comments enabled | Has comments |
| - | - |
| False | False |

1. In the WordPress app signed into a WordPress.com account, open Reader
2. Tap a post that has comments disabled and no comments
3. Expect a single badge to be shown under the "Comments are closed" label

| Before | After |
| - | - |
| ![Before - Test Post 1](https://user-images.githubusercontent.com/2092798/181142406-46614cdb-4c40-4d1d-a2f3-05d370f5c501.png) | ![After - Test Post 1](https://user-images.githubusercontent.com/2092798/181142446-2b996cb8-3f3e-48e1-8471-7eebcb1d5601.png) |

### Test Post 2

| Comments enabled | Has comments |
| - | - |
| True | False |

1. In the WordPress app signed into a WordPress.com account, open Reader
2. Tap a post that has comments enabled but no comments
3. Expect a single badge to be shown under the "Be the first to comment" button

| Before | After |
| - | - |
| ![Before - Test Post 2](https://user-images.githubusercontent.com/2092798/181142742-7f910276-2b9b-47c9-99bd-8840b9c5fa90.png) | ![After - Test Post 2](https://user-images.githubusercontent.com/2092798/181142791-9e436c3d-21ae-4696-853d-0841cef83047.png) |

### Test Post 3

| Comments enabled | Has comments |
| - | - |
| True | True |

1. In the WordPress app signed into a WordPress.com account, open Reader
2. Tap a post with comments enabled and at least one comment
3. Expect a single badge to be shown under the "View all comments" button

| Before | After |
| - | - |
| ![Before - Test Post 3](https://user-images.githubusercontent.com/2092798/181143127-161cefd1-36ec-46ef-8a51-e687a067b494.png) | ![After - Test Post 3](https://user-images.githubusercontent.com/2092798/181143178-bcf2bbbf-bf02-4e56-b322-3311e086ff6a.png) |

### Test Post 4

| Comments enabled | Has comments |
| - | - |
| False | True |

1. In the WordPress app signed into a WordPress.com account, open Reader
2. Tap a post with comments disabled and at least one comment
3. Expect a single badge to be shown under the "View all comments" button

| Before | After |
| - | - |
| ![Before - Test Post 4](https://user-images.githubusercontent.com/2092798/181143296-50fefed0-1a5b-4135-b079-e21772ee5f51.png) | ![After - Test Post 4](https://user-images.githubusercontent.com/2092798/181143354-8f0c336d-747a-4103-b510-ff3da7ac9d8f.png) |

## Regression Notes
1. Potential unintended areas of impact
    - Rendering of badge on Reader detail view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above in WordPress and Jetpack apps

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.