### PR TITLE
Stats Revamp: Views and Visitors showing data for the previously selected period or site

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -34,37 +34,41 @@
     case postStatsAverageViews
     case postStatsRecentWeeks
 
-    static let allInsights = FeatureFlag.statsNewInsights.enabled  ?
-                                    [StatSection.insightsViewsVisitors,
-                                     .insightsLatestPostSummary,
-                                     .insightsAllTime,
-                                     .insightsLikesTotals,
-                                     .insightsCommentsTotals,
-                                     .insightsFollowerTotals,
-                                     .insightsMostPopularTime,
-                                     .insightsTagsAndCategories,
-                                     .insightsAnnualSiteStats,
-                                     .insightsCommentsAuthors,
-                                     .insightsCommentsPosts,
-                                     .insightsFollowersWordPress,
-                                     .insightsFollowersEmail,
-                                     .insightsTodaysStats,
-                                     .insightsPostingActivity,
-                                     .insightsPublicize] :
-                                    [StatSection.insightsLatestPostSummary,
-                                    .insightsAllTime,
-                                    .insightsFollowerTotals,
-                                    .insightsMostPopularTime,
-                                    .insightsTagsAndCategories,
-                                    .insightsAnnualSiteStats,
-                                    .insightsCommentsAuthors,
-                                    .insightsCommentsPosts,
-                                    .insightsFollowersWordPress,
-                                    .insightsFollowersEmail,
-                                    .insightsTodaysStats,
-                                    .insightsPostingActivity,
-                                    .insightsPublicize,
-                                    .insightsAddInsight]
+    static var allInsights: [StatSection] {
+        if FeatureFlag.statsNewInsights.enabled {
+            return [StatSection.insightsViewsVisitors,
+                    .insightsLatestPostSummary,
+                    .insightsAllTime,
+                    .insightsLikesTotals,
+                    .insightsCommentsTotals,
+                    .insightsFollowerTotals,
+                    .insightsMostPopularTime,
+                    .insightsTagsAndCategories,
+                    .insightsAnnualSiteStats,
+                    .insightsCommentsAuthors,
+                    .insightsCommentsPosts,
+                    .insightsFollowersWordPress,
+                    .insightsFollowersEmail,
+                    .insightsTodaysStats,
+                    .insightsPostingActivity,
+                    .insightsPublicize]
+        } else {
+            return [StatSection.insightsLatestPostSummary,
+                    .insightsAllTime,
+                    .insightsFollowerTotals,
+                    .insightsMostPopularTime,
+                    .insightsTagsAndCategories,
+                    .insightsAnnualSiteStats,
+                    .insightsCommentsAuthors,
+                    .insightsCommentsPosts,
+                    .insightsFollowersWordPress,
+                    .insightsFollowersEmail,
+                    .insightsTodaysStats,
+                    .insightsPostingActivity,
+                    .insightsPublicize,
+                    .insightsAddInsight]
+        }
+    }
 
     static let allPeriods = [StatSection.periodOverviewViews,
                              .periodOverviewVisitors,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/InsightType.swift
@@ -25,7 +25,7 @@ enum InsightType: Int, SiteStatsPinnable {
     case commentsTotals
 
     // These Insights will be displayed in this order if a site's Insights have not been customized.
-    static let defaultInsights: [InsightType] = {
+    static var defaultInsights: [InsightType] {
         if FeatureFlag.statsNewInsights.enabled {
             return [.viewsVisitors,
                     .likesTotals,
@@ -40,11 +40,11 @@ enum InsightType: Int, SiteStatsPinnable {
                     .followers,
                     .comments]
         }
-    }()
+    }
 
     // This property is here to update the default list on existing installations.
     // If the list saved on UserDefaults matches the old one, it will be updated to the new one above.
-    static let oldDefaultInsights: [InsightType] = {
+    static var oldDefaultInsights: [InsightType] {
         if FeatureFlag.statsNewInsights.enabled {
             return [.mostPopularTime,
                     .allTimeStats,
@@ -57,7 +57,7 @@ enum InsightType: Int, SiteStatsPinnable {
                     .allTimeStats,
                     .followersTotals]
         }
-    }()
+    }
 
     static let defaultInsightsValues = InsightType.defaultInsights.map { $0.rawValue }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -606,16 +606,10 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func createLikesTotalInsightsRow() -> StatsTotalInsightsData {
-        let periodSummary = periodStore.getSummary()
-        updateMostRecentChartData(periodSummary)
-
         return StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore, insightsStore: insightsStore, statsSummaryType: .likes)
     }
 
     func createCommentsTotalInsightsRow() -> StatsTotalInsightsData {
-        let periodSummary = periodStore.getSummary()
-        updateMostRecentChartData(periodSummary)
-
         return StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore, insightsStore: insightsStore, statsSummaryType: .comments)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -834,7 +834,9 @@ private extension SiteStatsInsightsViewModel {
     }
 
     func updateMostRecentChartData(_ periodSummary: StatsSummaryTimeIntervalData?) {
-        if mostRecentChartData == nil {
+        if mostRecentChartData == nil,
+           let periodSummary = periodSummary,
+           periodSummary.periodEndDate >= lastRequestedDate.normalizedDate() {
             mostRecentChartData = periodSummary
         } else if let mostRecentChartData = mostRecentChartData,
                   let periodSummary = periodSummary,

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -168,13 +168,13 @@ struct CustomizeInsightsRow: ImmuTableRow {
 
 struct LatestPostSummaryRow: ImmuTableRow {
 
-    static let cell: ImmuTableCell = {
+    static var cell: ImmuTableCell {
         if FeatureFlag.statsNewInsights.enabled {
             return ImmuTableCell.class(StatsLatestPostSummaryInsightsCell.self)
         } else {
             return ImmuTableCell.nib(LatestPostSummaryCell.defaultNib, LatestPostSummaryCell.self)
         }
-    }()
+    }
 
     let summaryData: StatsLastPostInsight?
     let chartData: StatsPostDetails?


### PR DESCRIPTION
Fixes #19424

## Description

Views and Visitors showing data for the previously selected period or site

## Root cause

`StatsPeriodStore.getSummary` returns a cached version of summary for a previously selected period

An ideal fix would explore ways to change API of `StatsPeriodStore`, allowing to get a cached summary of a specific period, rather than having one `state.summary` which is changed when the period is changed. The scope of such a change is hard to determine so I decided against it.

## Solution

`SiteStatsInsightsViewModel` always expects to show the chart of `mostRecentData`. Don't set the value of `mostRecentChartData` if it doesn't belong to the most recent period.

## Testing instructions

1. Open Stats
3. See Views & Visitors
4. Open Week >
5. Change period (come back in weeks)
6. Go back to Stats
7. Go back to main menu
8. Select Stats
9. Views & Visitors card will show date for changed period and not for "This week".

## Regression Notes

1. Potential unintended areas of impact

Views & Visitors chart

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

I tried adding tests for `SiteStatsInsightsViewModel` but it would require refactoring to make it testable. Although I would recommend it since it would make making changes much easier and safer.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




