### PR TITLE
Stories: Deleting one of the images causes the next one not to load

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -55,7 +55,7 @@ def wordpress_kit
 end
 
 def kanvas
-  pod 'Kanvas', '~> 1.4.3'
+  pod 'Kanvas', '~> 1.4.4'
   # pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :tag => ''
   # pod 'Kanvas', :git => 'https://github.com/tumblr/Kanvas-iOS.git', :commit => ''
   # pod 'Kanvas', :path => '../Kanvas-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -63,7 +63,7 @@ PODS:
     - React-RCTImage (= 0.66.2)
     - RNTAztecView
   - JTAppleCalendar (8.0.3)
-  - Kanvas (1.4.3)
+  - Kanvas (1.4.4)
   - libwebp (1.2.3):
     - libwebp/demux (= 1.2.3)
     - libwebp/mux (= 1.2.3)
@@ -550,7 +550,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.1.0)
   - Gutenberg (from `https://github.com/wordpress-mobile/gutenberg-mobile.git`, tag `v1.82.1`)
   - JTAppleCalendar (~> 8.0.2)
-  - Kanvas (~> 1.4.3)
+  - Kanvas (~> 1.4.4)
   - MediaEditor (~> 1.2.1)
   - MRProgress (= 0.8.3)
   - NSObject-SafeExpectations (~> 0.0.4)
@@ -806,7 +806,7 @@ SPEC CHECKSUMS:
   GTMSessionFetcher: 5595ec75acf5be50814f81e9189490412bad82ba
   Gutenberg: 53477c378be2935b6fd6ee688b145670589b8cdd
   JTAppleCalendar: 932cadea40b1051beab10f67843451d48ba16c99
-  Kanvas: 6355398addfc9856c27cc780cbf54df7cd822ab1
+  Kanvas: f932eaed3d3f47aae8aafb6c2d27c968bdd49030
   libwebp: 60305b2e989864154bd9be3d772730f08fc6a59c
   MediaEditor: 20cdeb46bdecd040b8bc94467ac85a52b53b193a
   MRProgress: 16de7cc9f347e8846797a770db102a323fe7ef09
@@ -880,6 +880,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: e1daf1c1a5173622130a5c423ba9a25a002cf215
+PODFILE CHECKSUM: cd784500197c2e3dca4cbd2e37aab01502c0a04e
 
 COCOAPODS: 1.11.2

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] [WordPress-only] Powered by Jetpack banner: Fixed an edge case where some scroll views could momentarily become unresponsive to touch. [#19369]
 * [*] [Jetpack-only] Weekly roundup: Adds support for weekly roundup notifications to the Jetpack app. [#19364]
 * [*] Fixed an issue where the push notifications prompt button would overlap on iPad. [#19304]
+* [*] Story Post: Fixed an issue where deleting one image in a story draft would cause the following image not to load. [#16966]
 
 20.8
 -----


### PR DESCRIPTION
Fixes #16966

## Description

Deleting one image causes the next one not to load in the editor. The issue happens due to a bug in [kanvas-ios repository which was fixed, reviewed, and merged.](https://github.com/tumblr/kanvas-ios/pull/147)

## Solution

Use newest `kanvas-ios` version

## Testing instructions

1. Log in to WordPress/Jetpack app with a WordPress account
2. Create a Story post
3. Make / Select multiple (more than 2) photos
4. Delete one of the images by dragging
5. Another picture should load

## Images & Videos

### Before

https://user-images.githubusercontent.com/4062343/193037528-e7062915-f99c-4ece-86e1-dbaaf7af8fc5.mp4

### After

https://user-images.githubusercontent.com/4062343/193037668-5f062a9d-606b-47f2-96bf-5d947af8e682.MP4




