### PR TITLE
Demo possible build error

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -420,6 +420,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         NSNumber *todayExtensionSiteID = [sharedDefaults objectForKey:AppConfigurationWidget.statsTodayWidgetUserDefaultsSiteIdKey];
         NSString *todayExtensionBlogName = [sharedDefaults objectForKey:AppConfigurationWidget.statsTodayWidgetUserDefaultsSiteNameKey];
         NSString *todayExtensionBlogUrl = [sharedDefaults objectForKey:AppConfigurationWidget.statsTodayWidgetUserDefaultsSiteUrlKey];
+        NSString *worksInJetpackButNotInWordPress = [sharedDefaults objectForKey:AppConfigurationWidget.newValueOnlyInJetpack];
 
         Blog *todayExtensionBlog = [Blog lookupWithID:todayExtensionSiteID in:self.managedObjectContext];
         NSTimeZone *timeZone = [todayExtensionBlog timeZone];

--- a/WordPress/Jetpack/WidgetConfiguration.swift
+++ b/WordPress/Jetpack/WidgetConfiguration.swift
@@ -23,5 +23,6 @@ import Foundation
         @objc static let homeWidgetTodayFilename = "JetpackHomeWidgetTodayData.plist"
         @objc static let homeWidgetAllTimeFilename = "JetpackHomeWidgetAllTimeData.plist"
         @objc static let homeWidgetThisWeekFilename = "JetpackHomeWidgetThisWeekData.plist"
+        @objc static let newValueOnlyInJetpack = "test"
     }
 }

--- a/WordPress/JetpackStatsWidgets/LocalizationConfiguration.swift
+++ b/WordPress/JetpackStatsWidgets/LocalizationConfiguration.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension AppConfiguration.Widget {
     struct Localization {
         static let unconfiguredViewTodayTitle = LocalizableStrings.unconfiguredViewJetpackTodayTitle


### PR DESCRIPTION
Demonstrates a drawback of implementing shared configurations by duplicating a class implementation across targets.

It's possible to add a new configuration to the class defined in one target without adding the definition to the other.

<img width="1135" alt="image" src="https://user-images.githubusercontent.com/1218433/197431790-debc1f5b-d4a5-4c5e-8ea0-01ba81c66a4e.png">

Admittedly, our CI setup will reveal that error eventually and in the context of the PR that introduced the change. Still, we ought to find a way to make the error impossible, to avoid such a long feedback loop.