### PR TITLE
Rename `branch_to_build` parameter into `branch`

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -156,18 +156,20 @@ platform :ios do
 
   # Triggers a beta build on CI
   #
-  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`
+  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_beta_build do |options|
-    trigger_buildkite_release_build(branch: options[:branch], beta: true)
+    branch = options[:branch] || "release/#{ios_get_app_version}"
+    trigger_buildkite_release_build(branch: branch, beta: true)
   end
 
   # Triggers a stable release build on CI
   #
-  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`
+  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_release_build do |options|
-    trigger_buildkite_release_build(branch: options[:branch], beta: false)
+    branch = options[:branch] || "release/#{ios_get_app_version}"
+    trigger_buildkite_release_build(branch: branch, beta: false)
   end
 end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -209,7 +209,7 @@ lane :gutenberg_dep_check do
     end
   end
 
-  UI.message("Gutenberg version: #{(res.scan(/'([^']*)'/))[0][0]}")
+  UI.message("Gutenberg version: #{res.scan(/'([^']*)'/)[0][0]}")
 end
 
 # Returns the path to the extracted Release Notes file for the given `app`.

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -142,7 +142,7 @@ platform :ios do
 
     # Wrap up
     version = ios_get_app_version
-    removebranchprotection(repository: GHHELPER_REPO, branch: "release/#{version}")
+    removebranchprotection(repository: GHHELPER_REPO, branch: release_branch_name)
     setfrozentag(repository: GHHELPER_REPO, milestone: version, freeze: false)
     create_new_milestone(repository: GHHELPER_REPO)
     close_milestone(repository: GHHELPER_REPO, milestone: version)
@@ -155,7 +155,7 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_beta_build do |options|
-    branch = options[:branch] || "release/#{ios_get_app_version}"
+    branch = options[:branch] || release_branch_name
     trigger_buildkite_release_build(branch: branch, beta: true)
   end
 
@@ -164,7 +164,7 @@ platform :ios do
   # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`. Defaults to `release/<current version>`
   #
   lane :trigger_release_build do |options|
-    branch = options[:branch] || "release/#{ios_get_app_version}"
+    branch = options[:branch] || release_branch_name
     trigger_buildkite_release_build(branch: branch, beta: false)
   end
 end
@@ -247,4 +247,8 @@ def prompt_for_confirmation(message:, bypass:)
   return true if bypass
 
   UI.confirm(message)
+end
+
+def release_branch_name
+  "release/#{ios_get_app_version}"
 end

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -68,7 +68,7 @@ platform :ios do
       bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', nil)
     )
       push_to_git_remote(tags: false)
-      trigger_beta_build(branch: "release/#{ios_get_app_version}")
+      trigger_beta_build
     else
       UI.message('Aborting code freeze completion. See you later.')
     end
@@ -86,8 +86,7 @@ platform :ios do
     download_localized_strings_and_metadata(options)
     ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
     ios_bump_version_beta
-    version = ios_get_app_version
-    trigger_beta_build(branch: "release/#{version}")
+    trigger_beta_build
   end
 
   # Sets the stage to start working on a hotfix
@@ -116,9 +115,7 @@ platform :ios do
   lane :finalize_hotfix_release do |options|
     ios_finalize_prechecks(options)
     git_pull
-
-    version = ios_get_app_version
-    trigger_release_build(branch: "release/#{version}")
+    trigger_release_build
   end
 
   # Finalizes a release at the end of a sprint to submit to the App Store
@@ -150,8 +147,7 @@ platform :ios do
     create_new_milestone(repository: GHHELPER_REPO)
     close_milestone(repository: GHHELPER_REPO, milestone: version)
 
-    # Start the build
-    trigger_release_build(branch: "release/#{version}")
+    trigger_release_build
   end
 
   # Triggers a beta build on CI

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -68,7 +68,7 @@ platform :ios do
       bypass: ENV.fetch('RELEASE_TOOLKIT_SKIP_PUSH_CONFIRM', nil)
     )
       push_to_git_remote(tags: false)
-      trigger_beta_build(branch_to_build: "release/#{ios_get_app_version}")
+      trigger_beta_build(branch: "release/#{ios_get_app_version}")
     else
       UI.message('Aborting code freeze completion. See you later.')
     end
@@ -87,7 +87,7 @@ platform :ios do
     ios_lint_localizations(input_dir: 'WordPress/Resources', allow_retry: true)
     ios_bump_version_beta
     version = ios_get_app_version
-    trigger_beta_build(branch_to_build: "release/#{version}")
+    trigger_beta_build(branch: "release/#{version}")
   end
 
   # Sets the stage to start working on a hotfix
@@ -118,7 +118,7 @@ platform :ios do
     git_pull
 
     version = ios_get_app_version
-    trigger_release_build(branch_to_build: "release/#{version}")
+    trigger_release_build(branch: "release/#{version}")
   end
 
   # Finalizes a release at the end of a sprint to submit to the App Store
@@ -151,23 +151,23 @@ platform :ios do
     close_milestone(repository: GHHELPER_REPO, milestone: version)
 
     # Start the build
-    trigger_release_build(branch_to_build: "release/#{version}")
+    trigger_release_build(branch: "release/#{version}")
   end
 
   # Triggers a beta build on CI
   #
-  # @option [String] branch_to_build The name of the branch we want the CI to build, e.g. `release/19.3`
+  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`
   #
   lane :trigger_beta_build do |options|
-    trigger_buildkite_release_build(branch: options[:branch_to_build], beta: true)
+    trigger_buildkite_release_build(branch: options[:branch], beta: true)
   end
 
   # Triggers a stable release build on CI
   #
-  # @option [String] branch_to_build The name of the branch we want the CI to build, e.g. `release/19.3`
+  # @option [String] branch The name of the branch we want the CI to build, e.g. `release/19.3`
   #
   lane :trigger_release_build do |options|
-    trigger_buildkite_release_build(branch: options[:branch_to_build], beta: false)
+    trigger_buildkite_release_build(branch: options[:branch], beta: false)
   end
 end
 


### PR DESCRIPTION
This makes the lane parameter using the same name as the `buildkite_trigger_build` action, avoiding confusion in the rare cases we need to call it manually.

If you called the `trigger_release_build` or `trigger_beta_build` lane without a parameter, you'll get prompted to pass a `branch` one, by the underlying `buildkite_trigger_build` action.

But if you next time called the lane with a `branch` parameter, you'd still get prompted to pass one, because the lane expected `branch_to_build` , but this was not made clear by the messages Fastlane prompted.

<img width="3312" alt="Screen Shot 2022-09-05 at 3 17 53 pm" src="https://user-images.githubusercontent.com/1218433/188367153-13d8a06e-0117-4e5d-a33b-c16caf218a02.png">

_For some reason, Preview doesn't open the screenshot I uploaded above, so I can't highlight the parts that show the `branch` input inconsistencies._

Rather than adding extra code for this, I thought aligning the parameters name would sort out the issue.

The approach I took leans a bit into the convention over configuration realm, though. There's nothing stopping future developers to reintroduce the same confusion by renaming the parameter either at the lane or action level. Given the limited userbase of this code and the relative slow pace at which it changes, I think that's an acceptable tradeoff to have convenience for the time being.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
