### PR TITLE
Comment Detail Redesign: Moderation Bar Update

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -31,11 +31,11 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @objc weak var richContentDelegate: WPRichContentViewDelegate? = nil
 
     /// When set to true, the cell will always hide the moderation bar regardless of the user's moderating capabilities.
-    var hidesModerationBar: Bool = false {
-        didSet {
-            updateModerationBarVisibility()
-        }
-    }
+//    var hidesModerationBar: Bool = false {
+//        didSet {
+//            updateModerationBarVisibility()
+//        }
+//    }
 
     /// Encapsulate the accessory button image assignment through an enum, to apply a standardized image configuration.
     /// See `accessoryIconConfiguration` in `WPStyleGuide+CommentDetail`.
@@ -116,10 +116,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var replyButton: UIButton!
     @IBOutlet private weak var likeButton: UIButton!
 
-    // This is public so its delegate can be set directly.
-    @IBOutlet private(set) weak var moderationBar: CommentModerationBar!
-    @IBOutlet private weak var moderationBarView: UIView!
-
     @IBOutlet private weak var highlightBarView: UIView!
 
     // MARK: Private Properties
@@ -170,11 +166,11 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     }
 
     /// Controls the visibility of the moderation bar view.
-    private var isModerationEnabled: Bool = false {
-        didSet {
-            updateModerationBarVisibility()
-        }
-    }
+//    private var isModerationEnabled: Bool = false {
+//        didSet {
+//            updateModerationBarVisibility()
+//        }
+//    }
 
     private var isReactionBarVisible: Bool {
         return isCommentReplyEnabled || isCommentLikesEnabled
@@ -236,18 +232,18 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         isCommentReplyEnabled = comment.canReply()
         isCommentLikesEnabled = comment.canLike()
         isAccessoryButtonEnabled = comment.isApproved()
-        isModerationEnabled = comment.allowsModeration()
+//        isModerationEnabled = comment.allowsModeration()
 
         // When reaction bar is hidden, add some space between the webview and the moderation bar.
         containerStackView.setCustomSpacing(isReactionBarVisible ? 0 : customBottomSpacing, after: contentContainerView)
 
         // When both reaction bar and moderation bar is hidden, the custom spacing for the webview won't be applied since it's at the bottom of the stack view.
         // The reaction bar and the moderation bar have their own spacing, unlike the webview. Therefore, additional bottom spacing is needed.
-        containerStackBottomConstraint.constant = (isReactionBarVisible || isModerationEnabled) ? 0 : customBottomSpacing
+        containerStackBottomConstraint.constant = (isReactionBarVisible /* || isModerationEnabled */) ? 0 : customBottomSpacing
 
-        if isModerationEnabled {
-            moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)
-        }
+//        if isModerationEnabled {
+//            moderationBar.commentStatus = CommentStatusType.typeForStatus(comment.status)
+//        }
 
         // Configure content renderer.
         self.onContentLoaded = onContentLoaded
@@ -262,7 +258,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     func configureForPostDetails(with comment: Comment, onContentLoaded: ((CGFloat) -> Void)?) {
         configure(with: comment, onContentLoaded: onContentLoaded)
 
-        hidesModerationBar = true
+//        hidesModerationBar = true
         isCommentLikesEnabled = false
         isCommentReplyEnabled = false
         isAccessoryButtonEnabled = false
@@ -389,9 +385,9 @@ private extension CommentContentTableViewCell {
         avatarImageView.downloadGravatarWithEmail(someEmail, placeholderImage: Style.placeholderImage)
     }
 
-    func updateModerationBarVisibility() {
-        moderationBarView.isHidden = !isModerationEnabled || hidesModerationBar
-    }
+//    func updateModerationBarVisibility() {
+//        moderationBarView.isHidden = !isModerationEnabled || hidesModerationBar
+//    }
 
     func updateContainerLeadingConstraint() {
         containerStackLeadingConstraint?.constant = (indentationWidth * CGFloat(indentationLevel)) + defaultLeadingMargin

--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.xib
@@ -166,26 +166,6 @@
                                     </view>
                                 </subviews>
                             </stackView>
-                            <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LK0-LA-c0R" userLabel="Moderation Bar View">
-                                <rect key="frame" x="0.0" y="353" width="288" height="93"/>
-                                <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="T1Z-LV-01Y" customClass="CommentModerationBar" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="10" width="288" height="83"/>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="83" id="qRm-Qi-IXu"/>
-                                        </constraints>
-                                    </view>
-                                </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="T1Z-LV-01Y" secondAttribute="trailing" id="5pw-Ri-Jfp"/>
-                                    <constraint firstItem="T1Z-LV-01Y" firstAttribute="top" secondItem="LK0-LA-c0R" secondAttribute="top" constant="10" id="YQw-pq-YQg"/>
-                                    <constraint firstItem="T1Z-LV-01Y" firstAttribute="leading" secondItem="LK0-LA-c0R" secondAttribute="leading" id="h1E-6A-mIn"/>
-                                    <constraint firstAttribute="bottom" secondItem="T1Z-LV-01Y" secondAttribute="bottom" id="vnN-EZ-EwQ"/>
-                                    <constraint firstAttribute="height" constant="93" placeholder="YES" id="wqW-2g-tUS"/>
-                                </constraints>
-                            </view>
                         </subviews>
                     </stackView>
                 </subviews>
@@ -213,8 +193,6 @@
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
                 <outlet property="highlightBarView" destination="mNJ-fg-sKO" id="fjf-gA-HoE"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
-                <outlet property="moderationBar" destination="T1Z-LV-01Y" id="YUL-ft-QkO"/>
-                <outlet property="moderationBarView" destination="LK0-LA-c0R" id="5mo-la-sEw"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>
                 <outlet property="replyButton" destination="VoI-YI-Qgc" id="Z9J-Tp-bur"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1027,6 +1027,9 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
         case .moderation(let rows):
             switch rows[indexPath.row] {
             case .status(let statusType):
+                if commentStatus == statusType {
+                    break
+                }
                 commentStatus = statusType
                 tableView.reloadSections([1], with: .automatic)
                 notifyDelegateCommentModerated()

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -53,7 +53,7 @@ extension NSNotification.Name {
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
         cell.accessoryButtonType = isModerationMenuEnabled(for: comment) ? .ellipsis : .share
-        cell.hidesModerationBar = true
+//        cell.hidesModerationBar = true
 
         // if the comment can be moderated, show the context menu when tapping the accessory button.
         // Note that accessoryButtonAction will be ignored when the menu is assigned.


### PR DESCRIPTION
Fixes #18999

This PR removes the old moderation bar from comments section and adds a new table-view version of it.

To test:
1. Log in to a WP Account
2. In My Site, select Menu
3. Comments
4. Select any comment
5. Check if the old moderation bar has been removed.
6. Validate if a new section called "STATUS" has been added below and it is responsive to selections.

## Regression Notes
1. Potential unintended areas of impact
Comments' status may not function properly

7. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested it. Follow the steps above.,

8. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
