### PR TITLE
Jetpack Focus: Allow self-hosted sites to be added on the Jetpack app

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] [Jetpack-only] Recommend App: you can now share the Jetpack app with your friends. [#19174]
 * [*] [Jetpack-only] Feature Announcements: new features are highlighted via the What's New modals. [#19176]
+* [**] [Jetpack-only] Self-hosted sites: enables logging in via a self-hosted site / adding a self-hosted site [#19194]
 * [*] Pages List: Fixed an issue where the app would freeze when opening the pages list if one of the featured images is a GIF. [#19184]
 
 

--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -1,7 +1,6 @@
 import WordPressAuthenticator
 
 protocol AuthenticationHandler {
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void)
 
     /// Whether or not the AuthenticationHandler will override or handle the `presentLoginEpilogue` method.
     /// If this returns true, the `AuthenticationHandler.presentLoginEpilogue` method is called

--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -2,14 +2,6 @@ import WordPressAuthenticator
 
 protocol AuthenticationHandler {
 
-    /// Whether or not the AuthenticationHandler will override or handle the `presentLoginEpilogue` method.
-    /// If this returns true, the `AuthenticationHandler.presentLoginEpilogue` method is called
-    /// If not, then the default implementation will be called instead
-    /// - Returns: Bool, true if we should override the functionality, false if we should not
-    func willHandlePresentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials) -> Bool
-
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, windowManager: WindowManager, onDismiss: @escaping () -> Void) -> Bool
-
     /// Whether or not the AuthenticationHandler will override or handle the `presentSignupEpilogue` method.
     /// If this returns true, the `AuthenticationHandler.presentSignupEpilogue` method is called
     /// If not, then the default implementation will be called instead

--- a/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
+++ b/WordPress/Classes/Utility/App Configuration/AuthenticationHandler.swift
@@ -2,14 +2,6 @@ import WordPressAuthenticator
 
 protocol AuthenticationHandler {
 
-    /// Whether or not the AuthenticationHandler will override or handle the `presentSignupEpilogue` method.
-    /// If this returns true, the `AuthenticationHandler.presentSignupEpilogue` method is called
-    /// If not, then the default implementation will be called instead
-    /// - Returns: Bool, true if we should override the functionality, false if we should not
-    func willHandlePresentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) -> Bool
-
-    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?)
-
     // WPAuthenticator style overrides
     var statusBarStyle: UIStatusBarStyle { get }
     var prologueViewController: UIViewController? { get }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -383,11 +383,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Presents the Signup Epilogue, in the specified NavigationController.
     ///
     func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
-        if let authenticationHandler = authenticationHandler,
-           authenticationHandler.willHandlePresentSignupEpilogue(in: navigationController, for: credentials, service: service) {
-            authenticationHandler.presentSignupEpilogue(in: navigationController, for: credentials, service: service)
-            return
-        }
 
         let storyboard = UIStoryboard(name: "SignupEpilogue", bundle: .main)
         guard let epilogueViewController = storyboard.instantiateInitialViewController() as? SignupEpilogueViewController else {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -317,11 +317,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     /// Presents the Login Epilogue, in the specified NavigationController.
     ///
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, onDismiss: @escaping () -> Void) {
-        if let authenticationHandler = authenticationHandler,
-           authenticationHandler.willHandlePresentLoginEpilogue(in: navigationController, for: credentials),
-           authenticationHandler.presentLoginEpilogue(in: navigationController, for: credentials, windowManager: windowManager, onDismiss: onDismiss) {
-            return
-        }
 
         // If adding a self-hosted site, skip the Epilogue
         if let wporg = credentials.wporg,

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -309,10 +309,6 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///     - onCompletion: Closure to be executed on completion.
     ///
     func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
-        if let authenticationHandler = authenticationHandler {
-            authenticationHandler.shouldPresentUsernamePasswordController(for: siteInfo, onCompletion: onCompletion)
-            return
-        }
 
         let result: WordPressAuthenticatorResult = .presentPasswordController(value: true)
         onCompletion(result)

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -15,7 +15,7 @@ import Foundation
     @objc static let allowsDomainRegistration: Bool = true
     @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
-    @objc static let showAddSelfHostedSiteButton: Bool = false
+    @objc static let showAddSelfHostedSiteButton: Bool = true
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -9,45 +9,6 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
     var prologuePrimaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.continueButtonStyle
     var prologueSecondaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.siteAddressButtonStyle
 
-    func shouldPresentUsernamePasswordController(for siteInfo: WordPressComSiteInfo?, onCompletion: @escaping (WordPressAuthenticatorResult) -> Void) {
-        /// Jetpack is required. Present an error if we don't detect a valid installation.
-        guard let site = siteInfo, isValidJetpack(for: site) else {
-            let viewModel = JetpackNotFoundErrorViewModel(with: siteInfo?.url)
-            let controller = errorViewController(with: viewModel)
-
-            let authenticationResult: WordPressAuthenticatorResult = .injectViewController(value: controller)
-            onCompletion(authenticationResult)
-
-            return
-        }
-
-        /// WordPress must be present.
-        guard site.isWP else {
-            let viewModel = JetpackNotWPErrorViewModel()
-            let controller = errorViewController(with: viewModel)
-
-            let authenticationResult: WordPressAuthenticatorResult = .injectViewController(value: controller)
-            onCompletion(authenticationResult)
-
-            return
-        }
-
-        /// For self-hosted sites, navigate to enter the email address associated to the wp.com account:
-        guard site.isWPCom else {
-            let authenticationResult: WordPressAuthenticatorResult = .presentEmailController
-
-            onCompletion(authenticationResult)
-
-            return
-        }
-
-        /// We should never reach this point, as WPAuthenticator won't call its delegate for this case.
-        ///
-        DDLogWarn("⚠️ Present password controller for site: \(site.url)")
-        let authenticationResult: WordPressAuthenticatorResult = .presentPasswordController(value: false)
-        onCompletion(authenticationResult)
-    }
-
     func willHandlePresentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials) -> Bool {
         // Don't display the "no sites" epilogue if we allow site creation
         return !AppConfiguration.allowSiteCreation

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -9,23 +9,6 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
     var prologuePrimaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.continueButtonStyle
     var prologueSecondaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.siteAddressButtonStyle
 
-    func willHandlePresentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) -> Bool {
-        // Don't display the "no sites" epilogue if we allow site creation
-        return !AppConfiguration.allowSiteCreation
-    }
-
-    // If the user signs up using the Jetpack app (through SIWA, for example)
-    // We show right away the screen explaining that they do not have Jetpack sites
-    func presentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) {
-        let windowManager = WordPressAppDelegate.shared?.windowManager
-
-        windowManager?.dismissFullscreenSignIn()
-
-        let viewModel = JetpackNoSitesErrorViewModel()
-        let controller = errorViewController(with: viewModel)
-        windowManager?.show(controller, completion: nil)
-    }
-
     // MARK: - Private: Helpers
     private func isValidJetpack(for site: WordPressComSiteInfo) -> Bool {
         return site.hasJetpack &&

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -9,28 +9,6 @@ struct JetpackAuthenticationManager: AuthenticationHandler {
     var prologuePrimaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.continueButtonStyle
     var prologueSecondaryButtonStyle: NUXButtonStyle? = JetpackPrologueStyleGuide.siteAddressButtonStyle
 
-    func willHandlePresentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials) -> Bool {
-        // Don't display the "no sites" epilogue if we allow site creation
-        return !AppConfiguration.allowSiteCreation
-    }
-
-    func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, windowManager: WindowManager, onDismiss: @escaping () -> Void) -> Bool {
-        if AccountHelper.hasBlogs {
-            return false
-        }
-
-        // Exit out of the sign in process, if we don't do this we later can't
-        // display the sign in again
-        windowManager.dismissFullscreenSignIn()
-
-        // Display the no sites view
-        let viewModel = JetpackNoSitesErrorViewModel()
-        let controller = errorViewController(with: viewModel)
-        windowManager.show(controller, completion: nil)
-
-        return true
-    }
-
     func willHandlePresentSignupEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, service: SocialService?) -> Bool {
         // Don't display the "no sites" epilogue if we allow site creation
         return !AppConfiguration.allowSiteCreation


### PR DESCRIPTION
Part of #19164

## Description
This PR allows self-hosted sites to be added on the Jetpack app

- Updated the `showAddSelfHostedSiteButton` Jetpack app config flag to `true`
- Deleted the following `AuthenticationHandler` protocol methods to align Jetpack auth behavior with WordPress
    - `shouldPresentUsernamePasswordController`: deleting this enables self-hosted login on Jetpack
    - `willHandlePresentLoginEpilogue`, `presentLoginEpilogue`: `willHandlePresentLoginEpilogue` **always returns false** since site creation is allowed on Jetpack, which means that the override for `presentLoginEpilogue` is never called... so safe to delete
    - `willHandlePresentSignupEpilogue`, `presentSignupEpilogue`: `willHandlePresentSignupEpilogue` **always returns false** since site creation is allowed on Jetpack, which means that the override for `presentSignupEpilogue` is never called... so safe to delete

## Note

This change also enables logging in to the Jetpack app via a self-hosted site, even if that site doesn't have Jetpack installed (slack ref: p1659098581319709/1659097176.548059-slack-C0180B5PRJ4)

## How to test

### Log in via self-hosted site address (non-Jetpack connected)
0. Create a Jurassic Ninja site but **don't** set up Jetpack 
1. Build and run the Jetpack app, logout if needed
2. Tap **Enter your existing site address** and login via your site address
3. Once you're logged in, tap **Stats**
4. ✅ Verify: You should see the **Install Jetpack** prompt

### Log in via self-hosted site address (Jetpack connected)
0. Create a Jurassic Ninja site and set up Jetpack (i.e. connect to your account -- set up then approve connection to you account on wp admin)
1. Build and run the Jetpack app, logout if needed
2. Tap **Enter your existing site address** and login via your site address
3. Once you're logged in, tap **Stats**
4. ✅ Verify: You should see the **Log in** prompt

### Already logged in, add self-hosted site (non-Jetpack connected)
0. Create a Jurassic Ninja site but **don't** set up Jetpack 
1. Build and run the Jetpack app, log in via email if needed
2. Go to My Site > down chevron > + > **Add self-hosted site** 
3. Login in via the site address
4. Select the self-hosted site you just added
5. Go to Stats
6. ✅ Verify: You should see the **Install Jetpack** prompt

###  Already logged in, add self-hosted site (Jetpack connected)
0. Create a Jurassic Ninja site and set up Jetpack (i.e. connect to your account -- set up then approve connection to you account on wp admin)
1. Build and run the Jetpack app, make sure you're logged into the same account as step 0
2. Go to My Site > down chevron > + > **Add self-hosted site** 
3. On the My Sites screen, pull down to refresh
4. Select the Jurassic Ninja site you created in step 0 
5. Go to Stats
6. ✅ Verify: You can access stats


## Regression Notes
1. Potential unintended areas of impact
- Login -- JP auth handler now matches WP auth handler

7. What I did to test those areas of impact (or what existing automated tests I relied on)
- Tested the steps above

8. What automated tests I added (or what prevented me from doing so)
- n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.