### PR TITLE
[Jetpack] Shared Defaults Utility Variables

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -1,5 +1,4 @@
 protocol UserPersistentRepositoryReader {
-    func object(forKey key: String) -> Any?
     func string(forKey key: String) -> String?
     func bool(forKey key: String) -> Bool
     func integer(forKey key: String) -> Int
@@ -10,7 +9,7 @@ protocol UserPersistentRepositoryReader {
     func url(forKey key: String) -> URL?
 }
 
-protocol UserPersistentRepositoryWriter {
+protocol UserPersistentRepositoryWriter: KeyValueDatabase {
     func set(_ value: Any?, forKey key: String)
     func set(_ value: Int, forKey key: String)
     func set(_ value: Float, forKey key: String)
@@ -20,7 +19,7 @@ protocol UserPersistentRepositoryWriter {
     func removeObject(forKey key: String)
 }
 
-typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter
+typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter & UserPersistentRepositoryUtility
 
 extension UserDefaults: UserPersistentRepository {
     private static var isOneOffMigrationCompleteKey: String {

--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -21,7 +21,9 @@ protocol UserPersistentRepositoryWriter: KeyValueDatabase {
 
 typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter & UserPersistentRepositoryUtility
 
-extension UserDefaults: UserPersistentRepository {
+extension UserDefaults: UserPersistentRepository {}
+
+extension UserPersistentStore {
     private static var isOneOffMigrationCompleteKey: String {
         "defaults_one_off_migration"
     }

--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -10,6 +10,11 @@ private enum UPRUConstants {
     static let hasShownCustomAppIconUpgradeAlert = "custom-app-icon-upgrade-alert-shown"
     static let createButtonTooltipWasDisplayed = "CreateButtonTooltipWasDisplayed"
     static let createButtonTooltipDisplayCount = "CreateButtonTooltipDisplayCount"
+    static let savedPostsPromoWasDisplayed = "SavedPostsV1PromoWasDisplayed"
+    static let storiesIntroWasAcknowledged = "storiesIntroWasAcknowledged"
+    static let currentAnnouncementsKey = "currentAnnouncements"
+    static let currentAnnouncementsDateKey = "currentAnnouncementsDate"
+    static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -106,6 +111,57 @@ extension UserPersistentRepositoryUtility {
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.createButtonTooltipWasDisplayed)
+        }
+    }
+
+    var savedPostsPromoWasDisplayed: Bool {
+        get {
+            return UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.savedPostsPromoWasDisplayed)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.savedPostsPromoWasDisplayed)
+        }
+    }
+
+    var storiesIntroWasAcknowledged: Bool {
+        get {
+            return UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.storiesIntroWasAcknowledged)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.storiesIntroWasAcknowledged)
+        }
+    }
+
+    var announcements: [Announcement]? {
+        get {
+            guard let encodedAnnouncements = UserPersistentStoreFactory.instance().object(forKey: UPRUConstants.currentAnnouncementsKey) as? Data,
+                  let announcements = try? PropertyListDecoder().decode([Announcement].self, from: encodedAnnouncements) else {
+                return nil
+            }
+            return announcements
+        }
+
+        set {
+            guard let announcements = newValue, let encodedAnnouncements = try? PropertyListEncoder().encode(announcements) else {
+                UserPersistentStoreFactory.instance().removeObject(forKey: UPRUConstants.currentAnnouncementsKey)
+                UserPersistentStoreFactory.instance().removeObject(forKey: UPRUConstants.currentAnnouncementsDateKey)
+                return
+            }
+            UserPersistentStoreFactory.instance().set(encodedAnnouncements, forKey: UPRUConstants.currentAnnouncementsKey)
+            UserPersistentStoreFactory.instance().set(Date(), forKey: UPRUConstants.currentAnnouncementsDateKey)
+        }
+    }
+
+    var announcementsDate: Date? {
+        UserPersistentStoreFactory.instance().object(forKey: UPRUConstants.currentAnnouncementsDateKey) as? Date
+    }
+
+    var announcementsVersionDisplayed: String? {
+        get {
+            UserPersistentStoreFactory.instance().string(forKey: UPRUConstants.announcementsVersionDisplayedKey)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.announcementsVersionDisplayedKey)
         }
     }
 }

--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+private enum UPRUConstants {
+    static let promptKey = "onboarding_notifications_prompt_displayed"
+    static let questionKey = "onboarding_question_selection"
+    static let notificationPrimerAlertWasDisplayed = "NotificationPrimerAlertWasDisplayed"
+    static let notificationsTabAccessCount = "NotificationsTabAccessCount"
+    static let notificationPrimerInlineWasAcknowledged = "notificationPrimerInlineWasAcknowledged"
+    static let secondNotificationsAlertCount = "secondNotificationsAlertCount"
+}
+
+protocol UserPersistentRepositoryUtility: AnyObject {
+    var onboardingNotificationsPromptDisplayed: Bool { get set }
+    var onboardingQuestionSelected: OnboardingOption? { get set }
+    var notificationPrimerAlertWasDisplayed: Bool { get set }
+}
+
+extension UserPersistentRepositoryUtility {
+    var onboardingNotificationsPromptDisplayed: Bool {
+        get {
+            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.promptKey)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.promptKey)
+        }
+    }
+
+    var onboardingQuestionSelected: OnboardingOption? {
+        get {
+            if let str = UserPersistentStoreFactory.instance().string(forKey: UPRUConstants.questionKey) {
+                return OnboardingOption(rawValue: str)
+            }
+
+            return nil
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue?.rawValue, forKey: UPRUConstants.questionKey)
+        }
+    }
+
+    var notificationPrimerAlertWasDisplayed: Bool {
+        get {
+            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.notificationPrimerAlertWasDisplayed)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.notificationPrimerAlertWasDisplayed)
+        }
+    }
+
+    var notificationsTabAccessCount: Int {
+        get {
+            UserPersistentStoreFactory.instance().integer(forKey: UPRUConstants.notificationsTabAccessCount)
+        }
+
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.notificationsTabAccessCount)
+        }
+    }
+
+    var welcomeNotificationSeenKey: String {
+        return "welcomeNotificationSeen"
+    }
+
+    var notificationPrimerInlineWasAcknowledged: Bool {
+        get {
+            return UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.notificationPrimerInlineWasAcknowledged)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.notificationPrimerInlineWasAcknowledged)
+        }
+    }
+
+    var secondNotificationsAlertCount: Int {
+        get {
+            UserPersistentStoreFactory.instance().integer(forKey: UPRUConstants.secondNotificationsAlertCount)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.secondNotificationsAlertCount)
+        }
+    }
+}

--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -7,6 +7,9 @@ private enum UPRUConstants {
     static let notificationsTabAccessCount = "NotificationsTabAccessCount"
     static let notificationPrimerInlineWasAcknowledged = "notificationPrimerInlineWasAcknowledged"
     static let secondNotificationsAlertCount = "secondNotificationsAlertCount"
+    static let hasShownCustomAppIconUpgradeAlert = "custom-app-icon-upgrade-alert-shown"
+    static let createButtonTooltipWasDisplayed = "CreateButtonTooltipWasDisplayed"
+    static let createButtonTooltipDisplayCount = "CreateButtonTooltipDisplayCount"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -63,7 +66,7 @@ extension UserPersistentRepositoryUtility {
 
     var notificationPrimerInlineWasAcknowledged: Bool {
         get {
-            return UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.notificationPrimerInlineWasAcknowledged)
+            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.notificationPrimerInlineWasAcknowledged)
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.notificationPrimerInlineWasAcknowledged)
@@ -76,6 +79,33 @@ extension UserPersistentRepositoryUtility {
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.secondNotificationsAlertCount)
+        }
+    }
+
+    var hasShownCustomAppIconUpgradeAlert: Bool {
+        get {
+            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.hasShownCustomAppIconUpgradeAlert)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.hasShownCustomAppIconUpgradeAlert)
+        }
+    }
+
+    var createButtonTooltipDisplayCount: Int {
+        get {
+            UserPersistentStoreFactory.instance().integer(forKey: UPRUConstants.createButtonTooltipDisplayCount)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.createButtonTooltipDisplayCount)
+        }
+    }
+
+    var createButtonTooltipWasDisplayed: Bool {
+        get {
+            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.createButtonTooltipWasDisplayed)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.createButtonTooltipWasDisplayed)
         }
     }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -160,12 +160,12 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func copyToSharedDefaultsIfNeeded() {
-        if !AppConfiguration.isJetpack && FeatureFlag.sharedUserDefaults.enabled && !UserDefaults.standard.isOneOffMigrationComplete {
+        if !AppConfiguration.isJetpack && FeatureFlag.sharedUserDefaults.enabled && !UserPersistentStore.standard.isOneOffMigrationComplete {
             let dict = UserDefaults.standard.dictionaryRepresentation()
             for (key, value) in dict {
                 UserPersistentStore.standard.set(value, forKey: key)
-                UserDefaults.standard.isOneOffMigrationComplete = true
             }
+            UserPersistentStore.standard.isOneOffMigrationComplete = true
         }
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -227,7 +227,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, shouldRestoreApplicationState coder: NSCoder) -> Bool {
         let lastSavedStateVersionKey = "lastSavedStateVersionKey"
-        let defaults = UserDefaults.standard
+        let defaults = UserPersistentStoreFactory.instance()
 
         var shouldRestoreApplicationState = false
 
@@ -237,9 +237,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
                 shouldRestoreApplicationState = self.shouldRestoreApplicationState
             }
 
-            defaults.setValue(currentVersion, forKey: lastSavedStateVersionKey)
+            defaults.set(currentVersion, forKey: lastSavedStateVersionKey)
         }
-
         return shouldRestoreApplicationState
     }
 

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -43,9 +43,13 @@ class KeychainUtils: NSObject {
     }
 
     func copyKeychainToSharedKeychainIfNeeded() {
+        guard let defaults = UserDefaults(suiteName: WPAppGroupName) else {
+            return
+        }
+
         guard shouldUseSharedKeychain(),
               AppConfiguration.isWordPress,
-              !UserPersistentStoreFactory.instance().bool(forKey: "keychain-copied"),
+              !defaults.bool(forKey: "keychain-copied"),
               let items = try? keychainUtils.getAllPasswords(forAccessGroup: nil) else {
             return
         }
@@ -59,7 +63,7 @@ class KeychainUtils: NSObject {
 
             try? keychainUtils.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: WPAppKeychainAccessGroup, updateExisting: false)
         }
-        UserPersistentStoreFactory.instance().set(true, forKey: "keychain-copied")
+        defaults.set(true, forKey: "keychain-copied")
     }
 
 }

--- a/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
+++ b/WordPress/Classes/Utility/Migrations/20-21/AccountToAccount20to21.swift
@@ -18,8 +18,8 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
         if let unwrappedAccount = legacyDefaultWordPressAccount(manager.sourceContext) {
             let username = unwrappedAccount.value(forKey: "username") as! String
 
-            let userDefaults = UserDefaults.standard
-            userDefaults.setValue(username, forKey: defaultDotcomUsernameKey)
+            let userDefaults = UserPersistentStoreFactory.instance()
+            userDefaults.set(username, forKey: defaultDotcomUsernameKey)
 
             DDLogWarn(">> Migration process matched [\(username)] as the default WordPress.com account")
         } else {
@@ -29,7 +29,7 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
 
     override func end(_ mapping: NSEntityMapping, manager: NSMigrationManager) throws {
         // Load the default username
-        let userDefaults = UserDefaults.standard
+        let userDefaults = UserPersistentStoreFactory.instance()
         let defaultUsername = userDefaults.string(forKey: defaultDotcomUsernameKey) ?? String()
 
         // Find the Default Account
@@ -88,7 +88,7 @@ class AccountToAccount20to21: NSEntityMigrationPolicy {
 
         let accountURL = account.objectID.uriRepresentation()
 
-        let defaults = UserDefaults.standard
+        let defaults = UserPersistentStoreFactory.instance()
         defaults.set(accountURL, forKey: defaultDotcomKey)
     }
 }

--- a/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
+++ b/WordPress/Classes/Utility/Migrations/AccountToAccount22to23.swift
@@ -31,8 +31,8 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
         }
 
         if isDotCom! == true {
-            let userDefaults = UserDefaults.standard
-            userDefaults.setValue(username!, forKey: defaultDotcomUsernameKey)
+            let userDefaults = UserPersistentStoreFactory.instance()
+            userDefaults.set(username!, forKey: defaultDotcomUsernameKey)
 
             DDLogWarn(">> Migration process matched [\(username!)] as the default WordPress.com account")
         } else {
@@ -74,7 +74,7 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
         }
 
         // Set the defaultAccount (if any)
-        let userDefaults = UserDefaults.standard
+        let userDefaults = UserPersistentStoreFactory.instance()
 
         if defaultAccount != nil {
             let uuid = defaultAccount!.value(forKey: "uuid") as! String
@@ -142,7 +142,7 @@ class AccountToAccount22to23: NSEntityMigrationPolicy {
             return
         }
 
-        let defaults = UserDefaults.standard
+        let defaults = UserPersistentStoreFactory.instance()
         defaults.set(uuid, forKey: defaultDotcomUUIDKey)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteSettings.swift
@@ -9,8 +9,8 @@ protocol DefaultSectionProvider {
 ///
 @objc final class MySiteSettings: NSObject, DefaultSectionProvider {
 
-    private var userDefaults: UserDefaults {
-        UserDefaults.standard
+    private var userDefaults: UserPersistentRepository {
+        UserPersistentStoreFactory.instance()
     }
 
     var defaultSection: MySiteViewController.Section {

--- a/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingQuestionsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Onboarding Questions Prompt/OnboardingQuestionsCoordinator.swift
@@ -51,7 +51,7 @@ extension OnboardingQuestionsCoordinator {
         }
 
         track(.onboardingQuestionsItemSelected, option: option)
-        UserDefaults.standard.onboardingQuestionSelected = option
+        UserPersistentStoreFactory.instance().onboardingQuestionSelected = option
 
         // Check if notification's are already enabled
         // If they are just dismiss, if not then prompt
@@ -73,7 +73,7 @@ extension OnboardingQuestionsCoordinator {
 extension OnboardingQuestionsCoordinator {
     func notificationsDisplayed(option: OnboardingOption) {
         track(.onboardingEnableNotificationsDisplayed, option: option)
-        UserDefaults.standard.onboardingNotificationsPromptDisplayed = true
+        UserPersistentStoreFactory.instance().onboardingNotificationsPromptDisplayed = true
     }
 
     func notificationsEnabledTapped(selection: OnboardingOption) {
@@ -89,33 +89,5 @@ extension OnboardingQuestionsCoordinator {
     func notificationsSkipped(selection: OnboardingOption) {
         track(.onboardingEnableNotificationsSkipped, option: selection)
         dismiss(selection: selection)
-    }
-}
-
-
-extension UserDefaults {
-    private static let promptKey = "onboarding_notifications_prompt_displayed"
-    private static let questionKey = "onboarding_question_selection"
-
-    var onboardingNotificationsPromptDisplayed: Bool {
-        get {
-            bool(forKey: Self.promptKey)
-        }
-        set {
-            set(newValue, forKey: Self.promptKey)
-        }
-    }
-
-    var onboardingQuestionSelected: OnboardingOption? {
-        get {
-            if let str = string(forKey: Self.questionKey) {
-                return OnboardingOption(rawValue: str)
-            }
-
-            return nil
-        }
-        set {
-            set(newValue?.rawValue, forKey: Self.questionKey)
-        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Feature Highlight/FeatureHighlightStore.swift
+++ b/WordPress/Classes/ViewRelated/Feature Highlight/FeatureHighlightStore.swift
@@ -6,27 +6,27 @@ struct FeatureHighlightStore {
         static let followConversationTooltipCounterKey = "follow-conversation-tooltip-counter"
     }
 
-    private let userDefaults: UserDefaults
+    private let userStore: UserPersistentRepository
 
-    init(userDefaults: UserDefaults = UserDefaults.standard) {
-        self.userDefaults = userDefaults
+    init(userStore: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+        self.userStore = userStore
     }
 
     var didDismissTooltip: Bool {
         get {
-            return userDefaults.bool(forKey: Keys.didUserDismissTooltipKey)
+            return userStore.bool(forKey: Keys.didUserDismissTooltipKey)
         }
         set {
-            userDefaults.set(newValue, forKey: Keys.didUserDismissTooltipKey)
+            userStore.set(newValue, forKey: Keys.didUserDismissTooltipKey)
         }
     }
 
     var followConversationTooltipCounter: Int {
         get {
-            return userDefaults.integer(forKey: Keys.followConversationTooltipCounterKey)
+            return userStore.integer(forKey: Keys.followConversationTooltipCounterKey)
         }
         set {
-            userDefaults.set(newValue, forKey: Keys.followConversationTooltipCounterKey)
+            userStore.set(newValue, forKey: Keys.followConversationTooltipCounterKey)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppIconViewController.swift
@@ -110,7 +110,7 @@ open class AppIconViewController: UITableViewController {
         // Prevent showing the custom icon upgrade alert to a user
         // who's just set an icon for the first time.
         // We'll remove this alert after a couple of releases.
-        UserDefaults.standard.hasShownCustomAppIconUpgradeAlert = true
+        UserPersistentStoreFactory.instance().hasShownCustomAppIconUpgradeAlert = true
 
         UIApplication.shared.setAlternateIconName(iconName, completionHandler: { [weak self] error in
             if error == nil {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -406,7 +406,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
                 }
             }
 
-            UserPersistentStoreFactory.instance().set(false, forKey: UserDefaults.standard.welcomeNotificationSeenKey)
+            UserPersistentStoreFactory.instance().set(false, forKey: UserPersistentStoreFactory.instance().welcomeNotificationSeenKey)
         }
 
         navigationController.pushViewController(epilogueViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -8,7 +8,7 @@ extension NotificationsViewController {
 
     var shouldShowPrimeForPush: Bool {
         get {
-            return !UserDefaults.standard.notificationPrimerInlineWasAcknowledged
+            return !UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged
         }
     }
 
@@ -44,7 +44,7 @@ extension NotificationsViewController {
             InteractiveNotificationsManager.shared.requestAuthorization { _ in
                 DispatchQueue.main.async {
                     self?.hideInlinePrompt(delay: 0.0)
-                    UserDefaults.standard.notificationPrimerInlineWasAcknowledged = true
+                    UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
                 }
             }
         }
@@ -54,7 +54,7 @@ extension NotificationsViewController {
                 WPAnalytics.track(.pushNotificationPrimerNoTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }
             self?.hideInlinePrompt(delay: 0.0)
-            UserDefaults.standard.notificationPrimerInlineWasAcknowledged = true
+            UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
         }
 
         // We _seriously_ need to call the following method at last.
@@ -65,9 +65,9 @@ extension NotificationsViewController {
 
     private func setupWinback() {
         // only show the winback for folks that denied without seeing the post-login primer: aka users of a previous version
-        guard !UserDefaults.standard.notificationPrimerAlertWasDisplayed else {
+        guard !UserPersistentStoreFactory.instance().notificationPrimerAlertWasDisplayed else {
             // they saw the primer, and denied us. they aren't coming back, we aren't bothering them anymore.
-            UserDefaults.standard.notificationPrimerInlineWasAcknowledged = true
+            UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
             return
         }
 
@@ -91,7 +91,7 @@ extension NotificationsViewController {
             self?.hideInlinePrompt(delay: 0.0)
             let targetURL = URL(string: UIApplication.openSettingsURLString)
             UIApplication.shared.open(targetURL!)
-            UserDefaults.standard.notificationPrimerInlineWasAcknowledged = true
+            UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
         }
 
         inlinePromptView.setupNoButton(title: noTitle) { [weak self] button in
@@ -99,7 +99,7 @@ extension NotificationsViewController {
                 WPAnalytics.track(.pushNotificationWinbackNoTapped, withProperties: [Analytics.locationKey: Analytics.inlineKey])
             }
             self?.hideInlinePrompt(delay: 0.0)
-            UserDefaults.standard.notificationPrimerInlineWasAcknowledged = true
+            UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -103,34 +103,3 @@ extension NotificationsViewController {
         }
     }
 }
-
-// MARK: - User Defaults for Push Notifications
-
-extension UserDefaults {
-    private enum Keys: String {
-        case notificationPrimerInlineWasAcknowledged = "notificationPrimerInlineWasAcknowledged"
-        case secondNotificationsAlertCount = "secondNotificationsAlertCount"
-    }
-
-    var notificationPrimerInlineWasAcknowledged: Bool {
-        get {
-            return bool(forKey: Keys.notificationPrimerInlineWasAcknowledged.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.notificationPrimerInlineWasAcknowledged.rawValue)
-        }
-    }
-
-    var secondNotificationsAlertCount: Int {
-        get {
-            integer(forKey: Keys.secondNotificationsAlertCount.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.secondNotificationsAlertCount.rawValue)
-        }
-    }
-
-    @objc var welcomeNotificationSeenKey: String {
-        return "welcomeNotificationSeen"
-    }
-}

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1847,8 +1847,8 @@ private extension NotificationsViewController {
         return NotificationActionsService(managedObjectContext: mainContext)
     }
 
-    var userDefaults: UserDefaults {
-        return UserDefaults.standard
+    var userDefaults: UserPersistentRepository {
+        return UserPersistentStoreFactory.instance()
     }
 
     var lastSeenTime: String? {
@@ -1856,7 +1856,7 @@ private extension NotificationsViewController {
             return userDefaults.string(forKey: Settings.lastSeenTime)
         }
         set {
-            userDefaults.setValue(newValue, forKey: Settings.lastSeenTime)
+            userDefaults.set(newValue, forKey: Settings.lastSeenTime)
         }
     }
 
@@ -2037,7 +2037,7 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
                 return
             }
 
-            UserDefaults.standard.notificationPrimerAlertWasDisplayed = true
+            UserPersistentStoreFactory.instance().notificationPrimerAlertWasDisplayed = true
 
             let alert = alertController
             alert.modalPresentationStyle = .custom

--- a/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListFilterSettings.swift
@@ -104,7 +104,7 @@ class PostListFilterSettings: NSObject {
     /// currentPostListFilter: returns the index of the last active PostListFilter
     @objc func currentFilterIndex() -> Int {
 
-        let userDefaults = UserDefaults.standard
+        let userDefaults = UserPersistentStoreFactory.instance()
 
         if let filter = userDefaults.object(forKey: keyForCurrentListStatusFilter()) as? Int, filter < availablePostListFilters().count {
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderCSS.swift
@@ -50,7 +50,7 @@ struct ReaderCSS {
     }
 
     init(now: Int = Int(Date().timeIntervalSince1970),
-         store: KeyValueDatabase = UserDefaults.standard,
+         store: KeyValueDatabase = UserPersistentStoreFactory.instance(),
          isInternetReachable: @escaping () -> Bool = ReachabilityUtils.isInternetReachable) {
         self.store = store
         self.now = now

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -9,7 +9,7 @@ class ReaderSelectInterestsCoordinator {
     ///   - store: An optional backing store to keep track of if the user has seen the select interests view or not
     ///   - userId: The logged in user account, this makes sure the tracking is a per-user basis
     init(service: ReaderFollowedInterestsService? = nil,
-         store: KeyValueDatabase = UserDefaults.standard,
+         store: KeyValueDatabase = UserPersistentStoreFactory.instance(),
          userId: NSNumber? = nil,
          context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderWelcomeBanner.swift
@@ -20,7 +20,7 @@ class ReaderWelcomeBanner: UIView, NibLoadable {
 
     /// Present the Welcome banner just one time
     class func displayIfNeeded(in tableView: UITableView,
-                               database: KeyValueDatabase = UserDefaults.standard) {
+                               database: KeyValueDatabase = UserPersistentStoreFactory.instance()) {
         guard !database.bool(forKey: ReaderWelcomeBanner.bannerPresentedKey) else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsInformation.swift
@@ -32,7 +32,7 @@ import Foundation
 
 extension SiteStatsInformation {
 
-    func getCurrentSiteInsights(_ userDefaults: UserDefaults = UserDefaults.standard) -> [InsightType] {
+    func getCurrentSiteInsights(_ userDefaults: UserPersistentRepository = UserPersistentStoreFactory.instance()) -> [InsightType] {
 
         guard let siteID = siteID?.stringValue else {
             return InsightType.defaultInsights
@@ -44,7 +44,7 @@ extension SiteStatsInformation {
         return InsightType.typesForValues(values ?? InsightType.defaultInsightsValues)
     }
 
-    func saveCurrentSiteInsights(_ insightsCards: [InsightType], _ userDefaults: UserDefaults = UserDefaults.standard) {
+    func saveCurrentSiteInsights(_ insightsCards: [InsightType], _ userDefaults: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
 
         guard let siteID = siteID?.stringValue else {
             return

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -12,7 +12,7 @@ class SupportTableViewController: UITableViewController {
     var showHelpFromViewController: UIViewController?
 
     private var tableHandler: ImmuTableViewHandler?
-    private let userDefaults = UserDefaults.standard
+    private let userDefaults = UserPersistentStoreFactory.instance()
 
     /// This closure is called when this VC is about to be dismissed due to the user
     /// tapping the dismiss button.

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
@@ -12,11 +12,11 @@ extension FancyAlertViewController {
         guard AppConfiguration.allowsCustomAppIcons,
               AppIcon.isUsingCustomIcon,
               origin.presentedViewController == nil,
-              UserDefaults.standard.hasShownCustomAppIconUpgradeAlert == false else {
+              UserPersistentStoreFactory.instance().hasShownCustomAppIconUpgradeAlert == false else {
             return
         }
 
-        UserDefaults.standard.hasShownCustomAppIconUpgradeAlert = true
+        UserPersistentStoreFactory.instance().hasShownCustomAppIconUpgradeAlert = true
 
         let controller = FancyAlertViewController.makeCustomAppIconUpgradeAlertController(with: origin)
         controller.modalPresentationStyle = .custom

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+AppIcons.swift
@@ -54,20 +54,3 @@ extension FancyAlertViewController {
         return controller
     }
 }
-
-// MARK: - User Defaults
-
-extension UserDefaults {
-    private enum Keys: String {
-        case hasShownCustomAppIconUpgradeAlert = "custom-app-icon-upgrade-alert-shown"
-    }
-
-    var hasShownCustomAppIconUpgradeAlert: Bool {
-        get {
-            return bool(forKey: Keys.hasShownCustomAppIconUpgradeAlert.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.hasShownCustomAppIconUpgradeAlert.rawValue)
-        }
-    }
-}

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+NotificationPrimer.swift
@@ -75,32 +75,3 @@ extension FancyAlertViewController {
                                                approveAction: approveAction)
     }
 }
-
-// MARK: - User Defaults
-
-@objc
-extension UserDefaults {
-    private enum Keys: String {
-        case notificationPrimerAlertWasDisplayed = "NotificationPrimerAlertWasDisplayed"
-        case notificationsTabAccessCount = "NotificationsTabAccessCount"
-    }
-
-    var notificationPrimerAlertWasDisplayed: Bool {
-        get {
-            bool(forKey: Keys.notificationPrimerAlertWasDisplayed.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.notificationPrimerAlertWasDisplayed.rawValue)
-        }
-    }
-
-    var notificationsTabAccessCount: Int {
-        get {
-            integer(forKey: Keys.notificationsTabAccessCount.rawValue)
-        }
-
-        set {
-            set(newValue, forKey: Keys.notificationsTabAccessCount.rawValue)
-        }
-    }
-}

--- a/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
+++ b/WordPress/Classes/ViewRelated/System/FancyAlertViewController+SavedPosts.swift
@@ -11,8 +11,8 @@ extension FancyAlertViewController {
     }
 
     static func presentReaderSavedPostsAlertControllerIfNecessary(from origin: UIViewController & UIViewControllerTransitioningDelegate) {
-        if !UserDefaults.standard.savedPostsPromoWasDisplayed {
-            UserDefaults.standard.savedPostsPromoWasDisplayed = true
+        if !UserPersistentStoreFactory.instance().savedPostsPromoWasDisplayed {
+            UserPersistentStoreFactory.instance().savedPostsPromoWasDisplayed = true
 
             let controller = FancyAlertViewController.makeReaderSavedPostsAlertController()
             controller.modalPresentationStyle = .custom
@@ -39,22 +39,5 @@ extension FancyAlertViewController {
 
         let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
         return controller
-    }
-}
-
-// MARK: - User Defaults
-
-extension UserDefaults {
-    private enum Keys: String {
-        case savedPostsPromoWasDisplayed = "SavedPostsV1PromoWasDisplayed"
-    }
-
-    var savedPostsPromoWasDisplayed: Bool {
-        get {
-            return bool(forKey: Keys.savedPostsPromoWasDisplayed.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.savedPostsPromoWasDisplayed.rawValue)
-        }
     }
 }

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -39,20 +39,20 @@ import WordPressFlux
             if newValue >= Constants.maximumTooltipViews {
                 didDismissTooltip = true
             } else {
-                UserDefaults.standard.createButtonTooltipDisplayCount = newValue
+                UserPersistentStoreFactory.instance().createButtonTooltipDisplayCount = newValue
             }
         }
         get {
-            return UserDefaults.standard.createButtonTooltipDisplayCount
+            return UserPersistentStoreFactory.instance().createButtonTooltipDisplayCount
         }
     }
 
     private var didDismissTooltip: Bool {
         set {
-            UserDefaults.standard.createButtonTooltipWasDisplayed = newValue
+            UserPersistentStoreFactory.instance().createButtonTooltipWasDisplayed = newValue
         }
         get {
-            return UserDefaults.standard.createButtonTooltipWasDisplayed
+            return UserPersistentStoreFactory.instance().createButtonTooltipWasDisplayed
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -273,33 +273,6 @@ extension CreateButtonCoordinator: UIViewControllerTransitioningDelegate {
     }
 }
 
-@objc
-extension UserDefaults {
-    private enum Keys: String {
-        case createButtonTooltipWasDisplayed = "CreateButtonTooltipWasDisplayed"
-        case createButtonTooltipDisplayCount = "CreateButtonTooltipDisplayCount"
-    }
-
-    var createButtonTooltipDisplayCount: Int {
-        get {
-            return integer(forKey: Keys.createButtonTooltipDisplayCount.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.createButtonTooltipDisplayCount.rawValue)
-        }
-    }
-
-    var createButtonTooltipWasDisplayed: Bool {
-        get {
-            return bool(forKey: Keys.createButtonTooltipWasDisplayed.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.createButtonTooltipWasDisplayed.rawValue)
-        }
-    }
-}
-
-
 // MARK: - Blogging Prompts Methods
 
 private extension CreateButtonCoordinator {

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+ShowTab.swift
@@ -53,10 +53,10 @@ extension WPTabBarController {
             return
         }
 
-        if UserDefaults.standard.storiesIntroWasAcknowledged == false {
+        if UserPersistentStoreFactory.instance().storiesIntroWasAcknowledged == false {
             // Show Intro screen
             let intro = StoriesIntroViewController(continueTapped: { [weak self] in
-                UserDefaults.standard.storiesIntroWasAcknowledged = true
+                UserPersistentStoreFactory.instance().storiesIntroWasAcknowledged = true
                 self?.showStoryEditor()
             }, openURL: { [weak self] url in
                 let webViewController = WebViewControllerFactory.controller(url: url, source: "show_story_example")

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -556,7 +556,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 -(BOOL) welcomeNotificationSeen
 {
     NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    NSString *welcomeNotificationSeenKey = standardUserDefaults.welcomeNotificationSeenKey;
+    NSString *welcomeNotificationSeenKey = @"welcomeNotificationSeen";
     return [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
 }
 

--- a/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
@@ -12,46 +12,15 @@ struct UserDefaultsAnnouncementsCache: AnnouncementsCache {
 
     var announcements: [Announcement]? {
         get {
-            return UserDefaults.standard.announcements
+            return UserPersistentStoreFactory.instance().announcements
         }
         set {
-            UserDefaults.standard.announcements = newValue
+            UserPersistentStoreFactory.instance().announcements = newValue
         }
     }
 
     var date: Date? {
-        UserDefaults.standard.announcementsDate
+        UserPersistentStoreFactory.instance().announcementsDate
     }
 }
 
-
-// MARK: - Cache on disk
-private extension UserDefaults {
-
-    static let currentAnnouncementsKey = "currentAnnouncements"
-    static let currentAnnouncementsDateKey = "currentAnnouncementsDate"
-
-    var announcements: [Announcement]? {
-        get {
-            guard let encodedAnnouncements = value(forKey: Self.currentAnnouncementsKey) as? Data,
-                  let announcements = try? PropertyListDecoder().decode([Announcement].self, from: encodedAnnouncements) else {
-                return nil
-            }
-            return announcements
-        }
-
-        set {
-            guard let announcements = newValue, let encodedAnnouncements = try? PropertyListEncoder().encode(announcements) else {
-                removeObject(forKey: Self.currentAnnouncementsKey)
-                removeObject(forKey: Self.currentAnnouncementsDateKey)
-                return
-            }
-            set(encodedAnnouncements, forKey: Self.currentAnnouncementsKey)
-            set(Date(), forKey: Self.currentAnnouncementsDateKey)
-        }
-    }
-
-    var announcementsDate: Date? {
-        value(forKey: Self.currentAnnouncementsDateKey) as? Date
-    }
-}

--- a/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Presenter/WhatIsNewScenePresenter.swift
@@ -148,17 +148,6 @@ private extension WhatIsNewScenePresenter {
 
 
 private extension UserDefaults {
-
-    static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
-
-    var announcementsVersionDisplayed: String? {
-        get {
-            string(forKey: UserDefaults.announcementsVersionDisplayedKey)
-        }
-        set {
-            set(newValue, forKey: UserDefaults.announcementsVersionDisplayedKey)
-        }
-    }
 }
 
 fileprivate extension String {

--- a/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Views/StoriesIntroViewController.swift
@@ -86,20 +86,3 @@ class StoriesIntroViewController: WhatIsNewViewController {
         WPAnalytics.track(.storyIntroDismissed)
     }
 }
-
-// MARK: - Helpers
-
-extension UserDefaults {
-    private enum Keys: String {
-        case storiesIntroWasAcknowledged = "storiesIntroWasAcknowledged"
-    }
-
-    var storiesIntroWasAcknowledged: Bool {
-        get {
-            return bool(forKey: Keys.storiesIntroWasAcknowledged.rawValue)
-        }
-        set {
-            set(newValue, forKey: Keys.storiesIntroWasAcknowledged.rawValue)
-        }
-    }
-}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1499,30 +1499,6 @@
 		83A1B19E28AFE86A00E737AC /* FeatureFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690151F828FF000200E30 /* FeatureFlag.swift */; };
 		83A1B1A028AFE89700E737AC /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
 		83A1B1A328AFE89F00E737AC /* BuildConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D690141F828FF000200E30 /* BuildConfiguration.swift */; };
-		83A1B1A628AFF10900E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1A728AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1A828AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1A928AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1AA28AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1AB28AFF10C00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1AC28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1AD28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */; };
-		83A1B1AE28AFF11A00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1AF28AFF11B00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B028AFF11B00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B128AFF11C00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B228AFF11C00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B328AFF11D00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B428AFF11D00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B528AFF11E00E737AC /* UserPersistentRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */; };
-		83A1B1B628AFF15200E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1B728AFF15300E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1B828AFF15300E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1B928AFF15400E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1BA28AFF15400E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1BB28AFF15500E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1BC28AFF15500E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
-		83A1B1BD28AFF15600E737AC /* UserPersistentStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */; };
 		83B1D037282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
@@ -19959,7 +19935,6 @@
 				3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
 				3FCF66E925CAF8C50047F337 /* ListStatsView.swift in Sources */,
 				83A1B19A28AFE47C00E737AC /* KeychainUtils.swift in Sources */,
-				83A1B1BB28AFF15500E737AC /* UserPersistentStore.swift in Sources */,
 				3F6BC06D25B24787007369D3 /* BuildConfiguration.swift in Sources */,
 				3F1FD2502548AD8B0060C53A /* TodayWidgetStats.swift in Sources */,
 				3F2F0C16256C6B2C003351C7 /* StatsWidgetsService.swift in Sources */,
@@ -19983,7 +19958,6 @@
 				3F1FD27B2548AE900060C53A /* CocoaLumberjack.swift in Sources */,
 				3FCF66FB25CAF8E00047F337 /* ListRow.swift in Sources */,
 				8323789828526E6D003F4443 /* AppConfiguration.swift in Sources */,
-				83A1B1B328AFF11D00E737AC /* UserPersistentRepository.swift in Sources */,
 				3F8B138F25D09AA5004FAC0A /* WordPressHomeWidgetThisWeek.swift in Sources */,
 				3F5689F0254209790048A9E4 /* SingleStatView.swift in Sources */,
 				3FAA18CC25797B85002B1911 /* UnconfiguredView.swift in Sources */,
@@ -19994,7 +19968,6 @@
 				3FD675D925C87A15009AB3C1 /* Sites.intentdefinition in Sources */,
 				3FE77C8325B0CA89007DE9E5 /* LocalizableStrings.swift in Sources */,
 				3FCC8FD9256C911300810295 /* SFHFKeychainUtils.m in Sources */,
-				83A1B1AB28AFF10C00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				3FE20C3725CF211F00A15525 /* ListViewData.swift in Sources */,
 				3F71D5302548C2B200A4BA93 /* Double+Stats.swift in Sources */,
 				98390AD2254C985F00868F0A /* Tracks.swift in Sources */,
@@ -20067,12 +20040,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				83A1B1AC28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789928526E6E003F4443 /* AppConfiguration.swift in Sources */,
 				7345EAC4212DD49400607EC9 /* CircularImageView.swift in Sources */,
 				83A1B19B28AFE47D00E737AC /* KeychainUtils.swift in Sources */,
 				436110DD22C41AFD000773AD /* FeatureFlag.swift in Sources */,
-				83A1B1BC28AFF15500E737AC /* UserPersistentStore.swift in Sources */,
 				436110DC22C41ADB000773AD /* UIColor+MurielColors.swift in Sources */,
 				170BEC8A239153160017AEC1 /* FeatureFlagOverrideStore.swift in Sources */,
 				433ADC1B223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
@@ -20084,7 +20055,6 @@
 				FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
 				736584E6213752730029C9A4 /* SFHFKeychainUtils.m in Sources */,
-				83A1B1B428AFF11D00E737AC /* UserPersistentRepository.swift in Sources */,
 				73B05D2621374B960073ECAA /* Tracks.swift in Sources */,
 				1752D4FC238D703A002B79E7 /* KeyValueDatabase.swift in Sources */,
 				FAD2566F2611AEC700EDAF88 /* AppStyleGuide.swift in Sources */,
@@ -20105,10 +20075,8 @@
 				7335AC5C21220AF40012EF2D /* FormattableContentAction.swift in Sources */,
 				7335AC6B21220EF80012EF2D /* DefaultFormattableContentAction.swift in Sources */,
 				7335AC6421220E880012EF2D /* FormattableMediaContent.swift in Sources */,
-				83A1B1BD28AFF15600E737AC /* UserPersistentStore.swift in Sources */,
 				7335AC6521220E940012EF2D /* FormattableTextContent.swift in Sources */,
 				7335AC5D21220AFE0012EF2D /* FormattableContentActionCommand.swift in Sources */,
-				83A1B1AD28AFF10D00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				7335AC5A21220AD10012EF2D /* FormattableContentRange.swift in Sources */,
 				7335AC6821220EC10012EF2D /* FormattableCommentContent.swift in Sources */,
 				7335AC6921220ECE0012EF2D /* NotificationCommentRange.swift in Sources */,
@@ -20134,7 +20102,6 @@
 				83A1B19E28AFE86A00E737AC /* FeatureFlag.swift in Sources */,
 				73E8E592212CD635000B26A5 /* UIImage+Assets.swift in Sources */,
 				83A1B1A328AFE89F00E737AC /* BuildConfiguration.swift in Sources */,
-				83A1B1B528AFF11E00E737AC /* UserPersistentRepository.swift in Sources */,
 				73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */,
 				73768B6B212B4E4F005136A1 /* UNNotificationContent+RemoteNotification.swift in Sources */,
 				73F6DD45212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
@@ -20149,7 +20116,6 @@
 				74021A21202E173F006CC39F /* TextList+WordPress.swift in Sources */,
 				433ADC19223B2A0200ED9DE1 /* TextBundleWrapper.m in Sources */,
 				74021A07202E1307006CC39F /* UINavigationController+Extensions.swift in Sources */,
-				83A1B1B728AFF15300E737AC /* UserPersistentStore.swift in Sources */,
 				74021A1C202E158F006CC39F /* ShareExtensionService.swift in Sources */,
 				747F88C2203778E000523C7C /* ShareTagsPickerViewController.swift in Sources */,
 				7414A142203CD066005A7D9B /* ShareCategoriesPickerViewController.swift in Sources */,
@@ -20160,10 +20126,8 @@
 				74021A19202E14C1006CC39F /* NSAttributedStringKey+Conversion.swift in Sources */,
 				74021A03202E1307006CC39F /* NSExtensionContext+Extensions.swift in Sources */,
 				74021A22202E1740006CC39F /* Header+WordPress.swift in Sources */,
-				83A1B1AF28AFF11B00E737AC /* UserPersistentRepository.swift in Sources */,
 				74021A02202E12FF006CC39F /* Extensions.xcdatamodeld in Sources */,
 				FAD256B82611B01B00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
-				83A1B1A728AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				740219FF202E12F4006CC39F /* PostUploadOperation.swift in Sources */,
 				9822D8DE214194EB0092CBD1 /* NoResultsViewController.swift in Sources */,
 				74021A1A202E1502006CC39F /* WPStyleGuide+Gridicon.swift in Sources */,
@@ -20239,7 +20203,6 @@
 				741E224B1FC0E5C0007967AB /* UploadOperation.swift in Sources */,
 				43EE90EF223B1029006A33E9 /* TextBundleWrapper.m in Sources */,
 				74EA3B89202A0462004F802D /* ShareNoticeConstants.swift in Sources */,
-				83A1B1B628AFF15200E737AC /* UserPersistentStore.swift in Sources */,
 				B50248AF1C96FF6200AFBDED /* WPStyleGuide+Share.swift in Sources */,
 				E1CE41661E8D1026000CF5A4 /* ShareExtractor.swift in Sources */,
 				930F09191C7E1C1E00995926 /* ShareExtensionService.swift in Sources */,
@@ -20250,10 +20213,8 @@
 				74F5CD3A1FE0653500764E7C /* ShareExtensionEditorViewController.swift in Sources */,
 				B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */,
 				B50248C21C96FFCC00AFBDED /* WordPressShare-Lumberjack.m in Sources */,
-				83A1B1AE28AFF11A00E737AC /* UserPersistentRepository.swift in Sources */,
 				74FA4BE61FBFA0660031EAAD /* Extensions.xcdatamodeld in Sources */,
 				FAD256A62611B01A00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
-				83A1B1A628AFF10900E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				74D06FEB1FE0788500AF1788 /* TextList+WordPress.swift in Sources */,
 				74FA2EE4200E8A6C001DDC13 /* AppExtensionsService.swift in Sources */,
 				74F89407202A1965008610FA /* ExtensionNotificationManager.swift in Sources */,
@@ -20313,9 +20274,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				98906507237CC1DF00218CD2 /* WidgetTwoColumnCell.swift in Sources */,
-				83A1B1B028AFF11B00E737AC /* UserPersistentRepository.swift in Sources */,
 				433ADC1C223B2A7E00ED9DE1 /* TextBundleWrapper.m in Sources */,
-				83A1B1A828AFF10A00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				93E5284119A7741A003A1A9C /* TodayViewController.swift in Sources */,
 				FAD2566C2611AEC300EDAF88 /* AppStyleGuide.swift in Sources */,
 				938CF3DE1EF1BE8000AF838E /* CocoaLumberjack.swift in Sources */,
@@ -20325,7 +20284,6 @@
 				436110DA22C3ED44000773AD /* FeatureFlag.swift in Sources */,
 				436110DB22C3ED4C000773AD /* BuildConfiguration.swift in Sources */,
 				98906503237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */,
-				83A1B1B828AFF15300E737AC /* UserPersistentStore.swift in Sources */,
 				93C2075D1CC7FFC800C94D04 /* Tracks+TodayWidget.swift in Sources */,
 				98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				83A1B19728AFE47A00E737AC /* KeychainUtils.swift in Sources */,
@@ -20362,14 +20320,11 @@
 				98712D1F23DA1D0A00555316 /* WidgetNoConnectionCell.swift in Sources */,
 				FAD257F42611B54100EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				092C3802275E718100BBBDD9 /* AppLocalizedString.swift in Sources */,
-				83A1B1AA28AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789728526E6C003F4443 /* AppConfiguration.swift in Sources */,
 				98A3C3052399A2370048D38D /* ThisWeekViewController.swift in Sources */,
-				83A1B1BA28AFF15400E737AC /* UserPersistentStore.swift in Sources */,
 				17A4B6A324F911D5002DFB8E /* KeyValueDatabase.swift in Sources */,
 				989643E523A02F640070720A /* MurielColor.swift in Sources */,
 				83A1B19928AFE47B00E737AC /* KeychainUtils.swift in Sources */,
-				83A1B1B228AFF11C00E737AC /* UserPersistentRepository.swift in Sources */,
 				983AE84D2399AC6B00E5B7F6 /* Constants.m in Sources */,
 				989643ED23A0437B0070720A /* WidgetDifferenceCell.swift in Sources */,
 				FAD2566E2611AEC600EDAF88 /* AppStyleGuide.swift in Sources */,
@@ -20396,14 +20351,11 @@
 				98712D1E23DA1D0900555316 /* WidgetNoConnectionCell.swift in Sources */,
 				98A6B993239881860031AEBD /* MurielColor.swift in Sources */,
 				092C3801275E718100BBBDD9 /* AppLocalizedString.swift in Sources */,
-				83A1B1A928AFF10B00E737AC /* UserPersistentStoreFactory.swift in Sources */,
 				8323789628526E6C003F4443 /* AppConfiguration.swift in Sources */,
 				FAD256EE2611B01F00EDAF88 /* UIColor+WordPressColors.swift in Sources */,
-				83A1B1B928AFF15400E737AC /* UserPersistentStore.swift in Sources */,
 				17A4B6A224F911D4002DFB8E /* KeyValueDatabase.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				83A1B19828AFE47B00E737AC /* KeychainUtils.swift in Sources */,
-				83A1B1B128AFF11C00E737AC /* UserPersistentRepository.swift in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
 				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
 				FAD2566D2611AEC500EDAF88 /* AppStyleGuide.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -99,6 +99,8 @@
 		086F2482284F52DD00032F39 /* TooltipAnchor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 081E4B4B281C019A0085E89C /* TooltipAnchor.swift */; };
 		086F2483284F52DF00032F39 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08D553652821286300AA1E8D /* Tooltip.swift */; };
 		086F2484284F52E100032F39 /* FeatureHighlightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084A07052848E1820054508A /* FeatureHighlightStore.swift */; };
+		0878580328B4CF950069F96C /* UserPersistentRepositoryUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0878580228B4CF950069F96C /* UserPersistentRepositoryUtility.swift */; };
+		0878580428B4CF950069F96C /* UserPersistentRepositoryUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0878580228B4CF950069F96C /* UserPersistentRepositoryUtility.swift */; };
 		0879FC161E9301DD00E1EFC8 /* MediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0879FC151E9301DD00E1EFC8 /* MediaTests.swift */; };
 		087EBFA81F02313E001F7ACE /* MediaThumbnailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */; };
 		0885A3671E837AFE00619B4D /* URLIncrementalFilenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */; };
@@ -5121,6 +5123,7 @@
 		086C4D0F1E81F9240011D960 /* Media+Blog.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Media+Blog.swift"; sourceTree = "<group>"; };
 		086E1FDE1BBB35D2002D86CA /* MenusViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenusViewController.h; sourceTree = "<group>"; };
 		086E1FDF1BBB35D2002D86CA /* MenusViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenusViewController.m; sourceTree = "<group>"; };
+		0878580228B4CF950069F96C /* UserPersistentRepositoryUtility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserPersistentRepositoryUtility.swift; sourceTree = "<group>"; };
 		0879FC151E9301DD00E1EFC8 /* MediaTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaTests.swift; sourceTree = "<group>"; };
 		087EBFA71F02313E001F7ACE /* MediaThumbnailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaThumbnailService.swift; sourceTree = "<group>"; };
 		0885A3661E837AFE00619B4D /* URLIncrementalFilenameTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLIncrementalFilenameTests.swift; sourceTree = "<group>"; };
@@ -15087,6 +15090,7 @@
 				08A4E128289D202F001D9EC7 /* UserPersistentStore.swift */,
 				08A4E12B289D2337001D9EC7 /* UserPersistentRepository.swift */,
 				08E39B4428A3DEB200874CB8 /* UserPersistentStoreFactory.swift */,
+				0878580228B4CF950069F96C /* UserPersistentRepositoryUtility.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -19452,6 +19456,7 @@
 				086103961EE09C91004D7C01 /* MediaVideoExporter.swift in Sources */,
 				E126C81F1F95FC1B00A5F464 /* PluginViewController.swift in Sources */,
 				E61084C11B9B47BA008050C5 /* ReaderSiteTopic.swift in Sources */,
+				0878580328B4CF950069F96C /* UserPersistentRepositoryUtility.swift in Sources */,
 				FE18495827F5ACBA00D26879 /* DashboardPromptsCardCell.swift in Sources */,
 				FAB8004925AEDC2300D5D54A /* JetpackBackupCompleteViewController.swift in Sources */,
 				9A8ECE0C2254A3260043C8DA /* JetpackLoginViewController.swift in Sources */,
@@ -20998,6 +21003,7 @@
 				FABB217E2602FC2C00C8785C /* JetpackInstallError+Blocking.swift in Sources */,
 				FABB217F2602FC2C00C8785C /* QuickStartTourState.swift in Sources */,
 				FABB21802602FC2C00C8785C /* ReaderPostCardCell.swift in Sources */,
+				0878580428B4CF950069F96C /* UserPersistentRepositoryUtility.swift in Sources */,
 				F1585419267D3B5700A2E966 /* BloggingRemindersScheduler.swift in Sources */,
 				FABB21812602FC2C00C8785C /* DiffContentValue.swift in Sources */,
 				FABB21822602FC2C00C8785C /* FormattableTextContent.swift in Sources */,

--- a/WordPress/WordPressTest/FeatureHighlightStoreTests.swift
+++ b/WordPress/WordPressTest/FeatureHighlightStoreTests.swift
@@ -24,7 +24,7 @@ final class FeatureHighlightStoreTests: XCTestCase {
     }
 
     func testShouldShowTooltipReturnsTrueWhenCounterIsBelow3() {
-        var sut = FeatureHighlightStore(userDefaults: MockUserDefaults())
+        var sut = FeatureHighlightStore(userStore: MockUserDefaults())
         sut.didDismissTooltip = false
         sut.followConversationTooltipCounter = 2
 
@@ -32,7 +32,7 @@ final class FeatureHighlightStoreTests: XCTestCase {
     }
 
     func testShouldShowTooltipReturnsFalseWhenCounterIs3() {
-        var sut = FeatureHighlightStore(userDefaults: MockUserDefaults())
+        var sut = FeatureHighlightStore(userStore: MockUserDefaults())
         sut.didDismissTooltip = false
         sut.followConversationTooltipCounter = 3
 
@@ -40,7 +40,7 @@ final class FeatureHighlightStoreTests: XCTestCase {
     }
 
     func testShouldShowTooltipReturnsFalseWhenCounterIsBelow3DidDismissIsTrue() {
-        var sut = FeatureHighlightStore(userDefaults: MockUserDefaults())
+        var sut = FeatureHighlightStore(userStore: MockUserDefaults())
         sut.didDismissTooltip = true
         sut.followConversationTooltipCounter = 0
 
@@ -48,7 +48,7 @@ final class FeatureHighlightStoreTests: XCTestCase {
     }
 
     func testShouldShowTooltipReturnsFalseWhenCounterIsAbove3DidDismissIsTrue() {
-        var sut = FeatureHighlightStore(userDefaults: MockUserDefaults())
+        var sut = FeatureHighlightStore(userStore: MockUserDefaults())
         sut.didDismissTooltip = true
         sut.followConversationTooltipCounter = 7
 


### PR DESCRIPTION
Fixes #19235 

Extracts the utility variables to a protocol extension `UserPersistentRepositoryUtility` instead of extending the `UserDefaults` directly. The only remaining user default access' are from the file called `CommentsViewController`. Although as this is an objective-c file, it will require a bunch of modules to be marked as `@objc`. The 2 defaults don't seem critical to me and I rather keep it unpolluted for just the two.

Feature toggle is still set to false. It will be enabled once we have green light for release.

To test:
1. Install & Log in WP.
2. Set Shared Defaults Flag to true (so that both apps run on true)
3. Modify a persisting user setting like App Theme.
4. Run JP and Log in.
5. Enable the feature flag in JP. (You might need to re-run the JP app after if the default you're checking is only read in launch)
6. Check if changes reflect there.

## Regression Notes
1. Potential unintended areas of impact
Even though the change is repetitive, it is pretty all around. A lot of files are refactored. There were `value` calls instead of `object` which is (the former) not a `UserDefaults` function. The intended way is using `object` so I refactored accordingly.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
We have to manually test this. Ideally we enable the toggle after a release to have 2 weeks to test regression.

3. What automated tests I added (or what prevented me from doing so)
Changes are quite spread on legacy code. Testing it would require multitudes of more refactoring.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
