### PR TITLE
Add feature flag to use `ContainerContextFactory`

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -35,6 +35,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case sharedUserDefaults
     case sharedLogin
     case newLandingScreen
+    case newCoreDataContext
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -112,6 +113,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .sharedLogin:
             return false
         case .newLandingScreen:
+            return false
+        case .newCoreDataContext:
             return false
         }
     }
@@ -209,6 +212,8 @@ extension FeatureFlag {
             return "Shared Login"
         case .newLandingScreen:
             return "Jetpack and WordPress new landing screens"
+        case .newCoreDataContext:
+            return "Use new Core Data context structure (Require app restart)"
         }
     }
 

--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -50,7 +50,7 @@ static ContextManager *_instance;
     self = [super init];
     if (self) {
         if (factory == nil) {
-            factory = [LegacyContextFactory class];
+            factory = [Feature enabled:FeatureFlagNewCoreDataContext] ? [ContainerContextFactory class] : [LegacyContextFactory class];
         }
 
         NSParameterAssert([modelName isEqualToString:ContextManagerModelNameCurrent] || [modelName hasPrefix:@"WordPress "]);


### PR DESCRIPTION
## Change

Add a feature flag to switch between `LegacyContextFactory` and `ContainerContextFactory`. By default, the feature flag `newCoreDataContext` is off, meaning `LegacyContextFactory` is used.

## Test Instructions
Verify if the feature flag is taking effect. https://github.com/wordpress-mobile/WordPress-iOS/issues/19266 is a good indicator of whether the feature flag is turned on. If this issue can be reproduced in the app, then the recently added `ContainerContextFactory` is used.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
