### PR TITLE
Remove condition for Slack notify

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,10 +65,7 @@ steps:
     notify:
       - github_commit_status:
           context: "Unit Tests"
-      - slack:
-          channels:
-            - "#mobile-apps-tests-notif"
-        if: build.state == "failed"
+      - slack: "#mobile-apps-tests-notif"
 
   #################
   # UI Tests
@@ -85,10 +82,7 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
-          - slack:
-              channels:
-                - "#mobile-apps-tests-notif"
-            if: build.state == "failed"
+          - slack: "#mobile-apps-tests-notif"
 
       - label: "🔬 UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
@@ -100,10 +94,8 @@ steps:
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"
-          - slack:
-              channels:
-                - "#mobile-apps-tests-notif"
-            if: build.state == "failed"
+          - slack: "#mobile-apps-tests-notif"
+
 
   #################
   # Linters


### PR DESCRIPTION
This PR removes the condition that was added for the Slack notify attribute. The same condition has been set in the Buildkite settings page so it seems like this is unnecessary here. Also, we're not getting notification for all the steps for some reason so trying to see if changing this makes a difference.