### PR TITLE
Stats: Fix Stats view stuck on Insights tab if the grow audience card is showing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,4 +396,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.22
+   2.3.23

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -198,12 +198,17 @@ private extension SiteStatsDashboardViewController {
 private extension SiteStatsDashboardViewController {
 
     func saveSelectedPeriodToUserDefaults() {
-        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue,
-              !insightsTableViewController.isGrowAudienceShowing else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID?.intValue else {
             return
         }
 
         let key = Self.lastSelectedStatsPeriodTypeKey(forSiteID: siteID)
+
+        guard !insightsTableViewController.isGrowAudienceShowing else {
+            UserPersistentStoreFactory.instance().set(StatsPeriodType.insights.rawValue, forKey: key)
+            return
+        }
+
         UserPersistentStoreFactory.instance().set(currentSelectedPeriod.rawValue, forKey: key)
     }
 


### PR DESCRIPTION
## Description

Fixes an issue, when the stats view is stuck on the Insights tab and switching tabs, doesn't work.

## Root cause

The issue is caused by [Stay on insights tab if Grow Audience card is showing](https://github.com/wordpress-mobile/WordPress-iOS/pull/17332) change. 
- When `isGrowAudienceShowing` is `true` we don't save the selected tab to user defaults. 
- However, it fails in cases when we already have the selected tab saved. `updatePeriodView` incorrectly assumes that the wrong tab is selected and doesn't set `periodTableViewController` in `pageViewController`.

## Solution

When `isGrowAudienceShowing` is `true`, explicitly set selected tab to `insights`.

## Testing instructions

### Case 1:
1. Fresh install app
2. Open Stats
3. Notice "A tip to grow your audience" is shown
4. Dismiss this tip
5. Select any of Days/Weeks/Months/Years
6. Come back to Menu
7. Select Stats again
8. Previously selected Days/Weeks/Months/Years tab should open
9. Open Insights
10. Notice another "A tip to grow your audience" is shown
11. Select any of Days/Weeks/Months/Years
12. The tabs should be switching successfully

## Regression Notes

1. Potential unintended areas of impact

[Stay on insights tab if Grow Audience card is showing](https://github.com/wordpress-mobile/WordPress-iOS/pull/17332)

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing scenarios

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before

https://user-images.githubusercontent.com/4062343/194577145-c89208bf-1366-4883-820c-db8d580d40ff.MP4

### After

https://user-images.githubusercontent.com/4062343/194577250-1e8a7d01-d94d-48f0-b6e4-62171c3b3557.MP4