### PR TITLE
Update Charts to 4.1.0

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/danielgindi/Charts",
         "state": {
           "branch": null,
-          "revision": "b38b8d45a8cbda9f0f2a3566778ed114f06056b7",
-          "version": "4.0.3"
+          "revision": "07b23476ad52b926be772f317d8f1d4511ee8d02",
+          "version": "4.1.0"
         }
       },
       {


### PR DESCRIPTION
Charts 4.1.0 is compatible with Xcode 14. [Here](https://github.com/danielgindi/Charts/compare/v4.0.3...v4.1.0) are code changes between 4.0.3 and 4.1.0.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Went to Stats page and checked the displayed charts.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
