### PR TITLE
[Jetpack] Shared Defaults Objc Convenience Constructor

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -38,7 +38,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         return;
     }
 
-    [[NSUserDefaults standardUserDefaults] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
+    [[UserPersistentStoreFactory userDefaultsInstance] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
 
     NSManagedObjectID *accountID = account.objectID;
     void (^notifyAccountChange)(void) = ^{
@@ -91,7 +91,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     [[NSURLCache sharedURLCache] removeAllCachedResponses];
 
     // Remove defaults
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:DefaultDotcomAccountUUIDDefaultsKey];
+    [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:DefaultDotcomAccountUUIDDefaultsKey];
     
     [WPAnalytics refreshMetadata];
     [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:nil];
@@ -274,7 +274,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         // Assume we have a good candidate account and make it the default account in the app.
         // Note that this should be the account with the most blogs.
         // Updates user defaults here vs the setter method to avoid potential side-effects from dispatched notifications.
-        [[NSUserDefaults standardUserDefaults] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
+        [[UserPersistentStoreFactory userDefaultsInstance] setObject:account.uuid forKey:DefaultDotcomAccountUUIDDefaultsKey];
     }
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -76,7 +76,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 - (ReaderAbstractTopic *)currentTopicFromSavedPath
 {
     ReaderAbstractTopic *topic;
-    NSString *topicPathString = [[NSUserDefaults standardUserDefaults] stringForKey:ReaderTopicCurrentTopicPathKey];
+    NSString *topicPathString = [[UserPersistentStoreFactory userDefaultsInstance] stringForKey:ReaderTopicCurrentTopicPathKey];
     if (topicPathString) {
         NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];
         request.predicate = [NSPredicate predicateWithFormat:@"path = %@", topicPathString];
@@ -121,10 +121,10 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 - (void)setCurrentTopic:(ReaderAbstractTopic *)topic
 {
     if (!topic) {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:ReaderTopicCurrentTopicPathKey];
+        [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:ReaderTopicCurrentTopicPathKey];
         [NSUserDefaults resetStandardUserDefaults];
     } else {
-        [[NSUserDefaults standardUserDefaults] setObject:topic.path forKey:ReaderTopicCurrentTopicPathKey];
+        [[UserPersistentStoreFactory userDefaultsInstance] setObject:topic.path forKey:ReaderTopicCurrentTopicPathKey];
         [NSUserDefaults resetStandardUserDefaults];
         
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/WordPress/Classes/Stores/UserPersistentStoreFactory.swift
+++ b/WordPress/Classes/Stores/UserPersistentStoreFactory.swift
@@ -1,7 +1,17 @@
 import Foundation
 
-final class UserPersistentStoreFactory {
+@objc
+final class UserPersistentStoreFactory: NSObject {
     static func instance() -> UserPersistentRepository {
         FeatureFlag.sharedUserDefaults.enabled ? UserPersistentStore.standard : UserDefaults.standard
+    }
+
+    @objc
+    static func userDefaultsInstance() -> UserDefaults {
+        guard FeatureFlag.sharedUserDefaults.enabled, let defaults = UserDefaults(suiteName: WPAppGroupName) else {
+            return UserDefaults.standard
+        }
+
+        return defaults
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -194,10 +194,10 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
 - (NSString *)anonymousID
 {
     if (_anonymousID == nil || _anonymousID.length == 0) {
-        NSString *anonymousID = [[NSUserDefaults standardUserDefaults] stringForKey:TracksUserDefaultsAnonymousUserIDKey];
+        NSString *anonymousID = [[UserPersistentStoreFactory userDefaultsInstance] stringForKey:TracksUserDefaultsAnonymousUserIDKey];
         if (anonymousID == nil) {
             anonymousID = [[NSUUID UUID] UUIDString];
-            [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
+            [[UserPersistentStoreFactory userDefaultsInstance] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
         }
         
         _anonymousID = anonymousID;
@@ -211,17 +211,17 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     _anonymousID = anonymousID;
 
     if (anonymousID == nil) {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsAnonymousUserIDKey];
+        [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:TracksUserDefaultsAnonymousUserIDKey];
         return;
     }
 
-    [[NSUserDefaults standardUserDefaults] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
+    [[UserPersistentStoreFactory userDefaultsInstance] setObject:anonymousID forKey:TracksUserDefaultsAnonymousUserIDKey];
 }
 
 - (NSString *)loggedInID
 {
     if (_loggedInID == nil || _loggedInID.length == 0) {
-        NSString *loggedInID = [[NSUserDefaults standardUserDefaults] stringForKey:TracksUserDefaultsLoggedInUserIDKey];
+        NSString *loggedInID = [[UserPersistentStoreFactory userDefaultsInstance] stringForKey:TracksUserDefaultsLoggedInUserIDKey];
         if (loggedInID != nil) {
             _loggedInID = loggedInID;
         }
@@ -235,11 +235,11 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     _loggedInID = loggedInID;
 
     if (loggedInID == nil) {
-        [[NSUserDefaults standardUserDefaults] removeObjectForKey:TracksUserDefaultsLoggedInUserIDKey];
+        [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:TracksUserDefaultsLoggedInUserIDKey];
         return;
     }
 
-    [[NSUserDefaults standardUserDefaults] setObject:loggedInID forKey:TracksUserDefaultsLoggedInUserIDKey];
+    [[UserPersistentStoreFactory userDefaultsInstance] setObject:loggedInID forKey:TracksUserDefaultsLoggedInUserIDKey];
 }
 
 + (TracksEventPair *)eventPairForStat:(WPAnalyticsStat)stat

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -171,7 +171,7 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
 
 + (NSInteger)sessionCount
 {
-    return [[UserPersistentStoreFactory userDefaultsInstance] integerForKey:WPAppAnalyticsKeySessionCount];
+    return [[NSUserDefaults standardUserDefaults] integerForKey:WPAppAnalyticsKeySessionCount];
 }
 
 - (NSInteger)incrementSessionCount
@@ -183,7 +183,7 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
         [WPAnalytics track:WPAnalyticsStatAppInstalled];
     }
 
-    [[UserPersistentStoreFactory userDefaultsInstance] setInteger:sessionCount forKey:WPAppAnalyticsKeySessionCount];
+    [[NSUserDefaults standardUserDefaults] setInteger:sessionCount forKey:WPAppAnalyticsKeySessionCount];
 
     return sessionCount;
 }

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -171,7 +171,7 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
 
 + (NSInteger)sessionCount
 {
-    return [[NSUserDefaults standardUserDefaults] integerForKey:WPAppAnalyticsKeySessionCount];
+    return [[UserPersistentStoreFactory userDefaultsInstance] integerForKey:WPAppAnalyticsKeySessionCount];
 }
 
 - (NSInteger)incrementSessionCount
@@ -183,7 +183,7 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
         [WPAnalytics track:WPAnalyticsStatAppInstalled];
     }
 
-    [[NSUserDefaults standardUserDefaults] setInteger:sessionCount forKey:WPAppAnalyticsKeySessionCount];
+    [[UserPersistentStoreFactory userDefaultsInstance] setInteger:sessionCount forKey:WPAppAnalyticsKeySessionCount];
 
     return sessionCount;
 }
@@ -373,13 +373,13 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
 
 + (BOOL)isTrackingUsage
 {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
+    return [[UserPersistentStoreFactory userDefaultsInstance] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
 }
 
 - (void)setTrackingUsage:(BOOL)trackingUsage
 {
     if (trackingUsage != [WPAppAnalytics isTrackingUsage]) {
-        [[NSUserDefaults standardUserDefaults] setBool:trackingUsage
+        [[UserPersistentStoreFactory userDefaultsInstance] setBool:trackingUsage
                                                 forKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
     }
 }
@@ -392,9 +392,9 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
         return;
     }
 
-    if ([[NSUserDefaults standardUserDefaults] objectForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == nil) {
+    if ([[UserPersistentStoreFactory userDefaultsInstance] objectForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == nil) {
         [self setUserHasOptedOutValue:NO];
-    } else if ([[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == NO) {
+    } else if ([[UserPersistentStoreFactory userDefaultsInstance] boolForKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated] == NO) {
         // If the user has already explicitly disabled tracking,
         // then we should mirror that to the new setting
         [self setUserHasOptedOutValue:YES];
@@ -404,18 +404,18 @@ NSString * const WPAppAnalyticsValueSiteTypeP2                      = @"p2";
 }
 
 + (BOOL)userHasOptedOutIsSet {
-    return [[NSUserDefaults standardUserDefaults] objectForKey:WPAppAnalyticsDefaultsUserOptedOut] != nil;
+    return [[UserPersistentStoreFactory userDefaultsInstance] objectForKey:WPAppAnalyticsDefaultsUserOptedOut] != nil;
 }
 
 + (BOOL)userHasOptedOut {
-    return [[NSUserDefaults standardUserDefaults] boolForKey:WPAppAnalyticsDefaultsUserOptedOut];
+    return [[UserPersistentStoreFactory userDefaultsInstance] boolForKey:WPAppAnalyticsDefaultsUserOptedOut];
 }
 
 /// This method just sets the user defaults value for UserOptedOut, and doesn't
 /// do any additional configuration of sessions or trackers.
 - (void)setUserHasOptedOutValue:(BOOL)optedOut
 {
-    [[NSUserDefaults standardUserDefaults] setBool:optedOut forKey:WPAppAnalyticsDefaultsUserOptedOut];
+    [[UserPersistentStoreFactory userDefaultsInstance] setBool:optedOut forKey:WPAppAnalyticsDefaultsUserOptedOut];
 }
 
 - (void)setUserHasOptedOut:(BOOL)optedOut

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -104,7 +104,7 @@
 #pragma mark - Public static methods
 
 + (void)configureLoggerLevelWithExtraDebug {
-    BOOL extraDebug = [[NSUserDefaults standardUserDefaults] boolForKey:@"extra_debug"];
+    BOOL extraDebug = [[UserPersistentStoreFactory userDefaultsInstance] boolForKey:@"extra_debug"];
     if (extraDebug) {
         [WordPressAppDelegate setLogLevel:DDLogLevelVerbose];
     } else {

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
@@ -19,7 +19,7 @@
     DDLogInfo(@"%@ %@ (%@ -> %@)", self, NSStringFromSelector(_cmd), [mapping sourceEntityName], [mapping destinationEntityName]);
 
     NSString *const WPComDefaultAccountUsernameKey = @"wpcom_username_preference";
-    NSString *username = [[NSUserDefaults standardUserDefaults] objectForKey:WPComDefaultAccountUsernameKey];
+    NSString *username = [[UserPersistentStoreFactory userDefaultsInstance] objectForKey:WPComDefaultAccountUsernameKey];
     if (!username) {
         // There is no default WordPress.com account, nothing to do here
         return YES;
@@ -54,7 +54,7 @@
     }
 
     NSURL *accountURL = [[account objectID] URIRepresentation];
-    [[NSUserDefaults standardUserDefaults] setURL:accountURL forKey:WPComDefaultAccountUrlKey];
+    [[UserPersistentStoreFactory userDefaultsInstance] setURL:accountURL forKey:WPComDefaultAccountUrlKey];
 
     return YES;
 }

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
@@ -105,7 +105,7 @@ static NSString * const BlogJetpackKeychainPrefix = @"jetpackblog-";
 
 - (NSString *)jetpackUsernameForBlog:(NSManagedObject *)blog
 {
-    return [[NSUserDefaults standardUserDefaults] stringForKey:[self jetpackDefaultsKeyForBlog:blog]];
+    return [[UserPersistentStoreFactory userDefaultsInstance] stringForKey:[self jetpackDefaultsKeyForBlog:blog]];
 }
 
 - (NSString *)jetpackPasswordForBlog:(NSManagedObject *)blog

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -12,9 +12,9 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     static NSString * _defaultUserAgent;
     static dispatch_once_t _onceToken;
     dispatch_once(&_onceToken, ^{
-        NSDictionary * registrationDomain = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSRegistrationDomain];
+        NSDictionary * registrationDomain = [[UserPersistentStoreFactory userDefaultsInstance] volatileDomainForName:NSRegistrationDomain];
         NSString *storeCurrentUA = [registrationDomain objectForKey:WPUserAgentKeyUserAgent];
-        [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent: @(0)}];
+        [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:@{WPUserAgentKeyUserAgent: @(0)}];
         
         if ([NSThread isMainThread]){
             _defaultUserAgent = [WKWebView userAgent];
@@ -24,7 +24,7 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
             });
         }
         if (storeCurrentUA) {
-            [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent: storeCurrentUA}];
+            [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:@{WPUserAgentKeyUserAgent: storeCurrentUA}];
         }
     });
     NSAssert(_defaultUserAgent != nil, @"User agent shouldn't be nil");
@@ -48,8 +48,8 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
 + (void)useWordPressUserAgentInWebViews
 {
     // Cleanup unused NSUserDefaults keys from older WPUserAgent implementation
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"DefaultUserAgent"];
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:@"AppUserAgent"];
+    [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:@"DefaultUserAgent"];
+    [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:@"AppUserAgent"];
 
     NSString *userAgent = [self wordPressUserAgent];
 
@@ -57,7 +57,7 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     
     NSDictionary *dictionary = @{WPUserAgentKeyUserAgent: userAgent};
     // We have to call registerDefaults else the change isn't picked up by WKWebViews.
-    [[NSUserDefaults standardUserDefaults] registerDefaults:dictionary];
+    [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:dictionary];
     
     DDLogVerbose(@"User-Agent set to: %@", userAgent);
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -555,7 +555,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 -(BOOL) welcomeNotificationSeen
 {
-    NSUserDefaults *standardUserDefaults = [NSUserDefaults standardUserDefaults];
+    NSUserDefaults *standardUserDefaults = [UserPersistentStoreFactory userDefaultsInstance];
     NSString *welcomeNotificationSeenKey = @"welcomeNotificationSeen";
     return [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
 }


### PR DESCRIPTION
This PR adds a convenience function to `UserPersistentStoreFactory` so that we can save to shared suite from Obj-C files as well. This should resolve the issue you had @wargcm in `AccountService.m`. Now defaults calls from Obj-C are also refactored to take the Feature Flag in consideration.

## Regression Notes
1. Potential unintended areas of impact
The behavior will remain the same while the toggle is turned off. We must manually test thoroughly after enabling the flag as per the rest of this task.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
