### PR TITLE
[UI Tests] - Update ScreenObject version

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,9 +59,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": null,
-          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
-          "version": "0.2.1"
+          "branch": "add-isHittable-to-waitForScreen",
+          "revision": "644e10c3ca5b4f24f70b66851aaebae3730536cd",
+          "version": null
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,9 +59,9 @@
         "package": "ScreenObject",
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
-          "branch": "add-isHittable-to-waitForScreen",
-          "revision": "644e10c3ca5b4f24f70b66851aaebae3730536cd",
-          "version": null
+          "branch": null,
+          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
+          "version": "0.2.2"
         }
       },
       {

--- a/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
+++ b/WordPress/UITestsFoundation/Screens/TabNavComponent.swift
@@ -71,6 +71,7 @@ public class TabNavComponent: ScreenObject {
 
     public func goToNotificationsScreen() throws -> NotificationsScreen {
         notificationsTabButton.tap()
+        try dismissNotificationAlertIfNeeded()
         return try NotificationsScreen()
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26726,8 +26726,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				branch = "add-isHittable-to-waitForScreen";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -26726,8 +26726,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Automattic/ScreenObject";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.1;
+				branch = "add-isHittable-to-waitForScreen";
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/WordPress/WordPressUITests/Tests/LoginTests.swift
+++ b/WordPress/WordPressUITests/Tests/LoginTests.swift
@@ -85,11 +85,6 @@ class LoginTests: XCTestCase {
             // Login flow returns MySites modal, which needs to be closed.
             .closeModal()
 
-            // TODO: rewrite logoutIfNeeded() to handle logging out of a self-hosted site and then WordPress.com account.
-            // Currently, logoutIfNeeded() cannot handle logging out of both self-hosted and WordPress.com during tearDown().
-            // So, we remove the self-hosted site before tearDown() starts.
-            .removeSelfHostedSite()
-
         XCTAssert(MySiteScreen.isLoaded())
     }
 }


### PR DESCRIPTION
### What does this do?
This PR updates the ScreenObject package to latest version to get the update where we use `isHittable()` instead of `isEnabled()` on `WaitForScreen()`

### Testing
Ensure that UI tests pass locally and in CI

Related to: https://github.com/woocommerce/woocommerce-ios/issues/7526