### PR TITLE
Add new landing screens feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -34,6 +34,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackPoweredBottomSheet
     case sharedUserDefaults
     case sharedLogin
+    case newLandingScreen
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -109,6 +110,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .sharedUserDefaults:
             return false
         case .sharedLogin:
+            return false
+        case .newLandingScreen:
             return false
         }
     }
@@ -204,6 +207,8 @@ extension FeatureFlag {
             return "Shared User Defaults"
         case .sharedLogin:
             return "Shared Login"
+        case .newLandingScreen:
+            return "Jetpack and WordPress new landing screens"
         }
     }
 


### PR DESCRIPTION
Closes #19227

This PR adds a new feature flag that will be used for the new landing screens on WordPress and Jetpack iOS

<p align=center>
<img width="250" src="https://user-images.githubusercontent.com/34376330/186942402-3463698b-247c-4fff-bae6-8ed6cd71c8c1.png">
</p>

To test:

- checkout/build/run this branch (in debug configuration)
- Go to Me -> App Settings -> Debug
- Scroll down the Feature Flags section to find the "Jetpack and WordPress new landing screens" flag (see screenshot)
- Make sure the flag is disabled by default

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
