### PR TITLE
Reimplement invaliding `Notification` attributes cache

### DIFF
--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -413,7 +413,7 @@ extension Notification: Notifiable {
 }
 
 private class NotificationCachedAttributesObserver: NSObject {
-    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let keyPath, let notification = object as? Notification, Notification.cachedAttributes.contains(keyPath) else {
             return
         }

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -81,7 +81,7 @@ class Notification: NSManagedObject {
     ///
     fileprivate var cachedHeaderAndBodyContentGroups: [FormattableContentGroup]?
 
-    private var cachedAttributesObserver: NotificationCachedAttributesObserver? = nil
+    private var cachedAttributesObserver: NotificationCachedAttributesObserver?
 
     /// Array that contains the Cached Property Names
     ///
@@ -91,10 +91,11 @@ class Notification: NSManagedObject {
         super.awakeFromFetch()
 
         if cachedAttributesObserver == nil {
-            cachedAttributesObserver = NotificationCachedAttributesObserver()
+            let observer = NotificationCachedAttributesObserver()
             for attr in Notification.cachedAttributes {
-                addObserver(cachedAttributesObserver!, forKeyPath: attr, options: [.prior], context: nil)
+                addObserver(observer, forKeyPath: attr, options: [.prior], context: nil)
             }
+            cachedAttributesObserver = observer
         }
     }
 

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -93,7 +93,7 @@ class Notification: NSManagedObject {
         if cachedAttributesObserver == nil {
             cachedAttributesObserver = NotificationCachedAttributesObserver()
             for attr in Notification.cachedAttributes {
-                addObserver(cachedAttributesObserver!, forKeyPath: attr, context: nil)
+                addObserver(cachedAttributesObserver!, forKeyPath: attr, options: [.prior], context: nil)
             }
         }
     }
@@ -417,6 +417,10 @@ extension Notification: Notifiable {
 private class NotificationCachedAttributesObserver: NSObject {
     override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
         guard let keyPath, let notification = object as? Notification, Notification.cachedAttributes.contains(keyPath) else {
+            return
+        }
+
+        guard (change?[.notificationIsPriorKey] as? NSNumber)?.boolValue == true else {
             return
         }
 

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -81,18 +81,20 @@ class Notification: NSManagedObject {
     ///
     fileprivate var cachedHeaderAndBodyContentGroups: [FormattableContentGroup]?
 
-    private let cachedAttributesObserver: NotificationCachedAttributesObserver? = nil
+    private var cachedAttributesObserver: NotificationCachedAttributesObserver? = nil
 
     /// Array that contains the Cached Property Names
     ///
     fileprivate static let cachedAttributes = Set(arrayLiteral: "body", "header", "subject", "timestamp")
 
-    override init(entity: NSEntityDescription, insertInto context: NSManagedObjectContext?) {
-        super.init(entity: entity, insertInto: context)
+    override func awakeFromFetch() {
+        super.awakeFromFetch()
 
-        cachedAttributesObserver = NotificationCachedAttributesObserver()
-        for attr in Notification.cachedAttributes {
-            addObserver(cachedAttributesObserver!, forKeyPath: attr, context: nil)
+        if cachedAttributesObserver == nil {
+            cachedAttributesObserver = NotificationCachedAttributesObserver()
+            for attr in Notification.cachedAttributes {
+                addObserver(cachedAttributesObserver!, forKeyPath: attr, context: nil)
+            }
         }
     }
 


### PR DESCRIPTION
The original implementation overrides `NSManagedObject.willChangeValue` which must not be overridden as mentioned in [the API doc](https://developer.apple.com/documentation/coredata/nsmanagedobject/1506229-willchangevalue).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
