### PR TITLE
Fix oversize label in no result side menu on iPad

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 * [*] [Jetpack-only] Weekly roundup: Adds support for weekly roundup notifications to the Jetpack app. [#19364]
 * [*] Fixed an issue where the push notifications prompt button would overlap on iPad. [#19304]
+* [*] Fixed an issue where the no result label on the side menu is oversize on iPad. [#19305]
+
 
 20.8
 -----

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,7 +20,7 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Mkl-mm-wtH">
-                                        <rect key="frame" x="67.5" y="108.5" width="240.5" height="450"/>
+                                        <rect key="frame" x="67.5" y="105.5" width="240.5" height="456.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="3Mp-LB-oOz" userLabel="Accessory Stack View">
                                                 <rect key="frame" x="0.5" y="0.0" width="239" height="234"/>
@@ -39,19 +39,19 @@
                                                 </subviews>
                                             </stackView>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="gjj-bC-32w" userLabel="Label Button Stack View">
-                                                <rect key="frame" x="0.0" y="254" width="240.5" height="196"/>
+                                                <rect key="frame" x="0.0" y="254" width="240.5" height="202.5"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="v7c-T9-kZq" userLabel="Label Stack View">
-                                                        <rect key="frame" x="38" y="0.0" width="164.5" height="68"/>
+                                                        <rect key="frame" x="27" y="0.0" width="186.5" height="74.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is the title text." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="8BN-gx-7TL">
-                                                                <rect key="frame" x="0.0" y="0.0" width="164.5" height="23"/>
+                                                                <rect key="frame" x="1.5" y="0.0" width="183" height="26.5"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleTitle2"/>
                                                                 <color key="textColor" red="0.40000000000000002" green="0.55686274509803924" blue="0.66666666666666663" alpha="1" colorSpace="calibratedRGB"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" text="This is the subtitle text." textAlignment="center" adjustsFontForContentSizeCategory="YES" selectable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pAg-XC-9IM" userLabel="Subtitle Text View">
-                                                                <rect key="frame" x="2" y="33" width="160.5" height="35"/>
+                                                                <rect key="frame" x="0.0" y="36.5" width="186.5" height="38"/>
                                                                 <color key="textColor" red="0.1803921568627451" green="0.26666666666666666" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -59,13 +59,13 @@
                                                         </subviews>
                                                     </stackView>
                                                     <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3N8-XV-xJk" userLabel="Subtitle Image View">
-                                                        <rect key="frame" x="0.0" y="88" width="240.5" height="44"/>
+                                                        <rect key="frame" x="0.0" y="94.5" width="240.5" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="GdA-7V-dg9"/>
                                                         </constraints>
                                                     </imageView>
                                                     <button opaque="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="749" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageSizeForAccessibilityContentSizeCategory="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="CPl-cH-d7b" customClass="FancyButton" customModule="WordPressUI">
-                                                        <rect key="frame" x="84" y="152" width="72" height="44"/>
+                                                        <rect key="frame" x="78" y="158.5" width="84" height="44"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="44" id="ALu-HJ-Bk4"/>
                                                         </constraints>
@@ -92,7 +92,7 @@
                                 <constraints>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerX" secondItem="0Ae-eX-ae9" secondAttribute="centerX" id="NmZ-mA-W4r"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="awy-Qw-qAb"/>
-                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="htC-A3-u00"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0Ae-eX-ae9" secondAttribute="leading" constant="20" id="htC-A3-u00"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
+++ b/WordPress/Classes/ViewRelated/Views/NoResults.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -92,6 +92,7 @@
                                 <constraints>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerX" secondItem="0Ae-eX-ae9" secondAttribute="centerX" id="NmZ-mA-W4r"/>
                                     <constraint firstItem="Mkl-mm-wtH" firstAttribute="centerY" secondItem="0Ae-eX-ae9" secondAttribute="centerY" id="awy-Qw-qAb"/>
+                                    <constraint firstItem="Mkl-mm-wtH" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0Ae-eX-ae9" secondAttribute="leading" id="htC-A3-u00"/>
                                 </constraints>
                             </view>
                         </subviews>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2120,6 +2120,7 @@
 		AB2211D225ED68E300BF72FC /* CommentServiceRemoteFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2211D125ED68E300BF72FC /* CommentServiceRemoteFactory.swift */; };
 		AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB2211F325ED6E7A00BF72FC /* CommentServiceTests.swift */; };
 		AB758D9E25EFDF9C00961C0B /* LikesListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB758D9D25EFDF9C00961C0B /* LikesListController.swift */; };
+		ACACE3AE28D729FA000992F9 /* NoResultsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACACE3AD28D729FA000992F9 /* NoResultsViewControllerTests.swift */; };
 		ACBAB5FE0E121C7300F38795 /* PostSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = ACBAB5FD0E121C7300F38795 /* PostSettingsViewController.m */; };
 		ADF544C2195A0F620092213D /* CustomHighlightButton.m in Sources */ = {isa = PBXBuildFile; fileRef = ADF544C1195A0F620092213D /* CustomHighlightButton.m */; };
 		AE2F3125270B6DA000B2A9C2 /* Scanner+QuotedText.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2F3124270B6DA000B2A9C2 /* Scanner+QuotedText.swift */; };
@@ -7029,6 +7030,7 @@
 		AB2211F325ED6E7A00BF72FC /* CommentServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentServiceTests.swift; sourceTree = "<group>"; };
 		AB390AA9C94F16E78184E9D1 /* Pods_WordPressScreenshotGeneration.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressScreenshotGeneration.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB758D9D25EFDF9C00961C0B /* LikesListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikesListController.swift; sourceTree = "<group>"; };
+		ACACE3AD28D729FA000992F9 /* NoResultsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoResultsViewControllerTests.swift; sourceTree = "<group>"; };
 		ACBAB5FC0E121C7300F38795 /* PostSettingsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostSettingsViewController.h; sourceTree = "<group>"; usesTabs = 0; };
 		ACBAB5FD0E121C7300F38795 /* PostSettingsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostSettingsViewController.m; sourceTree = "<group>"; usesTabs = 0; };
 		ADE06D6829F9044164BBA5AB /* Pods-WordPressIntents.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressIntents.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressIntents/Pods-WordPressIntents.release.xcconfig"; sourceTree = "<group>"; };
@@ -11155,6 +11157,7 @@
 		732A4738218786F30015DA74 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				ACACE3AF28D76A62000992F9 /* Controllers */,
 				732A473B218787500015DA74 /* WPRichText */,
 			);
 			name = Views;
@@ -13308,6 +13311,14 @@
 				BE6AB7FB1BC62E0B00D980FC /* Style */,
 			);
 			path = Blog;
+			sourceTree = "<group>";
+		};
+		ACACE3AF28D76A62000992F9 /* Controllers */ = {
+			isa = PBXGroup;
+			children = (
+				ACACE3AD28D729FA000992F9 /* NoResultsViewControllerTests.swift */,
+			);
+			path = Controllers;
 			sourceTree = "<group>";
 		};
 		B0088A8F283D68B1008C9676 /* Stats Revamp v2 */ = {
@@ -20702,6 +20713,7 @@
 				DC06DFF927BD52BE00969974 /* WeeklyRoundupBackgroundTaskTests.swift in Sources */,
 				24C69A8B2612421900312D9A /* UserSettingsTests.swift in Sources */,
 				8B6BD55024293FBE00DB8F28 /* PrepublishingNudgesViewControllerTests.swift in Sources */,
+				ACACE3AE28D729FA000992F9 /* NoResultsViewControllerTests.swift in Sources */,
 				8BFE36FF230F1C850061EBA8 /* AbstractPost+fixLocalMediaURLsTests.swift in Sources */,
 				08A2AD791CCED2A800E84454 /* PostTagServiceTests.m in Sources */,
 				F543AF5723A84E4D0022F595 /* PublishSettingsControllerTests.swift in Sources */,

--- a/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
@@ -1,0 +1,109 @@
+//
+//  NoResultsViewControllerTests.swift
+//  WordPressTest
+//
+//  Created by Jack Chen on 2022/9/18.
+//  Copyright © 2022 WordPress. All rights reserved.
+//
+
+import XCTest
+@testable import WordPress
+
+class NoResultsViewControllerTests: XCTestCase {
+
+    private enum Constants {
+        static let shortText = "This is a text"
+        static let longText = """
+        This is a long Text. This is a long Text. This is a long Text. This is a long Text. This is a long Text.
+        This is a long Text. This is a long Text. This is a long Text. This is a long Text. This is a long Text.
+        This is a long Text. This is a long Text. This is a long Text. This is a long Text. This is a long Text.
+        """
+        static let iPhoneSeSize = CGSize(width: 320, height: 568)
+        static let iPadProSize = CGSize(width: 1024, height: 1366)
+        static let resultViewMaxWidth: CGFloat = 360
+    }
+
+    private var resultViewController: NoResultsViewController!
+    private var parentViewController: UIViewController!
+
+    override func setUpWithError() throws {
+        self.resultViewController = NoResultsViewController.controller()
+        self.parentViewController = UIViewController()
+    }
+
+    override func tearDownWithError() throws {
+        self.resultViewController = nil
+        self.parentViewController = nil
+    }
+
+    func testTitleLabelWidthForLongTextInSmallScreen() {
+        // Given
+        let parentViewSize = Constants.iPhoneSeSize
+        let title = Constants.longText
+
+        // When
+        parentViewController.view.frame = CGRect(origin: .zero, size: parentViewSize)
+        resultViewController.configure(title: title)
+        addResultViewControllerToParent()
+
+        // Then
+        XCTAssertEqual(resultViewController.titleLabel.text, title)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width < parentViewSize.width)
+    }
+
+    func testTitleLabelWidthForLongTextInLargeScreen() {
+        // Given
+        let parentViewSize = Constants.iPadProSize
+        let title = Constants.longText
+
+        // When
+        parentViewController.view.frame = CGRect(origin: .zero, size: parentViewSize)
+        resultViewController.configure(title: title)
+        addResultViewControllerToParent()
+
+        // Then
+        XCTAssertEqual(resultViewController.titleLabel.text, title)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width < parentViewSize.width)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width < Constants.resultViewMaxWidth)
+    }
+
+    func testSubtitleLabelWidthForLongTextInSmallScreen() {
+        // Given
+        let parentViewSize = Constants.iPhoneSeSize
+        let subtitle = Constants.longText
+
+        // When
+        parentViewController.view.frame = CGRect(origin: .zero, size: parentViewSize)
+        resultViewController.configure(title: Constants.shortText, subtitle: subtitle)
+        addResultViewControllerToParent()
+
+        // Then
+        XCTAssertEqual(resultViewController.subtitleTextView.text, subtitle)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < parentViewSize.width)
+    }
+
+    func testSubtitleLabelWidthForLongTextInLargeScreen() {
+        // Given
+        let parentViewSize = Constants.iPadProSize
+        let subtitle = Constants.longText
+
+        // When
+        parentViewController.view.frame = CGRect(origin: .zero, size: parentViewSize)
+        resultViewController.configure(title: Constants.shortText, subtitle: subtitle)
+        addResultViewControllerToParent()
+
+        // Then
+        XCTAssertEqual(resultViewController.subtitleTextView.text, subtitle)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < parentViewSize.width)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < Constants.resultViewMaxWidth)
+    }
+
+}
+
+private extension NoResultsViewControllerTests {
+    func addResultViewControllerToParent() {
+        parentViewController.view.addSubview(resultViewController.view)
+        resultViewController.view.frame = parentViewController.view.bounds
+        resultViewController.didMove(toParent: parentViewController)
+    }
+}

--- a/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
@@ -13,6 +13,7 @@ class NoResultsViewControllerTests: XCTestCase {
         static let iPhoneSeSize = CGSize(width: 320, height: 568)
         static let iPadProSize = CGSize(width: 1024, height: 1366)
         static let resultViewMaxWidth: CGFloat = 360
+        static let resultViewHorizontalMargin: CGFloat = 20
     }
 
     private var resultViewController: NoResultsViewController!
@@ -40,7 +41,7 @@ class NoResultsViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(resultViewController.titleLabel.text, title)
-        XCTAssertTrue(resultViewController.titleLabel.frame.width < parentViewSize.width)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width + Constants.resultViewHorizontalMargin * 2 <= parentViewSize.width)
     }
 
     func testTitleLabelWidthForLongTextInLargeScreen() {
@@ -55,8 +56,8 @@ class NoResultsViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(resultViewController.titleLabel.text, title)
-        XCTAssertTrue(resultViewController.titleLabel.frame.width < parentViewSize.width)
-        XCTAssertTrue(resultViewController.titleLabel.frame.width < Constants.resultViewMaxWidth)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width <= parentViewSize.width)
+        XCTAssertTrue(resultViewController.titleLabel.frame.width <= Constants.resultViewMaxWidth)
     }
 
     func testSubtitleLabelWidthForLongTextInSmallScreen() {
@@ -71,7 +72,7 @@ class NoResultsViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(resultViewController.subtitleTextView.text, subtitle)
-        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < parentViewSize.width)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width + Constants.resultViewHorizontalMargin * 2 <= parentViewSize.width)
     }
 
     func testSubtitleLabelWidthForLongTextInLargeScreen() {
@@ -86,8 +87,8 @@ class NoResultsViewControllerTests: XCTestCase {
 
         // Then
         XCTAssertEqual(resultViewController.subtitleTextView.text, subtitle)
-        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < parentViewSize.width)
-        XCTAssertTrue(resultViewController.subtitleTextView.frame.width < Constants.resultViewMaxWidth)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width <= parentViewSize.width)
+        XCTAssertTrue(resultViewController.subtitleTextView.frame.width <= Constants.resultViewMaxWidth)
     }
 
 }

--- a/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Views/Controllers/NoResultsViewControllerTests.swift
@@ -1,11 +1,3 @@
-//
-//  NoResultsViewControllerTests.swift
-//  WordPressTest
-//
-//  Created by Jack Chen on 2022/9/18.
-//  Copyright © 2022 WordPress. All rights reserved.
-//
-
 import XCTest
 @testable import WordPress
 


### PR DESCRIPTION
Fixes #19244 #19246
## Description:
This PR fixes the issue where the labels are oversizing in its container view.

• | Before | After
-- | -- | --
iPad | ![Q1](https://user-images.githubusercontent.com/10288494/189985863-6ada72f8-bc45-4bc5-bf91-facc7dc4cacc.png) | ![Q1-fix](https://user-images.githubusercontent.com/10288494/189985972-534207a3-0719-430c-9b0d-4d9200c6e59f.png)
iPad-RTL | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-09-19 at 01 17 04](https://user-images.githubusercontent.com/10288494/190919994-a3fc1251-1755-4a77-a2a3-091746cf2dda.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-09-19 at 01 12 12](https://user-images.githubusercontent.com/10288494/190919825-e21dfcfe-f4f1-442f-97f2-73660bbc4593.png)

## Root Cause:
In the xib `NoResults.storyboard`, the container view of the labels only has the width constraint `Width <= 360`, but it doesn't have a constraint related to its super view. This will let the labels go outside if its super view is smaller than the label's content.
![Constraint on superView](https://user-images.githubusercontent.com/10288494/189987929-70991a89-d20f-4d1f-afaf-6efa8f3a5721.png)
In this case, the side menu view only has `width == 320`. The container view will still go up to `360` because it doesn't care about its super view size. 

## Fix:
- Add missing width constraint between the container view and its super view

## Test Step:
1. Launch the app.
2. Log in with an account without any notification or sign up for a new account.
3. Navigate to the `Notifications` or `My Site` tab.
4. Notice the text should fit inside the left layout.
 
## Regression Notes
1. Potential unintended areas of impact
-  I list all impacted pages in [here](https://docs.google.com/spreadsheets/d/1pjd4YHRTLmDoONsN3gIoTY8pXDOjJuwID0Uipcr1mjg/edit?usp=sharing) with screenshots.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manually test on all impacted pages on iPad, and key pages on iPhone, and list the test result [here](https://docs.google.com/spreadsheets/d/1pjd4YHRTLmDoONsN3gIoTY8pXDOjJuwID0Uipcr1mjg/edit?usp=sharing) 

3. What automated tests I added (or what prevented me from doing so)
add unitTest at 41c4cb3900b9b4893dcabdbace0ca2c7a3d3246d for testing labels width in different sizes of the container.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
