### PR TITLE
[Jetpack] Reader -> Site search: Add Jetpack banner

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -26,6 +26,8 @@ class JetpackBannerView: UIView {
     }
 
     private func setup() {
+        translatesAutoresizingMaskIntoConstraints = false
+        heightAnchor.constraint(equalToConstant: JetpackBannerView.minimumHeight).isActive = true
         backgroundColor = Self.jetpackBannerBackgroundColor
 
         let jetpackButton = JetpackButton(style: .banner)
@@ -34,7 +36,6 @@ class JetpackBannerView: UIView {
         addSubview(jetpackButton)
 
         pinSubviewToSafeArea(jetpackButton)
-        jetpackButton.heightAnchor.constraint(greaterThanOrEqualToConstant: JetpackBannerView.minimumHeight).isActive = true
     }
 
     /// Preferred minimum height to be used for constraints

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -19,6 +19,8 @@ import UIKit
         configureJetpackBanner(stackView)
     }
 
+    // MARK: Configuration
+
     private func configureStackView(_ stackView: UIStackView) {
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -36,6 +38,10 @@ import UIKit
     }
 
     private func configureJetpackBanner(_ stackView: UIStackView) {
+        guard JetpackBrandingVisibility.all.enabled else {
+            return
+        }
+
         let jetpackBannerView = JetpackBannerView()
         stackView.addArrangedSubview(jetpackBannerView)
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -2,7 +2,8 @@ import Foundation
 import UIKit
 
 @objc class JetpackBannerWrapperViewController: UIViewController {
-    private var childVC: UIViewController?
+    /// The wrapped child view controller.
+    private(set) var childVC: UIViewController?
 
     @objc convenience init(childVC: UIViewController) {
         self.init()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -41,7 +41,10 @@ import Gridicons
 
     fileprivate var backgroundTapRecognizer: UITapGestureRecognizer!
     fileprivate var streamController: ReaderStreamViewController?
-    fileprivate var siteSearchController = ReaderSiteSearchViewController()
+    fileprivate lazy var jpSiteSearchController = JetpackBannerWrapperViewController(childVC: ReaderSiteSearchViewController())
+    fileprivate var siteSearchController: ReaderSiteSearchViewController? {
+        return jpSiteSearchController.childVC as? ReaderSiteSearchViewController
+    }
     fileprivate let searchBarSearchIconSize = CGFloat(13.0)
     fileprivate var suggestionsController: ReaderSearchSuggestionsViewController?
     fileprivate var restoredSearchTopic: ReaderSearchTopic?
@@ -231,25 +234,25 @@ import Gridicons
     }
 
     private func configureSiteSearchViewController() {
-        siteSearchController.view.translatesAutoresizingMaskIntoConstraints = false
+        jpSiteSearchController.view.translatesAutoresizingMaskIntoConstraints = false
 
-        addChild(siteSearchController)
+        addChild(jpSiteSearchController)
 
-        view.addSubview(siteSearchController.view)
+        view.addSubview(jpSiteSearchController.view)
         NSLayoutConstraint.activate([
-            view.leadingAnchor.constraint(equalTo: siteSearchController.view.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: siteSearchController.view.trailingAnchor),
-            filterBar.bottomAnchor.constraint(equalTo: siteSearchController.view.topAnchor),
-            view.bottomAnchor.constraint(equalTo: siteSearchController.view.bottomAnchor),
+            view.leadingAnchor.constraint(equalTo: jpSiteSearchController.view.leadingAnchor),
+            view.trailingAnchor.constraint(equalTo: jpSiteSearchController.view.trailingAnchor),
+            filterBar.bottomAnchor.constraint(equalTo: jpSiteSearchController.view.topAnchor),
+            view.bottomAnchor.constraint(equalTo: jpSiteSearchController.view.bottomAnchor),
             ])
 
-        siteSearchController.didMove(toParent: self)
+        jpSiteSearchController.didMove(toParent: self)
 
         if let topic = restoredSearchTopic {
-            siteSearchController.searchQuery = topic.title
+            siteSearchController?.searchQuery = topic.title
         }
 
-        siteSearchController.view.isHidden = true
+        jpSiteSearchController.view.isHidden = true
     }
 
     // MARK: - Actions
@@ -304,7 +307,7 @@ import Gridicons
     }
 
     private func performSitesSearch(for query: String) {
-        siteSearchController.searchQuery = query
+        siteSearchController?.searchQuery = query
     }
 
 
@@ -318,10 +321,10 @@ import Gridicons
         switch section {
         case .posts:
             streamController?.view.isHidden = false
-            siteSearchController.view.isHidden = true
+            jpSiteSearchController.view.isHidden = true
         case .sites:
             streamController?.view.isHidden = true
-            siteSearchController.view.isHidden = false
+            jpSiteSearchController.view.isHidden = false
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 /// Displays search results from a reader site search.
 ///
@@ -50,6 +51,10 @@ class ReaderSiteSearchViewController: UITableViewController, UIViewControllerRes
                                coder: NSCoder) -> UIViewController? {
         return ReaderSiteSearchViewController()
     }
+
+    // MARK: - JPScrollViewDelegate
+
+    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
 
     // MARK: - View lifecycle
 
@@ -399,5 +404,13 @@ class ReaderSiteSearchFooterView: UIView {
             frame.size.height = collapsedHeaderFooterHeight
             delegate?.readerSiteSearchFooterViewDidChangeFrame(self)
         }
+    }
+}
+
+// MARK: - JPScrollViewDelegate
+
+extension ReaderSiteSearchViewController: JPScrollViewDelegate {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
     }
 }


### PR DESCRIPTION
## Description

This PR:
- Fixes #19129
- Fixes a constraint conflict that would occur when showing the banner as an [input accessory view](https://github.com/wordpress-mobile/WordPress-iOS/blob/feature/jetpack-banner-site-search/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift#L192)
- Adds the ability to access (get only) the child view controller wrapped by a `JetpackBannerWrapperViewController`

## Testing

### Banner shows on Reader site search
1. Using the WordPress app, go to Reader
2. Open Reader search by tapping the magnifying glass icon
3. Search for something (e.g. "test")
4. Tap the "Sites" tab
5. **Expect** the Jetpack banner to be shown and it shows / hides when the view is scrolled

**Note:** The banner shown in the Sites tab and Posts tab are independent and won't necessary have matching visibility. For instance, if the Posts results are scrolled down and the banner is hiding, it may show again when tapping the Sites tab.

### The Jetpack banner doesn't appear when searching in landscape
1. Using the WordPress app, go to Reader
2. Open Reader search by tapping the magnifying glass icon
3. Rotate the device to landscape
4. Tap the input field so the device's keyboard is shown
5. **Expect** the Jetpack banner to not be shown above the keyboard

### Items to consider testing
- a11y / VoiceOver / Dynamic Type
- Dark / Light mode
- Portrait / Landscape
- Jetpack / WordPress app

## Regression Notes
1. Potential unintended areas of impact
    - Any place where the banner is shown: Reader, Notifications, Stats, Jetpack Activity Log

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
