### PR TITLE
[UI Tests] Added CODEOWNERS for WPiOS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
+
+/WordPress/UITestsFoundation/ @wordpress-mobile/mobile-ui-testing-squad
+/WordPress/WordPressUITests/ @wordpress-mobile/mobile-ui-testing-squad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 /WordPress/UITestsFoundation/ @wordpress-mobile/mobile-ui-testing-squad
 /WordPress/WordPressUITests/ @wordpress-mobile/mobile-ui-testing-squad
+/WordPress/WordPressScreenshotGeneration/ @wordpress-mobile/mobile-ui-testing-squad
+/WordPress/JetpackScreenshotGeneration/ @wordpress-mobile/mobile-ui-testing-squad

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,2 @@
-# Adding `mobile-ui-testing-squad` as codeowners for UI tests related folders
-
 /WordPress/UITestsFoundation/ @wordpress-mobile/mobile-ui-testing-squad
 /WordPress/WordPressUITests/ @wordpress-mobile/mobile-ui-testing-squad


### PR DESCRIPTION
### Description
As mentioned in p1659432783574949-slack-CC7L49W13, there might be a communicational benefit of adding folks from `mobile-ui-testing-squad` as code owners for UI-tests-related folders.

### Testing instructions
- #19142 which is based on the current branch, and adds a file to one of the folders listed in `CODEOWNERS`:
    - [x] Contains `mobile-ui-testing-squad` as reviewers.
- #19143 which is based on the current branch, and adds a file to NOT one of the folders listed in `CODEOWNERS`:
    - [x] DOES NOT contain `mobile-ui-testing-squad` as reviewers.