### PR TITLE
Shared Login: Prune old database transactions on initialization

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -68,6 +68,7 @@ static ContextManager *_instance;
         [[[NullBlogPropertySanitizer alloc] initWithContext:self.contextFactory.mainContext] sanitize];
         
         if ([self isSharedLoginEnabled]) {
+            [self pruneTransactionHistory];
             [self observeStoreChanges];
         }
     }
@@ -226,6 +227,18 @@ static ContextManager *_instance;
             weakSelf.updateUIObserver = nil;
         }];
     }
+}
+
+- (void)pruneTransactionHistory
+{
+    [self performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        NSDate *date = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitDay
+                                                                value:-7
+                                                               toDate:[NSDate date]
+                                                              options:0];
+        NSPersistentHistoryChangeRequest *deletionRequest = [NSPersistentHistoryChangeRequest deleteHistoryBeforeDate:date];
+        [context executeRequest:deletionRequest error:nil];
+    }];
 }
 
 #pragma mark - Setup


### PR DESCRIPTION
## Description

Prunes old database transactions since they take up space on disk. See purging history towards the bottom in: https://developer.apple.com/documentation/coredata/consuming_relevant_store_changes

## Testing

I don't really have a great way for testing this. The only thing I can think of is modifying the date so that it fires immediately, something like:
```objective-c
- (void)pruneTransactionHistory
{
    [self performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
//        NSDate *date = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitDay
//                                                                value:-7
//                                                               toDate:[NSDate date]
//                                                              options:0];
        NSDate *date = [NSDate date];
        NSPersistentHistoryChangeRequest *deletionRequest = [NSPersistentHistoryChangeRequest deleteHistoryBeforeDate:date];
        NSPersistentHistoryResult *result = [context executeRequest:deletionRequest error:nil];
        NSLog(@"Result: %@", result.result);
    }];
}

```

- Use the modified code from above ^
- With a fresh install of the app, log in
- Close the app
- Debug and step through the above code
- Verify:
  - `result.resultType` is `NSPersistentHistoryResultTypeStatusOnly`
  - `result.result` is `1` (I _think_ the `1` indicates success. I tried finding documentation on this but it isn't great. References: [[1]](https://developer.apple.com/documentation/coredata/nspersistenthistoryresult/2892350-result) [[2]](https://developer.apple.com/documentation/coredata/nspersistenthistoryresulttype/nspersistenthistoryresulttypestatusonly))

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
