### PR TITLE
[Jetpack] Removal modal support for views that present a Jetpack banner

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -38,7 +38,7 @@ import UIKit
     }
 
     private func configureJetpackBanner(_ stackView: UIStackView) {
-        guard JetpackBrandingVisibility.all.enabled else {
+        guard JetpackBrandingVisibility.all.enabled, !isModal() else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -501,6 +501,11 @@ import Combine
     }
 
     private func setupJetpackBanner(stackView: UIStackView) {
+        /// If being presented in a modal, don't show a Jetpack banner
+        if let nav = navigationController, nav.isModal() {
+            return
+        }
+
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }


### PR DESCRIPTION
## Description

We've decided to drop modal support for the Jetpack banner. This currently only affects viewing a site through reader's "Manage" view.

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-08-17 at 17 04 42](https://user-images.githubusercontent.com/2092798/185242826-e0d290e2-dde8-4981-9b52-57b8ed9840bf.png) | ![Simulator Screen Shot - iPhone 13 - 2022-08-17 at 17 03 41](https://user-images.githubusercontent.com/2092798/185242747-b9fb0d52-f007-407f-933a-21c64f6bbf8a.png) |

## Testing
1. Using the WordPress app with an account connected to Jetpack / Wordpress.com, tap Reader
2. Tap the gear icon at the top right to load the "Manage" view
3. Tap "Followed Sites"
4. Tap a site
5. **Expect** there to be no banner shown at the bottom of the view

## Regression Notes
1. Potential unintended areas of impact
    - Any cases where the Reader view is presented, especially as a modal

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
