### PR TITLE
[Jetpack] Add bottom sheet to jetpack powered button on My Site

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -321,3 +321,16 @@ extension BlogDashboardViewController: UIPopoverPresentationControllerDelegate {
         return .none
     }
 }
+
+extension BlogDashboardViewController: DashboardBadgeCellDelegate {
+    func didTapJetpackButton() {
+        let jetpackPoweredViewController = JetpackPoweredViewController()
+        let bottomSheet = BottomSheetViewController(childViewController: jetpackPoweredViewController)
+        let maxWidth = view.bounds.size.width
+        jetpackPoweredViewController.preferredContentSize = CGSize(
+            width: maxWidth,
+            height: JetpackPoweredViewController.height(maxContentWidth: maxWidth)
+        )
+        bottomSheet.show(from: self)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/Tooltip.swift
@@ -397,8 +397,8 @@ final class Tooltip: UIView {
     }
 }
 
-private extension String {
-    private func size(withMaxWidth maxWidth: CGFloat, font: UIFont) -> CGRect {
+extension String {
+    func size(withMaxWidth maxWidth: CGFloat, font: UIFont) -> CGRect {
         let constraintRect = CGSize(width: maxWidth, height: .greatestFiniteMagnitude)
         let boundingBox = self.boundingRect(
             with: constraintRect,

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
@@ -1,11 +1,21 @@
 import UIKit
 
+protocol DashboardBadgeCellDelegate {
+    func didTapJetpackButton()
+}
+
 /// A collection view cell with a "Jetpack powered" badge
 class DashboardBadgeCell: UICollectionViewCell, Reusable {
+    // takes into account the collection view cell spacing, which is 20
+    // to obtain an overall distance of 30.
+    private static let badgeTopInset: CGFloat = 10
+
+    var delegate: DashboardBadgeCellDelegate?
 
     private lazy var jetpackButton: JetpackButton = {
         let button = JetpackButton(style: .badge)
         button.translatesAutoresizingMaskIntoConstraints = false
+        button.addTarget(self, action: #selector(didTapJetpackButton), for: .touchUpInside)
         return button
     }()
 
@@ -28,11 +38,13 @@ class DashboardBadgeCell: UICollectionViewCell, Reusable {
         ])
     }
 
-    // takes into account the collection view cell spacing, which is 20
-    // to obtain an overall distance of 30.
-    private static let badgeTopInset: CGFloat = 10
+    @objc private func didTapJetpackButton() {
+        delegate?.didTapJetpackButton()
+    }
 }
 
 extension DashboardBadgeCell: BlogDashboardCardConfigurable {
-    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {}
+    func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
+        delegate = viewController
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -68,8 +68,6 @@ class JetpackButton: UIButton {
     }
 
     private func configureButton() {
-        // TODO: Remove this when the modal presentation is added
-        isUserInteractionEnabled = false
         setTitle(Appearance.title, for: .normal)
         tintColor = buttonTintColor
         backgroundColor = buttonBackgroundColor

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
@@ -126,7 +126,11 @@ final class JetpackPoweredViewController: UIViewController {
 }
 
 extension JetpackPoweredViewController: DrawerPresentable {
+    var allowsUserTransition: Bool {
+        false
+    }
+
     var collapsedHeight: DrawerHeight {
-        return .intrinsicHeight
+        .intrinsicHeight
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
@@ -5,23 +5,55 @@ final class JetpackPoweredViewController: UIViewController {
     private enum Constants {
         enum Constraints {
             static let animationViewTop: CGFloat = 70
+            static let animationViewHeight: CGFloat = 80
+            static let animationViewWidth: CGFloat = 147
             static let titleLabelTop: CGFloat = 45
             static let titleLabelHorizontal: CGFloat = 30
             static let descriptionLabelTop: CGFloat = 10
             static let redirectButtonTop: CGFloat = 50
+            static let redirectButtonHeight: CGFloat = 50
+            static let redirectButtonBottom: CGFloat = 60
+        }
+
+        enum Strings {
+            static let title = NSLocalizedString(
+                "jetpack.powered.title",
+                value: "Jetpack powered",
+                comment: "Title for Jetpack Powered bottom sheet."
+            )
+
+            static let description = NSLocalizedString(
+                "jetpack.powered.description",
+                value: "Stats, Reader, Notifications, and other features are provided by Jetpack.",
+                comment: "Description for Jetpack Powered bottom sheet."
+            )
+
+            static let buttonTitle = NSLocalizedString(
+                "jetpack.powered.button.title",
+                value: "Get the new Jetpack app",
+                comment: "Button title for Jetpack Powered bottom sheet."
+            )
         }
     }
 
-    // Temporary
+    // Placeholder. Replace with Lottie View for animation.
     private let animationView = UIView()
 
     private let titleLabel: UILabel = {
-        $0.font = WPStyleGuide.fontForTextStyle(.title1)
+        $0.font = WPStyleGuide.fontForTextStyle(.title1, fontWeight: .bold)
+        $0.textAlignment = .center
+        $0.numberOfLines = 2
+        $0.setContentHuggingPriority(.required, for: .vertical)
+        $0.text = Constants.Strings.title
         return $0
     }(UILabel())
 
     private let descriptionLabel: UILabel = {
-        $0.font = WPStyleGuide.fontForTextStyle(.title3)
+        $0.font = WPStyleGuide.fontForTextStyle(.subheadline)
+        $0.textAlignment = .center
+        $0.numberOfLines = 0
+        $0.setContentHuggingPriority(.required, for: .vertical)
+        $0.text = Constants.Strings.description
         return $0
     }(UILabel())
 
@@ -30,13 +62,27 @@ final class JetpackPoweredViewController: UIViewController {
             light: .muriel(color: .jetpackGreen, .shade40),
             dark: .muriel(color: .jetpackGreen, .shade40)
         )
+        $0.layer.cornerRadius = 6
+        $0.setTitle(Constants.Strings.buttonTitle, for: .normal)
         return $0
     }(UIButton())
+
+    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         view.addSubviews([animationView, titleLabel, descriptionLabel, redirectButton])
+        configureUI()
         setUpConstraints()
+    }
+
+    private func configureUI() {
+        view.backgroundColor = UIColor(
+            light: .muriel(color: .jetpackGreen, .shade0),
+            dark: .muriel(color: .jetpackGreen, .shade100)
+        )
     }
 
     private func setUpConstraints() {
@@ -44,11 +90,14 @@ final class JetpackPoweredViewController: UIViewController {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         redirectButton.translatesAutoresizingMaskIntoConstraints = false
+        view.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
             animationView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.Constraints.animationViewTop),
             animationView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            titleLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: Constants.Constraints.titleLabelTop),
+            animationView.heightAnchor.constraint(equalToConstant: Constants.Constraints.animationViewHeight),
+            animationView.widthAnchor.constraint(equalToConstant: Constants.Constraints.animationViewWidth),
+            titleLabel.topAnchor.constraint(equalTo: animationView.bottomAnchor, constant: Constants.Constraints.titleLabelTop),
             titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.Constraints.titleLabelHorizontal),
             view.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: Constants.Constraints.titleLabelHorizontal),
             descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constants.Constraints.descriptionLabelTop),
@@ -56,7 +105,28 @@ final class JetpackPoweredViewController: UIViewController {
             descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
             redirectButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: Constants.Constraints.redirectButtonTop),
             redirectButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            redirectButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor)
+            redirectButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            redirectButton.heightAnchor.constraint(equalToConstant: Constants.Constraints.redirectButtonHeight)
         ])
+    }
+
+    static func height(maxContentWidth: CGFloat) -> CGFloat {
+        var totalHeight: CGFloat = 0
+        totalHeight += Constants.Constraints.animationViewTop
+        totalHeight += Constants.Constraints.animationViewHeight
+        totalHeight += Constants.Constraints.titleLabelTop
+        totalHeight += Constants.Strings.title.height(withMaxWidth: maxContentWidth, font: WPStyleGuide.fontForTextStyle(.title1))
+        totalHeight += Constants.Constraints.descriptionLabelTop
+        totalHeight += Constants.Strings.description.height(withMaxWidth: maxContentWidth, font: WPStyleGuide.fontForTextStyle(.subheadline))
+        totalHeight += Constants.Constraints.redirectButtonTop
+        totalHeight += Constants.Constraints.redirectButtonHeight
+        totalHeight += Constants.Constraints.redirectButtonBottom
+        return totalHeight
+    }
+}
+
+extension JetpackPoweredViewController: DrawerPresentable {
+    var collapsedHeight: DrawerHeight {
+        return .intrinsicHeight
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackPoweredViewController.swift
@@ -1,0 +1,62 @@
+import Foundation
+import UIKit
+
+final class JetpackPoweredViewController: UIViewController {
+    private enum Constants {
+        enum Constraints {
+            static let animationViewTop: CGFloat = 70
+            static let titleLabelTop: CGFloat = 45
+            static let titleLabelHorizontal: CGFloat = 30
+            static let descriptionLabelTop: CGFloat = 10
+            static let redirectButtonTop: CGFloat = 50
+        }
+    }
+
+    // Temporary
+    private let animationView = UIView()
+
+    private let titleLabel: UILabel = {
+        $0.font = WPStyleGuide.fontForTextStyle(.title1)
+        return $0
+    }(UILabel())
+
+    private let descriptionLabel: UILabel = {
+        $0.font = WPStyleGuide.fontForTextStyle(.title3)
+        return $0
+    }(UILabel())
+
+    private let redirectButton: UIButton = {
+        $0.backgroundColor = UIColor(
+            light: .muriel(color: .jetpackGreen, .shade40),
+            dark: .muriel(color: .jetpackGreen, .shade40)
+        )
+        return $0
+    }(UIButton())
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubviews([animationView, titleLabel, descriptionLabel, redirectButton])
+        setUpConstraints()
+    }
+
+    private func setUpConstraints() {
+        animationView.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        redirectButton.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            animationView.topAnchor.constraint(equalTo: view.topAnchor, constant: Constants.Constraints.animationViewTop),
+            animationView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            titleLabel.topAnchor.constraint(equalTo: animationView.topAnchor, constant: Constants.Constraints.titleLabelTop),
+            titleLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Constants.Constraints.titleLabelHorizontal),
+            view.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor, constant: Constants.Constraints.titleLabelHorizontal),
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: Constants.Constraints.descriptionLabelTop),
+            descriptionLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            redirectButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor, constant: Constants.Constraints.redirectButtonTop),
+            redirectButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            redirectButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor)
+        ])
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -63,6 +63,8 @@
 		0807CB721CE670A800CDBDAC /* WPContentSearchHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0807CB711CE670A800CDBDAC /* WPContentSearchHelper.swift */; };
 		080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */; };
 		0815CF461E96F22600069916 /* MediaImportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0815CF451E96F22600069916 /* MediaImportService.swift */; };
+		0817A917288EC7AA0019A7F4 /* JetpackPoweredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0817A916288EC7AA0019A7F4 /* JetpackPoweredViewController.swift */; };
+		0817A918288EC7AA0019A7F4 /* JetpackPoweredViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0817A916288EC7AA0019A7F4 /* JetpackPoweredViewController.swift */; };
 		081E4B4C281C019A0085E89C /* TooltipAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081E4B4B281C019A0085E89C /* TooltipAnchor.swift */; };
 		08216FAA1CDBF95100304BA7 /* MenuItemEditing.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 08216FA71CDBF95100304BA7 /* MenuItemEditing.storyboard */; };
 		08216FAB1CDBF95100304BA7 /* MenuItemEditingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 08216FA91CDBF95100304BA7 /* MenuItemEditingViewController.m */; };
@@ -4996,6 +4998,7 @@
 		080C449D1CE14A9F00B3A02F /* MenuDetailsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuDetailsViewController.h; sourceTree = "<group>"; };
 		080C449E1CE14A9F00B3A02F /* MenuDetailsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuDetailsViewController.m; sourceTree = "<group>"; };
 		0815CF451E96F22600069916 /* MediaImportService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaImportService.swift; sourceTree = "<group>"; };
+		0817A916288EC7AA0019A7F4 /* JetpackPoweredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackPoweredViewController.swift; sourceTree = "<group>"; };
 		081E4B4B281C019A0085E89C /* TooltipAnchor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipAnchor.swift; sourceTree = "<group>"; };
 		08216FA71CDBF95100304BA7 /* MenuItemEditing.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MenuItemEditing.storyboard; sourceTree = "<group>"; };
 		08216FA81CDBF95100304BA7 /* MenuItemEditingViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemEditingViewController.h; sourceTree = "<group>"; };
@@ -10109,6 +10112,7 @@
 				3FFA5ED0287612AD00830E28 /* Banner */,
 				3F5B9B44288B0521001D17E9 /* Badge */,
 				3FFA5ED32876216700830E28 /* Button */,
+				0817A916288EC7AA0019A7F4 /* JetpackPoweredViewController.swift */,
 			);
 			path = Branding;
 			sourceTree = "<group>";
@@ -18330,6 +18334,7 @@
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,
 				9856A39D261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				08B6E51A1F036CAD00268F57 /* MediaFileManager.swift in Sources */,
+				0817A917288EC7AA0019A7F4 /* JetpackPoweredViewController.swift in Sources */,
 				594DB2951AB891A200E2E456 /* WPUserAgent.m in Sources */,
 				4093FE40218C384200B1D224 /* AztecVerificationPromptHelper.swift in Sources */,
 				8BC6020923900D8400EFE3D0 /* NullBlogPropertySanitizer.swift in Sources */,
@@ -22138,6 +22143,7 @@
 				FABB25C62602FC2C00C8785C /* TenorReponseParser.swift in Sources */,
 				FABB25C72602FC2C00C8785C /* WPStyleGuide+Gridicon.swift in Sources */,
 				FABB25C82602FC2C00C8785C /* RelatedPostsSettingsViewController.m in Sources */,
+				0817A918288EC7AA0019A7F4 /* JetpackPoweredViewController.swift in Sources */,
 				FABB25C92602FC2C00C8785C /* CreateButtonCoordinator.swift in Sources */,
 				3FBF21B8267AA17A0098335F /* BloggingRemindersAnimator.swift in Sources */,
 				FABB25CA2602FC2C00C8785C /* SearchManager.swift in Sources */,


### PR DESCRIPTION
This PR adds `JetpackPoweredViewController` to be displayed when the user taps on the JP button. It uses the existing bottom sheet functionality. 2 PR's should follow: Adding animation after Lottie is integrated and connecting the button in the sheet.

I did not add additional flags to this as the entry point is behind a flag itself. Let me know if we should still add another flag for it.

To test:
1. Log in to Wordpress.
2. Enable `Jetpack powered banners and badges` if it isn't already enabled.
3. My Site -> Scroll below until Jetpack powered button is visible.
4. Tap on the button. Verify it opens the bottom sheet.
5. It should not rotate on landscape mode when the sheet is open (I follow the same logic with Blogging Prompts here).

There will be a big gap on top for the animation. Lottie integration will follow with a later PR.


## Regression Notes
1. Potential unintended areas of impact
N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

7. What automated tests I added (or what prevented me from doing so)
Right now it is purely UI. Once we connect the button to deeplink in the bottom sheet, we can add a small VM for that interaction and unit test that.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

