### PR TITLE
Attempt to use docker to run danger

### DIFF
--- a/.buildkite/commands/rubocop-via-danger.sh
+++ b/.buildkite/commands/rubocop-via-danger.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
-install_gems
+bundle install
 
 echo "--- :rubocop: Run Rubocop via Danger"
 bundle exec danger --fail-on-errors=true

--- a/.buildkite/commands/rubocop-via-danger.sh
+++ b/.buildkite/commands/rubocop-via-danger.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
 echo "--- :rubygems: Setting up Gems"
-bundle install
+install_gems
 
 echo "--- :rubocop: Run Rubocop via Danger"
 bundle exec danger --fail-on-errors=true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -124,5 +124,8 @@ steps:
       # That is, it outwardly only mentions RuboCop, not Danger
       - label: ":rubocop: Lint Ruby Tooling"
         command: .buildkite/commands/rubocop-via-danger.sh
-        env: *common_env
-        plugins: *common_plugins
+        plugins:
+          - docker#v3.8.0:
+              image: "ruby:2.7"
+        agents:
+          queue: "default"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,10 +116,6 @@ steps:
         notify:
           - github_commit_status:
               context: "Lint Translations"
-      # TODO: This ought to be run on a Docker or Ubuntu agent as there's nothing that requires macOS.
-      # It's currently in the stock setup because... it was faster to build a proof of concept for it this way;
-      # I don't know how to pass the `DANGER_GITHUB_API_TOKEN` secret that we need to a Docker agent.
-      #
       # This step uses Danger to run RuboCop, but it's "agnostic" about it.
       # That is, it outwardly only mentions RuboCop, not Danger
       - label: ":rubocop: Lint Ruby Tooling"
@@ -128,5 +124,7 @@ steps:
           - docker#v3.8.0:
               image: "ruby:2.7"
               propagate-environment: true
+              environment:
+                - "DANGER_GITHUB_API_TOKEN"
         agents:
           queue: "default"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -120,11 +120,6 @@ steps:
       # That is, it outwardly only mentions RuboCop, not Danger
       - label: ":rubocop: Lint Ruby Tooling"
         command: .buildkite/commands/rubocop-via-danger.sh
-        plugins:
-          - docker#v3.8.0:
-              image: "ruby:2.7"
-              propagate-environment: true
-              environment:
-                - "DANGER_GITHUB_API_TOKEN"
+        plugins: *common_plugins
         agents:
-          queue: "default"
+          queue: "android"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -127,5 +127,6 @@ steps:
         plugins:
           - docker#v3.8.0:
               image: "ruby:2.7"
+              propagate-environment: true
         agents:
           queue: "default"


### PR DESCRIPTION
I noticed the TODO in the pipeline.yml and decided to implement it—also a good buildkite learning opportunity for me.

~~I had to swap the `install_gems` command with `bundle install` since I didn't find a way to let the docker container fetch the `common_plugins`, see [this job output](https://buildkite.com/automattic/wordpress-ios/builds/10356#0183d074-8b8e-4611-90b9-60806484aab3/286-287).~~ Update: No longer necessary on [the `android` queue](https://github.com/wordpress-mobile/WordPress-iOS/pull/19459#pullrequestreview-1141775560).

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
