### PR TITLE
[Jetpack] Add Jetpack powered bottom sheet feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -32,6 +32,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case betaSiteDesigns
     case featureHighlightTooltip
     case jetpackPowered
+    case jetpackPoweredBottomSheet
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -104,6 +105,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .jetpackPowered:
             return true
+        case .jetpackPoweredBottomSheet:
+            return false
         }
     }
 
@@ -194,6 +197,8 @@ extension FeatureFlag {
             return "Feature Highlight Tooltip"
         case .jetpackPowered:
             return "Jetpack powered banners and badges"
+        case .jetpackPoweredBottomSheet:
+            return "Jetpack powered bottom sheet"
         }
     }
 


### PR DESCRIPTION
## Description

This PR adds a feature flag for the "Jetpack powered" bottom sheet.

## Testing

Test with both the WordPress and Jetpack app.

1. Using a debug build, open the app
2. Tap the user icon at the top right to present the "Me" view
3. Tap App Settings
4. Tap Debug
5. Expect to see "Jetpack powered bottom sheet" in the feature flag list defaulted to off

<img src="https://user-images.githubusercontent.com/2092798/181363150-89bc25eb-61b8-42f2-9cb5-e680b80c55b2.png" width="350px" />

## Regression Notes
1. Potential unintended areas of impact
    - None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested steps above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
