### PR TITLE
Adopt NSPersistentContainer for handling context objects

### DIFF
--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -27,6 +27,7 @@
 
 #import "EditCommentViewController.h"
 
+#import "LegacyContextFactory.h"
 #import "LocalCoreDataService.h"
 
 #import "Media.h"

--- a/WordPress/Classes/Utility/ContainerContextFactory.swift
+++ b/WordPress/Classes/Utility/ContainerContextFactory.swift
@@ -1,0 +1,37 @@
+import ObjectiveC
+
+@objc
+class ContainerContextFactory: NSObject, ManagedObjectContextFactory {
+
+    private let container: NSPersistentContainer
+
+    let mainContext: NSManagedObjectContext
+
+    required init(persistentContainer container: NSPersistentContainer) {
+        self.container = container
+        self.mainContext = container.viewContext
+        self.mainContext.automaticallyMergesChangesFromParent = true
+        self.mainContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+    }
+
+    func newDerivedContext() -> NSManagedObjectContext {
+        let context = container.newBackgroundContext()
+        context.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy
+        return context
+    }
+
+    func save(_ context: NSManagedObjectContext, andWait wait: Bool, withCompletionBlock completionBlock: (() -> Void)?) {
+        let block: () -> Void = {
+            self.internalSave(context)
+            DispatchQueue.main.async {
+                completionBlock?()
+            }
+        }
+        if (wait) {
+            context.performAndWait(block)
+        } else {
+            context.perform(block)
+        }
+    }
+
+}

--- a/WordPress/Classes/Utility/ContainerContextFactory.swift
+++ b/WordPress/Classes/Utility/ContainerContextFactory.swift
@@ -27,7 +27,7 @@ class ContainerContextFactory: NSObject, ManagedObjectContextFactory {
                 completionBlock?()
             }
         }
-        if (wait) {
+        if wait {
             context.performAndWait(block)
         } else {
             context.perform(block)

--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -67,6 +67,10 @@ extension LegacyContextFactory {
 extension ManagedObjectContextFactory {
 
     func internalSave(_ context: NSManagedObjectContext) {
+        guard context.hasChanges else {
+            return
+        }
+
         let inserted = Array(context.insertedObjects)
         do {
             try context.obtainPermanentIDs(for: inserted)
@@ -74,12 +78,10 @@ extension ManagedObjectContextFactory {
             DDLogError("Error obtaining permanent object IDs for \(inserted), \(error)")
         }
 
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                handleSaveError(error as NSError, in: context)
-            }
+        do {
+            try context.save()
+        } catch {
+            handleSaveError(error as NSError, in: context)
         }
     }
 

--- a/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
+++ b/WordPress/Classes/Utility/ContextManager+ErrorHandling.swift
@@ -71,10 +71,10 @@ extension ManagedObjectContextFactory {
         do {
             try context.obtainPermanentIDs(for: inserted)
         } catch {
-            DDLogError("Error obtaining permanent object IDs for \(inserted), \(error)");
+            DDLogError("Error obtaining permanent object IDs for \(inserted), \(error)")
         }
 
-        if (context.hasChanges) {
+        if context.hasChanges {
             do {
                 try context.save()
             } catch {

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
 
+#import "ManagedObjectContextFactory.h"
+
 NS_ASSUME_NONNULL_BEGIN
 
 /**
@@ -59,8 +61,9 @@ FOUNDATION_EXTERN NSString * const ContextManagerModelNameCurrent;
                   Use ContextManagerModelNameCurrent for current version, or
                   "WordPress <version>" for specific version.
  @param storeURL Database location. Use +[ContextManager inMemoryStoreURL] to create an in-memory database.
+ @param contextFactory A type that conforms to `ManagedObjectContextFactory`.
  */
-- (instancetype)initWithModelName:(NSString *)modelName storeURL:(NSURL *)storeURL NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithModelName:(NSString *)modelName storeURL:(NSURL *)storeURL contextFactory:(Class<ManagedObjectContextFactory> _Nullable)factory NS_DESIGNATED_INITIALIZER;
 
 
 ///--------------------------

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -39,7 +39,7 @@ static ContextManager *_instance;
                                                                         YES) lastObject];
     NSURL *storeURL = [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPress.sqlite"]];
 
-    return [self initWithModelName:ContextManagerModelNameCurrent storeURL:storeURL contextFactory:[LegacyContextFactory class]];
+    return [self initWithModelName:ContextManagerModelNameCurrent storeURL:storeURL contextFactory:nil];
 }
 
 - (instancetype)initWithModelName:(NSString *)modelName storeURL:(NSURL *)storeURL contextFactory:(Class)factory

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -47,7 +47,7 @@ static ContextManager *_instance;
     self = [super init];
     if (self) {
         if (factory == nil) {
-            factory = [LegacyContextFactory class];
+            factory = [ContainerContextFactory class];
         }
 
         NSParameterAssert([modelName isEqualToString:ContextManagerModelNameCurrent] || [modelName hasPrefix:@"WordPress "]);

--- a/WordPress/Classes/Utility/LegacyContextFactory.h
+++ b/WordPress/Classes/Utility/LegacyContextFactory.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+#import "ManagedObjectContextFactory.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface LegacyContextFactory : NSObject <ManagedObjectContextFactory>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Utility/LegacyContextFactory.m
+++ b/WordPress/Classes/Utility/LegacyContextFactory.m
@@ -1,0 +1,119 @@
+#import "LegacyContextFactory.h"
+#import "WordPress-Swift.h"
+
+@interface LegacyContextFactory()
+
+@property (nonatomic, strong) NSPersistentContainer *container;
+@property (nonatomic, strong) NSManagedObjectContext *writerContext;
+@property (nonatomic, strong) NSManagedObjectContext *mainContext;
+
+@end
+
+@implementation LegacyContextFactory
+
+- (instancetype)initWithPersistentContainer:(NSPersistentContainer *)container
+{
+    self = [super init];
+    if (self) {
+        self.container = container;
+        [self createWriterContext];
+        [self createMainContext];
+        [self startListeningToMainContextNotifications];
+    }
+    return self;
+}
+
+- (NSManagedObjectContext *const)newDerivedContext
+{
+    return [self newChildContextWithConcurrencyType:NSPrivateQueueConcurrencyType];
+}
+
+- (void)createWriterContext
+{
+    NSAssert(self.writerContext == nil, @"%s should only be called once", __PRETTY_FUNCTION__);
+
+    NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
+    context.persistentStoreCoordinator = self.container.persistentStoreCoordinator;
+    self.writerContext = context;
+}
+
+- (void)createMainContext
+{
+    NSAssert(self.mainContext == nil, @"%s should only be called once", __PRETTY_FUNCTION__);
+
+    NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSMainQueueConcurrencyType];
+    context.parentContext = self.writerContext;
+    self.mainContext = context;
+}
+
+- (NSManagedObjectContext *const)newChildContextWithConcurrencyType:(NSManagedObjectContextConcurrencyType)concurrencyType
+{
+    NSManagedObjectContext *childContext = [[NSManagedObjectContext alloc]
+                                            initWithConcurrencyType:concurrencyType];
+    childContext.parentContext = self.mainContext;
+    childContext.mergePolicy = NSMergeByPropertyObjectTrumpMergePolicy;
+
+    return childContext;
+}
+
+- (void)saveContext:(NSManagedObjectContext *)context andWait:(BOOL)wait withCompletionBlock:(void (^)(void))completionBlock
+{
+    // Save derived contexts a little differently
+    if (context.parentContext == self.mainContext) {
+        [self saveDerivedContext:context andWait:wait withCompletionBlock:completionBlock];
+        return;
+    }
+
+    if (wait) {
+        [context performBlockAndWait:^{
+            [self internalSaveContext:context withCompletionBlock:completionBlock];
+        }];
+    } else {
+        [context performBlock:^{
+            [self internalSaveContext:context withCompletionBlock:completionBlock];
+        }];
+    }
+}
+
+- (void)saveDerivedContext:(NSManagedObjectContext *)context andWait:(BOOL)wait withCompletionBlock:(void (^)(void))completionBlock
+{
+    if (wait) {
+        [context performBlockAndWait:^{
+            [self internalSaveContext:context];
+            [self saveContext:self.mainContext andWait:wait withCompletionBlock:completionBlock];
+        }];
+    } else {
+        [context performBlock:^{
+            [self internalSaveContext:context];
+            [self saveContext:self.mainContext andWait:wait withCompletionBlock:completionBlock];
+        }];
+    }
+}
+
+- (void)internalSaveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock
+{
+    [self internalSaveContext:context];
+
+    if (completionBlock) {
+        dispatch_async(dispatch_get_main_queue(), completionBlock);
+    }
+}
+
+#pragma mark - Notification Helpers
+
+- (void)startListeningToMainContextNotifications
+{
+    NSNotificationCenter *nc = [NSNotificationCenter defaultCenter];
+    [nc addObserver:self selector:@selector(mainContextDidSave:) name:NSManagedObjectContextDidSaveNotification object:self.mainContext];
+}
+
+- (void)mainContextDidSave:(NSNotification *)notification
+{
+    // Defer I/O to a BG Writer Context. Simperium 4ever!
+    //
+    [self.writerContext performBlock:^{
+        [self internalSaveContext:self.writerContext];
+    }];
+}
+
+@end

--- a/WordPress/Classes/Utility/ManagedObjectContextFactory.h
+++ b/WordPress/Classes/Utility/ManagedObjectContextFactory.h
@@ -1,0 +1,18 @@
+#import <CoreData/CoreData.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// A type that's used to handle how `NSManagedObjectContext` objects are created and how the data in them are saved.
+@protocol ManagedObjectContextFactory<NSObject>
+
+- (instancetype)initWithPersistentContainer:(NSPersistentContainer *)container;
+
+@property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
+
+- (NSManagedObjectContext *const)newDerivedContext;
+
+- (void)saveContext:(NSManagedObjectContext *)context andWait:(BOOL)wait withCompletionBlock:(void (^_Nullable)(void))completionBlock;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -978,6 +978,8 @@
 		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
 		4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B8E282B05210089CF3D /* JSONObjectTests.swift */; };
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
+		4A50667C28B3216500DD09F4 /* LegacyContextFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */; };
+		4A50667D28B3216500DD09F4 /* LegacyContextFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */; };
 		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
@@ -5910,6 +5912,9 @@
 		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
 		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
+		4A50667A28B3216500DD09F4 /* LegacyContextFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LegacyContextFactory.h; sourceTree = "<group>"; };
+		4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LegacyContextFactory.m; sourceTree = "<group>"; };
+		4A50667E28B3218800DD09F4 /* ManagedObjectContextFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManagedObjectContextFactory.h; sourceTree = "<group>"; };
 		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextManagerMock.swift; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
@@ -13848,6 +13853,9 @@
 				3FD83CBD246C74B800381999 /* Migrator */,
 				C545E0A01811B9880020844C /* ContextManager.h */,
 				C545E0A11811B9880020844C /* ContextManager.m */,
+				4A50667E28B3218800DD09F4 /* ManagedObjectContextFactory.h */,
+				4A50667A28B3216500DD09F4 /* LegacyContextFactory.h */,
+				4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */,
 				E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */,
 				B5ECA6C91DBAA0020062D7E0 /* CoreDataHelper.swift */,
 				24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */,
@@ -18614,6 +18622,7 @@
 				8217380B1FE05EE600BEC94C /* BlogSettings+DateAndTimeFormat.swift in Sources */,
 				57047A4F22A961BC00B461DF /* PostSearchHeader.swift in Sources */,
 				088B89891DA6F93B000E8DEF /* ReaderPostCardContentLabel.swift in Sources */,
+				4A50667C28B3216500DD09F4 /* LegacyContextFactory.m in Sources */,
 				C3C2F84828AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift in Sources */,
 				F181EDE526B2AC7200C61241 /* BackgroundTasksCoordinator.swift in Sources */,
 				8B93412F257029F60097D0AC /* FilterChipButton.swift in Sources */,
@@ -21409,6 +21418,7 @@
 				F1D8C6EC26BABE3E002E3323 /* WeeklyRoundupDebugScreen.swift in Sources */,
 				FABB23072602FC2C00C8785C /* SiteCreationRotatingMessageView.swift in Sources */,
 				FABB23082602FC2C00C8785C /* SignupUsernameViewController.swift in Sources */,
+				4A50667D28B3216500DD09F4 /* LegacyContextFactory.m in Sources */,
 				FABB23092602FC2C00C8785C /* MediaItemViewController.swift in Sources */,
 				FABB230A2602FC2C00C8785C /* PostAnnotation.m in Sources */,
 				FABB230B2602FC2C00C8785C /* GutenbergViewController.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -980,6 +980,8 @@
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
 		4A50667C28B3216500DD09F4 /* LegacyContextFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */; };
 		4A50667D28B3216500DD09F4 /* LegacyContextFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */; };
+		4A50668028B364CA00DD09F4 /* ContainerContextFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */; };
+		4A50668128B364CA00DD09F4 /* ContainerContextFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */; };
 		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
@@ -5915,6 +5917,7 @@
 		4A50667A28B3216500DD09F4 /* LegacyContextFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LegacyContextFactory.h; sourceTree = "<group>"; };
 		4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LegacyContextFactory.m; sourceTree = "<group>"; };
 		4A50667E28B3218800DD09F4 /* ManagedObjectContextFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManagedObjectContextFactory.h; sourceTree = "<group>"; };
+		4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerContextFactory.swift; sourceTree = "<group>"; };
 		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextManagerMock.swift; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
@@ -13856,6 +13859,7 @@
 				4A50667E28B3218800DD09F4 /* ManagedObjectContextFactory.h */,
 				4A50667A28B3216500DD09F4 /* LegacyContextFactory.h */,
 				4A50667B28B3216500DD09F4 /* LegacyContextFactory.m */,
+				4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */,
 				E1E5EE36231E47A80018E9E3 /* ContextManager+ErrorHandling.swift */,
 				B5ECA6C91DBAA0020062D7E0 /* CoreDataHelper.swift */,
 				24F3789725E6E62100A27BB7 /* NSManagedObject+Lookup.swift */,
@@ -19204,6 +19208,7 @@
 				17523381246C4F9200870B4A /* HomepageSettingsViewController.swift in Sources */,
 				E62CE58E26B1D14200C9D147 /* AccountService+Cookies.swift in Sources */,
 				C81CCD7F243BF7A600A83E27 /* TenorMediaGroup.swift in Sources */,
+				4A50668028B364CA00DD09F4 /* ContainerContextFactory.swift in Sources */,
 				B0F2EFBF259378E600C7EB6D /* SiteSuggestionService.swift in Sources */,
 				4388FF0020A4E19C00783948 /* NotificationsViewController+PushPrimer.swift in Sources */,
 				98517E5928220411001FFD45 /* BloggingPromptTableViewCell.swift in Sources */,
@@ -22238,6 +22243,7 @@
 				FABB25AE2602FC2C00C8785C /* SearchWrapperView.swift in Sources */,
 				98830A932747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */,
 				FABB25AF2602FC2C00C8785C /* UserSettings.swift in Sources */,
+				4A50668128B364CA00DD09F4 /* ContainerContextFactory.swift in Sources */,
 				FABB25B02602FC2C00C8785C /* MediaImportService.swift in Sources */,
 				FABB25B12602FC2C00C8785C /* NSAttributedStringKey+Conversion.swift in Sources */,
 				FABB25B22602FC2C00C8785C /* SelectPostViewController.swift in Sources */,

--- a/WordPress/WordPressTest/ContextManagerMock.swift
+++ b/WordPress/WordPressTest/ContextManagerMock.swift
@@ -13,7 +13,7 @@ class ContextManagerMock: ContextManager {
     ///
     /// - SeeAlso `ContextManager`
     init(modelName: String) {
-        super.init(modelName: modelName, store: ContextManager.inMemoryStoreURL)
+        super.init(modelName: modelName, store: ContextManager.inMemoryStoreURL, contextFactory: nil)
     }
 
     override func saveContextAndWait(_ context: NSManagedObjectContext) {

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -41,7 +41,7 @@ class ContextManagerTests: XCTestCase {
         }
 
         // Migrate to the latest version
-        let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL)
+        let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL, contextFactory: nil)
 
         let object = try contextManager.mainContext.existingObject(with: XCTUnwrap(objectID))
         XCTAssertNotNil(object, "Object should exist in new PSC")
@@ -79,7 +79,7 @@ class ContextManagerTests: XCTestCase {
         }
 
         // Migrate to the latest
-        let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL)
+        let contextManager = ContextManager(modelName: ContextManagerModelNameCurrent, store: storeURL, contextFactory: nil)
         let object = try contextManager.mainContext.existingObject(with: XCTUnwrap(objectID))
         XCTAssertNotNil(object, "Object should exist in new PSC")
         XCTAssertNoThrow(object.value(forKey: "author"), "Theme.author should exist in current model version, but we were unable to fetch it")
@@ -106,7 +106,7 @@ class ContextManagerTests: XCTestCase {
         }
 
         // Initialize 24 > 25 Migration
-        let contextManager = ContextManager(modelName: model25Name, store: storeURL)
+        let contextManager = ContextManager(modelName: model25Name, store: storeURL, contextFactory: nil)
         let secondContext = contextManager.mainContext
 
         // Test the existence of Post object after migration

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -176,7 +176,6 @@ class ContextManagerTests: XCTestCase {
         // Discard the username change that's made above
         contextManager.mainContext.reset()
 
-        XCTExpectFailure("Known issue: the mainContext is saved along with the `ContextManager.save` functions")
         expect(try findFirstUser()?.username) == "First User"
     }
 

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -56,9 +56,6 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
         // Make sure the collection is empty, to begin with
         XCTAssert(mainContext.countObjects(ofType: Notification.self) == 0)
 
-        // CoreData Expectations
-        let contextSaved = expectation(forNotification: .NSManagedObjectContextDidSave, object: mainContext)
-
         // Mediator Expectations
         let expect = expectation(description: "Sync")
 
@@ -68,7 +65,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
             expect.fulfill()
         }
 
-        wait(for: [contextSaved, expect], timeout: timeout)
+        wait(for: [expect], timeout: timeout)
     }
 
 
@@ -122,9 +119,6 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
         // Make sure the collection is empty, to begin with
         XCTAssert(mainContext.countObjects(ofType: Notification.self) == 0)
 
-        // CoreData Expectations
-        let contextSaved = expectation(forNotification: .NSManagedObjectContextDidSave, object: mainContext)
-
         // Mediator Expectations
         let expect = expectation(description: "Sync")
 
@@ -135,7 +129,7 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
             expect.fulfill()
         }
 
-        wait(for: [contextSaved, expect], timeout: timeout)
+        wait(for: [expect], timeout: timeout)
     }
 
 


### PR DESCRIPTION
This PR is part of paaHJt-1I7-p2 ("Finish Implementing NSPersistentContainer" section in particular).

## Changes

Currently `ContextManager` creates its own `NSManagedObjectContext` objects. One side effect of this approach is we need to implement some logistics around saving the changes in those context objects. Replacing the current implementation with `NSPersistentContainer`'s context creation API would make things much easier for us, as `NSPersistentContainer` handles those logistics for us (see [`viewContext`](https://developer.apple.com/documentation/coredata/nspersistentcontainer/1640622-viewcontext) and [`newBackgroundContext`](https://developer.apple.com/documentation/coredata/nspersistentcontainer/1640581-newbackgroundcontext)).

Here are changes in this PR:

- The current implementation of creating and saving context objects is moved to `LegacyContextFactory`.
- A new implementation that's backed by `NSPersistentContainer` is added in `ContainerContextFactory`.
- `ContextManager` uses `LegacyContextFactory`, with the intention of _keeping the current behavior_.

So yes, this PR doesn't actually change anything (hopefully). I tried to keep the legacy code untouched so that the diff would appear as moving some code from one file to another. Hopefully, we can spot any unintended change in this code relocation.

I made these slightly more complicated changes (rather than simply replacing the legacy code with `NSPersistentContainer` context objects) because I'm not confident in this change. I don't know much about the issues we had dealt with regarding our Core Data stack. I had a quick look into Sentry, it appears there are still a few issues with the current implementation. Even though I have tested the new `ContainerContextFactory` by going through some areas in the app, I don't know how much coverage that gives the new implementation.

I guess there are two ways that can give me that confidence, either any of you trust the new implementation would 100% work with no major issue, or we test it in a close-to-production environment. This PR does later—set up a foundation for testing the new implementation and rolling back if needed.

But I'm not sure what an ideal "close-to-production environment" is, maybe development build, maybe beta build? Definitely not in the production build, I think?

Having said that, please do let me know if you think this cautiousness is unnecessary.

## Test instructions

As I mentioned above, this PR should not change any app behavior. Maybe going through many app features should be enough?

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I went through a few features in each tab, they all seemed working as expected.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.