### PR TITLE
Remove an unit test that doesn't test our code

### DIFF
--- a/WordPress/WordPressTest/CoreDataMigrationTests.m
+++ b/WordPress/WordPressTest/CoreDataMigrationTests.m
@@ -32,42 +32,6 @@
     XCTAssertNotNil(url);
 }
 
-- (void)testMigrate19to21Failure
-{
-    NSURL *model19Url = [self urlForModelName:@"WordPress 19" inDirectory:nil];
-    NSURL *model21Url = [self urlForModelName:@"WordPress 21" inDirectory:nil];
-    NSURL *storeUrl = [self urlForStoreWithName:@"WordPress20.sqlite"];
-    NSManagedObjectModel *model = [[NSManagedObjectModel alloc] initWithContentsOfURL:model19Url];
-    NSPersistentStoreCoordinator *psc = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    
-    NSDictionary *options = @{
-                              NSInferMappingModelAutomaticallyOption            : @(YES),
-                              NSMigratePersistentStoresAutomaticallyOption    : @(YES)
-                              };
-    
-    NSError *error = nil;
-    NSPersistentStore * ps = [psc addPersistentStoreWithType:NSSQLiteStoreType
-                                    configuration:nil
-                                              URL:storeUrl
-                                          options:options
-                                            error:&error];
-    
-    XCTAssertNotNil(ps);
-    //make sure we remove the persistent store to make sure it releases the file.
-    [psc removePersistentStore:ps error:&error];
-    
-    psc = nil;
-    model = [[NSManagedObjectModel alloc] initWithContentsOfURL:model21Url];
-    psc = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:model];
-    NSPersistentStore * psFail = [psc addPersistentStoreWithType:NSSQLiteStoreType
-                               configuration:nil
-                                         URL:storeUrl
-                                     options:options
-                                       error:&error];
-    
-    XCTAssertNil(psFail);
-}
-
 - (void)testMigrate19to21Success {
     NSURL *model19Url = [self urlForModelName:@"WordPress 19" inDirectory:nil];
     NSURL *model21Url = [self urlForModelName:@"WordPress 21" inDirectory:nil];


### PR DESCRIPTION
This PR removes the unit test `testMigrate19to21Failure` for a few reasons:

1. The use case—migrating database from version 19 to 21—isn't going to happen in reality, maybe 8 years ago, but not now.
1. It tests the Core Data built-in migration logic, but doesn't test any of our code.
1. This test fails in Xcode 14 beta. I havn't looked further into the failure, maybe CoreData fixed an bug in its migration logic? Or, maybe it's a bug in Xcode 14 beta.

## Regression Notes
No regression needed, since this PR only changes unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
