### PR TITLE
Use Jetpack icon on Jetpack app's about screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -178,7 +178,7 @@ class MeViewController: UITableViewController {
                                               loading: sharePresenter.isLoading))
 
                 rows.append(NavigationItemRow(title: RowTitles.about,
-                                              icon: UIImage.gridicon(.mySites),
+                                              icon: UIImage.gridicon(AppConfiguration.isJetpack ? .plans : .mySites),
                                               accessoryType: .disclosureIndicator,
                                               action: pushAbout(),
                                               accessibilityIdentifier: "About"))


### PR DESCRIPTION
This PR updates the icon used to represent the app on the Me screen. Mirrors the change made in https://github.com/wordpress-mobile/WordPress-Android/pull/17352.

## Screenshots

| Before | After |
| - | - |
| <img width="600" alt="Screen Shot 2022-10-20 at 15 08 14" src="https://user-images.githubusercontent.com/1898325/197026222-f6561742-d04c-40eb-a4e7-e4b6b4708564.png"> | <img width="600" alt="Screen Shot 2022-10-20 at 14 26 32" src="https://user-images.githubusercontent.com/1898325/197026230-091f842c-edf1-48ec-949d-e4440f3b9630.png"> |





## To test
1. Run the JPiOS app
2. Log in and tap the profile picture
3. On the Me screen, verify that the Jetpack icon is shown next to "About Jetpack for iOS"
4. Repeat steps 1 to 3 for WPiOS app, verifying this time that the WordPress icon is shown next to "About WordPress"

## Regression Notes
1. Potential unintended areas of impact

There is very little potential for unintended impact. If the new icon were to cause the app to crash, that would likely occur on the Me screen.

5. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing.

6. What automated tests I added (or what prevented me from doing so)

Automated testing isn't applicable here since it's just a change of icon

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
