### PR TITLE
[Jetpack] Sharing - replace Jetpack banner with badge

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1512,8 +1512,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         controller = [[SharingButtonsViewController alloc] initWithBlog:self.blog];
 
     } else {
-        SharingViewController *sharingVC = [[SharingViewController alloc] initWithBlog:self.blog delegate:nil];
-        controller = [[JetpackBannerWrapperViewController alloc] initWithChildVC: sharingVC];
+        controller = [[SharingViewController alloc] initWithBlog:self.blog delegate:nil];
     }
 
     [self trackEvent:WPAnalyticsStatOpenedSharingManagement fromSource:source];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -14,6 +14,8 @@ typedef NS_ENUM(NSInteger, SharingSectionIdentifier){
 };
 
 static NSString *const CellIdentifier = @"CellIdentifier";
+static CGFloat const jetpackBadgeTopPadding = 22;
+static CGFloat const jetpackBadgeBottomPadding = 8;
 
 @interface SharingViewController ()
 
@@ -247,6 +249,15 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     }
 
     [self.navigationController pushViewController:controller animated:YES];
+}
+
+- (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
+{
+    if (section == SharingButtons && [SharingViewController jetpackBrandingVisibile]) {
+        return [JetpackButton makeBadgeViewWithTopPadding:jetpackBadgeTopPadding bottomPadding:jetpackBadgeBottomPadding];
+    }
+
+    return nil;
 }
 
 #pragma mark - JetpackModuleHelper

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -262,11 +262,6 @@ static CGFloat const jetpackBadgePadding = 30;
     return nil;
 }
 
-- (void) jetpackButtonTapped
-{
-    // TODO
-}
-
 #pragma mark - JetpackModuleHelper
 
 - (void)jetpackModuleEnabled
@@ -375,6 +370,13 @@ static CGFloat const jetpackBadgePadding = 30;
     [sharingService syncSharingButtonsForBlog:self.blog success:nil failure:^(NSError *error) {
         DDLogError([error description]);
     }];
+}
+
+#pragma mark - Jetpack badge button
+
+- (void) jetpackButtonTapped
+{
+    [self presentJetpackOverlay];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -14,8 +14,7 @@ typedef NS_ENUM(NSInteger, SharingSectionIdentifier){
 };
 
 static NSString *const CellIdentifier = @"CellIdentifier";
-static CGFloat const jetpackBadgeTopPadding = 22;
-static CGFloat const jetpackBadgeBottomPadding = 8;
+static CGFloat const jetpackBadgePadding = 30;
 
 @interface SharingViewController ()
 
@@ -254,7 +253,7 @@ static CGFloat const jetpackBadgeBottomPadding = 8;
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
     if (section == SharingButtons && [SharingViewController jetpackBrandingVisibile]) {
-        return [JetpackButton makeBadgeViewWithTopPadding:jetpackBadgeTopPadding bottomPadding:jetpackBadgeBottomPadding];
+        return [JetpackButton makeBadgeViewWithTopPadding:jetpackBadgePadding bottomPadding:jetpackBadgePadding];
     }
 
     return nil;

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -45,12 +45,12 @@ static CGFloat const jetpackBadgePadding = 30;
 {
     [super viewDidLoad];
 
-    self.parentViewController.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
+    self.navigationItem.title = NSLocalizedString(@"Sharing", @"Title for blog detail sharing screen.");
     
     self.extendedLayoutIncludesOpaqueBars = YES;
     
     if (self.isModal) {
-        self.parentViewController.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+        self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
                                                                                                target:self
                                                                                                action:@selector(doneButtonTapped)];
     }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
@@ -5,4 +5,9 @@ extension SharingViewController {
     static func jetpackBrandingVisibile() -> Bool {
         return JetpackBrandingVisibility.all.enabled
     }
+
+    @objc
+    func presentJetpackOverlay() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension SharingViewController {
+    @objc
+    static func jetpackBrandingVisibile() -> Bool {
+        return JetpackBrandingVisibility.all.enabled
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -110,6 +110,7 @@ extension JetpackButton {
     /// Instantiates a view containing a Jetpack powered badge
     /// - Parameter padding: top and bottom padding, defaults to 30 pt
     /// - Returns: the view containing the badge
+    @objc
     static func makeBadgeView(topPadding: CGFloat = 30, bottomPadding: CGFloat = 30) -> UIView {
         let view = UIView()
         let badge = JetpackButton(style: .badge)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2273,6 +2273,8 @@
 		C352870627FDD35C004E2E51 /* SiteNameStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352870427FDD35C004E2E51 /* SiteNameStep.swift */; };
 		C35D4FF1280077F100DB90B5 /* SiteCreationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */; };
 		C35D4FF2280077F100DB90B5 /* SiteCreationStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */; };
+		C3643ACF28AC049D00FC5FD3 /* SharingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3643ACE28AC049D00FC5FD3 /* SharingViewController.swift */; };
+		C3643AD028AC049D00FC5FD3 /* SharingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3643ACE28AC049D00FC5FD3 /* SharingViewController.swift */; };
 		C373D6E728045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6E828045281008F8C26 /* SiteIntentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E628045281008F8C26 /* SiteIntentData.swift */; };
 		C373D6EA280452F6008F8C26 /* SiteIntentDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */; };
@@ -7178,6 +7180,7 @@
 		C3439B5E27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationWizardLauncherTests.swift; sourceTree = "<group>"; };
 		C352870427FDD35C004E2E51 /* SiteNameStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteNameStep.swift; sourceTree = "<group>"; };
 		C35D4FF0280077F100DB90B5 /* SiteCreationStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationStep.swift; sourceTree = "<group>"; };
+		C3643ACE28AC049D00FC5FD3 /* SharingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingViewController.swift; sourceTree = "<group>"; };
 		C373D6E628045281008F8C26 /* SiteIntentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentData.swift; sourceTree = "<group>"; };
 		C373D6E9280452F6008F8C26 /* SiteIntentDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIntentDataTests.swift; sourceTree = "<group>"; };
 		C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerWrapperViewController.swift; sourceTree = "<group>"; };
@@ -15101,6 +15104,7 @@
 				E6C892D51C601D55007AD612 /* SharingButtonsViewController.swift */,
 				E6431DE31C4E892900FD8D90 /* SharingViewController.h */,
 				E6431DE41C4E892900FD8D90 /* SharingViewController.m */,
+				C3643ACE28AC049D00FC5FD3 /* SharingViewController.swift */,
 				8BBBCE6F2717651200B277AC /* JetpackModuleHelper.swift */,
 				E6431DDF1C4E892900FD8D90 /* SharingConnectionsViewController.h */,
 				E6431DE01C4E892900FD8D90 /* SharingConnectionsViewController.m */,
@@ -18963,6 +18967,7 @@
 				E69BA1981BB5D7D300078740 /* WPStyleGuide+ReadableMargins.m in Sources */,
 				7E4123C320F4097B00DF8486 /* FormattableContentStyles.swift in Sources */,
 				735A9681228E421F00461135 /* StatsBarChartConfiguration.swift in Sources */,
+				C3643ACF28AC049D00FC5FD3 /* SharingViewController.swift in Sources */,
 				2F161B0622CC2DC70066A5C5 /* LoadingStatusView.swift in Sources */,
 				080C44A91CE14A9F00B3A02F /* MenuDetailsViewController.m in Sources */,
 				DCF892C9282FA37100BB71E1 /* SiteStatsBaseTableViewController.swift in Sources */,
@@ -21853,6 +21858,7 @@
 				FABB24A12602FC2C00C8785C /* UITableViewCell+enableDisable.swift in Sources */,
 				FABB24A22602FC2C00C8785C /* WPAnalyticsTrackerAutomatticTracks.m in Sources */,
 				FABB24A32602FC2C00C8785C /* CollapsableHeaderCollectionViewCell.swift in Sources */,
+				C3643AD028AC049D00FC5FD3 /* SharingViewController.swift in Sources */,
 				FABB24A42602FC2C00C8785C /* NotificationContentFactory.swift in Sources */,
 				FABB24A52602FC2C00C8785C /* SiteIconView.swift in Sources */,
 				FABB24A62602FC2C00C8785C /* JetpackRestoreCompleteViewController.swift in Sources */,


### PR DESCRIPTION
## Description

- Closes #19179
- Presents the Jetpack overlay when the badge is tapped

## Testing

**Prerequisites:** The "Jetpack powered bottom sheet" feature flag must be enabled.

1. Using the WordPress app connected to a Jetpack site, go to the Sharing view
2. **Expect** a Jetpack powered badge
3. **Expect** that tapping the badge shows the Jetpack overlay

### Items to test
- Light / Dark mode
- a11y / VoiceOver / Dynamic Type
- Portrait / Landscape
- iPhone / iPad
- Badge doesn't appear in the Jetpack app

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 14 25 36](https://user-images.githubusercontent.com/2092798/184951904-8b5eb6ad-143a-4cf6-88bf-177be7d563fa.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-16 at 14 30 52](https://user-images.githubusercontent.com/2092798/184953068-7ac64bc6-ddbf-4ea7-af40-ab5b5bacc763.png) |

## Regression Notes
1. Potential unintended areas of impact
    - Sharing view

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
