### PR TITLE
Jetpack Focus: Update iPad raw screenshots to showcase dashboard

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/dashboard/dashboard.json
@@ -1,0 +1,30 @@
+{
+    "request": {
+      "method": "GET",
+      "urlPath": "/wpcom/v2/sites/181977606/dashboard/cards-data/",
+      "queryParameters": {
+        "locale": {
+            "matches": "(.*)"
+        },
+        "cards": {
+            "equalTo": "todays_stats,posts"
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+        "todays_stats": {
+            "views": 56,
+            "visitors": 44,
+            "likes": 19,
+            "comments": 0
+        },
+        "posts": {
+            "has_published": true,
+            "draft": [{}],
+            "scheduled": [{}]
+        }
+      }
+    }
+  }

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/rest_v12_sites_181977606_posts-draft,pending.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/rest_v12_sites_181977606_posts-draft,pending.json
@@ -13,7 +13,7 @@
         "equalTo": "autosave"
       },
       "number": {
-        "equalTo": "40"
+        "matches": "3|40"
       },
       "status": {
         "equalTo": "draft,pending"
@@ -26,13 +26,13 @@
   "response": {
     "status": 200,
     "jsonBody": {
-      "found": 1,
+      "found": 2,
       "posts": [
         {
           "ID": 14,
           "site_ID": 181977606,
           "author": {
-            "ID": 191794483,
+            "ID": 152748359,
             "login": "appstorescreens",
             "email": "test@example.com",
             "name": "appstorescreens",
@@ -42,7 +42,7 @@
             "URL": "http://tricountyrealestate.wordpress.com",
             "avatar_URL": "https://0.gravatar.com/avatar/35029b2103460109f574c38dfeea5f3f?s=96&d=identicon&r=G",
             "profile_URL": "https://en.gravatar.com/appstorescreens",
-            "site_ID": 181851541
+            "site_ID": 181977606
           },
           "date": "2020-10-05T15:03:30+00:00",
           "modified": "2020-10-05T15:04:51+00:00",
@@ -74,6 +74,147 @@
           "global_ID": "33b4a6f0603d5c065b2e54737b34899c",
           "featured_image": "",
           "post_thumbnail": null,
+          "format": "standard",
+          "geo": false,
+          "menu_order": 0,
+          "page_template": "",
+          "publicize_URLs": [
+
+          ],
+          "terms": {
+            "category": {
+              "Uncategorized": {
+                "ID": 1,
+                "name": "Uncategorized",
+                "slug": "uncategorized",
+                "description": "",
+                "post_count": 3,
+                "parent": 0,
+                "meta": {
+                  "links": {
+                    "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/categories/slug:uncategorized",
+                    "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/categories/slug:uncategorized/help",
+                    "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606"
+                  }
+                }
+              }
+            },
+            "post_tag": {
+            },
+            "post_format": {
+            },
+            "mentions": {
+            }
+          },
+          "tags": {
+          },
+          "categories": {
+            "Uncategorized": {
+              "ID": 1,
+              "name": "Uncategorized",
+              "slug": "uncategorized",
+              "description": "",
+              "post_count": 3,
+              "parent": 0,
+              "meta": {
+                "links": {
+                  "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/categories/slug:uncategorized",
+                  "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/categories/slug:uncategorized/help",
+                  "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606"
+                }
+              }
+            }
+          },
+          "attachments": {
+          },
+          "attachment_count": 0,
+          "metadata": [
+            {
+              "id": "142",
+              "key": "jabber_published",
+              "value": "1601910212"
+            },
+            {
+              "id": "148",
+              "key": "timeline_notification",
+              "value": "1601910213"
+            }
+          ],
+          "meta": {
+            "links": {
+              "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14",
+              "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/posts/14/help",
+              "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606",
+              "replies": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14/replies/",
+              "likes": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14/likes/"
+            }
+          },
+          "capabilities": {
+            "publish_post": true,
+            "delete_post": true,
+            "edit_post": true
+          },
+          "revisions": [
+            15
+          ],
+          "other_URLs": {
+            "permalink_URL": "https://weekendbakesblog.wordpress.com/2020/10/05/%postname%/",
+            "suggested_slug": "easy-blueberry-muffins"
+          }
+        },
+        {
+          "ID": 24,
+          "site_ID": 181977606,
+          "author": {
+            "ID": 152748359,
+            "login": "appstorescreens",
+            "email": "test@example.com",
+            "name": "appstorescreens",
+            "first_name": "",
+            "last_name": "",
+            "nice_name": "appstorescreens",
+            "URL": "http://tricountyrealestate.wordpress.com",
+            "avatar_URL": "https://0.gravatar.com/avatar/35029b2103460109f574c38dfeea5f3f?s=96&d=identicon&r=G",
+            "profile_URL": "https://en.gravatar.com/appstorescreens",
+            "site_ID": 181977606
+          },
+          "date": "2021-10-05T15:03:30+00:00",
+          "modified": "2021-10-05T15:04:51+00:00",
+          "title": "Easy Strawberry Cake",
+          "URL": "https://weekendbakesblog.wordpress.com/easy-strawberry-cake/",
+          "short_URL": "https://wp.me/pcjyGG-e",
+          "content": "<!-- wp:heading {\"level\":4} -->\n<h4>Ingredients List</h4>\n<!-- /wp:heading -->\n\n<!-- wp:list -->\n<ul><li>1 cup fresh or frozen blueberries</li><li>1 3/4 cup flour</li><li>2 tsp baking powder</li><li>3/4 cups sugar</li><li>1/4 cup canola oil</li><li>1 egg</li></ul>\n<!-- /wp:list -->",
+          "excerpt": "",
+          "slug": "easy-blueberry-muffins",
+          "guid": "https://weekendbakesblog.wordpress.com/?p=14",
+          "status": "draft",
+          "sticky": false,
+          "password": "",
+          "parent": false,
+          "type": "post",
+          "discussion": {
+            "comments_open": true,
+            "comment_status": "open",
+            "pings_open": true,
+            "ping_status": "open",
+            "comment_count": 0
+          },
+          "likes_enabled": true,
+          "sharing_enabled": true,
+          "like_count": 0,
+          "i_like": false,
+          "is_reblogged": false,
+          "is_following": true,
+          "global_ID": "33b4a6f0603d5c065b2e54737b34899c",
+          "featured_image": "",
+          "post_thumbnail": {
+            "ID": 238,
+            "URL": "https://mobiledotblog.files.wordpress.com/2022/08/4551182892_9b33f3bdfb_b.jpg",
+            "guid": "https://mobiledotblog.files.wordpress.com/2022/08/4551182892_9b33f3bdfb_b.jpg",
+            "mime_type": "image/jpeg",
+            "width": 4256,
+            "height": 2628
+          },
           "format": "standard",
           "geo": false,
           "menu_order": 0,

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/rest_v12_sites_181977606_posts-scheduled.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/posts/rest_v12_sites_181977606_posts-scheduled.json
@@ -1,0 +1,181 @@
+{
+  "request": {
+    "method": "GET",
+    "urlPath": "/rest/v1.2/sites/181977606/posts",
+    "queryParameters": {
+      "locale": {
+        "matches": "(.*)"
+      },
+      "context": {
+        "equalTo": "edit"
+      },
+      "meta": {
+        "equalTo": "autosave"
+      },
+      "number": {
+        "matches": "3|40"
+      },
+      "status": {
+        "equalTo": "future"
+      },
+      "type": {
+        "equalTo": "post"
+      }
+    }
+  },
+  "response": {
+    "status": 200,
+    "jsonBody": {
+      "found": 1,
+      "posts": [
+        {
+          "ID": 15,
+          "site_ID": 181977606,
+          "author": {
+            "ID": 152748359,
+            "login": "appstorescreens",
+            "email": "test@example.com",
+            "name": "appstorescreens",
+            "first_name": "",
+            "last_name": "",
+            "nice_name": "appstorescreens",
+            "URL": "http://tricountyrealestate.wordpress.com",
+            "avatar_URL": "https://0.gravatar.com/avatar/35029b2103460109f574c38dfeea5f3f?s=96&d=identicon&r=G",
+            "profile_URL": "https://en.gravatar.com/appstorescreens",
+            "site_ID": 181977606
+          },
+          "date": "{{now offset='+2 days'}}",
+          "modified": "2020-10-05T15:04:51+00:00",
+          "title": "Lemon Cheesecake Tartlets",
+          "URL": "https://weekendbakesblog.wordpress.com/easy-blueberry-muffins/",
+          "short_URL": "https://wp.me/pcjyGG-e",
+          "content": "<!-- wp:heading {\"level\":4} -->\n<h4>Ingredients</h4>\n<!-- /wp:heading -->\n\n<!-- wp:list -->\n<ul><li>1 cup fresh or frozen blueberries</li><li>1 3/4 cup flour</li><li>2 tsp baking powder</li><li>3/4 cups sugar</li><li>1/4 cup canola oil</li><li>1 egg</li></ul>\n<!-- /wp:list -->",
+          "excerpt": "",
+          "slug": "easy-blueberry-muffins",
+          "guid": "https://weekendbakesblog.wordpress.com/?p=14",
+          "status": "future",
+          "sticky": false,
+          "password": "",
+          "parent": false,
+          "type": "post",
+          "discussion": {
+            "comments_open": true,
+            "comment_status": "open",
+            "pings_open": true,
+            "ping_status": "open",
+            "comment_count": 0
+          },
+          "likes_enabled": true,
+          "sharing_enabled": true,
+          "like_count": 0,
+          "i_like": false,
+          "is_reblogged": false,
+          "is_following": true,
+          "global_ID": "33b4a6f0603d5c065b2e54737b34899d",
+          "featured_image": "",
+          "post_thumbnail": {
+            "ID": 238,
+            "URL": "https://mobiledotblog.files.wordpress.com/2022/08/4957581385_d7b5c6a8ac_b.jpg",
+            "guid": "https://mobiledotblog.files.wordpress.com/2022/08/4957581385_d7b5c6a8ac_b.jpg",
+            "mime_type": "image/jpeg",
+            "width": 4256,
+            "height": 2628
+          },
+          "format": "standard",
+          "geo": false,
+          "menu_order": 0,
+          "page_template": "",
+          "publicize_URLs": [
+
+          ],
+          "terms": {
+            "category": {
+              "Uncategorized": {
+                "ID": 1,
+                "name": "Uncategorized",
+                "slug": "uncategorized",
+                "description": "",
+                "post_count": 3,
+                "parent": 0,
+                "meta": {
+                  "links": {
+                    "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/categories/slug:uncategorized",
+                    "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/categories/slug:uncategorized/help",
+                    "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606"
+                  }
+                }
+              }
+            },
+            "post_tag": {
+            },
+            "post_format": {
+            },
+            "mentions": {
+            }
+          },
+          "tags": {
+          },
+          "categories": {
+            "Uncategorized": {
+              "ID": 1,
+              "name": "Uncategorized",
+              "slug": "uncategorized",
+              "description": "",
+              "post_count": 3,
+              "parent": 0,
+              "meta": {
+                "links": {
+                  "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/categories/slug:uncategorized",
+                  "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/categories/slug:uncategorized/help",
+                  "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606"
+                }
+              }
+            }
+          },
+          "attachments": {
+          },
+          "attachment_count": 0,
+          "metadata": [
+            {
+              "id": "142",
+              "key": "jabber_published",
+              "value": "1601910212"
+            },
+            {
+              "id": "148",
+              "key": "timeline_notification",
+              "value": "1601910213"
+            }
+          ],
+          "meta": {
+            "links": {
+              "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14",
+              "help": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/posts/14/help",
+              "site": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606",
+              "replies": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14/replies/",
+              "likes": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/181977606/posts/14/likes/"
+            }
+          },
+          "capabilities": {
+            "publish_post": true,
+            "delete_post": true,
+            "edit_post": true
+          },
+          "revisions": [
+            15
+          ],
+          "other_URLs": {
+            "permalink_URL": "https://weekendbakesblog.wordpress.com/2020/10/05/%postname%/",
+            "suggested_slug": "easy-blueberry-muffins"
+          }
+        }
+      ],
+      "meta": {
+        "links": {
+          "counts": "{{request.requestLine.baseUrl}}/rest/v1.2/sites/181977606/post-counts/post"
+        },
+        "wpcom": true
+      }
+    }
+  }
+}

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_sites_181977606.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v11_sites_181977606.json
@@ -142,7 +142,22 @@
         "import_engine": null,
         "is_pending_plan": false,
         "is_wpforteams_site": false,
-        "is_cloud_eligible": false
+        "is_cloud_eligible": false,
+        "blogging_prompts_settings": {
+          "prompts_reminders_opted_in": false,
+          "reminders_days": {
+            "monday": false,
+            "tuesday": false,
+            "wednesday": false,
+            "thursday": false,
+            "friday": false,
+            "saturday": false,
+            "sunday": false
+          },
+          "reminders_time": "10.00",
+          "is_potential_blogging_site": true,
+          "prompts_card_opted_in": true
+        }
       },
       "plan": {
         "product_id": 1,

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_blogging_prompts.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/rest_v2_sites_blogging_prompts.json
@@ -243,7 +243,7 @@
           "title": "Prompt number 219",
           "content": "<!-- wp:pullquote -->\n<figure class=\"wp-block-pullquote\"><blockquote><p>What's the most money you've ever spent on a meal? Was it worth it?</p></blockquote></figure>\n<!-- /wp:pullquote -->",
           "attribution": "",
-          "date": "2022-08-08",
+          "date": "{{now format='yyyy-MM-dd'}}",
           "answered": false,
           "answered_users_count": 0,
           "answered_users_sample": []

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_181977606_users.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/sites_181977606_users.json
@@ -1,0 +1,44 @@
+{
+    "request": {
+      "method": "GET",
+      "urlPattern": "/rest/v1.1/sites/181977606/users.*",
+      "queryParameters": {
+        "locale": {
+          "matches": "(.*)"
+        },
+        "authors_only": {
+          "equalTo": "1"
+        },
+        "number": {
+          "equalTo": "100"
+        }
+      }
+    },
+    "response": {
+      "status": 200,
+      "jsonBody": {
+        "found": 1,
+        "users": [
+          {
+            "ID": 152748359,
+            "login": "appstorescreens",
+            "email": "test@example.com",
+            "name": "appstorescreens",
+            "first_name": "",
+            "last_name": "",
+            "nice_name": "e2eflowtestingmobile",
+            "URL": "http://tricountyrealestate.wordpress.com",
+            "avatar_URL": "https://0.gravatar.com/avatar/35029b2103460109f574c38dfeea5f3f?s=96&d=identicon&r=G",
+            "profile_URL": "https://en.gravatar.com/appstorescreens",
+            "ip_address": "",
+            "site_ID": 181977606,
+            "site_visible": true,
+            "roles": [
+              "administrator"
+            ],
+            "is_super_admin": false
+          }
+        ]
+      }
+    }
+  }

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -24,7 +24,9 @@ class JetpackScreenshotGeneration: XCTestCase {
             XCUIDevice.shared.orientation = UIDeviceOrientation.portrait
         }
 
-        try LoginFlow.login(email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        try LoginFlow.login(email: WPUITestCredentials.testWPcomUserEmail,
+                            password: WPUITestCredentials.testWPcomPassword,
+                            selectedSiteTitle: "yourjetpack.blog")
     }
 
     override func tearDown() {
@@ -36,8 +38,6 @@ class JetpackScreenshotGeneration: XCTestCase {
     func testGenerateScreenshots() throws {
 
         let mySite = try MySiteScreen()
-            .showSiteSwitcher()
-            .switchToSite(withTitle: "yourjetpack.blog")
 
         // Open Home
         if XCUIDevice.isPad {

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -63,6 +63,11 @@ class JetpackScreenshotGeneration: XCTestCase {
 
         try chooseLayout.closeModal()
 
+        // Open Menu to be able to access stats
+        if XCUIDevice.isPhone {
+            mySite.goToMenu()
+        }
+
         // Get Stats screenshot
         let statsScreen = try mySite.goToStatsScreen()
         statsScreen

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -39,6 +39,11 @@ class JetpackScreenshotGeneration: XCTestCase {
             .showSiteSwitcher()
             .switchToSite(withTitle: "yourjetpack.blog")
 
+        // Open Home
+        if XCUIDevice.isPad {
+            mySite.goToHomeScreen()
+        }
+
         // Get Site Creation screenshot
         let mySitesScreen = try mySite.showSiteSwitcher()
         let siteIntentScreen = try mySitesScreen

--- a/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/LoginEpilogueScreen.swift
@@ -17,9 +17,14 @@ public class LoginEpilogueScreen: ScreenObject {
         )
     }
 
-    public func continueWithSelectedSite() throws -> MySiteScreen {
-        let firstSite = loginEpilogueTable.cells.element(boundBy: 2)
-        firstSite.tap()
+    public func continueWithSelectedSite(title: String? = nil) throws -> MySiteScreen {
+        if let title = title {
+            let selectedSite = loginEpilogueTable.cells[title]
+            selectedSite.tap()
+        } else {
+            let firstSite = loginEpilogueTable.cells.element(boundBy: 2)
+            firstSite.tap()
+        }
 
         try dismissQuickStartPromptIfNeeded()
         try dismissOnboardingQuestionsPromptIfNeeded()

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -15,6 +15,7 @@ private struct ElementStringIDs {
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
     static let switchSiteButton = "SwitchSiteButton"
+    static let dashboardButton = "Home Row"
 }
 
 /// The home-base screen for an individual site. Used in many of our UI tests.
@@ -46,6 +47,10 @@ public class MySiteScreen: ScreenObject {
 
     let switchSiteButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons[ElementStringIDs.switchSiteButton]
+    }
+
+    let homeButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells[ElementStringIDs.dashboardButton]
     }
 
     static var isVisible: Bool {
@@ -133,6 +138,10 @@ public class MySiteScreen: ScreenObject {
     public func goToCreateSheet() throws -> ActionSheetComponent {
         createButtonGetter(app).tap()
         return try ActionSheetComponent()
+    }
+
+    public func goToHomeScreen() {
+        homeButtonGetter(app).tap()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -16,6 +16,7 @@ private struct ElementStringIDs {
     static let ReaderButton = "Reader"
     static let switchSiteButton = "SwitchSiteButton"
     static let dashboardButton = "Home Row"
+    static let segmentedControlMenuButton = "Menu"
 }
 
 /// The home-base screen for an individual site. Used in many of our UI tests.
@@ -51,6 +52,10 @@ public class MySiteScreen: ScreenObject {
 
     let homeButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells[ElementStringIDs.dashboardButton]
+    }
+
+    let segmentedControlMenuButton: (XCUIApplication) -> XCUIElement = {
+        $0.buttons[ElementStringIDs.segmentedControlMenuButton]
     }
 
     static var isVisible: Bool {
@@ -142,6 +147,10 @@ public class MySiteScreen: ScreenObject {
 
     public func goToHomeScreen() {
         homeButtonGetter(app).tap()
+    }
+
+    public func goToMenu() {
+        segmentedControlMenuButton(app).tap()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/WordPressUITests/Flows/LoginFlow.swift
+++ b/WordPress/WordPressUITests/Flows/LoginFlow.swift
@@ -4,11 +4,11 @@ import XCTest
 class LoginFlow {
 
     @discardableResult
-    static func login(email: String, password: String) throws -> MySiteScreen {
+    static func login(email: String, password: String, selectedSiteTitle: String? = nil) throws -> MySiteScreen {
         return try PrologueScreen().selectContinue()
             .proceedWith(email: email)
             .proceedWith(password: password)
-            .continueWithSelectedSite()
+            .continueWithSelectedSite(title: selectedSiteTitle)
             .dismissNotificationAlertIfNeeded()
     }
 


### PR DESCRIPTION
Part of #18960
Ref: pcdRpT-DL-p2

## Description
This PR tweaks the screenshot generation UI test so that it shows the dashboard in some screenshots instead of stats.

## New iPad Screenshots

|1|2|3|4|5|
| - | - | - | - | - |
|<img width="1366" alt="iPad Pro (12 9-inch) (5th generation)-1-light-SiteCreation" src="https://user-images.githubusercontent.com/25306722/183329664-585ae144-4e58-4580-9fe6-2a198ee8db9b.png">|<img width="1366" alt="iPad Pro (12 9-inch) (5th generation)-2-light-CreateNew" src="https://user-images.githubusercontent.com/25306722/183329675-bf3906b5-905e-4550-b226-a7ba26972332.png">|<img width="1366" alt="iPad Pro (12 9-inch) (5th generation)-3-light-PageBuilder" src="https://user-images.githubusercontent.com/25306722/183329678-4569219a-8af1-46ab-b271-cce9554a13ae.png">|<img width="1366" alt="iPad Pro (12 9-inch) (5th generation)-4-light-Stats" src="https://user-images.githubusercontent.com/25306722/183329683-d5dbcf5d-a1d0-4c45-b49b-ee2d7281dd25.png">|<img width="1366" alt="iPad Pro (12 9-inch) (5th generation)-5-light-Notifications" src="https://user-images.githubusercontent.com/25306722/183329686-3345a6af-367b-4ae6-9591-336846dd373b.png">|


## Testing Instructions

1. Run `rake mocks`
2. Switch to the `JetpackScreenshotGeneration` target
3. Run `testGenerateScreenshots()` on an iPad simulator
4. Make sure the test passes and the dashboard is in the background of the first three screenshots

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.