### PR TITLE
Mark `-[CoreDataStack newDerivedContext]` as deprecated

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -194,8 +194,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 - (void)refreshPostsForFollowedTopic
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     // Do all of this work on a background thread.
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
+
     ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:context];
     [context performBlock:^{
         ReaderAbstractTopic *topic = [topicService topicForFollowedSites];

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -167,7 +167,11 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
         return;
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
+
     ReaderPostService *postService = [[ReaderPostService alloc] initWithManagedObjectContext:context];
     [postService fetchPostsForTopic:followedSites earlierThan:[NSDate date] success:nil failure:nil];
 }

--- a/WordPress/Classes/Utility/ContextManager.h
+++ b/WordPress/Classes/Utility/ContextManager.h
@@ -14,7 +14,7 @@ FOUNDATION_EXTERN NSString * const ContextManagerModelNameCurrent;
 
 @protocol CoreDataStack
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
-- (NSManagedObjectContext *const)newDerivedContext;
+- (NSManagedObjectContext *const)newDerivedContext DEPRECATED_MSG_ATTRIBUTE("Use `performAndSave` instead");
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^)(void))completionBlock;

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -383,7 +383,10 @@ static NSInteger HideSearchMinSites = 3;
         });
     };
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
     BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
 
     [context performBlock:^{
@@ -946,7 +949,10 @@ static NSInteger HideSearchMinSites = 3;
             UIAlertAction *hideAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Hide All", @"Hide All")
                                                                    style:UIAlertActionStyleDestructive
                                                                  handler:^(UIAlertAction *action){
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
                                                                      NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
                                                                      [context performBlock:^{
                                                                          AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
                                                                          WPAccount *account = [WPAccount lookupDefaultWordPressComAccountInContext:context];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -236,7 +236,10 @@
 
 - (void)syncBlogs
 {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
     
     [context performBlock:^{
         BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -474,7 +474,12 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     [self refreshNoResultsView];
     
     __typeof(self) __weak weakSelf = self;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
+
     CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
     NSManagedObjectID *blogObjectID = self.blog.objectID;
 
@@ -515,7 +520,12 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncMoreWithSuccess:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
     __typeof(self) __weak weakSelf = self;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
+
     CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
     NSManagedObjectID *blogObjectID = self.blog.objectID;
     

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPickerDataSource.m
@@ -615,7 +615,11 @@
         [mediaTypes addObject:@(MediaTypeAudio)];
     }
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] newDerivedContext];
+#pragma clang diagnostic pop
+
     MediaService *mediaService = [[MediaService alloc] initWithManagedObjectContext:mainContext];
     NSInteger count = [mediaService getMediaLibraryCountForBlog:self.blog
                                                   forMediaTypes:mediaTypes];

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -1000,7 +1000,12 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
     self.failedToFetchComments = NO;
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
+#pragma clang diagnostic pop
+
     [service syncHierarchicalCommentsForPost:self.post page:1 success:^(BOOL hasMore, NSNumber *totalComments) {
         if (success) {
             success(hasMore);
@@ -1014,7 +1019,11 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     self.failedToFetchComments = NO;
     [self.activityFooter startAnimating];
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     CommentService *service = [[CommentService alloc] initWithManagedObjectContext:[[ContextManager sharedInstance] newDerivedContext]];
+#pragma clang diagnostic pop
+
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
     [service syncHierarchicalCommentsForPost:self.post page:page success:^(BOOL hasMore, NSNumber *totalComments) {
         if (success) {

--- a/WordPress/WordPressTest/Aztec/AztecPostViewController+MenuTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewController+MenuTests.swift
@@ -18,21 +18,10 @@ class AztecPostViewController_MenuTests: CoreDataTestCase {
     }
 
     private var aztecPostViewController: Mock!
-    private var context: NSManagedObjectContext!
-
-    override func setUpWithError() throws {
-        try super.setUpWithError()
-        context = contextManager.newDerivedContext()
-    }
-
-    override func tearDownWithError() throws {
-        try super.tearDownWithError()
-        context = nil
-    }
 
     private func blogPost(with content: String?) -> Post {
-        let blog = ModelTestHelper.insertSelfHostedBlog(context: context)
-        let post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: context) as! Post
+        let blog = ModelTestHelper.insertSelfHostedBlog(context: mainContext)
+        let post = NSEntityDescription.insertNewObject(forEntityName: Post.entityName(), into: mainContext) as! Post
         post.blog = blog
         post.content = content
         let settings = GutenbergSettings(database: EphemeralKeyValueDatabase())

--- a/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
+++ b/WordPress/WordPressTest/Aztec/AztecPostViewControllerAttachmentTests.swift
@@ -6,23 +6,10 @@ import Nimble
 
 class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
 
-    private var context: NSManagedObjectContext!
-
-    override func setUp() {
-        super.setUp()
-
-        context = contextManager.newDerivedContext()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        context = nil
-    }
-
     func testMediaUploadErrorsWillShowAnErrorMessageAndOverlay() {
         // Arrange
-        let media = Media(context: context)
-        let post = Fixtures.createPost(context: context, with: media)
+        let media = Media(context: mainContext)
+        let post = Fixtures.createPost(context: mainContext, with: media)
         let vc = Fixtures.createAztecPostViewController(with: post)
 
         let attachment = vc.findAttachment(withUploadID: media.uploadID)!
@@ -41,8 +28,8 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
 
     func testRestartingOfMediaUploadsWillClearErrorMessageAndOverlay() {
         // Arrange
-        let media = Media(context: context)
-        let post = Fixtures.createPost(context: context, with: media)
+        let media = Media(context: mainContext)
+        let post = Fixtures.createPost(context: mainContext, with: media)
         let vc = Fixtures.createAztecPostViewController(with: post)
 
         let attachment = vc.findAttachment(withUploadID: media.uploadID)!
@@ -63,8 +50,8 @@ class AztecPostViewControllerAttachmentTests: CoreDataTestCase {
 
     func testUpdatePostContentAfterAMediaThumbnailUpdate() {
         // Arrange
-        let media = Media(context: context)
-        let post = Fixtures.createPost(context: context, with: media)
+        let media = Media(context: mainContext)
+        let post = Fixtures.createPost(context: mainContext, with: media)
         let vc = Fixtures.createAztecPostViewController(with: post)
 
         // Act

--- a/WordPress/WordPressTest/BlogTitleTests.swift
+++ b/WordPress/WordPressTest/BlogTitleTests.swift
@@ -4,11 +4,9 @@ import XCTest
 class BlogTitleTests: CoreDataTestCase {
 
     private var blog: Blog!
-    private var context: NSManagedObjectContext!
 
     override func setUp() {
-        context = contextManager.newDerivedContext()
-        blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as? Blog
+        blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: mainContext) as? Blog
         blog.url = Constants.blogURL
         blog.xmlrpc = Constants.blogURL
     }
@@ -44,7 +42,7 @@ class BlogTitleTests: CoreDataTestCase {
     // MARK: - Private Helpers
     fileprivate func newSettings() -> BlogSettings {
         let name = BlogSettings.classNameWithoutNamespaces()
-        let entity = NSEntityDescription.insertNewObject(forEntityName: name, into: context)
+        let entity = NSEntityDescription.insertNewObject(forEntityName: name, into: mainContext)
 
         return entity as! BlogSettings
     }

--- a/WordPress/WordPressTest/BlogVideoLimitsTests.swift
+++ b/WordPress/WordPressTest/BlogVideoLimitsTests.swift
@@ -3,11 +3,9 @@ import XCTest
 class BlogVideoLimitsTests: CoreDataTestCase {
 
     private var blog: Blog!
-    private var context: NSManagedObjectContext!
 
     override func setUpWithError() throws {
-        context = contextManager.newDerivedContext()
-        blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as? Blog
+        blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: mainContext) as? Blog
         blog.url = Constants.blogURL
         blog.xmlrpc = Constants.blogURL
     }

--- a/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
@@ -9,7 +9,7 @@ class StatsWidgetsStoreTests: CoreDataTestCase {
 
     override func setUpWithError() throws {
         deleteHomeWidgetData()
-        blogService = BlogServiceMock(managedObjectContext: contextManager.newDerivedContext())
+        blogService = BlogServiceMock(managedObjectContext: mainContext)
         sut = StatsWidgetsStore(blogService: blogService)
     }
 

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPostsParserTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPostsParserTests.swift
@@ -4,27 +4,19 @@ import XCTest
 
 class BlogDashboardPostsParserTests: CoreDataTestCase {
 
-    private var context: NSManagedObjectContext!
-
     private var parser: BlogDashboardPostsParser!
 
     override func setUp() {
         super.setUp()
 
-        context = contextManager.newDerivedContext()
-        parser = BlogDashboardPostsParser(managedObjectContext: context)
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        context = nil
+        parser = BlogDashboardPostsParser(managedObjectContext: mainContext)
     }
 
     /// When the API return no drafts, but there are local drafts
     /// Return one local draft
     func testReturnLocalDraftWhenItExists() {
-        let blog = BlogBuilder(context).build()
-        _ = PostBuilder(context, blog: blog).drafted().build()
+        let blog = BlogBuilder(mainContext).build()
+        _ = PostBuilder(mainContext, blog: blog).drafted().build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithoutPosts["posts"] as! NSDictionary,
                                                  for: blog)
@@ -35,7 +27,7 @@ class BlogDashboardPostsParserTests: CoreDataTestCase {
     /// When the API return no drafts, and there are no local drafts
     /// Return zero drafts
     func testReturnZeroDraftsWhenNothingLocal() {
-        let blog = BlogBuilder(context).build()
+        let blog = BlogBuilder(mainContext).build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithoutPosts["posts"] as! NSDictionary,
                                                  for: blog)
@@ -45,7 +37,7 @@ class BlogDashboardPostsParserTests: CoreDataTestCase {
 
     /// When the API return drafts, keep the amount returned
     func testReturnDraftsTrimmedEvenWithZeroLocalDrafts() {
-        let blog = BlogBuilder(context).build()
+        let blog = BlogBuilder(mainContext).build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithPosts["posts"] as! NSDictionary,
                                                  for: blog)
@@ -56,8 +48,8 @@ class BlogDashboardPostsParserTests: CoreDataTestCase {
     /// When the API return no scheduled, but there are local scheduled posts
     /// Return one scheduled post
     func testReturnLocalScheduledWhenItExists() {
-        let blog = BlogBuilder(context).build()
-        _ = PostBuilder(context, blog: blog).scheduled().withRemote().build()
+        let blog = BlogBuilder(mainContext).build()
+        _ = PostBuilder(mainContext, blog: blog).scheduled().withRemote().build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithoutPosts["posts"] as! NSDictionary,
                                                  for: blog)
@@ -68,7 +60,7 @@ class BlogDashboardPostsParserTests: CoreDataTestCase {
     /// When the API return no scheduled, and there are no
     /// local scheduled posts, return zero scheduled posts
     func testReturnZeroScheduledWhenNothingLocal() {
-        let blog = BlogBuilder(context).build()
+        let blog = BlogBuilder(mainContext).build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithoutPosts["posts"] as! NSDictionary,
                                                  for: blog)
@@ -78,8 +70,8 @@ class BlogDashboardPostsParserTests: CoreDataTestCase {
 
     /// When the API return scheduled posts, keep the amount returned
     func testReturnScheduledAsItIsEvenWhenLocalScheduledExists() {
-        let blog = BlogBuilder(context).build()
-        _ = PostBuilder(context, blog: blog).scheduled().withRemote().build()
+        let blog = BlogBuilder(mainContext).build()
+        _ = PostBuilder(mainContext, blog: blog).scheduled().withRemote().build()
 
         let postsWithLocalContent = parser.parse(cardsResponseWithPosts["posts"] as! NSDictionary,
                                                  for: blog)

--- a/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
+++ b/WordPress/WordPressTest/Dashboard/DashboardCardTests.swift
@@ -11,20 +11,17 @@ class MockDefaultSectionProvider: DefaultSectionProvider {
 
 class DashboardCardTests: CoreDataTestCase {
 
-    private var context: NSManagedObjectContext!
     private var blog: Blog!
 
     override func setUp() {
         super.setUp()
 
         contextManager.useAsSharedInstance(untilTestFinished: self)
-        context = contextManager.newDerivedContext()
-        blog = BlogBuilder(context).build()
+        blog = BlogBuilder(mainContext).build()
     }
 
     override func tearDown() {
         QuickStartTourGuide.shared.remove(from: blog)
-        context = nil
         blog = nil
         super.tearDown()
     }

--- a/WordPress/WordPressTest/PostCardCellTests.swift
+++ b/WordPress/WordPressTest/PostCardCellTests.swift
@@ -7,15 +7,12 @@ import Nimble
 private typealias StatusMessages = PostCardStatusViewModel.StatusMessages
 
 class PostCardCellTests: CoreDataTestCase {
-    private var context: NSManagedObjectContext!
-
     private var postCell: PostCardCell!
     private var interactivePostViewDelegateMock: InteractivePostViewDelegateMock!
     private var postActionSheetDelegateMock: PostActionSheetDelegateMock!
 
     override func setUp() {
         super.setUp()
-        context = contextManager.newDerivedContext()
 
         postCell = postCellFromNib()
         interactivePostViewDelegateMock = InteractivePostViewDelegateMock()
@@ -24,17 +21,12 @@ class PostCardCellTests: CoreDataTestCase {
         postCell.setActionSheetDelegate(postActionSheetDelegateMock)
     }
 
-    override func tearDown() {
-        context = nil
-        super.tearDown()
-    }
-
     func testIsAUITableViewCell() {
         XCTAssertNotNil(postCell as UITableViewCell)
     }
 
     func testShowImageWhenAvailable() {
-        let post = PostBuilder(context).withImage().build()
+        let post = PostBuilder(mainContext).withImage().build()
 
         postCell.configure(with: post)
 
@@ -42,7 +34,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideImageWhenNotAvailable() {
-        let post = PostBuilder(context).build()
+        let post = PostBuilder(mainContext).build()
 
         postCell.configure(with: post)
 
@@ -50,7 +42,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowPostTitle() {
-        let post = PostBuilder(context).with(title: "Foo bar").build()
+        let post = PostBuilder(mainContext).with(title: "Foo bar").build()
 
         postCell.configure(with: post)
 
@@ -58,7 +50,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowPostSnippet() {
-        let post = PostBuilder(context).with(snippet: "Post content").build()
+        let post = PostBuilder(mainContext).with(snippet: "Post content").build()
 
         postCell.configure(with: post)
 
@@ -67,7 +59,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHidePostSnippet() {
-        let post = PostBuilder(context).with(snippet: "").build()
+        let post = PostBuilder(mainContext).with(snippet: "").build()
 
         postCell.configure(with: post)
 
@@ -75,7 +67,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowDate() {
-        let post = PostBuilder(context).with(dateModified: Date()).drafted().build()
+        let post = PostBuilder(mainContext).with(dateModified: Date()).drafted().build()
 
         postCell.configure(with: post)
 
@@ -83,7 +75,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowAuthor() {
-        let post = PostBuilder(context).with(author: "John Doe").build()
+        let post = PostBuilder(mainContext).with(author: "John Doe").build()
 
         postCell.configure(with: post)
 
@@ -91,7 +83,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowStickyLabelWhenPostIsSticky() {
-        let post = PostBuilder(context).is(sticked: true).with(remoteStatus: .sync).build()
+        let post = PostBuilder(mainContext).is(sticked: true).with(remoteStatus: .sync).build()
 
         postCell.configure(with: post)
 
@@ -99,7 +91,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideStickyLabelWhenPostIsntSticky() {
-        let post = PostBuilder(context).is(sticked: false).with(remoteStatus: .sync).build()
+        let post = PostBuilder(mainContext).is(sticked: false).with(remoteStatus: .sync).build()
 
         postCell.configure(with: post)
 
@@ -107,7 +99,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideStickyLabelWhenPostIsUploading() {
-        let post = PostBuilder(context).is(sticked: true).with(remoteStatus: .pushing).build()
+        let post = PostBuilder(mainContext).is(sticked: true).with(remoteStatus: .pushing).build()
 
         postCell.configure(with: post)
 
@@ -115,7 +107,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideStickyLabelWhenPostIsFailed() {
-        let post = PostBuilder(context).is(sticked: true).with(remoteStatus: .failed).build()
+        let post = PostBuilder(mainContext).is(sticked: true).with(remoteStatus: .failed).build()
 
         postCell.configure(with: post)
 
@@ -123,7 +115,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowPrivateLabelWhenPostIsPrivate() {
-        let post = PostBuilder(context).with(remoteStatus: .sync).private().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync).private().build()
 
         postCell.configure(with: post)
 
@@ -131,7 +123,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testDoNotShowTrashedLabel() {
-        let post = PostBuilder(context).with(remoteStatus: .sync).trashed().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync).trashed().build()
 
         postCell.configure(with: post)
 
@@ -139,7 +131,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testDoNotShowScheduledLabel() {
-        let post = PostBuilder(context).with(remoteStatus: .sync).scheduled().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync).scheduled().build()
 
         postCell.configure(with: post)
 
@@ -147,7 +139,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideHideStatusView() {
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
             .published().build()
 
@@ -157,7 +149,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowStatusView() {
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .failed)
             .published().build()
 
@@ -167,7 +159,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowProgressView() {
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .pushing)
             .published().build()
 
@@ -177,7 +169,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideProgressView() {
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .with(remoteStatus: .sync)
             .published().build()
 
@@ -187,7 +179,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testIsUserInteractionEnabled() {
-        let post = PostBuilder(context).withImage().build()
+        let post = PostBuilder(mainContext).withImage().build()
         postCell.isUserInteractionEnabled = false
 
         postCell.configure(with: post)
@@ -196,7 +188,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testEditAction() {
-        let post = PostBuilder(context).published().build()
+        let post = PostBuilder(mainContext).published().build()
         postCell.configure(with: post)
 
         postCell.edit()
@@ -205,7 +197,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testViewAction() {
-        let post = PostBuilder(context).published().build()
+        let post = PostBuilder(mainContext).published().build()
         postCell.configure(with: post)
 
         postCell.view()
@@ -215,7 +207,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testMoreAction() {
         let button = UIButton()
-        let post = PostBuilder(context).published().build()
+        let post = PostBuilder(mainContext).published().build()
         postCell.configure(with: post)
 
         postCell.more(button)
@@ -225,7 +217,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testRetryAction() {
-        let post = PostBuilder(context).published().build()
+        let post = PostBuilder(mainContext).published().build()
         postCell.configure(with: post)
 
         postCell.retry()
@@ -234,7 +226,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowPublishButtonAndHideViewButton() {
-        let post = PostBuilder(context).private().with(remoteStatus: .failed).build()
+        let post = PostBuilder(mainContext).private().with(remoteStatus: .failed).build()
 
         postCell.configure(with: post)
 
@@ -243,7 +235,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHideAuthorAndSeparator() {
-        let post = PostBuilder(context).with(author: "John Doe").build()
+        let post = PostBuilder(mainContext).with(author: "John Doe").build()
         postCell.configure(with: post)
 
         postCell.shouldHideAuthor = true
@@ -253,7 +245,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testDoesNotHideAuthorAndSeparator() {
-        let post = PostBuilder(context).with(author: "John Doe").build()
+        let post = PostBuilder(mainContext).with(author: "John Doe").build()
         postCell.configure(with: post)
 
         postCell.shouldHideAuthor = false
@@ -263,7 +255,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testHidesAuthorSeparatorWhenAuthorEmpty() {
-        let post = PostBuilder(context).with(author: "").build()
+        let post = PostBuilder(mainContext).with(author: "").build()
         postCell.configure(with: post)
 
         postCell.shouldHideAuthor = false
@@ -274,7 +266,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testShowsPostWillBePublishedWarningForFailedPublishedPostsWithRemote() {
         // Given
-        let post = PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         // When
         postCell.configure(with: post)
@@ -286,7 +278,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testShowsPostWillBePublishedWarningForLocallyPublishedPosts() {
         // Given
-        let post = PostBuilder(context).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         // When
         postCell.configure(with: post)
@@ -298,7 +290,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testShowsCancelButtonForUserConfirmedFailedPublishedPosts() {
         // Given
-        let post = PostBuilder(context).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         // When
         postCell.configure(with: post)
@@ -317,8 +309,8 @@ class PostCardCellTests: CoreDataTestCase {
 
         // Arrange
         let posts = [
-            PostBuilder(context).published().with(remoteStatus: .failed).build(),
-            PostBuilder(context).drafted().with(remoteStatus: .failed).build()
+            PostBuilder(mainContext).published().with(remoteStatus: .failed).build(),
+            PostBuilder(mainContext).drafted().with(remoteStatus: .failed).build()
         ]
 
         // Act and Assert
@@ -332,7 +324,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testDoesntShowFailedForCancelledAutoUploads() {
         // Given
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .published()
             .with(remoteStatus: .failed)
             .confirmedAutoUpload()
@@ -349,7 +341,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testShowsDraftWillBeUploadedMessageForDraftsWithRemote() {
         // Given
-        let post = PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         // When
         postCell.configure(with: post)
@@ -361,7 +353,7 @@ class PostCardCellTests: CoreDataTestCase {
 
     func testShowsDraftWillBeUploadedMessageForLocalDrafts() {
         // Given
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).build()
+        let post = PostBuilder(mainContext).drafted().with(remoteStatus: .failed).build()
 
         // When
         postCell.configure(with: post)
@@ -372,7 +364,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsFailedMessageWhenAttemptToAutoUploadADraft() {
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
+        let post = PostBuilder(mainContext).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).build()
 
         postCell.configure(with: post)
 
@@ -381,7 +373,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReached() {
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let post = PostBuilder(mainContext).drafted().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
 
         postCell.configure(with: post)
 
@@ -390,7 +382,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToAutoDraftIsReachedAndPostHasFailedMedia() {
-        let post = PostBuilder(context).with(image: "", status: .failed).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let post = PostBuilder(mainContext).with(image: "", status: .failed).with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
 
         postCell.configure(with: post)
 
@@ -399,7 +391,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsFailedMessageWhenAttemptToAutoUploadAPrivatePost() {
-        let post = PostBuilder(context).private().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).private().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -408,7 +400,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToUploadPrivateIsReached() {
-        let post = PostBuilder(context).private().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let post = PostBuilder(mainContext).private().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
 
         postCell.configure(with: post)
 
@@ -417,7 +409,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsPrivatePostWillBeUploadedMessageForPrivatePosts() {
-        let post = PostBuilder(context).private().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).private().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -426,7 +418,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsFailedMessageWhenAttemptToAutoUploadAScheduledPost() {
-        let post = PostBuilder(context).scheduled().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).scheduled().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -435,7 +427,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToUploadScheduledIsReached() {
-        let post = PostBuilder(context).scheduled().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let post = PostBuilder(mainContext).scheduled().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
 
         postCell.configure(with: post)
 
@@ -444,7 +436,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsScheduledPostWillBeUploadedMessageForScheduledPosts() {
-        let post = PostBuilder(context).scheduled().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).scheduled().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -453,7 +445,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsPostWillBeSubmittedMessageForPendingPost() {
-        let post = PostBuilder(context).pending().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).pending().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -462,7 +454,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsFailedMessageWhenAttemptToSubmitAPendingPost() {
-        let post = PostBuilder(context).pending().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).pending().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 2).confirmedAutoUpload().build()
 
         postCell.configure(with: post)
 
@@ -471,7 +463,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageWhenMaxNumberOfAttemptsToSubmitPendingPostIsReached() {
-        let post = PostBuilder(context).pending().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
+        let post = PostBuilder(mainContext).pending().with(remoteStatus: .failed).with(autoUploadAttemptsCount: 3).build()
 
         postCell.configure(with: post)
 
@@ -480,7 +472,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testFailedMessageForCanceledPostWithFailedMedias() {
-        let post = PostBuilder(context).drafted().with(remoteStatus: .failed).with(image: "test.png", status: .failed, autoUploadFailureCount: 3).cancelledAutoUpload().revision().build()
+        let post = PostBuilder(mainContext).drafted().with(remoteStatus: .failed).with(image: "test.png", status: .failed, autoUploadFailureCount: 3).cancelledAutoUpload().revision().build()
 
         postCell.configure(with: post)
 
@@ -489,7 +481,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testMessageWhenPostIsArevision() {
-        let post = PostBuilder(context).revision().with(remoteStatus: .failed).with(remoteStatus: .local).build()
+        let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).with(remoteStatus: .local).build()
 
         postCell.configure(with: post)
 
@@ -498,7 +490,7 @@ class PostCardCellTests: CoreDataTestCase {
     }
 
     func testShowsUnsavedChangesMessageWhenPostHasAutosave() {
-        let post = PostBuilder(context).with(remoteStatus: .sync).autosaved().build()
+        let post = PostBuilder(mainContext).with(remoteStatus: .sync).autosaved().build()
 
         postCell.configure(with: post)
 

--- a/WordPress/WordPressTest/PostListFilterTests.swift
+++ b/WordPress/WordPressTest/PostListFilterTests.swift
@@ -3,19 +3,6 @@ import XCTest
 import Nimble
 
 class PostListFilterTests: CoreDataTestCase {
-    private var context: NSManagedObjectContext!
-
-    override func setUp() {
-        super.setUp()
-
-        context = contextManager.newDerivedContext()
-    }
-
-    override func tearDown() {
-        super.tearDown()
-        context = nil
-    }
-
     func testSortDescriptorForPublished() {
         let filter = PostListFilter.publishedFilter()
         let descriptors = filter.sortDescriptors
@@ -208,7 +195,7 @@ private extension PostListFilterTests {
     func createPost(_ status: BasePost.Status,
                     hasRemote: Bool = false,
                     statusAfterSync: BasePost.Status? = nil) -> Post {
-        let post = Post(context: context)
+        let post = Post(context: mainContext)
         post.status = status
         post.statusAfterSync = statusAfterSync
 

--- a/WordPress/WordPressTest/ReaderCardTests.swift
+++ b/WordPress/WordPressTest/ReaderCardTests.swift
@@ -4,21 +4,13 @@ import Nimble
 @testable import WordPress
 
 class ReaderCardTests: CoreDataTestCase {
-    private var testContext: NSManagedObjectContext!
-
-    override func setUp() {
-        super.setUp()
-
-        testContext = contextManager.newDerivedContext()
-    }
-
     /// Create a Card of the type post from a RemoteReaderCard
     ///
     func testCreateCardPostFromRemote() {
         let expectation = self.expectation(description: "Create a Reader Card of type post")
 
         remoteCard(ofType: .post) { remoteCard in
-            let card = ReaderCard(context: self.testContext, from: remoteCard)
+            let card = ReaderCard(context: self.mainContext, from: remoteCard)
 
             expect(card?.post).toNot(beNil())
             expect(card?.post?.postTitle).to(equal("Pats, Please"))
@@ -35,7 +27,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Create a Reader Card of type interests")
 
         remoteCard(ofType: .interests) { remoteCard in
-            let card = ReaderCard(context: self.testContext, from: remoteCard)
+            let card = ReaderCard(context: self.mainContext, from: remoteCard)
             let topics = card?.topicsArray
 
             expect(topics?.count).to(equal(2))
@@ -53,7 +45,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Create a Reader Card of type sites")
 
         remoteCard(ofType: .sites) { remoteCard in
-            let card = ReaderCard(context: self.testContext, from: remoteCard)
+            let card = ReaderCard(context: self.mainContext, from: remoteCard)
             let topics = card?.sitesArray
 
             expect(topics?.count).to(equal(1))
@@ -71,7 +63,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Don't create a Reader Card")
 
         remoteCard(ofType: .unknown) { remoteCard in
-            let card = ReaderCard(context: self.testContext, from: remoteCard)
+            let card = ReaderCard(context: self.mainContext, from: remoteCard)
 
             expect(card).to(beNil())
             expectation.fulfill()

--- a/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
+++ b/WordPress/WordPressTest/Services/PostCoordinatorFailedPostsFetcherTests.swift
@@ -4,21 +4,17 @@ import XCTest
 @testable import WordPress
 
 class PostCoordinatorFailedPostsFetcherTests: CoreDataTestCase {
-    private var context: NSManagedObjectContext!
-
     private var fetcher: PostCoordinator.FailedPostsFetcher!
 
     override func setUp() {
         super.setUp()
 
-        context = contextManager.newDerivedContext()
-        fetcher = PostCoordinator.FailedPostsFetcher(context)
+        fetcher = PostCoordinator.FailedPostsFetcher(mainContext)
     }
 
     override func tearDown() {
         super.tearDown()
         fetcher = nil
-        context = nil
     }
 
     func testItReturnsPostsThatCanBeAutoUploadedOrAutoSaved() {
@@ -59,7 +55,7 @@ private extension PostCoordinatorFailedPostsFetcherTests {
                     remoteStatus: AbstractPostRemoteStatus = .failed,
                     hasRemote: Bool = false,
                     blog: Blog? = nil) -> Post {
-        let post = Post(context: context)
+        let post = Post(context: mainContext)
         post.status = status
         post.remoteStatus = remoteStatus
 
@@ -77,7 +73,7 @@ private extension PostCoordinatorFailedPostsFetcherTests {
     }
 
     func createBlog(supportsWPComAPI: Bool) -> Blog {
-        let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: context) as! Blog
+        let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: mainContext) as! Blog
 
         if supportsWPComAPI {
             blog.supportsWPComAPI()

--- a/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Utils/PostNoticeViewModelTests.swift
@@ -45,21 +45,12 @@ class PostNoticeViewModelTests: CoreDataTestCase {
         }
     }
 
-    private var context: NSManagedObjectContext!
-
     // MARK: - Test Setup
 
     override func setUp() {
         super.setUp()
 
         contextManager.useAsSharedInstance(untilTestFinished: self)
-        context = contextManager.newDerivedContext()
-    }
-
-    override func tearDown() {
-        context = nil
-
-        super.tearDown()
     }
 
     // MARK: - Expectations
@@ -227,13 +218,13 @@ class PostNoticeViewModelTests: CoreDataTestCase {
 
     func testFailedPublishedPostsCancelButtonWillCancelAutoUpload() {
         // Given
-        let post = PostBuilder(context)
+        let post = PostBuilder(mainContext)
             .published()
             .with(title: "Dr. Ed Simonis")
             .with(remoteStatus: .failed)
             .confirmedAutoUpload()
             .build()
-        try! context.save()
+        try! mainContext.save()
 
         let postCoordinator = MockPostCoordinator()
         let notice = PostNoticeViewModel(post: post, postCoordinator: postCoordinator).notice
@@ -247,13 +238,13 @@ class PostNoticeViewModelTests: CoreDataTestCase {
 
     func testFailedPublishedUploadedDraftPostsPublishButtonWillMarkForAutoUpload() {
         // Given
-        let post = PostBuilder(contextManager.mainContext)
+        let post = PostBuilder(mainContext)
             .drafted()
             .with(title: "I've been drafted!")
             .withRemote()
             .with(remoteStatus: .sync)
             .build()
-        try! context.save()
+        try! mainContext.save()
 
         let postCoordinator = MockPostCoordinator()
         let notice = PostNoticeViewModel(post: post, postCoordinator: postCoordinator).notice
@@ -266,7 +257,7 @@ class PostNoticeViewModelTests: CoreDataTestCase {
     }
 
     private func createPost(_ status: BasePost.Status, hasRemote: Bool = false, autoUploadAttemptsCount: Int = 0) -> Post {
-        var builder = PostBuilder(context)
+        var builder = PostBuilder(mainContext)
             .with(title: UUID().uuidString)
             .with(status: status)
             .with(remoteStatus: .failed)

--- a/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Post/Views/PostCardStatusViewModelTests.swift
@@ -6,59 +6,52 @@ import XCTest
 private typealias ButtonGroups = PostCardStatusViewModel.ButtonGroups
 
 class PostCardStatusViewModelTests: CoreDataTestCase {
-    private var context: NSManagedObjectContext!
-
-    override func setUp() {
-        super.setUp()
-        context = contextManager.newDerivedContext()
-    }
-
     func testExpectedButtonGroupsForVariousPostAttributeCombinations() {
         // Arrange
         let expectations: [(String, Post, ButtonGroups)] = [
             (
                 "Draft with remote",
-                PostBuilder(context).drafted().withRemote().build(),
+                PostBuilder(mainContext).drafted().withRemote().build(),
                 ButtonGroups(primary: [.edit, .view, .more], secondary: [.publish, .duplicate, .copyLink, .trash])
             ),
             (
                 "Draft that was not uploaded to the server",
-                PostBuilder(context).drafted().with(remoteStatus: .failed).build(),
+                PostBuilder(mainContext).drafted().with(remoteStatus: .failed).build(),
                 ButtonGroups(primary: [.edit, .publish, .more], secondary: [.duplicate, .copyLink, .trash])
             ),
             (
                 "Draft with remote and confirmed local changes",
-                PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                PostBuilder(mainContext).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.publish, .duplicate, .copyLink, .trash])
             ),
             (
                 "Draft with remote and canceled local changes",
-                PostBuilder(context).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().cancelledAutoUpload().build(),
+                PostBuilder(mainContext).drafted().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().cancelledAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .publish, .more], secondary: [.duplicate, .copyLink, .trash])
             ),
             (
                 "Local published draft with confirmed auto-upload",
-                PostBuilder(context).published().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                PostBuilder(mainContext).published().with(remoteStatus: .failed).confirmedAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.duplicate, .moveToDraft, .copyLink, .trash])
             ),
             (
                 "Local published draft with canceled auto-upload",
-                PostBuilder(context).published().with(remoteStatus: .failed).build(),
+                PostBuilder(mainContext).published().with(remoteStatus: .failed).build(),
                 ButtonGroups(primary: [.edit, .publish, .more], secondary: [.duplicate, .moveToDraft, .copyLink, .trash])
             ),
             (
                 "Published post",
-                PostBuilder(context).published().withRemote().build(),
+                PostBuilder(mainContext).published().withRemote().build(),
                 ButtonGroups(primary: [.edit, .view, .more], secondary: [.stats, .share, .duplicate, .moveToDraft, .copyLink, .trash])
             ),
             (
                 "Published post with local confirmed changes",
-                PostBuilder(context).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
+                PostBuilder(mainContext).published().withRemote().with(remoteStatus: .failed).confirmedAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .cancelAutoUpload, .more], secondary: [.stats, .share, .duplicate, .moveToDraft, .copyLink, .trash])
             ),
             (
                 "Post with the max number of auto uploades retry reached",
-                PostBuilder(context).with(remoteStatus: .failed)
+                PostBuilder(mainContext).with(remoteStatus: .failed)
                     .with(autoUploadAttemptsCount: 3).confirmedAutoUpload().build(),
                 ButtonGroups(primary: [.edit, .retry, .more], secondary: [.publish, .duplicate, .moveToDraft, .copyLink, .trash])
             ),
@@ -81,7 +74,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     /// If the post fails to upload and there is internet connectivity, show "Upload failed" message
     ///
     func testReturnFailedMessageIfPostFailedAndThereIsConnectivity() {
-        let post = PostBuilder(context).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: true)
 
@@ -92,7 +85,7 @@ class PostCardStatusViewModelTests: CoreDataTestCase {
     /// If the post fails to upload and there is NO internet connectivity, show a message that we'll publish when the user is back online
     ///
     func testReturnWillUploadLaterMessageIfPostFailedAndThereIsConnectivity() {
-        let post = PostBuilder(context).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
+        let post = PostBuilder(mainContext).revision().with(remoteStatus: .failed).confirmedAutoUpload().build()
 
         let viewModel = PostCardStatusViewModel(post: post, isInternetReachable: false)
 


### PR DESCRIPTION
## Changes

As declared in the code, `performAndSave` functions are preferred over the `newDerivedContext` function. I think this deprecation would make it a bit clear that we should pass `CoreDataStack` around, rather than `NSManagedObjectContext` instances.

This deprecation of coursed introduced a bunch of new warnings. I've "resolved" those in Objective-C files by making the compiler ignoring the deprecation flag. However, I can't do the same to the ones in Swift files since there are no equivalent feature in Swift. As a result, there about 10 new warnings introduced by this PR.

I also removed all usages of `newDerivedContext` in unit tests and replaced it with `mainContext`. I don't think it's necessarily useful to use derived context in unit tests. Please let me know if I missed anything.

## Test instructions

We're good if CI jobs pass since there is no app code behavior changed in this PR.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
