### PR TITLE
[Jetpack] Remove banner from Sharing modal shown from Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -477,9 +477,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
             return
         }
 
-        let controller: UIViewController = JetpackBannerWrapperViewController(childVC: sharingVC)
-        let navigationController = UINavigationController(rootViewController: controller)
-
+        let navigationController = UINavigationController(rootViewController: sharingVC)
         present(navigationController, animated: true)
 
         applyTableUpdates()


### PR DESCRIPTION
## Description

This PR removes the banner from the Sharing modal shown from Stats.

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/2092798/185236808-5d9c2231-c3ac-410c-a135-de50de01440c.png) | <video src="https://user-images.githubusercontent.com/2092798/185235595-e310d1c8-4c2f-46dc-9d31-3fbd7ac7e759.mp4" /> |

## Testing
1. In the WordPress app with a site connected to Jetpack and post sharing not yet enabled, go to the Stats view
2. Tap "Enable post sharing"
3. **Expect** that there's no banner at the bottom of the view

## Regression Notes
1. Potential unintended areas of impact
    - This should just be contained to the Sharing view when shown in a modal from Stats

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
