### PR TITLE
Fix Jetpack powered badge on Activity detail

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.storyboard
@@ -170,12 +170,9 @@
                                             <action selector="warningTapped:" destination="yav-nF-cx7" eventType="touchUpInside" id="XPM-6H-44L"/>
                                         </connections>
                                     </button>
-                                    <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vfz-Oz-LdY">
-                                        <rect key="frame" x="0.0" y="0.0" width="343" height="48"/>
+                                    <view hidden="YES" contentMode="scaleToFill" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="vfz-Oz-LdY">
+                                        <rect key="frame" x="0.0" y="0.0" width="343" height="0.0"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="48" id="W0E-Dq-QSH"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                             </stackView>

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -168,7 +168,6 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         jetpackBadgeView.addSubview(jetpackBadgeButton)
         NSLayoutConstraint.activate([
             jetpackBadgeButton.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor),
-            jetpackBadgeButton.widthAnchor.constraint(lessThanOrEqualTo: jetpackBadgeView.widthAnchor),
             jetpackBadgeButton.topAnchor.constraint(equalTo: jetpackBadgeView.topAnchor, constant: Constants.jetpackBadgeTopInset),
             jetpackBadgeButton.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor)
         ])


### PR DESCRIPTION
Fixes #19125
<p align=center>
<img height=400 src=https://user-images.githubusercontent.com/34376330/181811017-9458567b-99c9-4e1a-85f1-b7ce47b24f05.png>
</p>


To test:

1. Go to Settings → Accessibility
2. Tap `Display & Text Size` then tap `Larger Text`
3. Slide the text size control to the right edge
4. Open WordPress app
5. Tap `Menu` then tap `Activity Log`
6. Tap any activity item
   You need one activity item, if missing one quickly change the site name to generate an activity log item.
7. **Verify** that the "Jetpack powered" badge scales correctly (similarly to what it does on My Site Home). Note that the badge scaling is limited by design.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
