### PR TITLE
Remove finding cached comments function from `CommentService`

### DIFF
--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -34,9 +34,6 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 // Restore draft reply
 - (Comment * _Nullable)restoreReplyForComment:(Comment *)comment;
 
-// Find cached comments
-- (NSSet *)findCommentsWithPostID:(NSNumber *)postID inBlog:(Blog *)blog;
-
 - (Comment * _Nullable)findCommentWithID:(NSNumber *)commentID inBlog:(Blog *)blog;
 
 - (Comment * _Nullable)findCommentWithID:(NSNumber *)commentID fromPost:(ReaderPost *)post;

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -85,12 +85,6 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     return !isSyncing && (lastSynced == nil || ABS(lastSynced.timeIntervalSinceNow) > CommentsRefreshTimeoutInSeconds);
 }
 
-- (NSSet *)findCommentsWithPostID:(NSNumber *)postID inBlog:(Blog *)blog
-{
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"postID = %@", postID];
-    return [blog.comments filteredSetUsingPredicate:predicate];
-}
-
 #pragma mark Public methods
 
 #pragma mark Blog-centric methods

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -1000,10 +1000,9 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
 
 - (void)updateCommentsForPost:(AbstractPost *)post
 {
-    CommentService *commentService = [[CommentService alloc] initWithManagedObjectContext:self.managedObjectContext];
     NSMutableSet *currentComments = [post mutableSetValueForKey:@"comments"];
-    NSSet *allComments = [commentService findCommentsWithPostID:post.postID inBlog:post.blog];
-    [currentComments addObjectsFromArray:[allComments allObjects]];
+    NSSet *allComments = [post.blog.comments filteredSetUsingPredicate:[NSPredicate predicateWithFormat:@"postID = %@", post.postID]];
+    [currentComments unionSet:allComments];
 }
 
 - (NSDictionary *)dictionaryWithKey:(NSString *)key inMetadata:(NSArray *)metadata {


### PR DESCRIPTION
The function is moved to its one and only call site.

## A potential issue

I don't think this change has any quality impact since it's just moving a code block from one place to another. But I think this line in particular is problematic, in theory:

```
[currentComments addObjectsFromArray:[allComments allObjects]];
```

It merges two `Comment` sets, but I don't see `Comment` type implements `NSObject.hash` function, which means the `currentComments` may end up containing mulitple `Comment` instances that represent the same comment.

I opened this PR anyway, considering this potential issue isn't related to this PR. But I'll spend some time to see if I can reproduce it in the app.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
