### PR TITLE
[Fix] Comment Details Accessory Icon

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentContentTableViewCell.swift
@@ -6,6 +6,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     enum AccessoryButtonType {
         case share
         case ellipsis
+        case info
     }
 
     enum RenderMethod {
@@ -282,7 +283,14 @@ private extension CommentContentTableViewCell {
     typealias Style = WPStyleGuide.CommentDetail.Content
 
     var accessoryButtonImage: UIImage? {
-        return .init(systemName: Style.infoIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+        switch accessoryButtonType {
+        case .share:
+            return .init(systemName: Style.shareIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+        case .ellipsis:
+            return .init(systemName: Style.ellipsisIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+        case .info:
+            return .init(systemName: Style.infoIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+        }
     }
 
     var likeButtonTitle: String {

--- a/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/CommentDetailViewController.swift
@@ -509,6 +509,7 @@ private extension CommentDetailViewController {
             self?.openWebView(for: url)
         }
 
+        cell.accessoryButtonType = .info
         cell.accessoryButtonAction = { [weak self] senderView in
             self?.presentUserInfoSheet(senderView)
         }


### PR DESCRIPTION
Fixes comment details accessory button having the wrong icon on Reader Comments.

To test:
1. Install & Login to WP.
2. My Site -> Menu -> Comments -> {Any Comment}: Accessory button must have the info icon (ℹ️ circular version of this).
3. Reader -> {Comments of any post}: Personal comment must have 3 dot menu icon. Other accounts' comment must have share icon as the accessory button.

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
