### PR TITLE
Replace context object with `CoreDataStack` in `NotificationSettingsService`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [**] [Jetpack-only] Added a "Save as Draft" extension. Now users can save content to Jetpack through iOS's share sheet. This was previously only available on the WordPress app. [#19414]
 * [**] [Jetpack-only] Enables Rich Notifications for the Jetpack app. Now we display more details on most of the push notifications. This was previously only available on the WordPress app. [#19415]
 * [*] Reader: Comment Details have been redesigned. [#19387]
+* [*] [internal] A refactor in weekly roundup notification scheduler. [#19422]
 
 20.9
 -----

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -537,10 +537,15 @@ class WeeklyRoundupNotificationScheduler {
         comments: Int,
         likes: Int,
         periodEndDate: Date,
-        completion: @escaping (Result<Void, Error>) -> Void) {
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        var siteTitle: String?
+        var dotComID: Int?
 
-        let siteTitle = site.title
-        let dotComID = site.dotComID?.intValue
+        site.managedObjectContext?.performAndWait {
+            siteTitle = site.title
+            dotComID = site.dotComID?.intValue
+        }
 
         guard let dotComID = dotComID else {
             // Error

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -548,8 +548,7 @@ class WeeklyRoundupNotificationScheduler {
         }
 
         guard let dotComID = dotComID else {
-            // Error
-            return
+            fatalError("The argument site is not a WordPress.com site. Site: \(site)")
         }
 
         let title = notificationTitle(siteTitle)

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -3,7 +3,7 @@ import CoreData
 
 /// The main data provider for Weekly Roundup information.
 ///
-class WeeklyRoundupDataProvider {
+private class WeeklyRoundupDataProvider {
 
     // MARK: - Definitions
 
@@ -19,7 +19,7 @@ class WeeklyRoundupDataProvider {
 
     // MARK: - Misc Properties
 
-    private let context: NSManagedObjectContext
+    private let coreDataStack: CoreDataStack
 
     /// Method to report errors that won't interrupt the execution.
     ///
@@ -29,8 +29,8 @@ class WeeklyRoundupDataProvider {
     ///
     private let debugSettings = WeeklyRoundupDebugScreen.Settings()
 
-    init(context: NSManagedObjectContext, onError: @escaping (Error) -> Void) {
-        self.context = context
+    init(coreDataStack: CoreDataStack, onError: @escaping (Error) -> Void) {
+        self.coreDataStack = coreDataStack
         self.onError = onError
     }
 
@@ -55,7 +55,7 @@ class WeeklyRoundupDataProvider {
         }
     }
 
-    func getTopSiteStats(from sites: [Blog], completion: @escaping (Result<SiteStats?, Error>) -> Void) {
+    private func getTopSiteStats(from sites: [Blog], completion: @escaping (Result<SiteStats?, Error>) -> Void) {
         var endDateComponents = DateComponents()
         endDateComponents.weekday = 1
 
@@ -164,7 +164,7 @@ class WeeklyRoundupDataProvider {
     /// Filters the sites that have the Weekly Roundup notification setting enabled.
     ///
     private func filterWeeklyRoundupEnabledSites(_ sites: [Blog], result: @escaping (Result<[Blog], Error>) -> Void) {
-        let noteService = NotificationSettingsService(managedObjectContext: context)
+        let noteService = NotificationSettingsService(coreDataStack: coreDataStack)
 
         noteService.getAllSettings { settings in
             let weeklyRoundupEnabledSites = sites.filter { site in
@@ -193,7 +193,7 @@ class WeeklyRoundupDataProvider {
         ]
 
         do {
-            let result = try context.fetch(request)
+            let result = try coreDataStack.mainContext.fetch(request)
             return .success(result)
         } catch {
             return .failure(DataRequestError.siteFetchingError(error))
@@ -382,8 +382,7 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
             }
         }
 
-        let context = ContextManager.shared.newDerivedContext()
-        let dataProvider = WeeklyRoundupDataProvider(context: context, onError: onError)
+        let dataProvider = WeeklyRoundupDataProvider(coreDataStack: ContextManager.shared, onError: onError)
         var siteStats: [Blog: StatsSummaryData]? = nil
 
         let requestData = BlockOperation {
@@ -428,8 +427,8 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
                     views: stats.viewsCount,
                     comments: stats.commentsCount,
                     likes: stats.likesCount,
-                    periodEndDate: self.currentRunPeriodEndDate(),
-                    context: context) { result in
+                    periodEndDate: self.currentRunPeriodEndDate()
+                ) { result in
 
                     switch result {
                     case .success:
@@ -538,21 +537,15 @@ class WeeklyRoundupNotificationScheduler {
         comments: Int,
         likes: Int,
         periodEndDate: Date,
-        context: NSManagedObjectContext,
         completion: @escaping (Result<Void, Error>) -> Void) {
 
-            var siteTitle: String?
-            var dotComID: Int?
+        let siteTitle = site.title
+        let dotComID = site.dotComID?.intValue
 
-            context.performAndWait {
-                dotComID = site.dotComID?.intValue
-                siteTitle = site.title
-            }
-
-            guard let dotComID = dotComID else {
-                // Error
-                return
-            }
+        guard let dotComID = dotComID else {
+            // Error
+            return
+        }
 
         let title = notificationTitle(siteTitle)
         let body = notificationBodyWith(views: views, comments: likes, likes: comments)

--- a/WordPress/Classes/Utility/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/PushNotificationsManager.swift
@@ -101,7 +101,7 @@ final public class PushNotificationsManager: NSObject {
         deviceToken = newToken
 
         // Register against WordPress.com
-        let noteService = NotificationSettingsService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let noteService = NotificationSettingsService(coreDataStack: ContextManager.sharedInstance())
 
         noteService.registerDeviceForPushNotifications(newToken, success: { deviceId in
             DDLogVerbose("Successfully registered Device ID \(deviceId) for Push Notifications")
@@ -138,7 +138,7 @@ final public class PushNotificationsManager: NSObject {
 
         ZendeskUtils.unregisterDevice()
 
-        let noteService = NotificationSettingsService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let noteService = NotificationSettingsService(coreDataStack: ContextManager.sharedInstance())
 
         noteService.unregisterDeviceForPushNotifications(knownDeviceId, success: {
             DDLogInfo("Successfully unregistered Device ID \(knownDeviceId) for Push Notifications!")

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingDetailsViewController.swift
@@ -317,8 +317,7 @@ class NotificationSettingDetailsViewController: UITableViewController {
             return
         }
 
-        let context = ContextManager.sharedInstance().mainContext
-        let service = NotificationSettingsService(managedObjectContext: context)
+        let service = NotificationSettingsService(coreDataStack: ContextManager.shared)
 
         service.updateSettings(settings!,
             stream: stream!,

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -116,7 +116,7 @@ class NotificationSettingsViewController: UIViewController {
     // MARK: - Service Helpers
 
     fileprivate func reloadSettings() {
-        let service = NotificationSettingsService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = NotificationSettingsService(coreDataStack: ContextManager.sharedInstance())
 
         let dispatchGroup = DispatchGroup()
         let siteService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)

--- a/WordPress/WordPressTest/NotificationSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/NotificationSettingsServiceTests.swift
@@ -1,8 +1,8 @@
 import Foundation
 import XCTest
-import WordPress
 import OHHTTPStubs
 
+@testable import WordPress
 
 // MARK: - NotificationSettingsServiceTests
 //
@@ -26,8 +26,7 @@ class NotificationSettingsServiceTests: CoreDataTestCase {
         super.setUp()
 
         remoteApi           = WordPressComRestApi(oAuthToken: nil, userAgent: nil)
-        service             = NotificationSettingsService(managedObjectContext: contextManager.mainContext,
-                                                           wordPressComRestApi: remoteApi)
+        service             = NotificationSettingsService(coreDataStack: contextManager, wordPressComRestApi: remoteApi)
 
         stub(condition: { request in
             return request.url?.absoluteString.range(of: self.settingsEndpoint) != nil


### PR DESCRIPTION
It's one of the initiatives to pass `CoreDataStack` instead of `NSManagedContext`. This PR updates `NotificationSettingsService` to do exactly that. With this change, one usage of `newDerivedContext`(another thing that we'd like to move away from) is also removed.

I've tested the Weekly round up feature(My site -> Stats -> Weeks) and the notification scheduler(see "To test" section in https://github.com/wordpress-mobile/WordPress-iOS/pull/17766). I couldn't find any issue with this change.

But there are two changes that I can spot in the code:
1. The `blog` property in `NotificationSettings` instances created by `NotificationSettingsService` is now in `mainContext`, instead of a derived context. This change is caused by [the `BlogQuery().blogs(in: ...)` line in the diff](https://github.com/wordpress-mobile/WordPress-iOS/pull/19422/files#diff-f1b4caa96293e8b6db53e4359d9774c95ad7427cd640e926bb5cd498311a7500R183).
  I don't see this change causing any issue though: if the current code is okay with using a `Blog` which blogs to a discarded derived context, I don't see how it can break using a `Blog` which blogs to the main context.
1. `context.performAndWait` is removed when accessing `Blog` instance properties. The original code is added in #17766. But I don't think we need to use `context.perform` to guard access to a Core Data model's properties? @frosty I know it's been a while since you created PR#17766. but do you mind reviewing [this change](https://github.com/wordpress-mobile/WordPress-iOS/pull/19422/files#diff-613b9e0de8670cd7d053d38d4bbd118d4472713971701edf415c9e493114c468R542-R543) if you have some time? Thanks.

## Regression Notes
1. Potential unintended areas of impact
None.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
Covered in the description above.

4. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
