### PR TITLE
Minor DRY in Buildkite UI tests

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,10 +1,9 @@
 #!/bin/bash -eu
 
-TEST_NAME=$1
-DEVICE=$2
-IOS_VERSION=$3
+DEVICE=$1
+IOS_VERSION=$2
 
-echo "Running $TEST_NAME on $DEVICE for iOS $IOS_VERSION"
+echo "Running UI tests $DEVICE for iOS $IOS_VERSION"
 
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'
@@ -36,7 +35,7 @@ echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
-bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE" ios_version:"$IOS_VERSION"
+bundle exec fastlane test_without_building name:WordPressUITests device:"$DEVICE" ios_version:"$IOS_VERSION"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,7 +1,8 @@
 #!/bin/bash -eu
 
 DEVICE=$1
-IOS_VERSION=$2
+# Default to the latest iOS, with the option of overriding
+IOS_VERSION=${2:-15.0}
 
 echo "Running UI tests $DEVICE for iOS $IOS_VERSION"
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -36,7 +36,7 @@ echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
-bundle exec fastlane test_without_building name:"$TEST_NAME" try_count:3 device:"$DEVICE" ios_version:"$IOS_VERSION"
+bundle exec fastlane test_without_building name:"$TEST_NAME" device:"$DEVICE" ios_version:"$IOS_VERSION"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,10 +1,8 @@
 #!/bin/bash -eu
 
 DEVICE=$1
-# Default to the latest iOS, with the option of overriding
-IOS_VERSION=${2:-15.0}
 
-echo "Running UI tests $DEVICE for iOS $IOS_VERSION"
+echo "Running UI tests on $DEVICE. The iOS version will be the latest available in the CI host."
 
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'
@@ -36,7 +34,7 @@ echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
-bundle exec fastlane test_without_building name:WordPressUITests device:"$DEVICE" ios_version:"$IOS_VERSION"
+bundle exec fastlane test_without_building name:WordPressUITests device:"$DEVICE"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -17,7 +17,7 @@ install_gems
 
 echo "--- 🔬 Testing"
 set +e
-bundle exec fastlane test_without_building name:WordPressUnitTests try_count:3
+bundle exec fastlane test_without_building name:WordPressUnitTests
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh WordPressUITests 'iPhone 13' 15.0
+        command: .buildkite/commands/run-ui-tests.sh 'iPhone 13' 15.0
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins
@@ -91,7 +91,7 @@ steps:
             if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh WordPressUITests "iPad Air (5th generation)" 15.0
+        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)" 15.0
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh 'iPhone 13' 15.0
+        command: .buildkite/commands/run-ui-tests.sh 'iPhone 13'
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins
@@ -91,7 +91,7 @@ steps:
             if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)" 15.0
+        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
         depends_on: "build"
         env: *common_env
         plugins: *common_plugins


### PR DESCRIPTION
It seems unlikely we'll want to run multiple UI tests jobs from the same build with different schemes and/or iOS versions. So, I centralized the definition of those parameters.

For the record, these are some leftover tweaks I made when experimenting with Test Analytics. I haven't developed a sudden urge to DRY random scripts 😅 (or rather, I do have that urge but I try to keep it in check).

## Testing 

If CI is green, we're good.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
