### PR TITLE
I18n: Fix Gutenberg strings appearing in English for pt-BR locale

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+Localization.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+Localization.swift
@@ -11,7 +11,7 @@ extension GutenbergViewController {
             forResource: Localization.fileName,
             withExtension: "strings",
             subdirectory: nil,
-            localization: currentLProjFolderName()
+            localization: currentLProjFolderName(in: bundle)
             ) else {
                 return nil
         }
@@ -25,11 +25,11 @@ extension GutenbergViewController {
         return nil
     }
 
-    private func currentLProjFolderName() -> String? {
-        var lProjFolderName = Locale.current.identifier
-        if let identifierWithoutRegion = Locale.current.identifier.split(separator: "_").first {
-            lProjFolderName = String(identifierWithoutRegion)
-        }
-        return lProjFolderName
+    private func currentLProjFolderName(in bundle: Bundle) -> String? {
+        /// Localizable.strings file path use dashes for languages and regions (e.g. pt-BR)
+        /// We cannot use Locale.current.identifier directly because it uses underscores
+        /// Bundle.preferredLocalizations matches what NSLocalizedString uses
+        /// and is safer than parsing and converting identifiers ourselves
+        return bundle.preferredLocalizations.first
     }
 }


### PR DESCRIPTION
Fixes #18161

## Description

Some strings in the editor appear in English instead of Brazilian Portuguese. It happens because instead of using `pt-BR` localization file we pass  `pt` location file which contains much fewer translations.

`currentLProjFolderName` method in `GutenbergViewController+Localization` manually removes "region" part of the identifier which makes Gutenberg use different translations than the app uses.

### Solution

Use `bundle.preferredLocalizations` which takes into account:
- User preferences
- Localizations contained in the bundle

and returns them sorted in order. In practice it matches the behaviour of `NSLocalizedString`. 

For example, for `en_IN` locale previous solution would use `en` strings which are in American English.
However `NSLocalizedStrings` and `bundle.preferredLocalizations` use `en-gb` localizations. 

### Considered solutions

I planned to expand the logic of the current approach by first checking if there's Localization.strings for a full `Locale.identifier`  before returning `identifierWithoutRegion`. However, `Localization.strings` path uses dashes for identifiers (e.g.`pt-BR`) while `Locale.identifier` uses underscores (e.g. `pt_BR`), which would require additional identifier logic. Also with such a solution, we would make assumptions that a specific region always defaults to a locale without a region which is not necessarily true. It's safer to use existing Apple-developed logic.

## Test

1. Select Português (Brasil) language with a Brazil region
2. Open WordPress app and log in
3. Create a new post ("Post de blog")
4. Notice "Comece a escrever" written in the editor (instead of "Start writing" as before)

## Regression Notes
1. Potential unintended areas of impact

Gutenberg localization for other languages and regions.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually testing with multiple supported and non-supported languages and regions.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

![image](https://user-images.githubusercontent.com/4062343/189656855-f307f309-2b2d-4e47-9478-6dcd9c4822d5.png)

