### PR TITLE
[Jetpack overlay] Set overlay background to white

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
@@ -106,7 +106,7 @@ class JetpackOverlayView: UIView {
     }
 
     private func setup() {
-        backgroundColor = UIColor(light: .muriel(color: .jetpackGreen, .shade0),
+        backgroundColor = UIColor(light: .white,
                                   dark: .muriel(color: .jetpackGreen, .shade100))
         addSubview(dismissButton)
         addSubview(stackView)


### PR DESCRIPTION
Fixes #19379

| Before | After |
| - | - |
| ![Simulator Screen Shot - iPhone 13 - 2022-09-29 at 09 28 51](https://user-images.githubusercontent.com/2092798/193047859-23f1c398-5647-42cf-b9dd-268fc6d52440.png) | ![Simulator Screen Shot - iPhone 13 - 2022-09-29 at 09 41 29](https://user-images.githubusercontent.com/2092798/193047913-b056d6a5-59b6-436a-a1b6-78a296263a59.png) |


## Testing

In the WordPress app, the "Jetpack powered bottom sheet" feature flag must be enabled.

1. On an iPhone or iPad, go to a view that contains a Jetpack powered banner or badge, e.g. the Home tab on "My Site"
2. Tap the badge
3. Observe the overlay in light and dark mode
4. **Expect:** The overlay has a white background in light mode. The dark mode background color is equivalent to `rgba(0, 28, 9)`.

## Regression Notes
1. Potential unintended areas of impact
    - Only background colors of the Jetpack overlay view.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing steps above.

3. What automated tests I added (or what prevented me from doing so)
    - This is a visual update.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
