### PR TITLE
Specify in PRs whether work is behind feature flag

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,5 @@
+Is this work behind a feature flag: < Yes | No >
+
 Fixes #
 
 To test:


### PR DESCRIPTION
We'd like to easily identify whether a PR is going to be available to users or will be kept behind a feature flag until further notice.

This PR adds a sentence to the top of PRs to help authors make this information clear and visible to other contributors. Suggestions on alternatives welcome.

If we move forward with this, we should do a similar PR for Android.