### PR TITLE
Stats Revamp: Two Column Cell with View More button cuts off

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -10,7 +10,6 @@ class TwoColumnCell: StatsBaseCell, NibLoadable, Accessible {
     @IBOutlet weak var viewMoreLabel: UILabel!
     @IBOutlet weak var viewMoreButton: UIButton!
     @IBOutlet weak var bottomSeparatorLine: UIView!
-    @IBOutlet weak var rowsStackViewBottomConstraint: NSLayoutConstraint!
 
     private typealias Style = WPStyleGuide.Stats
     private var dataRows = [StatsTwoColumnRowData]()
@@ -84,7 +83,6 @@ private extension TwoColumnCell {
     func toggleViewMore() {
         let showViewMore = !dataRows.isEmpty && statSection == .insightsAnnualSiteStats
         viewMoreView.isHidden = !showViewMore
-        rowsStackViewBottomConstraint?.isActive = showViewMore
     }
 
     @IBAction func didTapViewMore(_ sender: UIButton) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.xib
@@ -17,48 +17,53 @@
                 <rect key="frame" x="0.0" y="0.0" width="375" height="395"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="53U-Zk-ZGa" userLabel="Rows Stack View">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="350.5"/>
-                    </stackView>
-                    <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Cfy-Hl-Mjq" userLabel="View More View">
-                        <rect key="frame" x="0.0" y="350.5" width="375" height="44"/>
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Xi5-qb-AP6" userLabel="Elements Stack View">
+                        <rect key="frame" x="0.0" y="0.5" width="375" height="394"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1To-pb-uoT" userLabel="View More Label">
-                                <rect key="frame" x="16" y="12" width="319" height="20"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="YNj-gn-f07" userLabel="Disclosure Image">
-                                <rect key="frame" x="351" y="15.5" width="8" height="13"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="53U-Zk-ZGa" userLabel="Rows Stack View">
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="197"/>
+                            </stackView>
+                            <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Cfy-Hl-Mjq" userLabel="View More View">
+                                <rect key="frame" x="0.0" y="197" width="375" height="197"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="View more" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1To-pb-uoT" userLabel="View More Label">
+                                        <rect key="frame" x="16" y="12" width="319" height="173"/>
+                                        <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="disclosure-chevron" translatesAutoresizingMaskIntoConstraints="NO" id="YNj-gn-f07" userLabel="Disclosure Image">
+                                        <rect key="frame" x="351" y="92" width="8" height="13"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="8" id="8eb-ZD-fXJ"/>
+                                            <constraint firstAttribute="height" constant="13" id="qmf-Yb-GSl"/>
+                                        </constraints>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uon-fL-Zcd" userLabel="View More Button">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="197"/>
+                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                        <connections>
+                                            <action selector="didTapViewMore:" destination="oVo-l2-Jhn" eventType="touchUpInside" id="gKm-HN-PCI"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="8" id="8eb-ZD-fXJ"/>
-                                    <constraint firstAttribute="height" constant="13" id="qmf-Yb-GSl"/>
+                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="44e-cc-T7y"/>
+                                    <constraint firstItem="uon-fL-Zcd" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" id="KZ2-hk-YCD"/>
+                                    <constraint firstItem="1To-pb-uoT" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" constant="12" id="Qwi-ZL-iXt"/>
+                                    <constraint firstAttribute="trailing" secondItem="YNj-gn-f07" secondAttribute="trailing" constant="16" id="SYx-K1-v17"/>
+                                    <constraint firstAttribute="trailing" secondItem="uon-fL-Zcd" secondAttribute="trailing" id="Vmf-wW-kgh"/>
+                                    <constraint firstItem="uon-fL-Zcd" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" id="Waq-GV-Y7c"/>
+                                    <constraint firstItem="YNj-gn-f07" firstAttribute="leading" secondItem="1To-pb-uoT" secondAttribute="trailing" constant="16" id="aEU-Da-e0s"/>
+                                    <constraint firstItem="1To-pb-uoT" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" constant="16" id="d7O-Xe-V7P"/>
+                                    <constraint firstAttribute="bottom" secondItem="1To-pb-uoT" secondAttribute="bottom" constant="12" id="jBf-At-vUw"/>
+                                    <constraint firstItem="YNj-gn-f07" firstAttribute="centerY" secondItem="Cfy-Hl-Mjq" secondAttribute="centerY" id="sgg-5x-f5z"/>
+                                    <constraint firstAttribute="bottom" secondItem="uon-fL-Zcd" secondAttribute="bottom" id="zPx-Uo-fJ0"/>
                                 </constraints>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uon-fL-Zcd" userLabel="View More Button">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                <connections>
-                                    <action selector="didTapViewMore:" destination="oVo-l2-Jhn" eventType="touchUpInside" id="gKm-HN-PCI"/>
-                                </connections>
-                            </button>
+                            </view>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                        <constraints>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="44e-cc-T7y"/>
-                            <constraint firstItem="uon-fL-Zcd" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" id="KZ2-hk-YCD"/>
-                            <constraint firstItem="1To-pb-uoT" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" constant="12" id="Qwi-ZL-iXt"/>
-                            <constraint firstAttribute="trailing" secondItem="YNj-gn-f07" secondAttribute="trailing" constant="16" id="SYx-K1-v17"/>
-                            <constraint firstAttribute="trailing" secondItem="uon-fL-Zcd" secondAttribute="trailing" id="Vmf-wW-kgh"/>
-                            <constraint firstItem="uon-fL-Zcd" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="top" id="Waq-GV-Y7c"/>
-                            <constraint firstItem="YNj-gn-f07" firstAttribute="leading" secondItem="1To-pb-uoT" secondAttribute="trailing" constant="16" id="aEU-Da-e0s"/>
-                            <constraint firstItem="1To-pb-uoT" firstAttribute="leading" secondItem="Cfy-Hl-Mjq" secondAttribute="leading" constant="16" id="d7O-Xe-V7P"/>
-                            <constraint firstAttribute="bottom" secondItem="1To-pb-uoT" secondAttribute="bottom" constant="12" id="jBf-At-vUw"/>
-                            <constraint firstItem="YNj-gn-f07" firstAttribute="centerY" secondItem="Cfy-Hl-Mjq" secondAttribute="centerY" id="sgg-5x-f5z"/>
-                            <constraint firstAttribute="bottom" secondItem="uon-fL-Zcd" secondAttribute="bottom" id="zPx-Uo-fJ0"/>
-                        </constraints>
-                    </view>
+                    </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="NTK-eu-Zrd" userLabel="Top Separator Line">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="0.5"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -76,28 +81,23 @@
                 </subviews>
                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 <constraints>
-                    <constraint firstItem="Cm8-Qw-O9e" firstAttribute="top" secondItem="Cfy-Hl-Mjq" secondAttribute="bottom" id="1qX-rv-2Jq"/>
                     <constraint firstAttribute="bottom" secondItem="Cm8-Qw-O9e" secondAttribute="bottom" id="3M7-TD-t69"/>
                     <constraint firstItem="NTK-eu-Zrd" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="7Ya-0E-IUF"/>
                     <constraint firstItem="NTK-eu-Zrd" firstAttribute="top" secondItem="aea-rN-rAD" secondAttribute="top" id="ARx-Y7-BtJ"/>
-                    <constraint firstItem="Cfy-Hl-Mjq" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="CW9-bq-3C0"/>
-                    <constraint firstItem="53U-Zk-ZGa" firstAttribute="top" secondItem="aea-rN-rAD" secondAttribute="top" id="HeU-RZ-kPi"/>
-                    <constraint firstAttribute="trailing" secondItem="53U-Zk-ZGa" secondAttribute="trailing" id="I9H-dB-FKj"/>
+                    <constraint firstAttribute="trailing" secondItem="Xi5-qb-AP6" secondAttribute="trailing" id="CoM-nd-zod"/>
+                    <constraint firstItem="Cm8-Qw-O9e" firstAttribute="top" secondItem="Xi5-qb-AP6" secondAttribute="bottom" id="Gh9-Ce-AED"/>
                     <constraint firstAttribute="trailing" secondItem="Cm8-Qw-O9e" secondAttribute="trailing" id="PzX-nO-5NH"/>
-                    <constraint firstItem="Cfy-Hl-Mjq" firstAttribute="top" secondItem="53U-Zk-ZGa" secondAttribute="bottom" id="S3E-t2-k5x"/>
-                    <constraint firstItem="53U-Zk-ZGa" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="aWs-1X-FnG"/>
-                    <constraint firstAttribute="trailing" secondItem="Cfy-Hl-Mjq" secondAttribute="trailing" id="bAa-4j-6TL"/>
+                    <constraint firstItem="Xi5-qb-AP6" firstAttribute="top" secondItem="NTK-eu-Zrd" secondAttribute="bottom" id="iPV-uy-osI"/>
                     <constraint firstAttribute="trailing" secondItem="NTK-eu-Zrd" secondAttribute="trailing" id="jHo-RQ-WZe"/>
+                    <constraint firstItem="Xi5-qb-AP6" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="qSe-fz-ZVi"/>
                     <constraint firstItem="Cm8-Qw-O9e" firstAttribute="leading" secondItem="aea-rN-rAD" secondAttribute="leading" id="s6O-Ci-p80"/>
-                    <constraint firstAttribute="bottom" secondItem="53U-Zk-ZGa" secondAttribute="bottom" priority="999" id="u0B-il-n2p"/>
                 </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="5pF-Tt-Ldy"/>
             <connections>
                 <outlet property="bottomSeparatorLine" destination="Cm8-Qw-O9e" id="aJ6-i9-r5U"/>
                 <outlet property="rowsStackView" destination="53U-Zk-ZGa" id="T8V-zp-KCA"/>
-                <outlet property="rowsStackViewBottomConstraint" destination="S3E-t2-k5x" id="Cff-fI-QJ1"/>
-                <outlet property="topConstraint" destination="HeU-RZ-kPi" id="CE0-3v-hwp"/>
+                <outlet property="topConstraint" destination="iPV-uy-osI" id="l7A-y2-I2i"/>
                 <outlet property="topSeparatorLine" destination="NTK-eu-Zrd" id="9Sq-Ea-hi8"/>
                 <outlet property="viewMoreButton" destination="uon-fL-Zcd" id="qrf-iG-gty"/>
                 <outlet property="viewMoreLabel" destination="1To-pb-uoT" id="nmB-Rf-6TI"/>


### PR DESCRIPTION
## Description

Stats Revamp: Two Column Cell with View More button cuts off

![image](https://user-images.githubusercontent.com/4062343/194526653-9fd16865-e974-47f8-862b-d2aa05b99a02.png)

It's always reproducible when the same type of cells but **without** `viewMore` button are presented as well (All-Time / Today). 

## Solution

After Deactivating / Activating constraints when deciding whether to present or not present `viewMore` button does not always layout the cell properly. 

Using `UIStackView` internally, which automatically adjusts layout then `viewMore` button is hidden. No need for any additional constraint activation logic.

## Testing instructions

### Case 1:
1. Enable `statsRevamp`
2. Open stats
3. Click settings
4. Add All-Time, Today and This Year cards
5. This Year card should appear with no information cut-off

## Regression Notes

1. Potential unintended areas of impact

Behaviour of all `TwoColumnStatsRow` using `TwoColumnCell`

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested with different types of appearance and dynamic type

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




