### PR TITLE
Fix a crash when attempting to purchase domains

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+DomainCredit.swift
@@ -31,7 +31,15 @@ extension BlogDetailsViewController {
     }
 
     private func presentDomainCreditRedemptionSuccess(domain: String) {
-        let controller = DomainCreditRedemptionSuccessViewController(domain: domain, delegate: self)
+        let controller = DomainCreditRedemptionSuccessViewController(domain: domain) { [weak self] _ in
+            self?.dismiss(animated: true) {
+                guard let email = self?.accountEmail() else {
+                    return
+                }
+                let title = String(format: NSLocalizedString("Verify your email address - instructions sent to %@", comment: "Notice displayed after domain credit redemption success."), email)
+                ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
+            }
+        }
         present(controller, animated: true) { [weak self] in
             self?.updateTableView {
                 guard
@@ -42,18 +50,6 @@ extension BlogDetailsViewController {
                 }
                 parent.sitePickerViewController?.blogDetailHeaderView.blog = blog
             }
-        }
-    }
-}
-
-extension BlogDetailsViewController: DomainCreditRedemptionSuccessViewControllerDelegate {
-    func continueButtonPressed(domain: String) {
-        dismiss(animated: true) { [weak self] in
-            guard let email = self?.accountEmail() else {
-                return
-            }
-            let title = String(format: NSLocalizedString("Verify your email address - instructions sent to %@", comment: "Notice displayed after domain credit redemption success."), email)
-            ActionDispatcher.dispatch(NoticeAction.post(Notice(title: title)))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditRedemptionSuccessViewController.swift
@@ -1,16 +1,12 @@
 import UIKit
 import WordPressUI
 
-protocol DomainCreditRedemptionSuccessViewControllerDelegate: AnyObject {
-    func continueButtonPressed(domain: String)
-}
-
 /// Displays messaging after user successfully redeems domain credit.
 class DomainCreditRedemptionSuccessViewController: UIViewController {
 
     private let domain: String
 
-    private weak var delegate: DomainCreditRedemptionSuccessViewControllerDelegate?
+    private var continueButtonPressed: (String) -> Void
 
     // MARK: - Views
 
@@ -102,9 +98,9 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
 
     // MARK: - View lifecycle
 
-    init(domain: String, delegate: DomainCreditRedemptionSuccessViewControllerDelegate) {
+    init(domain: String, continueButtonPressed: @escaping (String) -> Void) {
         self.domain = domain
-        self.delegate = delegate
+        self.continueButtonPressed = continueButtonPressed
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -196,7 +192,7 @@ class DomainCreditRedemptionSuccessViewController: UIViewController {
     // MARK: - Actions
 
     @objc func doneButtonTapped() {
-        delegate?.continueButtonPressed(domain: domain)
+        continueButtonPressed(domain)
     }
 
     // MARK: - Constants

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionViewControllerWrapper.swift
@@ -3,58 +3,45 @@ import UIKit
 import WordPressKit
 
 /// Makes RegisterDomainSuggestionsViewController available to SwiftUI
-final class DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable {
-
-    @SwiftUI.Environment(\.presentationMode) var presentationMode
+struct DomainSuggestionViewControllerWrapper: UIViewControllerRepresentable {
 
     private let blog: Blog
     private let domainType: DomainType
     private let onDismiss: () -> Void
 
-    private weak var domainSuggestionViewController: RegisterDomainSuggestionsViewController?
-    private weak var wrapperNavigationController: LightNavigationController?
+    private var domainSuggestionViewController: RegisterDomainSuggestionsViewController
 
     init(blog: Blog, domainType: DomainType, onDismiss: @escaping () -> Void) {
         self.blog = blog
         self.domainType = domainType
         self.onDismiss = onDismiss
+        self.domainSuggestionViewController = RegisterDomainSuggestionsViewController.instance(site: blog,
+                                                                                               domainType: domainType,
+                                                                                               includeSupportButton: false)
     }
 
     func makeUIViewController(context: Context) -> LightNavigationController {
         let blogService = BlogService(managedObjectContext: ContextManager.shared.mainContext)
 
-        let viewController = RegisterDomainSuggestionsViewController
-            .instance(site: blog,
-                      domainType: domainType,
-                      includeSupportButton: false,
-                      domainPurchasedCallback: { domain in
-                    blogService.syncBlogAndAllMetadata(self.blog) { }
-                    WPAnalytics.track(.domainCreditRedemptionSuccess)
-                    self.presentDomainCreditRedemptionSuccess(domain: domain)
-                })
-        domainSuggestionViewController = viewController
-        let navigationController = LightNavigationController(rootViewController: viewController)
-        wrapperNavigationController = navigationController
+        self.domainSuggestionViewController.domainPurchasedCallback = { domain in
+            blogService.syncBlogAndAllMetadata(self.blog) { }
+            WPAnalytics.track(.domainCreditRedemptionSuccess)
+            self.presentDomainCreditRedemptionSuccess(domain: domain)
+        }
+
+        let navigationController = LightNavigationController(rootViewController: domainSuggestionViewController)
         return navigationController
     }
 
     func updateUIViewController(_ uiViewController: LightNavigationController, context: Context) { }
 
     private func presentDomainCreditRedemptionSuccess(domain: String) {
-        guard let presentingController = domainSuggestionViewController else {
-            return
-        }
-        let controller = DomainCreditRedemptionSuccessViewController(domain: domain, delegate: self)
-        presentingController.present(controller, animated: true)
-    }
-}
 
-/// Handles the action after the domain registration confirmation is dismissed - go back to Domains Dashboard
-extension DomainSuggestionViewControllerWrapper: DomainCreditRedemptionSuccessViewControllerDelegate {
-
-    func continueButtonPressed(domain: String) {
-        domainSuggestionViewController?.dismiss(animated: true) { [weak self] in
-            self?.onDismiss()
+        let controller = DomainCreditRedemptionSuccessViewController(domain: domain) { _ in
+            self.domainSuggestionViewController.dismiss(animated: true) {
+                self.onDismiss()
+            }
         }
+        domainSuggestionViewController.present(controller, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -11,7 +11,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     private var constraintsInitialized = false
 
     private var site: Blog!
-    private var domainPurchasedCallback: ((String) -> Void)!
+    var domainPurchasedCallback: ((String) -> Void)!
 
     private var domain: FullyQuotedDomainSuggestion?
     private var siteName: String?
@@ -46,7 +46,7 @@ class RegisterDomainSuggestionsViewController: UIViewController {
     static func instance(site: Blog,
                          domainType: DomainType = .registered,
                          includeSupportButton: Bool = true,
-                         domainPurchasedCallback: @escaping ((String) -> Void)) -> RegisterDomainSuggestionsViewController {
+                         domainPurchasedCallback: ((String) -> Void)? = nil) -> RegisterDomainSuggestionsViewController {
         let storyboard = UIStoryboard(name: Constants.storyboardIdentifier, bundle: Bundle.main)
         let controller = storyboard.instantiateViewController(withIdentifier: Constants.viewControllerIdentifier) as! RegisterDomainSuggestionsViewController
         controller.site = site

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainSuggestionsViewController.swift
@@ -289,16 +289,8 @@ extension RegisterDomainSuggestionsViewController: NUXButtonViewControllerDelega
         let domainRegistrationSucceeded = newURL.absoluteString.starts(with: Self.checkoutSuccessURLPrefix)
 
         if domainRegistrationSucceeded {
-
-            let registerDomainService = RegisterDomainDetailsServiceProxy()
-
-            registerDomainService.recordDomainPurchase(
-                siteID: siteID,
-                domain: domain,
-                isPrimaryDomain: false)
-
             onSuccess(domain)
-            return
+
         }
     }
 


### PR DESCRIPTION
Fixes #19351

This PR addresses a crash, present in iOS 16 or later, that occurred when attempting to purchase a domain from the Domains page.
This PR also fixes an issue where, after a successful domain purchase, the new domain appeared duplicated (one instance with an actual expiration date, one with an erroneous "never expires") in the domains list

Domains Dashboard access | Register free domain with paid plan
-- | --
<img width="1023" src="https://user-images.githubusercontent.com/34376330/195682544-48c94883-6ca7-40dc-a6b9-e3ed5abfe8eb.png"> | <img width="480" src="https://user-images.githubusercontent.com/34376330/195682590-02a80fdc-5003-4f1d-b565-569bc6487162.png">


**To test:**
**NOTES:**
1. Because this problem does not seem to occur on the App Store released version, but it indeed occurs on a local build on iOS 16, I am targeting `trunk` and not adding release notes to this PR.
2. to test domain purchases, it is recommended to use the sandbox store. To find detailed instructions, find the post "Using the Store Sandbox in WPiOS" in WPMobile. If you don't use the sandbox store and test the domain purchase, please resign any domains using the Store Admin
3. It's recommended to use a non-automattician account
4. To avoid being asked for a payment method, add some free credit in the Store Admin (sandbox store if you're using it)
5. This PR needs to be tested on iOS 16 or later

**TESTING STEPS**
- checkout this branch and run the `Jetpack` target. Make sure you are running on iOS 16 or later.
- Login if needed, and select a site with no additional domains purchased yet
- Go to My Site, tap Menu and scroll down to Domains
- Start the purchase flow by tapping on "Search for domains" and make sure that no crash occurs
- Complete the purchase (see remarks above) and make sure that, after dismissing the "Congratulations" screen, the new domain appears in the list and it's not duplicated.
- Additionally, select a site with a paid plan (you can temporarily set this on the Store Admin as well)
- Tap on the "Register domain" cell that appears on the top of the "Menu" list
- Make sure the domain registration flow completes successfully. Note that this flow has a pre-existing issue (not addressed in this PR), where the "Register domain" button is greyed out during the registration process and there is no user feedback that indicates it. The process should eventually complete and the screen being dismissed, and you should see the "Congratulations" screen after that.
- Double check that the newly registered domain is present in the Domains list and it's not duplicated

## Regression Notes
1. Potential unintended areas of impact
Domain purchase

6. What I did to test those areas of impact (or what existing automated tests I relied on)
Test all the domain purchase flows

7. What automated tests I added (or what prevented me from doing so)
none
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
