### PR TITLE
Remove unnecessary `cp` of `project.env-example` from CI command

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -7,7 +7,6 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- :writing_hand: Copy Files"
-cp -v fastlane/env/project.env-example .configure-files/project.env
 mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 


### PR DESCRIPTION
The path `./.configure-files/project.env` is never read.

If CI is green, then this removal was appropriate.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
