### PR TITLE
[Jetpack landing screen] Remove two-line prompt limit

### DIFF
--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackPromptView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackPromptView.swift
@@ -8,7 +8,6 @@ struct JetpackPromptView: View {
         Text(text)
             .font(makeFont())
             .foregroundColor(color)
-            .lineLimit(Constants.lineLimit)
             .padding(Constants.textInsets)
             .accessibility(hidden: true)
     }
@@ -22,7 +21,6 @@ struct JetpackPromptView: View {
     }
 
     private enum Constants {
-        static let lineLimit = 2
         static let textInsets = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16)
         static let fontSize: CGFloat = 40
     }


### PR DESCRIPTION
Fixes #19465

## Description

This PR removes the two-line limit from prompts in the new Jetpack landing screen. This prevented some languages from showing the full prompt on smaller devices.

| Before | After |
| - | - |
| ![Before](https://user-images.githubusercontent.com/2092798/195933488-19748732-a6c4-4dea-a103-dc3636590ce3.png) | ![After](https://user-images.githubusercontent.com/2092798/195933515-9bb151a2-5808-46ed-a98e-1b330adaa67c.png) |

## Testing

💡 For all tests enable the [new landing screen](https://github.com/wordpress-mobile/WordPress-iOS/blob/5978e9dd7cb1b3f167f743e363950e96c051f358/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L116) feature flag

1. Use an iPhone SE with the language set to French
2. Clean install and load the Jetpack app (or log out of existing sessions to reach the landing screen).
3. **Expect** to be able to see all prompts in their entirety as they scroll on the screen. No prompt should be truncated.

## Regression Notes
1. Potential unintended areas of impact
    - Layout of prompts on the new landing screen in the Jetpack app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

2. What automated tests I added (or what prevented me from doing so)
    - None, as these are UI updates

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
