### PR TITLE
Stats: Hide file downloads stats section for Jetpack sites

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] [Jetpack-only] Recommend App: you can now share the Jetpack app with your friends. [#19174]
 * [*] [Jetpack-only] Feature Announcements: new features are highlighted via the What's New modals. [#19176]
 * [*] Pages List: Fixed an issue where the app would freeze when opening the pages list if one of the featured images is a GIF. [#19184]
+* [*] Stats: Fixed an issue where File Downloads section was being displayed for Jetpack sites even though it's not supported. [#19200]
 
 
 20.5

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -95,6 +95,8 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureLoomEmbed,
     /// Does the blog support Smartframe embed block?
     BlogFeatureSmartframeEmbed,
+    /// Does the blog support File Downloads section in stats?
+    BlogFeatureFileDownloadsStats,
 
 };
 

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -596,6 +596,8 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             return [self supportsEmbedVariation: @"9.0"];
         case BlogFeatureSmartframeEmbed:
             return [self supportsEmbedVariation: @"10.2"];
+        case BlogFeatureFileDownloadsStats:
+            return [self isHostedAtWPcom];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -13,6 +13,7 @@ import Foundation
     @objc var siteID: NSNumber?
     @objc var siteTimeZone: TimeZone?
     @objc var oauth2Token: String?
+    @objc var supportsFileDownloads: Bool = true
 
     func updateTimeZone() {
         let context = ContextManager.shared.mainContext

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -195,16 +195,18 @@ class SiteStatsPeriodViewModel: Observable {
             }, error: {
                 return errorBlock(.periodVideos)
         }))
-        tableRows.append(contentsOf: blocks(for: .topFileDownloads,
-                                            type: .period,
-                                            status: store.topFileDownloadsStatus,
-                                            block: { [weak self] in
-                                                return self?.fileDownloadsTableRows() ?? errorBlock(.periodFileDownloads)
-            }, loading: {
-                return loadingBlock(.periodFileDownloads)
-            }, error: {
-                return errorBlock(.periodFileDownloads)
-        }))
+        if SiteStatsInformation.sharedInstance.supportsFileDownloads {
+            tableRows.append(contentsOf: blocks(for: .topFileDownloads,
+                                                type: .period,
+                                                status: store.topFileDownloadsStatus,
+                                                block: { [weak self] in
+                                                    return self?.fileDownloadsTableRows() ?? errorBlock(.periodFileDownloads)
+                }, loading: {
+                    return loadingBlock(.periodFileDownloads)
+                }, error: {
+                    return errorBlock(.periodFileDownloads)
+            }))
+        }
 
         tableRows.append(TableFooterRow())
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -130,6 +130,7 @@ static NSString *const StatsBlogObjectURLRestorationKey = @"StatsBlogObjectURL";
         
         SiteStatsInformation.sharedInstance.oauth2Token = self.blog.account.authToken;
         SiteStatsInformation.sharedInstance.siteID = self.blog.dotComID;
+        SiteStatsInformation.sharedInstance.supportsFileDownloads = [self.blog supports:BlogFeatureFileDownloadsStats];
         
         [self addStatsViewControllerToView];
         [self initializeStatsWidgetsIfNeeded];


### PR DESCRIPTION
Fixes #13370

## Description
Avoid displaying File Downloads stats section for Jetpack sites, as this stat is not supported for self-hosted sites.

## Testing Instructions

### Jetpack Sites

1. Open a Jetpack site
2. Navigate to Stats
3. Navigate to any period (Days, Weeks...)
4. Scroll to the bottom
5. Make sure File Downloads section is not present

### WordPress Sites

1. Open a normal site (Hosted by wpcom)
2. Navigate to Stats
3. Navigate to any period (Days, Weeks...)
4. Scroll to the bottom
5. Make sure File Downloads section is present

## Regression Notes
1. Potential unintended areas of impact
N/A
2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A
3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.