### PR TITLE
Jetpack Focus: Fix notifications screenshot for iPad

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/me/rest_v11_me_sites.json
@@ -356,7 +356,7 @@
           "is_core_site_editor_enabled": false
         },
         {
-          "ID": 185124945,
+          "ID": 181977606,
           "description": "Site with everything enabled",
           "name": "Weekend Bakes",
           "URL": "yourjetpack.blog",

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_comments.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_comments.json
@@ -5,29 +5,53 @@
     "queryParameters": {
       "locale": {
         "matches": "(.*)"
-      },
-      "context": {
-        "equalTo": "edit"
-      },
-      "force": {
-        "equalTo": "wpcom"
-      },
-      "number": {
-        "equalTo": "100"
-      },
-      "status": {
-        "equalTo": "all"
       }
     }
   },
   "response": {
     "status": 200,
     "jsonBody": {
-      "found": 0,
-      "site_ID": 106707880,
-      "comments": [
-
-      ]
+      "ID": 2,
+      "post": {
+        "ID": 56,
+        "title": "My Top 10 Pastry Recipes",
+        "type": "post",
+        "link": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/posts\/56"
+      },
+      "author": {
+        "ID": 98380071,
+        "login": "",
+        "email": "test@example.com",
+        "name": "Reyansh Pawar",
+        "first_name": "",
+        "last_name": "",
+        "nice_name": "",
+        "URL": "http://reyanshpawar.wordpress.com",
+        "avatar_URL": "https://1.gravatar.com/avatar/4b7ac5a2b497adbd473313b0701023a4?s=256&d=https%3A%2F%2Fsecure.gravatar.com%2Favatar%2Fad516503a11cd5ca435acc9bb6523536%3Fs%3D256&r=G",
+        "profile_URL": "https:\/\/en.gravatar.com\/990973e34a3efd5373e44fd270755295",
+        "ip_address": "000.0.000.000"
+      },
+      "date": "{{now}}",
+      "URL": "https://weekendbakesblog.wordpress.com/2020/10/05/my-top-10-pastry-recipes/comment-page-1/#comment-2",
+      "short_URL": "https:\/\/wp.me\/pc82cg-sp%23comment-406",
+      "content": "Can you use almond or rice flour instead of the whole wheat to make the peach scone recipe gluten free?\n",
+      "status": "approved",
+      "parent": false,
+      "type": "comment",
+      "like_count": 4,
+      "i_like": true,
+      "meta": {
+        "links": {
+          "self": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/comments\/2",
+          "help": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/comments\/2\/help",
+          "site": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606",
+          "post": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/posts\/56",
+          "replies": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/comments\/2\/replies\/",
+          "likes": "https:\/\/public-api.wordpress.com\/rest\/v1.1\/sites\/181977606\/comments\/2\/likes\/"
+        }
+      },
+      "can_moderate": true,
+      "i_replied": false
     }
   }
 }

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -71,7 +71,6 @@ class JetpackScreenshotGeneration: XCTestCase {
         if XCUIDevice.isPad {
             notificationList
                 .openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
-                .replyToNotification()
         }
         notificationList.thenTakeScreenshot(5, named: "Notifications")
     }

--- a/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -11,6 +11,7 @@ public class NotificationsScreen: ScreenObject {
         )
     }
 
+    @discardableResult
     public func openNotification(withText notificationText: String) -> NotificationsScreen {
         app.staticTexts[notificationText].tap()
         return self

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -107,7 +107,6 @@ class WordPressScreenshotGeneration: XCTestCase {
         if XCUIDevice.isPad {
             notificationList
                 .openNotification(withText: "Reyansh Pawar commented on My Top 10 Pastry Recipes")
-                .replyToNotification()
         }
         notificationList.thenTakeScreenshot(5, named: "Notifications")
     }

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -59,7 +59,7 @@ class WordPressScreenshotGeneration: XCTestCase {
         if XCUIDevice.isPad {
             let ipadScreenshot = try MySiteScreen()
                 .showSiteSwitcher()
-                .switchToSite(withTitle: "weekendbakesblog.wordpress.com")
+                .switchToSite(withTitle: "yourjetpack.blog")
                 .gotoPostsScreen()
                 .showOnly(.drafts)
                 .selectPost(withSlug: "easy-blueberry-muffins")


### PR DESCRIPTION
Part of #18960 

## Description
This PR fixes and issue where the notification details screen wasn't loading properly on iPad for the screenshot targets (i.e. `WordPressScreenshotGeneration` and `JetpackScreenshotGeneration`).

## How to test

Test for both the  `WordPressScreenshotGeneration` and `JetpackScreenshotGeneration` targets

1. Run `rake mocks`
2. Switch to the screenshot generation target
3. Run `testGenerateScreenshots()` on an **iPad** simulator
4. ✅ Verify: tests succeed and the screenshots match design specs

Before | After
-- | --
![Simulator Screen Shot - iPad mini (6th generation) - 2022-07-22 at 16 34 47](https://user-images.githubusercontent.com/6711616/181799265-ce191c96-8e9b-40dd-aee0-6d878766da95.png) | ![Simulator Screen Shot - iPad mini (6th generation) - 2022-07-29 at 16 58 04 #2](https://user-images.githubusercontent.com/6711616/181799273-bee5dde6-39eb-4ae1-855a-696acdb04d26.png)


## Notes
FYI @shaunandrews @hassaanelgarem I removed the call to tap the reply button on the notification details screen. Previously, we were tapping the reply button which brought up the hardware keyboard onto the screen. For reference, [this](https://github.com/wordpress-mobile/WordPress-iOS/pull/15010#pullrequestreview-506023626) is what it used to look like. But the new notification details design fills up the screen, and bringing up the hardware keyboard would obscure a lot of the UI elements. Lmk what you think :)

Notif details screen | Notif details screen w reply
-- | --
![Simulator Screen Shot - iPad mini (6th generation) - 2022-07-29 at 16 58 04 #2](https://user-images.githubusercontent.com/6711616/181799361-e2a50df2-eb90-4fd9-affc-c574bb8e3b79.png) | ![Simulator Screen Shot - iPad mini (6th generation) - 2022-07-29 at 16 58 19](https://user-images.githubusercontent.com/6711616/181799370-972fd059-f410-45ce-82e8-4e99141140f6.png)


## Regression Notes
1. Potential unintended areas of impact
- `WordPressScreenshotGeneration` target

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Made sure the tests pass for `WordPressScreenshotGeneration`

3. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
