### PR TITLE
Remove derived context from post coordinator

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+MarkAsFailedAndDraftIfNeeded.swift
+++ b/WordPress/Classes/Models/AbstractPost+MarkAsFailedAndDraftIfNeeded.swift
@@ -1,4 +1,4 @@
-@objc extension PostService {
+@objc extension AbstractPost {
 
     // MARK: - Updating the Remote Status
 
@@ -21,16 +21,16 @@
     ///     eventually be made private.
     /// - SeeAlso: PostCoordinator.resume
     ///
-    func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
-        guard post.remoteStatus != .failed else {
+    func markAsFailedAndDraftIfNeeded() {
+        guard self.remoteStatus != .failed else {
             return
         }
 
-        post.remoteStatus = .failed
+        self.remoteStatus = .failed
 
-        if !post.hasRemote() && post is Page {
-            post.status = .draft
-            post.dateModified = Date()
+        if !self.hasRemote() && self is Page {
+            self.status = .draft
+            self.dateModified = Date()
         }
     }
 }

--- a/WordPress/Classes/Models/Post+RefreshStatus.swift
+++ b/WordPress/Classes/Models/Post+RefreshStatus.swift
@@ -1,4 +1,4 @@
-extension PostService {
+extension Post {
 
     /// This method checks the status of all post objects and updates them to the correct status if needed.
     /// The main cause of wrong status is the app being killed while uploads of posts are happening.
@@ -7,27 +7,23 @@ extension PostService {
     ///   - onCompletion: block to invoke when status update is finished.
     ///   - onError: block to invoke if any error occurs while the update is being made.
     ///
-    func refreshPostStatus(onCompletion: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
-        self.managedObjectContext.perform {
+    static func refreshStatus(with coreDataStack: CoreDataStack, onCompletion: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
+        coreDataStack.performAndSave { context in
             let fetch = NSFetchRequest<Post>(entityName: Post.classNameWithoutNamespaces())
             let pushingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.pushing.rawValue))
             let processingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
             fetch.predicate = NSCompoundPredicate(orPredicateWithSubpredicates: [pushingPredicate, processingPredicate])
-            do {
-                let postsPushing = try self.managedObjectContext.fetch(fetch)
-                for post in postsPushing {
-                    post.markAsFailedAndDraftIfNeeded()
-                }
-
-                ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {
-                    DispatchQueue.main.async {
-                        onCompletion?()
-                    }
-                })
-
-            } catch {
-                DDLogError("Error while attempting to update posts status: \(error.localizedDescription)")
-                DispatchQueue.main.async {
+            let postsPushing = try context.fetch(fetch)
+            for post in postsPushing {
+                post.markAsFailedAndDraftIfNeeded()
+            }
+        } completion: { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    onCompletion?()
+                case let .failure(error):
+                    DDLogError("Error while attempting to update posts status: \(error.localizedDescription)")
                     onError?(error)
                 }
             }

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -13,8 +13,6 @@ class PostCoordinator: NSObject {
 
     private let coreDataStack: CoreDataStack
 
-    private let backgroundContext: NSManagedObjectContext
-
     private var mainContext: NSManagedObjectContext {
         coreDataStack.mainContext
     }
@@ -25,7 +23,6 @@ class PostCoordinator: NSObject {
 
     private let mediaCoordinator: MediaCoordinator
 
-    private let backgroundService: PostService
     private let mainService: PostService
     private let failedPostsFetcher: FailedPostsFetcher
 
@@ -34,21 +31,14 @@ class PostCoordinator: NSObject {
     // MARK: - Initializers
 
     init(mainService: PostService? = nil,
-         backgroundService: PostService? = nil,
          mediaCoordinator: MediaCoordinator? = nil,
          failedPostsFetcher: FailedPostsFetcher? = nil,
          actionDispatcherFacade: ActionDispatcherFacade = ActionDispatcherFacade()) {
-        let contextManager = ContextManager.sharedInstance()
-        self.coreDataStack = contextManager
+        self.coreDataStack = ContextManager.sharedInstance()
 
-        let mainContext = contextManager.mainContext
-        let backgroundContext = contextManager.newDerivedContext()
-        backgroundContext.automaticallyMergesChangesFromParent = true
-
-        self.backgroundContext = backgroundContext
+        let mainContext = self.coreDataStack.mainContext
 
         self.mainService = mainService ?? PostService(managedObjectContext: mainContext)
-        self.backgroundService = backgroundService ?? PostService(managedObjectContext: backgroundContext)
         self.mediaCoordinator = mediaCoordinator ?? MediaCoordinator.shared
         self.failedPostsFetcher = failedPostsFetcher ?? FailedPostsFetcher(mainContext)
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -436,7 +436,7 @@ class PostCoordinator: NSObject {
 
         context.perform {
             if status == .failed {
-                self.mainService.markAsFailedAndDraftIfNeeded(post: post)
+                post.markAsFailedAndDraftIfNeeded()
             } else {
                 post.remoteStatus = status
             }

--- a/WordPress/Classes/Services/PostService+RefreshStatus.swift
+++ b/WordPress/Classes/Services/PostService+RefreshStatus.swift
@@ -16,7 +16,7 @@ extension PostService {
             do {
                 let postsPushing = try self.managedObjectContext.fetch(fetch)
                 for post in postsPushing {
-                    self.markAsFailedAndDraftIfNeeded(post: post)
+                    post.markAsFailedAndDraftIfNeeded()
                 }
 
                 ContextManager.sharedInstance().save(self.managedObjectContext, withCompletionBlock: {

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -324,7 +324,7 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
         [self.managedObjectContext performBlock:^{
             Post *postInContext = (Post *)[self.managedObjectContext existingObjectWithID:postObjectID error:nil];
             if (postInContext) {
-                [self markAsFailedAndDraftIfNeededWithPost:postInContext];
+                [postInContext markAsFailedAndDraftIfNeeded];
                 [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
             }
             if (failure) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1636,7 +1636,7 @@
 		8BBC778B27B5531700DBA087 /* BlogDashboardPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */; };
 		8BBC778C27B5531700DBA087 /* BlogDashboardPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */; };
 		8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */; };
-		8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
+		8BC12F7523201917004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift */; };
 		8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */; };
 		8BC6020923900D8400EFE3D0 /* NullBlogPropertySanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */; };
 		8BC6020D2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */; };
@@ -3795,7 +3795,7 @@
 		FABB22842602FC2C00C8785C /* PeopleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1B912881BB01288003C25B9 /* PeopleViewController.swift */; };
 		FABB22852602FC2C00C8785C /* ConfettiView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FEC241425D73E8B007AFE63 /* ConfettiView.swift */; };
 		FABB22862602FC2C00C8785C /* RegisterDomainSuggestionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436D560C2117312600CEAA33 /* RegisterDomainSuggestionsViewController.swift */; };
-		FABB22872602FC2C00C8785C /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */; };
+		FABB22872602FC2C00C8785C /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC12F732320181E004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift */; };
 		FABB22882602FC2C00C8785C /* UserSuggestion+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0B68A9B252FA91E0001B28C /* UserSuggestion+CoreDataProperties.swift */; };
 		FABB22892602FC2C00C8785C /* FollowersCountStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405BFB1F223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataProperties.swift */; };
 		FABB228A2602FC2C00C8785C /* ReaderHeaderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8212CC620AA85C1008E8AE8 /* ReaderHeaderAction.swift */; };
@@ -6576,7 +6576,7 @@
 		8BBBEBB124B8F8C0005E358E /* ReaderCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCardTests.swift; sourceTree = "<group>"; };
 		8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersistence.swift; sourceTree = "<group>"; };
 		8BC12F71231FEBA1004DDA72 /* PostCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCoordinatorTests.swift; sourceTree = "<group>"; };
-		8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
+		8BC12F732320181E004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+MarkAsFailedAndDraftIfNeeded.swift"; sourceTree = "<group>"; };
 		8BC12F7623201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+MarkAsFailedAndDraftIfNeededTests.swift"; sourceTree = "<group>"; };
 		8BC6020823900D8400EFE3D0 /* NullBlogPropertySanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizer.swift; sourceTree = "<group>"; };
 		8BC6020C2390412000EFE3D0 /* NullBlogPropertySanitizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NullBlogPropertySanitizerTests.swift; sourceTree = "<group>"; };
@@ -9388,6 +9388,7 @@
 				40232A9C230A6A740036B0B6 /* AbstractPost+HashHelpers.h */,
 				40232A9D230A6A740036B0B6 /* AbstractPost+HashHelpers.m */,
 				F15272FC243B27BC00C8DC7A /* AbstractPost+Local.swift */,
+				8BC12F732320181E004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift */,
 				E19B17B11E5C8F36007517C6 /* AbstractPost.swift */,
 				74729CAD205722E300D1394D /* AbstractPost+Searchable.swift */,
 				8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */,
@@ -12525,7 +12526,6 @@
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
 				98E0829E2637545C00537BF1 /* PostService+Likes.swift */,
-				8BC12F732320181E004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift */,
 				FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */,
 				9A4F8F55218B88E000EEDCCC /* PostService+Revisions.swift */,
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
@@ -18906,7 +18906,7 @@
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,
 				3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */,
 				436D561F2117312700CEAA33 /* RegisterDomainSuggestionsViewController.swift in Sources */,
-				8BC12F7523201917004DDA72 /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */,
+				8BC12F7523201917004DDA72 /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift in Sources */,
 				B0B68A9D252FA91E0001B28C /* UserSuggestion+CoreDataProperties.swift in Sources */,
 				DC772AF3282009BA00664C02 /* StatsLineChartConfiguration.swift in Sources */,
 				405BFB21223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataProperties.swift in Sources */,
@@ -21407,7 +21407,7 @@
 				FABB22842602FC2C00C8785C /* PeopleViewController.swift in Sources */,
 				FABB22852602FC2C00C8785C /* ConfettiView.swift in Sources */,
 				FABB22862602FC2C00C8785C /* RegisterDomainSuggestionsViewController.swift in Sources */,
-				FABB22872602FC2C00C8785C /* PostService+MarkAsFailedAndDraftIfNeeded.swift in Sources */,
+				FABB22872602FC2C00C8785C /* AbstractPost+MarkAsFailedAndDraftIfNeeded.swift in Sources */,
 				FABB22882602FC2C00C8785C /* UserSuggestion+CoreDataProperties.swift in Sources */,
 				C743535727BD7144008C2644 /* AnimatedGifAttachmentViewProvider.swift in Sources */,
 				FABB22892602FC2C00C8785C /* FollowersCountStatsRecordValue+CoreDataProperties.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3550,7 +3550,7 @@
 		FABB21862602FC2C00C8785C /* CountriesCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981676D4221B7A4300B81C3F /* CountriesCell.swift */; };
 		FABB21872602FC2C00C8785C /* NavBarTitleDropdownButton.m in Sources */ = {isa = PBXBuildFile; fileRef = 5D2C05551AD2F56200A753FE /* NavBarTitleDropdownButton.m */; };
 		FABB21882602FC2C00C8785C /* ReaderTopicsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BCF957924C6044000712056 /* ReaderTopicsCardCell.swift */; };
-		FABB21892602FC2C00C8785C /* PostService+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */; };
+		FABB21892602FC2C00C8785C /* Post+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* Post+RefreshStatus.swift */; };
 		FABB218A2602FC2C00C8785C /* ImageDimensionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 326E281A250AC4A50029EBF0 /* ImageDimensionParser.swift */; };
 		FABB218B2602FC2C00C8785C /* FollowersCountStatsRecordValue+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 405BFB1E223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataClass.swift */; };
 		FABB218C2602FC2C00C8785C /* DocumentUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F126FDFF20A33BDB0010EB6E /* DocumentUploadProcessor.swift */; };
@@ -4868,7 +4868,7 @@
 		FF0AAE0A1A150A560089841D /* WPProgressTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF0AAE091A150A560089841D /* WPProgressTableViewCell.m */; };
 		FF0B2567237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */; };
 		FF0D8146205809C8000EE505 /* PostCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0D8145205809C8000EE505 /* PostCoordinator.swift */; };
-		FF0F722C206E5345000DAAB5 /* PostService+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */; };
+		FF0F722C206E5345000DAAB5 /* Post+RefreshStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF0F722B206E5345000DAAB5 /* Post+RefreshStatus.swift */; };
 		FF1933FF1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */; };
 		FF1B11E5238FDFE70038B93E /* GutenbergGalleryUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1B11E4238FDFE70038B93E /* GutenbergGalleryUploadProcessor.swift */; };
 		FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1B11E6238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift */; };
@@ -8249,7 +8249,7 @@
 		FF0AAE0B1A16550D0089841D /* WPMediaProgressTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WPMediaProgressTableViewController.h; sourceTree = "<group>"; };
 		FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergVideoUploadProcessorTests.swift; sourceTree = "<group>"; };
 		FF0D8145205809C8000EE505 /* PostCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostCoordinator.swift; sourceTree = "<group>"; };
-		FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostService+RefreshStatus.swift"; sourceTree = "<group>"; };
+		FF0F722B206E5345000DAAB5 /* Post+RefreshStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+RefreshStatus.swift"; sourceTree = "<group>"; };
 		FF1933FD1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RelatedPostsPreviewTableViewCell.h; sourceTree = "<group>"; };
 		FF1933FE1BB17DA3006825B8 /* RelatedPostsPreviewTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RelatedPostsPreviewTableViewCell.m; sourceTree = "<group>"; };
 		FF1B11E4238FDFE70038B93E /* GutenbergGalleryUploadProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergGalleryUploadProcessor.swift; sourceTree = "<group>"; };
@@ -9429,6 +9429,7 @@
 				E1E89C6B1FD80E74006E7A33 /* Plugin.swift */,
 				591AA4FF1CEF9BF20074934F /* Post.swift */,
 				591AA5001CEF9BF20074934F /* Post+CoreDataProperties.swift */,
+				FF0F722B206E5345000DAAB5 /* Post+RefreshStatus.swift */,
 				E148362E1C6DF7D8005ACF53 /* Product.swift */,
 				833AF259114575A50016DE8F /* PostAnnotation.h */,
 				833AF25A114575A50016DE8F /* PostAnnotation.m */,
@@ -12526,7 +12527,6 @@
 				E1A6DBE319DC7D230071AC1E /* PostService.h */,
 				E1A6DBE419DC7D230071AC1E /* PostService.m */,
 				98E0829E2637545C00537BF1 /* PostService+Likes.swift */,
-				FF0F722B206E5345000DAAB5 /* PostService+RefreshStatus.swift */,
 				9A4F8F55218B88E000EEDCCC /* PostService+Revisions.swift */,
 				2F08ECFB2283A4FB000F8E11 /* PostService+UnattachedMedia.swift */,
 				08472A1E1C7273FA0040769D /* PostServiceOptions.h */,
@@ -18605,7 +18605,7 @@
 				981676D6221B7A4300B81C3F /* CountriesCell.swift in Sources */,
 				5D2C05561AD2F56200A753FE /* NavBarTitleDropdownButton.m in Sources */,
 				8BCF957A24C6044000712056 /* ReaderTopicsCardCell.swift in Sources */,
-				FF0F722C206E5345000DAAB5 /* PostService+RefreshStatus.swift in Sources */,
+				FF0F722C206E5345000DAAB5 /* Post+RefreshStatus.swift in Sources */,
 				326E281C250AC4A50029EBF0 /* ImageDimensionParser.swift in Sources */,
 				405BFB20223B37A000CD5BEA /* FollowersCountStatsRecordValue+CoreDataClass.swift in Sources */,
 				F126FE0220A33BDB0010EB6E /* DocumentUploadProcessor.swift in Sources */,
@@ -21097,7 +21097,7 @@
 				FA25FA342609AAAA0005E08F /* AppConfiguration.swift in Sources */,
 				83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */,
 				3FE3D1FC26A6F2AC00F3CD10 /* ListTableViewCell.swift in Sources */,
-				FABB21892602FC2C00C8785C /* PostService+RefreshStatus.swift in Sources */,
+				FABB21892602FC2C00C8785C /* Post+RefreshStatus.swift in Sources */,
 				F1585405267D3B5000A2E966 /* BloggingRemindersFlowIntroViewController.swift in Sources */,
 				FABB218A2602FC2C00C8785C /* ImageDimensionParser.swift in Sources */,
 				FABB218B2602FC2C00C8785C /* FollowersCountStatsRecordValue+CoreDataClass.swift in Sources */,

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -29,7 +29,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         postCoordinator.save(post)
 
-        expect(postServiceMock.didCallMarkAsFailedAndDraftIfNeeded).toEventually(beTrue())
+        expect((try! self.mainContext.existingObject(with: post.objectID) as! Post).remoteStatus).toEventually(equal(.failed))
         expect(postServiceMock.didCallUploadPost).to(beFalse())
     }
 
@@ -458,7 +458,6 @@ class PostServiceMock: PostService {
         let forceDraftIfCreating: Bool
     }
 
-    private(set) var didCallMarkAsFailedAndDraftIfNeeded = false
     private(set) var didCallAutoSave = false
 
     private(set) var lastUploadPostInvocation: UploadPostInvocation?
@@ -497,10 +496,6 @@ class PostServiceMock: PostService {
 
     override func autoSave(_ post: AbstractPost, success: ((AbstractPost, String) -> Void)?, failure: @escaping (Error?) -> Void) {
         didCallAutoSave = true
-    }
-
-    override func markAsFailedAndDraftIfNeeded(post: AbstractPost) {
-        didCallMarkAsFailedAndDraftIfNeeded = true
     }
 
     override func syncPosts(ofType postType: PostServiceType, with options: PostServiceSyncOptions, for blog: Blog, success: @escaping PostServiceSyncSuccess, failure: @escaping PostServiceSyncFailure) {

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -25,7 +25,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
         let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError()))
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
 
         postCoordinator.save(post)
 
@@ -35,7 +35,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testUploadAPostWithNoFailedMedia() {
         let postServiceMock = PostServiceMock()
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext)
             .with(image: "test.jpeg")
             .build()
@@ -47,7 +47,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testEventuallyMarkThePostRemoteStatusAsUploading() {
         let postServiceMock = PostServiceMock()
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext)
             .with(image: "test.jpeg")
             .build()
@@ -59,7 +59,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testAttemptCountIsIncrementedAfterFailingToAutomaticallyUpload() {
         let postServiceMock = PostServiceMock()
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext).build()
 
         postCoordinator.save(post, automatedRetry: true)
@@ -69,7 +69,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testAttemptCountIsResetWhenNotAutomaticallyUpload() {
         let postServiceMock = PostServiceMock()
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext).with(autoUploadAttemptsCount: 3).build()
 
         postCoordinator.save(post, automatedRetry: false)
@@ -79,7 +79,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testReturnPostWhenServiceSucceed() {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext).build()
         postServiceMock.returnPost = post
         var returnedPost: AbstractPost?
@@ -98,7 +98,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testReturnErrorWhenServiceFails() {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext).build()
         postServiceMock.returnError = NSError(domain: "", code: 1, userInfo: nil)
         var returnedError: Error?
@@ -122,7 +122,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .local)
             .build()
         let mediaCoordinatorMock = MediaCoordinatorMock(media: post.media.first!, mediaState: .failed(error: NSError()))
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
         var returnedError: Error?
 
         postCoordinator.save(post) { result in
@@ -139,7 +139,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testResumeWillAutoSaveUnconfirmedExistingPosts() {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         _ = PostBuilder(mainContext)
             .withRemote()
             .with(status: .draft)
@@ -156,7 +156,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testResumeWillUploadUnconfirmedPublishedPostsAsDraftsOnSelfHostedSites() {
         // Arrange
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         _ = PostBuilder(mainContext)
             .with(status: .publish)
             .with(remoteStatus: .failed)
@@ -179,7 +179,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testCancelAutoUploadOfAPost() {
         let post = PostBuilder(mainContext).confirmedAutoUpload().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.cancelAutoUploadOf(post)
 
@@ -193,7 +193,7 @@ class PostCoordinatorTests: CoreDataTestCase {
             .with(remoteStatus: .failed)
             .build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.cancelAutoUploadOf(post)
 
@@ -203,7 +203,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testChangeDraftToPublishWhenPublishing() {
         let post = PostBuilder(mainContext).drafted().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.publish(post)
 
@@ -213,7 +213,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testDoNotChangeDateCreatedForAScheduledPost() {
         let post = PostBuilder(mainContext).with(dateCreated: Date(timeIntervalSince1970: 50)).scheduled().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.publish(post)
 
@@ -223,7 +223,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testSetShouldAttemptAutoUploadToTrue() {
         let post = PostBuilder(mainContext).drafted().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.publish(post)
 
@@ -233,7 +233,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testCallPostCoordinatorToSaveAPost() {
         let post = PostBuilder(mainContext).drafted().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.publish(post)
 
@@ -243,7 +243,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testChangePostToDraftWhenMovingToDraft() {
         let post = PostBuilder(mainContext).published().build()
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
 
         postCoordinator.moveToDraft(post)
 
@@ -253,7 +253,7 @@ class PostCoordinatorTests: CoreDataTestCase {
     func testTracksAutoUploadPostInvoked() {
         // Arrange
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let interactor = PostAutoUploadInteractor()
         let post = PostBuilder(mainContext)
             .withRemote()
@@ -296,9 +296,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock,
-                                              backgroundService: postServiceMock,
-                                              actionDispatcherFacade: actionDispatcherFacadeMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, actionDispatcherFacade: actionDispatcherFacadeMock)
 
         // Act
         var result: Result<AbstractPost, Error>? = nil
@@ -335,9 +333,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock,
-                                              backgroundService: postServiceMock,
-                                              actionDispatcherFacade: actionDispatcherFacadeMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, actionDispatcherFacade: actionDispatcherFacadeMock)
 
         // Act
         var result: Result<AbstractPost, Error>? = nil
@@ -374,9 +370,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
         let actionDispatcherFacadeMock = ActionDispatcherFacadeMock()
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock,
-                                              backgroundService: postServiceMock,
-                                              mediaCoordinator: mediaCoordinatorMock,
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock,
                                               actionDispatcherFacade: actionDispatcherFacadeMock)
 
         // Act
@@ -415,9 +409,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
         let postServiceMock = PostServiceMock(managedObjectContext: mainContext)
 
-        let postCoordinator = PostCoordinator(mainService: postServiceMock,
-                                              backgroundService: postServiceMock,
-                                              mediaCoordinator: mediaCoordinatorMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock, mediaCoordinator: mediaCoordinatorMock)
 
         // Act
         var results = [Result<AbstractPost, Error>]()
@@ -434,7 +426,7 @@ class PostCoordinatorTests: CoreDataTestCase {
 
     func testPostSavedButNotReturned() {
         let postServiceMock = PostServiceMock()
-        let postCoordinator = PostCoordinator(mainService: postServiceMock, backgroundService: postServiceMock)
+        let postCoordinator = PostCoordinator(mainService: postServiceMock)
         let post = PostBuilder(mainContext).build()
         postServiceMock.returnNilPost = true
         var returnedError: Error?

--- a/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
+++ b/WordPress/WordPressTest/PostService+MarkAsFailedAndDraftIfNeededTests.swift
@@ -4,17 +4,16 @@ import Nimble
 
 @testable import WordPress
 
-/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
-class PostServiceMarkAsFailedAndDraftIfNeededTests: CoreDataTestCase {
+/// Test cases for Post.markAsFailedAndDraftIfNeeded()
+class PostMarkAsFailedAndDraftIfNeededTests: CoreDataTestCase {
 
     func testMarkAPostAsFailedAndKeepItsStatus() {
         let post = PostBuilder(mainContext)
             .with(status: .pending)
             .withRemote()
             .build()
-        let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: post)
+        post.markAsFailedAndDraftIfNeeded()
 
         expect(post.remoteStatus).to(equal(.failed))
         expect(post.status).to(equal(.pending))
@@ -26,9 +25,8 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: CoreDataTestCase {
             .with(status: .pending)
             .confirmedAutoUpload()
             .build()
-        let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: post)
+        post.markAsFailedAndDraftIfNeeded()
 
         expect(post.shouldAttemptAutoUpload).to(beTrue())
     }
@@ -39,9 +37,8 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: CoreDataTestCase {
             .with(remoteStatus: .pushing)
             .with(dateModified: Date(timeIntervalSince1970: 0))
             .build()
-        let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: page)
+        page.markAsFailedAndDraftIfNeeded()
 
         expect(page.remoteStatus).to(equal(.failed))
         expect(page.status).to(equal(.draft))
@@ -54,9 +51,8 @@ class PostServiceMarkAsFailedAndDraftIfNeededTests: CoreDataTestCase {
             .with(remoteStatus: .pushing)
             .withRemote()
             .build()
-        let postService = PostService()
 
-        postService.markAsFailedAndDraftIfNeeded(post: page)
+        page.markAsFailedAndDraftIfNeeded()
 
         expect(page.status).to(equal(.scheduled))
         expect(page.remoteStatus).to(equal(.failed))

--- a/WordPress/WordPressTest/PostServiceUploadingListTests.swift
+++ b/WordPress/WordPressTest/PostServiceUploadingListTests.swift
@@ -4,7 +4,6 @@ import Nimble
 
 @testable import WordPress
 
-/// Test cases for PostService.markAsFailedAndDraftIfNeeded()
 class PostServiceUploadingListTests: CoreDataTestCase {
 
     /// Returns true if a single post is added to the list


### PR DESCRIPTION
## Changes

The core change is in the original `PostService.refreshPostStatus` function, using `CoreDataStack.performAndSave` function in its implementation rather than using a derived context created in `PostCoordinator`. This change led to a couple of properties in `PostCoordinator` become redundnat and get removed.

## Test instructions

I think this change is fairly safe, there is no logic change, just using a different function to do the same thing—updating `Post` status. But I tried to create a post, kill the app, and launch the app, didn't notice any issue with the new code.

BTW, the "app did launch" function is the only place that calls the `Post.refreshStatus` function.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
