### PR TITLE
Mentions: Fix empty suggestions table issue

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -1128,6 +1128,7 @@ extension CommentDetailViewController: ReplyTextViewDelegate {
         guard let lastSearchText = lastSearchText, !lastSearchText.isEmpty else {
             return
         }
+        suggestionsTableView?.viewModel.reloadData()
         suggestionsTableView?.showSuggestions(forWord: lastSearchText)
     }
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -70,7 +70,9 @@ CGFloat const STVSeparatorHeight = 1.f;
 
 - (void)didMoveToSuperview {
     [super didMoveToSuperview];
-    [self.viewModel reloadData];
+    if (self.superview) {
+        [self.viewModel reloadData];
+    }
 }
 
 #pragma mark Private methods


### PR DESCRIPTION
Fixes #18988
Fixes #19329

## Description
Fixes an issue where the suggestions list would appear empty.

## Root Cause
- When we expand the reply field we actually create a new view with a new suggestions table view.
- Sometimes the new suggestions table view would trigger an API request to update the available suggestions.
- When successful we delete the old suggestions and persist the new suggestions.
- However, we never update the suggestions that populate the original table, so the original table ends up pointing at CoreData faults.

## Solution
Reload the original table with new data when we exit fullscreen.

## Testing Instructions

1. Tap the "My Site" tab.
2. Tap on "Menu"
3. Tap on "Comments" row.
4. Tap any comment.
5. Tap "Reply" button.
6. Type "@". You should see the suggestions list.
7. Tap on the chevron up button: the reply input is expanded.
8. Wait for about 70 seconds to trigger an update.
9. Collapse the reply field
10. Expand again
11. Collapse again
12. Make sure the suggestions list is properly populated.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.