### PR TITLE
[Jetpack plugin install prompt] Prompt accessibility improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
@@ -67,6 +67,7 @@ class JetpackInstallPromptViewController: UIViewController {
 
         applyStyles()
         localizeText()
+        configureAccessibility()
 
         backgroundView.addSubview(starFieldView)
         backgroundView.layer.addSublayer(gradientLayer)
@@ -160,6 +161,17 @@ class JetpackInstallPromptViewController: UIViewController {
         button.primaryHighlightBackgroundColor = style.highlighted.backgroundColor
         button.primaryHighlightBorderColor = style.highlighted.borderColor
     }
+
+    private func configureAccessibility() {
+        learnMoreButton.accessibilityHint = Strings.learnMoreButtonHint
+        learnMoreButton.accessibilityTraits = .link
+
+        installButton.accessibilityHint = Strings.installButtonHint
+        installButton.accessibilityTraits = .button
+
+        noThanksButton.accessibilityHint = Strings.noThanksButtonHint
+        noThanksButton.accessibilityTraits = .button
+    }
 }
 
 // MARK: - Notifications
@@ -176,8 +188,11 @@ private struct Strings {
     static let andMore = NSLocalizedString("... and more!", comment: "Label, hint there are more features")
 
     static let learnMoreButton = NSLocalizedString("Learn More", comment: "Button title, opens a webview with more features")
+    static let learnMoreButtonHint = NSLocalizedString("Opens Jetpack website for more information.", comment: "VoiceOver accessibility hint, informating the user that the button opens a website with more information")
     static let installButton = NSLocalizedString("Install", comment: "Button title, accepting the install offer")
+    static let installButtonHint = NSLocalizedString("Opens the Jetpack installation view.", comment: "VoiceOver accessibility hint, informating the user that the button opens a view that installs Jetpack")
     static let noThanksButton = NSLocalizedString("No Thanks", comment: "Button title, declining the offer")
+    static let noThanksButtonHint = NSLocalizedString("Closes the installation prompt.", comment: "VoiceOver accessibility hint, informating the user that the button closes current view")
 }
 
 // MARK: - Styles

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
@@ -33,6 +33,7 @@ class JetpackInstallPromptViewController: UIViewController {
     @IBOutlet weak var noThanksButton: FancyButton!
     @IBOutlet weak var learnMoreButton: FancyButton!
 
+    @IBOutlet weak var textStackView: UIStackView!
     @IBOutlet weak var lineItemStats: UILabel!
     @IBOutlet weak var lineItemNotifications: UILabel!
     @IBOutlet weak var lineItemAndMore: UILabel!
@@ -171,6 +172,9 @@ class JetpackInstallPromptViewController: UIViewController {
 
         noThanksButton.accessibilityHint = Strings.noThanksButtonHint
         noThanksButton.accessibilityTraits = .button
+
+        textStackView.isAccessibilityElement = true
+        textStackView.accessibilityLabel = [Strings.title, Strings.stats, Strings.notifications, Strings.andMore].joined(separator: "\n")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
@@ -127,12 +127,14 @@ class JetpackInstallPromptViewController: UIViewController {
         // Title
         titleLabel.font = JetpackPromptStyles.Title.font
         titleLabel.textColor = JetpackPromptStyles.Title.textColor
+        titleLabel.adjustsFontForContentSizeCategory = true
 
         // Line items
         let lineItems = [lineItemStats, lineItemNotifications, lineItemAndMore]
         for lineItem in lineItems {
             lineItem?.font = JetpackPromptStyles.LineItem.font
             lineItem?.textColor = JetpackPromptStyles.LineItem.textColor
+            lineItem?.adjustsFontForContentSizeCategory = true
         }
 
         // Buttons

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -128,6 +128,8 @@
                             <constraints>
                                 <constraint firstAttribute="trailing" secondItem="Msb-FG-hPu" secondAttribute="trailing" id="7at-nh-oXA"/>
                                 <constraint firstItem="Msb-FG-hPu" firstAttribute="leading" secondItem="69h-bg-uwt" secondAttribute="leading" id="8lm-cv-1EJ"/>
+                                <constraint firstItem="Msb-FG-hPu" firstAttribute="top" relation="greaterThanOrEqual" secondItem="69h-bg-uwt" secondAttribute="top" id="LxU-4d-MmZ"/>
+                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Msb-FG-hPu" secondAttribute="bottom" id="a8e-nN-bdB"/>
                                 <constraint firstItem="Msb-FG-hPu" firstAttribute="centerY" secondItem="69h-bg-uwt" secondAttribute="centerY" id="ej7-kc-ALM"/>
                             </constraints>
                         </view>

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.xib
@@ -20,6 +20,7 @@
                 <outlet property="lineItemNotifications" destination="o3P-Vj-6QF" id="4gP-Fe-MKj"/>
                 <outlet property="lineItemStats" destination="k6V-58-BCL" id="QK6-Xr-Fd6"/>
                 <outlet property="noThanksButton" destination="gpx-gG-s9d" id="xoH-Lr-VIa"/>
+                <outlet property="textStackView" destination="Msb-FG-hPu" id="f4v-2M-fug"/>
                 <outlet property="titleLabel" destination="z18-fN-ZJi" id="Fgm-tN-OYA"/>
                 <outlet property="view" destination="ae3-3D-D7u" id="a7K-Mo-dvf"/>
             </connections>


### PR DESCRIPTION
This is part of [Show Jetpack plugin install prompt during Jetpack app login process](https://github.com/wordpress-mobile/WordPress-iOS/issues/19213). Merging to the parent branch.

## Description

Improving Accessibility of the view based on [Accessibility best practices](https://github.com/wordpress-mobile/WordPress-iOS/tree/trunk/docs#accessibility).

## Testing instructions

Before:
1. Fresh install Jetpack App on the iPad
2. Log into a self-hosted site that doesn't have the Jetpack plugin installed
3. Jetpack plugin install prompt should appear

### Font sizes
1. Increase Dynamic Type / Font Sizes
2. Button and Jetpack description text font sizes should increase
4. Jetpack description text should scroll once the text becomes large

### Voiceover
1. Each button explains what it opens through the hint
2. Jetpack description text is read as one element

### RTL
1. Jetpack description text should switch to the right after switching to RTL language locale

## Regression Notes

1. Potential unintended areas of impact

None

5. What I did to test those areas of impact (or what existing automated tests I relied on)

None

6. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Videos

### Voiceover

https://user-images.githubusercontent.com/4062343/186895532-22501a00-165e-4088-817e-86017b6db98d.mov

### Dynamic type

https://user-images.githubusercontent.com/4062343/186895580-60391b07-97a1-4299-b01f-b6b824449538.mp4

### RLT

https://user-images.githubusercontent.com/4062343/186895637-14d4436f-7a7b-48f0-a38d-f61aad1cd0b1.mp4


