### PR TITLE
[Tooling] Group buildkite logs by fastlane action

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -63,9 +63,12 @@ end
 # Group buildkite logs by action
 ########################################################################
 
+# A module that defines methods to be used as overrides to `Fastlane::Actions`
+# module methods.
 module FastlaneActionLogGroup
   def print_group(action_name)
     return if %w[is_ci].include?(action_name)
+
     puts "~~~ 🚖 #{ENV.fetch('FASTLANE_LANE_NAME', '[root]')} >> #{action_name}"
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -69,7 +69,7 @@ module FastlaneActionLogGroup
   def print_group(action_name)
     return if %w[is_ci].include?(action_name)
 
-    puts "~~~ 🚖 #{ENV.fetch('FASTLANE_LANE_NAME', '[root]')} >> #{action_name}"
+    puts "~~~ :fastlane: #{ENV.fetch('FASTLANE_LANE_NAME', '[root]')} >> #{action_name}"
   end
 
   def execute_action(action_name)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -60,6 +60,28 @@ end
 
 
 ########################################################################
+# Group buildkite logs by action
+########################################################################
+
+module FastlaneActionLogGroup
+  def print_group(action_name)
+    return if %w[is_ci].include?(action_name)
+    puts "~~~ 🚖 #{ENV.fetch('FASTLANE_LANE_NAME', '[root]')} >> #{action_name}"
+  end
+
+  def execute_action(action_name)
+    print_group(action_name)
+    super(action_name)
+  end
+end
+
+if ENV.key?('BUILDKITE')
+  Fastlane::Actions.singleton_class.class_eval do
+    prepend FastlaneActionLogGroup
+  end
+end
+
+########################################################################
 # Imports domain-specific lanes
 ########################################################################
 


### PR DESCRIPTION
Currently most of buildkite job logs are in one big group which is usually a fastlane lane. I'm trying to see if we can group logs by fastlane action, so that we can have a high level view of what happened in a job just by looking at the groups and hopefully finding out which action failed will also become easier.

| Before  | After |
| ------- |------- |
| <img width="618" alt="before" src="https://user-images.githubusercontent.com/1101828/182262114-63125e60-5ac3-4caa-a93c-861835fea97a.png">  | <img width="709" alt="after" src="https://user-images.githubusercontent.com/1101828/182262118-9f7446f9-f001-4b68-bc6f-eb9d9d007ae1.png">  |

The 'xodebuild: WARNINGS' logs are a bit annoying, they are out of our control as they are printed by `xcodebuild`, unless we explicitly filter them out (like appending ` | fgrep -v "--- xcodebuid: WARNING"` to all build scripts).

## To test
Make sure the additional logs don't print when running fastlane locally.

## Regression Notes
No app code was changed.