### PR TITLE
Update WordPressAuthenticator in release 20.5

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -222,7 +222,7 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 2.0.0'
+  pod 'WordPressAuthenticator', '~> 2.0.1'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile
+++ b/Podfile
@@ -222,7 +222,7 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 2.1.0'
+  pod 'WordPressAuthenticator', '~> 2.1'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile
+++ b/Podfile
@@ -222,7 +222,7 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 2.0.1'
+  pod 'WordPressAuthenticator', '~> 2.1.0'
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :branch => ''
   # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # pod 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -603,7 +603,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 2.1.0)
+  - WordPressAuthenticator (~> 2.1)
   - WordPressKit (~> 4.57.0)
   - WordPressShared (~> 1.18.0)
   - WordPressUI (~> 1.12.5)
@@ -884,6 +884,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 6de269c9c15437b272a025a41941e8d00de0e6d0
+PODFILE CHECKSUM: b04afabe26bbaa890ee18a5c48d3b5faf73b8ebb
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -53,10 +53,10 @@ PODS:
     - GTMAppAuth (~> 1.0)
     - GTMSessionFetcher/Core (~> 1.1)
   - Gridicons (1.1.0)
-  - GTMAppAuth (1.2.2):
+  - GTMAppAuth (1.3.0):
     - AppAuth/Core (~> 1.4)
     - GTMSessionFetcher/Core (~> 1.5)
-  - GTMSessionFetcher/Core (1.7.0)
+  - GTMSessionFetcher/Core (1.7.2)
   - Gutenberg (1.81.0):
     - React (= 0.66.2)
     - React-CoreModules (= 0.66.2)
@@ -492,7 +492,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
     - WordPress-Aztec-iOS (= 1.19.8)
-  - WordPressAuthenticator (2.0.0):
+  - WordPressAuthenticator (2.0.1):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -603,7 +603,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 2.0.0)
+  - WordPressAuthenticator (~> 2.0.1)
   - WordPressKit (~> 4.57.0)
   - WordPressShared (~> 1.18.0)
   - WordPressUI (~> 1.12.5)
@@ -805,8 +805,8 @@ SPEC CHECKSUMS:
   glog: 67060cb66a7ea4b1e8947dc9936d7fce11b100b0
   GoogleSignIn: fd381840dbe7c1137aa6dc30849a5c3e070c034a
   Gridicons: 17d660b97ce4231d582101b02f8280628b141c9a
-  GTMAppAuth: ad5c2b70b9a8689e1a04033c9369c4915bfcbe89
-  GTMSessionFetcher: 43748f93435c2aa068b1cbe39655aaf600652e91
+  GTMAppAuth: 4d8f864896f3646f0c33baf38a28362f4c601e15
+  GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   Gutenberg: 831b17012a9ee05241917cb6968ac1e02becf78c
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
   Kanvas: 6355398addfc9856c27cc780cbf54df7cd822ab1
@@ -868,7 +868,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 5163f732e4e529781f931f158f54b1a1545bc536
+  WordPressAuthenticator: 7f41297c3ac33ff19a65cb84950c6260932e47c0
   WordPressKit: e0842cc41664fe93dbcb4c73c584f47ec7600a66
   WordPressShared: e5a479220643f46dc4d7726ef8dd45f18bf0c53b
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -884,6 +884,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: cd832a3c916ec8bca4c21865fb8672f67c671038
+PODFILE CHECKSUM: 32d92d73e9069f1ad3f6475602932fa67ea93cb1
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -492,7 +492,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
     - WordPress-Aztec-iOS (= 1.19.8)
-  - WordPressAuthenticator (2.0.1):
+  - WordPressAuthenticator (2.1.1):
     - Alamofire (~> 4.8)
     - CocoaLumberjack (~> 3.5)
     - GoogleSignIn (~> 6.0.1)
@@ -603,7 +603,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 2.0.1)
+  - WordPressAuthenticator (~> 2.1.0)
   - WordPressKit (~> 4.57.0)
   - WordPressShared (~> 1.18.0)
   - WordPressUI (~> 1.12.5)
@@ -868,7 +868,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: af4e11e25a2ea670078e2bd677bb0e8144f9f063
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 7f41297c3ac33ff19a65cb84950c6260932e47c0
+  WordPressAuthenticator: 6d8a091552644aebe38724b5df00b5d00137aa65
   WordPressKit: e0842cc41664fe93dbcb4c73c584f47ec7600a66
   WordPressShared: e5a479220643f46dc4d7726ef8dd45f18bf0c53b
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -884,6 +884,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 32d92d73e9069f1ad3f6475602932fa67ea93cb1
+PODFILE CHECKSUM: 6de269c9c15437b272a025a41941e8d00de0e6d0
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
Following up on [this comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/19161#discussion_r940090779) in the 20.5 code freeze PR, this PR updates WordPressAuthenticator to the latest stable version, 2.1.1.

I explained why I didn't upgrade during code freeze in [that comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/19161#discussion_r940090779). While working on this PR, I tried to verified that 2.1.1 respects SemVer and integrates well with WordPress.

I was in particular curious to see whether the "What is WordPress.com" button, a new > 2.0.0 feature, would have appeared. It did not, which is good.

In hindsight, I could have controlled the diff between versions to learn more about the new code's behavior, see [this code in particular](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/compare/2.0.0...2.1.1#diff-210c95513e5b99c278b3f3a3e55f7a360908b842305ce90cdadb6a15fbf01ebdR32-R36). Still, I think this was a useful exercise, even though a time consuming one.


**WordPress 20.5.0.0, running WordPressAuthenticator 2.0.0**

<img alt="IMG_4681" src="https://user-images.githubusercontent.com/1218433/183787790-23646152-0c76-44b2-ba85-5a104afb546c.PNG" width=300/>

**WordPress `pr19163-524e05d`, running WordPressAuthenticator 2.0.1**

<img alt="IMG_37B0E6C0ADF3-1" src="https://user-images.githubusercontent.com/1218433/183788743-e53d73d3-f995-4ce7-b8ab-986d3bcaaa14.jpeg" width=300/>

**WordPress `pr19163-3740c92 `, running WordPressAuthenticator 2.1.1**

<img alt="IMG_EED300D50FC3-1" src="https://user-images.githubusercontent.com/1218433/183809686-9c647aa0-e850-4ed5-9d41-d6cb6cf3821f.jpeg" width=300/>

**WooCommerce 9.8.0.0, running WordPressAuthenticator 2.1.1** notice the "What is WordPress.com" link

<img alt="IMG_4680" src="https://user-images.githubusercontent.com/1218433/183787895-f3c7c9e4-1c61-454e-bf4d-103ac723df5f.PNG" width=300/>


## Regression Notes
1. Potential unintended areas of impact - The authentication screen and flow
2. What I did to test those areas of impact (or what existing automated tests I relied on) – I tried to login and succeeded
3. What automated tests I added (or what prevented me from doing so) – N.A.

PR submission checklist:

- [x] I have completed the Regression Notes. – N.A.
- [x] I have considered adding unit tests for my changes. – N.A.
- [x] I have considered adding accessibility improvements for my changes. – N.A.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.
