### PR TITLE
Update lane running Fastlane match to run for both apps

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -86,6 +86,7 @@ platform :ios do
     match(
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
+      # Warning: Turning this to `false` will also require authenticating using `FASTLANE_USER` and `FASTLANE_PASSWORD`, because the Enterprise portal does not support API key authentication.
       readonly: true,
       app_identifier: ALL_BUNDLE_IDENTIFIERS.map { |id| id.sub(APP_STORE_VERSION_BUNDLE_IDENTIFIER, 'org.wordpress.alpha') }
     )
@@ -97,6 +98,7 @@ platform :ios do
     match(
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
+      # Warning: Turning this to `false` will also require authenticating using `FASTLANE_USER` and `FASTLANE_PASSWORD`, because the Enterprise portal does not support API key authentication.
       readonly: true,
       app_identifier: ALL_BUNDLE_IDENTIFIERS.map { |id| id.sub(APP_STORE_VERSION_BUNDLE_IDENTIFIER, 'org.wordpress.internal') }
     )
@@ -119,6 +121,7 @@ platform :ios do
     match(
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
+      # Warning: Turning this to `false` will also require authenticating using `FASTLANE_USER` and `FASTLANE_PASSWORD`, because the Enterprise portal does not support API key authentication.
       readonly: true,
       app_identifier: 'com.jetpack.alpha'
     )
@@ -130,6 +133,7 @@ platform :ios do
     match(
       type: 'enterprise',
       team_id: get_required_env('INT_EXPORT_TEAM_ID'),
+      # Warning: Turning this to `false` will also require authenticating using `FASTLANE_USER` and `FASTLANE_PASSWORD`, because the Enterprise portal does not support API key authentication.
       readonly: true,
       app_identifier: 'com.jetpack.internal'
     )

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -53,12 +53,27 @@ platform :ios do
     )
   end
 
-  # Downloads all the required certificates and profiles (using `match``) for all variants
+  # Downloads all the required certificates and profiles (using `match`) for all variants
   #
   lane :update_certs_and_profiles do
+    update_wordpress_certs_and_profiles
+    update_jetpack_certs_and_profiles
+  end
+
+  # Downloads all the required certificates and profiles (using `match`) for all WordPress variants
+  #
+  lane :update_wordpress_certs_and_profiles do
     alpha_code_signing
     internal_code_signing
     appstore_code_signing
+  end
+
+  # Downloads all the required certificates and profiles (using `match`) for all Jetpack variants
+  #
+  lane :update_jetpack_certs_and_profiles do
+    jetpack_alpha_code_signing
+    jetpack_internal_code_signing
+    jetpack_appstore_code_signing
   end
 
   ########################################################################


### PR DESCRIPTION
We noticed in #19328 that the Jetpack provisioning profiles were not in sync with the information
stored in the Developer Portal.

While it's possible that whoever updated the Developer Portal (most likely me) simply forgot to run the provisioning profiles automation in this repo, even if they had it's likely the would have run into this issue anyways because the public lane only updated the WordPress profiles but the change was in the Jetpack ones.

## To test

I used these changes to update certificates and make #19328 build in CI. One can also verify they work as expected by running `bundle exec fastlane update_certs_and_profiles`.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
