### PR TITLE
[Jetpack plugin install prompt] Add event tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -408,6 +408,12 @@ import Foundation
     case jetpackPoweredBannerTapped
     case jetpackPoweredBottomSheetButtonTapped
 
+    // Jetpack plugin install prompt
+    case jetpackInstallPromptShown
+    case jetpackInstallPromptLearnMoreTapped
+    case jetpackInstallPromptInstallTapped
+    case jetpackInstallPromptDismissTapped
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1102,6 +1108,17 @@ import Foundation
             return "jetpack_powered_banner_tapped"
         case .jetpackPoweredBottomSheetButtonTapped:
             return "jetpack_powered_bottom_sheet_button_tapped"
+
+        // Jetpack plugin install prompt
+        case .jetpackInstallPromptShown:
+            return "jetpack_install_prompt_shown"
+        case .jetpackInstallPromptLearnMoreTapped:
+            return "jetpack_install_prompt_learn_more_tapped"
+        case .jetpackInstallPromptInstallTapped:
+            return "jetpack_install_prompt_install_tapped"
+        case .jetpackInstallPromptDismissTapped:
+            return "jetpack_install_prompt_dismiss_tapped"
+
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/JetpackInstallPromptViewController.swift
@@ -80,6 +80,8 @@ class JetpackInstallPromptViewController: UIViewController {
 
         backgroundView.addSubview(starFieldView)
         backgroundView.layer.addSublayer(gradientLayer)
+
+        WPAnalytics.track(.jetpackInstallPromptShown, properties: [:], blog: blog)
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -114,15 +116,21 @@ class JetpackInstallPromptViewController: UIViewController {
                 self.delegate?.jetpackInstallPromptDidDismiss(.install)
             }
 
+        WPAnalytics.track(.jetpackInstallPromptInstallTapped, properties: [:], blog: blog)
+
         coordinator?.openJetpackRemoteInstall()
     }
 
     @IBAction func noThanksTapped(_ sender: Any) {
+        WPAnalytics.track(.jetpackInstallPromptDismissTapped, properties: [:], blog: blog)
+
         delegate?.jetpackInstallPromptDidDismiss(.noThanks)
         dismiss(animated: true)
     }
 
     @IBAction func learnMoreButtonTapped(_ sender: Any) {
+        WPAnalytics.track(.jetpackInstallPromptLearnMoreTapped, properties: [:], blog: blog)
+
         guard let url = URL(string: "https://jetpack.com/features/") else {
             return
         }


### PR DESCRIPTION
## Description

Track 4 events:
- Prompt presentation
- Dismiss action
- Learn more action
- Install action

## Testing instructions

### Case 1:
1. Fresh install app and log in to self-hosted site without Jetpack
2. Install prompt appears
3. `Tracked: jetpack_install_prompt_shown <site_type: blog>` appears in console
4. Tap "Learn more"
5. `Tracked: jetpack_install_prompt_learn_more_tapped <site_type: blog>` appears in console
6. Tap "Install"
7. `Tracked: jetpack_install_prompt_install_tapped <site_type: blog>` appears in console
8. Come back and tap "No Thanks"
9. `Tracked: jetpack_install_prompt_dismiss_tapped <site_type: blog>` appears in console

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Nothing

3. What automated tests I added (or what prevented me from doing so)

none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

<img width="628" alt="tracked events" src="https://user-images.githubusercontent.com/4062343/189355427-d1b244a8-f7f3-44eb-8f7c-8b3f3cac7619.png">


