### PR TITLE
Enables the new Jetpack Landing Screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 21.1
 -----
-[**] [Jetpack-only] We added a new landing screen with a cool animation that responds to device motion! [#19251, #19264, #19277, #19381, #19404, #19410, #19432, #19434, #19442, #19443, #19468, #19469]
+* [**] [Jetpack-only] We added a new landing screen with a cool animation that responds to device motion! [#19251, #19264, #19277, #19381, #19404, #19410, #19432, #19434, #19442, #19443, #19468, #19469]
 * [*] [internal] Database access change: the 'new Core Data context structure' feature flag is turned on by default. [#19433]
 
 21.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 21.1
 -----
-
+[**] [Jetpack-only] We added a new landing screen with a cool animation that responds to device motion! [#19251, #19264, #19277, #19381, #19404, #19410, #19432, #19434, #19442, #19443, #19468, #19469]
 
 21.0
 -----

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -34,7 +34,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackPoweredBottomSheet
     case sharedUserDefaults
     case sharedLogin
-    case newLandingScreen
+    case newJetpackLandingScreen
+    case newWordPressLandingScreen
     case newCoreDataContext
 
     /// Returns a boolean indicating if the feature is enabled
@@ -112,7 +113,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .sharedLogin:
             return false
-        case .newLandingScreen:
+        case .newJetpackLandingScreen:
+            return true
+        case .newWordPressLandingScreen:
             return false
         case .newCoreDataContext:
             return false
@@ -210,8 +213,10 @@ extension FeatureFlag {
             return "Shared User Defaults"
         case .sharedLogin:
             return "Shared Login"
-        case .newLandingScreen:
-            return "Jetpack and WordPress new landing screens"
+        case .newJetpackLandingScreen:
+            return "New Jetpack landing screen"
+        case .newWordPressLandingScreen:
+            return "New WordPress landing screen"
         case .newCoreDataContext:
             return "Use new Core Data context structure (Require app restart)"
         }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -80,7 +80,7 @@ extension WordPressAuthenticationManager {
     private func authenticatorStyle() -> WordPressAuthenticatorStyle {
         let prologueVC: UIViewController? = {
             guard let viewController = authenticationHandler?.prologueViewController else {
-                if FeatureFlag.newLandingScreen.enabled {
+                if FeatureFlag.newWordPressLandingScreen.enabled {
                     return SplashPrologueViewController()
                 }
 
@@ -113,7 +113,7 @@ extension WordPressAuthenticationManager {
         var prologuePrimaryButtonStyle: NUXButtonStyle?
         var prologueSecondaryButtonStyle: NUXButtonStyle?
 
-        if FeatureFlag.newLandingScreen.enabled, AppConfiguration.isWordPress {
+        if FeatureFlag.newWordPressLandingScreen.enabled, AppConfiguration.isWordPress {
             prologuePrimaryButtonStyle = SplashPrologueStyleGuide.primaryButtonStyle
             prologueSecondaryButtonStyle = SplashPrologueStyleGuide.secondaryButtonStyle
         } else {

--- a/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
+++ b/WordPress/Jetpack/Classes/JetpackAuthenticationManager.swift
@@ -2,7 +2,7 @@ import WordPressAuthenticator
 import UIKit
 
 struct JetpackAuthenticationManager: AuthenticationHandler {
-    let statusBarStyle: UIStatusBarStyle = FeatureFlag.newLandingScreen.enabled ? .default : .lightContent
+    let statusBarStyle: UIStatusBarStyle = FeatureFlag.newJetpackLandingScreen.enabled ? .default : .lightContent
     let prologueViewController: UIViewController? = JetpackPrologueViewController()
     let buttonViewTopShadowImage: UIImage? = UIImage()
     let prologueButtonsBackgroundColor: UIColor? = JetpackPrologueStyleGuide.backgroundColor

--- a/WordPress/Jetpack/Classes/NUX/JetpackPrologueStyleGuide.swift
+++ b/WordPress/Jetpack/Classes/NUX/JetpackPrologueStyleGuide.swift
@@ -9,13 +9,13 @@ struct JetpackPrologueStyleGuide {
     // old
     static let oldBackgroundColor = UIColor(red: 0.00, green: 0.11, blue: 0.18, alpha: 1.00)
     // combined
-    static let backgroundColor = FeatureFlag.newLandingScreen.enabled ? .clear : oldBackgroundColor
+    static let backgroundColor = FeatureFlag.newJetpackLandingScreen.enabled ? .clear : oldBackgroundColor
 
     // Gradient overlay colors
     // new
     static let newGradientColor = UIColor(light: .muriel(color: .jetpackGreen, .shade0), dark: .muriel(color: .jetpackGreen, .shade100))
     // combined
-    static let gradientColor = FeatureFlag.newLandingScreen.enabled ? newGradientColor : oldBackgroundColor
+    static let gradientColor = FeatureFlag.newJetpackLandingScreen.enabled ? newGradientColor : oldBackgroundColor
 
     // Continue with WordPress button colors
     // old
@@ -26,10 +26,10 @@ struct JetpackPrologueStyleGuide {
     static let newContinueTextColor = UIColor(light: .white, dark: .muriel(color: .jetpackGreen, .shade80))
 
     // combined
-    static let continueFillColor = FeatureFlag.newLandingScreen.enabled ? newContinueFillColor : .white
-    static let continueHighlightedFillColor = FeatureFlag.newLandingScreen.enabled ? newContinueHighlightedFillColor : oldContinueHighlightedFillColor
-    static let continueTextColor = FeatureFlag.newLandingScreen.enabled ? newContinueTextColor : oldBackgroundColor
-    static let continueHighlightedTextColor = FeatureFlag.newLandingScreen.enabled ? whiteWithAlpha07 : oldBackgroundColor
+    static let continueFillColor = FeatureFlag.newJetpackLandingScreen.enabled ? newContinueFillColor : .white
+    static let continueHighlightedFillColor = FeatureFlag.newJetpackLandingScreen.enabled ? newContinueHighlightedFillColor : oldContinueHighlightedFillColor
+    static let continueTextColor = FeatureFlag.newJetpackLandingScreen.enabled ? newContinueTextColor : oldBackgroundColor
+    static let continueHighlightedTextColor = FeatureFlag.newJetpackLandingScreen.enabled ? whiteWithAlpha07 : oldBackgroundColor
 
 
     // Enter your site address button
@@ -39,20 +39,20 @@ struct JetpackPrologueStyleGuide {
     static let newSiteHighlightedTextColor = UIColor(light: .muriel(color: .jetpackGreen, .shade50), dark: whiteWithAlpha07)
     static let oldSiteHighlightedBorderColor = UIColor(red: 1.00, green: 1.00, blue: 1.00, alpha: 0.20)
     // combined
-    static let siteFillColor = FeatureFlag.newLandingScreen.enabled ? .clear : oldBackgroundColor
-    static let siteBorderColor = FeatureFlag.newLandingScreen.enabled ? .clear : oldSiteBorderColor
-    static let siteTextColor = FeatureFlag.newLandingScreen.enabled ? newSiteTextColor : UIColor.white
-    static let siteHighlightedFillColor = FeatureFlag.newLandingScreen.enabled ? whiteWithAlpha07 : oldBackgroundColor
-    static let siteHighlightedBorderColor = FeatureFlag.newLandingScreen.enabled ? whiteWithAlpha07 : oldSiteHighlightedBorderColor
-    static let siteHighlightedTextColor = FeatureFlag.newLandingScreen.enabled ? newSiteHighlightedTextColor : whiteWithAlpha07
+    static let siteFillColor = FeatureFlag.newJetpackLandingScreen.enabled ? .clear : oldBackgroundColor
+    static let siteBorderColor = FeatureFlag.newJetpackLandingScreen.enabled ? .clear : oldSiteBorderColor
+    static let siteTextColor = FeatureFlag.newJetpackLandingScreen.enabled ? newSiteTextColor : UIColor.white
+    static let siteHighlightedFillColor = FeatureFlag.newJetpackLandingScreen.enabled ? whiteWithAlpha07 : oldBackgroundColor
+    static let siteHighlightedBorderColor = FeatureFlag.newJetpackLandingScreen.enabled ? whiteWithAlpha07 : oldSiteHighlightedBorderColor
+    static let siteHighlightedTextColor = FeatureFlag.newJetpackLandingScreen.enabled ? newSiteHighlightedTextColor : whiteWithAlpha07
 
     // Color used in both old and versions
     static let whiteWithAlpha07 = UIColor.white.withAlphaComponent(0.7)
 
     // Background image with gradient for the new Jetpack prologue screen
-    static let prologueBackgroundImage: UIImage? = FeatureFlag.newLandingScreen.enabled ? UIImage(named: "JPBackground") : nil
+    static let prologueBackgroundImage: UIImage? = FeatureFlag.newJetpackLandingScreen.enabled ? UIImage(named: "JPBackground") : nil
     // Blur effect for the prologue buttons
-    static let prologueButtonsBlurEffect: UIBlurEffect?  = FeatureFlag.newLandingScreen.enabled ? UIBlurEffect(style: .regular) : nil
+    static let prologueButtonsBlurEffect: UIBlurEffect?  = FeatureFlag.newJetpackLandingScreen.enabled ? UIBlurEffect(style: .regular) : nil
 
 
 

--- a/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
+++ b/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
@@ -14,7 +14,7 @@ class JetpackPrologueViewController: UIViewController {
     }()
 
     private let motion: CMMotionManager? = {
-        guard FeatureFlag.newLandingScreen.enabled else {
+        guard FeatureFlag.newJetpackLandingScreen.enabled else {
             return nil
         }
         let motion = CMMotionManager()
@@ -52,11 +52,11 @@ class JetpackPrologueViewController: UIViewController {
         let midBottomColor = JetpackPrologueStyleGuide.gradientColor.withAlphaComponent(0.2)
         let endColor = JetpackPrologueStyleGuide.gradientColor
 
-        gradientLayer.colors = FeatureFlag.newLandingScreen.enabled ?
+        gradientLayer.colors = FeatureFlag.newJetpackLandingScreen.enabled ?
         [endColor.cgColor, midTopColor.cgColor, midBottomColor.cgColor, startColor.cgColor] :
         [startColor.cgColor, endColor.cgColor]
 
-        gradientLayer.locations = FeatureFlag.newLandingScreen.enabled ? [0.0, 0.4, 0.6, 1.0] : [0.0, 0.9]
+        gradientLayer.locations = FeatureFlag.newJetpackLandingScreen.enabled ? [0.0, 0.4, 0.6, 1.0] : [0.0, 0.9]
 
         return gradientLayer
     }
@@ -66,7 +66,7 @@ class JetpackPrologueViewController: UIViewController {
 
         view.backgroundColor = JetpackPrologueStyleGuide.backgroundColor
 
-        guard FeatureFlag.newLandingScreen.enabled else {
+        guard FeatureFlag.newJetpackLandingScreen.enabled else {
             loadOldPrologueView()
             return
         }
@@ -133,7 +133,7 @@ class JetpackPrologueViewController: UIViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        guard FeatureFlag.newLandingScreen.enabled,
+        guard FeatureFlag.newJetpackLandingScreen.enabled,
         previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else {
             updateLabel(for: traitCollection)
             return
@@ -145,7 +145,7 @@ class JetpackPrologueViewController: UIViewController {
 
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
-        if !FeatureFlag.newLandingScreen.enabled {
+        if !FeatureFlag.newJetpackLandingScreen.enabled {
             starFieldView.frame = view.bounds
         }
         gradientLayer.frame = view.bounds


### PR DESCRIPTION
Fixes #19480 

This PR enables the new Jetpack Landing Screen on the Jetpack target. Keeps the new WordPress landing screen disabled on the WordPress target

To test:

- Checkout this branch 
- build/run the Jetpack target
- Logout if needed, and make sure the new Jetpack landing screen appears
- Build/run the WordPress target
- Logout if needed, and make sure the OLD landing screen with the carousel appears
- Stop the WordPress execution, and set the `newWordPressLandingScreen` feature flag to `true`
- Build/run again the WordPress target and make sure the new landing screen appears.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
