### PR TITLE
UI Tests: Login Flow - Stop checking 'Continue' state after tapping it.

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -37,7 +37,6 @@ public class PasswordScreen: ScreenObject {
         passwordTextField.typeText(password)
         let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
-        XCTAssertEqual(continueButton.waitFor(predicateString: "exists == false"), .completed)
 
         return self
     }

--- a/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Login/Unified/PasswordScreen.swift
@@ -37,9 +37,8 @@ public class PasswordScreen: ScreenObject {
         passwordTextField.typeText(password)
         let continueButton = app.buttons["Continue Button"]
         continueButton.tap()
-        if continueButton.exists && !continueButton.isHittable {
-            XCTAssertEqual(continueButton.waitFor(predicateString: "isEnabled == true"), .completed)
-        }
+        XCTAssertEqual(continueButton.waitFor(predicateString: "exists == false"), .completed)
+
         return self
     }
 


### PR DESCRIPTION
The `setUp()` loop was failing intermittently during the Login Flow in different tests. 

### Failure
```
Assertions: Assertion Failure at PasswordScreen.swift:41: XCTAssertEqual failed: ("XCTWaiterResult(rawValue: 2)") is not equal to ("XCTWaiterResult(rawValue: 1)")
  File: PasswordScreen.swift:41
```

### Cause
During the Login, in `PasswordScreen`, `proceedWith(password: String)` is called and calls `tryProceed(password: String)`, which will type the password and tap the `continueButton`. To be able to handle two cases, the successful login and the login failure with a wrong password, there's an `if` statement checking the `continueButton` state.

```
[...]
continueButton.tap()
if continueButton.exists && !continueButton.isHittable {
    XCTAssertEqual(continueButton.waitFor(predicateString: "isEnabled == true"), .completed)
}
```
The code inside the `if` is only expected to be executed in case the password is wrong. However, after tapping the `Continue` button, depending on execution timing, the `if` condition might evaluate `true` for the valid password and the assertion would fail because the button is no longer enabled.

### Solution
Remove the `if` statement since it's an unnecessary complexity. For the valid password cases, our Screen Object already handles the screen transition time, for the invalid/wrong cases, the assertions will already check if the expected screen is loaded.


To test:
All tests must pass.

`testAddRemoveFeaturedImage` [running 50 times in CI](https://buildkite.com/automattic/wordpress-ios/builds/9625#_) in [a Test PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19189/commits/d1890251d6f2212b9ccae3168bc8f1c31d60cdea).

## Regression Notes
1. Potential unintended areas of impact
Login Flow impacts the `setUp()`  of all UI Tests.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ran all UI Tests and they passed.

3. What automated tests I added (or what prevented me from doing so)
N/A