### PR TITLE
Comment Details: Add Activity Indicator to Moderation Cells

### DIFF
--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -58,6 +58,8 @@ class BorderedButtonTableViewCell: UITableViewCell {
 
         view.addSubview(loadingBackgroundView)
         view.pinSubviewToAllEdges(loadingBackgroundView)
+        loadingBackgroundView.backgroundColor = buttonBackgroundColor
+        loadingBackgroundView.layer.cornerRadius = 8
 
         view.addSubview(activityIndicator)
         view.pinSubviewAtCenter(activityIndicator)

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -845,14 +845,16 @@ private extension CommentDetailViewController {
     func trashComment() {
         isNotificationComment ? WPAppAnalytics.track(.notificationsCommentTrashed, withBlogID: notification?.metaSiteID) :
                                 CommentAnalytics.trackCommentTrashed(comment: comment)
+        trashButtonCell.isLoading = true
 
         commentService.trashComment(comment, success: { [weak self] in
+            self?.trashButtonCell.isLoading = false
             self?.showActionableNotice(title: ModerationMessages.trashSuccess)
             self?.refreshData()
         }, failure: { [weak self] error in
+            self?.trashButtonCell.isLoading = false
             self?.displayNotice(title: ModerationMessages.trashFail)
             self?.commentStatus = CommentStatusType.typeForStatus(self?.comment.status)
-
         })
     }
 
@@ -1032,6 +1034,13 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
                 }
                 commentStatus = statusType
                 notifyDelegateCommentModerated()
+
+                guard let cell = tableView.cellForRow(at: indexPath) else {
+                    return
+                }
+                let activityIndicator = UIActivityIndicatorView(style: .medium)
+                cell.accessoryView = activityIndicator
+                activityIndicator.startAnimating()
             default:
                 break
             }


### PR DESCRIPTION
Following @iamthomasbishop feedback on the other [PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19387). 

Activity Indicator has been added to communicate to the user the request delay.

To test:

1. Log in to a WP Account
2. In My Site, select Menu
3. Comments
4. Select any comment
5. Interact with the moderation cells (approve, pending, spam) and the trash button and verify if an activity indicator appears when tapped.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

https://user-images.githubusercontent.com/15968946/195368105-6267536a-be3f-42a4-a03e-61cceab0a736.mp4



