### PR TITLE
Replace a `do`-`catch` block with `Result(catching:)`

### DIFF
--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -199,13 +199,11 @@ extension CoreDataStack {
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T, completion: ((Result<T, Error>) -> Void)?) {
         let context = newDerivedContext()
         context.perform {
-            do {
-                let result = try block(context)
+            let result = Result(catching: { try block(context) })
+            if case .success = result {
                 self.saveContextAndWait(context)
-                completion?(.success(result))
-            } catch {
-                completion?(.failure(error))
             }
+            completion?(result)
         }
     }
 


### PR DESCRIPTION
This `Result` initializer takes a throwing closure as input and returns a `Result` wrapping its result.

See https://developer.apple.com/documentation/swift/result/init(catching:)

## Regression Notes

1. Potential unintended areas of impact – The behavior of the method I edited is covered by unit tests. If I made a mistake, the test will tell us.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
