### PR TITLE
WeeklyRoundupBackgroundTask - format notification body

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -555,7 +555,7 @@ class WeeklyRoundupNotificationScheduler {
             }
 
         let title = notificationTitle(siteTitle)
-        let body = String(format: TextContent.dynamicNotificationBody, views, comments, likes)
+        let body = notificationBodyWith(views: views, comments: likes, likes: comments)
 
         // The dynamic notification date is defined by when the background task is run.
         // Since these lines of code execute when the BG Task is run, we can just schedule
@@ -585,6 +585,25 @@ class WeeklyRoundupNotificationScheduler {
                     completion(.failure(NotificationSchedulingError.dynamicNotificationSchedulingError(error: error)))
                 }
             }
+    }
+
+    func notificationBodyWith(views: Int, comments: Int, likes: Int) -> String {
+        var body = ""
+        let hideLikesCount = likes <= 0
+        let hideCommentsCount = comments <= 0
+
+        switch (hideLikesCount, hideCommentsCount) {
+        case (true, true):
+            body = String(format: TextContent.dynamicNotificationBodyViewsOnly, views.abbreviatedString())
+        case (false, true):
+            body = String(format: TextContent.dynamicNotificationBodyViewsAndLikes, views.abbreviatedString(), likes.abbreviatedString())
+        case (true, false):
+            body = String(format: TextContent.dynamicNotificationBodyViewsAndComments, views.abbreviatedString(), comments.abbreviatedString())
+        default:
+            body = String(format: TextContent.dynamicNotificationBodyAll, views.abbreviatedString(), comments.abbreviatedString(), likes.abbreviatedString())
+        }
+
+        return body
     }
 
     private func scheduleNotification(
@@ -664,6 +683,9 @@ class WeeklyRoundupNotificationScheduler {
         static let staticNotificationTitle = NSLocalizedString("Weekly Roundup", comment: "Title of Weekly Roundup push notification")
         static let dynamicNotificationTitle = NSLocalizedString("Weekly Roundup: %@", comment: "Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites.")
         static let staticNotificationBody = NSLocalizedString("Your weekly roundup is ready, tap here to see the details!", comment: "Prompt displayed as part of the stats Weekly Roundup push notification.")
-        static let dynamicNotificationBody = NSLocalizedString("Last week you had %1$d views, %2$d comments and %3$d likes.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views, comments, and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments, 3 is likes.")
+        static let dynamicNotificationBodyViewsOnly = NSLocalizedString("Last week you had %@ views.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % marker is a placeholder and will be replaced by the appropriate number of views")
+        static let dynamicNotificationBodyViewsAndLikes = NSLocalizedString("Last week you had %1$@ views and %2$@ likes.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is likes.")
+        static let dynamicNotificationBodyViewsAndComments = NSLocalizedString("Last week you had %1$@ views and %2$@ comments.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views and comments. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments.")
+        static let dynamicNotificationBodyAll = NSLocalizedString("Last week you had %1$@ views, %2$@ comments and %3$@ likes.", comment: "Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views, comments, and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments, 3 is likes.")
     }
 }

--- a/WordPress/WordPressTest/BackgroundTasks/WeeklyRoundupBackgroundTaskTests.swift
+++ b/WordPress/WordPressTest/BackgroundTasks/WeeklyRoundupBackgroundTaskTests.swift
@@ -77,4 +77,21 @@ class WeeklyRoundupBackgroundTaskTests: XCTestCase {
         XCTAssertEqual(task.notificationScheduler.notificationTitle(siteTitle),
                        String(format: WeeklyRoundupNotificationScheduler.TextContent.dynamicNotificationTitle, unwrappedSiteTitle))
     }
+
+    func testNotificationBodyShouldNotIncludeLikesCommentsWith0Count() {
+        XCTAssertEqual(task.notificationScheduler.notificationBodyWith(views: 44, comments: 0, likes: 0), "Last week you had 44 views.")
+    }
+
+    func testNotificationBodyShouldNotIncludeLikesWith0Count() {
+        XCTAssertEqual(task.notificationScheduler.notificationBodyWith(views: 88, comments: 44, likes: 0), "Last week you had 88 views and 44 comments.")
+    }
+
+    func testNotificationBodyShouldNotIncludeCommentsWith0Count() {
+        XCTAssertEqual(task.notificationScheduler.notificationBodyWith(views: 88, comments: 0, likes: 44), "Last week you had 88 views and 44 likes.")
+    }
+
+    func testNotificationBodyShouldIncludeViewsLikesCommentsWithGreaterThan0Count() {
+        XCTAssertEqual(task.notificationScheduler.notificationBodyWith(views: 88, comments: 44, likes: 22), "Last week you had 88 views, 44 comments and 22 likes.")
+    }
+
 }


### PR DESCRIPTION
This PR updates the WeeklyRoundupBackgroundTask notification body so that when either the comments count or likes count is 0 then that property will not appear in the notification body

Fixes #19137

Before:

![](https://user-images.githubusercontent.com/88816724/182308361-4f002c5d-e5e3-4297-b0ea-c1f2a106430a.png)


After: The 2nd notification had 0 comments and so the comments string was removed

<img width="299" alt="image" src="https://user-images.githubusercontent.com/88816724/182609047-9983c129-91bb-4cb7-8fcf-e0b49b91d559.png">


To test:
1. Test on device.  When app launches go to Me -> App Settings -> Debug.  Tap Weekly Roundup
2. If you don't have enough blogs / history also slide to the right to "Include A8c P2s"
3. Tap one of the Schedule in 10 sec options and then minimise the app in background
4. Weekly Round up Notification should eventually appear.  The notification body should be updated so that 0 comments or likes no longer appear
5. Run WeeklyRoundupBackgrountTask unit tests which tests the notificationBody + all scenarios

## Regression Notes
1. Potential unintended areas of impact
WeeklyRoundupBackgroundTask notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested on device and added to the unit tests

3. What automated tests I added (or what prevented me from doing so)
I added unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
