### PR TITLE
Jetpack Social: Update the jetpack social sharing

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -110,7 +110,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if ([self hasConnectedAccounts] && section == 0) {
         title = NSLocalizedString(@"Connected Accounts", @"Noun. Title. Title for the list of accounts for third party sharing services.");
     } else {
-        NSString *format = NSLocalizedString(@"Publicize to %@", @"Title. `Publicize` is used as a verb here but `Share` (verb) would also work here. The `%@` is a placeholder for the service name.");
+        NSString *format = NSLocalizedString(@"Share post to %@", @"Title. `Publicize` is used as a verb here but `Share` (verb) would also work here. The `%@` is a placeholder for the service name.");
         title = [NSString stringWithFormat:format, self.publicizeService.label];
     }
     return title;

--- a/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingConnectionsViewController.m
@@ -110,7 +110,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if ([self hasConnectedAccounts] && section == 0) {
         title = NSLocalizedString(@"Connected Accounts", @"Noun. Title. Title for the list of accounts for third party sharing services.");
     } else {
-        NSString *format = NSLocalizedString(@"Share post to %@", @"Title. `Publicize` is used as a verb here but `Share` (verb) would also work here. The `%@` is a placeholder for the service name.");
+        NSString *format = NSLocalizedString(@"Share post to %@", @"Title. `The `%@` is a placeholder for the service name.");
         title = [NSString stringWithFormat:format, self.publicizeService.label];
     }
     return title;

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -336,7 +336,7 @@ static CGFloat const jetpackBadgePadding = 30;
         if (!ReachabilityUtils.isInternetReachable) {
             [weakSelf showConnectionError];
         } else {
-            [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize service synchronization failed", @"Message to show when Publicize service synchronization failed")];
+            [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Jetpack Social service synchronization failed", @"Message to show when Publicize service synchronization failed")];
             [weakSelf refreshPublicizers];
         }
     }];
@@ -352,7 +352,7 @@ static CGFloat const jetpackBadgePadding = 30;
         if (!ReachabilityUtils.isInternetReachable) {
             [weakSelf showConnectionError];
         } else {
-            [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Publicize connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
+            [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Jetpack Social connection synchronization failed", @"Message to show when Publicize connection synchronization failed")];
             [weakSelf refreshPublicizers];
         }
     }];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -118,7 +118,7 @@ static CGFloat const jetpackBadgePadding = 30;
 {
     switch (section) {
         case SharingPublicizeServices:
-            return NSLocalizedString(@"Connections", @"Section title for Publicize services in Sharing screen");
+            return NSLocalizedString(@"Jetpack Social Connections", @"Section title for Publicize services in Sharing screen");
         case SharingButtons:
             return NSLocalizedString(@"Sharing Buttons", @"Section title for the sharing buttons section in the Sharing screen");
         default:

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -430,7 +430,7 @@ FeaturedImageViewControllerDelegate>
         return NSLocalizedString(@"Mark as Sticky", @"Label for the Mark as Sticky option in post settings.");
         
     } else if (sec == PostSettingsSectionShare && [self numberOfRowsForShareSection] > 0) {
-        return NSLocalizedString(@"Sharing", @"Label for the Sharing section in post Settings. Should be the same as WP core.");
+        return NSLocalizedString(@"Jetpack Social", @"Label for the Sharing section in post Settings. Should be the same as WP core.");
 
     } else if (sec == PostSettingsSectionMoreOptions) {
         return NSLocalizedString(@"More Options", @"Label for the More Options area in post settings. Should use the same translation as core WP.");

--- a/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
+++ b/WordPress/Classes/ViewRelated/What's New/Data store/Cache/AnnouncementsCache.swift
@@ -23,4 +23,3 @@ struct UserDefaultsAnnouncementsCache: AnnouncementsCache {
         UserPersistentStoreFactory.instance().announcementsDate
     }
 }
-


### PR DESCRIPTION
Updates the Apps to have make Jetpack Social more predominant in the apps. 
See pdrWKz-vt-p2

To test:

Go to Site > Settings > Sharing 
Notice the new label. 
Add a social account. Notice it says share post to %.

Go create a new post. 
Select Post settings. 
Notice it says Jetpack Social as a heading for the social connections.


## Regression Notes
1. Potential unintended areas of impact
No regressions this is a text change only.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I looked at the UI in the.

3. What automated tests I added (or what prevented me from doing so)
none.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.