### PR TITLE
[Jetpack plugin install prompt] Show prompt only on Jetpack app

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -20,5 +20,6 @@ import Foundation
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = false
+    @objc static let showJetpackPluginInstallPrompt: Bool = false
     @objc static let qrLoginEnabled: Bool = false
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptSettings.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptSettings.swift
@@ -2,11 +2,14 @@ import Foundation
 
 public final class JetpackInstallPromptSettings {
     private let userDefaults: UserDefaults
+    private let showJetpackPluginInstallPrompt: Bool
 
     // MARK: - Init
 
-    init(userDefaults: UserDefaults = .standard) {
+    init(userDefaults: UserDefaults = .standard,
+         showJetpackPluginInstallPrompt: Bool = AppConfiguration.showJetpackPluginInstallPrompt) {
         self.userDefaults = userDefaults
+        self.showJetpackPluginInstallPrompt = showJetpackPluginInstallPrompt
     }
 
     // MARK: - User Defaults Storage
@@ -20,6 +23,10 @@ public final class JetpackInstallPromptSettings {
     /// - Parameter blog: The blog object to check against
     /// - Returns: Whether the prompt can be displayed
     func canDisplay(for blog: Blog) -> Bool {
+        guard showJetpackPluginInstallPrompt else {
+            return false
+        }
+
         guard let jetpack = blog.jetpack else {
             return false
         }

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -20,5 +20,6 @@ import Foundation
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let showsStatsRevampV2: Bool = false
+    @objc static let showJetpackPluginInstallPrompt: Bool = true
     @objc static let qrLoginEnabled: Bool = true
 }

--- a/WordPress/WordPressTest/Jetpack/JetpackInstallPromptTests.swift
+++ b/WordPress/WordPressTest/Jetpack/JetpackInstallPromptTests.swift
@@ -18,7 +18,10 @@ class JetpackInstallPromptTests: XCTestCase {
         userDefaults = UserDefaults(suiteName: name)
         userDefaults.removePersistentDomain(forName: name)
 
-        settings = JetpackInstallPromptSettings(userDefaults: userDefaults)
+        settings = JetpackInstallPromptSettings(
+            userDefaults: userDefaults,
+            showJetpackPluginInstallPrompt: true
+        )
     }
 
     override func tearDown() {
@@ -55,6 +58,17 @@ class JetpackInstallPromptTests: XCTestCase {
         blog.isAdmin = true
 
         settings.setPromptWasDismissed(true, for: blog)
+
+        XCTAssertFalse(settings.canDisplay(for: blog))
+    }
+
+    func testPromptWillNotShowForSitesWithoutJetpackPluginInstallPromptFlagEnabled() {
+        settings = JetpackInstallPromptSettings(
+            userDefaults: userDefaults,
+            showJetpackPluginInstallPrompt: false
+        )
+        let blog = BlogBuilder(context).withJetpack(version: nil, username: nil, email: nil).build()
+        blog.isAdmin = true
 
         XCTAssertFalse(settings.canDisplay(for: blog))
     }


### PR DESCRIPTION
This is part of [Show Jetpack plugin install prompt during Jetpack app login process](https://github.com/wordpress-mobile/WordPress-iOS/issues/19213). Merging to the parent branch.

## Description

Show Jetpack plugin install prompt only on the Jetpack app. 

### Solution

- Use `AppConfiguration` to set different value of `showJetpackPluginInstallPrompt` depending on the target
- Use this configuration in `JetpackInstallPromptSettings`

## Testing instructions

**Jetpack app:**
1. Fresh install application
2. Log into a self-hosted site that doesn't have the Jetpack plugin installed
3. Install prompt should appear after login

**WordPress app:**
1. Fresh install application
2. Log into a self-hosted site that doesn't have the Jetpack plugin installed
3. No install prompt should appear after login

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

Expanded `JetpackInstallPromptTests` testing the case with `showJetpackPluginInstallPrompt` flag disabled.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Video

**Jetpack app:**

https://user-images.githubusercontent.com/4062343/186106152-990359bb-eb0e-4af6-82c8-a015b3af6c95.mp4

**WordPress app:**

https://user-images.githubusercontent.com/4062343/186106415-4bc6069f-979e-4d62-a337-cbdb357077ac.mp4


