### PR TITLE
[Jetpack] Shared User Defaults update posts instance

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -56,7 +56,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     @IBOutlet weak var filterTabBarBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var tableViewTopConstraint: NSLayoutConstraint!
 
-    private var database: KeyValueDatabase = UserDefaults.standard
+    private var database: UserPersistentRepository = UserPersistentStoreFactory.instance()
 
     private lazy var _tableViewHandler: PostListTableViewHandler = {
         let tableViewHandler = PostListTableViewHandler(tableView: tableView)


### PR DESCRIPTION
This PR updates the UserDefaults instance in PostListViewController to use new factory instance and updates the KeyValueDatabase conformance.

To test:

1. Enable Shared Defaults by setting the FeatureFlag to true
2. Launch WP iOS & Login (if not already launched and logged in)
3. Go to posts and toggle the grid/list icon from right top.
4. Launch JP iOS.
5. Go to posts and verify if the icon and the list's state matches of the WP app.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
