### PR TITLE
Only notify group observers when the media group is updated

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -573,9 +573,17 @@
 
 - (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
 {
-    Media *media = [[[ContextManager sharedInstance] mainContext] existingObjectWithID:self.imageMediaID error:nil];
-    if (media == nil)
-    {
+    Media *media = nil;
+
+    if (self.imageMediaID == nil) {
+        [self refreshImageMedia];
+    }
+
+    if (self.imageMediaID != nil) {
+        media = [[[ContextManager sharedInstance] mainContext] existingObjectWithID:self.imageMediaID error:nil];
+    }
+
+    if (media == nil) {
         UIImage *placeholderImage = [UIImage imageNamed:@"WordPress-share"];
         completionHandler(placeholderImage, nil);
         return 0;

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -24,6 +24,14 @@
 
 @end
 
+@interface MediaLibraryGroup()
+@property (nonatomic, strong) Blog *blog;
+@property (nonatomic, assign) NSInteger itemsCount;
+@property (nonatomic, strong) NSManagedObjectID *imageMediaID;
+
+- (void)refreshImageMedia;
+@end
+
 @implementation MediaLibraryPickerDataSource
 
 - (instancetype)initWithBlog:(Blog *)blog
@@ -503,7 +511,9 @@
 
 
 - (void)controllerDidChangeContent:(NSFetchedResultsController *)controller {
-    if ([self.mediaChanged containsIndex:0] || [self.mediaInserted containsIndex:0] || [self.mediaRemoved containsIndex:0]) {
+    NSManagedObjectID *oldGroupMediaID = self.mediaGroup.imageMediaID;
+    [self.mediaGroup refreshImageMedia];
+    if (![oldGroupMediaID isEqual:self.mediaGroup.imageMediaID]) {
         [self notifyGroupObservers];
     }
     [self notifyObserversWithIncrementalChanges:YES
@@ -515,11 +525,6 @@
 
 @end
 
-@interface MediaLibraryGroup()
-    @property (nonatomic, strong) Blog *blog;
-    @property (nonatomic, assign) NSInteger itemsCount;
-@end
-
 @implementation MediaLibraryGroup
 
 - (instancetype)initWithBlog:(Blog *)blog
@@ -528,9 +533,18 @@
     if (self) {
         _blog = blog;
         _filter = WPMediaTypeAll;
-        _itemsCount = NSNotFound;        
+        _itemsCount = NSNotFound;
+        [self refreshImageMedia];
     }
     return self;
+}
+
+- (void)setFilter:(WPMediaType)filter {
+    if (_filter != filter) {
+        _filter = filter;
+
+        [self refreshImageMedia];
+    }
 }
 
 - (id)baseGroup
@@ -543,27 +557,30 @@
     return NSLocalizedString(@"WordPress Media", @"Name for the WordPress Media Library");
 }
 
-- (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
+- (void)refreshImageMedia
 {
     NSString *entityName = NSStringFromClass([Media class]);
     NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
     request.predicate = [MediaLibraryPickerDataSource predicateForFilter:self.filter blog:self.blog];
     NSSortDescriptor *sortDescriptor = [NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:NO];
     request.sortDescriptors = @[sortDescriptor];
+    request.fetchLimit = 1;
     NSError *error;
     NSArray *mediaAssets = [[[ContextManager sharedInstance] mainContext] executeFetchRequest:request error:&error];
-    if (mediaAssets.count == 0)
-    {
-        if (completionHandler){
-            completionHandler(nil, nil);
-        }
-    }
     Media *media = [mediaAssets firstObject];
-    if (!media) {
+    self.imageMediaID = media.objectID;
+}
+
+- (WPMediaRequestID)imageWithSize:(CGSize)size completionHandler:(WPMediaImageBlock)completionHandler
+{
+    Media *media = [[[ContextManager sharedInstance] mainContext] existingObjectWithID:self.imageMediaID error:nil];
+    if (media == nil)
+    {
         UIImage *placeholderImage = [UIImage imageNamed:@"WordPress-share"];
         completionHandler(placeholderImage, nil);
         return 0;
     }
+
     return [media imageWithSize:size completionHandler:completionHandler];
 }
 

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -109,7 +109,7 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         oldImage.mediaType = .image
         oldImage.creationDate = Date().advanced(by: -60)
         contextManager.saveContextAndWait(context)
-        expect(changes).toEventually(equal(1))
+        expect(changes).toNever(beGreaterThan(1))
     }
 
     fileprivate func newImageMedia() -> Media? {

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -91,7 +91,7 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         video.blog = self.blog
         video.mediaType = .video
         contextManager.saveContextAndWait(context)
-        expect(changes).toEventually(equal(0))
+        expect(changes).toNever(beGreaterThan(0))
 
         // Adding a newly created image changes the album cover.
         let newImage = MediaBuilder(context).build()

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -102,7 +102,7 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         contextManager.saveContextAndWait(context)
         expect(changes).toEventually(equal(1))
 
-        // Added an old image does not change the album cover.
+        // Adding an old image does not change the album cover.
         let oldImage = MediaBuilder(context).build()
         oldImage.remoteStatus = .sync
         oldImage.blog = self.blog

--- a/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
+++ b/WordPress/WordPressTest/MediaPicker/MediaLibraryPickerDataSourceTests.swift
@@ -78,11 +78,14 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         contextManager.useAsSharedInstance(untilTestFinished: self)
         dataSource.setMediaTypeFilter(.image)
 
+        // This variable tracks how many times the album cover (which is what
+        // the "group" is in this use case) has changed.
         var changes = 0
         dataSource.registerGroupChangeObserverBlock {
             changes += 1
         }
 
+        // Adding a video does not change the album cover.
         let video = MediaBuilder(context).build()
         video.remoteStatus = .sync
         video.blog = self.blog
@@ -90,6 +93,7 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         contextManager.saveContextAndWait(context)
         expect(changes).toEventually(equal(0))
 
+        // Adding a newly created image changes the album cover.
         let newImage = MediaBuilder(context).build()
         newImage.remoteStatus = .sync
         newImage.blog = self.blog
@@ -98,6 +102,7 @@ class MediaLibraryPickerDataSourceTests: CoreDataTestCase {
         contextManager.saveContextAndWait(context)
         expect(changes).toEventually(equal(1))
 
+        // Added an old image does not change the album cover.
         let oldImage = MediaBuilder(context).build()
         oldImage.remoteStatus = .sync
         oldImage.blog = self.blog


### PR DESCRIPTION
Fix #19266.

## Changes

See https://github.com/wordpress-mobile/WordPress-iOS/pull/19274 for the root cause of #19266.

```mermaid
stateDiagram-v2
  [*] --> WPMediaGroupPickerViewController : 1. User taps "Set Featured Image"
  WPMediaGroupPickerViewController --> WPMediaGroupPickerViewController.loadData
  WPMediaGroupPickerViewController.loadData --> MediaCoordinator.syncMedia : 2. Fetch media library
  MediaCoordinator.syncMedia --> MediaLibraryPickerDataSource.fetchedResultController : 3. Media in database is updated, FRC delegate is notified
  MediaLibraryPickerDataSource.fetchedResultController --> WPMediaGroupPickerViewController.loadData : 4. Data changed, please reload
```

This PR breaks the reloading loop shown in the above diagram at step 4. Previously, all updates to the media library would cause a reload. This PR checks if the media group(which is basically the most recent media in the media library) has changed and calls the group observers only when the media group is changed which is the designed behaviour of "group observers".

## Test Instructions

1. Change `ContextManager` to [use `ContainerContextFactory`](https://github.com/wordpress-mobile/WordPress-iOS/blob/7f44120b43ca36401791036912e834ade49f79c9/WordPress/Classes/Utility/ContextManager.m#L53)
2. Make sure #19266 is not reproducible.
3. The added unit test should pass.

## Regression Notes
1. Potential unintended areas of impact
All places that let user to pick an image from the site's WordPress media library.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Verified #19266 is fixed.

5. What automated tests I added (or what prevented me from doing so)
Added a unit test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
