### PR TITLE
[Jetpack landing screen] Reduce logo size

### DIFF
--- a/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
+++ b/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
@@ -102,10 +102,10 @@ class JetpackPrologueViewController: UIViewController {
         view.layer.insertSublayer(gradientLayer, above: jetpackAnimatedView.layer)
         // constraints
         NSLayoutConstraint.activate([
-            logoImageView.widthAnchor.constraint(equalToConstant: 72),
+            logoImageView.widthAnchor.constraint(equalToConstant: 68),
             logoImageView.heightAnchor.constraint(equalTo: logoImageView.widthAnchor),
             logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            logoImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 72)
+            logoImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 68)
         ])
     }
 


### PR DESCRIPTION
Fixes #19357

## Description

This PR reduces the Jetpack logo diameter on the new landing screen from 72pts to 68pts.

**Note:** Visually the logo in the Figma design seems to translate to around 68pts in diameter, although the value is set to 70pts. I chose to match them visually rather than numerically, but have included the 70pts design for comparison.

| Design | 68pts | 70pts |
| - | - | - |
| <img width="200px" src="https://user-images.githubusercontent.com/2092798/195927260-396f7205-bd0b-4f3d-bc83-731cb83ac6e5.png" /> | <img src="https://user-images.githubusercontent.com/2092798/195926948-fde771e7-f111-4ede-9d10-06f902ce33b1.png" width="200px" /> | <img width="200px" src="https://user-images.githubusercontent.com/2092798/195927087-f25d0682-fc97-4f8b-aece-c8ab2f07b6a9.png" /> |


## Testing

💡 For all tests enable the [new landing screen](https://github.com/wordpress-mobile/WordPress-iOS/blob/5978e9dd7cb1b3f167f743e363950e96c051f358/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L116) feature flag

1. Clean install and load the Jetpack app (or log out of existing sessions to reach the landing screen).
2. **Expect** the logo to match the diameter of the Figma design visually.

### Regression tests
- iPhone / iPad
- iPad orientations
- Light / Dark mode

## Regression Notes
1. Potential unintended areas of impact
    - Jetpack logo size on the new landing screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None, as these are UI changes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
