### PR TITLE
Jetpack Focus: Create Jetpack phases helper

### DIFF
--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -22,7 +22,7 @@ class RemoteFeatureFlagStore {
     /// - Parameter remote: An optional FeatureFlagRemote with a default WordPressComRestApi instance. Inject a FeatureFlagRemote with a different WordPressComRestApi instance
     /// to authenticate with the Remote Feature Flags endpoint – this allows customizing flags server-side on a per-user basis.
     /// - Parameter callback: An optional callback that can be used to update UI following the fetch. It is not called on the UI thread.
-    public func updateIfNeeded(using remote: FeatureFlagRemote = FeatureFlagRemote(wordPressComRestApi: WordPressComRestApi.defaultApi()),
+    public func update(using remote: FeatureFlagRemote = FeatureFlagRemote(wordPressComRestApi: WordPressComRestApi.defaultApi()),
                                then callback: FetchCallback? = nil) {
         remote.getRemoteFeatureFlags(forDeviceId: deviceID) { [weak self] result in
             switch result {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -660,7 +660,7 @@ extension WordPressAppDelegate {
             let defaultAccount = try WPAccount.lookupDefaultWordPressComAccount(in: mainContext)
             let api = defaultAccount?.wordPressComRestV2Api ?? WordPressComRestApi.defaultApi()
             let remote = FeatureFlagRemote(wordPressComRestApi: api)
-            remoteFeatureFlagStore.updateIfNeeded(using: remote)
+            remoteFeatureFlagStore.update(using: remote)
         } catch {
             DDLogError("Error fetching default user account: \(error)")
         }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -37,6 +37,11 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newJetpackLandingScreen
     case newWordPressLandingScreen
     case newCoreDataContext
+    case jetpackBrandingPhaseOne
+    case jetpackBrandingPhaseTwo
+    case jetpackBrandingPhaseThree
+    case jetpackBrandingPhaseFour
+    case jetpackBrandingPhaseNewUsers
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -119,6 +124,16 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .newCoreDataContext:
             return true
+        case .jetpackBrandingPhaseOne:
+            return false
+        case .jetpackBrandingPhaseTwo:
+            return false
+        case .jetpackBrandingPhaseThree:
+            return false
+        case .jetpackBrandingPhaseFour:
+            return false
+        case .jetpackBrandingPhaseNewUsers:
+            return false
         }
     }
 
@@ -129,6 +144,16 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     /// This key must match the server-side one for remote feature flagging
     var remoteKey: String? {
         switch self {
+        case .jetpackBrandingPhaseOne:
+            return "jp_removal_one"
+        case .jetpackBrandingPhaseTwo:
+            return "jp_removal_two"
+        case .jetpackBrandingPhaseThree:
+            return "jp_removal_three"
+        case .jetpackBrandingPhaseFour:
+            return "jp_removal_four"
+        case .jetpackBrandingPhaseNewUsers:
+            return "jp_removal_new_users"
             default:
                 return nil
         }
@@ -219,6 +244,16 @@ extension FeatureFlag {
             return "New WordPress landing screen"
         case .newCoreDataContext:
             return "Use new Core Data context structure (Require app restart)"
+        case .jetpackBrandingPhaseOne:
+            return "Jetpack Branding Phase One"
+        case .jetpackBrandingPhaseTwo:
+            return "Jetpack Branding Phase Two"
+        case .jetpackBrandingPhaseThree:
+            return "Jetpack Branding Phase Three"
+        case .jetpackBrandingPhaseFour:
+            return "Jetpack Branding Phase Four"
+        case .jetpackBrandingPhaseNewUsers:
+            return "Jetpack Branding Phase For New Users"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -37,11 +37,11 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case newJetpackLandingScreen
     case newWordPressLandingScreen
     case newCoreDataContext
-    case jetpackBrandingPhaseOne
-    case jetpackBrandingPhaseTwo
-    case jetpackBrandingPhaseThree
-    case jetpackBrandingPhaseFour
-    case jetpackBrandingPhaseNewUsers
+    case jetpackFeaturesRemovalPhaseOne
+    case jetpackFeaturesRemovalPhaseTwo
+    case jetpackFeaturesRemovalPhaseThree
+    case jetpackFeaturesRemovalPhaseFour
+    case jetpackFeaturesRemovalPhaseNewUsers
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -124,15 +124,15 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .newCoreDataContext:
             return true
-        case .jetpackBrandingPhaseOne:
+        case .jetpackFeaturesRemovalPhaseOne:
             return false
-        case .jetpackBrandingPhaseTwo:
+        case .jetpackFeaturesRemovalPhaseTwo:
             return false
-        case .jetpackBrandingPhaseThree:
+        case .jetpackFeaturesRemovalPhaseThree:
             return false
-        case .jetpackBrandingPhaseFour:
+        case .jetpackFeaturesRemovalPhaseFour:
             return false
-        case .jetpackBrandingPhaseNewUsers:
+        case .jetpackFeaturesRemovalPhaseNewUsers:
             return false
         }
     }
@@ -144,15 +144,15 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     /// This key must match the server-side one for remote feature flagging
     var remoteKey: String? {
         switch self {
-        case .jetpackBrandingPhaseOne:
+        case .jetpackFeaturesRemovalPhaseOne:
             return "jp_removal_one"
-        case .jetpackBrandingPhaseTwo:
+        case .jetpackFeaturesRemovalPhaseTwo:
             return "jp_removal_two"
-        case .jetpackBrandingPhaseThree:
+        case .jetpackFeaturesRemovalPhaseThree:
             return "jp_removal_three"
-        case .jetpackBrandingPhaseFour:
+        case .jetpackFeaturesRemovalPhaseFour:
             return "jp_removal_four"
-        case .jetpackBrandingPhaseNewUsers:
+        case .jetpackFeaturesRemovalPhaseNewUsers:
             return "jp_removal_new_users"
             default:
                 return nil
@@ -244,16 +244,16 @@ extension FeatureFlag {
             return "New WordPress landing screen"
         case .newCoreDataContext:
             return "Use new Core Data context structure (Require app restart)"
-        case .jetpackBrandingPhaseOne:
-            return "Jetpack Branding Phase One"
-        case .jetpackBrandingPhaseTwo:
-            return "Jetpack Branding Phase Two"
-        case .jetpackBrandingPhaseThree:
-            return "Jetpack Branding Phase Three"
-        case .jetpackBrandingPhaseFour:
-            return "Jetpack Branding Phase Four"
-        case .jetpackBrandingPhaseNewUsers:
-            return "Jetpack Branding Phase For New Users"
+        case .jetpackFeaturesRemovalPhaseOne:
+            return "Jetpack Features Removal Phase One"
+        case .jetpackFeaturesRemovalPhaseTwo:
+            return "Jetpack Features Removal Phase Two"
+        case .jetpackFeaturesRemovalPhaseThree:
+            return "Jetpack Features Removal Phase Three"
+        case .jetpackFeaturesRemovalPhaseFour:
+            return "Jetpack Features Removal Phase Four"
+        case .jetpackFeaturesRemovalPhaseNewUsers:
+            return "Jetpack Features Removal Phase For New Users"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -17,4 +17,16 @@ class JetpackBrandingCoordinator {
     static func makeJetpackOverlayView(redirectAction: (() -> Void)? = nil) -> UIView {
         JetpackOverlayView(buttonAction: redirectAction)
     }
+
+    static func shouldShowBannerForJetpackDependentFeatures() -> Bool {
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
+        switch phase {
+        case .two:
+            fallthrough
+        case .three:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// A class containing convenience methods for the the Jetpack features removal experience
+class JetpackFeaturesRemovalCoordinator {
+
+    /// Enum descibing the current phase of the Jetpack features removal
+    enum GeneralPhase {
+        case normal
+        case one
+        case two
+        case three
+        case four
+        case newUsers
+    }
+
+    /// Enum descibing the current phase of the site creation flow removal
+    enum SiteCreationPhase {
+        case normal
+        case one
+        case two
+    }
+
+    static func generalPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> GeneralPhase {
+        if AppConfiguration.isJetpack {
+            return .normal // Always return normal for Jetpack
+        }
+
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseNewUsers) {
+            return .newUsers
+        }
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseFour) {
+            return .four
+        }
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseThree) {
+            return .three
+        }
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseTwo) {
+            return .two
+        }
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseOne) {
+            return .one
+        }
+
+        return .normal
+    }
+
+    static func siteCreationPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> SiteCreationPhase {
+        if AppConfiguration.isJetpack {
+            return .normal // Always return normal for Jetpack
+        }
+
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseNewUsers)
+            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseFour) {
+            return .two
+        }
+        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseThree)
+            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseTwo)
+            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseOne) {
+            return .one
+        }
+
+        return .normal
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -25,19 +25,19 @@ class JetpackFeaturesRemovalCoordinator {
             return .normal // Always return normal for Jetpack
         }
 
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseNewUsers) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers) {
             return .newUsers
         }
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseFour) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseFour) {
             return .four
         }
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseThree) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseThree) {
             return .three
         }
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseTwo) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseTwo) {
             return .two
         }
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseOne) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseOne) {
             return .one
         }
 
@@ -49,13 +49,13 @@ class JetpackFeaturesRemovalCoordinator {
             return .normal // Always return normal for Jetpack
         }
 
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseNewUsers)
-            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseFour) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers)
+            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseFour) {
             return .two
         }
-        if featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseThree)
-            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseTwo)
-            || featureFlagStore.value(for: FeatureFlag.jetpackBrandingPhaseOne) {
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseThree)
+            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseTwo)
+            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseOne) {
             return .one
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1438,6 +1438,9 @@
 		803DE81928FFB7B5007D4E9C /* RemoteConfigParameterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE81828FFB7B5007D4E9C /* RemoteConfigParameterTests.swift */; };
 		803DE81B28FFC0B7007D4E9C /* RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE81A28FFC0B7007D4E9C /* RemoteConfig.swift */; };
 		803DE81C28FFC0B7007D4E9C /* RemoteConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE81A28FFC0B7007D4E9C /* RemoteConfig.swift */; };
+		803DE81F290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */; };
+		803DE821290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE820290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift */; };
+		803DE822290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803DE820290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
@@ -6767,6 +6770,8 @@
 		803DE81528FFAEF2007D4E9C /* RemoteConfigParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigParameter.swift; sourceTree = "<group>"; };
 		803DE81828FFB7B5007D4E9C /* RemoteConfigParameterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigParameterTests.swift; sourceTree = "<group>"; };
 		803DE81A28FFC0B7007D4E9C /* RemoteConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfig.swift; sourceTree = "<group>"; };
+		803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackFeaturesRemovalCoordinatorTests.swift; sourceTree = "<group>"; };
+		803DE820290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackFeaturesRemovalCoordinator.swift; sourceTree = "<group>"; };
 		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
 		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
 		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
@@ -10528,6 +10533,7 @@
 			isa = PBXGroup;
 			children = (
 				3F43704328932F0100475B6E /* JetpackBrandingCoordinator.swift */,
+				803DE820290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -12275,6 +12281,14 @@
 				7E3E7A6320E44ED60075D159 /* SubjectContentGroup.swift */,
 			);
 			path = Groups;
+			sourceTree = "<group>";
+		};
+		803DE81D29063689007D4E9C /* Jetpack */ = {
+			isa = PBXGroup;
+			children = (
+				803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */,
+			);
+			name = Jetpack;
 			sourceTree = "<group>";
 		};
 		8096212828E5535E00940A5D /* JetpackShareExtension */ = {
@@ -15473,6 +15487,7 @@
 				E1C9AA541C1041E600732665 /* Extensions */,
 				FF9A6E6F21F9359200D36D14 /* Gutenberg */,
 				32110548250BFC5A0048446F /* Image Dimension Parser */,
+				803DE81D29063689007D4E9C /* Jetpack */,
 				FF7C89A11E3A1029000472A8 /* MediaPicker */,
 				5D7A577D1AFBFD7C0097C028 /* Models */,
 				85F8E1991B017A8E000859BB /* Networking */,
@@ -19888,6 +19903,7 @@
 				B0A3A6D9283D778E0019C530 /* StatsRevampV2IntroductionPresenter.swift in Sources */,
 				F5E63129243BC8190088229D /* FilterSheetView.swift in Sources */,
 				A0E293F10E21027E00C6919C /* WPAddPostCategoryViewController.m in Sources */,
+				803DE821290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift in Sources */,
 				17C1D67C2670E3DC006C8970 /* SiteIconPickerView.swift in Sources */,
 				E6BDEA731CE4824300682885 /* ReaderSearchTopic.swift in Sources */,
 				FEA7949026DF7F3700CEC520 /* WPStyleGuide+CommentDetail.swift in Sources */,
@@ -22066,6 +22082,7 @@
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */,
 				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,
+				803DE81F290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift in Sources */,
 				937250EE267A492D0086075F /* StatsPeriodStoreTests.swift in Sources */,
 				F1B1E7A324098FA100549E2A /* BlogTests.swift in Sources */,
 				57889AB823589DF100DAE56D /* PageBuilder.swift in Sources */,
@@ -22652,6 +22669,7 @@
 				FABB21AE2602FC2C00C8785C /* NotificationSettingStreamsViewController.swift in Sources */,
 				FABB21AF2602FC2C00C8785C /* SiteDesignPreviewViewController.swift in Sources */,
 				FABB21B02602FC2C00C8785C /* ReaderReblogFormatter.swift in Sources */,
+				803DE822290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift in Sources */,
 				FABB21B12602FC2C00C8785C /* Array.swift in Sources */,
 				FABB21B22602FC2C00C8785C /* NotificationActionParser.swift in Sources */,
 				FABB21B32602FC2C00C8785C /* SiteTagsViewController.swift in Sources */,

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -253,11 +253,11 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
                                phaseFour: Bool,
                                phaseNewUsers: Bool) -> [WordPressKit.FeatureFlag] {
         return [
-            .init(title: FeatureFlag.jetpackBrandingPhaseOne.remoteKey ?? "", value: phaseOne),
-            .init(title: FeatureFlag.jetpackBrandingPhaseTwo.remoteKey ?? "", value: phaseTwo),
-            .init(title: FeatureFlag.jetpackBrandingPhaseThree.remoteKey ?? "", value: phaseThree),
-            .init(title: FeatureFlag.jetpackBrandingPhaseFour.remoteKey ?? "", value: phaseFour),
-            .init(title: FeatureFlag.jetpackBrandingPhaseNewUsers.remoteKey ?? "", value: phaseNewUsers),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseOne.remoteKey ?? "", value: phaseOne),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseTwo.remoteKey ?? "", value: phaseTwo),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseThree.remoteKey ?? "", value: phaseThree),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseFour.remoteKey ?? "", value: phaseFour),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.remoteKey ?? "", value: phaseNewUsers),
         ]
     }
 }

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -1,0 +1,263 @@
+import XCTest
+@testable import WordPress
+
+final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
+
+    private var mockUserDefaults: InMemoryUserDefaults!
+
+    override func setUp() {
+        mockUserDefaults = InMemoryUserDefaults()
+    }
+
+    // MARK: General Phase Tests
+
+    func testNormalGeneralPhase() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .normal)
+    }
+
+    func testNewUsersGeneralPhase() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .newUsers)
+    }
+
+    func testNewUsersGeneralPhasePrecedence() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: true)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .newUsers)
+    }
+
+    func testGeneralPhaseOne() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .one)
+    }
+
+    func testGeneralPhaseTwo() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+    }
+
+    func testGeneralPhaseTwoPrecedence() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+    }
+
+    func testGeneralPhaseThree() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .three)
+    }
+
+    func testGeneralPhaseThreePrecedence() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .three)
+    }
+
+    func testGeneralPhaseFour() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .four)
+    }
+
+    func testGeneralPhaseFourPrecedence() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .four)
+    }
+
+    // MARK: Site Creation Phase Tests
+
+    func testNormalSiteCreationPhase() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .normal)
+    }
+
+    func testSiteCreationPhaseOne() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+
+        // When
+        var flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+        var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .one)
+
+        // When
+        flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        remote.flags = flags
+        store.updateIfNeeded(using: remote)
+        phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .one)
+
+        // When
+        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        remote.flags = flags
+        store.updateIfNeeded(using: remote)
+        phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .one)
+    }
+
+    func testSiteCreationPhaseTwo() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+
+        // When
+        var flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+        var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+
+        // When
+        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
+        remote.flags = flags
+        store.updateIfNeeded(using: remote)
+        phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+    }
+
+    func testSiteCreationPhaseTwoPrecedence() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+
+        // When
+        var flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.updateIfNeeded(using: remote)
+        var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+
+        // When
+        flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: true)
+        remote.flags = flags
+        store.updateIfNeeded(using: remote)
+        phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .two)
+    }
+
+    // MARK: Helpers
+
+    private func generateFlags(phaseOne: Bool,
+                               phaseTwo: Bool,
+                               phaseThree: Bool,
+                               phaseFour: Bool,
+                               phaseNewUsers: Bool) -> [WordPressKit.FeatureFlag] {
+        return [
+            .init(title: FeatureFlag.jetpackBrandingPhaseOne.remoteKey ?? "", value: phaseOne),
+            .init(title: FeatureFlag.jetpackBrandingPhaseTwo.remoteKey ?? "", value: phaseTwo),
+            .init(title: FeatureFlag.jetpackBrandingPhaseThree.remoteKey ?? "", value: phaseThree),
+            .init(title: FeatureFlag.jetpackBrandingPhaseFour.remoteKey ?? "", value: phaseFour),
+            .init(title: FeatureFlag.jetpackBrandingPhaseNewUsers.remoteKey ?? "", value: phaseNewUsers),
+        ]
+    }
+}

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -16,7 +16,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -30,7 +30,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -44,7 +44,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: true)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -58,7 +58,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -72,7 +72,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -86,7 +86,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -100,7 +100,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -114,7 +114,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -128,7 +128,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -142,7 +142,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
@@ -158,7 +158,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
         let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
 
         // When
         let phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -174,7 +174,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         var flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -183,7 +183,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
         remote.flags = flags
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -192,7 +192,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
         remote.flags = flags
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -206,7 +206,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         var flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -215,7 +215,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
         remote.flags = flags
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -229,7 +229,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         var flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
         let remote = MockFeatureFlagRemote(flags: flags)
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then
@@ -238,7 +238,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         // When
         flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: true)
         remote.flags = flags
-        store.updateIfNeeded(using: remote)
+        store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
 
         // Then

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -45,7 +45,7 @@ class RemoteFeatureFlagTests: XCTestCase {
     }
 
     func testThatUpdateCachesNewFlags() {
-        let mock = MockFeatureFlagRemote(flags: MockFeatureFlag.remoteCases)
+        let mock = MockFeatureFlagRemote(mockFlags: MockFeatureFlag.remoteCases)
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
 
         store.updateIfNeeded(using: mock)
@@ -75,9 +75,14 @@ class MockFeatureFlagRemote: FeatureFlagRemote {
     var flags: FeatureFlagList
     var deviceIdCallback: ((String) -> Void)?
 
-    init(flags: [MockFeatureFlag] = [], shouldSucceed: Bool = true) {
-        self.flags = flags
+    init(mockFlags: [MockFeatureFlag] = []) {
+        self.flags = mockFlags
             .compactMap { $0.toFeatureFlag }
+        super.init()
+    }
+
+    init(flags: [WordPressKit.FeatureFlag]) {
+        self.flags = flags
         super.init()
     }
 

--- a/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagTests.swift
@@ -22,8 +22,8 @@ class RemoteFeatureFlagTests: XCTestCase {
             exp.fulfill()
         }
 
-        store.updateIfNeeded(using: mock)
-        store.updateIfNeeded(using: mock)
+        store.update(using: mock)
+        store.update(using: mock)
 
         wait(for: [exp], timeout: 1.0)
     }
@@ -48,7 +48,7 @@ class RemoteFeatureFlagTests: XCTestCase {
         let mock = MockFeatureFlagRemote(mockFlags: MockFeatureFlag.remoteCases)
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
 
-        store.updateIfNeeded(using: mock)
+        store.update(using: mock)
 
         // All of the remotely defined values should be present
         XCTAssertTrue(store.hasValue(for: MockFeatureFlag.remotelyEnabledLocallyEnabledFeature))


### PR DESCRIPTION
Closes #19446

## Description
- Added remote feature flags
- Added `JetpackFeaturesRemovalCoordinator` with helpers to determine the current phase
- Added helper function to determine if we should show banners for JP-dependent features based on the current phase

## Testing Instructions

No testing is required since no changes to the running code were made. The PR only adds helpers to be used in subsequent PRs.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
