### PR TITLE
The bundler workaround is not needed when using xcode-14 CI image

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -26,9 +26,6 @@ steps:
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
       echo "--- :rubygems: Setting up Gems"
-      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       install_gems
 
       echo "--- :cocoapods: Rebuilding Pod Cache"

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/installable-build-jetpack.sh
+++ b/.buildkite/commands/installable-build-jetpack.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli

--- a/.buildkite/commands/installable-build-wordpress.sh
+++ b/.buildkite/commands/installable-build-wordpress.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/rubocop-via-danger.sh
+++ b/.buildkite/commands/rubocop-via-danger.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -20,10 +20,6 @@ echo "--- :wrench: Fixing VM"
 brew install openjdk@11
 sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
-# Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -8,10 +8,6 @@ echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products.tar
 tar -xf build-products.tar
 
-# Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16

This PR is good to merge if CI jobs pass.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
