### PR TITLE
Add a couple unit tests for 19266

### DIFF
--- a/WordPress/WordPressTest/MediaBuilder.swift
+++ b/WordPress/WordPressTest/MediaBuilder.swift
@@ -31,4 +31,22 @@ class MediaBuilder {
 
         return self
     }
+
+    func with(title: String) -> Self {
+        media.title = title
+
+        return self
+    }
+
+    func with(blog: Blog) -> Self {
+        media.blog = blog
+
+        return self
+    }
+
+    func with(mediaType: MediaType) -> Self {
+        media.mediaType = mediaType
+
+        return self
+    }
 }


### PR DESCRIPTION
This PR adds a couple unit tests to reproduce issue #19266. These new unit tests will fail if `ContextManager` [switches to use `ContainerContextFactory`](https://github.com/wordpress-mobile/WordPress-iOS/blob/7f44120b43ca36401791036912e834ade49f79c9/WordPress/Classes/Utility/ContextManager.m#L53)

## Root cause

When `ContextManager` uses `ContainerContextFactory`, the "Albums" list (aka `WPMediaGroupPickerViewController`)  enters a loop after it's presented. This loop keeps reloading data and the albums list, causing the UI to blink. The loop can be loosely shown as below in step 2 to 4.

```mermaid
stateDiagram-v2
  [*] --> WPMediaGroupPickerViewController : 1. User taps "Set Featured Image"
  WPMediaGroupPickerViewController --> WPMediaGroupPickerViewController.loadData
  WPMediaGroupPickerViewController.loadData --> MediaCoordinator.syncMedia : 2. Fetch media library
  MediaCoordinator.syncMedia --> MediaLibraryPickerDataSource.fetchedResultController : 3. Media in database is updated, FRC delegate is notified
  MediaLibraryPickerDataSource.fetchedResultController --> WPMediaGroupPickerViewController.loadData : 4. Data changed, please reload
```

The important piece here is step 3. The expected behavior is, if there is no media change(i.e. the media returned from API was already saved in the local database), FRC delegate `controllerDidChangeContent` should not be called. If FRC delegate is not called, then there is no loop. This is the case when using `LegacyContextFactory`, but not when using `ContainerContextFactory`.

## Potential fix

I did find a fix: [setting `container.viewContext.automaticallyMergesChangesFromParent` to false](https://github.com/wordpress-mobile/WordPress-iOS/blob/7f44120b43ca36401791036912e834ade49f79c9/WordPress/Classes/Utility/ContainerContextFactory.swift#L13). I have no idea why, or is it even correct for this property to be set as `false`. I'll need to read more to understand it, which is why I didn't include it in this PR. But please let me know if you have any thoughts on this one line change.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
All changes in this PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
