### PR TITLE
Rollback to `LegacyContextFactory`

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -50,7 +50,7 @@ static ContextManager *_instance;
     self = [super init];
     if (self) {
         if (factory == nil) {
-            factory = [ContainerContextFactory class];
+            factory = [LegacyContextFactory class];
         }
 
         NSParameterAssert([modelName isEqualToString:ContextManagerModelNameCurrent] || [modelName hasPrefix:@"WordPress "]);

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -176,6 +176,7 @@ class ContextManagerTests: XCTestCase {
         // Discard the username change that's made above
         contextManager.mainContext.reset()
 
+        XCTExpectFailure("Known issue: the mainContext is saved along with the `ContextManager.save` functions")
         expect(try findFirstUser()?.username) == "First User"
     }
 


### PR DESCRIPTION
There is an issue in `MediaLibraryPickerDataSource`, where its `fetchController` keeps receiving updates and causes the UI to blink. Roll back until we find a fix.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
