### PR TITLE
Replace deprecated `mediumString()` usage with valid alternative

### DIFF
--- a/WordPress/WordPressTest/ReaderPostCardCellTests.swift
+++ b/WordPress/WordPressTest/ReaderPostCardCellTests.swift
@@ -179,7 +179,7 @@ final class ReaderPostCardCellTests: XCTestCase {
     }
 
     func testHeaderLabelMatchesExpectation() {
-        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().mediumString()), "Incorrect accessibility label: Header Button ")
+        XCTAssertEqual(cell?.getHeaderButtonForTesting().accessibilityLabel, String(format: TestConstants.headerLabel, "An author", "A blog name" + ", " + mock!.dateForDisplay().toMediumString()), "Incorrect accessibility label: Header Button ")
     }
 
     func testSaveForLaterButtonLabelMatchesExpectation() {


### PR DESCRIPTION
On `trunk`, I noticed this:

![image](https://user-images.githubusercontent.com/1218433/198197421-e61c244e-7ee7-4a77-b0d0-bb3368d266f2.png)

I replaced it with `toMediumString()` and the tests passed.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
