### PR TITLE
Replace a couple usages of `newDerivedContext` with `performAndSave`

### DIFF
--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -221,8 +221,7 @@ class MediaFileManager: NSObject {
     /// Removes any local Media files, except any Media matching the predicate.
     ///
     fileprivate func purgeMediaFiles(exceptMedia predicate: NSPredicate, onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
-        let context = ContextManager.sharedInstance().newDerivedContext()
-        context.perform {
+        ContextManager.shared.performAndSave { context in
             let fetch = NSFetchRequest<NSDictionary>(entityName: Media.classNameWithoutNamespaces())
             fetch.predicate = predicate
             fetch.resultType = .dictionaryResultType
@@ -230,31 +229,28 @@ class MediaFileManager: NSObject {
             let localThumbnailURLProperty = #selector(getter: Media.localThumbnailURL).description
             fetch.propertiesToFetch = [localURLProperty,
                                        localThumbnailURLProperty]
-            do {
-                let mediaToKeep = try context.fetch(fetch)
-                var filesToKeep: Set<String> = []
-                for dictionary in mediaToKeep {
-                    if let localPath = dictionary[localURLProperty] as? String,
-                        let localURL = URL(string: localPath) {
-                        filesToKeep.insert(localURL.lastPathComponent)
-                    }
-                    if let localThumbnailPath = dictionary[localThumbnailURLProperty] as? String,
-                        let localThumbnailURL = URL(string: localThumbnailPath) {
-                        filesToKeep.insert(localThumbnailURL.lastPathComponent)
-                    }
+
+            let mediaToKeep = try context.fetch(fetch)
+            var filesToKeep: Set<String> = []
+            for dictionary in mediaToKeep {
+                if let localPath = dictionary[localURLProperty] as? String,
+                    let localURL = URL(string: localPath) {
+                    filesToKeep.insert(localURL.lastPathComponent)
                 }
-                try self.purgeDirectory(exceptFiles: filesToKeep)
-                if let onCompletion = onCompletion {
-                    DispatchQueue.main.async {
-                        onCompletion()
-                    }
+                if let localThumbnailPath = dictionary[localThumbnailURLProperty] as? String,
+                    let localThumbnailURL = URL(string: localThumbnailPath) {
+                    filesToKeep.insert(localThumbnailURL.lastPathComponent)
                 }
-            } catch {
-                DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
-                if let onError = onError {
-                    DispatchQueue.main.async {
-                        onError(error)
-                    }
+            }
+            try self.purgeDirectory(exceptFiles: filesToKeep)
+        } completion: { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    onCompletion?()
+                case let .failure(error):
+                    DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
+                    onError?(error)
                 }
             }
         }


### PR DESCRIPTION
Uses the new writer API, instead of creating a new context.

I think these changes are pretty safe since they don't change the code behaviour.

Tip: turn on ["hide whitespaces"](https://github.com/wordpress-mobile/WordPress-iOS/pull/19390/files?w=1) for easier code review.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
