### PR TITLE
Remove redundant `#available(iOS 13, *)` checks

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -94,7 +94,7 @@ class FilterChipButton: UIView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13, *), traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
+        if traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             applyColors()
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
@@ -66,13 +66,7 @@ extension GravatarButtonView {
 extension GravatarButtonView {
 
     private struct StandardBorder {
-        static var color: UIColor {
-            if #available(iOS 13, *) {
-                return .separator
-            }
-
-            return .gray(.shade20)
-        }
+        static var color: UIColor = .separator
 
         static let width = CGFloat(0.5)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
@@ -66,7 +66,7 @@ extension GravatarButtonView {
 extension GravatarButtonView {
 
     private struct StandardBorder {
-        static var color: UIColor = .separator
+        static let color: UIColor = .separator
 
         static let width = CGFloat(0.5)
     }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -118,10 +118,8 @@ class DomainSuggestionsTableViewController: UITableViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if #available(iOS 13, *) {
-            if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
-                tableView.reloadData()
-            }
+        if traitCollection.userInterfaceStyle != previousTraitCollection?.userInterfaceStyle {
+            tableView.reloadData()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
@@ -32,9 +32,7 @@ class GutenbergWebNavigationController: UINavigationController {
             super.present(viewControllerToPresent, animated: flag, completion: completion)
         }
 
-        guard
-            #available(iOS 13, *),
-            let menuViewControllerClass = NSClassFromString("UIDocumentMenuViewController"), // Silence deprecation warning.
+        guard let menuViewControllerClass = NSClassFromString("UIDocumentMenuViewController"), // Silence deprecation warning.
             viewControllerToPresent.isKind(of: menuViewControllerClass),
             UIDevice.current.userInterfaceIdiom == .phone
         else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
@@ -93,17 +93,11 @@ class GutenGhostView: UIView {
 }
 
 private extension UIColor {
-    static var ghostToolbarBackground: UIColor = UIColor(light: .clear, dark: UIColor.colorFromHex("2e2e2e"))
+    static let ghostToolbarBackground = UIColor(light: .clear, dark: UIColor.colorFromHex("2e2e2e"))
 
-    static var ghostBlockBackground: UIColor {
-        return UIColor(light: .clear, dark: .systemGray5)
-    }
+    static let ghostBlockBackground = UIColor(light: .clear, dark: .systemGray5)
 
-    static var beatEndColor: UIColor {
-        return UIColor(light: .systemGray6, dark: .clear)
-    }
+    static let beatEndColor = UIColor(light: .systemGray6, dark: .clear)
 
-    static var background: UIColor {
-        return .systemBackground
-    }
+    static let background = UIColor.systemBackground
 }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Views/GutenGhostView.swift
@@ -93,12 +93,7 @@ class GutenGhostView: UIView {
 }
 
 private extension UIColor {
-    static var ghostToolbarBackground: UIColor {
-        if #available(iOS 13, *) {
-            return UIColor(light: .clear, dark: UIColor.colorFromHex("2e2e2e"))
-        }
-        return .clear
-    }
+    static var ghostToolbarBackground: UIColor = UIColor(light: .clear, dark: UIColor.colorFromHex("2e2e2e"))
 
     static var ghostBlockBackground: UIColor {
         return UIColor(light: .clear, dark: .systemGray5)

--- a/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/AuthorFilterViewController.swift
@@ -48,11 +48,7 @@ class AuthorFilterViewController: UITableViewController {
         tableView.separatorColor = .clear
         tableView.isScrollEnabled = false
         tableView.showsVerticalScrollIndicator = false
-        if #available(iOS 13, *) {
-            tableView.contentInset = .zero
-        } else {
-            tableView.contentInset = UIEdgeInsets(top: -Metrics.topinset, left: 0, bottom: 0, right: 0)
-        }
+        tableView.contentInset = .zero
     }
 
     required init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostTagPickerViewController.swift
@@ -145,9 +145,7 @@ class PostTagPickerViewController: UIViewController {
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        if #available(iOS 13, *) {
-            textViewContainer.layer.borderColor = UIColor.divider.cgColor
-        }
+        textViewContainer.layer.borderColor = UIColor.divider.cgColor
     }
 
     @objc func doneButtonPressed() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -159,19 +159,15 @@ class ReaderWebView: WKWebView {
     /// Maps app colors to CSS colors to be applied in the webview
     ///
     private func cssColors() -> String {
-        if #available(iOS 13, *) {
-            return """
-                @media (prefers-color-scheme: dark) {
-                    \(mappedCSSColors(.dark))
-                }
+        return """
+            @media (prefers-color-scheme: dark) {
+                \(mappedCSSColors(.dark))
+            }
 
-                @media (prefers-color-scheme: light) {
-                    \(mappedCSSColors(.light))
-                }
-            """
-        }
-
-        return lightCSSColors()
+            @media (prefers-color-scheme: light) {
+                \(mappedCSSColors(.light))
+            }
+        """
     }
 
     /// If iOS 13, returns light and dark colors

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -36,7 +36,7 @@ class ReaderInterestsStyleGuide {
     }
 
     // MARK: - Next Button
-    public static var buttonContainerViewBackgroundColor: UIColor = .tertiarySystemBackground
+    public static let buttonContainerViewBackgroundColor: UIColor = .tertiarySystemBackground
 
     public class func applyNextButtonStyle(button: FancyButton) {
         let disabledBackgroundColor: UIColor

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -36,13 +36,7 @@ class ReaderInterestsStyleGuide {
     }
 
     // MARK: - Next Button
-    public class var buttonContainerViewBackgroundColor: UIColor {
-        if #available(iOS 13, *) {
-            return .tertiarySystemBackground
-        }
-
-        return .white
-    }
+    public static var buttonContainerViewBackgroundColor: UIColor = .tertiarySystemBackground
 
     public class func applyNextButtonStyle(button: FancyButton) {
         let disabledBackgroundColor: UIColor

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleTextfieldHeader.swift
@@ -90,12 +90,7 @@ final class SearchTextField: UITextField {
     }()
 
     private lazy var activityIndicator: UIActivityIndicatorView = {
-        let activityIndicator: UIActivityIndicatorView
-        if #available(iOS 13, *) {
-            activityIndicator = UIActivityIndicatorView(style: .medium)
-        } else {
-            activityIndicator = UIActivityIndicatorView(style: .gray)
-        }
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
         activityIndicator.backgroundColor = UIColor.clear
 
         return activityIndicator

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -262,7 +262,7 @@ extension WPStyleGuide {
             static let selectedDay = UIColor.accent
         }
 
-        static var mapBackground: UIColor = .systemGray4
+        static let mapBackground: UIColor = .systemGray4
 
         // MARK: - Posting Activity Collection View Styles
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -262,12 +262,7 @@ extension WPStyleGuide {
             static let selectedDay = UIColor.accent
         }
 
-        static var mapBackground: UIColor {
-            if #available(iOS 13, *) {
-                return .systemGray4
-            }
-            return .neutral(.shade10)
-        }
+        static var mapBackground: UIColor = .systemGray4
 
         // MARK: - Posting Activity Collection View Styles
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -67,12 +67,11 @@ private extension CountriesMapView {
     }
 
     func mapColors() -> [UIColor] {
-        if #available(iOS 13, *) {
-            if traitCollection.userInterfaceStyle == .dark {
-                return [.primary(.shade90), .primary]
-            }
+        if traitCollection.userInterfaceStyle == .dark {
+            return [.primary(.shade90), .primary]
+        } else {
+            return [.primary(.shade5), .primary]
         }
-        return [.primary(.shade5), .primary]
     }
 
     func setGradientColors() {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -8,7 +8,7 @@ class WidgetStyles: NSObject {
     static let headlineFont = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
     static let footnoteNote = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
 
-    static var separatorColor: UIColor = .separator
+    static let separatorColor: UIColor = .separator
 
     static var separatorVibrancyEffect: UIVibrancyEffect = {
         if #available(iOS 13, *) {

--- a/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Today Widgets/WidgetStyles.swift
@@ -8,13 +8,7 @@ class WidgetStyles: NSObject {
     static let headlineFont = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .headline).pointSize)
     static let footnoteNote = UIFont.systemFont(ofSize: UIFont.preferredFont(forTextStyle: .footnote).pointSize)
 
-    static var separatorColor: UIColor = {
-        if #available(iOS 13, *) {
-            return .separator
-        } else {
-            return .divider
-        }
-    }()
+    static var separatorColor: UIColor = .separator
 
     static var separatorVibrancyEffect: UIVibrancyEffect = {
         if #available(iOS 13, *) {

--- a/WordPress/WordPressShareExtension/ExtensionPresentationController.swift
+++ b/WordPress/WordPressShareExtension/ExtensionPresentationController.swift
@@ -63,10 +63,6 @@ class ExtensionPresentationController: UIPresentationController {
             presentedView?.layer.cornerRadius = Appearance.cornerRadius
             presentedView?.clipsToBounds = true
         }
-        guard #available(iOS 13, *) else {
-            presentedView?.frame = frameOfPresentedViewInContainerView
-            return
-        }
         presentedView?.frame = viewFrame
     }
 

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -96,14 +96,8 @@ private extension MainShareViewController {
 
         let shareNavController = UINavigationController(rootViewController: editorController)
 
-        if #available(iOS 13, *), editorController.originatingExtension == .saveToDraft {
-            // iOS 13 has proper animations and presentations for share and action sheets. So the `else` case should be removed when iOS 13 is minimum.
-            // We  need to make sure we don't end up with stacked modal view controllers by using this:
-            shareNavController.modalPresentationStyle = .overFullScreen
-        } else {
-            shareNavController.transitioningDelegate = extensionTransitioningManager
-            shareNavController.modalPresentationStyle = .custom
-        }
+        // We need to make sure we don't end up with stacked modal view controllers by using this:
+        shareNavController.modalPresentationStyle = .overFullScreen
 
         present(shareNavController, animated: true)
     }

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -96,8 +96,10 @@ private extension MainShareViewController {
 
         let shareNavController = UINavigationController(rootViewController: editorController)
 
-        // We need to make sure we don't end up with stacked modal view controllers by using this:
-        shareNavController.modalPresentationStyle = .overFullScreen
+        if editorController.originatingExtension == .saveToDraft {
+            // We need to make sure we don't end up with stacked modal view controllers by using this:
+            shareNavController.modalPresentationStyle = .overFullScreen
+        }
 
         present(shareNavController, animated: true)
     }

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -99,6 +99,9 @@ private extension MainShareViewController {
         if editorController.originatingExtension == .saveToDraft {
             // We need to make sure we don't end up with stacked modal view controllers by using this:
             shareNavController.modalPresentationStyle = .overFullScreen
+        } else {
+            shareNavController.transitioningDelegate = extensionTransitioningManager
+            shareNavController.modalPresentationStyle = .custom
         }
 
         present(shareNavController, animated: true)


### PR DESCRIPTION
They always return `true` since the deployment version is 13.0, and will soon become 14.0.

Only one has been left, in `WidgetStyles.swift`, because it will change again when bumping the deployment target to 14+.

I was looking at #available statements as part of https://github.com/wordpress-mobile/WordPress-iOS/pull/19496 and realized we still has some of these laying around.

See also #19511.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
