### PR TITLE
[Crash] Fix crash on 3 dots menu in Comments Screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -736,7 +736,7 @@ private extension CommentDetailViewController {
         })
     }
 
-    @objc func shareCommentURL(_ senderView: UIView) {
+    @objc func shareCommentURL(_ barButtonItem: UIBarButtonItem) {
         guard let commentURL = comment.commentURL() else {
             return
         }
@@ -745,7 +745,7 @@ private extension CommentDetailViewController {
         WPAnalytics.track(.siteCommentsCommentShared)
 
         let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
-        activityViewController.popoverPresentationController?.sourceView = senderView
+        activityViewController.popoverPresentationController?.barButtonItem = barButtonItem
         present(activityViewController, animated: true, completion: nil)
     }
 


### PR DESCRIPTION
Fixes the crash on iPad introduced by Comment Detail Redesign changes.

To test:
1. Install WordPress & login on iPad.
2. Menu -> Comments -> {Tap Any Comment} -> {Tap 3 dot menu on right top}
3. Verify if the pop-up opens properly without crashing.

## Regression Notes
1. Potential unintended areas of impact
This is the intended way of the API usage and it has no effect on rest of the functionality.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
