### PR TITLE
Stats Revamp: Text in the card not responding to changes between Dark and Light mode

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -225,8 +225,8 @@ class StatsTotalInsightsCell: StatsBaseCell {
         guideView.pinSubviewToAllEdges(guideViewLabel, insets: UIEdgeInsets(allEdges: 16.0), priority: .required)
     }
 
-    func configure(dataRow: StatsTotalInsightsData, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
-        self.guideURL = guideURL
+    func configure(dataRow: StatsTotalInsightsData, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+        self.guideURL = dataRow.guideURL
 
         self.statSection = statSection
         self.lastPostInsight = dataRow.lastPostInsight

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -225,22 +225,22 @@ class StatsTotalInsightsCell: StatsBaseCell {
         guideView.pinSubviewToAllEdges(guideViewLabel, insets: UIEdgeInsets(allEdges: 16.0), priority: .required)
     }
 
-    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, lastPostInsight: StatsLastPostInsight?, statsSummaryType: StatsSummaryType?, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(dataRow: StatsTotalInsightsData, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.guideURL = guideURL
 
         self.statSection = statSection
-        self.lastPostInsight = lastPostInsight
-        self.statsSummaryType = statsSummaryType
+        self.lastPostInsight = dataRow.lastPostInsight
+        self.statsSummaryType = dataRow.statsSummaryType
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
 
-        graphView.data = sparklineData ?? []
-        graphView.chartColor = chartColor(for: difference ?? 0)
+        graphView.data = dataRow.sparklineData ?? []
+        graphView.chartColor = chartColor(for: dataRow.difference ?? 0)
 
-        countLabel.text = count.abbreviatedString()
+        countLabel.text = dataRow.count.abbreviatedString()
 
         updateGuideView()
-        updateComparisonLabel(withCount: count, difference: difference, percentage: percentage)
+        updateComparisonLabel(withCount: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage)
     }
 
     private func updateGuideView() {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -12,6 +12,9 @@ struct StatsTotalInsightsData {
     // Used to allow a URL to be displayed in response to a guide being tapped
     var guideURL: URL? = nil
 
+    var lastPostInsight: StatsLastPostInsight? = nil
+    var statsSummaryType: StatsSummaryType? = nil
+
     public static func followersCount(insightsStore: StatsInsightsStore) -> StatsTotalInsightsData {
         return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount())
     }
@@ -35,10 +38,10 @@ struct StatsTotalInsightsData {
 
         let sparklineData: [Int] = makeSparklineData(countKey: countKey, splitSummaryTimeIntervalData: splitSummaryTimeIntervalData)
         let data = SiteStatsInsightsViewModel.intervalData(periodSummary, summaryType: statsSummaryType)
-        let guideText = makeTotalInsightsGuideText(insightsStore: insightsStore, statsSummaryType: statsSummaryType)
+        let guideText = makeTotalInsightsGuideText(lastPostInsight: insightsStore.getLastPostInsight(), statsSummaryType: statsSummaryType)
         let guideURL: URL? = statsSummaryType == .likes ? insightsStore.getLastPostInsight()?.url : nil
 
-        return StatsTotalInsightsData(count: data.count, difference: data.difference, percentage: data.percentage, sparklineData: sparklineData, guideText: guideText, guideURL: guideURL)
+        return StatsTotalInsightsData(count: data.count, difference: data.difference, percentage: data.percentage, sparklineData: sparklineData, guideText: guideText, guideURL: guideURL, lastPostInsight: insightsStore.getLastPostInsight(), statsSummaryType: statsSummaryType)
     }
 
     static func makeSparklineData(countKey: KeyPath<StatsSummaryData, Int>, splitSummaryTimeIntervalData: [StatsSummaryTimeIntervalDataAsAWeek]) -> [Int] {
@@ -57,10 +60,10 @@ struct StatsTotalInsightsData {
         return sparklineData
     }
 
-    public static func makeTotalInsightsGuideText(insightsStore: StatsInsightsStore, statsSummaryType: StatsSummaryType) -> NSAttributedString? {
+    public static func makeTotalInsightsGuideText(lastPostInsight: StatsLastPostInsight?, statsSummaryType: StatsSummaryType) -> NSAttributedString? {
         switch statsSummaryType {
         case .likes:
-            guard let summary = insightsStore.getLastPostInsight() else {
+            guard let summary = lastPostInsight else {
                 return nil
             }
 
@@ -104,6 +107,7 @@ struct StatsTotalInsightsData {
 class StatsTotalInsightsCell: StatsBaseCell {
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private var lastPostInsight: StatsLastPostInsight?
+    private var statsSummaryType: StatsSummaryType?
     private var guideURL: URL? = nil
 
     private let outerStackView = UIStackView()
@@ -135,6 +139,12 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         guideViewLabel.text = ""
         guideView.removeFromSuperview()
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        updateGuideView()
     }
 
     private func configureView() {
@@ -215,10 +225,12 @@ class StatsTotalInsightsCell: StatsBaseCell {
         guideView.pinSubviewToAllEdges(guideViewLabel, insets: UIEdgeInsets(allEdges: 16.0), priority: .required)
     }
 
-    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, guideText: NSAttributedString? = nil, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
+    func configure(count: Int, difference: Int? = nil, percentage: Int? = nil, sparklineData: [Int]? = nil, lastPostInsight: StatsLastPostInsight?, statsSummaryType: StatsSummaryType?, guideURL: URL? = nil, statSection: StatSection, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) {
         self.guideURL = guideURL
 
         self.statSection = statSection
+        self.lastPostInsight = lastPostInsight
+        self.statsSummaryType = statsSummaryType
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
 
@@ -227,12 +239,13 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         countLabel.text = count.abbreviatedString()
 
-        updateGuideView(withGuideText: guideText)
+        updateGuideView()
         updateComparisonLabel(withCount: count, difference: difference, percentage: percentage)
     }
 
-    private func updateGuideView(withGuideText guideText: NSAttributedString?) {
-        if let guideText = guideText,
+    private func updateGuideView() {
+        if let statsSummaryType = statsSummaryType,
+           let guideText = StatsTotalInsightsData.makeTotalInsightsGuideText(lastPostInsight: lastPostInsight, statsSummaryType: statsSummaryType),
            guideText.string.isEmpty == false {
             outerStackView.addArrangedSubview(guideView)
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -336,7 +336,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(dataRow: dataRow, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(dataRow: dataRow, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -336,7 +336,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, lastPostInsight: dataRow.lastPostInsight, statsSummaryType: dataRow.statsSummaryType, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(dataRow: dataRow, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -336,7 +336,7 @@ struct TotalInsightStatsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, guideText: dataRow.guideText, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        cell.configure(count: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage, sparklineData: dataRow.sparklineData, lastPostInsight: dataRow.lastPostInsight, statsSummaryType: dataRow.statsSummaryType, guideURL: dataRow.guideURL, statSection: statSection, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 }
 


### PR DESCRIPTION
Fixes #19015

## Description

Text in the card not responding to changes between Dark and Light mode. Is is noticeable on `Likes Total` and `Comments Total` cards "guide" area.

The issue happens because we use `NSAttributedString` which is built together with `foregroundColor` attributes and passed to the cell. It does not automatically update color when Light/Dark mode changes. 

## Solution

Currently we build `guideText` inside `StatsTotalInsightsData` and then pass to `StatsTotalInsightsCell`. Instead, building `guideText` directly in `StatsTotalInsightsCell` and rebuilding it when `traitCollectionDidChange` is triggered. It requires passing some additional dependencies to `StatsTotalInsightsCell`.

## Testing instructions

### Before all:
1. Enable showsStatsRevampV2 feature flag
3. Launch the application and open Stats

### Case 1:
1. Add Likes total and Comments Total cards
2. Ensure you're on the Insights screen
4. Change the device appearance mode between Light and Dark
5. Notice that the guide text color changes when the appearance mode changes

## Regression Notes

1. Potential unintended areas of impact

Building of `Likes Total` and `Cards Total` cards

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually testing that the cards continue working

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

https://user-images.githubusercontent.com/4062343/192844286-2aa74577-b259-4fd4-8593-59c8e5e377d7.mp4


