### PR TITLE
Adopt the new Core Data writer API

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -330,13 +330,14 @@ private extension BloggingPromptsService {
     /// - Parameters:
     ///   - remoteSettings: The blogging prompt settings from the remote.
     ///   - completion: Closure to be called on completion.
-    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @MainActor @escaping () -> Void) {
-        Task {
-            await contextManager.save { derivedContext in
-                let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
-                settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
+    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping () -> Void) {
+        contextManager.save { derivedContext in
+            let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
+            settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
+        } completion: {
+            DispatchQueue.main.async {
+                completion()
             }
-            await completion()
         }
     }
 

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -331,7 +331,7 @@ private extension BloggingPromptsService {
     ///   - remoteSettings: The blogging prompt settings from the remote.
     ///   - completion: Closure to be called on completion.
     func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping () -> Void) {
-        contextManager.save { derivedContext in
+        contextManager.performAndSave { derivedContext in
             let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
             settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
         } completion: {

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -330,17 +330,13 @@ private extension BloggingPromptsService {
     /// - Parameters:
     ///   - remoteSettings: The blogging prompt settings from the remote.
     ///   - completion: Closure to be called on completion.
-    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @escaping () -> Void) {
-        let derivedContext = contextManager.newDerivedContext()
-        derivedContext.perform {
-            let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
-            settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
-
-            self.contextManager.save(derivedContext) {
-                DispatchQueue.main.async {
-                    completion()
-                }
+    func saveSettings(_ remoteSettings: RemoteBloggingPromptsSettings, completion: @MainActor @escaping () -> Void) {
+        Task {
+            await contextManager.save { derivedContext in
+                let settings = self.loadSettings(context: derivedContext) ?? BloggingPromptSettings(context: derivedContext)
+                settings.configure(with: remoteSettings, siteID: self.siteID.int32Value, context: derivedContext)
             }
+            await completion()
         }
     }
 

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -94,17 +94,15 @@ private extension CommentService {
             return
         }
 
-        Task {
-            await ContextManager.shared.save { derivedContext in
-                let likers = remoteLikeUsers.map { remoteUser in
-                    LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
-                }
-
-                if purgeExisting {
-                    self.deleteExistingUsersFor(commentID: commentID, siteID: siteID, from: derivedContext, likesToKeep: likers)
-                }
+        ContextManager.shared.save { derivedContext in
+            let likers = remoteLikeUsers.map { remoteUser in
+                LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }
 
+            if purgeExisting {
+                self.deleteExistingUsersFor(commentID: commentID, siteID: siteID, from: derivedContext, likesToKeep: likers)
+            }
+        } completion: {
             DispatchQueue.main.async {
                 onComplete()
             }

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -90,7 +90,9 @@ private extension CommentService {
 
         guard let remoteLikeUsers = remoteLikeUsers,
               !remoteLikeUsers.isEmpty else {
-            onComplete()
+            DispatchQueue.main.async {
+                onComplete()
+            }
             return
         }
 

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -94,7 +94,7 @@ private extension CommentService {
             return
         }
 
-        ContextManager.shared.save { derivedContext in
+        ContextManager.shared.performAndSave { derivedContext in
             let likers = remoteLikeUsers.map { remoteUser in
                 LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }

--- a/WordPress/Classes/Services/LikeUserHelpers.swift
+++ b/WordPress/Classes/Services/LikeUserHelpers.swift
@@ -59,7 +59,7 @@ import CoreData
     }
 
     class func purgeStaleLikes() {
-        ContextManager.shared.save {
+        ContextManager.shared.performAndSave {
             purgeStaleLikes(fromContext: $0)
         }
     }

--- a/WordPress/Classes/Services/LikeUserHelpers.swift
+++ b/WordPress/Classes/Services/LikeUserHelpers.swift
@@ -59,11 +59,8 @@ import CoreData
     }
 
     class func purgeStaleLikes() {
-        let derivedContext = ContextManager.shared.newDerivedContext()
-
-        derivedContext.perform {
-            purgeStaleLikes(fromContext: derivedContext)
-            ContextManager.shared.save(derivedContext)
+        ContextManager.shared.save {
+            purgeStaleLikes(fromContext: $0)
         }
     }
 

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -236,10 +236,7 @@ extension PlanService {
 
 struct PlanStorage {
     static func activatePlan(_ planID: Int, forSite siteID: Int) {
-        let manager = ContextManager.sharedInstance()
-        let context = manager.newDerivedContext()
-
-        context.performAndWait {
+        ContextManager.shared.save { context in
             guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to activate a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)
@@ -248,16 +245,12 @@ struct PlanStorage {
             }
             if blog.planID?.intValue != planID {
                 blog.planID = NSNumber(value: planID)
-                manager.saveContextAndWait(context)
             }
         }
     }
 
     static func updateHasDomainCredit(_ planID: Int, forSite siteID: Int, hasDomainCredit: Bool) {
-        let manager = ContextManager.sharedInstance()
-        let context = manager.newDerivedContext()
-
-        context.performAndWait {
+        ContextManager.shared.save { context in
             guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to update a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)
@@ -266,7 +259,6 @@ struct PlanStorage {
             }
             if blog.hasDomainCredit != hasDomainCredit {
                 blog.hasDomainCredit = hasDomainCredit
-                manager.saveContextAndWait(context)
             }
         }
     }

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -236,7 +236,7 @@ extension PlanService {
 
 struct PlanStorage {
     static func activatePlan(_ planID: Int, forSite siteID: Int) {
-        ContextManager.shared.save { context in
+        ContextManager.shared.performAndSave { context in
             guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to activate a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)
@@ -250,7 +250,7 @@ struct PlanStorage {
     }
 
     static func updateHasDomainCredit(_ planID: Int, forSite siteID: Int, hasDomainCredit: Bool) {
-        ContextManager.shared.save { context in
+        ContextManager.shared.performAndSave { context in
             guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
                 let error = "Tried to update a plan for a non-existing site (ID: \(siteID))"
                 assertionFailure(error)

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -94,17 +94,15 @@ private extension PostService {
             return
         }
 
-        Task {
-            await ContextManager.shared.save { derivedContext in
-                let likers = remoteLikeUsers.map { remoteUser in
-                    LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
-                }
-
-                if purgeExisting {
-                    self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext, likesToKeep: likers)
-                }
+        ContextManager.shared.save { derivedContext in
+            let likers = remoteLikeUsers.map { remoteUser in
+                LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }
 
+            if purgeExisting {
+                self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext, likesToKeep: likers)
+            }
+        } completion: {
             DispatchQueue.main.async {
                 onComplete()
             }

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -94,7 +94,7 @@ private extension PostService {
             return
         }
 
-        ContextManager.shared.save { derivedContext in
+        ContextManager.shared.performAndSave { derivedContext in
             let likers = remoteLikeUsers.map { remoteUser in
                 LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -90,7 +90,9 @@ private extension PostService {
 
         guard let remoteLikeUsers = remoteLikeUsers,
               !remoteLikeUsers.isEmpty else {
-            onComplete()
+            DispatchQueue.main.async {
+                onComplete()
+            }
             return
         }
 

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -94,22 +94,19 @@ private extension PostService {
             return
         }
 
-        let derivedContext = ContextManager.shared.newDerivedContext()
-
-        derivedContext.perform {
-
-            let likers = remoteLikeUsers.map { remoteUser in
-                LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
-            }
-
-            if purgeExisting {
-                self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext, likesToKeep: likers)
-            }
-
-            ContextManager.shared.save(derivedContext) {
-                DispatchQueue.main.async {
-                    onComplete()
+        Task {
+            await ContextManager.shared.save { derivedContext in
+                let likers = remoteLikeUsers.map { remoteUser in
+                    LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
                 }
+
+                if purgeExisting {
+                    self.deleteExistingUsersFor(postID: postID, siteID: siteID, from: derivedContext, likesToKeep: likers)
+                }
+            }
+
+            DispatchQueue.main.async {
+                onComplete()
             }
         }
     }

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -16,8 +16,8 @@ FOUNDATION_EXTERN NSString * const ContextManagerModelNameCurrent;
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;
-- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
-- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion;
+- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
+- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion;
 @end
 
 @interface ContextManager : NSObject <CoreDataStack>

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -195,7 +195,7 @@ static ContextManager *_instance;
     }];
 }
 
-- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock
+- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock
 {
     NSManagedObjectContext *context = [self newDerivedContext];
     [context performBlockAndWait:^{
@@ -205,7 +205,7 @@ static ContextManager *_instance;
     }];
 }
 
-- (void)saveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion
+- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion
 {
     NSManagedObjectContext *context = [self newDerivedContext];
     [context performBlock:^{

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -148,7 +148,7 @@ class ContextManagerTests: XCTestCase {
         }
         XCTAssertEqual(numberOfAccounts(), 0)
 
-        await contextManager.save { context in
+        await contextManager.performAndSave { context in
             let account = WPAccount(context: context)
             account.userID = 1
             account.username = "First User"
@@ -163,7 +163,7 @@ class ContextManagerTests: XCTestCase {
         // From: https://github.com/apple/swift-evolution/blob/main/proposals/0296-async-await.md#overloading-and-overload-resolution
         // > "In non-async functions, and closures without any await expression, the compiler selects the non-async overload"
         let sync: () -> Void = {
-            contextManager.save { context in
+            contextManager.performAndSave { context in
                 let account = WPAccount(context: context)
                 account.userID = 2
                 account.username = "Second User"
@@ -187,12 +187,12 @@ class ContextManagerTests: XCTestCase {
             self.expectation(description: "Second User is saved"),
         ]
 
-        contextManager.save {
+        contextManager.performAndSave {
             let account = WPAccount(context: $0)
             account.userID = 1
             account.username = "First User"
 
-            contextManager.save {
+            contextManager.performAndSave {
                 let account = WPAccount(context: $0)
                 account.userID = 2
                 account.username = "Second User"


### PR DESCRIPTION
This PR is part of #15830.

### Changes

This PR replaces a few usages of `newDerivedContext` with the new writer API introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/19169.

In this PR, I've taken advantage of the nicely translated `async` function of the new writer API. The async version of new writer API is wrapped inside `Task`, to avoid the "async" syntax being exposed further up the call tree. Mainly because I'm not familiar with the codebase and I worry too many code path changes(i.e. when the completion block argument is getting called, immediately, or in an async way) may cause issues.

### Test instructions

_I think_ (according to my understanding of the codebase, not the product...), here is a list of area that are changed in this PR. To test, make sure they are working as expected:
* blogging prompts settings are reflected in the app.
* The users that liked a comment or a post can be displayed (i.e. from an "a user liked your comment" notification).
* Staled likes(the ones that are 7 days old?) are not displayed on posts or comments.
* The app enables and disables features based on the logged in WP.com user's plan.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
* View comments and posts likes.
* Premium theme is available for my blog which is on Pro plan.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
