### PR TITLE
[Jetpack] Shared Data `MediaSettings`

### DIFF
--- a/WordPress/Classes/Services/MediaSettings.swift
+++ b/WordPress/Classes/Services/MediaSettings.swift
@@ -91,7 +91,7 @@ class MediaSettings: NSObject {
     }
 
     convenience override init() {
-        self.init(database: UserDefaults() as KeyValueDatabase)
+        self.init(database: UserPersistentStoreFactory.instance() as KeyValueDatabase)
     }
 
     // MARK: Public accessors


### PR DESCRIPTION
This PR replaces the `UserDefaults` constructor in `MediaSettings` with the factory instance so that we can share the media data in App Settings.

To test:
1. Enable Shared Defaults by setting the FeatureFlag to true
2. Launch WP iOS & Login (if not already launched and logged in)
3. User Settings (tap on Avatar) > App Settings
4. Set "Max Image Upload Size" & "Max Video Upload Size" to specific values
5. Launch JP iOS.
6. Go to the same screen and verify if the values are the same there.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
