### PR TITLE
Add branch condition for slack message

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -68,7 +68,7 @@ steps:
       - slack:
           channels:
             - "#mobile-apps-tests-notif"
-        if: build.state == "failed"
+        if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # UI Tests
@@ -88,7 +88,7 @@ steps:
           - slack:
               channels:
                 - "#mobile-apps-tests-notif"
-            if: build.state == "failed"
+            if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
@@ -103,7 +103,7 @@ steps:
           - slack:
               channels:
                 - "#mobile-apps-tests-notif"
-            if: build.state == "failed"
+            if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # Linters


### PR DESCRIPTION
**What does this do:**
Currently, the Slack message that is sent to the channel includes non-trunk builds as well. Since the YAML file configuration takes precedence over the settings (see: [this](https://buildkite.com/docs/integrations/slack#adding-a-notification-service)), we need to add the branch condition as well.
