### PR TITLE
Remove Bundler workaround from CI setup

### DIFF
--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -7,7 +7,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.2.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
@@ -26,9 +26,6 @@ steps:
   - label: ":cocoapods: Rebuild CocoaPods cache"
     command: |
       echo "--- :rubygems: Setting up Gems"
-      # See https://github.com/Automattic/bash-cache-buildkite-plugin/issues/16
-      gem install bundler
-
       install_gems
 
       echo "--- :cocoapods: Rebuilding Pod Cache"

--- a/.buildkite/cache-builder.yml
+++ b/.buildkite/cache-builder.yml
@@ -13,7 +13,7 @@ common_params:
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 steps:
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/installable-build-jetpack.sh
+++ b/.buildkite/commands/installable-build-jetpack.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli

--- a/.buildkite/commands/installable-build-wordpress.sh
+++ b/.buildkite/commands/installable-build-wordpress.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 # FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :arrow_down: Installing Release Dependencies"
 brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick

--- a/.buildkite/commands/rubocop-via-danger.sh
+++ b/.buildkite/commands/rubocop-via-danger.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -20,10 +20,6 @@ echo "--- :wrench: Fixing VM"
 brew install openjdk@11
 sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
 
-# Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -8,10 +8,6 @@ echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products.tar
 tar -xf build-products.tar
 
-# Temporary fix until we're on the Xcode 13.1 VM
-echo "--- :rubygems: Fixing Ruby Setup"
-gem install bundler
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,16 +2,12 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.6.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    # Remember to address all "FIXIT-13.1" comments when we'll update to new image.
-    #
-    # `xcode-13.4.1` note: The issue "FIXIT-13.1" addresses is still there in this image.
-    # See: https://buildkite.com/automattic/wordpress-ios/builds/8187#01813c28-1c1d-4a25-95c0-0fdd6f2af399
     IMAGE_ID: xcode-14
 
 # This is the default pipeline – it will build and test the app

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -10,7 +10,7 @@ common_params:
         repo: "wordpress-mobile/wordpress-ios/"
   # Common environment values to use with the `env` key.
   - &common_env
-    IMAGE_ID: xcode-13.4.1
+    IMAGE_ID: xcode-14
 
 steps:
 

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -4,7 +4,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.2.0
+    - automattic/bash-cache#2.8.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"


### PR DESCRIPTION
The latest `[bash-cache](https://github.com/Automattic/bash-cache-buildkite-plugin/releases/tag/2.8.0)` Buildkite plugin version includes the `gem install bundler` workaround. Since it's centralized there, we can remove it from our pipelines and scripts.

_While I was at it, I updated the remaining pipelines to use Xcode 14._

If CI is green, this can be merged.