### PR TITLE
Stats: Show Views Visitors for this week instead of last 7 days

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -5,10 +5,16 @@ import Foundation
 ///
 class SiteStatsImmuTableRows {
 
-    static func viewVisitorsImmuTableRows(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, periodDate: Date, statsLineChartViewDelegate: StatsLineChartViewDelegate?, siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) -> [ImmuTableRow] {
+    /// Helper method to create the rows for the Views and Visitors section
+    ///
+    static func viewVisitorsImmuTableRows(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?,
+                                          periodDate: Date,
+                                          periodEndDate: Date? = nil,
+                                          statsLineChartViewDelegate: StatsLineChartViewDelegate?,
+                                          siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
 
-        let viewsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .views)
+        let viewsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .views, periodEndDate: periodEndDate)
         let viewsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewViews.tabTitle,
                 segmentData: viewsData.count,
                 segmentPrevData: viewsData.prevCount,
@@ -20,7 +26,7 @@ class SiteStatsImmuTableRows {
                 accessibilityHint: StatSection.periodOverviewViews.tabAccessibilityHint,
                 differencePercent: viewsData.percentage)
 
-        let visitorsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .visitors)
+        let visitorsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .visitors, periodEndDate: periodEndDate)
         let visitorsSegmentData = StatsSegmentedControlData(segmentTitle: StatSection.periodOverviewVisitors.tabTitle,
                 segmentData: visitorsData.count,
                 segmentPrevData: visitorsData.prevCount,
@@ -36,7 +42,7 @@ class SiteStatsImmuTableRows {
         var lineChartStyling = [LineChartStyling]()
 
         if let chartData = statsSummaryTimeIntervalData {
-            let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(chartData)
+            let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(chartData, periodEndDate: periodEndDate)
             let viewsChart = InsightsLineChart(data: splitSummaryTimeIntervalData, filterDimension: .views)
             lineChartData.append(contentsOf: viewsChart.lineChartData)
             lineChartStyling.append(contentsOf: viewsChart.lineChartStyling)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -399,12 +399,12 @@ class SiteStatsInsightsViewModel: Observable {
         pinnedItemStore?.markPinnedItemAsHidden(item)
     }
 
-    static func intervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, summaryType: StatsSummaryType) -> (count: Int, prevCount: Int, difference: Int, percentage: Int) {
+    static func intervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, summaryType: StatsSummaryType, periodEndDate: Date? = nil) -> (count: Int, prevCount: Int, difference: Int, percentage: Int) {
         guard let statsSummaryTimeIntervalData = statsSummaryTimeIntervalData else {
             return (0, 0, 0, 0)
         }
 
-        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(statsSummaryTimeIntervalData)
+        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(statsSummaryTimeIntervalData, periodEndDate: periodEndDate)
 
         var currentCount: Int = 0
         var previousCount: Int = 0
@@ -853,20 +853,60 @@ extension SiteStatsInsightsViewModel: AsyncBlocksLoadable {
         return insightsStore
     }
 
-    public static func splitStatsSummaryTimeIntervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData) ->
+
+    /// Splits the SummaryData into an array of 2 weeks, one for the current week and one for the previous week
+    ///
+    /// - Parameters:
+    ///     - statsSummaryTimeIntervalData: summarydata to split
+    ///     - periodEndDate: when the current period is not nil it will be used to pad forward until this date
+    /// - Returns: an array of 2 weeks
+    ///
+    public static func splitStatsSummaryTimeIntervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData, periodEndDate: Date? = nil) ->
             [StatsSummaryTimeIntervalDataAsAWeek] {
-        switch statsSummaryTimeIntervalData.summaryData.count {
+
+        var summaryData = statsSummaryTimeIntervalData.summaryData
+
+        if let periodEndDate = periodEndDate {
+            summaryData = splitStatsSummaryTimeIntervalDataPadForward(statsSummaryTimeIntervalData, periodEndDate: periodEndDate)
+        }
+
+        return splitStatsSummaryData(summaryData)
+    }
+
+    /// When a periodEndDate is defined we pad forward the data to match the weeks view user experience on WordPress.com
+    ///
+    public static func splitStatsSummaryTimeIntervalDataPadForward(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData, periodEndDate: Date) ->
+            [StatsSummaryData] {
+        var summaryData = statsSummaryTimeIntervalData.summaryData
+        let daysElapsedSincePeriodEndDate = Calendar.autoupdatingCurrent.dateComponents([.day], from: statsSummaryTimeIntervalData.periodEndDate, to: periodEndDate).day ?? 0
+        if daysElapsedSincePeriodEndDate > 0 {
+            for i in 1...daysElapsedSincePeriodEndDate {
+                if let date = Calendar.autoupdatingCurrent.date(byAdding: .day, value: i, to: statsSummaryTimeIntervalData.periodEndDate) {
+                    summaryData.append(StatsSummaryData(period: .day,
+                                                        periodStartDate: date,
+                                                        viewsCount: 0,
+                                                        visitorsCount: 0,
+                                                        likesCount: 0,
+                                                        commentsCount: 0))
+                }
+            }
+        }
+
+        return summaryData
+    }
+
+    public static func splitStatsSummaryData(_ summaryData: [StatsSummaryData]) -> [StatsSummaryTimeIntervalDataAsAWeek] {
+        var summaryData = summaryData
+
+        switch summaryData.count {
         case let count where count == Constants.fourteenDays:
             // normal case api returns 14 rows
-            let summaryData = statsSummaryTimeIntervalData.summaryData[0..<Constants.fourteenDays]
-            return createStatsSummaryTimeIntervalDataAsAWeeks(summaryData: Array(summaryData))
+            return createStatsSummaryTimeIntervalDataAsAWeeks(summaryData: Array(summaryData[0..<Constants.fourteenDays]))
         case let count where count > Constants.fourteenDays:
             // when more than 14 rows we take the last 14 rows for most recent data
-            let summaryData = statsSummaryTimeIntervalData.summaryData[count-Constants.fourteenDays..<count]
-            return createStatsSummaryTimeIntervalDataAsAWeeks(summaryData: Array(summaryData))
+            return createStatsSummaryTimeIntervalDataAsAWeeks(summaryData: Array(summaryData[count-Constants.fourteenDays..<count]))
         case let count where count < Constants.fourteenDays:
             // when 0 to 14 rows presume the user could be new / doesn't have enough data.  Pad 0's to prev week
-            var summaryData = statsSummaryTimeIntervalData.summaryData
             summaryData.reverse()
 
             guard var date = summaryData.last?.periodStartDate else {
@@ -877,11 +917,11 @@ extension SiteStatsInsightsViewModel: AsyncBlocksLoadable {
                 if let newPeriodStartDate = Calendar.autoupdatingCurrent.date(byAdding: .day, value: -1, to: date) {
                     date = newPeriodStartDate
                     summaryData.append(StatsSummaryData(period: .day,
-                            periodStartDate: newPeriodStartDate,
-                            viewsCount: 0,
-                            visitorsCount: 0,
-                            likesCount: 0,
-                            commentsCount: 0))
+                                                        periodStartDate: newPeriodStartDate,
+                                                        viewsCount: 0,
+                                                        visitorsCount: 0,
+                                                        likesCount: 0,
+                                                        commentsCount: 0))
                 }
             }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -276,10 +276,17 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     let referrersData = referrersRowData()
                     let chartViewModel = StatsReferrersChartViewModel(referrers: referrers)
                     let chartView: UIView? = referrers.totalReferrerViewsCount > 0 ?  chartViewModel.makeReferrersChartView() : nil
+                    let week = StatsPeriodHelper().weekIncludingDate(periodSummary.periodEndDate)
 
                     // Views Visitors
-                    rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!,
-                            statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
+                    // when selectedDate is < end of the week we pad forward days to match the weeks view on WordPress.com
+                    if let weekEnd = week?.weekEnd, weekEnd > periodSummary.periodEndDate {
+                        rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!, periodEndDate: weekEnd,
+                                                                                                 statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
+                    } else {
+                        rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!,
+                                                                                                 statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
+                    }
 
                     // Referrers
                     var referrersRow = TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,


### PR DESCRIPTION
This PR adds functionality so that when a user navigates to show Views Visitors information for this week, it should show this week's data instead of the last 7 days.  This makes the Views Visitors information for this week consistent with the Web

Fixes #19345

See example screenshots comparing this PR with web

Visitors
![image](https://user-images.githubusercontent.com/88816724/193639623-f01144c8-c79e-4a9d-936d-4cf821d3921c.png)

Views
![image](https://user-images.githubusercontent.com/88816724/193639708-cec0a447-cb4c-49b1-9dcf-ac7030bad2b7.png)



To test:
	1. Enable new stats feature flags
	2. Go to Stats screen -> Insights
	3. Tab Week on the Views & Visitors chart
	4. The Views and Visitors stats data should be consistent with the Web and the chart data should be inline with the DateRange header at top of screen
Test for WordPress and Jetpack


## Regression Notes
1. Potential unintended areas of impact
Stats

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tested and added unit test

3. What automated tests I added (or what prevented me from doing so)
Added a unit test

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
