### PR TITLE
Fix an issue where the `persistentContainer` ivar isn't set

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -232,6 +232,7 @@ static ContextManager *_instance;
 
     // Initialize the container
     NSPersistentContainer *persistentContainer = [[NSPersistentContainer alloc] initWithName:@"WordPress" managedObjectModel:self.managedObjectModel];
+    _persistentContainer = persistentContainer;
     persistentContainer.persistentStoreDescriptions = @[self.storeDescription];
     [persistentContainer loadPersistentStoresWithCompletionHandler:^(NSPersistentStoreDescription *description, NSError *error) {
         if (error != nil) {


### PR DESCRIPTION
### Changes
The `_persistentStoreCoordinator` instance variable is never assigned a value in its lazy getter. This is going to be an issue if the getter is called multiple times, which isn't the case now. But I wasted a few hours on this issue when making other changes.

### Test instructions
Unit and UI test suite should be able to cover this change.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
