### PR TITLE
[Pages List] Fix app freeze when loading page with GIF as its featured image

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 20.6
 -----
 * [*] [Jetpack-only] Recommend App: you can now share the Jetpack app with your friends. [#19174]
+* [*] Pages List: Fixed an issue where the app would freeze when opening the pages list if one of the featured images is a GIF. [#19184]
 
 
 20.5

--- a/WordPress/Classes/Networking/MediaHost+Blog.swift
+++ b/WordPress/Classes/Networking/MediaHost+Blog.swift
@@ -9,9 +9,14 @@ extension MediaHost {
     }
 
     init(with blog: Blog, failure: (BlogError) -> ()) {
+        let isAtomic = blog.isAtomic()
+        self.init(with: blog, isAtomic: isAtomic, failure: failure)
+    }
+
+    init(with blog: Blog, isAtomic: Bool, failure: (BlogError) -> ()) {
         self.init(isAccessibleThroughWPCom: blog.isAccessibleThroughWPCom(),
             isPrivate: blog.isPrivate(),
-            isAtomic: blog.isAtomic(),
+            isAtomic: isAtomic,
             siteID: blog.dotComID?.intValue,
             username: blog.usernameForSite,
             authToken: blog.authToken,

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -322,7 +322,7 @@ extension ImageLoader {
     ///   - media: The media object
     ///   - placeholder: A placeholder to show while the image is loading.
     ///   - size: The preferred size of the image to load.
-    ///   - isBlogAtomic: Whether the blog associated to the media item is Atomic of not
+    ///   - isBlogAtomic: Whether the blog associated to the media item is Atomic or not
     ///   - success: A closure to be called if the image was loaded successfully.
     ///   - error: A closure to be called if there was an error loading the image.
     ///

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -314,7 +314,7 @@ import AutomatticTracks
 // MARK: - Loading Media object
 
 extension ImageLoader {
-    @objc(loadImageFromMedia:preferredSize:placeholder:success:error:)
+    @objc(loadImageFromMedia:preferredSize:placeholder:isBlogAtomic:success:error:)
     /// Load an image from the given Media object. If it's a gif, it will animate it.
     /// For any other type of media, this will load the corresponding static image.
     ///
@@ -322,10 +322,16 @@ extension ImageLoader {
     ///   - media: The media object
     ///   - placeholder: A placeholder to show while the image is loading.
     ///   - size: The preferred size of the image to load.
+    ///   - isBlogAtomic: Whether the blog associated to the media item is Atomic of not
     ///   - success: A closure to be called if the image was loaded successfully.
     ///   - error: A closure to be called if there was an error loading the image.
     ///
-    func loadImage(media: Media, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
+    func loadImage(media: Media,
+                   preferredSize size: CGSize = .zero,
+                   placeholder: UIImage?,
+                   isBlogAtomic: Bool,
+                   success: ImageLoaderSuccessBlock?,
+                   error: ImageLoaderFailureBlock?) {
         guard let mediaId = media.mediaID?.stringValue else {
             let error = createError(description: "The Media id doesn't exist")
             callErrorHandler(with: error)
@@ -342,7 +348,7 @@ extension ImageLoader {
                     if let fetchedMedia = fetchedMedia,
                         let fetchedMediaId = fetchedMedia.mediaID?.stringValue, fetchedMediaId == mediaId {
                         DispatchQueue.main.async {
-                            self?.loadImage(media: fetchedMedia, preferredSize: size, placeholder: placeholder, success: success, error: error)
+                            self?.loadImage(media: fetchedMedia, preferredSize: size, placeholder: placeholder, isBlogAtomic: isBlogAtomic, success: success, error: error)
                         }
                     } else {
                         self?.callErrorHandler(with: fetchedMediaError)
@@ -357,7 +363,7 @@ extension ImageLoader {
         }
 
         if url.isGif {
-            let host = MediaHost(with: media.blog) { error in
+            let host = MediaHost(with: media.blog, isAtomic: isBlogAtomic) { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
                 WordPressAppDelegate.crashLogging?.logError(error)
             }

--- a/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Cells/MediaItemTableViewCells.swift
@@ -216,7 +216,8 @@ struct MediaImageRow: ImmuTableRow {
     }
 
     private func loadImageFor(_ cell: MediaItemImageTableViewCell) {
-        cell.imageLoader.loadImage(media: media, placeholder: placeholderImage, success: nil) { (error) in
+        let isBlogAtomic = media.blog.isAtomic()
+        cell.imageLoader.loadImage(media: media, placeholder: placeholderImage, isBlogAtomic: isBlogAtomic, success: nil) { (error) in
             self.show(error)
         }
     }

--- a/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageListTableViewCell.m
@@ -193,11 +193,13 @@ static CGFloat const FeaturedImageSize = 120.0;
     BOOL hideFeaturedImage = page.featuredImage == nil;
     self.featuredImageView.hidden = hideFeaturedImage;
     self.labelsContainerTrailing.active = !hideFeaturedImage;
+    BOOL isBlogAtomic = [page.featuredImage.blog isAtomic];
     
     if (!hideFeaturedImage) {
         [self.featuredImageLoader loadImageFromMedia:page.featuredImage
                                        preferredSize:CGSizeMake(FeaturedImageSize, FeaturedImageSize)
                                          placeholder:nil
+                                        isBlogAtomic:isBlogAtomic
                                              success:nil
                                                error:^(NSError *error) {
                                                    DDLogError(@"Failed to load the media: %@", error);

--- a/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/WPImageViewController.m
@@ -281,7 +281,8 @@ static CGFloat const MinimumZoomScale = 0.1;
     self.imageView.image = self.image;
     self.isLoadingImage = YES;
     __weak __typeof__(self) weakSelf = self;
-    [self.imageLoader loadImageFromMedia:self.media preferredSize:CGSizeZero placeholder:self.image success:^{
+    BOOL isBlogAtomic = [self.media.blog isAtomic];
+    [self.imageLoader loadImageFromMedia:self.media preferredSize:CGSizeZero placeholder:self.image isBlogAtomic:isBlogAtomic success:^{
         weakSelf.isLoadingImage = NO;
         weakSelf.image = weakSelf.imageView.image;
         [weakSelf updateImageView];


### PR DESCRIPTION
Fixes #19183

## Description
Pages list page freezes if a page has a GIF as a featured image.

## Root Cause
The issue was a threading deadlock.
- `ImageLoader.loadImage` gets called from main thread
- Inside of it, `MediaThumbnailCoordinator.shared.fetchStubMedia` gets called
- Which fetches the media from the API and then performs an **async** block on a `NSManagedObjectContext`'s thread
- This block calls the completion handler, which in turn propagates back to `ImageLoader.loadImage`
- `ImageLoader.loadImage` calls `ImageLoader.loadImage` on the main thread (line 351) but this time it goes down a different a different path
- This path leads to `Blog.isAtomic()` being called (from `MediaHost.init()`) which runs a **sync** block on the same `NSManagedObjectContext` thread
- The two blocks form a deadlock

## Solution
Call `Blog.isAtomic()` before anything else, and pass the value directly to `MediaHost.init()`

## Testing Instructions

1. Upload a GIF to the media library
2. Create a new page and set its featured image to the GIF
3. Run the app
4. Navigate to pages
5. Make sure the app doesn't freeze and GIF is loaded normally

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.