### PR TITLE
[Jetpack] Update Jetpack banner visibility algorithm

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -3,7 +3,7 @@ import Combine
 
 class JetpackActivityLogViewController: BaseActivityListViewController {
     private let jetpackBannerView = JetpackBannerView()
-    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    let scrollViewPublisher = PassthroughSubject<JPScrollViewDataDelegate, Never>()
 
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         let activityListConfiguration = ActivityListConfiguration(
@@ -54,6 +54,6 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
 extension JetpackActivityLogViewController: JPScrollViewDelegate {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        scrollViewPublisher.send(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDataDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDataDelegate.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+protocol JPScrollViewDataDelegate {
+
+    var translationY: CGFloat { get }
+    var scrollViewFrameHeight: CGFloat { get }
+    var scrollViewContentHeight: CGFloat { get }
+    var scrollViewContentOffsetY: CGFloat { get }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
@@ -4,13 +4,13 @@ import CoreGraphics
 /// Conform to this protocol to send scrollview translations to a `JetpackBannerView` instance
 protocol JPScrollViewDelegate: UIScrollViewDelegate {
 
-    var scrollViewTranslationPublisher: PassthroughSubject<CGFloat, Never> { get }
+    var scrollViewPublisher: PassthroughSubject<JPScrollViewDataDelegate, Never> { get }
     func addTranslationObserver(_ receiver: JetpackBannerView)
 }
 
 extension JPScrollViewDelegate {
 
     func addTranslationObserver(_ receiver: JetpackBannerView) {
-        scrollViewTranslationPublisher.subscribe(receiver)
+        scrollViewPublisher.subscribe(receiver)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -32,16 +32,26 @@ class JetpackBannerView: UIView {
 // MARK: Responding to scroll events
 extension JetpackBannerView: Subscriber {
 
-    typealias Input = CGFloat
+    typealias Input = JPScrollViewDataDelegate
     typealias Failure = Never
 
     func receive(subscription: Subscription) {
         subscription.request(.unlimited)
     }
 
-    func receive(_ input: CGFloat) -> Subscribers.Demand {
+    func receive(_ input: JPScrollViewDataDelegate) -> Subscribers.Demand {
+        let isHidden: Bool
 
-        let isHidden: Bool = input < 0
+        /// The scrollable content isn't any larger than its frame, so don't hide the banner if the view is bounced.
+        if input.scrollViewContentHeight <= input.scrollViewFrameHeight {
+            isHidden = false
+        /// Don't hide the banner until the view has scrolled down some. Currently the height of the banner itself.
+        } else if input.scrollViewContentOffsetY <= frame.height {
+            isHidden = false
+        /// The banner hides on scrolling down, shows on scrolling up.
+        } else {
+            isHidden = input.translationY < 0
+        }
 
         guard self.isHidden != isHidden else {
             return .unlimited

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/UIScrollView+JPScrollViewDataDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/UIScrollView+JPScrollViewDataDelegate.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+extension UIScrollView: JPScrollViewDataDelegate {
+
+    var translationY: CGFloat {
+        return panGestureRecognizer.translation(in: superview).y
+    }
+
+    var scrollViewFrameHeight: CGFloat {
+        frame.height
+    }
+
+    var scrollViewContentHeight: CGFloat {
+        contentSize.height
+    }
+
+    var scrollViewContentOffsetY: CGFloat {
+        contentOffset.y + adjustedContentInset.top
+    }
+}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -135,7 +135,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
     }()
 
     /// Used by JPScrollViewDelegate to send scroll position
-    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    internal let scrollViewPublisher = PassthroughSubject<JPScrollViewDataDelegate, Never>()
 
     // MARK: - View Lifecycle
 
@@ -2074,6 +2074,6 @@ extension NotificationsViewController: WPScrollableViewController {
 //
 extension NotificationsViewController: JPScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        scrollViewPublisher.send(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -47,13 +47,6 @@ import Gridicons
     fileprivate var restoredSearchTopic: ReaderSearchTopic?
     fileprivate var didBumpStats = false
 
-    private lazy var bannerView: JetpackBannerView = {
-        let bannerView = JetpackBannerView()
-        bannerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: JetpackBannerView.minimumHeight)
-        return bannerView
-    }()
-
-
     fileprivate let sections: [Section] = [ .posts, .sites ]
 
     /// A convenience method for instantiating the controller from the storyboard.
@@ -124,9 +117,6 @@ import Gridicons
         configureBackgroundTapRecognizer()
         configureForRestoredTopic()
         configureSiteSearchViewController()
-        // hide the parent viewController's banner, if it exists
-        // because this viewController has its own.
-        streamController?.jetpackBannerView?.isHidden = true
     }
 
 
@@ -186,17 +176,13 @@ import Gridicons
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }
-        searchBar.inputAccessoryView = bannerView
         hideBannerViewIfNeeded()
     }
 
     /// hides the Jetpack powered banner on iPhone landscape
     private func hideBannerViewIfNeeded() {
-        guard JetpackBrandingVisibility.all.enabled else {
-            return
-        }
         // hide the banner on iPhone landscape
-        bannerView.isHidden = traitCollection.verticalSizeClass == .compact
+        streamController?.jetpackBannerView?.isHidden = traitCollection.verticalSizeClass == .compact
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -173,21 +173,6 @@ import Gridicons
 
         searchBar.becomeFirstResponder()
         WPStyleGuide.configureSearchBar(searchBar)
-        guard JetpackBrandingVisibility.all.enabled else {
-            return
-        }
-        hideBannerViewIfNeeded()
-    }
-
-    /// hides the Jetpack powered banner on iPhone landscape
-    private func hideBannerViewIfNeeded() {
-        // hide the banner on iPhone landscape
-        streamController?.jetpackBannerView?.isHidden = traitCollection.verticalSizeClass == .compact
-    }
-
-    open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        hideBannerViewIfNeeded()
     }
 
     func configureFilterBar() {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -505,6 +505,7 @@ import Combine
             return
         }
         let bannerView = JetpackBannerView()
+        hideBannerViewIfNeeded()
         jetpackBannerView = bannerView
         addTranslationObserver(bannerView)
         stackView.addArrangedSubview(bannerView)
@@ -2001,11 +2002,32 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
     }
 }
 
+// MARK: - Jetpack banner visibility
+
+extension ReaderStreamViewController {
+
+    private func shouldHideBannerView() -> Bool {
+        /// Hide the banner on iPhone landscape
+        return traitCollection.verticalSizeClass == .compact
+    }
+
+    /// hides the Jetpack powered banner on iPhone landscape
+    private func hideBannerViewIfNeeded() {
+        jetpackBannerView?.isHidden = shouldHideBannerView()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        hideBannerViewIfNeeded()
+    }
+}
+
 // MARK: - Jetpack banner delegate
 
 extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate {
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard !shouldHideBannerView() else { return }
         scrollViewPublisher.send(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -101,7 +101,7 @@ import Combine
     private var didSetupView = false
     private var listentingForBlockedSiteNotification = false
     private var didBumpStats = false
-    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    internal let scrollViewPublisher = PassthroughSubject<JPScrollViewDataDelegate, Never>()
 
     /// Content management
     let content = ReaderTableContent()
@@ -2004,7 +2004,8 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
 // MARK: - Jetpack banner delegate
 
 extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate {
+
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        scrollViewPublisher.send(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
@@ -5,7 +5,7 @@ import Foundation
 
 final class BottomScrollAnalyticsTracker: NSObject {
 
-    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    let scrollViewPublisher = PassthroughSubject<JPScrollViewDataDelegate, Never>()
 
     private func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
         if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
@@ -39,6 +39,6 @@ extension BottomScrollAnalyticsTracker: JPScrollViewDelegate {
         }
     }
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        scrollViewPublisher.send(scrollView)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2255,6 +2255,10 @@
 		C352870627FDD35C004E2E51 /* SiteNameStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352870427FDD35C004E2E51 /* SiteNameStep.swift */; };
 		C35D4FF1280077F100DB90B5 /* SiteCreationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */; };
 		C35D4FF2280077F100DB90B5 /* SiteCreationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */; };
+		C370F9FE2895920F004A8593 /* JPScrollViewDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C370F9FD2895920F004A8593 /* JPScrollViewDataDelegate.swift */; };
+		C370F9FF2895920F004A8593 /* JPScrollViewDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C370F9FD2895920F004A8593 /* JPScrollViewDataDelegate.swift */; };
+		C370FA01289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C370FA00289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift */; };
+		C370FA02289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C370FA00289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift */; };
 		C373D6E728045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6E828045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */; };
@@ -7153,6 +7157,8 @@
 		C3439B5E27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationWizardLauncherTests.swift; sourceTree = "<group>"; };
 		C352870427FDD35C004E2E51 /* SiteNameStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteNameStep.swift; sourceTree = "<group>"; };
 		C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationStep.swift; sourceTree = "<group>"; };
+		C370F9FD2895920F004A8593 /* JPScrollViewDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JPScrollViewDataDelegate.swift; sourceTree = "<group>"; };
+		C370FA00289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIScrollView+JPScrollViewDataDelegate.swift"; sourceTree = "<group>"; };
 		C373D6E628045281008F8C26 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
 		C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentDataTests.swift; sourceTree = "<group>"; };
 		C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerWrapperViewController.swift; sourceTree = "<group>"; };
@@ -10119,6 +10125,8 @@
 				B0CD27CE286F8858009500BF /* JetpackBannerView.swift */,
 				C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */,
 				3FAE0651287C8FC500F46508 /* JPScrollViewDelegate.swift */,
+				C370F9FD2895920F004A8593 /* JPScrollViewDataDelegate.swift */,
+				C370FA00289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift */,
 			);
 			path = Banner;
 			sourceTree = "<group>";
@@ -19064,6 +19072,7 @@
 				D8212CB520AA68D5008E8AE8 /* ReaderSubscribingNotificationAction.swift in Sources */,
 				FF8C54AD21F677260003ABCF /* GutenbergMediaInserterHelper.swift in Sources */,
 				176BA53B268266E70025E4A3 /* BlogService+Reminders.swift in Sources */,
+				C370F9FE2895920F004A8593 /* JPScrollViewDataDelegate.swift in Sources */,
 				40C403F32215D66A00E8C894 /* TopViewedAuthorStatsRecordValue+CoreDataClass.swift in Sources */,
 				E11C4B72201096EF00A6619C /* JetpackState.swift in Sources */,
 				437542E31DD4E19E00D6B727 /* EditPostViewController.swift in Sources */,
@@ -19412,6 +19421,7 @@
 				400A2C832217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,
 				DCCDF75E283BF02D00AA347E /* SiteStatsInsightsDetailsViewModel.swift in Sources */,
 				F1C740BF26B18E42005D0809 /* StoreSandboxSecretScreen.swift in Sources */,
+				C370FA01289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift in Sources */,
 				5D42A3E2175E7452005CFF05 /* ReaderPost.m in Sources */,
 				FEA7948D26DD136700CEC520 /* CommentHeaderTableViewCell.swift in Sources */,
 				C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */,
@@ -20805,6 +20815,7 @@
 				FABB21782602FC2C00C8785C /* NotificationActionsService.swift in Sources */,
 				FABB21792602FC2C00C8785C /* JetpackScanService.swift in Sources */,
 				FABB217A2602FC2C00C8785C /* FilterSheetView.swift in Sources */,
+				C370FA02289592C8004A8593 /* UIScrollView+JPScrollViewDataDelegate.swift in Sources */,
 				FABB217B2602FC2C00C8785C /* WPAddPostCategoryViewController.m in Sources */,
 				FABB217C2602FC2C00C8785C /* ReaderSearchTopic.swift in Sources */,
 				3F2ABE1B277118C4005D8916 /* Blog+VideoLimits.swift in Sources */,
@@ -21026,6 +21037,7 @@
 				FABB222E2602FC2C00C8785C /* WPStyleGuide+Sharing.swift in Sources */,
 				FABB222F2602FC2C00C8785C /* StoryPoster.swift in Sources */,
 				8B074A5127AC3A64003A2EB8 /* BlogDashboardViewModel.swift in Sources */,
+				C370F9FF2895920F004A8593 /* JPScrollViewDataDelegate.swift in Sources */,
 				FEAC916F28001FC4005026E7 /* AvatarTrainView.swift in Sources */,
 				FABB22302602FC2C00C8785C /* Double+Stats.swift in Sources */,
 				FABB22312602FC2C00C8785C /* CircularProgressView.swift in Sources */,


### PR DESCRIPTION
## Description

This PR:
- Reuses the Jetpack banner on ReaderStreamViewController for ReaderSearchViewController
- Adds new data points for deciding the Jetpack banner visibility: The scroll view's content size and offset
- Fixes #19097 and bugs related to rotation

## Testing

**The views that currently show a Jetpack banner and can be tested are:**
- My Site -> Stats
- My Site -> Activity Log
- Reader
- Notifications

### Views without enough content to scroll don't toggle banner visibility

A view that doesn't have enough content to scroll may still "bounce" with elasticity. This movement counts as a scrolling event, but shouldn't affect the banner.

**Testable views:**
- Activity Log without a few events (creating a new WP.com site is an easy way to achieve this)
- Reader search
    - Airplane mode
    - Searches with no or few results
- Notifications (a new account with few notifications would work)

#### Reader

1. Using the WordPress app, go to Reader
2. Search for `testtest123qwerty`
3. Expect to see a "No posts found" view (if results appear, try a similar search)
4. Observe that you can bounce the view
5. Expect the banner to stay visible
6. Rotate to landscape
7. Expect the banner to disappear (this is currently only for the Reader view)
8. Bounce / scroll the view
9. Expect the banner visibility to stay hidden
10. Rotate back to landscape
11. Expect the banner to return


https://user-images.githubusercontent.com/2092798/181994575-eeaff0a0-3e73-4b70-a586-6959fbb05254.mp4



## Regression Notes
1. Potential unintended areas of impact
All views with a Jetpack banner:
- My Site -> Stats
- My Site -> Activity Log
- Reader
- Notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
