### PR TITLE
[Jetpack landing screen] Add padding, enlarge text and enlarge logo on iPad

### DIFF
--- a/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
+++ b/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
@@ -188,7 +188,7 @@ class JetpackPrologueViewController: UIViewController {
         static let defaultAngleDegrees: Double = 30.0
         /// Uniform multiplier used to tweak the rate generated from an angle
         static let angleRateMultiplier: CGFloat = 1.3
-        ///
+        /// Returns the Jetpack logo width depending on the given size class
         static func logoWidth(for sizeClass: UIUserInterfaceSizeClass) -> CGFloat {
             return sizeClass == .compact ? 68 : 78
         }

--- a/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
+++ b/WordPress/Jetpack/Classes/NUX/JetpackPrologueViewController.swift
@@ -39,6 +39,11 @@ class JetpackPrologueViewController: UIViewController {
         makeGradientLayer()
     }()
 
+    private lazy var logoWidthConstraint: NSLayoutConstraint = {
+        let width = Constants.logoWidth(for: traitCollection.horizontalSizeClass)
+        return logoImageView.widthAnchor.constraint(equalToConstant: width)
+    }()
+
     private func makeGradientLayer() -> CAGradientLayer {
         let gradientLayer = CAGradientLayer()
 
@@ -99,7 +104,7 @@ class JetpackPrologueViewController: UIViewController {
         view.layer.insertSublayer(gradientLayer, above: jetpackAnimatedView.layer)
         // constraints
         NSLayoutConstraint.activate([
-            logoImageView.widthAnchor.constraint(equalToConstant: 68),
+            logoWidthConstraint,
             logoImageView.heightAnchor.constraint(equalTo: logoImageView.widthAnchor),
             logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
             logoImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 68)
@@ -129,9 +134,13 @@ class JetpackPrologueViewController: UIViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        guard FeatureFlag.newJetpackLandingScreen.enabled else {
+            return
+        }
 
-        guard FeatureFlag.newJetpackLandingScreen.enabled,
-        previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else {
+        logoWidthConstraint.constant = Constants.logoWidth(for: traitCollection.horizontalSizeClass)
+
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else {
             updateLabel(for: traitCollection)
             return
         }
@@ -179,6 +188,10 @@ class JetpackPrologueViewController: UIViewController {
         static let defaultAngleDegrees: Double = 30.0
         /// Uniform multiplier used to tweak the rate generated from an angle
         static let angleRateMultiplier: CGFloat = 1.3
+        ///
+        static func logoWidth(for sizeClass: UIUserInterfaceSizeClass) -> CGFloat {
+            return sizeClass == .compact ? 68 : 78
+        }
     }
 }
 

--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
@@ -6,9 +6,6 @@ final class JetpackLandingScreenView: UIView {
 
     private var labels: [UILabel] = []
 
-    private var compactConstraints = [NSLayoutConstraint]()
-    private var regularConstraints = [NSLayoutConstraint]()
-
     // MARK: - Init
 
     init() {
@@ -45,30 +42,16 @@ final class JetpackLandingScreenView: UIView {
         let insets = Constants.insets
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: insets.top),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom)
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -insets.bottom),
+            stackView.leadingAnchor.constraint(equalTo: readableContentGuide.leadingAnchor, constant: insets.leading),
+            stackView.trailingAnchor.constraint(equalTo: readableContentGuide.trailingAnchor, constant: -insets.trailing)
         ])
-        self.compactConstraints = [
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: insets.left),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -insets.right)
-        ]
-        self.regularConstraints = [
-            stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth),
-            stackView.centerXAnchor.constraint(equalTo: centerXAnchor)
-        ]
     }
 
     // MARK: - Layout Lifecycle
 
-    override func updateConstraints() {
-        super.updateConstraints()
-        let isCompactSizeClass = traitCollection.horizontalSizeClass == .compact
-        self.compactConstraints.forEach { $0.isActive = isCompactSizeClass }
-        self.regularConstraints.forEach { $0.isActive = !isCompactSizeClass }
-    }
-
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        self.setNeedsUpdateConstraints()
         self.updateLabelsTextAttributes()
     }
 
@@ -118,7 +101,7 @@ final class JetpackLandingScreenView: UIView {
         static let oddColor = JetpackPromptsConfiguration.Constants.oddColor
 
         static let interitemSpacing: CGFloat = 8
-        static let insets = UIEdgeInsets(top: Self.interitemSpacing, left: 16, bottom: 0, right: 16)
+        static let insets = NSDirectionalEdgeInsets(top: Self.interitemSpacing, leading: 16, bottom: 0, trailing: 16)
         static let maxWidth: CGFloat = 579
 
         static let lineHeightMultiple: CGFloat = 0.8

--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
@@ -102,7 +102,6 @@ final class JetpackLandingScreenView: UIView {
 
         static let interitemSpacing: CGFloat = 8
         static let insets = NSDirectionalEdgeInsets(top: Self.interitemSpacing, leading: 16, bottom: 0, trailing: 16)
-        static let maxWidth: CGFloat = 579
 
         static let lineHeightMultiple: CGFloat = 0.8
 

--- a/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
+++ b/WordPress/Jetpack/Classes/NUX/New Landing Screen/Views/JetpackLandingScreenView.swift
@@ -91,6 +91,8 @@ final class JetpackLandingScreenView: UIView {
         for (index, label) in labels.enumerated() {
             label.attributedText = Self.attributedTextForLabel(atIndex: index, text: label.text, traits: traitCollection)
         }
+        self.setNeedsLayout()
+        self.layoutIfNeeded()
     }
 
     // MARK: - Constants


### PR DESCRIPTION
Fixes #19499

Tweak Jetpack Landing Screen Prompts on iPad to align with the design on Figma:
- Fonts are enlarged.
- Prompts width is limited with large padding on the side.
- Jetpack logo is enlarged.

## Screen Recording
https://user-images.githubusercontent.com/9609223/198606763-f51e2140-a9c8-4165-a36a-3422d9b15f4e.mp4

## To test:
1. Launch the Jetpack app on iPad and log out to reach the Landing Screen.
2. **Verify** that the Landing Screen is visually close to the [Figma design](https://github.com/wordpress-mobile/WordPress-iOS/issues/19499#issue-1418660852).
3. [Open another app in Split View.](https://support.apple.com/en-gb/guide/ipad/ipad08c9970c/ipados)
4. Drag the Split View's divider to increase / decrease Jetpack window's width.
5. **Verify** that the prompts fonts, padding and Jetpack logo are smaller when the Jetpack window is compact. The app's design is similar to when the app is running on <a href="https://user-images.githubusercontent.com/9609223/197196522-85129c97-9bcc-4fa5-8ad2-e74f56997827.png">iPhone</a>.
6. **Verify** the prompts fonts, padding and Jetpack logo are large when the Jetpack window is large.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual Tests.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
