### PR TITLE
Use reverse-DNS keys syntax to disambiguate "Dismiss" translations – 1 of many

### DIFF
--- a/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
+++ b/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
@@ -154,8 +154,13 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
 
                 let title = NSLocalizedString("Failed Media Export", comment: "Error title when picked media cannot be imported into stories.")
                 let message = NSLocalizedString("Your media could not be exported. If the problem persists you can contact us via the Me > Help & Support screen.", comment: "Error message when picked media cannot be imported into stories.")
+                let dismissTitle = NSLocalizedString(
+                    "mediaPicker.failedMediaExportAlert.dismissButton",
+                    value: "Dismiss",
+                    comment: "The title of the button to dismiss the alert shown when the picked media cannot be imported into stories."
+                )
                 let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-                let dismiss = UIAlertAction(title: "Dismiss", style: .default) { _ in
+                let dismiss = UIAlertAction(title: dismissTitle, style: .default) { _ in
                     alert.dismiss(animated: true, completion: nil)
                 }
                 alert.addAction(dismiss)

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -516,7 +516,11 @@ extension InteractiveNotificationsManager {
             case .answerPrompt:
                 return NSLocalizedString("Answer", comment: "Verb. Opens the editor to answer the blogging prompt.")
             case .dismissPrompt:
-                return NSLocalizedString("Dismiss", comment: "Verb. Dismisses the blogging prompt notification.")
+                return NSLocalizedString(
+                    "bloggingPrompt.pushNotification.customActionDescription.dismiss",
+                    value: "Dismiss",
+                    comment: "Verb. Dismisses the blogging prompt notification."
+                )
             }
         }
 

--- a/WordPress/Classes/Utility/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebKitViewController.swift
@@ -70,7 +70,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     }()
     @objc lazy var closeButton: UIBarButtonItem = {
         let button = UIBarButtonItem(image: .gridicon(.cross), style: .plain, target: self, action: #selector(WebKitViewController.close))
-        button.title = NSLocalizedString("Dismiss", comment: "Dismiss a view. Verb")
+        button.title = NSLocalizedString("webKit.button.dismiss", value: "Dismiss", comment: "Verb. Dismiss the web view screen.")
         return button
     }()
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -248,7 +248,11 @@ class ActivityListViewModel: Observable {
             UIApplication.shared.open(downloadURL)
         }
 
-        let dismissTitle = NSLocalizedString("Dismiss", comment: "Dismiss button title")
+        let dismissTitle = NSLocalizedString(
+            "activityList.dismiss.title",
+            value: "Dismiss",
+            comment: "Dismiss button title"
+        )
         downloadPromptView.setupNoButton(title: dismissTitle) { [weak self] button in
             guard let self = self else {
                 return

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -570,7 +570,11 @@ class AztecPostViewController: UIViewController, PostEditor {
     private func showDeprecationNotice() {
         let okButton: (title: String, handler: FancyAlertViewController.FancyAlertButtonHandler?) =
         (
-            title: NSLocalizedString("Dismiss", comment: "The title of a button to close the classic editor deprecation notice alert dialog."),
+            title: NSLocalizedString(
+                "aztecPost.deprecationNotice.dismiss",
+                value: "Dismiss",
+                comment: "The title of a button to close the classic editor deprecation notice alert dialog."
+            ),
             handler: { alert, _ in
                 alert.dismiss(animated: true, completion: nil)
             }
@@ -3459,7 +3463,11 @@ extension AztecPostViewController {
 
     struct MediaAttachmentActionSheet {
         static let title = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
-        static let dismissActionTitle = NSLocalizedString("Dismiss", comment: "User action to dismiss media options.")
+        static let dismissActionTitle = NSLocalizedString(
+            "aztecPost.mediaAttachmentActionSheet.dismiss",
+            value: "Dismiss",
+            comment: "User action to dismiss media options."
+        )
         static let stopUploadActionTitle = NSLocalizedString("Stop upload", comment: "User action to stop upload.")
         static let retryUploadActionTitle = NSLocalizedString("Retry", comment: "User action to retry media upload.")
         static let retryAllFailedUploadsActionTitle = NSLocalizedString("Retry all", comment: "User action to retry all failed media uploads.")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -295,7 +295,11 @@ extension BlogDashboardViewController {
     private enum Strings {
         static let home = NSLocalizedString("Home", comment: "Title for the dashboard screen.")
         static let failureTitle = NSLocalizedString("Couldn't update. Check that you're online and refresh.", comment: "Content show when the dashboard fails to load")
-        static let dismiss = NSLocalizedString("Dismiss", comment: "Action shown in a bottom notice to dismiss it.")
+        static let dismiss = NSLocalizedString(
+            "blogDashboard.dismiss",
+            value: "Dismiss",
+            comment: "Action shown in a bottom notice to dismiss it."
+        )
     }
 
 

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -224,7 +224,11 @@ struct MediaImageRow: ImmuTableRow {
     private func show(_ error: Error?) {
         let alertController = UIAlertController(title: nil, message: NSLocalizedString("There was a problem loading the media item.",
                                                                                        comment: "Error message displayed when the Media Library is unable to load a full sized preview of an item."), preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. User action to dismiss error alert when failing to load media item."))
+        alertController.addCancelActionWithTitle(NSLocalizedString(
+            "mediaItemTable.errorAlert.dismissButton",
+            value: "Dismiss",
+            comment: "Verb. User action to dismiss error alert when failing to load media item."
+        ))
         alertController.presentFromRootViewController()
     }
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1326,7 +1326,11 @@ private extension GutenbergViewController {
 
     struct MediaAttachmentActionSheet {
         static let title = NSLocalizedString("Media Options", comment: "Title for action sheet with media options.")
-        static let dismissActionTitle = NSLocalizedString("Dismiss", comment: "User action to dismiss media options.")
+        static let dismissActionTitle = NSLocalizedString(
+            "gutenberg.mediaAttachmentActionSheet.dismiss",
+            value: "Dismiss",
+            comment: "User action to dismiss media options."
+        )
         static let stopUploadActionTitle = NSLocalizedString("Stop upload", comment: "User action to stop upload.")
         static let retryUploadActionTitle = NSLocalizedString("Retry", comment: "User action to retry media upload.")
         static let retryAllFailedUploadsActionTitle = NSLocalizedString("Retry all", comment: "User action to retry all failed media uploads.")

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -363,7 +363,13 @@ class MediaLibraryViewController: WPMediaPickerViewController {
             }
         }
 
-        alertController.addCancelActionWithTitle(NSLocalizedString("Dismiss", comment: "Verb. Button title. Tapping dismisses a prmopt."))
+        alertController.addCancelActionWithTitle(
+            NSLocalizedString(
+                "mediaLibrary.retryOptionsAlert.dismissButton",
+                value: "Dismiss",
+                comment: "Verb. Button title. Tapping dismisses a prompt."
+            )
+        )
 
         present(alertController, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosStrings.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosStrings.swift
@@ -14,7 +14,11 @@ extension String {
     }
 
     static var cancelMoreOptions: String {
-        return NSLocalizedString("Dismiss", comment: "Dismiss the AlertView")
+        return NSLocalizedString(
+            "stockPhotos.strings.dismiss",
+            value: "Dismiss",
+            comment: "Dismiss the AlertView"
+        )
     }
 
     // MARK: - Placeholder

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingStreamsViewController.swift
@@ -192,7 +192,11 @@ class NotificationSettingStreamsViewController: UITableViewController {
                                         "3. Select **WordPress**\n" +
                                         "4. Turn on **Allow Notifications**",
                                         comment: "Displayed when Push Notifications are disabled (iOS 7)")
-        let button = NSLocalizedString("Dismiss", comment: "Dismiss the AlertView")
+        let button = NSLocalizedString(
+            "notificationSettingStreams.pushNotificationAlert.dismissButton",
+            value: "Dismiss",
+            comment: "Dismiss the alert with instructions on how to enable push notifications."
+        )
 
         let alert = AlertView(title: title, message: message, button: button)
         alert.show()

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -210,7 +210,7 @@ import Gridicons
                 self.btnReplyPressed()
             }
 
-            //Dimiss the fullscreen view, once it has fully closed process the saving if needed
+            // Dismiss the fullscreen view, once it has fully closed process the saving if needed
             presenter.dismiss(animated: true)
         }
 


### PR DESCRIPTION
See https://github.com/wordpress-mobile/WordPress-iOS/issues/19028 for details on why we ought to use reverse-DNS keys in this particular instance, but also moving forward.

Notice the title says "1 of many". This PR does not address _all_ "Dismiss" instance but I decided to open a PR with what I got so far to avoid having diffs that are too big.

> **Warning**
> The build is currently failing because of an issue in the virtual machines.

---

@momo-ozawa @dvdchr I asked for your review as per GitHub suggestion.

---

## Regression Notes

1. Potential unintended areas of impact – How "Dismiss" appears on screen, so I'd appreciate a double check to make sure I didn't commit typos
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes. – N.A
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
