### PR TITLE
Stats: Fix for Referrers Card Not Showing Search Engine Details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,8 @@
 * [*] User Mention: Split the suggestions list into a prominent section and a regular section. [#19064]
 * [*] Use larger thumbnail previews for recommended themes during site creation [https://github.com/wordpress-mobile/WordPress-iOS/pull/18972]
 * [***] [internal] Block Editor: List block: Adds support for V2 behind a feature flag [https://github.com/WordPress/gutenberg/pull/42702]
+* [**] Fix for Referrers Card Not Showing Search Engine Details [https://github.com/wordpress-mobile/WordPress-iOS/pull/19158]
+* [*] WeeklyRoundupBackgroundTask - format notification body [https://github.com/wordpress-mobile/WordPress-iOS/pull/19144]
 
 20.4
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 final class ReferrerDetailsTableViewController: UITableViewController {
     private var data: StatsTotalRowData
     private lazy var tableHandler = ImmuTableViewHandler(takeOver: self)
-    private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self)
+    private lazy var viewModel = ReferrerDetailsViewModel(data: data, delegate: self, referrersDelegate: self)
     private let periodStore = StoreContainer.shared.statsPeriod
 
     init(data: StatsTotalRowData) {
@@ -85,6 +85,14 @@ extension ReferrerDetailsTableViewController: StatsPeriodStoreDelegate {
     }
 }
 
+// MARK: - SiteStatsReferrerDelegate
+extension ReferrerDetailsTableViewController: SiteStatsReferrerDelegate {
+    func showReferrerDetails(_ data: StatsTotalRowData) {
+        let referrerViewController = ReferrerDetailsTableViewController(data: data)
+        navigationController?.pushViewController(referrerViewController, animated: true)
+    }
+}
+
 // MARK: - Private Methods
 private extension ReferrerDetailsTableViewController {
     func setupViews() {
@@ -114,6 +122,7 @@ private extension ReferrerDetailsTableViewController {
     var rows: [ImmuTableRow.Type] {
         [ReferrerDetailsHeaderRow.self,
          ReferrerDetailsRow.self,
-         ReferrerDetailsSpamActionRow.self]
+         ReferrerDetailsSpamActionRow.self,
+         DetailExpandableRow.self]
     }
 }


### PR DESCRIPTION
This PR fixes the issue where Search Engine referrer results with nested results were being displayed on web but not in the app. 

Fixes #18172

### Before
![image](https://user-images.githubusercontent.com/88816724/183067167-0eb4144d-411c-47a2-9985-9cbb22d0e772.png)

### After
![image](https://user-images.githubusercontent.com/88816724/183067312-b596abc2-7155-4235-bb98-64f8dae318c8.png)

![image](https://user-images.githubusercontent.com/88816724/183067362-459860f9-ca94-4ab0-b131-e4509d552fd5.png)

![image](https://user-images.githubusercontent.com/88816724/183067378-789ceae3-7318-4a0c-b9df-a8bd192080a2.png)



To test:
1. Test using a site that has referrer traffic 
2. In the WP web app go to the Stats screen and click to view all Referrers
3. In the app go to Stats, then tap to select the top time period option "Days"
4. Scroll down to the referrers section and tap "Search Engines" 
5. In the "Search Engines" screen you should now see a disclosure indicator on Search Engine referrers with nested results e.g. "Google Search". Compare with the web results and they should have the same Referrer entries
6. Tap the row to segue to view the nested results and compare with web and again, they should have the same Referrer entries


## Regression Notes
1. Potential unintended areas of impact
Stats - Referrers

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested on device and added a unit test

3. What automated tests I added (or what prevented me from doing so)4. 
I added a unit test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
