### PR TITLE
Move the function that counts local draft out of `PostService`

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+Local.swift
+++ b/WordPress/Classes/Models/AbstractPost+Local.swift
@@ -9,4 +9,14 @@ extension AbstractPost {
     var isLocalRevision: Bool {
         return self.originalIsDraft() && self.isRevision() && self.remoteStatus == .local
     }
+
+    /// Count posts that have never been uploaded to the server.
+    ///
+    /// - Parameter context: A `NSManagedObjectContext` in which to count the posts
+    /// - Returns: number of local posts in the given context.
+    static func countLocalPosts(using context: NSManagedObjectContext) -> Int {
+        let request = NSFetchRequest<AbstractPost>(entityName: NSStringFromClass(AbstractPost.self))
+        request.predicate = NSPredicate(format: "postID = NULL OR postID <= 0")
+        return (try? context.count(for: request)) ?? 0
+    }
 }

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -36,8 +36,6 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
 
 - (nullable AbstractPost *)findPostWithID:(NSNumber *)postID inBlog:(Blog *)blog;
 
-- (NSUInteger)countPostsWithoutRemote;
-
 /**
  Sync a specific post from the API
 

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -777,14 +777,6 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     return [posts firstObject];
 }
 
-- (NSUInteger)countPostsWithoutRemote
-{
-    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:NSStringFromClass([AbstractPost class])];
-    request.predicate = [NSPredicate predicateWithFormat:@"postID = NULL OR postID <= 0"];
-
-    return [self.managedObjectContext countForFetchRequest:request error:nil];
-}
-
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote
                                               withOptions:(nonnull PostServiceSyncOptions *)options
 {

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -398,8 +398,7 @@ class MeViewController: UITableViewController {
 
     private var logOutAlertTitle: String {
         let context = ContextManager.sharedInstance().mainContext
-        let service = PostService(managedObjectContext: context)
-        let count = service.countPostsWithoutRemote()
+        let count = AbstractPost.countLocalPosts(using: context)
 
         guard count > 0 else {
             return LogoutAlert.defaultTitle


### PR DESCRIPTION
Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/19317, this PR removes one more place where `PostService` is created and discarded immediately (only the context object is needed, not the `PostService` instance).

I don't see much risk in this change since the new function is a direct translation of the original Objective-C implementation.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
