### PR TITLE
Blog service lookup blog

### DIFF
--- a/WordPress/Classes/Models/Blog+History.swift
+++ b/WordPress/Classes/Models/Blog+History.swift
@@ -34,7 +34,7 @@ extension Blog {
         do {
             return try context.fetch(request).first
         } catch {
-            DDLogError("Couldn't fetch blogs with predicate \(predicate): \(error)");
+            DDLogError("Couldn't fetch blogs with predicate \(predicate): \(error)")
             return nil
         }
     }

--- a/WordPress/Classes/Models/Blog+History.swift
+++ b/WordPress/Classes/Models/Blog+History.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+extension Blog {
+
+    /// Returns the blog currently flagged as the one last used, or the primary blog,
+    /// or the first blog in an alphanumerically sorted list, whichever is found first.
+    @objc(lastUsedOrFirstBlogInContext:)
+    static func lastUsedOrFirstBlog(in context: NSManagedObjectContext) -> Blog? {
+        lastUsedBlog(in: context)
+            ?? (try? WPAccount.lookupDefaultWordPressComAccount(in: context))?.defaultBlog
+            ?? firstBlog(in: context)
+    }
+
+    /// Returns the blog currently flaged as the one last used.
+    static func lastUsedBlog(in context: NSManagedObjectContext) -> Blog? {
+        guard let url = RecentSitesService().recentSites.first else {
+            return nil
+        }
+
+        return blog(with: NSPredicate(format: "visible = YES AND url = %@", url), in: context)
+    }
+
+    private static func firstBlog(in context: NSManagedObjectContext) -> Blog? {
+        blog(with: NSPredicate(format: "visible = YES"), in: context)
+    }
+
+    private static func blog(with predicate: NSPredicate, in context: NSManagedObjectContext) -> Blog? {
+        let request = NSFetchRequest<Blog>(entityName: NSStringFromClass(Blog.self))
+        request.includesSubentities = false
+        request.predicate = predicate
+        request.fetchLimit = 1
+        request.sortDescriptors = [NSSortDescriptor(key: "settings.name", ascending: true)]
+
+        do {
+            return try context.fetch(request).first
+        } catch {
+            DDLogError("Couldn't fetch blogs with predicate \(predicate): \(error)");
+            return nil
+        }
+    }
+
+}

--- a/WordPress/Classes/Models/Blog+History.swift
+++ b/WordPress/Classes/Models/Blog+History.swift
@@ -4,15 +4,15 @@ extension Blog {
 
     /// Returns the blog currently flagged as the one last used, or the primary blog,
     /// or the first blog in an alphanumerically sorted list, whichever is found first.
-    @objc(lastUsedOrFirstBlogInContext:)
-    static func lastUsedOrFirstBlog(in context: NSManagedObjectContext) -> Blog? {
-        lastUsedBlog(in: context)
+    @objc(lastUsedOrFirstInContext:)
+    static func lastUsedOrFirst(in context: NSManagedObjectContext) -> Blog? {
+        lastUsed(in: context)
             ?? (try? WPAccount.lookupDefaultWordPressComAccount(in: context))?.defaultBlog
             ?? firstBlog(in: context)
     }
 
     /// Returns the blog currently flaged as the one last used.
-    static func lastUsedBlog(in context: NSManagedObjectContext) -> Blog? {
+    static func lastUsed(in context: NSManagedObjectContext) -> Blog? {
         guard let url = RecentSitesService().recentSites.first else {
             return nil
         }

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -27,23 +27,6 @@ extern NSString *const WPBlogUpdatedNotification;
 - (nullable Blog *)blogByHostname:(NSString *)hostname;
 
 /**
- Returns the blog currently flagged as the one last used, or the primary blog,
- or the first blog in an alphanumerically sorted list, whichever is found first.
- */
-- (nullable Blog *)lastUsedOrFirstBlog;
-
-/**
- Returns the blog currently flaged as the one last used.
- */
-- (nullable Blog *)lastUsedBlog;
-
-/**
- Returns the default WPCom blog.
- */
-- (nullable Blog *)primaryBlog;
-
-
-/**
  *  Sync all available blogs for an acccount
  *
  *  @param account the account for the associated blogs.

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -38,11 +38,6 @@ extern NSString *const WPBlogUpdatedNotification;
 - (nullable Blog *)lastUsedBlog;
 
 /**
- Returns the first blog in an alphanumerically sorted list.
- */
-- (nullable Blog *)firstBlog;
-
-/**
  Returns the default WPCom blog.
  */
 - (nullable Blog *)primaryBlog;

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -33,13 +33,6 @@ extern NSString *const WPBlogUpdatedNotification;
 - (nullable Blog *)lastUsedOrFirstBlog;
 
 /**
- Returns the blog currently flagged as the one last used, or the primary blog,
- or the first blog in an alphanumerically sorted list that supports the given
- feature, whichever is found first.
- */
-- (nullable Blog *)lastUsedOrFirstBlogThatSupports:(BlogFeature)feature;
-
-/**
  Returns the blog currently flaged as the one last used.
  */
 - (nullable Blog *)lastUsedBlog;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -55,17 +55,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
     return blog;
 }
 
-- (Blog *)lastUsedOrFirstBlogThatSupports:(BlogFeature)feature
-{
-    Blog *blog = [self lastUsedOrPrimaryBlog];
-
-    if (![blog supports:feature]) {
-        blog = [self firstBlogThatSupports:feature];
-    }
-
-    return blog;
-}
-
 - (Blog *)lastUsedOrPrimaryBlog
 {
     Blog *blog = [self lastUsedBlog];
@@ -95,19 +84,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
 - (Blog *)primaryBlog
 {
     return [[WPAccount lookupDefaultWordPressComAccountInContext:self.managedObjectContext] defaultBlog];
-}
-
-- (Blog *)firstBlogThatSupports:(BlogFeature)feature
-{
-    NSPredicate *predicate = [self predicateForVisibleBlogs];
-    NSArray *results = [self blogsWithPredicate:predicate];
-
-    for (Blog *blog in results) {
-        if ([blog supports:feature]) {
-            return blog;
-        }
-    }
-    return nil;
 }
 
 - (Blog *)firstBlog

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -44,54 +44,6 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
     return [blogs firstObject];
 }
 
-- (Blog *)lastUsedOrFirstBlog
-{
-    Blog *blog = [self lastUsedOrPrimaryBlog];
-
-    if (!blog) {
-        blog = [self firstBlog];
-    }
-
-    return blog;
-}
-
-- (Blog *)lastUsedOrPrimaryBlog
-{
-    Blog *blog = [self lastUsedBlog];
-
-    if (!blog) {
-        blog = [self primaryBlog];
-    }
-
-    return blog;
-}
-
-- (Blog *)lastUsedBlog
-{
-    // Try to get the last used blog, if there is one.
-    RecentSitesService *recentSitesService = [RecentSitesService new];
-    NSString *url = [[recentSitesService recentSites] firstObject];
-    if (!url) {
-        return nil;
-    }
-
-    NSPredicate *predicate = [NSPredicate predicateWithFormat:@"visible = YES AND url = %@", url];
-    Blog *blog = [self blogWithPredicate:predicate];
-
-    return blog;
-}
-
-- (Blog *)primaryBlog
-{
-    return [[WPAccount lookupDefaultWordPressComAccountInContext:self.managedObjectContext] defaultBlog];
-}
-
-- (Blog *)firstBlog
-{
-    NSPredicate *predicate = [self predicateForVisibleBlogs];
-    return [self blogWithPredicate:predicate];
-}
-
 - (void)syncBlogsForAccount:(WPAccount *)account
                     success:(void (^)(void))success
                     failure:(void (^)(NSError *error))failure

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -79,7 +79,7 @@ open class WP3DTouchShortcutCreator: NSObject {
     fileprivate func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
         var defaultBlogName: String?
         if blogService.blogCountForAllAccounts() > 1 {
-            defaultBlogName = Blog.lastUsedOrFirstBlog(in: mainContext)?.settings?.name
+            defaultBlogName = Blog.lastUsedOrFirst(in: mainContext)?.settings?.name
         }
 
         let notificationsShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.Notifications.type,
@@ -154,7 +154,7 @@ open class WP3DTouchShortcutCreator: NSObject {
     }
 
     fileprivate func doesCurrentBlogSupportStats() -> Bool {
-        guard let currentBlog = Blog.lastUsedOrFirstBlog(in: mainContext) else {
+        guard let currentBlog = Blog.lastUsedOrFirst(in: mainContext) else {
             return false
         }
 

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutCreator.swift
@@ -79,7 +79,7 @@ open class WP3DTouchShortcutCreator: NSObject {
     fileprivate func loggedInShortcutArray() -> [UIApplicationShortcutItem] {
         var defaultBlogName: String?
         if blogService.blogCountForAllAccounts() > 1 {
-            defaultBlogName = blogService.lastUsedOrFirstBlog()?.settings?.name
+            defaultBlogName = Blog.lastUsedOrFirstBlog(in: mainContext)?.settings?.name
         }
 
         let notificationsShortcut = UIMutableApplicationShortcutItem(type: WP3DTouchShortcutHandler.ShortcutIdentifier.Notifications.type,
@@ -154,7 +154,7 @@ open class WP3DTouchShortcutCreator: NSObject {
     }
 
     fileprivate func doesCurrentBlogSupportStats() -> Bool {
-        guard let currentBlog = blogService.lastUsedOrFirstBlog() else {
+        guard let currentBlog = Blog.lastUsedOrFirstBlog(in: mainContext) else {
             return false
         }
 

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -42,7 +42,7 @@ open class WP3DTouchShortcutHandler: NSObject {
             case ShortcutIdentifier.Stats.type:
                 WPAnalytics.track(.shortcutStats)
                 clearCurrentViewController()
-                if let mainBlog = Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext) {
+                if let mainBlog = Blog.lastUsedOrFirst(in: ContextManager.sharedInstance().mainContext) {
                     tabBarController.mySitesCoordinator.showStats(for: mainBlog)
                 }
                 return true

--- a/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
+++ b/WordPress/Classes/System/3DTouch/WP3DTouchShortcutHandler.swift
@@ -42,8 +42,7 @@ open class WP3DTouchShortcutHandler: NSObject {
             case ShortcutIdentifier.Stats.type:
                 WPAnalytics.track(.shortcutStats)
                 clearCurrentViewController()
-                let blogService: BlogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-                if let mainBlog = blogService.lastUsedOrFirstBlog() {
+                if let mainBlog = Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext) {
                     tabBarController.mySitesCoordinator.showStats(for: mainBlog)
                 }
                 return true

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -143,8 +143,7 @@ import AutomatticTracks
         let tags = params.value(of: NewPostKey.tags)
 
         let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        guard let blog = blogService.lastUsedOrFirstBlog() else {
+        guard let blog = Blog.lastUsedOrFirstBlog(in: context) else {
             return false
         }
 
@@ -181,8 +180,7 @@ import AutomatticTracks
         let title = params.value(of: NewPostKey.title)
 
         let context = ContextManager.sharedInstance().mainContext
-        let blogService = BlogService(managedObjectContext: context)
-        guard let blog = blogService.lastUsedOrFirstBlog() else {
+        guard let blog = Blog.lastUsedOrFirstBlog(in: context) else {
             return false
         }
 

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -143,7 +143,7 @@ import AutomatticTracks
         let tags = params.value(of: NewPostKey.tags)
 
         let context = ContextManager.sharedInstance().mainContext
-        guard let blog = Blog.lastUsedOrFirstBlog(in: context) else {
+        guard let blog = Blog.lastUsedOrFirst(in: context) else {
             return false
         }
 
@@ -180,7 +180,7 @@ import AutomatticTracks
         let title = params.value(of: NewPostKey.title)
 
         let context = ContextManager.sharedInstance().mainContext
-        guard let blog = Blog.lastUsedOrFirstBlog(in: context) else {
+        guard let blog = Blog.lastUsedOrFirst(in: context) else {
             return false
         }
 

--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -4,7 +4,7 @@ import WordPressFlux
 extension NavigationAction {
     func defaultBlog() -> Blog? {
         let context = ContextManager.sharedInstance().mainContext
-        return Blog.lastUsedOrFirstBlog(in: context)
+        return Blog.lastUsedOrFirst(in: context)
     }
 
     func blog(from values: [String: String]?) -> Blog? {

--- a/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
+++ b/WordPress/Classes/Utility/Universal Links/NavigationActionHelpers.swift
@@ -4,9 +4,7 @@ import WordPressFlux
 extension NavigationAction {
     func defaultBlog() -> Blog? {
         let context = ContextManager.sharedInstance().mainContext
-        let service = BlogService(managedObjectContext: context)
-
-        return service.lastUsedOrFirstBlog()
+        return Blog.lastUsedOrFirstBlog(in: context)
     }
 
     func blog(from values: [String: String]?) -> Blog? {

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -700,7 +700,7 @@ private extension ZendeskUtils {
             }
         }
 
-        if let currentSite = blogService.lastUsedOrFirstBlog(), !currentSite.isHostedAtWPcom, !currentSite.isAtomic() {
+        if let currentSite = Blog.lastUsedOrFirstBlog(in: context), !currentSite.isHostedAtWPcom, !currentSite.isAtomic() {
             tags.append(Constants.mobileSelfHosted)
         }
 
@@ -1045,9 +1045,7 @@ private extension ZendeskUtils {
 
     /// Provides the current site id to `getZendeskMetadata`, if it exists
     private static var currentSiteID: Int? {
-        guard let siteID = BlogService(managedObjectContext: ContextManager.shared.mainContext)
-                .lastUsedOrFirstBlog()?
-                .dotComID else {
+        guard let siteID = Blog.lastUsedOrFirstBlog(in: ContextManager.shared.mainContext)?.dotComID else {
             return nil
         }
         return Int(truncating: siteID)

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -413,7 +413,7 @@ private extension ZendeskUtils {
 
         // 2. Use information from selected site.
 
-        guard let blog = Blog.lastUsedBlog(in: context) else {
+        guard let blog = Blog.lastUsed(in: context) else {
             // We have no user information.
             completion()
             return
@@ -629,7 +629,7 @@ private extension ZendeskUtils {
     }
 
     static func getCurrentSiteDescription() -> String {
-        guard let blog = Blog.lastUsedBlog(in: ContextManager.sharedInstance().mainContext) else {
+        guard let blog = Blog.lastUsed(in: ContextManager.sharedInstance().mainContext) else {
             return Constants.noValue
         }
 
@@ -691,13 +691,13 @@ private extension ZendeskUtils {
 
 
         // Add gutenbergIsDefault tag
-        if let blog = Blog.lastUsedBlog(in: context) {
+        if let blog = Blog.lastUsed(in: context) {
             if blog.isGutenbergEnabled {
                 tags.append(Constants.gutenbergIsDefault)
             }
         }
 
-        if let currentSite = Blog.lastUsedOrFirstBlog(in: context), !currentSite.isHostedAtWPcom, !currentSite.isAtomic() {
+        if let currentSite = Blog.lastUsedOrFirst(in: context), !currentSite.isHostedAtWPcom, !currentSite.isAtomic() {
             tags.append(Constants.mobileSelfHosted)
         }
 
@@ -1042,7 +1042,7 @@ private extension ZendeskUtils {
 
     /// Provides the current site id to `getZendeskMetadata`, if it exists
     private static var currentSiteID: Int? {
-        guard let siteID = Blog.lastUsedOrFirstBlog(in: ContextManager.shared.mainContext)?.dotComID else {
+        guard let siteID = Blog.lastUsedOrFirst(in: ContextManager.shared.mainContext)?.dotComID else {
             return nil
         }
         return Int(truncating: siteID)

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -412,9 +412,8 @@ private extension ZendeskUtils {
         }
 
         // 2. Use information from selected site.
-        let blogService = BlogService(managedObjectContext: context)
 
-        guard let blog = blogService.lastUsedBlog() else {
+        guard let blog = Blog.lastUsedBlog(in: context) else {
             // We have no user information.
             completion()
             return
@@ -630,9 +629,7 @@ private extension ZendeskUtils {
     }
 
     static func getCurrentSiteDescription() -> String {
-        let blogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-
-        guard let blog = blogService.lastUsedBlog() else {
+        guard let blog = Blog.lastUsedBlog(in: ContextManager.sharedInstance().mainContext) else {
             return Constants.noValue
         }
 
@@ -694,7 +691,7 @@ private extension ZendeskUtils {
 
 
         // Add gutenbergIsDefault tag
-        if let blog = blogService.lastUsedBlog() {
+        if let blog = Blog.lastUsedBlog(in: context) {
             if blog.isGutenbergEnabled {
                 tags.append(Constants.gutenbergIsDefault)
             }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -396,7 +396,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     /// - Returns:the main blog for an account (last selected, or first blog in list).
     ///
     private func mainBlog() -> Blog? {
-        return blogService.lastUsedOrFirstBlog()
+        return Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext)
     }
 
     /// This VC is prepared to either show the details for a blog, or show a no-results VC configured to let the user know they have no blogs.
@@ -911,7 +911,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        guard let blog = blogService.lastUsedOrFirstBlog() else {
+        guard let blog = Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -396,7 +396,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     /// - Returns:the main blog for an account (last selected, or first blog in list).
     ///
     private func mainBlog() -> Blog? {
-        return Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext)
+        return Blog.lastUsedOrFirst(in: ContextManager.sharedInstance().mainContext)
     }
 
     /// This VC is prepared to either show the details for a blog, or show a no-results VC configured to let the user know they have no blogs.
@@ -911,7 +911,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        guard let blog = Blog.lastUsedOrFirstBlog(in: ContextManager.sharedInstance().mainContext) else {
+        guard let blog = Blog.lastUsedOrFirst(in: ContextManager.sharedInstance().mainContext) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -111,8 +111,8 @@ private class AccountSettingsController: SettingsController {
 
         // If the primary site has no Site Title, then show the displayURL.
         if primarySiteName.isEmpty {
-            let blogService = BlogService(managedObjectContext: ContextManager.sharedInstance().mainContext)
-            primarySiteName = blogService.primaryBlog()?.displayURL as String? ?? ""
+            let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.sharedInstance().mainContext)
+            primarySiteName = account?.defaultBlog.displayURL as String? ?? ""
         }
 
         let primarySite = EditableTextRow(

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
@@ -1,7 +1,7 @@
 extension NotificationsViewController {
 
     func promptForJetpackCredentials() {
-        guard let blog = blogService.lastUsedBlog() else {
+        guard let blog = Blog.lastUsedBlog(in: managedObjectContext()) else {
             return
         }
 
@@ -36,13 +36,6 @@ extension NotificationsViewController {
                 controller?.updateMessageAndButton()
             }
         }
-    }
-
-
-    // MARK: - Private Computed Properties
-
-    fileprivate var blogService: BlogService {
-        return BlogService(managedObjectContext: managedObjectContext())
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
@@ -1,7 +1,7 @@
 extension NotificationsViewController {
 
     func promptForJetpackCredentials() {
-        guard let blog = Blog.lastUsedBlog(in: managedObjectContext()) else {
+        guard let blog = Blog.lastUsed(in: managedObjectContext()) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -39,7 +39,7 @@ class ReaderReblogPresenter {
             }
             presentEditor(with: readerPost, blog: blog, origin: origin)
         default:
-            guard let blog = blogService.lastUsedOrFirstBlog() else {
+            guard let blog = Blog.lastUsedOrFirstBlog(in: blogService.managedObjectContext) else {
                 return
             }
             presentBlogPicker(from: origin,

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReblogPresenter.swift
@@ -39,11 +39,7 @@ class ReaderReblogPresenter {
             }
             presentEditor(with: readerPost, blog: blog, origin: origin)
         default:
-            guard let blog = Blog.lastUsedOrFirstBlog(in: blogService.managedObjectContext) else {
-                return
-            }
             presentBlogPicker(from: origin,
-                              blog: blog,
                               blogService: blogService,
                               readerPost: readerPost)
         }
@@ -55,7 +51,6 @@ class ReaderReblogPresenter {
 private extension ReaderReblogPresenter {
     /// presents the blog picker before the editor, for users with multiple sites
     func presentBlogPicker(from origin: UIViewController,
-                           blog: Blog,
                            blogService: BlogService,
                            readerPost: ReaderPost) {
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -158,7 +158,7 @@ class MySitesCoordinator: NSObject {
 
     func showCreateSheet(for blog: Blog?) {
         let context = ContextManager.shared.mainContext
-        guard let targetBlog = blog ?? Blog.lastUsedOrFirstBlog(in: context) else {
+        guard let targetBlog = blog ?? Blog.lastUsedOrFirst(in: context) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -158,8 +158,7 @@ class MySitesCoordinator: NSObject {
 
     func showCreateSheet(for blog: Blog?) {
         let context = ContextManager.shared.mainContext
-        let service = BlogService(managedObjectContext: context)
-        guard let targetBlog = blog ?? service.lastUsedOrFirstBlog() else {
+        guard let targetBlog = blog ?? Blog.lastUsedOrFirstBlog(in: context) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -446,8 +446,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
     if (blog == nil) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-        blog = [blogService lastUsedOrFirstBlog];
+        blog = [Blog lastUsedOrFirstBlogInContext: context];
     }
     
     return blog;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -446,7 +446,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
     if (blog == nil) {
         NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
-        blog = [Blog lastUsedOrFirstBlogInContext: context];
+        blog = [Blog lastUsedOrFirstInContext: context];
     }
     
     return blog;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -998,6 +998,8 @@
 		4A50668128B364CA00DD09F4 /* ContainerContextFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */; };
 		4A82C43128D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
 		4A82C43228D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
+		4AD5656F28E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
+		4AD5657028E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
 		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4C8A715EBCE7E73AEE216293 /* Pods_WordPressShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F47DB4A8EC2E6844E213A3FA /* Pods_WordPressShareExtension.framework */; };
@@ -5966,6 +5968,7 @@
 		4A50667E28B3218800DD09F4 /* ManagedObjectContextFactory.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ManagedObjectContextFactory.h; sourceTree = "<group>"; };
 		4A50667F28B364CA00DD09F4 /* ContainerContextFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerContextFactory.swift; sourceTree = "<group>"; };
 		4A82C43028D321A300486CFF /* Blog+Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog+Post.swift"; sourceTree = "<group>"; };
+		4AD5656E28E413160054C676 /* Blog+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+History.swift"; sourceTree = "<group>"; };
 		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextManagerMock.swift; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
@@ -13432,6 +13435,7 @@
 				2420BEF025D8DAB300966129 /* Blog+Lookup.swift */,
 				F10D634E26F0B78E00E46CC7 /* Blog+Organization.swift */,
 				8B4EDADC27DF9D5E004073B6 /* Blog+MySite.swift */,
+				4AD5656E28E413160054C676 /* Blog+History.swift */,
 			);
 			name = Blog;
 			sourceTree = "<group>";
@@ -18929,6 +18933,7 @@
 				FA681F8A25CA946B00DAA544 /* BaseRestoreStatusFailedViewController.swift in Sources */,
 				081E4B4C281C019A0085E89C /* TooltipAnchor.swift in Sources */,
 				3F851415260D0A3300A4B938 /* UnifiedPrologueEditorContentView.swift in Sources */,
+				4AD5656F28E413160054C676 /* Blog+History.swift in Sources */,
 				179A70F02729834B006DAC0A /* Binding+OnChange.swift in Sources */,
 				D8D7DF5A20AD18A400B40A2D /* ImgUploadProcessor.swift in Sources */,
 				436D56222117312700CEAA33 /* RegisterDomainDetailsViewModel.swift in Sources */,
@@ -22120,6 +22125,7 @@
 				3F46EEC928BC493E004F02B2 /* JetpackPromptsViewModel.swift in Sources */,
 				FABB24D22602FC2C00C8785C /* ReaderHelpers.swift in Sources */,
 				FABB24D32602FC2C00C8785C /* SubjectContentStyles.swift in Sources */,
+				4AD5657028E413160054C676 /* Blog+History.swift in Sources */,
 				FABB24D42602FC2C00C8785C /* AbstractPost.m in Sources */,
 				FABB24D52602FC2C00C8785C /* PostStatsTableViewController.swift in Sources */,
 				FABB24D62602FC2C00C8785C /* BlogService+Deduplicate.swift in Sources */,

--- a/WordPress/WordPressTest/ReaderReblogActionTests.swift
+++ b/WordPress/WordPressTest/ReaderReblogActionTests.swift
@@ -13,7 +13,6 @@ class MockReblogPresenter: ReaderReblogPresenter {
 
 class MockBlogService: BlogService {
     var blogsForAllAccountsExpectation: XCTestExpectation?
-    var lastUsedOrFirstBlogExpectation: XCTestExpectation?
 
     var blogCount = 1
 
@@ -24,10 +23,6 @@ class MockBlogService: BlogService {
     override func visibleBlogsForWPComAccounts() -> [Blog] {
         blogsForAllAccountsExpectation?.fulfill()
         return [Blog(context: self.managedObjectContext), Blog(context: self.managedObjectContext)]
-    }
-    override func lastUsedOrFirstBlog() -> Blog? {
-        lastUsedOrFirstBlogExpectation?.fulfill()
-        return Blog(context: self.managedObjectContext)
     }
 }
 
@@ -97,11 +92,12 @@ class ReblogPresenterTests: ReblogTestCase {
 
     func testPresentEditorForMultipleSites() {
         // Given
-        blogService!.lastUsedOrFirstBlogExpectation = expectation(description: "lastUsedOrFirstBlog was called")
         blogService!.blogCount = 2
         let presenter = ReaderReblogPresenter(postService: postService!)
+        let origin = MockViewController()
+        origin.presentExpectation = expectation(description: "blog selector is presented")
         // When
-        presenter.presentReblog(blogService: blogService!, readerPost: readerPost!, origin: UIViewController())
+        presenter.presentReblog(blogService: blogService!, readerPost: readerPost!, origin: origin)
         // Then
         waitForExpectations(timeout: 4) { error in
             if let error = error {
@@ -144,4 +140,15 @@ class ReblogFormatterTests: XCTestCase {
                        "</figure>\n<!-- /wp:image -->",
                        wpImage)
     }
+}
+
+private class MockViewController: UIViewController {
+
+    var presentExpectation: XCTestExpectation?
+
+    override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+        presentExpectation?.fulfill()
+        super.present(viewControllerToPresent, animated: flag, completion: completion)
+    }
+
 }


### PR DESCRIPTION
This PR moves some Blog history query functions from `BlogService` to a `Blog` extension.

Again, the new code (the extension) in this PR is translated from Objective-C code. I don't see big risk in it. Most changes in this PR are switching to call the new API. An outlier is https://github.com/wordpress-mobile/WordPress-iOS/commit/e0ebe8fb43e2c707570101d79c5c959f4308760a, I noticed the `blog` argument is not used anywhere, so I removed it, along with a Core Data query.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
