### PR TITLE
[Jetpack] Add Tracks events for "Jetpack powered" elements

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -403,6 +403,11 @@ import Foundation
     case promptsNotificationTapped
     case promptsNotificationDismissed
 
+    // Jetpack branding
+    case jetpackPoweredBadgeTapped
+    case jetpackPoweredBannerTapped
+    case jetpackPoweredBottomSheetButtonTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1089,6 +1094,14 @@ import Foundation
             return "blogging_reminders_notification_prompt_tapped"
         case .promptsNotificationDismissed:
             return "blogging_reminders_notification_prompt_dismissed"
+
+        // Jetpack branding
+        case .jetpackPoweredBadgeTapped:
+            return "jetpack_powered_badge_tapped"
+        case .jetpackPoweredBannerTapped:
+            return "jetpack_powered_banner_tapped"
+        case .jetpackPoweredBottomSheetButtonTapped:
+            return "jetpack_powered_bottom_sheet_button_tapped"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -177,6 +177,7 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
 
     @objc private func jetpackButtonTapped() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .activityDetail)
     }
 
     private func setupText() {

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -46,6 +46,7 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
         addTranslationObserver(jetpackBannerView)
         jetpackBannerView.buttonAction = { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .activityLog)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
@@ -9,5 +9,6 @@ extension SharingViewController {
     @objc
     func presentJetpackOverlay() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .sharing)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
@@ -46,5 +46,6 @@ extension DashboardBadgeCell: BlogDashboardCardConfigurable {
             return
         }
         JetpackBrandingCoordinator.presentOverlay(from: viewController)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .home)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -1,13 +1,19 @@
 import Foundation
 import UIKit
+import WordPressShared
 
-@objc class JetpackBannerWrapperViewController: UIViewController {
+class JetpackBannerWrapperViewController: UIViewController {
     /// The wrapped child view controller.
     private(set) var childVC: UIViewController?
+    private var analyticsId: JetpackBrandingAnalyticsHelper.JetpackBannerScreen?
 
-    @objc convenience init(childVC: UIViewController) {
+    convenience init(
+        childVC: UIViewController,
+        analyticsId: JetpackBrandingAnalyticsHelper.JetpackBannerScreen? = nil
+    ) {
         self.init()
         self.childVC = childVC
+        self.analyticsId = analyticsId
     }
 
     override func viewDidLoad() {
@@ -44,6 +50,9 @@ import UIKit
 
         let jetpackBannerView = JetpackBannerView() { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            if let screen = analyticsId {
+                JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: screen)
+            }
         }
         stackView.addArrangedSubview(jetpackBannerView)
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -1,0 +1,41 @@
+import Foundation
+import AutomatticTracks
+
+struct JetpackBrandingAnalyticsHelper {
+    private static let screenPropertyKey = "screen"
+
+    // MARK: - Jetpack powered badge tapped
+    static func trackJetpackPoweredBadgeTapped(screen: Self.JetpackBadgeScreen) {
+        let properties = [screenPropertyKey: screen.rawValue]
+        WPAnalytics.track(.jetpackPoweredBadgeTapped, properties: properties)
+    }
+
+    // MARK: - Jetpack powered banner tapped
+    static func trackJetpackPoweredBannerTapped(screen: Self.JetpackBannerScreen) {
+        let properties = [screenPropertyKey: screen.rawValue]
+        WPAnalytics.track(.jetpackPoweredBannerTapped, properties: properties)
+    }
+
+    // MARK: - Jetpack powered bottom sheet button tapped
+    static func trackJetpackPoweredBottomSheetButtonTapped() {
+        WPAnalytics.track(.jetpackPoweredBottomSheetButtonTapped)
+    }
+
+    enum JetpackBannerScreen: String {
+        case activityLog
+        case notifications
+        case reader
+        case readerSearch
+        case stats
+    }
+
+    enum JetpackBadgeScreen: String {
+        case activityDetail
+        case appSettings
+        case home
+        case me
+        case notificationsSettings
+        case readerDetail
+        case sharing
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -22,20 +22,20 @@ struct JetpackBrandingAnalyticsHelper {
     }
 
     enum JetpackBannerScreen: String {
-        case activityLog
+        case activityLog = "activity_log"
         case notifications
         case reader
-        case readerSearch
+        case readerSearch = "reader_search"
         case stats
     }
 
     enum JetpackBadgeScreen: String {
-        case activityDetail
-        case appSettings
+        case activityDetail = "activity_detail"
+        case appSettings = "app_settings"
         case home
         case me
-        case notificationsSettings
-        case readerDetail
+        case notificationsSettings = "notifications_settings"
+        case readerDetail = "reader_detail"
         case sharing
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
@@ -95,6 +95,7 @@ class JetpackOverlayView: UIView {
 
     @objc private func didTapButton() {
         buttonAction?()
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBottomSheetButtonTapped()
     }
 
     @objc private func dismissTapped() {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -549,5 +549,6 @@ extension AppSettingsViewController {
 
     @objc private func jetpackButtonTapped() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .appSettings)
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -558,5 +558,6 @@ extension MeViewController {
 
     @objc private func jetpackButtonTapped() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .me)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -595,6 +595,7 @@ private extension NotificationSettingsViewController {
 
     @objc func jetpackButtonTapped() {
         JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .notificationsSettings)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -626,6 +626,7 @@ extension NotificationsViewController {
         }
         jetpackBannerView.buttonAction = { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .notifications)
         }
         jetpackBannerView.isHidden = false
         addTranslationObserver(jetpackBannerView)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -159,6 +159,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
             return
         }
         JetpackBrandingCoordinator.presentOverlay(from: presentingViewController)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .readerDetail)
     }
 
     struct Constants {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -41,7 +41,10 @@ import Gridicons
 
     fileprivate var backgroundTapRecognizer: UITapGestureRecognizer!
     fileprivate var streamController: ReaderStreamViewController?
-    fileprivate lazy var jpSiteSearchController = JetpackBannerWrapperViewController(childVC: ReaderSiteSearchViewController())
+    fileprivate lazy var jpSiteSearchController = JetpackBannerWrapperViewController(
+        childVC: ReaderSiteSearchViewController(),
+        analyticsId: .readerSearch
+    )
     fileprivate var siteSearchController: ReaderSiteSearchViewController? {
         return jpSiteSearchController.childVC as? ReaderSiteSearchViewController
     }
@@ -53,6 +56,7 @@ import Gridicons
     private lazy var bannerView: JetpackBannerView = {
         let bannerView = JetpackBannerView() { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .readerSearch)
         }
         bannerView.frame = CGRect(x: 0, y: 0, width: view.frame.width, height: JetpackBannerView.minimumHeight)
         return bannerView

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -511,6 +511,7 @@ import Combine
         }
         let bannerView = JetpackBannerView() { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .reader)
         }
         jetpackBannerView = bannerView
         addTranslationObserver(bannerView)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -114,6 +114,7 @@ class SiteStatsDashboardViewController: UIViewController {
         }
         jetpackBannerView.buttonAction = { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
+            JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .stats)
         }
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2305,6 +2305,8 @@
 		C3DA0EE02807062600DA3250 /* SiteCreationNameTracksEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */; };
 		C3E2462926277B7700B99EA6 /* PostAuthorSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */; };
 		C3E42AB027F4D30E00546706 /* MenuItemsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3E42AAF27F4D30E00546706 /* MenuItemsViewControllerTests.swift */; };
+		C3FBF4E828AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */; };
+		C3FBF4E928AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */; };
 		C3FF78E828354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FF78E728354A91008FA600 /* SiteDesignSectionLoader.swift */; };
 		C3FF78E928354A91008FA600 /* SiteDesignSectionLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3FF78E728354A91008FA600 /* SiteDesignSectionLoader.swift */; };
 		C533CF350E6D3ADA000C3DE8 /* CommentsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C533CF340E6D3ADA000C3DE8 /* CommentsViewController.m */; };
@@ -7211,6 +7213,7 @@
 		C3DA0EDF2807062600DA3250 /* SiteCreationNameTracksEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationNameTracksEventTests.swift; sourceTree = "<group>"; };
 		C3E2462826277B7700B99EA6 /* PostAuthorSelectorViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostAuthorSelectorViewController.swift; sourceTree = "<group>"; };
 		C3E42AAF27F4D30E00546706 /* MenuItemsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItemsViewControllerTests.swift; sourceTree = "<group>"; };
+		C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingAnalyticsHelper.swift; sourceTree = "<group>"; };
 		C3FF78E728354A91008FA600 /* SiteDesignSectionLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSectionLoader.swift; sourceTree = "<group>"; };
 		C52812131832E071008931FD /* WordPress 13.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 13.xcdatamodel"; sourceTree = "<group>"; };
 		C533CF330E6D3ADA000C3DE8 /* CommentsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommentsViewController.h; sourceTree = "<group>"; };
@@ -10175,6 +10178,7 @@
 			isa = PBXGroup;
 			children = (
 				3F720C2028899DD900519938 /* JetpackBrandingVisibility.swift */,
+				C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */,
 				3FFA5ED0287612AD00830E28 /* Banner */,
 				3F5B9B44288B0521001D17E9 /* Badge */,
 				3F43703D28931FF800475B6E /* Overlay */,
@@ -18405,6 +18409,7 @@
 				F1D690171F82914200200E30 /* BuildConfiguration.swift in Sources */,
 				E1BEEC651C4E3978000B4FA0 /* PaddedLabel.swift in Sources */,
 				E1A6DBE519DC7D230071AC1E /* PostService.m in Sources */,
+				C3FBF4E828AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift in Sources */,
 				F1D8C6F026C17A6C002E3323 /* WeeklyRoundupBackgroundTask.swift in Sources */,
 				E62AFB6E1DC8E593007484FC /* WPTextAttachmentManager.swift in Sources */,
 				9F3EFC9E208E2E8A00268758 /* ReaderSiteInfoSubscriptions.swift in Sources */,
@@ -20888,6 +20893,7 @@
 				9856A39E261FC21E008D6354 /* UserProfileUserInfoCell.swift in Sources */,
 				FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */,
 				FABB21632602FC2C00C8785C /* FeatureItemCell.swift in Sources */,
+				C3FBF4E928AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift in Sources */,
 				803C493C283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */,
 				FABB21642602FC2C00C8785C /* WPRichContentView.swift in Sources */,
 				FABB21652602FC2C00C8785C /* MediaFileManager.swift in Sources */,


### PR DESCRIPTION
Fixes #19154

## Testing

**Prerequisites:**
- Enable the "Jetpack powered bottom sheet" feature flag
- The WordPress app should be used for all tests

### Banners

Tap the banner in the following views:
- Stats
- Notifications
- Reader
- Reader search
- Activity log

**Expect** to see a Tracks event `jetpack_powered_banner_tapped` in the device logs that contains a property matching the view's name. e.g.:

`Tracked: jetpack_powered_banner_tapped <screen: reader>`

### Badges

Tap the badge in the following views:
- Home
- Activity detail
- Reader detail
- App settings
- Notifications settings
- Me
- Sharing

**Expect** to see a Tracks event `jetpack_powered_badge_tapped` in the device logs that contains a property matching the view's name. e.g.:

`Tracked: jetpack_powered_badge_tapped <screen: home>`

### Bottom sheet button
1. Using any of the views above containing a banner or a badge to present the bottom sheet overlay
2. Tap "Try the new Jetpack app"
3. **Expect** to see `Tracked: jetpack_powered_bottom_sheet_button_tapped <>` in the device logs

## Regression Notes
1. Potential unintended areas of impact
    - A banner or badge that should send an event may have been missed

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
