### PR TITLE
Use a shared operation queue among `NotificationSyncMediator` instances

### DIFF
--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -22,7 +22,7 @@ let NotificationSyncMediatorDidUpdateNotifications = "NotificationSyncMediatorDi
 
 // MARK: - NotificationSyncMediator
 //
-class NotificationSyncMediator {
+final class NotificationSyncMediator {
     /// Returns the Main Managed Context
     ///
     fileprivate let contextManager: CoreDataStack
@@ -41,14 +41,16 @@ class NotificationSyncMediator {
         return contextManager.mainContext
     }
 
-    /// Thread Safety Helper!
+    /// Shared serial operation queue among all instances.
     ///
-    fileprivate static let lock = NSLock()
-
-    /// Shared PrivateContext among all of the Sync Service Instances
-    ///
-    fileprivate static var privateContext: NSManagedObjectContext!
-
+    /// This queue is used to ensure notification operations (like syncing operations) invoked from various places of
+    /// the app are performed sequentially, to prevent potential data corruption.
+    private static let operationQueue = {
+        let queue = OperationQueue()
+        queue.name = "org.wordpress.NotificationSyncMediator"
+        queue.maxConcurrentOperationCount = 1
+        return queue
+    }()
 
 
     /// Designed Initializer
@@ -265,17 +267,17 @@ class NotificationSyncMediator {
     /// Deletes the note with the given ID from Core Data.
     ///
     func deleteNote(noteID: String) {
-        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        Self.operationQueue.addOperation(AsyncBlockOperation { [contextManager] done in
+            contextManager.performAndSave { context in
+                let predicate = NSPredicate(format: "(notificationId == %@)", noteID)
 
-        derivedContext.perform {
-            let predicate = NSPredicate(format: "(notificationId == %@)", noteID)
-
-            for orphan in derivedContext.allObjects(ofType: Notification.self, matching: predicate) {
-                derivedContext.deleteObject(orphan)
+                for orphan in context.allObjects(ofType: Notification.self, matching: predicate) {
+                    context.deleteObject(orphan)
+                }
+            } completion: {
+                done()
             }
-
-            self.contextManager.save(derivedContext)
-        }
+        })
     }
 
     /// Invalidates the local cache for the notification with the specified ID.
@@ -287,16 +289,16 @@ class NotificationSyncMediator {
     /// Invalidates the local cache for all the notifications with specified ID's in the array.
     ///
     func invalidateCacheForNotifications(_ noteIDs: [String]) {
-        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        Self.operationQueue.addOperation(AsyncBlockOperation { [contextManager] done in
+            contextManager.performAndSave { context in
+                let predicate = NSPredicate(format: "(notificationId IN %@)", noteIDs)
+                let notifications = context.allObjects(ofType: Notification.self, matching: predicate)
 
-        derivedContext.perform {
-            let predicate = NSPredicate(format: "(notificationId IN %@)", noteIDs)
-            let notifications = derivedContext.allObjects(ofType: Notification.self, matching: predicate)
-
-            notifications.forEach { $0.notificationHash = nil }
-
-            self.contextManager.save(derivedContext)
-        }
+                notifications.forEach { $0.notificationHash = nil }
+            } completion: {
+                done()
+            }
+        })
     }
 }
 
@@ -312,30 +314,30 @@ private extension NotificationSyncMediator {
     ///     - completion: Callback to be executed on completion
     ///
     func determineUpdatedNotes(with remoteHashes: [RemoteNotification], completion: @escaping (([String]) -> Void)) {
-        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+            contextManager.performAndSave { context in
+                let remoteIds = remoteHashes.map { $0.notificationId }
+                let predicate = NSPredicate(format: "(notificationId IN %@)", remoteIds)
+                var localHashes = [String: String]()
 
-        derivedContext.perform {
-            let remoteIds = remoteHashes.map { $0.notificationId }
-            let predicate = NSPredicate(format: "(notificationId IN %@)", remoteIds)
-            var localHashes = [String: String]()
+                for note in context.allObjects(ofType: Notification.self, matching: predicate) {
+                    localHashes[note.notificationId] = note.notificationHash ?? ""
+                }
 
-            for note in derivedContext.allObjects(ofType: Notification.self, matching: predicate) {
-                localHashes[note.notificationId] = note.notificationHash ?? ""
+                let filtered = remoteHashes.filter { remote in
+                    let localHash = localHashes[remote.notificationId]
+                    return localHash == nil || localHash != remote.notificationHash
+                }
+
+                let outdatedIds = filtered.map { $0.notificationId }
+
+                DispatchQueue.main.async {
+                    completion(outdatedIds)
+                }
+
+                done()
             }
-
-            let filtered = remoteHashes.filter { remote in
-                let localHash = localHashes[remote.notificationId]
-                return localHash == nil || localHash != remote.notificationHash
-            }
-
-            derivedContext.reset()
-
-            let outdatedIds = filtered.map { $0.notificationId }
-
-            DispatchQueue.main.async {
-                completion(outdatedIds)
-            }
-        }
+        })
     }
 
 
@@ -347,22 +349,21 @@ private extension NotificationSyncMediator {
     ///     - completion: Callback to be executed on completion
     ///
     func updateLocalNotes(with remoteNotes: [RemoteNotification], completion: (() -> Void)? = nil) {
-        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+            contextManager.performAndSave { context in
+                for remoteNote in remoteNotes {
+                    let predicate = NSPredicate(format: "(notificationId == %@)", remoteNote.notificationId)
+                    let localNote = context.firstObject(ofType: Notification.self, matching: predicate) ?? context.insertNewObject(ofType: Notification.self)
 
-        derivedContext.perform {
-            for remoteNote in remoteNotes {
-                let predicate = NSPredicate(format: "(notificationId == %@)", remoteNote.notificationId)
-                let localNote = derivedContext.firstObject(ofType: Notification.self, matching: predicate) ?? derivedContext.insertNewObject(ofType: Notification.self)
-
-                localNote.update(with: remoteNote)
-            }
-
-            self.contextManager.save(derivedContext) {
+                    localNote.update(with: remoteNote)
+                }
+            } completion: {
+                done()
                 DispatchQueue.main.async {
                     completion?()
                 }
             }
-        }
+        })
     }
 
 
@@ -372,22 +373,21 @@ private extension NotificationSyncMediator {
     /// - Parameter remoteHashes: Collection of remoteNotifications.
     ///
     func deleteLocalMissingNotes(from remoteHashes: [RemoteNotification], completion: @escaping (() -> Void)) {
-        let derivedContext = type(of: self).sharedDerivedContext(with: contextManager)
+        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+            contextManager.performAndSave { context in
+                let remoteIds = remoteHashes.map { $0.notificationId }
+                let predicate = NSPredicate(format: "NOT (notificationId IN %@)", remoteIds)
 
-        derivedContext.perform {
-            let remoteIds = remoteHashes.map { $0.notificationId }
-            let predicate = NSPredicate(format: "NOT (notificationId IN %@)", remoteIds)
-
-            for orphan in derivedContext.allObjects(ofType: Notification.self, matching: predicate) {
-                derivedContext.deleteObject(orphan)
-            }
-
-            self.contextManager.save(derivedContext) {
+                for orphan in context.allObjects(ofType: Notification.self, matching: predicate) {
+                    context.deleteObject(orphan)
+                }
+            } completion: {
+                done()
                 DispatchQueue.main.async {
                     completion()
                 }
             }
-        }
+        })
     }
 
 
@@ -429,30 +429,5 @@ private extension NotificationSyncMediator {
     func notifyNotificationsWereUpdated() {
         let notificationCenter = NotificationCenter.default
         notificationCenter.post(name: Foundation.Notification.Name(rawValue: NotificationSyncMediatorDidUpdateNotifications), object: nil)
-    }
-}
-
-
-
-// MARK: - Thread Safety Helpers
-//
-extension NotificationSyncMediator {
-    /// Returns the current Shared Derived Context, if any. Otherwise, proceeds to create a new
-    /// derived context, given a specified ContextManager.
-    ///
-    static func sharedDerivedContext(with manager: CoreDataStack) -> NSManagedObjectContext {
-        lock.lock()
-        if privateContext == nil {
-            privateContext = manager.newDerivedContext()
-        }
-        lock.unlock()
-
-        return privateContext
-    }
-
-    /// Nukes the private Shared Derived Context instance. For unit testing purposes.
-    ///
-    static func resetSharedDerivedContext() {
-        privateContext = nil
     }
 }

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -314,7 +314,7 @@ private extension NotificationSyncMediator {
     ///     - completion: Callback to be executed on completion
     ///
     func determineUpdatedNotes(with remoteHashes: [RemoteNotification], completion: @escaping (([String]) -> Void)) {
-        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+        Self.operationQueue.addOperation(AsyncBlockOperation { [contextManager] done in
             contextManager.performAndSave { context in
                 let remoteIds = remoteHashes.map { $0.notificationId }
                 let predicate = NSPredicate(format: "(notificationId IN %@)", remoteIds)
@@ -349,7 +349,7 @@ private extension NotificationSyncMediator {
     ///     - completion: Callback to be executed on completion
     ///
     func updateLocalNotes(with remoteNotes: [RemoteNotification], completion: (() -> Void)? = nil) {
-        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+        Self.operationQueue.addOperation(AsyncBlockOperation { [contextManager] done in
             contextManager.performAndSave { context in
                 for remoteNote in remoteNotes {
                     let predicate = NSPredicate(format: "(notificationId == %@)", remoteNote.notificationId)
@@ -373,7 +373,7 @@ private extension NotificationSyncMediator {
     /// - Parameter remoteHashes: Collection of remoteNotifications.
     ///
     func deleteLocalMissingNotes(from remoteHashes: [RemoteNotification], completion: @escaping (() -> Void)) {
-        Self.operationQueue.addOperation(AsyncBlockOperation{ [contextManager] done in
+        Self.operationQueue.addOperation(AsyncBlockOperation { [contextManager] done in
             contextManager.performAndSave { context in
                 let remoteIds = remoteHashes.map { $0.notificationId }
                 let predicate = NSPredicate(format: "NOT (notificationId IN %@)", remoteIds)

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -324,12 +324,12 @@ private extension NotificationSyncMediator {
                     localHashes[note.notificationId] = note.notificationHash ?? ""
                 }
 
-                let filtered = remoteHashes.filter { remote in
-                    let localHash = localHashes[remote.notificationId]
-                    return localHash == nil || localHash != remote.notificationHash
-                }
-
-                let outdatedIds = filtered.map { $0.notificationId }
+                let outdatedIds = remoteHashes
+                    .filter { remote in
+                        let localHash = localHashes[remote.notificationId]
+                        return localHash == nil || localHash != remote.notificationHash
+                    }
+                    .map { $0.notificationId }
 
                 DispatchQueue.main.async {
                     completion(outdatedIds)

--- a/WordPress/Classes/ViewRelated/Stats/Operation/AsyncBlockOperation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Operation/AsyncBlockOperation.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 class AsyncBlockOperation: AsyncOperation {
 
     private let block: (@escaping () -> Void) -> Void

--- a/WordPress/Classes/ViewRelated/Stats/Operation/AsyncBlockOperation.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Operation/AsyncBlockOperation.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+class AsyncBlockOperation: AsyncOperation {
+
+    private let block: (@escaping () -> Void) -> Void
+
+    init(block: @escaping (@escaping () -> Void) -> Void) {
+        self.block = block
+    }
+
+    override func main() {
+        self.block { [weak self] in
+            self?.state = .isFinished
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -992,6 +992,8 @@
 		46F584B82624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F584B72624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift */; };
 		46F58501262605930010A723 /* BlockEditorSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */; };
+		4A072CD229093704006235BE /* AsyncBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A072CD129093704006235BE /* AsyncBlockOperation.swift */; };
+		4A072CD329093704006235BE /* AsyncBlockOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A072CD129093704006235BE /* AsyncBlockOperation.swift */; };
 		4A17C1A4281A823E0001FFE5 /* NSManagedObject+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */; };
 		4A2172F828EAACFF0006F4F1 /* BlogQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2172F728EAACFF0006F4F1 /* BlogQuery.swift */; };
 		4A2172F928EAACFF0006F4F1 /* BlogQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2172F728EAACFF0006F4F1 /* BlogQuery.swift */; };
@@ -6324,6 +6326,7 @@
 		46F58500262605930010A723 /* BlockEditorSettingsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlockEditorSettingsServiceTests.swift; sourceTree = "<group>"; };
 		46F84612185A8B7E009D0DA5 /* PostContentProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostContentProvider.h; sourceTree = "<group>"; };
 		49E3445F1B568603958DA79D /* Pods-JetpackNotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JetpackNotificationServiceExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-JetpackNotificationServiceExtension/Pods-JetpackNotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
+		4A072CD129093704006235BE /* AsyncBlockOperation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncBlockOperation.swift; sourceTree = "<group>"; };
 		4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSManagedObject+Fixture.swift"; sourceTree = "<group>"; };
 		4A2172F728EAACFF0006F4F1 /* BlogQuery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogQuery.swift; sourceTree = "<group>"; };
 		4A2172FD28F688890006F4F1 /* Blog+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Media.swift"; sourceTree = "<group>"; };
@@ -13802,6 +13805,7 @@
 			isa = PBXGroup;
 			children = (
 				9AA0ADB0235F116F0027AB5D /* AsyncOperation.swift */,
+				4A072CD129093704006235BE /* AsyncBlockOperation.swift */,
 				9AA0ADB2235F11DC0027AB5D /* StatsPeriodAsyncOperation.swift */,
 			);
 			path = Operation;
@@ -19983,6 +19987,7 @@
 				577C2AB422943FEC00AD1F03 /* PostCompactCell.swift in Sources */,
 				315FC2C51A2CB29300E7CDA2 /* MeHeaderView.m in Sources */,
 				E1222B631F877FD700D23173 /* WebProgressView.swift in Sources */,
+				4A072CD229093704006235BE /* AsyncBlockOperation.swift in Sources */,
 				E185042F1EE6ABD9005C234C /* Restorer.swift in Sources */,
 				02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */,
 				984B138E21F65F870004B6A2 /* SiteStatsPeriodTableViewController.swift in Sources */,
@@ -23785,6 +23790,7 @@
 				FABB25422602FC2C00C8785C /* AnimatedImageCache.swift in Sources */,
 				FABB25432602FC2C00C8785C /* PostListFilterSettings.swift in Sources */,
 				FABB25442602FC2C00C8785C /* FooterTextContent.swift in Sources */,
+				4A072CD329093704006235BE /* AsyncBlockOperation.swift in Sources */,
 				FABB25452602FC2C00C8785C /* Blog+Interface.swift in Sources */,
 				FABB25462602FC2C00C8785C /* PostFeaturedImageCell.m in Sources */,
 				FABB25472602FC2C00C8785C /* WPException.m in Sources */,

--- a/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
+++ b/WordPress/WordPressTest/NotificationSyncMediatorTests.swift
@@ -28,13 +28,6 @@ class NotificationSyncMediatorTests: CoreDataTestCase {
 
         dotcomAPI = WordPressComRestApi(oAuthToken: "1234", userAgent: "yosemite")
         mediator = NotificationSyncMediator(manager: contextManager, dotcomAPI: dotcomAPI)
-
-        // Note:
-        // Since the ContextManagerMock actually changed, and thus, the entire Core Data stack,
-        // we'll need to manually reset the global shared Derived Context.
-        // This definitely won't be needed in the actual app.
-        //
-        NotificationSyncMediator.resetSharedDerivedContext()
     }
 
     override func tearDown() {


### PR DESCRIPTION
## Why

Removing the static context object shared among `NotificationSyncMediator` so that we can use the new writer API `ContextManager.performAndSave`.

## Changes

The shared context object is used as a serial queue to prevent accessing (especially updating) notification records in database concurrently. This PR keeps this protection, but using a serial `OperationQueue`, instead of the `NSManagedContextObject` queue.

It might be easier to review this PR [with "hide whitespace" option on](https://github.com/wordpress-mobile/WordPress-iOS/pull/19521/files?w=1).

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
