### PR TITLE
Jetpack Focus: Enable separate tracking for Jetpack extensions and widgets

### DIFF
--- a/WordPress/Jetpack/TracksConfiguration.swift
+++ b/WordPress/Jetpack/TracksConfiguration.swift
@@ -1,0 +1,3 @@
+struct TracksConfiguration {
+    static let eventNamePrefix = "jpios"
+}

--- a/WordPress/Tracks+ShareExtension.swift
+++ b/WordPress/Tracks+ShareExtension.swift
@@ -61,15 +61,15 @@ extension Tracks {
     // MARK: - Private Enums
 
     fileprivate enum ExtensionEvents: String {
-        case launched       = "wpios_share_extension_launched"
-        case posted         = "wpios_share_extension_posted"
-        case tagsOpened     = "wpios_share_extension_tags_opened"
-        case tagsSelected   = "wpios_share_extension_tags_selected"
-        case canceled       = "wpios_share_extension_canceled"
-        case error          = "wpios_share_extension_error"
-        case categoriesOpened   = "wpios_share_extension_categories_opened"
-        case categoriesSelected = "wpios_share_extension_categories_selected"
-        case postTypeOpened   = "wpios_share_extension_post_type_opened"
-        case postTypeSelected = "wpios_share_extension_post_type_selected"
+        case launched       = "share_extension_launched"
+        case posted         = "share_extension_posted"
+        case tagsOpened     = "share_extension_tags_opened"
+        case tagsSelected   = "share_extension_tags_selected"
+        case canceled       = "share_extension_canceled"
+        case error          = "share_extension_error"
+        case categoriesOpened   = "share_extension_categories_opened"
+        case categoriesSelected = "share_extension_categories_selected"
+        case postTypeOpened   = "share_extension_post_type_opened"
+        case postTypeSelected = "share_extension_post_type_selected"
     }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -138,6 +138,18 @@
 		0107E18F29000EA200DE87DB /* UIColor+MurielColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 435B762122973D0600511813 /* UIColor+MurielColors.swift */; };
 		0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */; };
 		0148CC2B2859C87000CF5D96 /* BlogServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */; };
+		01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5009290A88BE00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE500A290A88BE00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE500B290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE500C290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE500E290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE500F290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5013290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5014290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
+		01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */; };
 		02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */; };
 		02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */; };
@@ -1108,7 +1120,7 @@
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4BB2296498BE66D515E3D610 /* Pods_JetpackShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23052F0F1F9B2503E33D0A26 /* Pods_JetpackShareExtension.framework */; };
 		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
-		4EB01830172E59A8E91E576C /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		4EB01830172E59A8E91E576C /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		570265152298921800F2214C /* PostListTableViewHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570265142298921800F2214C /* PostListTableViewHandler.swift */; };
 		570265172298960B00F2214C /* PostListTableViewHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570265162298960B00F2214C /* PostListTableViewHandlerTests.swift */; };
 		5703A4C622C003DC0028A343 /* WPStyleGuide+Posts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5703A4C522C003DC0028A343 /* WPStyleGuide+Posts.swift */; };
@@ -1224,7 +1236,7 @@
 		5DFA7EC71AF814E40072023B /* PageListTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC51AF814E40072023B /* PageListTableViewCell.m */; };
 		5DFA7EC81AF814E40072023B /* PageListTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5DFA7EC61AF814E40072023B /* PageListTableViewCell.xib */; };
 		638E2F3D4DFE9E93AF660CED /* Pods_WordPressAllTimeWidget.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0075A07B739C4EDB5EC613B8 /* Pods_WordPressAllTimeWidget.framework */; };
-		660A036E6EE9D353F2712081 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		660A036E6EE9D353F2712081 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		6E5BA46926A59D620043A6F2 /* SupportScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */; };
 		730354BA21C867E500CD18C2 /* SiteCreatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730354B921C867E500CD18C2 /* SiteCreatorTests.swift */; };
 		7305138321C031FC006BD0A1 /* AssembledSiteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7305138221C031FC006BD0A1 /* AssembledSiteView.swift */; };
@@ -3512,7 +3524,7 @@
 		F5E6312B243BC83E0088229D /* FilterSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5E6312A243BC83E0088229D /* FilterSheetViewController.swift */; };
 		F5EF481723ABCAD8004C3532 /* MainShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74337EDC20054D5500777997 /* MainShareViewController.swift */; };
 		F5EF481823ABCAE0004C3532 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 740C7C4E202F4CD6001C31B0 /* MainInterface.storyboard */; };
-		F7951F7A469484D9D9F736D3 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; };
+		F7951F7A469484D9D9F736D3 /* (null) in Frameworks */ = {isa = PBXBuildFile; };
 		F913BB0E24B3C58B00C19032 /* EventLoggingDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913BB0D24B3C58B00C19032 /* EventLoggingDelegate.swift */; };
 		F913BB1024B3C5CE00C19032 /* EventLoggingDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F913BB0F24B3C5CE00C19032 /* EventLoggingDataProvider.swift */; };
 		F928EDA3226140620030D451 /* WPCrashLoggingProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = F928EDA2226140620030D451 /* WPCrashLoggingProvider.swift */; };
@@ -5524,6 +5536,8 @@
 		011A2815DB0DE7E3973CBC0E /* Pods-Apps-Jetpack.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release.xcconfig"; sourceTree = "<group>"; };
 		0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsStoreTests.swift; sourceTree = "<group>"; };
 		0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceMock.swift; sourceTree = "<group>"; };
+		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
+		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+SectionHelpers.swift"; sourceTree = "<group>"; };
 		02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSubsectionToSectionCategoryTests.swift; sourceTree = "<group>"; };
 		02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionIndexTests.swift; sourceTree = "<group>"; };
@@ -7729,7 +7743,7 @@
 		B5F641B21E37C36700B7819F /* AdaptiveNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AdaptiveNavigationController.swift; sourceTree = "<group>"; };
 		B5F67AC61DB7D81300482C62 /* NotificationSyncMediator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSyncMediator.swift; sourceTree = "<group>"; };
 		B5F94DBF1DB8035200DD505D /* WordPress 53.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 53.xcdatamodel"; sourceTree = "<group>"; };
-		B5FA22821C99F6180016CA7C /* Tracks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tracks.swift; path = WordPressShareExtension/Tracks.swift; sourceTree = SOURCE_ROOT; };
+		B5FA22821C99F6180016CA7C /* Tracks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tracks.swift; path = WordPressShareExtension/Tracks.swift; sourceTree = SOURCE_ROOT; wrapsLines = 0; };
 		B5FA868A1D10A41600AB5F7E /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+Extensions.swift"; path = "WordPressShareExtension/UIImage+Extensions.swift"; sourceTree = SOURCE_ROOT; };
 		B5FD4520199D0C9A00286FBB /* WordPress-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; lineEnding = 0; path = "WordPress-Bridging-Header.h"; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objcpp; };
 		B5FDF9F220D842D2006D14E3 /* AztecNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AztecNavigationController.swift; sourceTree = "<group>"; };
@@ -9035,7 +9049,7 @@
 			files = (
 				3F526C502538CF2A0069706C /* SwiftUI.framework in Frameworks */,
 				3F526C4E2538CF2A0069706C /* WidgetKit.framework in Frameworks */,
-				4EB01830172E59A8E91E576C /* BuildFile in Frameworks */,
+				4EB01830172E59A8E91E576C /* (null) in Frameworks */,
 				EB6DF027AF96D801F280E805 /* Pods_WordPressStatsWidgets.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9064,7 +9078,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				660A036E6EE9D353F2712081 /* BuildFile in Frameworks */,
+				660A036E6EE9D353F2712081 /* (null) in Frameworks */,
 				DF6D9E10C4CEE05331B4DAE5 /* Pods_WordPressNotificationServiceExtension.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9159,7 +9173,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F7951F7A469484D9D9F736D3 /* BuildFile in Frameworks */,
+				F7951F7A469484D9D9F736D3 /* (null) in Frameworks */,
 				F99B8B0DFEA7B43FAB6DEC03 /* Pods_WordPressIntents.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -9933,7 +9947,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -14797,6 +14811,7 @@
 			children = (
 				B5FA22821C99F6180016CA7C /* Tracks.swift */,
 				B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */,
+				01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */,
 			);
 			name = Tracks;
 			sourceTree = "<group>";
@@ -16872,6 +16887,7 @@
 				FAADE3F02615996E00BF29FE /* AppConstants.swift */,
 				C7F7BDBC26262A1B00CE547F /* AppDependency.swift */,
 				0107E15C28FFE99300DE87DB /* WidgetConfiguration.swift */,
+				01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */,
 			);
 			name = "App Configuration";
 			sourceTree = "<group>";
@@ -17899,14 +17915,14 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -20023,6 +20039,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0107E0B428F97D5000DE87DB /* Constants.m in Sources */,
+				01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				0107E0B528F97D5000DE87DB /* StatsWidgetEntry.swift in Sources */,
 				0107E0B628F97D5000DE87DB /* HomeWidgetCache.swift in Sources */,
 				0107E18C29000E2A00DE87DB /* AppStyleGuide.swift in Sources */,
@@ -21791,6 +21808,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3F1FD30D2548B0A80060C53A /* Constants.m in Sources */,
+				01CE500C290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				3F63B93C258179D100F581BE /* StatsWidgetEntry.swift in Sources */,
 				3FA53E9D256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
 				0107E18D29000E3300DE87DB /* AppStyleGuide.swift in Sources */,
@@ -21917,6 +21935,7 @@
 				736584EB2137533A0029C9A4 /* NotificationContentView.swift in Sources */,
 				73D5AC63212622B200ADDDD2 /* NotificationViewController.swift in Sources */,
 				436110DE22C41B02000773AD /* BuildConfiguration.swift in Sources */,
+				01CE500F290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */,
 				FAD257F52611B54200EDAF88 /* UIColor+WordPressColors.swift in Sources */,
 				0107E16B28FFED1800DE87DB /* WidgetConfiguration.swift in Sources */,
 				73F6DD44212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
@@ -21944,6 +21963,7 @@
 				7335AC6521220E940012EF2D /* FormattableTextContent.swift in Sources */,
 				7335AC5D21220AFE0012EF2D /* FormattableContentActionCommand.swift in Sources */,
 				7335AC5A21220AD10012EF2D /* FormattableContentRange.swift in Sources */,
+				01CE500E290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */,
 				7335AC6821220EC10012EF2D /* FormattableCommentContent.swift in Sources */,
 				7335AC6921220ECE0012EF2D /* NotificationCommentRange.swift in Sources */,
 				7335AC6121220E580012EF2D /* NotificationContentFactory.swift in Sources */,
@@ -22020,6 +22040,7 @@
 				83A1B19628AFE47A00E737AC /* KeychainUtils.swift in Sources */,
 				CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */,
+				01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				74E44AD92031ED2300556205 /* WordPressDraft-Lumberjack.m in Sources */,
 				741AF3A5202F3E2A00C771A5 /* Tracks+DraftAction.swift in Sources */,
 				74021A1F202E16DC006CC39F /* SFHFKeychainUtils.m in Sources */,
@@ -22094,6 +22115,7 @@
 				809620F828E540D700940A5D /* CategoryTree.swift in Sources */,
 				809620F928E540D700940A5D /* ExtensionPresentationController.swift in Sources */,
 				809620FA28E540D700940A5D /* Constants.m in Sources */,
+				01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				809620FB28E540D700940A5D /* RemoteBlog+Capabilities.swift in Sources */,
 				809620FC28E540D700940A5D /* ShareModularViewController.swift in Sources */,
 				809620FD28E540D700940A5D /* NSExtensionContext+Extensions.swift in Sources */,
@@ -22168,6 +22190,7 @@
 				8096215928E55C9400940A5D /* RemoteBlog+Capabilities.swift in Sources */,
 				8096215A28E55C9400940A5D /* ExtensionTransitioningManager.swift in Sources */,
 				8096215B28E55C9400940A5D /* WordPressDraft-Lumberjack.m in Sources */,
+				01CE5014290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				8096215C28E55C9400940A5D /* Tracks+DraftAction.swift in Sources */,
 				8096215D28E55C9400940A5D /* SFHFKeychainUtils.m in Sources */,
 				8096215E28E55C9400940A5D /* WPStyleGuide+Share.swift in Sources */,
@@ -22214,6 +22237,7 @@
 				80F6D02B28EE866A00953C1A /* FormattableTextContent.swift in Sources */,
 				80F6D02C28EE866A00953C1A /* FormattableContentActionCommand.swift in Sources */,
 				80F6D02D28EE866A00953C1A /* FormattableContentRange.swift in Sources */,
+				01CE5013290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				80F6D02E28EE866A00953C1A /* FormattableCommentContent.swift in Sources */,
 				80F6D02F28EE866A00953C1A /* NotificationCommentRange.swift in Sources */,
 				80F6D03028EE866A00953C1A /* NotificationContentFactory.swift in Sources */,
@@ -22304,6 +22328,7 @@
 				83A1B19528AFE47900E737AC /* KeychainUtils.swift in Sources */,
 				74448F542044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74402F2A200528F200A1D4A2 /* ExtensionPresentationController.swift in Sources */,
+				01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				B5BEA55F1C7CE6D100C8035B /* Constants.m in Sources */,
 				CE39E17220CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				BE6787F51FFF2886005D9F01 /* ShareModularViewController.swift in Sources */,
@@ -22350,6 +22375,7 @@
 				436110DA22C3ED44000773AD /* FeatureFlag.swift in Sources */,
 				436110DB22C3ED4C000773AD /* BuildConfiguration.swift in Sources */,
 				98906503237CC1DF00218CD2 /* WidgetUnconfiguredCell.swift in Sources */,
+				01CE5009290A88BE00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				93C2075D1CC7FFC800C94D04 /* Tracks+TodayWidget.swift in Sources */,
 				98E58A302360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				83A1B19728AFE47A00E737AC /* KeychainUtils.swift in Sources */,
@@ -22391,6 +22417,7 @@
 				17A4B6A324F911D5002DFB8E /* KeyValueDatabase.swift in Sources */,
 				989643E523A02F640070720A /* MurielColor.swift in Sources */,
 				0107E16928FFED1800DE87DB /* WidgetConfiguration.swift in Sources */,
+				01CE500B290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				83A1B19928AFE47B00E737AC /* KeychainUtils.swift in Sources */,
 				983AE84D2399AC6B00E5B7F6 /* Constants.m in Sources */,
 				989643ED23A0437B0070720A /* WidgetDifferenceCell.swift in Sources */,
@@ -22423,6 +22450,7 @@
 				17A4B6A224F911D4002DFB8E /* KeyValueDatabase.swift in Sources */,
 				98D31BC223972A79009CFF43 /* SFHFKeychainUtils.m in Sources */,
 				0107E16828FFED1800DE87DB /* WidgetConfiguration.swift in Sources */,
+				01CE500A290A88BE00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				83A1B19828AFE47B00E737AC /* KeychainUtils.swift in Sources */,
 				98D31BAE239708FB009CFF43 /* Constants.m in Sources */,
 				98C0CE9B23C559C800D0F27C /* Double+Stats.swift in Sources */,
@@ -30023,7 +30051,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -30096,12 +30124,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {

--- a/WordPress/WordPressDraftActionExtension/Tracks+DraftAction.swift
+++ b/WordPress/WordPressDraftActionExtension/Tracks+DraftAction.swift
@@ -60,15 +60,15 @@ extension Tracks {
     // MARK: - Private Enums
 
     fileprivate enum ExtensionEvents: String {
-        case launched       = "wpios_draft_extension_launched"
-        case posted         = "wpios_draft_extension_posted"
-        case tagsOpened     = "wpios_draft_extension_tags_opened"
-        case tagsSelected   = "wpios_draft_extension_tags_selected"
-        case canceled       = "wpios_draft_extension_canceled"
-        case error          = "wpios_draft_extension_error"
-        case categoriesOpened   = "wpios_draft_extension_categories_opened"
-        case categoriesSelected = "wpios_draft_extension_categories_selected"
-        case postTypeOpened   = "wpios_draft_extension_post_type_opened"
-        case postTypeSelected = "wpios_draft_extension_post_type_selected"
+        case launched       = "draft_extension_launched"
+        case posted         = "draft_extension_posted"
+        case tagsOpened     = "draft_extension_tags_opened"
+        case tagsSelected   = "draft_extension_tags_selected"
+        case canceled       = "draft_extension_canceled"
+        case error          = "draft_extension_error"
+        case categoriesOpened   = "draft_extension_categories_opened"
+        case categoriesSelected = "draft_extension_categories_selected"
+        case postTypeOpened   = "draft_extension_post_type_opened"
+        case postTypeSelected = "draft_extension_post_type_selected"
     }
 }

--- a/WordPress/WordPressNotificationContentExtension/Sources/Tracks/Tracks+ContentExtension.swift
+++ b/WordPress/WordPressNotificationContentExtension/Sources/Tracks/Tracks+ContentExtension.swift
@@ -6,8 +6,8 @@ import Foundation
 /// - launched: the content extension was successfully entered & launched
 ///
 private enum ContentExtensionEvents: String {
-    case launched           = "wpios_notification_content_extension_launched"
-    case failedToMarkAsRead = "wpios_notification_content_extension_failed_mark_as_read"
+    case launched           = "notification_content_extension_launched"
+    case failedToMarkAsRead = "notification_content_extension_failed_mark_as_read"
 }
 
 // MARK: - Supports tracking notification content extension events.

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -9,12 +9,12 @@ import Foundation
 /// - assembled: the service extension successfully prepared content
 ///
 private enum ServiceExtensionEvents: String {
-    case launched   = "wpios_notification_service_extension_launched"
-    case discarded  = "wpios_notification_service_extension_discarded"
-    case failed     = "wpios_notification_service_extension_failed"
-    case assembled  = "wpios_notification_service_extension_assembled"
-    case malformed  = "wpios_notification_service_extension_malformed_payload"
-    case timedOut   = "wpios_notification_service_extension_timed_out"
+    case launched   = "notification_service_extension_launched"
+    case discarded  = "notification_service_extension_discarded"
+    case failed     = "notification_service_extension_failed"
+    case assembled  = "notification_service_extension_assembled"
+    case malformed  = "notification_service_extension_malformed_payload"
+    case timedOut   = "notification_service_extension_timed_out"
 }
 
 // MARK: - Supports tracking notification service extension events.

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -23,7 +23,8 @@ open class Tracks {
 
     // MARK: - Public Methods
     open func track(_ eventName: String, properties: [String: Any]? = nil) {
-        let payload  = payloadWithEventName(eventName, properties: properties)
+        let prefixedEventName = "\(TracksConfiguration.eventNamePrefix)_\(eventName)"
+        let payload  = payloadWithEventName(prefixedEventName, properties: properties)
         uploader.send(payload)
     }
 

--- a/WordPress/WordPressShareExtension/TracksConfiguration.swift
+++ b/WordPress/WordPressShareExtension/TracksConfiguration.swift
@@ -1,0 +1,3 @@
+struct TracksConfiguration {
+    static let eventNamePrefix = "wpios"
+}

--- a/WordPress/WordPressStatsWidgets/Tracks/Tracks+StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/Tracks/Tracks+StatsWidgets.swift
@@ -66,15 +66,15 @@ extension Tracks {
 
     fileprivate enum ExtensionEvents: String {
         // User taps widget to view Stats in the app
-        case statsLaunched  = "wpios_today_home_extension_stats_launched"
+        case statsLaunched  = "today_home_extension_stats_launched"
         // User taps widget to login to the app
-        case loginLaunched  = "wpios_today_home_extension_login_launched"
+        case loginLaunched  = "today_home_extension_login_launched"
         // User installs an instance of the today widget
-        case todayWidgetUpdated = "wpios_today_home_extension_widget_updated"
+        case todayWidgetUpdated = "today_home_extension_widget_updated"
         // User installs an instance of the all time widget
-        case allTimeWidgetUpdated = "wpios_alltime_home_extension_widget_updated"
+        case allTimeWidgetUpdated = "alltime_home_extension_widget_updated"
         // Users installs an instance of the this week widget
-        case thisWeekWidgetUpdated = "wpios_thisweek_home_extension_widget_updated"
+        case thisWeekWidgetUpdated = "thisweek_home_extension_widget_updated"
 
         case noEvent
 

--- a/WordPress/WordPressStatsWidgets/Tracks/Tracks+StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/Tracks/Tracks+StatsWidgets.swift
@@ -65,10 +65,6 @@ extension Tracks {
     // MARK: - Private Enums
 
     fileprivate enum ExtensionEvents: String {
-        // User taps widget to view Stats in the app
-        case statsLaunched  = "today_home_extension_stats_launched"
-        // User taps widget to login to the app
-        case loginLaunched  = "today_home_extension_login_launched"
         // User installs an instance of the today widget
         case todayWidgetUpdated = "today_home_extension_widget_updated"
         // User installs an instance of the all time widget


### PR DESCRIPTION
## Description

Extensions are using separate `Tracks` logic and has `wpios_` hardcoded to all the events. Making a prefix dynamic.

## Testing instructions

Tested locally:
1. Attached to `{AppName}StatsWidgets`, `{AppName}ShareExtension`, `{AppName}DraftActionExtension`
2. Made sure `wpios_` is prefixed to events that belong to `WordPress`
3. Made sure `jpios_` is prefixed to events that belongs to `Jetpack`

## Regression Notes

1. Potential unintended areas of impact

Changing existing wpios events

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Code review, made sure only a prefixed part of event name is replaced

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

<img width="356" alt="image" src="https://user-images.githubusercontent.com/4062343/198254002-366dd360-62ec-460a-8bd6-3681219b3495.png">
<img width="344" alt="image" src="https://user-images.githubusercontent.com/4062343/198255797-30007d5c-77f5-47b4-880b-2da7435835c6.png">


<img width="242" alt="image" src="https://user-images.githubusercontent.com/4062343/198254824-290a1e18-0a13-4126-9887-ef0f8f598a48.png">
<img width="252" alt="image" src="https://user-images.githubusercontent.com/4062343/198256012-c7d3d645-2f5a-4601-b645-e0e00d1d4f20.png">

<img width="258" alt="image" src="https://user-images.githubusercontent.com/4062343/198255107-75a2abe5-0cb8-447f-bd6a-8621659e8c22.png">
<img width="248" alt="image" src="https://user-images.githubusercontent.com/4062343/198256121-42fc7235-95e2-47d6-9932-7f88d1741163.png">



