### PR TITLE
Refocus About screen on core WordPress

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,7 +6,7 @@
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
           "branch": "fix/remove-wp-logo",
-          "revision": "098040602fe48194fbb5fb5677b35efe9d63dddc",
+          "revision": "541213b81f08c1fcd052e5fa0ea197d67913db7f",
           "version": null
         }
       },

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": "fix/remove-wp-logo",
-          "revision": "541213b81f08c1fcd052e5fa0ea197d67913db7f",
-          "version": null
+          "branch": null,
+          "revision": "0f784591b324e5d3ddc5771808ef8eca923e3de2",
+          "version": "1.1.2"
         }
       },
       {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,9 +5,9 @@
         "package": "AutomatticAbout",
         "repositoryURL": "https://github.com/automattic/AutomatticAbout-swift",
         "state": {
-          "branch": null,
-          "revision": "d3e8b4d8133984d9ae20936a55e747d27661e2a1",
-          "version": "1.1.1"
+          "branch": "fix/remove-wp-logo",
+          "revision": "098040602fe48194fbb5fb5677b35efe9d63dddc",
+          "version": null
         }
       },
       {

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -5,8 +5,8 @@ import WordPressAuthenticator
     static let itunesAppID = "335703880"
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
-    static let productBlogURL = "https://blog.wordpress.com"
-    static let productBlogDisplayURL = "blog.wordpress.com"
+    static let productBlogURL = "https://wordpress.org/news/"
+    static let productBlogDisplayURL = "wordpress.org/news"
     static let zendeskSourcePlatform = "mobile_-_ios"
     static let shareAppName: ShareAppName = .wordpress
     static let mobileAnnounceAppId = "2"
@@ -34,6 +34,12 @@ import WordPressAuthenticator
 
 // MARK: - Localized Strings
 extension AppConstants {
+
+    struct AboutScreen {
+        static let blogName = NSLocalizedString("News", comment: "Title of a button that displays the WordPress.org blog")
+        static let workWithUs = NSLocalizedString("Contribute", comment: "Title of button that displays the WordPress.org contributor page")
+        static let workWithUsURL = "https://make.wordpress.org/mobile/handbook"
+    }
 
     struct PostSignUpInterstitial {
         static let welcomeTitleText = NSLocalizedString("Welcome to WordPress", comment: "Post Signup Interstitial Title Text for WordPress iOS")

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
@@ -42,7 +42,7 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
                     self?.tracker.buttonPressed(.twitter)
                     self?.webViewPresenter.present(for: Links.twitter, context: context)
                 }),
-                AboutItem(title: TextContent.blog, subtitle: AppConstants.productBlogDisplayURL, cellStyle: .value1, action: { [weak self] context in
+                AboutItem(title: AppConstants.AboutScreen.blogName, subtitle: AppConstants.productBlogDisplayURL, cellStyle: .value1, action: { [weak self] context in
                     self?.tracker.buttonPressed(.blog)
                     self?.webViewPresenter.present(for: Links.blog, context: context)
                 })
@@ -53,20 +53,21 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
                     context.showSubmenu(title: TextContent.legalAndMore, configuration: LegalAndMoreSubmenuConfiguration())
                 }),
             ],
+            AppConfiguration.isJetpack ?
             [
                 AboutItem(title: TextContent.automatticFamily, accessoryType: .disclosureIndicator, hidesSeparator: true, action: { [weak self] context in
                     self?.tracker.buttonPressed(.automatticFamily)
                     self?.webViewPresenter.present(for: Links.automattic, context: context)
                 }),
                 AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
-            ],
+            ] : nil,
             [
-                AboutItem(title: TextContent.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
+                AboutItem(title: AppConstants.AboutScreen.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
                     self?.tracker.buttonPressed(.workWithUs)
                     self?.webViewPresenter.present(for: Links.workWithUs, context: context)
                 }),
             ]
-        ]
+        ].compactMap { $0 }
     }()
 
     func dismissScreen(_ actionContext: AboutItemActionContext) {
@@ -89,17 +90,15 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
         static let rateUs             = NSLocalizedString("Rate Us", comment: "Title for button allowing users to rate the app in the App Store")
         static let share              = NSLocalizedString("Share with Friends", comment: "Title for button allowing users to share information about the app with friends, such as via Messages")
         static let twitter            = NSLocalizedString("Twitter", comment: "Title of button that displays the app's Twitter profile")
-        static let blog               = NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress product blog")
         static let legalAndMore       = NSLocalizedString("Legal and More", comment: "Title of button which shows a list of legal documentation such as privacy policy and acknowledgements")
         static let automatticFamily   = NSLocalizedString("Automattic Family", comment: "Title of button that displays information about the other apps available from Automattic")
-        static let workWithUs         = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
-        static let workWithUsSubtitle = NSLocalizedString("Join From Anywhere", comment: "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world")
+        static var workWithUsSubtitle = AppConfiguration.isJetpack ? NSLocalizedString("Join From Anywhere", comment: "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world") : nil
     }
 
     private enum Links {
         static let twitter    = URL(string: AppConstants.productTwitterURL)!
         static let blog       = URL(string: AppConstants.productBlogURL)!
-        static let workWithUs = URL(string: "https://automattic.com/work-with-us")!
+        static let workWithUs = URL(string: AppConstants.AboutScreen.workWithUsURL)!
         static let automattic = URL(string: "https://automattic.com")!
     }
 }

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -35,6 +35,12 @@ import WordPressKit
 // MARK: - Localized Strings
 extension AppConstants {
 
+    struct AboutScreen {
+        static let blogName = NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress.com blog")
+        static let workWithUs = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
+        static let workWithUsURL = "https://automattic.com/work-with-us"
+    }
+
     struct PostSignUpInterstitial {
         static let welcomeTitleText = NSLocalizedString("Welcome to Jetpack", comment: "Post Signup Interstitial Title Text for Jetpack iOS")
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -29057,8 +29057,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				branch = "fix/remove-wp-logo";
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.2;
 			};
 		};
 		3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */ = {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -29057,8 +29057,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/automattic/AutomatticAbout-swift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				branch = "fix/remove-wp-logo";
+				kind = branch;
 			};
 		};
 		3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */ = {


### PR DESCRIPTION
Updates the app's About screen to focus on core WordPress. Mirrors changes in https://github.com/wordpress-mobile/WordPress-Android/pull/17282.

This PR should be updated after https://github.com/Automattic/AutomatticAbout-Swift/pull/7 is merged. Meanwhile, this PR points to a feature branch of `AutomatticAbout-Swift` package.

### To test

#### Verify WP app

1. Log in to the WordPress app
2. Navigate to the About screen (tap profile pic → tap "About WordPress")
3. Verify that the "Blog" button has been replaced by a "News" button that opens https://wordpress.org/news
4. Verify that there is no "Automattic Family" section
5. Verify that the "Work With Us" button has been replaced by a "Contribute" button that opens https://make.wordpress.org/mobile/handbook

| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/1898325/196436260-e14458b2-5ef1-4737-b906-7507d223c01e.jpeg" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/1898325/196433762-ab5aeef0-3258-4143-87ca-4de7022f29a5.jpeg" alt="" width="350">  |

#### Verify JP app

1. Log in to the Jetpack app
2. Navigate to the About screen (tap profile pic → tap "About Jetpack for iOS")
3. Verify that the "Automattic Family" section no longer shows a WP marble


| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/1898325/196307277-a0c62e11-6d9d-4309-ad5a-ed31639c7a96.PNG" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/1898325/196431277-e11fc102-ff36-4fc3-9c7b-c328ab89f977.PNG" alt="" width="350"> |
 


## Regression Notes
1. Potential unintended areas of impact

The WP/JP apps' About screens are updated by this PR, so there could be unintended areas of impact there.

7. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually checking those screens.

8. What automated tests I added (or what prevented me from doing so)

Tests would likely belong in the https://github.com/Automattic/AutomatticAbout-Swift repo. This repo doesn't have a CI test runner yet, so any tests that are added wouldn't be run automatically unless a test runner (e.g. CircleCI or BuildKite) was integrated. So the effort to add tests here is high.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
