### PR TITLE
UserPersistentStore: UserDefaults abstraction layer

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -1,0 +1,14 @@
+protocol UserPersistentRepositoryReader {
+
+}
+
+protocol UserPersistentRepositoryWriter {
+    func set(_ value: Int, forKey defaultName: String)
+    func set(_ value: Float, forKey defaultName: String)
+    func set(_ value: Double, forKey defaultName: String)
+    func set(_ value: Bool, forKey defaultName: String)
+}
+
+typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter
+
+extension UserDefaults: UserPersistentRepository { }

--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -3,10 +3,12 @@ protocol UserPersistentRepositoryReader {
 }
 
 protocol UserPersistentRepositoryWriter {
+    func set(_ value: Any?, forKey defaultName: String)
     func set(_ value: Int, forKey defaultName: String)
     func set(_ value: Float, forKey defaultName: String)
     func set(_ value: Double, forKey defaultName: String)
     func set(_ value: Bool, forKey defaultName: String)
+    func set(_ url: URL?, forKey defaultName: String)
 }
 
 typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter

--- a/WordPress/Classes/Stores/UserPersistentStore.swift
+++ b/WordPress/Classes/Stores/UserPersistentStore.swift
@@ -4,8 +4,11 @@ class UserPersistentStore: UserPersistentRepository {
 
     private let userDefaults: UserDefaults
 
-    init(defaultsSuiteName: String) {
-        userDefaults = UserDefaults(suiteName: defaultsSuiteName)!
+    init?(defaultsSuiteName: String) {
+        guard let suiteDefaults = UserDefaults(suiteName: defaultsSuiteName) else {
+            return nil
+        }
+        userDefaults = suiteDefaults
     }
 
     // MARK: - UserePersistentRepositoryWriter

--- a/WordPress/Classes/Stores/UserPersistentStore.swift
+++ b/WordPress/Classes/Stores/UserPersistentStore.swift
@@ -1,0 +1,28 @@
+class UserPersistentStore: UserPersistentRepository {
+    static let standard = UserPersistentStore(defaultsSuiteName: defaultsSuiteName)
+    private static let defaultsSuiteName = "temporary.suite.name"
+
+    private let userDefaults: UserDefaults
+
+    init(defaultsSuiteName: String) {
+        userDefaults = UserDefaults(suiteName: defaultsSuiteName)!
+    }
+
+    // MARK: - UserePersistentRepositoryWriter
+    func set(_ value: Int, forKey defaultName: String) {
+        userDefaults.set(value, forKey: defaultName)
+    }
+
+    func set(_ value: Float, forKey defaultName: String) {
+        userDefaults.set(value, forKey: defaultName)
+    }
+
+    func set(_ value: Double, forKey defaultName: String) {
+        userDefaults.set(value, forKey: defaultName)
+    }
+
+    func set(_ value: Bool, forKey defaultName: String) {
+        userDefaults.set(value, forKey: defaultName)
+    }
+}
+

--- a/WordPress/Classes/Stores/UserPersistentStore.swift
+++ b/WordPress/Classes/Stores/UserPersistentStore.swift
@@ -12,6 +12,10 @@ class UserPersistentStore: UserPersistentRepository {
     }
 
     // MARK: - UserePersistentRepositoryWriter
+    func set(_ value: Any?, forKey defaultName: String) {
+        userDefaults.set(value, forKey: defaultName)
+    }
+
     func set(_ value: Int, forKey defaultName: String) {
         userDefaults.set(value, forKey: defaultName)
     }
@@ -26,6 +30,10 @@ class UserPersistentStore: UserPersistentRepository {
 
     func set(_ value: Bool, forKey defaultName: String) {
         userDefaults.set(value, forKey: defaultName)
+    }
+
+    func set(_ url: URL?, forKey defaultName: String) {
+        userDefaults.set(url, forKey: defaultName)
     }
 }
 

--- a/WordPress/Classes/Stores/UserPersistentStore.swift
+++ b/WordPress/Classes/Stores/UserPersistentStore.swift
@@ -1,6 +1,6 @@
 class UserPersistentStore: UserPersistentRepository {
     static let standard = UserPersistentStore(defaultsSuiteName: defaultsSuiteName)
-    private static let defaultsSuiteName = "temporary.suite.name"
+    private static let defaultsSuiteName = "temporary.suite.name" // TBD
 
     private let userDefaults: UserDefaults
 

--- a/WordPress/Classes/Stores/UserPersistentStore.swift
+++ b/WordPress/Classes/Stores/UserPersistentStore.swift
@@ -36,4 +36,3 @@ class UserPersistentStore: UserPersistentRepository {
         userDefaults.set(url, forKey: defaultName)
     }
 }
-

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -110,6 +110,7 @@
 		08A4E12A289D202F001D9EC7 /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
 		08A4E12C289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
 		08A4E12D289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		08A4E12F289D2795001D9EC7 /* UserPersistentStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12E289D2795001D9EC7 /* UserPersistentStoreTests.swift */; };
 		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
 		08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
@@ -5080,6 +5081,7 @@
 		08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategoryServiceTests.m; sourceTree = "<group>"; };
 		08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentStore.swift; sourceTree = "<group>"; };
 		08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentRepository.swift; sourceTree = "<group>"; };
+		08A4E12E289D2795001D9EC7 /* UserPersistentStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentStoreTests.swift; sourceTree = "<group>"; };
 		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
 		08AAD69E1CBEA47D002B2418 /* MenusService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusService.m; sourceTree = "<group>"; };
 		08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceTests.m; sourceTree = "<group>"; };
@@ -10605,6 +10607,7 @@
 				572FB400223A806000933C76 /* NoticeStoreTests.swift */,
 				937250ED267A492D0086075F /* StatsPeriodStoreTests.swift */,
 				0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */,
+				08A4E12E289D2795001D9EC7 /* UserPersistentStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -20479,6 +20482,7 @@
 				C3E42AB027F4D30E00546706 /* MenuItemsViewControllerTests.swift in Sources */,
 				D842EA4021FABB1800210E96 /* SiteSegmentTests.swift in Sources */,
 				C3C70C562835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift in Sources */,
+				08A4E12F289D2795001D9EC7 /* UserPersistentStoreTests.swift in Sources */,
 				436D55F5211632B700CEAA33 /* RegisterDomainDetailsViewModelTests.swift in Sources */,
 				E180BD4C1FB462FF00D0D781 /* CookieJarTests.swift in Sources */,
 				9813512E22F0FC2700F7425D /* FileDownloadsStatsRecordValueTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -106,6 +106,10 @@
 		088CC594282BEC41007B9421 /* TooltipPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 088CC593282BEC41007B9421 /* TooltipPresenter.swift */; };
 		08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */; };
 		08A2AD7B1CCED8E500E84454 /* PostCategoryServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */; };
+		08A4E129289D202F001D9EC7 /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		08A4E12A289D202F001D9EC7 /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		08A4E12C289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		08A4E12D289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
 		08AAD69F1CBEA47D002B2418 /* MenusService.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD69E1CBEA47D002B2418 /* MenusService.m */; };
 		08AAD6A11CBEA610002B2418 /* MenusServiceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */; };
 		08B6D6F31C8F7DCE0052C52B /* PostType.m in Sources */ = {isa = PBXBuildFile; fileRef = 08B6D6F11C8F7DCE0052C52B /* PostType.m */; };
@@ -5074,6 +5078,8 @@
 		088CC593282BEC41007B9421 /* TooltipPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TooltipPresenter.swift; sourceTree = "<group>"; };
 		08A2AD781CCED2A800E84454 /* PostTagServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostTagServiceTests.m; sourceTree = "<group>"; };
 		08A2AD7A1CCED8E500E84454 /* PostCategoryServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostCategoryServiceTests.m; sourceTree = "<group>"; };
+		08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentStore.swift; sourceTree = "<group>"; };
+		08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentRepository.swift; sourceTree = "<group>"; };
 		08AAD69D1CBEA47D002B2418 /* MenusService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusService.h; sourceTree = "<group>"; };
 		08AAD69E1CBEA47D002B2418 /* MenusService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusService.m; sourceTree = "<group>"; };
 		08AAD6A01CBEA610002B2418 /* MenusServiceTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusServiceTests.m; sourceTree = "<group>"; };
@@ -15004,6 +15010,8 @@
 				9A09F914230C3E9700F42AB7 /* StoreFetchingStatus.swift */,
 				24ADA24B24F9A4CB001B5DAE /* RemoteFeatureFlagStore.swift */,
 				3F3CA64F25D3003C00642A89 /* StatsWidgetsStore.swift */,
+				08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */,
+				08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -19475,6 +19483,7 @@
 				17A09B99238FE13B0022AE0D /* FeatureFlagOverrideStore.swift in Sources */,
 				FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */,
 				B54075D41D3D7D5B0095C318 /* IntrinsicTableView.swift in Sources */,
+				08A4E12C289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */,
 				3FB34ADA25672AA5001A74A6 /* HomeWidgetTodayData.swift in Sources */,
 				172E27D31FD98135003EA321 /* NoticePresenter.swift in Sources */,
 				3F43704428932F0100475B6E /* JetpackBrandingCoordinator.swift in Sources */,
@@ -19771,6 +19780,7 @@
 				E6311C431ECA017E00122529 /* UserProfile.swift in Sources */,
 				B5CABB171C0E382C0050AB9F /* PickerTableViewCell.swift in Sources */,
 				F5AE43E425DD02C1003675F4 /* StoryEditor.swift in Sources */,
+				08A4E129289D202F001D9EC7 /* UserPersistentStore.swift in Sources */,
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				436D56302117410C00CEAA33 /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
@@ -22084,6 +22094,7 @@
 				FABB256F2602FC2C00C8785C /* QuickStartSpotlightView.swift in Sources */,
 				FABB25702602FC2C00C8785C /* ReaderReblogAction.swift in Sources */,
 				FABB25712602FC2C00C8785C /* SiteAssemblyWizardContent.swift in Sources */,
+				08A4E12A289D202F001D9EC7 /* UserPersistentStore.swift in Sources */,
 				FEDDD47026A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */,
 				FABB25722602FC2C00C8785C /* UITableView+Header.swift in Sources */,
 				FABB25732602FC2C00C8785C /* RichTextContentStyles.swift in Sources */,
@@ -22287,6 +22298,7 @@
 				F10D635026F0B78E00E46CC7 /* Blog+Organization.swift in Sources */,
 				FABB26112602FC2C00C8785C /* LastPostStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB26122602FC2C00C8785C /* ActivityRangesFactory.swift in Sources */,
+				08A4E12D289D2337001D9EC7 /* UserPersistentRepository.swift in Sources */,
 				C35D4FF2280077F100DB90B5 /* SiteCreationStep.swift in Sources */,
 				C79C308026EA975000E88514 /* ReferrerDetailsRow.swift in Sources */,
 				FABB26132602FC2C00C8785C /* SFHFKeychainUtils.m in Sources */,

--- a/WordPress/WordPressTest/Classes/Stores/UserPersistentStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/UserPersistentStoreTests.swift
@@ -66,4 +66,17 @@ final class UserPersistentStoreTests: XCTestCase {
         userDefaults.removeObject(forKey: keyName)
     }
 
+    func testSetURLUpdatesDefaults() {
+        let keyName = #function
+        let url = URL(string: "https://wordpress.com")!
+        sut?.set(url, forKey: keyName)
+
+        guard let userDefaults = UserDefaults(suiteName: Self.mockSuiteName) else {
+            XCTFail("Initialization with \(Self.mockSuiteName) failed.")
+            return
+        }
+
+        XCTAssertEqual(userDefaults.url(forKey: keyName), url)
+        userDefaults.removeObject(forKey: keyName)
+    }
 }

--- a/WordPress/WordPressTest/Classes/Stores/UserPersistentStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/UserPersistentStoreTests.swift
@@ -1,0 +1,69 @@
+import XCTest
+@testable import WordPress
+
+final class UserPersistentStoreTests: XCTestCase {
+    private static let mockSuiteName = "user.persistent.store.tests"
+    private let sut = UserPersistentStore(defaultsSuiteName: mockSuiteName)
+
+    // From the `UserDefaults(suiteName:)` docs:
+    // "The globalDomain is also an invalid suite name, because it isn't writeable by apps."
+    // Therefore it should return nil.
+    func testInitFailsWhenGlobalDomainIsUsed() {
+        XCTAssertNil(UserPersistentStore(defaultsSuiteName: UserDefaults.globalDomain))
+    }
+
+    func testSetIntUpdatesDefaults() {
+        let keyName = #function
+        sut?.set(1987, forKey: keyName)
+
+        guard let userDefaults = UserDefaults(suiteName: Self.mockSuiteName) else {
+            XCTFail("Initialization with \(Self.mockSuiteName) failed.")
+            return
+        }
+
+        XCTAssertEqual(userDefaults.integer(forKey: keyName), 1987)
+        userDefaults.removeObject(forKey: keyName)
+    }
+
+    func testSetFloatUpdatesDefaults() {
+        let keyName = #function
+        let testValue: Float = 7.2
+        sut?.set(testValue, forKey: keyName)
+
+        guard let userDefaults = UserDefaults(suiteName: Self.mockSuiteName) else {
+            XCTFail("Initialization with \(Self.mockSuiteName) failed.")
+            return
+        }
+
+        XCTAssertEqual(userDefaults.float(forKey: keyName), testValue)
+        userDefaults.removeObject(forKey: keyName)
+    }
+
+    func testSetDoubleUpdatesDefaults() {
+        let keyName = #function
+        let testValue: Double = 18.82732
+        sut?.set(testValue, forKey: keyName)
+
+        guard let userDefaults = UserDefaults(suiteName: Self.mockSuiteName) else {
+            XCTFail("Initialization with \(Self.mockSuiteName) failed.")
+            return
+        }
+
+        XCTAssertEqual(userDefaults.double(forKey: keyName), testValue)
+        userDefaults.removeObject(forKey: keyName)
+    }
+
+    func testSetBoolUpdatesDefaults() {
+        let keyName = #function
+        sut?.set(true, forKey: keyName)
+
+        guard let userDefaults = UserDefaults(suiteName: Self.mockSuiteName) else {
+            XCTFail("Initialization with \(Self.mockSuiteName) failed.")
+            return
+        }
+
+        XCTAssert(userDefaults.bool(forKey: keyName))
+        userDefaults.removeObject(forKey: keyName)
+    }
+
+}


### PR DESCRIPTION
Adds `UserPersistentStore` along with write function implementations. It is a simple abstraction layer over UserDefaults to replace our direct calls and use a suite instead. This way we can share the locals between two apps. Reader part will follow along with actual refactoring of the existing calls. Suite Name is TBD.

To test:
Run `UserPersistentStoreTests`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
