### PR TITLE
Explicitly prevent `xcodebuild` from changing the binary's build number

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -6,6 +6,13 @@ SENTRY_PROJECT_SLUG_JETPACK = 'jetpack-ios'
 APPCENTER_OWNER_NAME = 'automattic'
 APPCENTER_OWNER_TYPE = 'organization'
 
+# Shared options to use when invoking `gym` / `build_app`.
+#
+# - `manageAppVersionAndBuildNumber: false` prevents `xcodebuild` from bumping
+#   the build number when extracting an archive into an IPA file. We want to
+#   use the build number we set!
+COMMON_EXPORT_OPTIONS = { manageAppVersionAndBuildNumber: false }.freeze
+
 # https://buildkite.com/docs/test-analytics/ci-environments
 TEST_ANALYTICS_ENVIRONMENT = %w[
   BUILDKITE_ANALYTICS_TOKEN
@@ -120,7 +127,7 @@ platform :ios do
       output_directory: BUILD_PRODUCTS_PATH,
       derived_data_path: DERIVED_DATA_PATH,
       export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
-      export_options: { method: 'app-store' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
     testflight(
@@ -170,7 +177,7 @@ platform :ios do
       export_team_id: get_required_env('EXT_EXPORT_TEAM_ID'),
       output_directory: BUILD_PRODUCTS_PATH,
       derived_data_path: DERIVED_DATA_PATH,
-      export_options: { method: 'app-store' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'app-store' }
     )
 
     testflight(
@@ -212,7 +219,7 @@ platform :ios do
       derived_data_path: DERIVED_DATA_PATH,
       export_team_id: get_required_env('INT_EXPORT_TEAM_ID'),
       export_method: 'enterprise',
-      export_options: { method: 'enterprise' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'enterprise' }
     )
 
     appcenter_upload(
@@ -261,7 +268,7 @@ platform :ios do
       derived_data_path: DERIVED_DATA_PATH,
       export_team_id: ENV.fetch('INT_EXPORT_TEAM_ID', nil),
       export_method: 'enterprise',
-      export_options: { method: 'enterprise' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'enterprise' }
     )
 
     appcenter_upload(
@@ -314,7 +321,7 @@ platform :ios do
       derived_data_path: DERIVED_DATA_PATH,
       export_team_id: ENV.fetch('INT_EXPORT_TEAM_ID', nil),
       export_method: 'enterprise',
-      export_options: { method: 'enterprise' }
+      export_options: { **COMMON_EXPORT_OPTIONS, method: 'enterprise' }
     )
 
     appcenter_upload(


### PR DESCRIPTION
Without any apparent change on our side, we saw a couple of Pocket Casts builds with unexpected, and unexpectedly incrementing, build numbers on TestFlight. From 7.24.0.3, to 8, to 9.

This behavior could be replicated locally in that project by running the Fastlane automation, but not when archiving via Xcode.

I pin pointed it to the `manageAppVersionAndBuildNumber` option being true by default in the `ExportOptions.plist` that Fastlane / `xcodebuild` generates for `gym` to convert an archive into an IPA.

Explicitly setting the option to `false` solves the issue locally.

See https://github.com/Automattic/pocket-casts-ios/pull/373 .

Something noteworthy that I didn't realize when working with Pocket Casts is that the behavior occurs only in `method: 'app-store'` exports.

To verify the issue on this project, checkout the current tip of the release branch, 838058f4e506f5b0546416fd02fe880ca2b5de09, and apply the following patch:

```
index 1c05a77b05..e3cb20e4ae 100644
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -123,6 +123,8 @@ platform :ios do
       export_options: { method: 'app-store' }
     )

+    UI.user_error! 'Aborting after building. This was just a test.'
+
     testflight(
       skip_waiting_for_build_processing: true,
       team_id: get_required_env('FASTLANE_ITC_TEAM_ID'),
@@ -173,6 +175,8 @@ platform :ios do
       export_options: { method: 'app-store' }
     )

+    UI.user_error! 'Aborting after building. This was just a test.'
+
     testflight(
       skip_waiting_for_build_processing: true,
       team_id: '299112',
@@ -215,6 +219,8 @@ platform :ios do
       export_options: { method: 'enterprise' }
     )

+    UI.user_error! 'Aborting after building. This was just a test.'
+
     appcenter_upload(
       api_token: get_required_env('APPCENTER_API_TOKEN'),
       owner_name: APPCENTER_OWNER_NAME,
@@ -264,6 +270,8 @@ platform :ios do
       export_options: { method: 'enterprise' }
     )

+    UI.user_error! 'Aborting after building. This was just a test.'
+
     appcenter_upload(
       api_token: get_required_env('APPCENTER_API_TOKEN'),
       owner_name: APPCENTER_OWNER_NAME,
@@ -317,6 +325,8 @@ platform :ios do
       export_options: { method: 'enterprise' }
     )

+    UI.user_error! 'Aborting after building. This was just a test.'
+
     appcenter_upload(
       api_token: get_required_env('APPCENTER_API_TOKEN'),
       owner_name: APPCENTER_OWNER_NAME,
```

Run a lane to build a binary for App Store Connect (`method: 'app-store'`) and notice how the build number is `21` instead of the `20.9.0.0` coming from `config/Version.public.xcconfig`.

```
bundle exec fastlane build_and_upload_app_store_connect skip_confirm:true skip_prechecks:true
```

![image](https://user-images.githubusercontent.com/1218433/194796570-daa6b26f-7c53-4190-ba26-3bebff7290ee.png)


Conversely, a lane with `method: 'enterprise'` won't show that behavior:

```
bundle exec fastlane build_and_upload_app_center skip_confirm:true skip_prechecks:true
```

![image](https://user-images.githubusercontent.com/1218433/194796573-307a7731-4a11-4f82-9ab3-bf38391e9948.png)


---

Note that this PR targets `release/20.9` because that's where the next builds will be deployed.