### PR TITLE
Add Jetpack Overlay presentation from all badges and banners

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -165,6 +165,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
         jetpackBadgeView.isHidden = false
         let jetpackBadgeButton = JetpackButton(style: .badge)
         jetpackBadgeButton.translatesAutoresizingMaskIntoConstraints = false
+        jetpackBadgeButton.addTarget(self, action: #selector(jetpackButtonTapped), for: .touchUpInside)
         jetpackBadgeView.addSubview(jetpackBadgeButton)
         NSLayoutConstraint.activate([
             jetpackBadgeButton.centerXAnchor.constraint(equalTo: jetpackBadgeView.centerXAnchor),
@@ -172,6 +173,10 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
             jetpackBadgeButton.bottomAnchor.constraint(equalTo: jetpackBadgeView.bottomAnchor)
         ])
         jetpackBadgeView.backgroundColor = .listBackground
+    }
+
+    @objc private func jetpackButtonTapped() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
     }
 
     private func setupText() {

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -44,6 +44,9 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
     private func configureBanner() {
         containerStackView.addArrangedSubview(jetpackBannerView)
         addTranslationObserver(jetpackBannerView)
+        jetpackBannerView.buttonAction = { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -3,7 +3,7 @@ import UIKit
 
 class JetpackBannerView: UIView {
 
-    private var buttonAction: (() -> Void)?
+    var buttonAction: (() -> Void)?
 
     init(buttonAction: (() -> Void)? = nil) {
         super.init(frame: .zero)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -35,7 +35,9 @@ import UIKit
     }
 
     private func configureJetpackBanner(_ stackView: UIStackView) {
-        let jetpackBannerView = JetpackBannerView()
+        let jetpackBannerView = JetpackBannerView() { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
         stackView.addArrangedSubview(jetpackBannerView)
 
         if let childVC = childVC as? JPScrollViewDelegate {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -108,9 +108,15 @@ class JetpackButton: CircularImageButton {
 extension JetpackButton {
 
     /// Instantiates a view containing a Jetpack powered badge
-    /// - Parameter padding: top and bottom padding, defaults to 30 pt
+    /// - Parameter topPadding: top padding, defaults to 30 pt
+    /// - Parameter bottomPadding: bottom padding, defaults to 30 pt
+    /// - Parameter target: optional target for the button action
+    /// - Parameter selector: optional selector for the button action
     /// - Returns: the view containing the badge
-    static func makeBadgeView(topPadding: CGFloat = 30, bottomPadding: CGFloat = 30) -> UIView {
+    static func makeBadgeView(topPadding: CGFloat = 30,
+                              bottomPadding: CGFloat = 30,
+                              target: Any? = nil,
+                              selector: Selector? = nil) -> UIView {
         let view = UIView()
         let badge = JetpackButton(style: .badge)
         badge.translatesAutoresizingMaskIntoConstraints = false
@@ -120,6 +126,9 @@ extension JetpackButton {
             badge.topAnchor.constraint(equalTo: view.topAnchor, constant: topPadding),
             badge.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -bottomPadding)
         ])
+        if let target = target, let selector = selector {
+            badge.addTarget(target, action: selector, for: .touchUpInside)
+        }
         return view
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -543,6 +543,12 @@ extension AppSettingsViewController {
               JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView()
+        let jetpackButton = JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+
+        return jetpackButton
+    }
+
+    @objc private func jetpackButtonTapped() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -553,6 +553,10 @@ extension MeViewController {
               JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView()
+        return JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+    }
+
+    @objc private func jetpackButtonTapped() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -327,7 +327,9 @@ private extension NotificationSettingsViewController {
         labelView.translatesAutoresizingMaskIntoConstraints = false
 
         let badgeView = JetpackButton.makeBadgeView(topPadding: FooterMetrics.jetpackBadgeTopPadding,
-                                                    bottomPadding: FooterMetrics.jetpackBadgeBottomPatting)
+                                                    bottomPadding: FooterMetrics.jetpackBadgeBottomPatting,
+                                                    target: self,
+                                                    selector: #selector(jetpackButtonTapped))
         badgeView.translatesAutoresizingMaskIntoConstraints = false
 
         let stackView = UIStackView(arrangedSubviews: [labelView, badgeView])
@@ -589,6 +591,10 @@ private extension NotificationSettingsViewController {
             let streamsViewController = NotificationSettingStreamsViewController(settings: settings)
             navigationController?.pushViewController(streamsViewController, animated: true)
         }
+    }
+
+    @objc func jetpackButtonTapped() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -624,7 +624,9 @@ extension NotificationsViewController {
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }
-
+        jetpackBannerView.buttonAction = { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
         jetpackBannerView.isHidden = false
         addTranslationObserver(jetpackBannerView)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -119,7 +119,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         guard section == 0, JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView(bottomPadding: Constants.jetpackBadgeBottomPadding)
+        return JetpackButton.makeBadgeView(bottomPadding: Constants.jetpackBadgeBottomPadding,
+                                           target: self,
+                                           selector: #selector(jetpackButtonTapped))
     }
 
     func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
@@ -150,6 +152,13 @@ private extension ReaderDetailCommentsTableViewDelegate {
         cell.configure(buttonTitle: title, borderColor: .textTertiary, buttonInsets: Constants.buttonInsets)
         cell.delegate = buttonDelegate
         return cell
+    }
+
+    @objc func jetpackButtonTapped() {
+        guard let presentingViewController = presentingViewController else {
+            return
+        }
+        JetpackBrandingCoordinator.presentOverlay(from: presentingViewController)
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -48,7 +48,9 @@ import Gridicons
     fileprivate var didBumpStats = false
 
     private lazy var bannerView: JetpackBannerView = {
-        let bannerView = JetpackBannerView()
+        let bannerView = JetpackBannerView() { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
         bannerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: JetpackBannerView.minimumHeight)
         return bannerView
     }()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -504,7 +504,9 @@ import Combine
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }
-        let bannerView = JetpackBannerView()
+        let bannerView = JetpackBannerView() { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
         jetpackBannerView = bannerView
         addTranslationObserver(bannerView)
         stackView.addArrangedSubview(bannerView)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -112,6 +112,9 @@ class SiteStatsDashboardViewController: UIViewController {
             jetpackBannerView.removeFromSuperview()
             return
         }
+        jetpackBannerView.buttonAction = { [unowned self] in
+            JetpackBrandingCoordinator.presentOverlay(from: self)
+        }
     }
 
     @objc func manageInsightsButtonTapped() {


### PR DESCRIPTION
Fixes #19187

This PR adds the capability of presenting the Jetpack overlay from all "Jetpack powered" badges and banners. It affects the following screens

- My Site - Home (already connected in a previous PR)
- My Site/Stats
- My Site/Activity log
- My Site/Activity log/activity detail
- My Site/Sharing (this is subject to change from banner to badge, but we can still set it up for now)
- Reader
- Reader/Search
- Reader/Reader detail
- Notifications
- Notifications/Notifications Settings

To test:
- Checkout this branch and enable the `jetpackPoweredBottomSheet` feature flag
- Build/run the WordPress target
- Navigate to each of the above screens and make sure that tapping on a badge or banner presents the Jetpack overlay

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] ~~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.~~ Not released
