### PR TITLE
Add app groups and keychain access groups to Jetpack release entitlements

### DIFF
--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -9,5 +9,13 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.wordpress.alpha</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>99KV9Z6BKV.org.wordpress.alpha</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -9,5 +9,13 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.wordpress.internal</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>99KV9Z6BKV.org.wordpress.internal</string>
+	</array>
 </dict>
 </plist>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -13,5 +13,13 @@
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
 	</array>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.wordpress</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>3TMU3BH3NK.org.wordpress</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Description

Adds app group and keychain access group entitlements to Jetpack's release entitlements. These are used by both shared user data and shared login.

This is just adding the entitlements and does not actually enable any features.

cc: @mokagio

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
