### PR TITLE
Remove the function that finds posts with upload failure

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -50,13 +50,6 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
               failure:(void (^)(NSError *))failure;
 
 /**
- Get all posts that failed to upload.
- 
- @param result a block that will be invoked to return the requested posts.
- */
-- (void)getFailedPosts:(nonnull void (^)( NSArray<AbstractPost *>* _Nonnull posts))result;
-
-/**
  Sync an initial batch of posts from the specified blog.
  Please note that success and/or failure are called in the context of the
  NSManagedObjectContext supplied when the PostService was initialized, and may not

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -92,26 +92,6 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
     return page;
 }
 
-
-- (void)getFailedPosts:(void (^)( NSArray<AbstractPost *>* posts))result {
-    [self.managedObjectContext performBlock:^{
-        NSString *entityName = NSStringFromClass([AbstractPost class]);
-        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:entityName];
-        
-        request.predicate = [NSPredicate predicateWithFormat:@"remoteStatusNumber == %d", AbstractPostRemoteStatusFailed];
-        
-        NSError *error = nil;
-        NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
-        
-        if (!results) {
-            result(@[]);
-        } else {
-            result(results);
-        }
-    }];
-}
-
-
 - (void)getPostWithID:(NSNumber *)postID
               forBlog:(Blog *)blog
               success:(void (^)(AbstractPost *post))success


### PR DESCRIPTION
The main purpose is further simplifying `PostService` class. The original function was only used in one place. I removed it since I don't see the need of extract the logic into its own function, considering the function did a very specific, which is finding posts that failed to be saved onto the server and sounds like appropriate to be consolidated into `FailedPostsFetcher`.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None. The new Swift implementation is a direct translation of the original Objective-C implementation.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
