### PR TITLE
[Jetpack plugin install prompt] Show prompt when Jetpack is not connected

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptSettings.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptSettings.swift
@@ -24,7 +24,7 @@ public final class JetpackInstallPromptSettings {
             return false
         }
 
-        return !jetpack.isInstalled && blog.isAdmin && !promptWasDismissed(for: blog)
+        return !jetpack.isConnected && blog.isAdmin && !promptWasDismissed(for: blog)
     }
 
     func setPromptWasDismissed(_ value: Bool, for blog: Blog) {

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -35,8 +35,8 @@ final class BlogBuilder {
         return self
     }
 
-    func withJetpack(version: String? = nil, username: String? = nil, email: String? = nil) -> Self {
-        set(blogOption: "jetpack_client_id", value: 1)
+    func withJetpack(clientId: Int? = 1, version: String? = nil, username: String? = nil, email: String? = nil) -> Self {
+        set(blogOption: "jetpack_client_id", value: clientId as Any)
         set(blogOption: "jetpack_version", value: version as Any)
         set(blogOption: "jetpack_user_login", value: username as Any)
         set(blogOption: "jetpack_user_email", value: email as Any)

--- a/WordPress/WordPressTest/Jetpack/JetpackInstallPromptTests.swift
+++ b/WordPress/WordPressTest/Jetpack/JetpackInstallPromptTests.swift
@@ -33,29 +33,42 @@ class JetpackInstallPromptTests: XCTestCase {
     }
 
     func testPromptWillShowForSitesWithoutJetpack() {
-        let blog = BlogBuilder(context).withJetpack(version: nil, username: nil, email: nil).build()
-        blog.isAdmin = true
+        let blog = buildSelfHostedBlog(jetpackInstalled: false, jetpackConnected: false, isAdmin: true)
         XCTAssertTrue(settings.canDisplay(for: blog))
     }
 
     func testPromptWillNotShowForNonAdmins() {
-        let blog = BlogBuilder(context).withJetpack(version: nil, username: nil, email: nil).build()
-        blog.isAdmin = false
+        let blog = buildSelfHostedBlog(jetpackInstalled: false, jetpackConnected: false, isAdmin: false)
         XCTAssertFalse(settings.canDisplay(for: blog))
     }
 
-    func testPromptWillNotShowForBlogsWithJetpack() {
-        let blog = BlogBuilder(context).withJetpack(version: "1.0", username: "test", email: "test@example.com").build()
-        blog.isAdmin = true
+    func testPromptWillShowForBlogsWithJetpackNotConnected() {
+        let blog = buildSelfHostedBlog(jetpackInstalled: true, jetpackConnected: false, isAdmin: true)
+        XCTAssertTrue(settings.canDisplay(for: blog))
+    }
+
+    func testPromptWillNotShowForBlogsWithJetpackConnected() {
+        let blog = buildSelfHostedBlog(jetpackInstalled: true, jetpackConnected: true, isAdmin: true)
         XCTAssertFalse(settings.canDisplay(for: blog))
     }
 
     func testPromptWillNotShowIfDismissedBefore() {
-        let blog = BlogBuilder(context).withJetpack(version: nil, username: nil, email: nil).build()
-        blog.isAdmin = true
+        let blog = buildSelfHostedBlog(jetpackInstalled: false, jetpackConnected: false, isAdmin: true)
 
         settings.setPromptWasDismissed(true, for: blog)
 
         XCTAssertFalse(settings.canDisplay(for: blog))
+    }
+}
+
+private extension JetpackInstallPromptTests {
+    func buildSelfHostedBlog(jetpackInstalled: Bool, jetpackConnected: Bool, isAdmin: Bool) -> Blog {
+        let version: String? = jetpackInstalled ? "1.0" : nil
+        let clientId: Int? = jetpackConnected ? 1 : nil
+
+        let blog = BlogBuilder(context).withJetpack(clientId: clientId, version: version, username: nil, email: nil).build()
+        blog.isAdmin = isAdmin
+
+        return blog
     }
 }


### PR DESCRIPTION
This is part of [Show Jetpack plugin install prompt during Jetpack app login process](https://github.com/wordpress-mobile/WordPress-iOS/issues/19213). Merging to the parent branch.

## Description

Show Jetpack plugin install prompt when Jetpack is not connected. Use the same presentation logic throughout all the Jetpack plugin install prompts: 1) Log in 2) Stats 3) Notifications

There're 3 states of Jetpack plugin that I identified:
1. `blog.jetpack.installed` true if Jetpack plugin is installed and active
2. `blog.jetpack.connected` true if "Set up" of Jetpack is done (completing log in to WP.com account is not necessary for it to become true)
3. `blog.account` has value if WP.com account is connected

Previously, [the logic to present Jetpack plugin install prompt used](https://github.com/wordpress-mobile/WordPress-iOS/pull/18319/commits/746d706fd8189db8f26e3e00f7601244334a32a9) `jetpack.installed` check. However, it creates differences between the login prompt and other prompts. So the user might not be prompted to install after logging in but would be prompted to install after trying to access stats. Therefore, using `jetpack.connected` check instead. 

## Testing instructions


### Case 1: Jetpack plugin not installed
1. Fresh install Jetpack App
2. Log into a self-hosted site that doesn't have the Jetpack plugin installed
3. Install prompt should appear after login

### Case 2: Jetpack plugin is installed and not connected
1. Fresh install Jetpack App
2. Log into a self-hosted site that has Jetpack installed and active but not connected
3. Install prompt should appear after login

### Case 3: Jetpack plugin is installed and connected
1. Fresh install Jetpack App
2. Log into a self-hosted site that has Jetpack installed and connected (doing "Set Up" step without completing WP.com log in)
3. Install prompt should not appear after login

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

Expanded `JetpackInstallPromptTests` tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images

1. Jetpack installed, Jetpack not connected
<img width="1293" alt="Jetpack mobile + Set Up Jetpack on web" src="https://user-images.githubusercontent.com/4062343/186373163-d4da01a8-1902-4c94-83f6-7b4812f19a17.png">

If we click "Set Up" / "Install" but don't successfully log in into account we'll arrive at such state:
<img width="231" alt="image" src="https://user-images.githubusercontent.com/4062343/186375317-7b1f5886-4c89-4ccb-a314-14cb303ead68.png">


