### PR TITLE
Merge Editorialized Release Notes for 20.8

### DIFF
--- a/WordPress/Jetpack/Resources/AppStoreStrings.po
+++ b/WordPress/Jetpack/Resources/AppStoreStrings.po
@@ -81,11 +81,10 @@ msgctxt "app_store_keywords"
 msgid "social,notes,jetpack,writing,geotagging,media,blog,website,blogging,journal"
 msgstr ""
 
-msgctxt "v20.7-whats-new"
+msgctxt "v20.8-whats-new"
 msgid ""
-"Links in action sheets (those pop-up menus on your device that bring up extra options) are now blue instead of green.\n"
-"\n"
-"We’ve also made Jetpack Social more noticeable in the Sharing section of your site settings, as well as in your post settings. Let’s get social.\n"
+"We made some changes to user mentions. When you reply to a post or comment and tag another user, your list of suggested users will begin with names that start with your search query. The list will then continue alphabetically after that.\n"
+"We also fixed a problem where the list of suggested users would vanish after expanding or collapsing the field for reply content. Presto, no more disappearing act.\n"
 msgstr ""
 
 #. translators: This is a promo message that will be attached on top of the first screenshot in the App Store.

--- a/WordPress/Jetpack/Resources/release_notes.txt
+++ b/WordPress/Jetpack/Resources/release_notes.txt
@@ -1,4 +1,2 @@
-* [*] User Mention: When replying to a post or a comment, sort user-mentions suggestions by prefix first then alphabetically. [#19218]
-* [*] User Mention: Fixed an issue where the user-mentions suggestions were disappearing after expanding/collapsing the reply field. [#19248]
-* [***] [internal] Update Sentry, our crash monitoring tool, to its latest major version [#19315]
-
+We made some changes to user mentions. When you reply to a post or comment and tag another user, your list of suggested users will begin with names that start with your search query. The list will then continue alphabetically after that.
+We also fixed a problem where the list of suggested users would vanish after expanding or collapsing the field for reply content. Presto, no more disappearing act.

--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -45,9 +45,10 @@ msgctxt "app_store_keywords"
 msgid "blogger,writing,blogging,web,maker,online,store,business,make,create,write,blogs"
 msgstr ""
 
-msgctxt "v20.7-whats-new"
+msgctxt "v20.8-whats-new"
 msgid ""
-"This release is short and sweet: we’ve made Jetpack Social more noticeable in the Sharing section of your site settings, as well as in your post settings. Let’s get social.\n"
+"We made some changes to user mentions. When you reply to a post or comment and tag another user, your list of suggested users will begin with names that start with your search query. The list will then continue alphabetically after that.\n"
+"We also fixed a problem where the list of suggested users would vanish after expanding or collapsing the field for reply content. Presto, no more disappearing act.\n"
 msgstr ""
 
 #. translators: This is a standard chunk of text used to tell a user what's new with a release when nothing major has changed.

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,4 +1,2 @@
-* [*] User Mention: When replying to a post or a comment, sort user-mentions suggestions by prefix first then alphabetically. [#19218]
-* [*] User Mention: Fixed an issue where the user-mentions suggestions were disappearing after expanding/collapsing the reply field. [#19248]
-* [***] [internal] Update Sentry, our crash monitoring tool, to its latest major version [#19315]
-
+We made some changes to user mentions. When you reply to a post or comment and tag another user, your list of suggested users will begin with names that start with your search query. The list will then continue alphabetically after that.
+We also fixed a problem where the list of suggested users would vanish after expanding or collapsing the field for reply content. Presto, no more disappearing act.


### PR DESCRIPTION
- Add editorialized release notes for version 20.8
- Update metadata strings
- Update metadata strings

[Internal ref for the copy: p1663812771623849-slack-C02S5P5MBGA]