### PR TITLE
Update draft release notes for 20.9

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 20.9
 -----
 * [*] [Jetpack-only] Weekly roundup: Adds support for weekly roundup notifications to the Jetpack app. [#19364]
+* [*] Fix push prompt button overlapping on iPad. [#19304]
 
 20.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 20.9
 -----
 * [*] [Jetpack-only] Weekly roundup: Adds support for weekly roundup notifications to the Jetpack app. [#19364]
-* [*] Fix push prompt button overlapping on iPad. [#19304]
+* [*] Fixed an issue where the push notifications prompt button would overlap on iPad. [#19304]
 
 20.8
 -----


### PR DESCRIPTION
Update `RELEASE-NOTE.txt` in version `20.9` for issue: 
- #19304: Fixed an issue where the push notifications prompt button would overlap on iPad. 
