### PR TITLE
Remove VoiceOver from the new Jetpack prologue decorative elements

### DIFF
--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackPromptView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackPromptView.swift
@@ -11,6 +11,7 @@ struct JetpackPromptView: View {
             .bold()
             .lineLimit(Constants.lineLimit)
             .padding(Constants.textInsets)
+            .accessibility(hidden: true)
     }
 
     private func makeFont() -> Font {


### PR DESCRIPTION

Fixes #19327

To test:

- checkout this branch and enable the `newLandingScreen` feature flag
- build/run the `Jetpack` target and logout if needed
- Turn VoiceOver on and make sure the decorative scrolling text is ignored by VoiceOver

## Regression Notes
1. Potential unintended areas of impact
none

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
