### PR TITLE
[Jetpack] Update Jetpack banner visibility algorithm

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -3,7 +3,7 @@ import Combine
 
 class JetpackActivityLogViewController: BaseActivityListViewController {
     private let jetpackBannerView = JetpackBannerView()
-    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         let activityListConfiguration = ActivityListConfiguration(
@@ -53,6 +53,6 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
 extension JetpackActivityLogViewController: JPScrollViewDelegate {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         super.scrollViewDidScroll(scrollView)
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
@@ -1,10 +1,11 @@
 import Combine
 import CoreGraphics
+import UIKit
 
 /// Conform to this protocol to send scrollview translations to a `JetpackBannerView` instance
 protocol JPScrollViewDelegate: UIScrollViewDelegate {
 
-    var scrollViewTranslationPublisher: PassthroughSubject<CGFloat, Never> { get }
+    var scrollViewTranslationPublisher: PassthroughSubject<Bool, Never> { get }
     func addTranslationObserver(_ receiver: JetpackBannerView)
 }
 
@@ -12,5 +13,31 @@ extension JPScrollViewDelegate {
 
     func addTranslationObserver(_ receiver: JetpackBannerView) {
         scrollViewTranslationPublisher.subscribe(receiver)
+    }
+
+    func processJetpackBannerVisibility(_ scrollView: UIScrollView) {
+        let shouldHideJetpackBanner = Self.shouldHideJetpackBanner(
+            contentHeight: scrollView.contentSize.height,
+            frameHeight: scrollView.frame.height,
+            verticalContentOffset: scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+        )
+
+        scrollViewTranslationPublisher.send(shouldHideJetpackBanner)
+    }
+
+    static func shouldHideJetpackBanner(
+        contentHeight: CGFloat,
+        frameHeight: CGFloat,
+        verticalContentOffset: CGFloat
+    ) -> Bool {
+        /// The scrollable content isn't any larger than its frame, so don't hide the banner if the view is bounced.
+        if contentHeight <= frameHeight {
+            return false
+        /// Don't hide the banner until the view has scrolled down some. Currently the height of the banner itself.
+        } else if verticalContentOffset <= JetpackBannerView.minimumHeight {
+            return false
+        }
+
+        return true
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JPScrollViewDelegate.swift
@@ -16,28 +16,7 @@ extension JPScrollViewDelegate {
     }
 
     func processJetpackBannerVisibility(_ scrollView: UIScrollView) {
-        let shouldHideJetpackBanner = Self.shouldHideJetpackBanner(
-            contentHeight: scrollView.contentSize.height,
-            frameHeight: scrollView.frame.height,
-            verticalContentOffset: scrollView.contentOffset.y + scrollView.adjustedContentInset.top
-        )
-
-        scrollViewTranslationPublisher.send(shouldHideJetpackBanner)
-    }
-
-    static func shouldHideJetpackBanner(
-        contentHeight: CGFloat,
-        frameHeight: CGFloat,
-        verticalContentOffset: CGFloat
-    ) -> Bool {
-        /// The scrollable content isn't any larger than its frame, so don't hide the banner if the view is bounced.
-        if contentHeight <= frameHeight {
-            return false
-        /// Don't hide the banner until the view has scrolled down some. Currently the height of the banner itself.
-        } else if verticalContentOffset <= JetpackBannerView.minimumHeight {
-            return false
-        }
-
-        return true
+        let shouldHide = JetpackBannerScrollVisibility.shouldHide(scrollView)
+        scrollViewTranslationPublisher.send(shouldHide)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerScrollVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerScrollVisibility.swift
@@ -1,0 +1,28 @@
+import Foundation
+import UIKit
+
+struct JetpackBannerScrollVisibility {
+    static func shouldHide(_ scrollView: UIScrollView) -> Bool {
+        return Self.shouldHide(
+            contentHeight: scrollView.contentSize.height,
+            frameHeight: scrollView.frame.height,
+            verticalContentOffset: scrollView.contentOffset.y + scrollView.adjustedContentInset.top
+        )
+    }
+
+    static func shouldHide(
+        contentHeight: CGFloat,
+        frameHeight: CGFloat,
+        verticalContentOffset: CGFloat
+    ) -> Bool {
+        /// The scrollable content isn't any larger than its frame, so don't hide the banner if the view is bounced.
+        if contentHeight <= frameHeight {
+            return false
+        /// Don't hide the banner until the view has scrolled down some. Currently the height of the banner itself.
+        } else if verticalContentOffset <= JetpackBannerView.minimumHeight {
+            return false
+        }
+
+        return true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -47,16 +47,15 @@ class JetpackBannerView: UIView {
 // MARK: Responding to scroll events
 extension JetpackBannerView: Subscriber {
 
-    typealias Input = CGFloat
+    typealias Input = Bool
     typealias Failure = Never
 
     func receive(subscription: Subscription) {
         subscription.request(.unlimited)
     }
 
-    func receive(_ input: CGFloat) -> Subscribers.Demand {
-
-        let isHidden: Bool = input < 0
+    func receive(_ input: Bool) -> Subscribers.Demand {
+        let isHidden = input
 
         guard self.isHidden != isHidden else {
             return .unlimited

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -135,7 +135,7 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
     }()
 
     /// Used by JPScrollViewDelegate to send scroll position
-    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    internal let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     // MARK: - View Lifecycle
 
@@ -2075,6 +2075,6 @@ extension NotificationsViewController: WPScrollableViewController {
 //
 extension NotificationsViewController: JPScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -129,9 +129,6 @@ import Gridicons
         configureBackgroundTapRecognizer()
         configureForRestoredTopic()
         configureSiteSearchViewController()
-        // hide the parent viewController's banner, if it exists
-        // because this viewController has its own.
-        streamController?.jetpackBannerView?.isHidden = true
     }
 
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -54,7 +54,7 @@ class ReaderSiteSearchViewController: UITableViewController, UIViewControllerRes
 
     // MARK: - JPScrollViewDelegate
 
-    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     // MARK: - View lifecycle
 
@@ -411,6 +411,6 @@ class ReaderSiteSearchFooterView: UIView {
 
 extension ReaderSiteSearchViewController: JPScrollViewDelegate {
     override func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -101,7 +101,7 @@ import Combine
     private var didSetupView = false
     private var listentingForBlockedSiteNotification = false
     private var didBumpStats = false
-    internal let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    internal let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     /// Content management
     let content = ReaderTableContent()
@@ -2006,6 +2006,6 @@ extension ReaderStreamViewController: ReaderTopicsChipsDelegate {
 
 extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
@@ -5,7 +5,7 @@ import Foundation
 
 final class BottomScrollAnalyticsTracker: NSObject {
 
-    let scrollViewTranslationPublisher = PassthroughSubject<CGFloat, Never>()
+    let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     private func captureAnalyticsEvent(_ event: WPAnalyticsStat) {
         if let blogIdentifier = SiteStatsInformation.sharedInstance.siteID {
@@ -39,6 +39,6 @@ extension BottomScrollAnalyticsTracker: JPScrollViewDelegate {
         }
     }
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        scrollViewTranslationPublisher.send(scrollView.panGestureRecognizer.translation(in: scrollView.superview).y)
+        processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2291,6 +2291,9 @@
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
 		C3C21EB928385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
 		C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
+		C3C2F84628AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */; };
+		C3C2F84828AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F84728AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift */; };
+		C3C2F84928AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F84728AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift */; };
 		C3C39B0726F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C39B0826F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */; };
 		C3C70C562835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C70C552835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift */; };
@@ -7193,6 +7196,8 @@
 		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSiteDesigns.swift; sourceTree = "<group>"; };
+		C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerScrollVisibilityTests.swift; sourceTree = "<group>"; };
+		C3C2F84728AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerScrollVisibility.swift; sourceTree = "<group>"; };
 		C3C39B0626F50D3900B1238D /* WordPressSupportSourceTag+Editor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "WordPressSupportSourceTag+Editor.swift"; sourceTree = "<group>"; };
 		C3C70C552835C5BB00DD2546 /* SiteDesignSectionLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSectionLoaderTests.swift; sourceTree = "<group>"; };
 		C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationNameTracksEventTests.swift; sourceTree = "<group>"; };
@@ -10174,6 +10179,7 @@
 			isa = PBXGroup;
 			children = (
 				B0CD27CE286F8858009500BF /* JetpackBannerView.swift */,
+				C3C2F84728AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift */,
 				C3835558288B02B00062E402 /* JetpackBannerWrapperViewController.swift */,
 				3FAE0651287C8FC500F46508 /* JPScrollViewDelegate.swift */,
 			);
@@ -13925,6 +13931,7 @@
 		BE20F5E11B2F738E0020694C /* ViewRelated */ = {
 			isa = PBXGroup;
 			children = (
+				C3C2F84428AC8B9E00937E45 /* Jetpack */,
 				F44FB6C92878957E0001E3CE /* Mention */,
 				8B69F0E2255C2BC0006B1CEF /* Activity */,
 				8BD36E042395CC2F00EFFF1C /* Aztec */,
@@ -14062,6 +14069,14 @@
 				C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		C3C2F84428AC8B9E00937E45 /* Jetpack */ = {
+			isa = PBXGroup;
+			children = (
+				C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */,
+			);
+			path = Jetpack;
 			sourceTree = "<group>";
 		};
 		C3E42AAD27F4D2CF00546706 /* Menus */ = {
@@ -18586,6 +18601,7 @@
 				8217380B1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				57047A4F22A961BC00B461DF /* PostSearchHeader.swift in Sources */,
 				088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */,
+				C3C2F84828AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */,
 				F181EDE526B2AC7200C61241 /* BackgroundTasksCoordinator.swift in Sources */,
 				8B93412F257029F60097D0AC /* FilterChipButton.swift in Sources */,
 				40A71C68220E1952002E3D25 /* StatsRecordValue+CoreDataClass.swift in Sources */,
@@ -20397,6 +20413,7 @@
 				FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */,
 				F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
+				C3C2F84628AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift in Sources */,
 				D8B6BEB7203E11F2007C8A19 /* Bundle+LoadFromNib.swift in Sources */,
 				8B2D4F5527ECE376009B085C /* BlogDashboardPostsParserTests.swift in Sources */,
 				4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */,
@@ -21474,6 +21491,7 @@
 				FABB235A2602FC2C00C8785C /* ReaderCardsStreamViewController.swift in Sources */,
 				FABB235B2602FC2C00C8785C /* DeleteSiteViewController.swift in Sources */,
 				FABB235C2602FC2C00C8785C /* WPAnalyticsTrackerWPCom.m in Sources */,
+				C3C2F84928AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */,
 				FABB235D2602FC2C00C8785C /* AztecAttachmentViewController.swift in Sources */,
 				FABB235F2602FC2C00C8785C /* LoginEpilogueBlogCell.swift in Sources */,
 				FABB23602602FC2C00C8785C /* PostServiceRemoteFactory.swift in Sources */,

--- a/WordPress/WordPressTest/Jetpack/JetpackBannerScrollVisibilityTests.swift
+++ b/WordPress/WordPressTest/Jetpack/JetpackBannerScrollVisibilityTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+
+@testable import WordPress
+
+class JetpackBannerScrollVisibilityTests: XCTestCase {
+
+    /// A scroll view without enough content to scroll, so it "bounces"
+    func testBannerIsNotHiddenWhenScrollViewBounces() {
+        // When
+        let hidden = JetpackBannerScrollVisibility.shouldHide(
+            contentHeight: 400,
+            frameHeight: 400,
+            verticalContentOffset: 200
+        )
+
+        // Then
+        XCTAssertFalse(hidden)
+    }
+
+    /// A scroll view with enough content to scroll and has been scrolled past the minimum height of a Jetpack Banner
+    func testBannerIsHiddenWhenScrolledDown() {
+        // When
+        let hidden = JetpackBannerScrollVisibility.shouldHide(
+            contentHeight: 600,
+            frameHeight: 400,
+            verticalContentOffset: JetpackBannerView.minimumHeight + 1
+        )
+
+        // Then
+        XCTAssertTrue(hidden)
+    }
+
+}


### PR DESCRIPTION
## Description

**This PR:**
- Fixes #19097
  - Bouncing `UIScrollView`s should no longer affect banner visibility
- Hides the banner when a scroll view is scrolled past the height of the banner, otherwise shows it
- No longer hides the `ReaderStreamViewController` Jetpack banner when the keyboard is shown on the `ReaderSearchViewController`
    - This keeps us from having to add logic to show / hide banners depending on the keyboard visibility

## Testing

### Bouncing scroll view behavior

The banner should always be shown on scroll views that bounce.

1. Go to Reader
2. Tap the magnifying glass to start a search
3. Search for gibberish to ensure no results will be found (see https://github.com/wordpress-mobile/WordPress-iOS/issues/19097)
4. Bounce the scroll view by moving it up and down
5. **Expect** that the banner is always shown

This applies to any scroll view without enough content to exceed its frame's height.

### Banner visibility behavior

The banner should be hidden if a scrolling (non-bouncing) scroll view is scrolled below the height of a banner. Otherwise it should be shown.

1. Go to Reader
2. Tap the magnifying glass to start a search
3. Search for a generic term that results in many results
4. Scroll down
5. **Expect** the banner to hide once scrolled past the minimum of a banner, [currently defined as 50 pts](https://github.com/wordpress-mobile/WordPress-iOS/blob/9dc27140b2023ba046876917cc890d1b61eb6e6c/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift#L42)
6. **Expect** the banner not to reappear until the top offset is less than or equal to the 50 pt minimum defined above

### Banners to test:
- Jetpack activity log
- Notifications
- Reader
- Reader searching (there should be a banner above the keyboard)
- Reader search results - Posts and Sites tab

### Items to consider testing:
- a11y / VoiceOver / Dynamic Type
- Dark / Light mode
- Portrait / Landscape
- Jetpack / WordPress app

## Regression Notes
1. Potential unintended areas of impact
    - All Jetpack banner views in the app
    - Presenting the Jetpack overlay when a banner is tapped

7. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manually tested steps above

8. What automated tests I added (or what prevented me from doing so)
    - Added `JetpackBannerScrollVisibilityTests`

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
