### PR TITLE
[Tooling] Fix emojis used in Buildkite Release Builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,7 +14,7 @@ common_params:
 
 steps:
 
-  - label: ":wordpress::testflight: WordPress Release Build (App Store Connect)"
+  - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
     env: *common_env
     plugins: *common_plugins
@@ -22,14 +22,14 @@ steps:
     - slack: "#build-and-ship"
 
   # There is no App Center emojiy
-  - label: ":wordpress::hockeyapp: WordPress Release Build (App Center)"
+  - label: ":wordpress: :appcenter: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
     env: *common_env
     plugins: *common_plugins
     notify:
     - slack: "#build-and-ship"
 
-  - label: ":jetpack::testflight: Jetpack Release Build (App Store Connect)"
+  - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
     env: *common_env
     plugins: *common_plugins


### PR DESCRIPTION
Trivial PR to fix the emojis used in `.buildkite/release-builds.yml` so that it uses `:appcenter:` instead of `:hockeyapp:`

### Why?

 - Hockey App has been absorbed by App Center, so we should use the latest name of the service for consistency and to avoid confusion
 - The `:appcenter:` emoji was [recently added to Buildkite](https://github.com/buildkite/emojis/pull/397), so it's perfect timing to switch to it
 - Our Slack has a custom emoji for `:appcenter:` (†) but it doesn't have one for `:hockeyapp:`, so the notification in Slack for Release Builds looked odd:

<img width="505" alt="image" src="https://user-images.githubusercontent.com/216089/187199606-ecf9e033-bc6e-4a99-b28c-05752fa2df9c.png">


(†) Ok, confession time, I just added it minutes ago 😅 