### PR TITLE
[CI] Remove obsolete comment in Buildkite pipeline #trivial

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -21,7 +21,6 @@ steps:
     notify:
     - slack: "#build-and-ship"
 
-  # There is no App Center emojiy
   - label: ":wordpress: :appcenter: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
     env: *common_env


### PR DESCRIPTION
Follow-up for https://github.com/wordpress-mobile/WordPress-iOS/pull/19254/files#r962669948

When [I changed the emojis used for App Center builds in the Buildkite pipeline](https://github.com/wordpress-mobile/WordPress-iOS/pull/19254/files), I forgot to remove a comment about the App Center emoji not existing in Buildkite. That comment is now obsolete as [that emoji was actually added very recently](https://github.com/buildkite/emojis/pull/397) (which is why I made #19254 in the first place to use it).