### PR TITLE
Adopt the new Core Data writer API part 2

### DIFF
--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -286,37 +286,30 @@ private extension BloggingPromptsService {
         let fetchRequest = BloggingPrompt.fetchRequest()
         fetchRequest.predicate = predicate
 
-        Task {
-            do {
-                try await contextManager.save { derivedContext in
-                    var foundExistingIDs = [Int32]()
-                    let results = try derivedContext.fetch(fetchRequest)
-                    results.forEach { prompt in
-                        guard let remotePrompt = remotePromptsDictionary[prompt.promptID] else {
-                            return
-                        }
+        contextManager.performAndSave { derivedContext in
+            var foundExistingIDs = [Int32]()
+            let results = try derivedContext.fetch(fetchRequest)
+            results.forEach { prompt in
+                guard let remotePrompt = remotePromptsDictionary[prompt.promptID] else {
+                    return
+                }
 
-                        foundExistingIDs.append(prompt.promptID)
-                        prompt.configure(with: remotePrompt, for: self.siteID.int32Value)
-                    }
+                foundExistingIDs.append(prompt.promptID)
+                prompt.configure(with: remotePrompt, for: self.siteID.int32Value)
+            }
 
-                    // Insert new prompts
-                    let newPromptIDs = remoteIDs.subtracting(foundExistingIDs)
-                    newPromptIDs.forEach { newPromptID in
-                        guard let remotePrompt = remotePromptsDictionary[newPromptID],
-                              let newPrompt = BloggingPrompt.newObject(in: derivedContext) else {
-                            return
-                        }
-                        newPrompt.configure(with: remotePrompt, for: self.siteID.int32Value)
-                    }
+            // Insert new prompts
+            let newPromptIDs = remoteIDs.subtracting(foundExistingIDs)
+            newPromptIDs.forEach { newPromptID in
+                guard let remotePrompt = remotePromptsDictionary[newPromptID],
+                      let newPrompt = BloggingPrompt.newObject(in: derivedContext) else {
+                    return
                 }
-                DispatchQueue.main.async {
-                    completion(.success(()))
-                }
-            } catch {
-                DispatchQueue.main.async {
-                    completion(.failure(error))
-                }
+                newPrompt.configure(with: remotePrompt, for: self.siteID.int32Value)
+            }
+        } completion: { result in
+            DispatchQueue.main.async {
+                completion(result)
             }
         }
     }

--- a/WordPress/Classes/Services/PageLayoutService.swift
+++ b/WordPress/Classes/Services/PageLayoutService.swift
@@ -98,23 +98,21 @@ extension PageLayoutService {
 
     /// This will use a wipe all and rebuild strategy for managing the stored layouts. They are stored and associated per blog to prevent weird edge cases of downloading one set of layouts then having that bleed to another site (like a self hosted one) which may have a different set of suggested layouts.
     private static func persistToCoreData(_ blogPersistentID: NSManagedObjectID, _ layouts: RemotePageLayouts, _ completion: @escaping (Swift.Result<Void, Error>) -> Void) {
-        let context = ContextManager.shared.newDerivedContext()
-        context.perform {
+        Task {
             do {
-                guard let blog = context.object(with: blogPersistentID) as? Blog else {
-                    let userInfo = [NSLocalizedFailureReasonErrorKey: "Couldn't find blog to save the fetched results to."]
-                    completion(.failure(NSError(domain: "PageLayoutService.persistToCoreData", code: 0, userInfo: userInfo)))
-                    return
+                try await ContextManager.shared.save { context in
+                    guard let blog = context.object(with: blogPersistentID) as? Blog else {
+                        let userInfo = [NSLocalizedFailureReasonErrorKey: "Couldn't find blog to save the fetched results to."]
+                        throw NSError(domain: "PageLayoutService.persistToCoreData", code: 0, userInfo: userInfo)
+                    }
+                    cleanUpStoredLayouts(forBlog: blog, context: context)
+                    try persistCategoriesToCoreData(blog, layouts.categories, context: context)
+                    try persistLayoutsToCoreData(blog, layouts.layouts, context: context)
                 }
-                cleanUpStoredLayouts(forBlog: blog, context: context)
-                try persistCategoriesToCoreData(blog, layouts.categories, context: context)
-                try persistLayoutsToCoreData(blog, layouts.layouts, context: context)
+                completion(.success(()))
             } catch {
                 completion(.failure(error))
-                return
             }
-            ContextManager.shared.save(context)
-            completion(.success(()))
         }
     }
 

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -199,13 +199,11 @@ extension CoreDataStack {
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T, completion: ((Result<T, Error>) -> Void)?) {
         let context = newDerivedContext()
         context.perform {
-            do {
-                let result = try block(context)
+            let result = Result(catching: { try block(context) })
+            if case .success = result {
                 self.saveContextAndWait(context)
-                completion?(.success(result))
-            } catch {
-                completion?(.failure(error))
             }
+            completion?(result)
         }
     }
 

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -193,3 +193,20 @@ extension ContextManager {
         ContextManager.overrideInstance = instance
     }
 }
+
+extension CoreDataStack {
+    func save(_ block: @escaping (NSManagedObjectContext) throws -> Void) async throws {
+        let context = newDerivedContext()
+        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+            context.perform {
+                do {
+                    try block(context)
+                    self.saveContextAndWait(context)
+                    continuation.resume()
+                } catch {
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -156,7 +156,7 @@ class ContextManagerTests: XCTestCase {
         XCTAssertEqual(numberOfAccounts(), 1)
 
         do {
-            try await contextManager.save { context in
+            try await contextManager.performAndSave { context in
                 let account = WPAccount(context: context)
                 account.userID = 100
                 account.username = "Unknown User"

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -155,6 +155,19 @@ class ContextManagerTests: XCTestCase {
         }
         XCTAssertEqual(numberOfAccounts(), 1)
 
+        do {
+            try await contextManager.save { context in
+                let account = WPAccount(context: context)
+                account.userID = 100
+                account.username = "Unknown User"
+                throw NSError(domain: "save", code: 1)
+            }
+            XCTFail("The above call should throw")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "save")
+        }
+        XCTAssertEqual(numberOfAccounts(), 1)
+
         // In the translated Swift API of `ContextManager`, there are two `save(_: (NSManagedContext) -> Void)`
         // functions. The only difference between them is, one is async function, the other is not.
         // When compiling statement `try save { context in doSomething(context) }`, Swift picks which overload to use


### PR DESCRIPTION
Part 2 of https://github.com/wordpress-mobile/WordPress-iOS/pull/19185.

### Changes

This PR introduces a new write API which accepts a `throw` closure, which is the main reason that this PR is separated from the one I mentioned above. This new API is implemented in Swift, since a `throw` closure isn't something can be done in Objective-C—unlike its ["sibling APIs"](https://github.com/wordpress-mobile/WordPress-iOS/pull/19169).

This new API is used in a few `newDerivedContext` usages where the Core Data operations throw.

_Review tip_: [turning on "Hide whitespace"](https://github.com/wordpress-mobile/WordPress-iOS/pull/19186/files?w=1) may make this PR easier to review.

### Test instructions

_I think_ (according to my understanding of the codebase, not the product...), here is a list of area that are changed in this PR. To test, make sure they are working as expected:
* blogging prompts settings are reflected in the app.
* Add and remove an user to a site.
* Create a page with selected layout.


## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
* Added and removed an user from my blog.
* Created a few pages with a few different layouts.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
