### PR TITLE
Shared Login: Replace old keychain calls, copy keychain, and copy database to shared directory

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -5,7 +5,6 @@
 #import "ContextManager.h"
 #import "Constants.h"
 #import "WordPress-Swift.h"
-#import "SFHFKeychainUtils.h"
 #import "WPUserAgent.h"
 #import "WordPress-Swift.h"
 
@@ -466,7 +465,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (NSString *)password
 {
-    return [SFHFKeychainUtils getPasswordForUsername:self.username andServiceName:self.xmlrpc error:nil];
+    return [KeychainUtils.shared getPasswordForUsername:self.username serviceName:self.xmlrpc accessGroup:nil error:nil];
 }
 
 - (void)setPassword:(NSString *)password
@@ -474,15 +473,17 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     NSAssert(self.username != nil, @"Can't set password if we don't know the username yet");
     NSAssert(self.xmlrpc != nil, @"Can't set password if we don't know the XML-RPC endpoint yet");
     if (password) {
-        [SFHFKeychainUtils storeUsername:self.username
-                             andPassword:password
-                          forServiceName:self.xmlrpc
-                          updateExisting:YES
-                                   error:nil];
+        [KeychainUtils.shared storeUsername:self.username
+                                   password:password
+                                serviceName:self.xmlrpc
+                                accessGroup:nil
+                             updateExisting:YES
+                                      error:nil];
     } else {
-        [SFHFKeychainUtils deleteItemForUsername:self.username
-                                  andServiceName:self.xmlrpc
-                                           error:nil];
+        [KeychainUtils.shared deleteItemWithUsername:self.username
+                                         serviceName:self.xmlrpc
+                                         accessGroup:nil
+                                               error:nil];
     }
 }
 

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -1,5 +1,4 @@
 #import "WPAccount.h"
-#import "SFHFKeychainUtils.h"
 #import "WordPress-Swift.h"
 
 static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.wordpress.com";
@@ -84,11 +83,12 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 {
     if (authToken) {
         NSError *error = nil;
-        [SFHFKeychainUtils storeUsername:self.username
-                             andPassword:authToken
-                          forServiceName:WordPressComOAuthKeychainServiceName
-                          updateExisting:YES
-                                   error:&error];
+        [KeychainUtils.shared storeUsername:self.username
+                                   password:authToken
+                                serviceName:WordPressComOAuthKeychainServiceName
+                                accessGroup:nil
+                             updateExisting:YES
+                                      error:&error];
 
         if (error) {
             DDLogError(@"Error while updating WordPressComOAuthKeychainServiceName token: %@", error);
@@ -96,9 +96,10 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 
     } else {
         NSError *error = nil;
-        [SFHFKeychainUtils deleteItemForUsername:self.username
-                                  andServiceName:WordPressComOAuthKeychainServiceName
-                                           error:&error];
+        [KeychainUtils.shared deleteItemWithUsername:self.username
+                                         serviceName:WordPressComOAuthKeychainServiceName
+                                         accessGroup:nil
+                                               error:&error];
         if (error) {
             DDLogError(@"Error while deleting WordPressComOAuthKeychainServiceName token: %@", error);
         }
@@ -132,8 +133,10 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 + (NSString *)tokenForUsername:(NSString *)username
 {
     NSError *error = nil;
-    NSString *authToken = [SFHFKeychainUtils getPasswordForUsername:username
-                                                     andServiceName:WordPressComOAuthKeychainServiceName error:&error];
+    NSString *authToken = [KeychainUtils.shared getPasswordForUsername:username
+                                                           serviceName:WordPressComOAuthKeychainServiceName
+                                                           accessGroup:nil
+                                                                 error:&error];
     if (error) {
         DDLogError(@"Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error);
     }

--- a/WordPress/Classes/Services/CredentialsService.swift
+++ b/WordPress/Classes/Services/CredentialsService.swift
@@ -4,7 +4,7 @@ protocol CredentialsProvider {
 
 struct KeychainCredentialsProvider: CredentialsProvider {
     func getPassword(username: String, service: String) -> String? {
-        return try? SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: service)
+        return try? KeychainUtils.shared.getPasswordForUsername(username, serviceName: service)
     }
 }
 

--- a/WordPress/Classes/Services/NotificationSupportService.swift
+++ b/WordPress/Classes/Services/NotificationSupportService.swift
@@ -9,11 +9,13 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertContentExtensionToken(_ oauthToken: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPNotificationContentExtensionKeychainTokenKey,
-                                                andPassword: oauthToken,
-                                                forServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                                accessGroup: WPAppKeychainAccessGroup,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(
+                    WPNotificationContentExtensionKeychainTokenKey,
+                    password: oauthToken,
+                    serviceName: WPNotificationContentExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup,
+                    updateExisting: true
+            )
         } catch {
             DDLogDebug("Error while saving Notification Content Extension OAuth token: \(error)")
         }
@@ -26,11 +28,13 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertContentExtensionUsername(_ username: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPNotificationContentExtensionKeychainUsernameKey,
-                                                andPassword: username,
-                                                forServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                                accessGroup: WPAppKeychainAccessGroup,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(
+                    WPNotificationContentExtensionKeychainUsernameKey,
+                    password: username,
+                    serviceName: WPNotificationContentExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup,
+                    updateExisting: true
+            )
         } catch {
             DDLogDebug("Error while saving Notification Content Extension username: \(error)")
         }
@@ -43,11 +47,13 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionToken(_ oauthToken: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPNotificationServiceExtensionKeychainTokenKey,
-                                                andPassword: oauthToken,
-                                                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                accessGroup: WPAppKeychainAccessGroup,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(
+                    WPNotificationServiceExtensionKeychainTokenKey,
+                    password: oauthToken,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup,
+                    updateExisting: true
+            )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension OAuth token: \(error)")
         }
@@ -60,11 +66,13 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionUsername(_ username: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPNotificationServiceExtensionKeychainUsernameKey,
-                                                andPassword: username,
-                                                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                accessGroup: WPAppKeychainAccessGroup,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(
+                    WPNotificationServiceExtensionKeychainUsernameKey,
+                    password: username,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup,
+                    updateExisting: true
+            )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension username: \(error)")
         }
@@ -77,11 +85,13 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionUserID(_ userID: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPNotificationServiceExtensionKeychainUserIDKey,
-                                                andPassword: userID,
-                                                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                accessGroup: WPAppKeychainAccessGroup,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(
+                    WPNotificationServiceExtensionKeychainUserIDKey,
+                    password: userID,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup,
+                    updateExisting: true
+            )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension userID: \(error)")
         }
@@ -92,9 +102,11 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteContentExtensionToken() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationContentExtensionKeychainTokenKey,
-                                             andServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                             accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                    username: WPNotificationContentExtensionKeychainTokenKey,
+                    serviceName: WPNotificationContentExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             DDLogDebug("Error while removing Notification Content Extension OAuth token: \(error)")
         }
@@ -105,9 +117,11 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteContentExtensionUsername() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationContentExtensionKeychainUsernameKey,
-                                             andServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                             accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                    username: WPNotificationContentExtensionKeychainUsernameKey,
+                    serviceName: WPNotificationContentExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             DDLogDebug("Error while removing Notification Content Extension username: \(error)")
         }
@@ -118,9 +132,11 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionToken() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationServiceExtensionKeychainTokenKey,
-                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                             accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                    username: WPNotificationServiceExtensionKeychainTokenKey,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension OAuth token: \(error)")
         }
@@ -131,9 +147,11 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionUsername() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationServiceExtensionKeychainUsernameKey,
-                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                             accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                    username: WPNotificationServiceExtensionKeychainUsernameKey,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension username: \(error)")
         }
@@ -144,9 +162,11 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionUserID() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPNotificationServiceExtensionKeychainUserIDKey,
-                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                             accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                    username: WPNotificationServiceExtensionKeychainUserIDKey,
+                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                    accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension userID: \(error)")
         }

--- a/WordPress/Classes/Services/ShareExtensionService.swift
+++ b/WordPress/Classes/Services/ShareExtensionService.swift
@@ -8,11 +8,13 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func configureShareExtensionToken(_ oauth2Token: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPShareExtensionKeychainTokenKey,
-                andPassword: oauth2Token,
-                forServiceName: WPShareExtensionKeychainServiceName,
+            try KeychainUtils.shared.storeUsername(
+                WPShareExtensionKeychainTokenKey,
+                password: oauth2Token,
+                serviceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup,
-                updateExisting: true)
+                updateExisting: true
+            )
         } catch {
             print("Error while saving Share Extension OAuth bearer token: \(error)")
         }
@@ -24,11 +26,13 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func configureShareExtensionUsername(_ username: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPShareExtensionKeychainUsernameKey,
-                andPassword: username,
-                forServiceName: WPShareExtensionKeychainServiceName,
+            try KeychainUtils.shared.storeUsername(
+                WPShareExtensionKeychainUsernameKey,
+                password: username,
+                serviceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup,
-                updateExisting: true)
+                updateExisting: true
+            )
         } catch {
             print("Error while saving Share Extension OAuth bearer token: \(error)")
         }
@@ -94,17 +98,21 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func removeShareExtensionConfiguration() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPShareExtensionKeychainTokenKey,
-                andServiceName: WPShareExtensionKeychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                username: WPShareExtensionKeychainTokenKey,
+                serviceName: WPShareExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             print("Error while removing Share Extension OAuth2 bearer token: \(error)")
         }
 
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPShareExtensionKeychainUsernameKey,
-                andServiceName: WPShareExtensionKeychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup)
+            try KeychainUtils.shared.deleteItem(
+                username: WPShareExtensionKeychainUsernameKey,
+                serviceName: WPShareExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
+            )
         } catch {
             print("Error while removing Share Extension Username: \(error)")
         }
@@ -122,8 +130,9 @@ open class ShareExtensionService: NSObject {
     /// Retrieves the WordPress.com OAuth Token, meant for Extension usage.
     ///
     @objc class func retrieveShareExtensionToken() -> String? {
-        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainTokenKey,
-            andServiceName: WPShareExtensionKeychainServiceName, accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPShareExtensionKeychainTokenKey,
+                                                                                 serviceName: WPShareExtensionKeychainServiceName,
+                                                                                 accessGroup: WPAppKeychainAccessGroup) else {
             return nil
         }
 
@@ -133,8 +142,9 @@ open class ShareExtensionService: NSObject {
     /// Retrieves the WordPress.com Username, meant for Extension usage.
     ///
     @objc class func retrieveShareExtensionUsername() -> String? {
-        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainUsernameKey,
-            andServiceName: WPShareExtensionKeychainServiceName, accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPShareExtensionKeychainUsernameKey,
+                                                                                 serviceName: WPShareExtensionKeychainServiceName,
+                                                                                 accessGroup: WPAppKeychainAccessGroup) else {
             return nil
         }
 

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -1,7 +1,6 @@
 #import "TodayExtensionService.h"
 #import <NotificationCenter/NotificationCenter.h>
 #import "Constants.h"
-#import "SFHFKeychainUtils.h"
 #import "WordPress-Swift.h"
 
 @implementation TodayExtensionService
@@ -33,12 +32,12 @@
     [sharedDefaults setObject:blogUrl forKey:WPStatsTodayWidgetUserDefaultsSiteUrlKey];
     
     NSError *error;
-    [SFHFKeychainUtils storeUsername:WPStatsTodayWidgetKeychainTokenKey
-                         andPassword:oauth2Token
-                      forServiceName:WPStatsTodayWidgetKeychainServiceName
-                         accessGroup:WPAppKeychainAccessGroup
-                      updateExisting:YES
-                               error:&error];
+    [KeychainUtils.shared storeUsername:WPStatsTodayWidgetKeychainTokenKey
+                               password:oauth2Token
+                            serviceName:WPStatsTodayWidgetKeychainServiceName
+                            accessGroup:WPAppKeychainAccessGroup
+                         updateExisting:YES
+                                  error:&error];
     if (error) {
         DDLogError(@"Today Widget OAuth2Token error: %@", error);
     }
@@ -53,20 +52,20 @@
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteNameKey];
     [sharedDefaults removeObjectForKey:WPStatsTodayWidgetUserDefaultsSiteUrlKey];
     
-    [SFHFKeychainUtils deleteItemForUsername:WPStatsTodayWidgetKeychainTokenKey
-                              andServiceName:WPStatsTodayWidgetKeychainServiceName
-                                 accessGroup:WPAppKeychainAccessGroup
-                                       error:nil];
+    [KeychainUtils.shared deleteItemWithUsername:WPStatsTodayWidgetKeychainTokenKey
+                                     serviceName:WPStatsTodayWidgetKeychainServiceName
+                                     accessGroup:WPAppKeychainAccessGroup
+                                           error:nil];
 }
 
 - (BOOL)widgetIsConfigured
 {
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
     NSString *siteId = [sharedDefaults stringForKey:WPStatsTodayWidgetUserDefaultsSiteIdKey];
-    NSString *oauth2Token = [SFHFKeychainUtils getPasswordForUsername:WPStatsTodayWidgetKeychainTokenKey
-                                                       andServiceName:WPStatsTodayWidgetKeychainServiceName
-                                                          accessGroup:WPAppKeychainAccessGroup
-                                                                error:nil];
+    NSString *oauth2Token = [KeychainUtils.shared getPasswordForUsername:WPStatsTodayWidgetKeychainTokenKey
+                                                             serviceName:WPStatsTodayWidgetKeychainServiceName
+                                                             accessGroup:WPAppKeychainAccessGroup
+                                                                   error:nil];
     
     if (siteId.length == 0 || oauth2Token.length == 0) {
         return NO;

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -90,6 +90,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Application lifecycle
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        KeychainUtils.shared.copyKeychainToSharedKeychainIfNeeded()
+
         window = UIWindow(frame: UIScreen.main.bounds)
         AppAppearance.overrideAppearance()
 
@@ -908,8 +910,8 @@ extension WordPressAppDelegate {
         // Get the Apple User ID from the keychain
         let appleUserID: String
         do {
-            appleUserID = try SFHFKeychainUtils.getPasswordForUsername(WPAppleIDKeychainUsernameKey,
-                                                                  andServiceName: WPAppleIDKeychainServiceName)
+            appleUserID = try KeychainUtils.shared.getPasswordForUsername(WPAppleIDKeychainUsernameKey,
+                                                                          serviceName: WPAppleIDKeychainServiceName)
         } catch {
             DDLogInfo("checkAppleIDCredentialState: No Apple ID found.")
             return
@@ -961,8 +963,8 @@ extension WordPressAppDelegate {
 
     func removeAppleIDFromKeychain() {
         do {
-            try SFHFKeychainUtils.deleteItem(forUsername: WPAppleIDKeychainUsernameKey,
-                                             andServiceName: WPAppleIDKeychainServiceName)
+            try KeychainUtils.shared.deleteItem(username: WPAppleIDKeychainUsernameKey,
+                                                serviceName: WPAppleIDKeychainServiceName)
         } catch let error as NSError {
             if error.code != errSecItemNotFound {
                 DDLogError("Error while removing Apple User ID from keychain: \(error.localizedDescription)")

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
@@ -1,8 +1,8 @@
 #import "BlogToAccount.h"
 #import <NSURL_IDN/NSURL+IDN.h>
-#import "SFHFKeychainUtils.h"
 #import "WPAccount.h"
 #import "Constants.h"
+#import "WordPress-Swift.h"
 
 @implementation BlogToAccount {
     NSString *_defaultWpcomUsername;
@@ -42,11 +42,10 @@
         NSString *newKey = WPComXMLRPCUrl;
 
         NSError *error;
-        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:oldKey error:&error];
+        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:oldKey accessGroup:nil error:&error];
         if (password) {
-            if ([SFHFKeychainUtils storeUsername:username andPassword:password 
-                                  forServiceName:newKey updateExisting:YES error:&error]) {
-                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:oldKey error:&error];
+            if ([KeychainUtils.shared storeUsername:username password:password serviceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
+                [KeychainUtils.shared deleteItemWithUsername:username serviceName:oldKey accessGroup:nil error:&error];
             }
         }
         if (error) {
@@ -113,10 +112,10 @@
             newKey = xmlrpc;
         }
         NSError *error;
-        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:oldKey error:&error];
+        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:oldKey accessGroup:nil error:&error];
         if (password) {
-            if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:newKey updateExisting:YES error:&error]) {
-                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:oldKey error:&error];
+            if ([KeychainUtils.shared storeUsername:username password:password serviceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
+                [KeychainUtils.shared deleteItemWithUsername:username serviceName:oldKey accessGroup:nil error:&error];
             }
         }
         if (error) {

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.h
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.h
@@ -1,5 +1,7 @@
 #import <CoreData/CoreData.h>
 
+static NSString * const WPComXMLRPCUrl = @"https://wordpress.com/xmlrpc.php";
+
 @interface BlogToJetpackAccount : NSEntityMigrationPolicy
 
 @end

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
@@ -1,9 +1,8 @@
 #import "BlogToJetpackAccount.h"
-#import "SFHFKeychainUtils.h"
 #import "WPAccount.h"
+#import "WordPress-Swift.h"
 
 static NSString * const BlogJetpackKeychainPrefix = @"jetpackblog-";
-static NSString * const WPComXMLRPCUrl = @"https://wordpress.com/xmlrpc.php";
 
 @implementation BlogToJetpackAccount
 
@@ -53,10 +52,10 @@ static NSString * const WPComXMLRPCUrl = @"https://wordpress.com/xmlrpc.php";
 
         // Migrate passwords
         NSError *error;
-        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:@"WordPress.com" error:&error];
+        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:@"WordPress.com" accessGroup:nil error:&error];
         if (password) {
-            if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:WPComXMLRPCUrl updateExisting:YES error:&error]) {
-                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:@"WordPress.com" error:&error];
+            if ([KeychainUtils.shared storeUsername:username password:password serviceName:WPComXMLRPCUrl accessGroup:nil updateExisting:YES error:&error]) {
+                [KeychainUtils.shared deleteItemWithUsername:username serviceName:@"WordPress.com" accessGroup:nil error:&error];
             }
         }
         if (error) {
@@ -112,7 +111,7 @@ static NSString * const WPComXMLRPCUrl = @"https://wordpress.com/xmlrpc.php";
 - (NSString *)jetpackPasswordForBlog:(NSManagedObject *)blog
 {
     NSError *error = nil;
-    return [SFHFKeychainUtils getPasswordForUsername:[self jetpackUsernameForBlog:blog] andServiceName:@"WordPress.com" error:&error];
+    return [KeychainUtils.shared getPasswordForUsername:[self jetpackUsernameForBlog:blog] serviceName:@"WordPress.com" accessGroup:nil error:&error];
 }
 
 @end

--- a/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
+++ b/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
@@ -44,8 +44,8 @@ class BlogToBlog32to33: NSEntityMigrationPolicy {
                 let username = sInstance.value(forKeyPath: "account.username") as! String
 
                 do {
-                    let password = try SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: accountXmlrpc)
-                    try SFHFKeychainUtils.storeUsername(username, andPassword: password, forServiceName: blogXmlrpc, updateExisting: true)
+                    let password = try KeychainUtils.shared.getPasswordForUsername(username, serviceName: accountXmlrpc)
+                    try KeychainUtils.shared.storeUsername(username, password: password, serviceName: blogXmlrpc, updateExisting: true)
                 } catch {
                     DDLogError("Error getting/saving password for \(accountXmlrpc): \(error)")
                 }

--- a/WordPress/Classes/Utility/SFHFKeychainUtils.h
+++ b/WordPress/Classes/Utility/SFHFKeychainUtils.h
@@ -65,4 +65,7 @@
                   accessGroup:(NSString *)accessGroup
                         error:(NSError **)error;
 
++ (NSArray<NSDictionary<NSString *, NSString *> *> *)getAllPasswordsForAccessGroup:(NSString *)accessGroup
+                                                                             error:(NSError **)error;
+
 @end

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -445,10 +445,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func userAuthenticatedWithAppleUserID(_ appleUserID: String) {
         do {
-            try SFHFKeychainUtils.storeUsername(WPAppleIDKeychainUsernameKey,
-                                                andPassword: appleUserID,
-                                                forServiceName: WPAppleIDKeychainServiceName,
-                                                updateExisting: true)
+            try KeychainUtils.shared.storeUsername(WPAppleIDKeychainUsernameKey,
+                                                   password: appleUserID,
+                                                   serviceName: WPAppleIDKeychainServiceName,
+                                                   updateExisting: true)
         } catch {
             DDLogInfo("Error while saving Apple User ID: \(error)")
         }

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -6,7 +6,6 @@
 #import "WPAccount.h"
 #import "ContextManager.h"
 #import "BlogService.h"
-#import "SFHFKeychainUtils.h"
 #import "TodayExtensionService.h"
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"

--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -13,5 +13,13 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.wordpress</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>3TMU3BH3NK.org.wordpress</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1486,6 +1486,41 @@
 		8384C64428AAC85F00EABE26 /* KeychainUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64328AAC85F00EABE26 /* KeychainUtilsTests.swift */; };
 		839B150B2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
 		839B150C2795DEE0009F5E77 /* UIView+Margins.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839B150A2795DEE0009F5E77 /* UIView+Margins.swift */; };
+		83A1B19528AFE47900E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19628AFE47A00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19728AFE47A00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19828AFE47B00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19928AFE47B00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19A28AFE47C00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19B28AFE47D00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19C28AFE47D00E737AC /* KeychainUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8384C64028AAC82600EABE26 /* KeychainUtils.swift */; };
+		83A1B19E28AFE86A00E737AC /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
+		83A1B1A028AFE89700E737AC /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
+		83A1B1A328AFE89F00E737AC /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
+		83A1B1A628AFF10900E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1A728AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1A828AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1A928AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1AA28AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1AB28AFF10C00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1AC28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1AD28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
+		83A1B1AE28AFF11A00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1AF28AFF11B00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B028AFF11B00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B128AFF11C00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B228AFF11C00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B328AFF11D00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B428AFF11D00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B528AFF11E00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
+		83A1B1B628AFF15200E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1B728AFF15300E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1B828AFF15300E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1B928AFF15400E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1BA28AFF15400E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1BB28AFF15500E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1BC28AFF15500E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
+		83A1B1BD28AFF15600E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
 		83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
@@ -19913,6 +19948,8 @@
 				3F63B93C258179D100F581BE /* StatsWidgetEntry.swift in Sources */,
 				3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
 				3FCF66E925CAF8C50047F337 /* ListStatsView.swift in Sources */,
+				83A1B19A28AFE47C00E737AC /* KeychainUtils.swift in Sources */,
+				83A1B1BB28AFF15500E737AC /* UserPersistentStore.swift in Sources */,
 				3F6BC06D25B24787007369D3 /* BuildConfiguration.swift in Sources */,
 				3F1FD2502548AD8B0060C53A /* TodayWidgetStats.swift in Sources */,
 				3F2F0C16256C6B2C003351C7 /* StatsWidgetsService.swift in Sources */,
@@ -19936,6 +19973,7 @@
 				3F1FD27B2548AE900060C53A /* CocoaLumberjack.swift in Sources */,
 				3FCF66FB25CAF8E00047F337 /* ListRow.swift in Sources */,
 				8323789828526E6D003F4443 /* AppConfiguration.swift in Sources */,
+				83A1B1B328AFF11D00E737AC /* UserPersistentRepository.swift in Sources */,
 				3F8B138F25D09AA5004FAC0A /* WordPressHomeWidgetThisWeek.swift in Sources */,
 				3F5689F0254209790048A9E4 /* SingleStatView.swift in Sources */,
 				3FAA18CC25797B85002B1911 /* UnconfiguredView.swift in Sources */,
@@ -19946,6 +19984,7 @@
 				3FD675D925C87A15009AB3C1 /* Sites.intentdefinition in Sources */,
 				3FE77C8325B0CA89007DE9E5 /* LocalizableStrings.swift in Sources */,
 				3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */,
+				83A1B1AB28AFF10C00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				3FE20C3725CF211F00A15525 /* ListViewData.swift in Sources */,
 				3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */,
 				98390AD2254C985F00868F0A /* Tracks.swift in Sources */,
@@ -20018,9 +20057,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				83A1B1AC28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789928526E6E003F4443 /* AppConfiguration.swift in Sources */,
 				7345EAC4212DD49400607EC9 /* CircularImageView.swift in Sources */,
+				83A1B19B28AFE47D00E737AC /* KeychainUtils.swift in Sources */,
 				436110DD22C41AFD000773AD /* FeatureFlag.swift in Sources */,
+				83A1B1BC28AFF15500E737AC /* UserPersistentStore.swift in Sources */,
 				436110DC22C41ADB000773AD /* UIColor+MurielColors.swift in Sources */,
 				170BEC8A239153160017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
 				433ADC1B223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
@@ -20032,6 +20074,7 @@
 				FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
 				736584E6213752730029C9A4 /* SFHFKeychainUtils.m in Sources */,
+				83A1B1B428AFF11D00E737AC /* UserPersistentRepository.swift in Sources */,
 				73B05D2621374B960073ECAA /* Tracks.swift in Sources */,
 				1752D4FC238D703A002B79E7 /* KeyValueDatabase.swift in Sources */,
 				FAD2566F2611AEC700EDAF88 /* AppStyleGuide.swift in Sources */,
@@ -20046,13 +20089,16 @@
 				73ACDF9D2118AF7D00233AD4 /* Constants.m in Sources */,
 				7335AC6021220D550012EF2D /* RemoteNotificationActionParser.swift in Sources */,
 				7335AC6621220EA60012EF2D /* NotificationContentRange.swift in Sources */,
+				83A1B1A028AFE89700E737AC /* AppConfiguration.swift in Sources */,
 				7335AC5B21220ADD0012EF2D /* FormattableContentStyles.swift in Sources */,
 				7335AC6A21220ED90012EF2D /* FormattableRangesFactory.swift in Sources */,
 				7335AC5C21220AF40012EF2D /* FormattableContentAction.swift in Sources */,
 				7335AC6B21220EF80012EF2D /* DefaultFormattableContentAction.swift in Sources */,
 				7335AC6421220E880012EF2D /* FormattableMediaContent.swift in Sources */,
+				83A1B1BD28AFF15600E737AC /* UserPersistentStore.swift in Sources */,
 				7335AC6521220E940012EF2D /* FormattableTextContent.swift in Sources */,
 				7335AC5D21220AFE0012EF2D /* FormattableContentActionCommand.swift in Sources */,
+				83A1B1AD28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				7335AC5A21220AD10012EF2D /* FormattableContentRange.swift in Sources */,
 				7335AC6821220EC10012EF2D /* FormattableCommentContent.swift in Sources */,
 				7335AC6921220ECE0012EF2D /* NotificationCommentRange.swift in Sources */,
@@ -20071,10 +20117,14 @@
 				7396FE66210F730600496D0D /* NotificationService.swift in Sources */,
 				73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */,
 				7335AC5821220AB40012EF2D /* FormattableContentGroup.swift in Sources */,
+				83A1B19C28AFE47D00E737AC /* KeychainUtils.swift in Sources */,
 				170BEC8C2391533D0017AEC1 /* KeyValueDatabase.swift in Sources */,
 				7335AC5E21220C630012EF2D /* Notifiable.swift in Sources */,
 				7335AC6321220E6E0012EF2D /* NotificationTextContent.swift in Sources */,
+				83A1B19E28AFE86A00E737AC /* FeatureFlag.swift in Sources */,
 				73E8E592212CD635000B26A5 /* UIImage+Assets.swift in Sources */,
+				83A1B1A328AFE89F00E737AC /* BuildConfiguration.swift in Sources */,
+				83A1B1B528AFF11E00E737AC /* UserPersistentRepository.swift in Sources */,
 				73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */,
 				73768B6B212B4E4F005136A1 /* UNNotificationContent+RemoteNotification.swift in Sources */,
 				73F6DD45212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
@@ -20089,6 +20139,7 @@
 				74021A21202E173F006CC39F /* TextList+WordPress.swift in Sources */,
 				433ADC19223B2A0200ED9DE1 /* TextBundleWrapper.m in Sources */,
 				74021A07202E1307006CC39F /* UINavigationController+Extensions.swift in Sources */,
+				83A1B1B728AFF15300E737AC /* UserPersistentStore.swift in Sources */,
 				74021A1C202E158F006CC39F /* ShareExtensionService.swift in Sources */,
 				747F88C2203778E000523C7C /* ShareTagsPickerViewController.swift in Sources */,
 				7414A142203CD066005A7D9B /* ShareCategoriesPickerViewController.swift in Sources */,
@@ -20099,8 +20150,10 @@
 				74021A19202E14C1006CC39F /* NSAttributedStringKey+Conversion.swift in Sources */,
 				74021A03202E1307006CC39F /* NSExtensionContext+Extensions.swift in Sources */,
 				74021A22202E1740006CC39F /* Header+WordPress.swift in Sources */,
+				83A1B1AF28AFF11B00E737AC /* UserPersistentRepository.swift in Sources */,
 				74021A02202E12FF006CC39F /* Extensions.xcdatamodeld in Sources */,
 				FAD256B82611B01B00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
+				83A1B1A728AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */,
 				9822D8DE214194EB0092CBD1 /* NoResultsViewController.swift in Sources */,
 				74021A1A202E1502006CC39F /* WPStyleGuide+Gridicon.swift in Sources */,
@@ -20123,6 +20176,7 @@
 				170BEC88239153110017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
 				74021A14202E1393006CC39F /* ShareExtensionEditorViewController.swift in Sources */,
 				CBF6201426E8FB8A0061A1F8 /* RemotePost+ShareData.swift in Sources */,
+				83A1B19628AFE47A00E737AC /* KeychainUtils.swift in Sources */,
 				CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */,
 				74E44AD92031ED2300556205 /* WordPressDraft-Lumberjack.m in Sources */,
@@ -20175,6 +20229,7 @@
 				741E224B1FC0E5C0007967AB /* UploadOperation.swift in Sources */,
 				43EE90EF223B1029006A33E9 /* TextBundleWrapper.m in Sources */,
 				74EA3B89202A0462004F802D /* ShareNoticeConstants.swift in Sources */,
+				83A1B1B628AFF15200E737AC /* UserPersistentStore.swift in Sources */,
 				B50248AF1C96FF6200AFBDED /* WPStyleGuide+Share.swift in Sources */,
 				E1CE41661E8D1026000CF5A4 /* ShareExtractor.swift in Sources */,
 				930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */,
@@ -20185,8 +20240,10 @@
 				74F5CD3A1FE0653500764E7C /* ShareExtensionEditorViewController.swift in Sources */,
 				B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */,
 				B50248C21C96FFCC00AFBDED /* WordPressShare-Lumberjack.m in Sources */,
+				83A1B1AE28AFF11A00E737AC /* UserPersistentRepository.swift in Sources */,
 				74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
 				FAD256A62611B01A00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
+				83A1B1A628AFF10900E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */,
 				74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */,
 				74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */,
@@ -20209,6 +20266,7 @@
 				745EAF472003FDAA0066F415 /* ShareExtensionAbstractViewController.swift in Sources */,
 				170BEC872391530D0017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
 				CBF6201326E8FB520061A1F8 /* RemotePost+ShareData.swift in Sources */,
+				83A1B19528AFE47900E737AC /* KeychainUtils.swift in Sources */,
 				74448F542044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74402F2A200528F200A1D4A2 /* ExtensionPresentationController.swift in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
@@ -20245,7 +20303,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				98906507237CC1DF00218CD2 /* WidgetTwoColumnCell.swift in Sources */,
+				83A1B1B028AFF11B00E737AC /* UserPersistentRepository.swift in Sources */,
 				433ADC1C223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
+				83A1B1A828AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				93E5284119A7741A003A1A9C /* TodayViewController.swift in Sources */,
 				FAD2566C2611AEC300EDAF88 /* AppStyleGuide.swift in Sources */,
 				938CF3DE1EF1BE8000AF838E /* CocoaLumberjack.swift in Sources */,
@@ -20255,8 +20315,10 @@
 				436110DA22C3ED44000773AD /* FeatureFlag.swift in Sources */,
 				436110DB22C3ED4C000773AD /* BuildConfiguration.swift in Sources */,
 				98906503237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */,
+				83A1B1B828AFF15300E737AC /* UserPersistentStore.swift in Sources */,
 				93C2075D1CC7FFC800C94D04 /* Tracks+TodayWidget.swift in Sources */,
 				98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */,
+				83A1B19728AFE47A00E737AC /* KeychainUtils.swift in Sources */,
 				4326191722FCB9F9003C7642 /* MurielColor.swift in Sources */,
 				436110D922C3ED18000773AD /* UIColor+MurielColors.swift in Sources */,
 				FAD256CA2611B01C00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
@@ -20290,10 +20352,14 @@
 				98712D1F23DA1D0A00555316 /* WidgetNoConnectionCell.swift in Sources */,
 				FAD257F42611B54100EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				092C3802275E718100BBBDD9 /* AppLocalizedString.swift in Sources */,
+				83A1B1AA28AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789728526E6C003F4443 /* AppConfiguration.swift in Sources */,
 				98A3C3052399A2370048D38D /* ThisWeekViewController.swift in Sources */,
+				83A1B1BA28AFF15400E737AC /* UserPersistentStore.swift in Sources */,
 				17A4B6A324F911D5002DFB8E /* KeyValueDatabase.swift in Sources */,
 				989643E523A02F640070720A /* MurielColor.swift in Sources */,
+				83A1B19928AFE47B00E737AC /* KeychainUtils.swift in Sources */,
+				83A1B1B228AFF11C00E737AC /* UserPersistentRepository.swift in Sources */,
 				983AE84D2399AC6B00E5B7F6 /* Constants.m in Sources */,
 				989643ED23A0437B0070720A /* WidgetDifferenceCell.swift in Sources */,
 				FAD2566E2611AEC600EDAF88 /* AppStyleGuide.swift in Sources */,
@@ -20320,10 +20386,14 @@
 				98712D1E23DA1D0900555316 /* WidgetNoConnectionCell.swift in Sources */,
 				98A6B993239881860031AEBD /* MurielColor.swift in Sources */,
 				092C3801275E718100BBBDD9 /* AppLocalizedString.swift in Sources */,
+				83A1B1A928AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789628526E6C003F4443 /* AppConfiguration.swift in Sources */,
 				FAD256EE2611B01F00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
+				83A1B1B928AFF15400E737AC /* UserPersistentStore.swift in Sources */,
 				17A4B6A224F911D4002DFB8E /* KeyValueDatabase.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
+				83A1B19828AFE47B00E737AC /* KeychainUtils.swift in Sources */,
+				83A1B1B128AFF11C00E737AC /* UserPersistentRepository.swift in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
 				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
 				FAD2566D2611AEC500EDAF88 /* AppStyleGuide.swift in Sources */,

--- a/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
+++ b/WordPress/WordPressAllTimeWidget/AllTimeViewController.swift
@@ -258,7 +258,7 @@ private extension AllTimeViewController {
     }
 
     func fetchOAuthBearerToken() -> String? {
-        let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, andServiceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
+        let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, serviceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
 
         return oauth2Token as String?
     }

--- a/WordPress/WordPressNotificationContentExtension/Sources/NotificationViewController.swift
+++ b/WordPress/WordPressNotificationContentExtension/Sources/NotificationViewController.swift
@@ -131,9 +131,9 @@ private extension NotificationViewController {
     /// - Returns: the token if found; `nil` otherwise
     ///
     func readExtensionToken() -> String? {
-        guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationContentExtensionKeychainTokenKey,
-                                                                           andServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                                                           accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauthToken = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationContentExtensionKeychainTokenKey,
+                                                                                serviceName: WPNotificationContentExtensionKeychainServiceName,
+                                                                                accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Content Extension OAuth token")
             return nil
         }
@@ -146,9 +146,9 @@ private extension NotificationViewController {
     /// - Returns: the username if found; `nil` otherwise
     ///
     func readExtensionUsername() -> String? {
-        guard let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationContentExtensionKeychainUsernameKey,
-                                                                           andServiceName: WPNotificationContentExtensionKeychainServiceName,
-                                                                           accessGroup: WPAppKeychainAccessGroup) else {
+        guard let username = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationContentExtensinoKeychainUsernameKey,
+                                                                              serviceName: WPNotificationContentExtensionKeychainServiceName,
+                                                                              accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Content Extension username")
             return nil
         }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -279,9 +279,9 @@ private extension NotificationService {
     /// - Returns: the token if found; `nil` otherwise
     ///
     func readExtensionToken() -> String? {
-        guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
-                                                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                             accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauthToken = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
+                                                                                serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                                accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension OAuth token")
             return nil
         }
@@ -294,9 +294,9 @@ private extension NotificationService {
     /// - Returns: the username if found; `nil` otherwise
     ///
     func readExtensionUsername() -> String? {
-        guard let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
-                                                                           andServiceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                           accessGroup: WPAppKeychainAccessGroup) else {
+        guard let username = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
+                                                                              serviceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                              accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension username")
             return nil
         }
@@ -309,8 +309,8 @@ private extension NotificationService {
     /// - Returns: the userID if found; `nil` otherwise
     ///
     func readExtensionUserID() -> String? {
-        guard let userID = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUserIDKey,
-                                                                         andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+        guard let userID = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainUserIDKey,
+                                                                            serviceName: WPNotificationServiceExtensionKeychainServiceName,
                                                                             accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension userID")
             return nil

--- a/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -30,9 +30,9 @@ class StatsWidgetsService {
         state = .loading
 
         do {
-            let token = try SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey,
-                                                                     andServiceName: WPStatsTodayWidgetKeychainServiceName,
-                                                                     accessGroup: WPAppKeychainAccessGroup)
+            let token = try KeychainUtils.shared.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey,
+                                                                        serviceName: WPStatsTodayWidgetKeychainServiceName,
+                                                                        accessGroup: WPAppKeychainAccessGroup)
 
             let wpApi = WordPressComRestApi(oAuthToken: token)
             let service = StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: widgetData.siteID, siteTimezone: widgetData.timeZone)

--- a/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
+++ b/WordPress/WordPressThisWeekWidget/ThisWeekViewController.swift
@@ -253,7 +253,7 @@ private extension ThisWeekViewController {
     }
 
     func fetchOAuthBearerToken() -> String? {
-        let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, andServiceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
+        let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, serviceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
 
         return oauth2Token as String?
     }

--- a/WordPress/WordPressTodayWidget/TodayViewController.swift
+++ b/WordPress/WordPressTodayWidget/TodayViewController.swift
@@ -258,7 +258,7 @@ private extension TodayViewController {
     }
 
     func fetchOAuthBearerToken() -> String? {
-        let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, andServiceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
+        let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPStatsTodayWidgetKeychainTokenKey, serviceName: WPStatsTodayWidgetKeychainServiceName, accessGroup: WPAppKeychainAccessGroup)
 
         return oauth2Token as String?
     }


### PR DESCRIPTION
## Description

- Replaces existing calls to `SFHFKeychainUtils` with `KeychainUtils`
- Copies the local keychain to the shared keychain on app launch
- Copies the local database to the shared directory on `init` for `ContextManager`

## Testing

The keychain sharing doesn't seem to work quite right on the simulator so I was using a real device to test. On the simulator, the access group seems to be ignored. Everything _should_ still work on a simulator though.

To test:
- Fresh install WordPress with the feature flag set to `false`
- Login
- Tap on your avatar > App Settings > Debug > Enable `Shared Login`
- Close and relaunch WordPress
- Verify you are still logged in
- Close WordPress
- Set the feature flag `sharedLogin` to `true` in `FeatureFlag.swift`
- Fresh install Jetpack
- Verify you are logged in without needing to login
- Log out from Jetpack
- Close Jetpack
- Open WordPress
- Verify you are logged out

**Note:** There are some strange behaviors if you keep both apps open in memory and logout from one or the other. We will probably have to address what to do in this scenario in a future PR.

## Regression Notes
1. Potential unintended areas of impact
Anywhere that uses the keychain or core data

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually testing, running unit tests, it'll require further extensive testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
