### PR TITLE
Fix crash on tapping Account Settings menu for accounts with no sites

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -396,4 +396,4 @@ DEPENDENCIES
   xcpretty-travis-formatter
 
 BUNDLED WITH
-   2.3.22
+   2.3.23

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -112,7 +112,7 @@ private class AccountSettingsController: SettingsController {
         // If the primary site has no Site Title, then show the displayURL.
         if primarySiteName.isEmpty {
             let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.sharedInstance().mainContext)
-            primarySiteName = account?.defaultBlog.displayURL as String? ?? ""
+            primarySiteName = account?.defaultBlog?.displayURL as String? ?? ""
         }
 
         let primarySite = EditableTextRow(


### PR DESCRIPTION
Fixes #19413

## Description

Crash on tapping Account Settings menu for accounts with no sites. It happens because `defaultBlog` is nil. 

Regression from [Blog service lookup blog](https://github.com/wordpress-mobile/WordPress-iOS/pull/19366)

## Solution

Treat `defaultBlog` as an optional.

To avoid such issues in the future we could set `nullable`/`nonnull` attributes in `WPAccount.h`.

## Testing instructions

### Case 1:
1. Fresh install the app
2. Create a new account or login with an account with no sites created or added
3. Go to My Site
4. Click on Me (Avatar on the right top corner of the screen)
5. Click on Account Settings
6. It should open without a crash

## Regression Notes

1. Potential unintended areas of impact

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




