### PR TITLE
Add notify slack attribute to Unit and UI tests steps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 11' 15.0
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 11' 15.0
+        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,6 +65,10 @@ steps:
     notify:
       - github_commit_status:
           context: "Unit Tests"
+      - slack:
+          channels:
+            - "#mobile-apps-tests-notif"
+        if: build.state == "failed"
 
   #################
   # UI Tests
@@ -81,6 +85,10 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
+          - slack:
+              channels:
+                - "#mobile-apps-tests-notif"
+            if: build.state == "failed"
 
       - label: "🔬 UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
@@ -92,6 +100,10 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"
+          - slack:
+              channels:
+                - "#mobile-apps-tests-notif"
+            if: build.state == "failed"
 
   #################
   # Linters

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -54,7 +54,7 @@ class LoginTests: XCTestCase {
             .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .removeSelfHostedSite()
 
-        XCTAssert(prologueScreen.isLoaded)
+        XCTAssert(prologueScreen.isLoaded == false)
     }
 
     // Unified WordPress.com email login failure due to incorrect password

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -54,7 +54,7 @@ class LoginTests: XCTestCase {
             .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
             .removeSelfHostedSite()
 
-        XCTAssert(prologueScreen.isLoaded == false)
+        XCTAssert(prologueScreen.isLoaded)
     }
 
     // Unified WordPress.com email login failure due to incorrect password


### PR DESCRIPTION
To test:
We're experimenting with slack messaging to see if sending a message for the Unit/UI tests step every time a build fails will be helpful to QEs or not. This is the first iteration where it's only notifying which step failed. The message will be sent to a dedicated channel (`#mobile-apps-tests-notif`), for now, to reduce the noise in the main channel.

## Regression Notes
1. Potential unintended areas of impact
- No areas should be impacted. 

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested that the slack messages are sent when the build failed.

3. What automated tests I added (or what prevented me from doing so)
- No tests were added as no functional changes were made

