### PR TITLE
Fix Jetpack app review URL

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
-          "version": "0.2.1"
+          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
+          "version": "0.2.2"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/Automattic/ScreenObject",
         "state": {
           "branch": null,
-          "revision": "cb38a32bbcc733ba03e307ca7bcae63f8c5de729",
-          "version": "0.2.2"
+          "revision": "e27405a65672c62e5a055697eafdeaf073ea63ff",
+          "version": "0.2.1"
         }
       },
       {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -437,9 +437,11 @@ extension WordPressAppDelegate {
         utility.register(section: "notifications", significantEventCount: 5)
         utility.systemWideSignificantEventCountRequiredForPrompt = 10
         utility.setVersion(version)
-        utility.checkIfAppReviewPromptsHaveBeenDisabled(success: nil, failure: {
-            DDLogError("Was unable to retrieve data about throttling")
-        })
+        if AppConfiguration.isWordPress {
+            utility.checkIfAppReviewPromptsHaveBeenDisabled(success: nil, failure: {
+                DDLogError("Was unable to retrieve data about throttling")
+            })
+        }
     }
 
     @objc func configureAppCenterSDK() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/19300

Ratings submitted for the Jetpack app were submitted to the WordPress app's store listing. This happened because the app used the incorrect URL to open the App Store app review screen. While the app correctly defined the URL for the Jetpack app, it was then overwritten at runtime by a URL fetched from an endpoint. This endpoint was only returning a URL for the WordPress app, so it overwrote the Jetpack app's URL with the WordPress app's one.

This PR mitigates the problem on the Jetpack app by skipping the endpoint request for the Jetpack app only. This doesn't change behavior on the WordPress app. The impact of this change is that we can no longer remotely disable in-app requests for reviews. However, I don't recall this ever being used. The priority here is to restore the Rate Us functionality for the Jetpack app so that follow-up work can look for a more permanent fix.

### To test

0. Run the Jetpack app on a physical device
1. Go to the "My Site" tab
2. Tap profile pic
3. Tap "About Jetpack for iOS"
4. Tap "Rate Us"
5. When the modal screen is presented to rate the app, the Jetpack app listing should be shown behind the modal
6. Submit a review
7. Verify that the review was submitted for the Jetpack app:
  a. Open the App Store app
  b. Tap your profile picture
  c. Tap your name 
  d. Tap "Ratings and Reviews"
  e. Ensure that the rating was submitted for the Jetpack app
8. Repeat Steps 0-7 for the WordPress app, but this time ensure the review is submitted for the WordPress app

## Regression Notes
1. Potential unintended areas of impact

This PR intentionally disables the ability to remotely turn off in-app review prompts for the Jetpack app. My current understanding is that this remote ability was not used often, so disabling it won't cause a significant negative impact.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Tested the review submission process using the above testing steps.

4. What automated tests I added (or what prevented me from doing so)

None, automated testing isn't practical for the review submission UI.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
