### PR TITLE
Hide logo and background image from VoiceOver.

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/SplashPrologueView.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SplashPrologueView.swift
@@ -14,6 +14,7 @@ struct SplashPrologueView: View {
                     .frame(minWidth: 0, maxWidth: .infinity)
                     .padding(.trailing, 20)
                     .foregroundColor(Color(SplashPrologueStyleGuide.BrushStroke.color))
+                    .accessibility(hidden: true)
             }
 
             VStack {
@@ -21,6 +22,7 @@ struct SplashPrologueView: View {
                     .resizable()
                     .frame(width: 50, height: 50)
                     .padding(10)
+                    .accessibility(hidden: true)
                 Text(Self.caption)
                     .multilineTextAlignment(.center)
                     .font(SplashPrologueStyleGuide.Title.font)


### PR DESCRIPTION
Fixes #19466

## Description

This PR disabled the background brush stroke image and logo from being recognized by VoiceOver.

<img src="https://user-images.githubusercontent.com/2092798/195939669-f5dbcefd-7f1a-48e8-b2ac-899ca190ac53.png" width="350px" />

## Testing

💡 For all tests enable the [new landing screen](https://github.com/wordpress-mobile/WordPress-iOS/blob/5978e9dd7cb1b3f167f743e363950e96c051f358/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift#L116) feature flag

1. Clean install and load the WordPress app (or log out of existing sessions to reach the landing screen).
2. Enable VoiceOver and attempt to interact with the brush stroke background and WordPress logo
3. **Expect** that VoiceOver ignores the background image and logo, and properly works with the other elements.

## Regression Notes
1. Potential unintended areas of impact
    - New WordPress landing screen and VoiceOver interactions

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual tests above

3. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
