### PR TITLE
Replace `XCNSPredicateExpectation` with faster Nimble alternative

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/EditorPostSettings.swift
@@ -1,3 +1,4 @@
+import Nimble
 import ScreenObject
 import XCTest
 
@@ -71,24 +72,13 @@ public class EditorPostSettings: ScreenObject {
         let imageCount = settingsTable.images.count
         if hasImage {
             XCTAssertTrue(imageCount == 1, "Featured image not set")
-            XCTAssertTrue(isFeaturedImageLoaded(), "Featured image is not displayed")
+            expect(self.changeFeaturedImageButton.images.descendants(matching: .other).element.exists)
+                .toEventually(beFalse(), timeout: .seconds(30), description: "Featured image is not displayed")
         } else {
             XCTAssertTrue(imageCount == 0, "Featured image is set but should not be")
         }
 
         return try EditorPostSettings()
-    }
-
-    private func isFeaturedImageLoaded() -> Bool {
-        return waitForLoadingIconToDisappear()
-    }
-
-    private func waitForLoadingIconToDisappear() -> Bool {
-        let loadingIconDisappearedPredicate = XCTNSPredicateExpectation(
-            predicate: NSPredicate(format: "exists == false"),
-            object: changeFeaturedImageButton.images.descendants(matching: .other).element)
-
-        return XCTWaiter.wait(for: [loadingIconDisappearedPredicate], timeout: 30) == .completed
     }
 
     /// - Note: Returns `Void` because the return screen depends on which editor the user is in.

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -554,6 +554,7 @@
 		3F3087C424EDB7040087B548 /* AnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3087C324EDB7040087B548 /* AnnouncementCell.swift */; };
 		3F30E50923FB362700225013 /* WPTabBarController+MeNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F30E50823FB362700225013 /* WPTabBarController+MeNavigation.swift */; };
 		3F338B71289BD3040014ADC5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B70289BD3040014ADC5 /* Nimble */; };
+		3F338B73289BD5970014ADC5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B72289BD5970014ADC5 /* Nimble */; };
 		3F39C93527A09927001EC300 /* TracksLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39C93427A09927001EC300 /* TracksLogger.swift */; };
 		3F39C93627A09927001EC300 /* TracksLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39C93427A09927001EC300 /* TracksLogger.swift */; };
 		3F3B23C22858A1B300CACE60 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = 3F3B23C12858A1B300CACE60 /* BuildkiteTestCollector */; };
@@ -8304,6 +8305,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3FA640662670CEFF0064401E /* XCTest.framework in Frameworks */,
+				3F338B73289BD5970014ADC5 /* Nimble in Frameworks */,
 				3FC2C33D26C4CF0A00C6D98F /* XCUITestHelpers in Frameworks */,
 				3F95FF4026C4F385007731D3 /* ScreenObject in Frameworks */,
 			);
@@ -16032,6 +16034,7 @@
 			packageProductDependencies = (
 				3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */,
 				3FC2C34226C4E8B700C6D98F /* ScreenObject */,
+				3F338B72289BD5970014ADC5 /* Nimble */,
 			);
 			productName = UITestsFoundation;
 			productReference = 3FA640572670CCD40064401E /* UITestsFoundation.framework */;
@@ -26665,6 +26668,11 @@
 			productName = Charts;
 		};
 		3F338B70289BD3040014ADC5 /* Nimble */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */;
+			productName = Nimble;
+		};
+		3F338B72289BD5970014ADC5 /* Nimble */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */;
 			productName = Nimble;


### PR DESCRIPTION
Resolves #19080.

To test: If the UI tests pass in CI, we're good.

## Regression Notes

1. Potential unintended areas of impact – The editor UI tests
2. What I did to test those areas of impact (or what existing automated tests I relied on) – Checked that the tests passed in CI
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
