### PR TITLE
Jetpack Content Migration Flow: Move synced database to single copy

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.m
+++ b/WordPress/Classes/Utility/ContextManager.m
@@ -24,9 +24,6 @@ static ContextManager *_instance;
 @property (nonatomic, strong) NSString *modelName;
 @property (nonatomic, strong) NSURL *storeURL;
 @property (nonatomic, strong) id<ManagedObjectContextFactory> contextFactory;
-@property (nonatomic, strong) NSOperationQueue *remoteChangeQueue;
-@property (nonatomic, strong) NSPersistentHistoryToken *historyToken;
-@property (nonatomic, strong) id updateUIObserver;
 
 @end
 
@@ -37,14 +34,7 @@ static ContextManager *_instance;
 
 - (instancetype)init
 {
-    NSURL *storeURL;
-    if ([self isSharedLoginEnabled]) {
-        [self copyDatabaseToSharedDirectoryIfNeeded];
-        storeURL = [self sharedDatabasePath];
-    } else {
-        storeURL = [self localDatabasePath];
-    }
-
+    NSURL *storeURL = [self localDatabasePath];
     return [self initWithModelName:ContextManagerModelNameCurrent storeURL:storeURL contextFactory:nil];
 }
 
@@ -66,11 +56,6 @@ static ContextManager *_instance;
         [NSValueTransformer registerCustomTransformers];
         self.contextFactory = (id<ManagedObjectContextFactory>)[[factory alloc] initWithPersistentContainer:self.persistentContainer];
         [[[NullBlogPropertySanitizer alloc] initWithContext:self.contextFactory.mainContext] sanitize];
-        
-        if ([self isSharedLoginEnabled]) {
-            [self pruneTransactionHistory];
-            [self observeStoreChanges];
-        }
     }
 
     return self;
@@ -140,107 +125,6 @@ static ContextManager *_instance;
     }];
 }
 
-#pragma mark - Store Changes
-
-- (void)observeStoreChanges
-{
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleStoreChanges:)
-                                                 name:NSPersistentStoreRemoteChangeNotification
-                                               object:self.persistentContainer.persistentStoreCoordinator];
-}
-
-- (void)handleStoreChanges:(NSNotification *)notification
-{
-    __weak __typeof(self) weakSelf = self;
-    [self.remoteChangeQueue addOperationWithBlock:^{
-        [weakSelf processRemoteChanges];
-    }];
-}
-
-- (void)processRemoteChanges
-{
-    // When changes are made to the database outside the app, a `NSPersistentStoreRemoteChangeNotification` notification
-    // will fire. When we receive one of these notifications, we need to check for database transactions made outside the
-    // current app and process them. We merge these transactions into the main context to sync it with the outside changes
-    // and then update the app's UI.
-    NSManagedObjectContext *context = [self newDerivedContext];
-    [context performBlockAndWait:^{
-        // Fetch all transactions after the last processed transaction or all if no history token is set
-        NSPersistentHistoryChangeRequest *historyChangeRequest = [NSPersistentHistoryChangeRequest fetchHistoryAfterToken:self.historyToken];
-        NSFetchRequest *fetchRequest = [NSPersistentHistoryTransaction fetchRequest];
-
-        // Filters the transactions based on the bundle ID. This is so we only fetch changes made outside the current
-        // running app
-        fetchRequest.predicate = [NSPredicate predicateWithFormat:@"bundleID != %@", [[NSBundle mainBundle] bundleIdentifier]];
-        historyChangeRequest.fetchRequest = fetchRequest;
-
-        NSPersistentHistoryResult *result = [context executeRequest:historyChangeRequest error:nil];
-        NSArray<NSPersistentHistoryTransaction *> *transactions = result.result;
-
-        if (transactions.count > 0) {
-            // Transactions to the database were made outside the current app so we need to merge them into the main
-            // context of the current app
-            for (NSPersistentHistoryTransaction *transaction in transactions) {
-                NSDictionary *userInfo = transaction.objectIDNotification.userInfo;
-
-                if (userInfo) {
-                    // Merge the transaction into the main context
-                    [NSManagedObjectContext mergeChangesFromRemoteContextSave:userInfo
-                                                                 intoContexts:@[self.mainContext]];
-                }
-            }
-            [self saveContext:self.mainContext];
-            // Store the history token of the last transaction so we don't process the same ones again
-            self.historyToken = transactions.lastObject.token;
-            dispatch_async(dispatch_get_main_queue(), ^{
-                // Force the app to update the current UI
-                [self handleUIUpdate];
-            });
-        }
-    }];
-}
-
-- (void)handleUIUpdate
-{
-    UIApplicationState state = UIApplication.sharedApplication.applicationState;
-    
-    void (^showUI)(void) = ^{
-        WordPressAppDelegate *delegate = (WordPressAppDelegate *) UIApplication.sharedApplication.delegate;
-        if (AccountHelper.isLoggedIn) {
-            [WPTabBarController.sharedInstance reloadSplitViewControllers];
-            [delegate.windowManager showAppUIFor:nil completion:nil];
-        } else {
-            [delegate.windowManager showFullscreenSignIn];
-        }
-    };
-    if (state == UIApplicationStateActive) {
-        showUI();
-    } else if (!self.updateUIObserver) {
-        __weak __typeof(self) weakSelf = self;
-        self.updateUIObserver = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidBecomeActiveNotification
-                                                                                object:nil
-                                                                                 queue:[NSOperationQueue mainQueue]
-                                                                            usingBlock:^(NSNotification * _Nonnull note) {
-            showUI();
-            [[NSNotificationCenter defaultCenter] removeObserver:weakSelf.updateUIObserver];
-            weakSelf.updateUIObserver = nil;
-        }];
-    }
-}
-
-- (void)pruneTransactionHistory
-{
-    [self performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-        NSDate *date = [[NSCalendar currentCalendar] dateByAddingUnit:NSCalendarUnitDay
-                                                                value:-7
-                                                               toDate:[NSDate date]
-                                                              options:0];
-        NSPersistentHistoryChangeRequest *deletionRequest = [NSPersistentHistoryChangeRequest deleteHistoryBeforeDate:date];
-        [context executeRequest:deletionRequest error:nil];
-    }];
-}
-
 #pragma mark - Setup
 
 - (NSPersistentContainer *)persistentContainer
@@ -296,12 +180,6 @@ static ContextManager *_instance;
     NSPersistentStoreDescription *storeDescription = [[NSPersistentStoreDescription alloc] initWithURL:self.storeURL];
     storeDescription.shouldInferMappingModelAutomatically = true;
     storeDescription.shouldMigrateStoreAutomatically = true;
-    
-    if ([self isSharedLoginEnabled]) {
-        [storeDescription setOption:@YES forKey:NSPersistentHistoryTrackingKey];
-        [storeDescription setOption:@YES forKey:NSPersistentStoreRemoteChangeNotificationPostOptionKey];
-    }
-    
     return storeDescription;
 }
 
@@ -324,40 +202,6 @@ static ContextManager *_instance;
     }
     return _managedObjectModel;
 }
-
-- (NSOperationQueue *)remoteChangeQueue
-{
-    if (_remoteChangeQueue) {
-        return _remoteChangeQueue;
-    }
-    
-    _remoteChangeQueue = [[NSOperationQueue alloc] init];
-    _remoteChangeQueue.maxConcurrentOperationCount = 1;
-    return _remoteChangeQueue;
-}
-
-- (void)setHistoryToken:(NSPersistentHistoryToken *)historyToken
-{
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:historyToken
-                                         requiringSecureCoding:YES
-                                                         error:nil];
-    
-    [[NSUserDefaults standardUserDefaults] setObject:data forKey:@"transactionHistoryToken"];
-}
-
-- (NSPersistentHistoryToken *)historyToken
-{
-    NSData *data = [[NSUserDefaults standardUserDefaults] objectForKey:@"transactionHistoryToken"];
-    if (data) {
-        NSPersistentHistoryToken *token = [NSKeyedUnarchiver unarchivedObjectOfClass:[NSPersistentHistoryToken class]
-                                                                            fromData:data
-                                                                               error:nil];
-        return token;
-    }
-    
-    return nil;
-}
-
 
 #pragma mark - Private Helpers
 
@@ -410,39 +254,12 @@ static ContextManager *_instance;
     return [[NSBundle mainBundle] pathForResource:@"WordPress" ofType:@"momd"];
 }
 
-- (BOOL)isSharedLoginEnabled
-{
-   return [Feature enabled:FeatureFlagSharedLogin];
-}
-
 - (NSURL *)localDatabasePath
 {
     NSString *documentsDirectory = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory,
                                                                         NSUserDomainMask,
                                                                         YES) lastObject];
     return [NSURL fileURLWithPath:[documentsDirectory stringByAppendingPathComponent:@"WordPress.sqlite"]];
-}
-
-- (NSURL *)sharedDatabasePath
-{
-    NSURL *sharedDirectory = [[NSFileManager defaultManager] containerURLForSecurityApplicationGroupIdentifier:@"group.org.wordpress"];
-    return [sharedDirectory URLByAppendingPathComponent:@"WordPress.sqlite"];
-}
-
-- (void)copyDatabaseToSharedDirectoryIfNeeded
-{
-    BOOL sharedDatabaseExists = [[NSFileManager defaultManager] fileExistsAtPath:[[self sharedDatabasePath] absoluteString]];
-    if (![self isSharedLoginEnabled] || sharedDatabaseExists) {
-        return;
-    }
-    
-    NSString *shmLocalFilePath = [[[self localDatabasePath] absoluteString] stringByAppendingString:@"-shm"];
-    NSString *walLocalFilePath = [[[self localDatabasePath] absoluteString] stringByAppendingString:@"-wal"];
-    NSString *shmSharedFilePath = [[[self sharedDatabasePath] absoluteString] stringByAppendingString:@"-shm"];
-    NSString *walSharedFilePath = [[[self sharedDatabasePath] absoluteString] stringByAppendingString:@"-wal"];
-    [[NSFileManager defaultManager] copyItemAtURL:[self localDatabasePath] toURL:[self sharedDatabasePath] error:nil];
-    [[NSFileManager defaultManager] copyItemAtURL:[NSURL URLWithString:shmLocalFilePath] toURL:[NSURL URLWithString:shmSharedFilePath] error:nil];
-    [[NSFileManager defaultManager] copyItemAtURL:[NSURL URLWithString:walLocalFilePath] toURL:[NSURL URLWithString:walSharedFilePath] error:nil];
 }
 
 @end


### PR DESCRIPTION
Resolves #19476 

## Description

- Removes old shared database code
- Adds a function to save the active open database to a file
- Adds a function to overwrite the open database from a file

## Testing

I used some test code:

<details><summary>SheetActions.swift</summary>
I replaced the story post action with:

```swift
    func makeButton() -> ActionSheetButton {
        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
                                 image: .gridicon(.story),
                                 identifier: "storyButton",
                                 action: {
            print("[CM]: Copying database")
            let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")
            let sharedDatabase = sharedDirectory?.appendingPathComponent("WordPress.sqlite")
            try? ContextManager.shared.createStoreCopy(to: sharedDatabase!)
        })
    }
```

</details>

<details><summary>WordPressAppDelegate.swift</summary>

<pre>
 // MARK: - Application lifecycle

    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
        KeychainUtils.shared.copyKeychainToSharedKeychainIfNeeded()

        window = UIWindow(frame: UIScreen.main.bounds)
        AppAppearance.overrideAppearance()

        // Start CrashLogging as soon as possible (in case a crash happens during startup)
        try? loggingStack.start()

        // Configure WPCom API overrides
        configureWordPressComApi()

        configureWordPressAuthenticator()

        configureReachability()
        configureSelfHostedChallengeHandler()
        updateFeatureFlags()

        window?.makeKeyAndVisible()

        // Restore a disassociated account prior to fixing tokens.
        AccountService(managedObjectContext: mainContext).restoreDisassociatedAccountIfNecessary()

        customizeAppearance()
        configureAnalytics()

        let solver = WPAuthTokenIssueSolver()
        let isFixingAuthTokenIssue = solver.fixAuthTokenIssueAndDo { [weak self] in
            self?.runStartupSequence(with: launchOptions ?? [:])
        }

        shouldRestoreApplicationState = !isFixingAuthTokenIssue

        <b>let rootViewController = window?.rootViewController
        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
        tapGesture.numberOfTapsRequired = 3
        tapGesture.numberOfTouchesRequired = 2
        rootViewController?.view.addGestureRecognizer(tapGesture)</b>

        return true
    }

    <b>@objc func handleTap() {
        print("[CM]: Copying shared database to local file")
        let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")
        let sharedDatabase = sharedDirectory?.appendingPathComponent("WordPress.sqlite")
        try? ContextManager.shared.restoreStoreCopy(from: sharedDatabase!)
    }</b>
</pre>

</details>

To test:

- Use the test code from ^ or add your own to trigger the two functions
- Login to WordPress
- Trigger the copy (with test code: FAB (+) > Story post)
- Launch Jetpack
- Trigger the copy (Test code: Triple tap two fingers (option + left click for simulator))
- Close Jetpack (There's nothing to reload the state at the moment)
- Open Jetpack
- Verify you are logged in

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
