### PR TITLE
Use `ios_get_app_version` action instead of bespoke method

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -397,21 +397,6 @@ platform :ios do
     )
   end
 
-  # Returns the value of `VERSION_SHORT`` from the `Version.public.xcconfig` file
-  #
-  # FIXME: This ought to be extracted into the release toolkit, ideally in a configurable way but with smart defaults.
-  #        See discussion in https://github.com/wordpress-mobile/WordPress-iOS/pull/16805/files/5f3009c5e0d01448cf0369656dddc1fe3757e45f#r664069046
-  #
-  def read_version_from_config
-    fastlane_require 'Xcodeproj'
-
-    # If the file is not available, the method will raise so we should be fine not handling that case. We'll never return an empty string.
-    File.open(File.join(PROJECT_ROOT_FOLDER, 'Config', 'Version.public.xcconfig')) do |config|
-      configuration = Xcodeproj::Config.new(config)
-      configuration.attributes['VERSION_SHORT']
-    end
-  end
-
   def inject_buildkite_analytics_environment(xctestrun_path:)
     require 'plist'
 

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -100,7 +100,7 @@ MANUALLY_MAINTAINED_STRINGS_FILES = {
 # Used in `update_*_metadata_on_app_store_connect` lanes.
 #
 UPLOAD_TO_APP_STORE_COMMON_PARAMS = {
-  app_version: read_version_from_config,
+  app_version: ios_get_app_version,
   skip_binary_upload: true,
   overwrite_screenshots: true,
   phased_release: true,


### PR DESCRIPTION
The result can be verified by adding a test lane such as:

```ruby
lane :test_lane do
  UI.success UPLOAD_TO_APP_STORE_COMMON_PARAMS
end
```

The result should include `app_version: 20.6` (or whichever version you have set locally).

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
