### PR TITLE
Replace some `newDerivedContext` in ObjC with `performAndSave`

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -194,14 +194,8 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 - (void)refreshPostsForFollowedTopic
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    // Do all of this work on a background thread.
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:context];
-    [context performBlock:^{
+    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:context];
         ReaderAbstractTopic *topic = [topicService topicForFollowedSites];
         if (topic) {
             ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];

--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController.m
@@ -383,13 +383,8 @@ static NSInteger HideSearchMinSites = 3;
         });
     };
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-    BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
-
-    [context performBlock:^{
+    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
         [blogService syncBlogsForAccount:defaultAccount success:^{
             completionBlock();
         } failure:^(NSError * _Nonnull error) {
@@ -948,15 +943,10 @@ static NSInteger HideSearchMinSites = 3;
             UIAlertAction *hideAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Hide All", @"Hide All")
                                                                    style:UIAlertActionStyleDestructive
                                                                  handler:^(UIAlertAction *action){
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-                                                                     NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-                                                                     [context performBlock:^{
+                                                                     [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
                                                                          AccountService *accountService = [[AccountService alloc] initWithManagedObjectContext:context];
                                                                          WPAccount *account = [WPAccount lookupDefaultWordPressComAccountInContext:context];
                                                                          [accountService setVisibility:visible forBlogs:[account.blogs allObjects]];
-                                                                         [[ContextManager sharedInstance] saveContext:context];
                                                                      }];
                                                                  }];
             [alertController addAction:cancelAction];

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -236,19 +236,13 @@
 
 - (void)syncBlogs
 {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-    
-    [context performBlock:^{
-        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
+    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         WPAccount *defaultAccount = [WPAccount lookupDefaultWordPressComAccountInContext:context];
-
         if (!defaultAccount) {
             return;
         }
-        
+
+        BlogService *blogService = [[BlogService alloc] initWithManagedObjectContext:context];
         [blogService syncBlogsForAccount:defaultAccount success:nil failure:nil];
     }];
 }

--- a/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/CommentsViewController.m
@@ -475,22 +475,16 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
     
     __typeof(self) __weak weakSelf = self;
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-
-    CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
     NSManagedObjectID *blogObjectID = self.blog.objectID;
-
     BOOL filterUnreplied = [self isUnrepliedFilterSelected:self.filterTabBar];
 
-    [context performBlock:^{
+    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         Blog *blogInContext = (Blog *)[context existingObjectWithID:blogObjectID error:nil];
         if (!blogInContext) {
             return;
         }
 
+        CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
         [commentService syncCommentsForBlog:blogInContext
                                  withStatus:self.currentStatusFilter
                             filterUnreplied:filterUnreplied
@@ -520,21 +514,15 @@ static NSString *RestorableFilterIndexKey = @"restorableFilterIndexKey";
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncMoreWithSuccess:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
     __typeof(self) __weak weakSelf = self;
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSManagedObjectContext *context = [[ContextManager sharedInstance] newDerivedContext];
-#pragma clang diagnostic pop
-
-    CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
     NSManagedObjectID *blogObjectID = self.blog.objectID;
-    
-    [context performBlock:^{
+
+    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext * _Nonnull context) {
         Blog *blogInContext = (Blog *)[context existingObjectWithID:blogObjectID error:nil];
         if (!blogInContext) {
             return;
         }
 
+        CommentService *commentService  = [[CommentService alloc] initWithManagedObjectContext:context];
         [commentService loadMoreCommentsForBlog:blogInContext
                                      withStatus:self.currentStatusFilter
                                         success:^(BOOL hasMore) {


### PR DESCRIPTION
Pay the debt I introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/19388 (warnings generated from `newDerivedContext` usages in Objective-C files are ignored).

All changes in this PR should be pretty safe since the original already uses `performBlock` function, which means swapping to the new writer API doesn't change anything in terms of which queue the block runs in.

There are a few more usages of `newDerivedContext` in Objective-C files, which don't use `performBlock`, I'll take a closer look at them and see if it's okay to simply replace them with the new writer API (I don't see any major risk on first glance).

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
