### PR TITLE
[Jetpack] Add Safe Area support for Jetpack banner

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -43,10 +43,6 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
 
     private func configureBanner() {
         containerStackView.addArrangedSubview(jetpackBannerView)
-
-        NSLayoutConstraint.activate([
-            jetpackBannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight)
-        ])
         addTranslationObserver(jetpackBannerView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -20,7 +20,8 @@ class JetpackBannerView: UIView {
         jetpackButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(jetpackButton)
 
-        pinSubviewToAllEdges(jetpackButton)
+        pinSubviewToSafeArea(jetpackButton)
+        jetpackButton.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
     }
 
     /// Preferred minimum height to be used for constraints

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -35,24 +35,11 @@ import UIKit
     }
 
     private func configureJetpackBanner(_ stackView: UIStackView) {
-        guard shouldShowBanner() else { return }
-
         let jetpackBannerView = JetpackBannerView()
         stackView.addArrangedSubview(jetpackBannerView)
-        jetpackBannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
 
         if let childVC = childVC as? JPScrollViewDelegate {
             childVC.addTranslationObserver(jetpackBannerView)
         }
-    }
-
-    /// Note: This could be improved to be delegated to the wrapped view.
-    private func shouldShowBanner() -> Bool {
-        /// Presenting as a modal currently isn't supported due to Safe Area overlap
-        guard !isModal() else {
-            return false
-        }
-
-        return JetpackBrandingVisibility.all.enabled
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -33,9 +33,6 @@
                                         <rect key="frame" x="0.0" y="667" width="375" height="0.0"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="NJ5-tg-zLZ"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                             </stackView>

--- a/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
+++ b/WordPress/Classes/ViewRelated/Notifications/Notifications.storyboard
@@ -66,11 +66,11 @@
                                 <constraint firstAttribute="height" constant="100" placeholder="YES" id="pxu-yE-rHC"/>
                             </constraints>
                         </view>
-                        <view contentMode="scaleToFill" ambiguous="YES" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rKm-gY-cFw" userLabel="Filters View">
+                        <view contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" layoutMarginsFollowReadableWidth="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rKm-gY-cFw" userLabel="Filters View">
                             <rect key="frame" x="0.0" y="100" width="600" height="44"/>
                             <subviews>
-                                <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XgY-0j-kFz" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="600" height="44"/>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XgY-0j-kFz" customClass="FilterTabBar" customModule="WordPress" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="600" height="34"/>
                                     <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 </view>
                             </subviews>
@@ -78,6 +78,7 @@
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="XgY-0j-kFz" secondAttribute="trailing" priority="999" id="7Mp-Sv-zuM"/>
                                 <constraint firstItem="XgY-0j-kFz" firstAttribute="leading" secondItem="rKm-gY-cFw" secondAttribute="leading" priority="999" id="JVy-y6-rph"/>
+                                <constraint firstAttribute="height" priority="999" constant="44" id="dte-R2-ISl"/>
                                 <constraint firstAttribute="bottom" secondItem="XgY-0j-kFz" secondAttribute="bottom" constant="10" id="mxz-xp-47Y"/>
                                 <constraint firstItem="XgY-0j-kFz" firstAttribute="top" secondItem="rKm-gY-cFw" secondAttribute="top" id="udW-ag-i42"/>
                             </constraints>

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -508,7 +508,6 @@ import Combine
         jetpackBannerView = bannerView
         addTranslationObserver(bannerView)
         stackView.addArrangedSubview(bannerView)
-        bannerView.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
     }
 
     private func setupTableView(stackView: UIStackView) {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboard.storyboard
@@ -44,17 +44,15 @@
                                         </constraints>
                                     </view>
                                     <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="J6j-x0-sMS">
-                                        <rect key="frame" x="0.0" y="46" width="375" height="527"/>
+                                        <rect key="frame" x="0.0" y="46" width="375" height="577"/>
                                         <connections>
                                             <segue destination="83f-eK-Wfs" kind="embed" id="Vur-EF-t51"/>
                                         </connections>
                                     </containerView>
-                                    <view contentMode="scaleToFill" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zMO-yu-sCx" customClass="JetpackBannerView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="573" width="375" height="50"/>
+                                    <view contentMode="scaleToFill" verticalHuggingPriority="750" id="zMO-yu-sCx" customClass="JetpackBannerView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="623" width="375" height="0.0"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="50" id="AcA-iz-xbe"/>
-                                        </constraints>
                                     </view>
                                 </subviews>
                             </stackView>


### PR DESCRIPTION
## Description

This PR:
- Fixes #19131
- Moves the Jetpack banner view's constraints to the view itself
- Adjusts the Jetpack banner view to respect safe areas
- Reenables the banner on modals that are wrapped with `JetpackBannerWrapperViewController`

## Testing

### Test 1: Reader modals

Prerequisites:
- A site connected to Jetpack + the app logged into .com

Steps:
1. In the WordPress app, go to Reader
2. Tap the cog at the top right
3. Tap Followed Sites
4. Tap a site view it
5. Observe the Jetpack banner at the bottom
6. Expect the banner to be above the bottom safe area

| Before | After |
| - | - |
| ![Before - Reader site](https://user-images.githubusercontent.com/2092798/182040301-9ee8e7ac-acca-4be4-b275-39fb8da6310b.png) | ![After - Reader site](https://user-images.githubusercontent.com/2092798/182040308-3ffe86fd-1000-4b8e-acb1-68f4151b57f4.png) |

### Test 2: Stats -> Sharing

Prerequisites:
- A site connected to Jetpack + the app logged into .com
- A site that hasn't enabled post sharing in Stats (see screenshot)

Steps:
1. In the WordPress app, tap "Stats"
2. Expect a section entitled: "A tip to grow your audience"
3. Tap "Enable post sharing"
4. Observe the Jetpack banner at the bottom
5. Expect the banner to be shown, and above the bottom safe area

| Stats sharing screen | Before | After |
| - | - | - |
| ![Stats - Enable post sharing](https://user-images.githubusercontent.com/2092798/182040496-5c2221e7-58a3-4a17-8c5c-b316bdada669.png) | ![Before - Stats sharing](https://user-images.githubusercontent.com/2092798/182040528-e9191298-0c6e-4eec-8232-1b614be60556.png) | ![After - Stats sharing](https://user-images.githubusercontent.com/2092798/182040541-6b01e560-295f-4d39-a33c-691ca974615b.png) |


## Regression Notes
1. Potential unintended areas of impact
    - Any view that shows the Jetpack banner
        - Notifications
        - Reader
        - Stats
        - Jetpack Activity Log
    - Jetpack banner with large accessibility fonts
    - Jetpack banner when the device is in landscape

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested each view
    - Tested in the Jetpack app to ensure no banners are shown
    - Tested on iPad

| iPad Reader modal | iPad Sharing modal |
| - | - |
| ![Simulator Screen Shot - iPad (9th generation) - 2022-07-31 at 14 54 36](https://user-images.githubusercontent.com/2092798/182041128-9ed11dbf-8996-4d02-936e-28c241aeeb3f.png) | ![Simulator Screen Shot - iPad (9th generation) - 2022-07-31 at 14 54 19](https://user-images.githubusercontent.com/2092798/182041138-ee743690-ec41-4b8e-8871-8913d416d4d8.png) |

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
