### PR TITLE
Update MediaPicker to 1.8.6

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -512,7 +512,7 @@ PODS:
     - CocoaLumberjack (~> 3.4)
     - FormatterKit/TimeIntervalFormatter (~> 1.8)
   - WordPressUI (1.12.5)
-  - WPMediaPicker (1.8.5)
+  - WPMediaPicker (1.8.6)
   - wpxmlrpc (0.9.0)
   - Yoga (1.14.0)
   - ZendeskCommonUISDK (6.1.2)
@@ -868,7 +868,7 @@ SPEC CHECKSUMS:
   WordPressKit: 476ac76ac7ba610a694c55729cc4f0191bb820dc
   WordPressShared: e5a479220643f46dc4d7726ef8dd45f18bf0c53b
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
-  WPMediaPicker: 5a74a91e11c1047e942a65de0193f93432fc2c6d
+  WPMediaPicker: 749ebfa75fb2b6df4f5e5d9d0847e9512ad74d28
   wpxmlrpc: bf55a43a7e710bd2a4fb8c02dfe83b1246f14f13
   Yoga: 2ca978c40e0fd6d7f54bcb1602bc0cbbc79454a7
   ZendeskCommonUISDK: 5f0a83f412e07ae23701f18c412fe783b3249ef5


### PR DESCRIPTION
Fixes #19505

The MediaPicker branch containing the crash fix is used currently, but I'll update to the 1.8.6 once the new release become available (after [this PR](https://github.com/wordpress-mobile/MediaPicker-iOS/pull/398) is merged).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
