### PR TITLE
Remove redundant `#available(iOS 12, *)` checks

### DIFF
--- a/WordPress/Classes/Models/ValueTransformers.swift
+++ b/WordPress/Classes/Models/ValueTransformers.swift
@@ -3,10 +3,6 @@ import Foundation
 extension ValueTransformer {
     @objc
     static func registerCustomTransformers() {
-        guard #available(iOS 12.0, *) else {
-            return
-        }
-
         CoordinateValueTransformer.register()
         NSErrorValueTransformer.register()
         SetValueTransformer.register()

--- a/WordPress/Classes/Utility/Spotlight/SearchableActivityConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/SearchableActivityConvertable.swift
@@ -103,13 +103,10 @@ extension SearchableActivityConvertable where Self: UIViewController {
 
         activity.isEligibleForSearch = true
         activity.isEligibleForHandoff = false
+        activity.isEligibleForPrediction = true
 
-        if #available(iOS 12.0, *) {
-            activity.isEligibleForPrediction = true
-
-            if let wpActivityType = WPActivityType(rawValue: activityType) {
-                activity.suggestedInvocationPhrase = wpActivityType.suggestedInvocationPhrase
-            }
+        if let wpActivityType = WPActivityType(rawValue: activityType) {
+            activity.suggestedInvocationPhrase = wpActivityType.suggestedInvocationPhrase
         }
 
         // Set the UIViewController's userActivity property, which is defined in UIResponder. Doing this allows

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
@@ -14,10 +14,8 @@ class GutenGhostView: UIView {
     @IBOutlet var toolbarViews: [UIView]!
     @IBOutlet weak var toolbarTopBorderView: UIView! {
         didSet {
-            if #available(iOS 12.0, *) {
-                let isDarkStyle = traitCollection.userInterfaceStyle == .dark
-                toolbarTopBorderView.isHidden = isDarkStyle
-            }
+            let isDarkStyle = traitCollection.userInterfaceStyle == .dark
+            toolbarTopBorderView.isHidden = isDarkStyle
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -287,9 +287,7 @@ class AppSettingsViewController: UITableViewController {
 
             tableView?.deselectSelectedRowWithAnimation(true)
 
-            if #available(iOS 12.0, *) {
-                NSUserActivity.deleteAllSavedUserActivities {}
-            }
+            NSUserActivity.deleteAllSavedUserActivities {}
 
             let notice = Notice(title: NSLocalizedString("Siri Reset Confirmation", value: "Successfully cleared Siri Shortcut Suggestions", comment: "Notice displayed to the user after clearing the Siri activity donations."), feedbackType: .success)
             ActionDispatcher.dispatch(NoticeAction.post(notice))
@@ -460,14 +458,12 @@ private extension AppSettingsViewController {
             spotlightClearCacheRow
         ]
 
-        if #available(iOS 12.0, *) {
-            let siriClearCacheRow = BrandedNavigationRow(
-                title: NSLocalizedString("Siri Reset Prompt", value: "Clear Siri Shortcut Suggestions", comment: "Label for button that clears user activities donated to Siri."),
-                action: clearSiriActivityDonations(),
-                accessibilityIdentifier: "spotlightClearCacheButton")
+        let siriClearCacheRow = BrandedNavigationRow(
+            title: NSLocalizedString("Siri Reset Prompt", value: "Clear Siri Shortcut Suggestions", comment: "Label for button that clears user activities donated to Siri."),
+            action: clearSiriActivityDonations(),
+            accessibilityIdentifier: "spotlightClearCacheButton")
 
-            tableRows.append(siriClearCacheRow)
-        }
+        tableRows.append(siriClearCacheRow)
 
         tableRows.append(mediaRemoveLocation)
         let removeLocationFooterText = NSLocalizedString("Removes location metadata from photos before uploading them to your site.", comment: "Explanatory text for removing the location from uploaded media.")

--- a/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/SignupEpilogueCell.swift
@@ -188,10 +188,6 @@ private extension SignupEpilogueCell {
     }
 
     func configureTextContentTypeIfNeeded(for cellType: EpilogueCellType) {
-        guard #available(iOS 12, *) else {
-            return
-        }
-
         switch cellType {
         case .displayName:
             cellField.textContentType = .name

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/FloatingActionButton.swift
@@ -36,11 +36,7 @@ class FloatingActionButton: UIButton {
         layer.shadowColor = Constants.shadowColor.cgColor
         layer.shadowOffset = .zero
         layer.shadowRadius = Constants.shadowRadius
-        if #available(iOS 12.0, *) {
-            layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 1 : 0
-        } else {
-            layer.shadowOpacity = 1
-        }
+        layer.shadowOpacity = traitCollection.userInterfaceStyle == .light ? 1 : 0
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -146,9 +146,7 @@ class WPSplitViewController: UISplitViewController {
         // This is to work around an apparent bug in iOS 13 where the detail view is assuming the system is in dark
         // mode when switching out of the app and then back in. Here we ensure the overridden user interface style
         // traits are replaced with the correct current traits before we use them.
-        if #available(iOS 12.0, *) {
-            traits.append(UITraitCollection(userInterfaceStyle: traitCollection.userInterfaceStyle))
-        }
+        traits.append(UITraitCollection(userInterfaceStyle: traitCollection.userInterfaceStyle))
 
         return UITraitCollection(traitsFrom: traits)
     }


### PR DESCRIPTION
They always return `true` since the deployment version is higher than iOS 12.

I was looking at `#available` statements as part of #19496 and realized we still has some of these laying around.

There are even `#available(iOS 11, *)` and below showing up in the project, but they are all in the Pods or in `SnapshotHelper.swift`, which is code generated.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
