### PR TITLE
App Store Screenshots: Optimize Jetpack screenshots lane

### DIFF
--- a/fastlane/lanes/screenshots.rb
+++ b/fastlane/lanes/screenshots.rb
@@ -65,10 +65,12 @@ platform :ios do
       end
     end
 
+    dark_mode_values = options[:skip_dark_mode] ? [false] : [true, false]
+
     UI.message "--- Generating screenshots for the following languages: #{languages}"
 
     create_missing_simulators_for_screenshots
-    [true, false].each do |dark_mode_enabled|
+    dark_mode_values.each do |dark_mode_enabled|
       capture_ios_screenshots(
         workspace: WORKSPACE_PATH,
         scheme: scheme,
@@ -99,7 +101,8 @@ platform :ios do
       scheme: 'JetpackScreenshotGeneration',
       output_directory: File.join(Dir.pwd, '/jetpack_screenshots'),
       language: options[:language],
-      skip_clean: options[:skip_clean]
+      skip_clean: options[:skip_clean],
+      skip_dark_mode: true
     )
   end
 


### PR DESCRIPTION
## Description
The screenshots lane generates screenshots for both light and dark modes by default. The jetpack screenshots lane uses this lane, however for Jetpack (unlike WordPress) we only need light mode screenshots. This means half the time consumed by the JP screenshots lane is unnecessary.

This PR tweaks the screenshot lane to support skipping dark mode. And updates the Jetpack screenshots lane to make use of this new option. In turn, cutting the lane's execution time in half 🎉 

## Testing Instructions

_Given the limited scope of the changes, testing may not be required. But here are the instructions either way._

1. Modify `SCREENSHOT_SIMULATORS` in `screenshots.rb` to have only one simulator. (This is only to save time)
2. Clear the `fastlane/jetpack_screenshots` and `fastlane/screenshots` folders
3. Run `rake mocks`
4. Run `bundle exec fastlane jetpack_screenshots language:en-US skip_clean:true`
5. Check `fastlane/jetpack_screenshots` for the generated Jetpack screenshots. Make sure only light mode screenshots were generated.
6. Run `bundle exec fastlane screenshots language:en-US skip_clean:true`
7. Check `fastlane/screenshots` for the generated WordPress screenshots. Make sure both light and dark mode screenshots were generated.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.