### PR TITLE
Use Fastlane's `AccountManager` to manage user in `register_new_device`

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -29,6 +29,17 @@ platform :ios do
       api_key_path: APP_STORE_CONNECT_KEY_PATH
     )
 
+    # We're about to use `add_development_certificates_to_provisioning_profiles` and `add_all_devices_to_provisioning_profiles`.
+    # These actions use Developer Portal APIs that don't yet support authentication via API key (-.-').
+    # Let's preemptively ask for and set the email here to avoid being asked twice for it if not set.
+
+    require 'credentials_manager'
+
+    # If Fastlane cannot instantiate a user, it will ask the caller for the email.
+    # Once we have it, we can set it as `FASTLANE_USER` in the environment (which has lifecycle limited to this call) so that the next commands will already have access to it.
+    # Note that if the user is already available to `AccountManager`, setting it in the environment is redundant, but Fastlane doesn't provide a way to check it so we have to do it anyway.
+    ENV['FASTLANE_USER'] = CredentialsManager::AccountManager.new.user
+
     # Add all development certificates to the provisioning profiles (just in case – this is an easy step to miss)
     add_development_certificates_to_provisioning_profiles(
       team_id: team_id,


### PR DESCRIPTION
This removes a tiny bit of friction when addressing internal requests to add a device to the Developer Portal, namely that if one forgets to call the lane with their user in the environment, they'll get asked to insert the credentials twice.

We can avoid that by pre-emptively configuring the users' credential for Fastlane to use.

The logic and commentary are the same as WooCommerce iOS, see https://github.com/woocommerce/woocommerce-ios/pull/7522 .

This begs the question of why not extracting the whole logic into a dedicated new action. I guess that's something we might consider next time we'll find ourselves editing this code.

## Testing
I used this code to address a request today. See in the screenshot below how, after authenticating, there is no further credentials prompt.

![Untitled](https://user-images.githubusercontent.com/1218433/191156140-3fb4835f-91af-48a0-a662-734006828e8b.jpg)

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**