### PR TITLE
Add a new Core Data write API

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -16,6 +16,8 @@ FOUNDATION_EXTERN NSString * const ContextManagerModelNameCurrent;
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
+- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
+- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion;
 @end
 
 @interface ContextManager : NSObject <CoreDataStack>

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -195,6 +195,26 @@ static ContextManager *_instance;
     }];
 }
 
+- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock
+{
+    NSManagedObjectContext *context = [self newDerivedContext];
+    [context performBlockAndWait:^{
+        aBlock(context);
+
+        [self saveContextAndWait:context];
+    }];
+}
+
+- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion
+{
+    NSManagedObjectContext *context = [self newDerivedContext];
+    [context performBlock:^{
+        aBlock(context);
+
+        [self saveContext:context andWait:NO withCompletionBlock:completion];
+    }];
+}
+
 
 #pragma mark - Setup
 

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -141,6 +141,73 @@ class ContextManagerTests: XCTestCase {
         }
     }
 
+    func testSaveUsingBlock() async {
+        let contextManager = ContextManagerMock()
+        let numberOfAccounts: () -> Int = {
+            contextManager.mainContext.countObjects(ofType: WPAccount.self)
+        }
+        XCTAssertEqual(numberOfAccounts(), 0)
+
+        await contextManager.save { context in
+            let account = WPAccount(context: context)
+            account.userID = 1
+            account.username = "First User"
+        }
+        XCTAssertEqual(numberOfAccounts(), 1)
+
+        // In the translated Swift API of `ContextManager`, there are two `save(_: (NSManagedContext) -> Void)`
+        // functions. The only difference between them is, one is async function, the other is not.
+        // When compiling statement `try save { context in doSomething(context) }`, Swift picks which overload to use
+        // based on the context—there is no syntax or keyword to explicitly pick one ourselves.
+        //
+        // From: https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md#overloading-and-overload-resolution
+        // > "In non-async functions, and closures without any await expression, the compiler selects the non-async overload"
+        let sync: () -> Void = {
+            contextManager.save { context in
+                let account = WPAccount(context: context)
+                account.userID = 2
+                account.username = "Second User"
+            }
+        }
+        sync()
+
+        XCTAssertEqual(numberOfAccounts(), 2)
+    }
+
+    func testSaveUsingBlockWithNestedCalls() {
+        let contextManager = ContextManagerMock()
+        let accounts: () -> Set<String> = {
+            let all = (try? contextManager.mainContext.fetch(NSFetchRequest<WPAccount>(entityName: "Account"))) ?? []
+            return Set(all.map { $0.username! })
+        }
+        XCTAssertTrue(accounts().isEmpty)
+
+        let saveOperations = [
+            self.expectation(description: "First User is saved"),
+            self.expectation(description: "Second User is saved"),
+        ]
+
+        contextManager.save {
+            let account = WPAccount(context: $0)
+            account.userID = 1
+            account.username = "First User"
+
+            contextManager.save {
+                let account = WPAccount(context: $0)
+                account.userID = 2
+                account.username = "Second User"
+            }
+            saveOperations[1].fulfill()
+
+            XCTAssertEqual(accounts(), ["Second User"])
+        } completion: {
+            saveOperations[0].fulfill()
+        }
+
+        wait(for: saveOperations, timeout: 0.1)
+        XCTAssertEqual(accounts(), ["First User", "Second User"])
+    }
+
     private func newAccountInContext(context: NSManagedObjectContext) -> WPAccount {
         let account = NSEntityDescription.insertNewObject(forEntityName: "Account", into: context) as! WPAccount
         account.username = "username"


### PR DESCRIPTION
Fixes #15821

This change is part of paaHJt-1I7-p2. This PR only introduces the new write API and doesn't update the app code to use it.

Two functions are introduced in `ContextManager`; one is a synchronous call, and the other is an asynchronous call. I'm aware this doesn't follow the existing pattern: `saveContext:` and `saveContextAndWait:`. The fact that `saveUsingBlock:` doesn't take a completion block implies it's synchronous. I'm keen to hear what you all think about these new functions. Does it simplify the API, or on the contrary, make the API confusing?

The implementation of both functions reuses the existing saving context method to ensure database changes are propagated through to the `mainContext` and `writerContext`.

## Regression Notes
No regression needed, since no app code uses this new API yet.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.