### PR TITLE
Fix the prompt to install jetpack not shown when logout WP account

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] [Jetpack-only] We added a new landing screen with a cool animation that responds to device motion! [#19251, #19264, #19277, #19381, #19404, #19410, #19432, #19434, #19442, #19443, #19468, #19469]
 * [*] [internal] Database access change: the 'new Core Data context structure' feature flag is turned on by default. [#19433]
+* [*] Fixed an issue where the notification tab's prompt view doesn't match the login account [#19403]
 
 21.0
 -----

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -411,6 +411,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
+        RecentSitesService().touch(blog: mainBlog)
         showSitePicker(for: mainBlog)
         showBlogDetails(for: mainBlog)
         updateNavigationTitle(for: mainBlog)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+JetpackPrompt.swift
@@ -17,6 +17,7 @@ extension NotificationsViewController {
             let controller = JetpackLoginViewController(blog: blog)
             controller.promptType = .notifications
             addChild(controller)
+            tableView.setContentOffset(.zero, animated: false)
             tableView.addSubview(withFadeAnimation: controller.view)
             controller.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -2083,6 +2083,9 @@ extension NotificationsViewController: WPScrollableViewController {
 //
 extension NotificationsViewController: JPScrollViewDelegate {
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        guard JetpackBrandingVisibility.all.enabled else {
+            return
+        }
         processJetpackBannerVisibility(scrollView)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1543,6 +1543,7 @@ private extension NotificationsViewController {
 
     func addNoResultsToView() {
         addChild(noResultsViewController)
+        tableView.setContentOffset(.zero, animated: false)
         tableView.insertSubview(noResultsViewController.view, belowSubview: tableHeaderView)
         noResultsViewController.view.frame = tableView.frame
         setupNoResultsViewConstraints()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -627,17 +627,20 @@ private extension NotificationsViewController {
 //
 extension NotificationsViewController {
 
-    /// Called on view load to determine whether the Jetpack banner should be shown on the view
+    /// Called on viewDidLoad/defaultAccountDidChange to determine whether the Jetpack banner should be shown on the view
     /// Also called in the completion block of the JetpackLoginViewController to show the banner once the user connects to a .com account
     func configureJetpackBanner() {
-        guard JetpackBrandingVisibility.all.enabled else {
+        guard isViewLoaded else {
+            return
+        }
+        jetpackBannerView.isHidden = !JetpackBrandingVisibility.all.enabled
+        guard jetpackBannerView.buttonAction == nil else {
             return
         }
         jetpackBannerView.buttonAction = { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .notifications)
         }
-        jetpackBannerView.isHidden = false
         addTranslationObserver(jetpackBannerView)
     }
 }
@@ -698,6 +701,7 @@ private extension NotificationsViewController {
         resetNotifications()
         resetLastSeenTime()
         resetApplicationBadge()
+        configureJetpackBanner()
         guard isViewLoaded == true && view.window != nil else {
             needsReloadResults = true
             return


### PR DESCRIPTION
Fixes #19398

| -- | before | after |
| -- | -- | -- |
| iPhone | ![Simulator Screen Shot - iPhone 14 - 2022-10-06 at 02 53 18](https://user-images.githubusercontent.com/10288494/194139502-d9865a14-a0b5-4bbc-b31f-f5ae6b33a329.png) | ![Simulator Screen Shot - iPhone 14 - 2022-10-06 at 02 10 36](https://user-images.githubusercontent.com/10288494/194137937-990785df-1c6a-43f5-902c-4749ae04cff2.png) |
| iPad | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-10-06 at 02 49 06](https://user-images.githubusercontent.com/10288494/194138790-01d4f39e-4341-4bff-a82a-928f398e4074.png) | ![Simulator Screen Shot - iPad Pro (9 7-inch) - 2022-10-06 at 02 13 56](https://user-images.githubusercontent.com/10288494/194137988-c9970ffa-8c2f-416c-b346-bdf2647f55b1.png) |

## Root Cause
When the user logout the WP.com account. It will trigger `MySiteViewController` [showBlogDetailsForMainBlogOrNoSites()](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Blog/My%20Site/MySiteViewController.swift#L408) to display an available blog on the page. But it doesn't update the `RecentSitesService` for blog usage history.

So, when the `Notifications` tab appear, it couldn't get the correct [last-used](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController%2BJetpackPrompt.swift#L4) blog for displaying jetpack prompt.

## Fix
801e14bb08720a697c0615454b06ec5579af9394 :
- update `RecentSitesService`'s history when the `MySiteViewController` change it's blog.

ea0339c3b25523d90aa6f5a1af4b3d0c2d9cdee2 :
- At `showBlogDetailsForMainBlogOrNoSites` method, and it should call `createFABIfNeeded`, `fetchPrompt(for: newBlog)` when changing blog. So remove the duplicate code by using `didSet` in `self.blog`

04a9c84e4010afa3a3bddbcd968bb5333e41c0da 
aff4383ab2a1ec311b8ed7d6320a5f2125d34d68 :
- fix Jetpack banner hidden logic when scrolling
- update jetpack banner appearance when `Notifications` tab `viewDidLoad`, `defaultAccountDidChange`

97bb5d50c4a664758d05cf29f07d227640a21d48 : 
- Fix empty view not in the center if the tableView has been scroll before logout.

| before | after |
| -- | -- |
| ![Simulator Screen Shot - iPhone 14 - 2022-10-08 at 02 40 17](https://user-images.githubusercontent.com/10288494/194640969-2a5550f7-cedb-4b4b-b8ac-fc138f0b9faa.png) | ![Simulator Screen Shot - iPhone 14 - 2022-10-06 at 02 10 36](https://user-images.githubusercontent.com/10288494/194640905-6fc8fbab-0464-42f5-a15f-8795cbc5ca0d.png) |


## To test:
1. With a clean install of the WordPress app, log into a self-hosted site that doesn't have Jetpack connected
2. Tap the "Notifications" tab
3. Observe the button to install Jetpack and the text "To get helpful notifications on your phone from your WordPress site..."
4. Tap "My Site" and present the "Me" view by tapping the avatar at the top right
5. Log into a WordPress.com account
6. Tap the "Notifications" tab
7. Observe a list of notifications and the "Jetpack powered" banner at the bottom (if no notifications exist for the account, you'll see a "No notifications yet" message)
8. Return to "My Site" -> "Me" and log out of the WordPress.com account
9. Tap the "Notifications" tab
10. observe jetpack prompt and without the "Jetpack powered" banner at the bottom

## Related Issue:
Currently, there is a bug in the onboarding login process. ([issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/19419)). 
If you select `skip` on the onboarding page `What would you like to focus on first?`.
The onboarding process will cause a wrong history of `RecentSitesService` and let the `Notifications` tab won't change to the `Install Jetpack` view after you logout,. 
It's a known issue and will fix it later with the [issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/19419).

## Regression Notes
1. Potential unintended areas of impact
- The jetpack banner on the `Notifications` tab
- switch account behavior on `My Site` tab

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing on [iPhone/iPad] with [WordPress.com/self-hosted] account switching.

3. What automated tests I added (or what prevented me from doing so)
NA, This is a visual fix.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
