### PR TITLE
Shared Login: Remove app check when copying keychain and database

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -432,7 +432,7 @@ static ContextManager *_instance;
 - (void)copyDatabaseToSharedDirectoryIfNeeded
 {
     BOOL sharedDatabaseExists = [[NSFileManager defaultManager] fileExistsAtPath:[[self sharedDatabasePath] absoluteString]];
-    if (![self isSharedLoginEnabled] || sharedDatabaseExists || AppConfiguration.isJetpack) {
+    if (![self isSharedLoginEnabled] || sharedDatabaseExists) {
         return;
     }
     

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -48,7 +48,6 @@ class KeychainUtils: NSObject {
         }
 
         guard shouldUseSharedKeychain(),
-              AppConfiguration.isWordPress,
               !defaults.bool(forKey: "keychain-copied"),
               let items = try? keychainUtils.getAllPasswords(forAccessGroup: nil) else {
             return


### PR DESCRIPTION
## Description

Fixes an issue where Jetpack wouldn't copy its data when enabling the `Shared Login` feature flag.

## Testing

To test:
- Disable `Shared Login`
- Launch Jetpack
- Login
- Enable `Shared Login`
- Launch Jetpack
- Verify you are still logged in

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
