### PR TITLE
[Jetpack landing screen] Add vertical spacing where repeated views are connected

### DIFF
--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
@@ -7,7 +7,7 @@ struct JetpackLandingScreenView: View {
     private let oddColor = JetpackPromptsConfiguration.Constants.oddColor
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 0) {
             ForEach(0..<prompts.count * 2, id: \.hashValue) { index in
                 JetpackPromptView(
                     text: prompts[index % prompts.count],


### PR DESCRIPTION
Fixes #19431

## Description

In `JetpackLandingScreenView` we generate a single `VStack` by iterating over the prompts twice. 

~Though the prompts have 8pts of padding in between, the bottom of this view doesn't. This PR adds that padding.~

I reevaluated this problem and determined that we should remove the default padding from the `JetpackLandingScreenView` `VStack`. This should allow us to control all vertical spacing from the single `JetpackPromptView` insets value.

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/2092798/195435402-5f9f68e1-65b8-4183-976f-13c354a9ddff.png) | ![After](https://user-images.githubusercontent.com/2092798/195446820-92dfcdc2-3eca-494b-8fca-96c62789fe4d.png) |

_Blue borders are for demonstration purposes only._

## Testing

💡 For all tests enable the [new landing screen](https://github.com/wordpress-mobile/WordPress-iOS/blob/5978e9dd7cb1b3f167f743e363950e96c051f358/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L116) feature flag

1. Clean install and load the Jetpack app (or log out of existing sessions to reach the landing screen).
2. As the Landing Screen prompts scroll, look for the prompt array delimiters: "Read an article" and "Watch your stats" (be sure to inspect these at least twice in a row - the prompts _inside_ the `JetpackLandingScreenView` `VStack` don't have this issue.
3. **Expect:** Spacing between prompts is uniform.

## Regression Notes
1. Potential unintended areas of impact
    - Prompt spacing in the new landing screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above. It can be helpful to temporarily add a border around prompts and enable user interaction on the infinite scroller view for manual control.

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
