### PR TITLE
[Jetpack plugin install prompt] Refresh Stats view after Jetpack is installed from the prompt

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallCoordinator.swift
@@ -1,5 +1,10 @@
 import UIKit
 
+extension NSNotification.Name {
+    static let jetpackPluginInstallCompleted = NSNotification.Name(rawValue: "JetpackPluginInstallCompleted")
+    static let jetpackPluginInstallCanceled = NSNotification.Name(rawValue: "JetpackPluginInstallCanceled")
+}
+
 final class JetpackInstallCoordinator {
     private let promptType: JetpackLoginPromptType
     private let blog: Blog
@@ -106,11 +111,15 @@ private extension JetpackInstallCoordinator {
         trackStat(.installJetpackCompleted)
         trackStat(.signedInToJetpack, blog: blog)
 
+        NotificationCenter.default.post(name: .jetpackPluginInstallCompleted, object: nil)
+
         navigationController?.dismiss(animated: true, completion: completionBlock)
     }
 
     func jetpackIsCanceled() {
         trackStat(.installJetpackCanceled)
+
+        NotificationCenter.default.post(name: .jetpackPluginInstallCanceled, object: nil)
 
         navigationController?.dismiss(animated: true, completion: completionBlock)
     }


### PR DESCRIPTION
This is part of [Show Jetpack plugin install prompt during Jetpack app login process](https://github.com/wordpress-mobile/WordPress-iOS/issues/19213). Merging to the parent branch.

This was a draft PR until https://github.com/wordpress-mobile/WordPress-iOS/pull/19240 got approved and merged

**Note:** Selecting "What would you like to focus on first?" breaks the installation flow and this fix doesn't work. [It will be addressed in the separate PR.](https://github.com/wordpress-mobile/WordPress-iOS/issues/19301)

## Description

`StatsViewController` does not reload after installing Jetpack from the prompt after login. It's only visible on the iPad since `StatsViewController` is the initial view controller of details view controller and can be presented before Jetpack is installed.

`StatsViewController` continues showing `JetpackLoginViewController` as a child view controller even when Jetpack is installed.

## Testing instructions

### Case 0: Jetpack plugin prompt appears
1. Fresh install Jetpack App on the iPad
2. Log into a self-hosted site that doesn't have the Jetpack plugin installed

### Case 1: Jetpack plugin is installed + WP.com logged in
1. Execute Case 0
2. Click "Install"
3. Follow the whole installation flow
4. Log in to WP.com account when prompted
5. After successful log in, the install prompt is dismissed and Stats view shows "Enable Site Stats" instead of "Install Jetpack"

**Note:** If after that we click "Enable Site Stats" we [encounter another issue]( https://github.com/wordpress-mobile/WordPress-iOS/issues/19260) which already exists in Stats view and is not related to the prompt.

### Case 2: Cancel installation
1. Execute Case 0
2. Click "Install"
3. Click "Continue"
4. Click "Set up"
5. When login view appears, click cancel and dismiss the installation
6. Stats view shows "Log in" instead of "Install Jetpack"

## Regression Notes

1. Potential unintended areas of impact

Stats view

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Tests installing Jetpack manually from Stats view

3. What automated tests I added (or what prevented me from doing so)

none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

## Before the fix, stats page doesn't reload after installing Jetpack from prompt:

https://user-images.githubusercontent.com/4062343/187846372-2997e71f-db08-49f8-87f1-4a25c11ec7dc.mp4

## After the fix, stats page reloads after installing Jetpack from prompt:

https://user-images.githubusercontent.com/4062343/189096038-3d90930c-4589-41e6-8357-c299ea6b4252.mp4




