### PR TITLE
Add function to copy keychains and remove shared keychain code

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -465,7 +465,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (NSString *)password
 {
-    return [KeychainUtils.shared getPasswordForUsername:self.username serviceName:self.xmlrpc accessGroup:nil error:nil];
+    return [SFHFKeychainUtils getPasswordForUsername:self.username andServiceName:self.xmlrpc accessGroup:nil error:nil];
 }
 
 - (void)setPassword:(NSString *)password
@@ -473,17 +473,17 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     NSAssert(self.username != nil, @"Can't set password if we don't know the username yet");
     NSAssert(self.xmlrpc != nil, @"Can't set password if we don't know the XML-RPC endpoint yet");
     if (password) {
-        [KeychainUtils.shared storeUsername:self.username
-                                   password:password
-                                serviceName:self.xmlrpc
-                                accessGroup:nil
-                             updateExisting:YES
-                                      error:nil];
+        [SFHFKeychainUtils storeUsername:self.username
+                             andPassword:password
+                          forServiceName:self.xmlrpc
+                             accessGroup:nil
+                          updateExisting:YES
+                                   error:nil];
     } else {
-        [KeychainUtils.shared deleteItemWithUsername:self.username
-                                         serviceName:self.xmlrpc
-                                         accessGroup:nil
-                                               error:nil];
+        [SFHFKeychainUtils deleteItemForUsername:self.username
+                                  andServiceName:self.xmlrpc
+                                     accessGroup:nil
+                                           error:nil];
     }
 }
 

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -83,12 +83,12 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 {
     if (authToken) {
         NSError *error = nil;
-        [KeychainUtils.shared storeUsername:self.username
-                                   password:authToken
-                                serviceName:WordPressComOAuthKeychainServiceName
-                                accessGroup:nil
-                             updateExisting:YES
-                                      error:&error];
+        [SFHFKeychainUtils storeUsername:self.username
+                             andPassword:authToken
+                          forServiceName:WordPressComOAuthKeychainServiceName
+                             accessGroup:nil
+                          updateExisting:YES
+                                   error:&error];
 
         if (error) {
             DDLogError(@"Error while updating WordPressComOAuthKeychainServiceName token: %@", error);
@@ -96,10 +96,10 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 
     } else {
         NSError *error = nil;
-        [KeychainUtils.shared deleteItemWithUsername:self.username
-                                         serviceName:WordPressComOAuthKeychainServiceName
-                                         accessGroup:nil
-                                               error:&error];
+        [SFHFKeychainUtils deleteItemForUsername:self.username
+                                  andServiceName:WordPressComOAuthKeychainServiceName
+                                     accessGroup:nil
+                                           error:&error];
         if (error) {
             DDLogError(@"Error while deleting WordPressComOAuthKeychainServiceName token: %@", error);
         }
@@ -133,10 +133,10 @@ static NSString * const WordPressComOAuthKeychainServiceName = @"public-api.word
 + (NSString *)tokenForUsername:(NSString *)username
 {
     NSError *error = nil;
-    NSString *authToken = [KeychainUtils.shared getPasswordForUsername:username
-                                                           serviceName:WordPressComOAuthKeychainServiceName
-                                                           accessGroup:nil
-                                                                 error:&error];
+    NSString *authToken = [SFHFKeychainUtils getPasswordForUsername:username
+                                                     andServiceName:WordPressComOAuthKeychainServiceName
+                                                        accessGroup:nil
+                                                              error:&error];
     if (error) {
         DDLogError(@"Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error);
     }

--- a/WordPress/Classes/Services/CredentialsService.swift
+++ b/WordPress/Classes/Services/CredentialsService.swift
@@ -4,7 +4,7 @@ protocol CredentialsProvider {
 
 struct KeychainCredentialsProvider: CredentialsProvider {
     func getPassword(username: String, service: String) -> String? {
-        return try? KeychainUtils.shared.getPasswordForUsername(username, serviceName: service)
+        return try? SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: service)
     }
 }
 

--- a/WordPress/Classes/Services/NotificationSupportService.swift
+++ b/WordPress/Classes/Services/NotificationSupportService.swift
@@ -9,12 +9,12 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertContentExtensionToken(_ oauthToken: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
-                    WPNotificationContentExtensionKeychainTokenKey,
-                    password: oauthToken,
-                    serviceName: WPNotificationContentExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup,
-                    updateExisting: true
+            try SFHFKeychainUtils.storeUsername(
+                WPNotificationContentExtensionKeychainTokenKey,
+                andPassword: oauthToken,
+                forServiceName: WPNotificationContentExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true
             )
         } catch {
             DDLogDebug("Error while saving Notification Content Extension OAuth token: \(error)")
@@ -28,12 +28,12 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertContentExtensionUsername(_ username: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
-                    WPNotificationContentExtensionKeychainUsernameKey,
-                    password: username,
-                    serviceName: WPNotificationContentExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup,
-                    updateExisting: true
+            try SFHFKeychainUtils.storeUsername(
+                WPNotificationContentExtensionKeychainUsernameKey,
+                andPassword: username,
+                forServiceName: WPNotificationContentExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true
             )
         } catch {
             DDLogDebug("Error while saving Notification Content Extension username: \(error)")
@@ -47,12 +47,12 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionToken(_ oauthToken: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
-                    WPNotificationServiceExtensionKeychainTokenKey,
-                    password: oauthToken,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup,
-                    updateExisting: true
+            try SFHFKeychainUtils.storeUsername(
+                WPNotificationServiceExtensionKeychainTokenKey,
+                andPassword: oauthToken,
+                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true
             )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension OAuth token: \(error)")
@@ -66,12 +66,12 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionUsername(_ username: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
-                    WPNotificationServiceExtensionKeychainUsernameKey,
-                    password: username,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup,
-                    updateExisting: true
+            try SFHFKeychainUtils.storeUsername(
+                WPNotificationServiceExtensionKeychainUsernameKey,
+                andPassword: username,
+                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true
             )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension username: \(error)")
@@ -85,12 +85,12 @@ open class NotificationSupportService: NSObject {
     @objc
     class func insertServiceExtensionUserID(_ userID: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
-                    WPNotificationServiceExtensionKeychainUserIDKey,
-                    password: userID,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup,
-                    updateExisting: true
+            try SFHFKeychainUtils.storeUsername(
+                WPNotificationServiceExtensionKeychainUserIDKey,
+                andPassword: userID,
+                forServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup,
+                updateExisting: true
             )
         } catch {
             DDLogDebug("Error while saving Notification Service Extension userID: \(error)")
@@ -102,10 +102,10 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteContentExtensionToken() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                    username: WPNotificationContentExtensionKeychainTokenKey,
-                    serviceName: WPNotificationContentExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPNotificationContentExtensionKeychainTokenKey,
+                andServiceName: WPNotificationContentExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Content Extension OAuth token: \(error)")
@@ -117,10 +117,10 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteContentExtensionUsername() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                    username: WPNotificationContentExtensionKeychainUsernameKey,
-                    serviceName: WPNotificationContentExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPNotificationContentExtensionKeychainUsernameKey,
+                andServiceName: WPNotificationContentExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Content Extension username: \(error)")
@@ -132,10 +132,10 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionToken() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                    username: WPNotificationServiceExtensionKeychainTokenKey,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPNotificationServiceExtensionKeychainTokenKey,
+                andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension OAuth token: \(error)")
@@ -147,10 +147,10 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionUsername() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                    username: WPNotificationServiceExtensionKeychainUsernameKey,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPNotificationServiceExtensionKeychainUsernameKey,
+                andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension username: \(error)")
@@ -162,10 +162,10 @@ open class NotificationSupportService: NSObject {
     @objc
     class func deleteServiceExtensionUserID() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                    username: WPNotificationServiceExtensionKeychainUserIDKey,
-                    serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                    accessGroup: WPAppKeychainAccessGroup
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPNotificationServiceExtensionKeychainUserIDKey,
+                andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension userID: \(error)")

--- a/WordPress/Classes/Services/ShareExtensionService.swift
+++ b/WordPress/Classes/Services/ShareExtensionService.swift
@@ -8,10 +8,10 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func configureShareExtensionToken(_ oauth2Token: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
+            try SFHFKeychainUtils.storeUsername(
                 WPShareExtensionKeychainTokenKey,
-                password: oauth2Token,
-                serviceName: WPShareExtensionKeychainServiceName,
+                andPassword: oauth2Token,
+                forServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup,
                 updateExisting: true
             )
@@ -26,10 +26,10 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func configureShareExtensionUsername(_ username: String) {
         do {
-            try KeychainUtils.shared.storeUsername(
+            try SFHFKeychainUtils.storeUsername(
                 WPShareExtensionKeychainUsernameKey,
-                password: username,
-                serviceName: WPShareExtensionKeychainServiceName,
+                andPassword: username,
+                forServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup,
                 updateExisting: true
             )
@@ -98,9 +98,9 @@ open class ShareExtensionService: NSObject {
     ///
     @objc class func removeShareExtensionConfiguration() {
         do {
-            try KeychainUtils.shared.deleteItem(
-                username: WPShareExtensionKeychainTokenKey,
-                serviceName: WPShareExtensionKeychainServiceName,
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPShareExtensionKeychainTokenKey,
+                andServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
@@ -108,9 +108,9 @@ open class ShareExtensionService: NSObject {
         }
 
         do {
-            try KeychainUtils.shared.deleteItem(
-                username: WPShareExtensionKeychainUsernameKey,
-                serviceName: WPShareExtensionKeychainServiceName,
+            try SFHFKeychainUtils.deleteItem(
+                forUsername: WPShareExtensionKeychainUsernameKey,
+                andServiceName: WPShareExtensionKeychainServiceName,
                 accessGroup: WPAppKeychainAccessGroup
             )
         } catch {
@@ -130,9 +130,9 @@ open class ShareExtensionService: NSObject {
     /// Retrieves the WordPress.com OAuth Token, meant for Extension usage.
     ///
     @objc class func retrieveShareExtensionToken() -> String? {
-        guard let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPShareExtensionKeychainTokenKey,
-                                                                                 serviceName: WPShareExtensionKeychainServiceName,
-                                                                                 accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainTokenKey,
+                                                                              andServiceName: WPShareExtensionKeychainServiceName,
+                                                                              accessGroup: WPAppKeychainAccessGroup) else {
             return nil
         }
 
@@ -142,9 +142,9 @@ open class ShareExtensionService: NSObject {
     /// Retrieves the WordPress.com Username, meant for Extension usage.
     ///
     @objc class func retrieveShareExtensionUsername() -> String? {
-        guard let oauth2Token = try? KeychainUtils.shared.getPasswordForUsername(WPShareExtensionKeychainUsernameKey,
-                                                                                 serviceName: WPShareExtensionKeychainServiceName,
-                                                                                 accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauth2Token = try? SFHFKeychainUtils.getPasswordForUsername(WPShareExtensionKeychainUsernameKey,
+                                                                              andServiceName: WPShareExtensionKeychainServiceName,
+                                                                              accessGroup: WPAppKeychainAccessGroup) else {
             return nil
         }
 

--- a/WordPress/Classes/Services/TodayExtensionService.m
+++ b/WordPress/Classes/Services/TodayExtensionService.m
@@ -33,12 +33,12 @@
     
     NSError *error;
     
-    [KeychainUtils.shared storeUsername:AppConfigurationWidgetStats.keychainTokenKey
-                               password:oauth2Token
-                            serviceName:AppConfigurationWidgetStats.keychainServiceName
-                            accessGroup:WPAppKeychainAccessGroup
-                         updateExisting:YES
-                                  error:&error];
+    [SFHFKeychainUtils storeUsername:AppConfigurationWidgetStats.keychainTokenKey
+                         andPassword:oauth2Token
+                      forServiceName:AppConfigurationWidgetStats.keychainServiceName
+                         accessGroup:WPAppKeychainAccessGroup
+                      updateExisting:YES
+                               error:&error];
     if (error) {
         DDLogError(@"Today Widget OAuth2Token error: %@", error);
     }
@@ -53,20 +53,20 @@
     [sharedDefaults removeObjectForKey:AppConfigurationWidgetStatsToday.userDefaultsSiteNameKey];
     [sharedDefaults removeObjectForKey:AppConfigurationWidgetStatsToday.userDefaultsSiteUrlKey];
     
-    [KeychainUtils.shared deleteItemWithUsername:AppConfigurationWidgetStats.keychainTokenKey
-                                     serviceName:AppConfigurationWidgetStats.keychainServiceName
-                                     accessGroup:WPAppKeychainAccessGroup
-                                           error:nil];
+    [SFHFKeychainUtils deleteItemForUsername:AppConfigurationWidgetStats.keychainTokenKey
+                              andServiceName:AppConfigurationWidgetStats.keychainServiceName
+                                 accessGroup:WPAppKeychainAccessGroup
+                                       error:nil];
 }
 
 - (BOOL)widgetIsConfigured
 {
     NSUserDefaults *sharedDefaults = [[NSUserDefaults alloc] initWithSuiteName:WPAppGroupName];
     NSString *siteId = [sharedDefaults stringForKey:AppConfigurationWidgetStatsToday.userDefaultsSiteIdKey];
-    NSString *oauth2Token = [KeychainUtils.shared getPasswordForUsername:AppConfigurationWidgetStats.keychainTokenKey
-                                                             serviceName:AppConfigurationWidgetStats.keychainServiceName
-                                                             accessGroup:WPAppKeychainAccessGroup
-                                                                   error:nil];
+    NSString *oauth2Token = [SFHFKeychainUtils getPasswordForUsername:AppConfigurationWidgetStats.keychainTokenKey
+                                                       andServiceName:AppConfigurationWidgetStats.keychainServiceName
+                                                          accessGroup:WPAppKeychainAccessGroup
+                                                                error:nil];
     
     if (siteId.length == 0 || oauth2Token.length == 0) {
         return NO;

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -90,8 +90,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     // MARK: - Application lifecycle
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
-        KeychainUtils.shared.copyKeychainToSharedKeychainIfNeeded()
-
         window = UIWindow(frame: UIScreen.main.bounds)
         AppAppearance.overrideAppearance()
 
@@ -942,8 +940,8 @@ extension WordPressAppDelegate {
         // Get the Apple User ID from the keychain
         let appleUserID: String
         do {
-            appleUserID = try KeychainUtils.shared.getPasswordForUsername(WPAppleIDKeychainUsernameKey,
-                                                                          serviceName: WPAppleIDKeychainServiceName)
+            appleUserID = try SFHFKeychainUtils.getPasswordForUsername(WPAppleIDKeychainUsernameKey,
+                                                                       andServiceName: WPAppleIDKeychainServiceName)
         } catch {
             DDLogInfo("checkAppleIDCredentialState: No Apple ID found.")
             return
@@ -995,8 +993,8 @@ extension WordPressAppDelegate {
 
     func removeAppleIDFromKeychain() {
         do {
-            try KeychainUtils.shared.deleteItem(username: WPAppleIDKeychainUsernameKey,
-                                                serviceName: WPAppleIDKeychainServiceName)
+            try SFHFKeychainUtils.deleteItem(forUsername: WPAppleIDKeychainUsernameKey,
+                                             andServiceName: WPAppleIDKeychainServiceName)
         } catch let error as NSError {
             if error.code != errSecItemNotFound {
                 DDLogError("Error while removing Apple User ID from keychain: \(error.localizedDescription)")

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -1,68 +1,25 @@
 @objcMembers
 class KeychainUtils: NSObject {
 
-    static let shared = KeychainUtils()
-
-    private let shouldUseSharedKeychain: () -> Bool
     private let keychainUtils: SFHFKeychainUtils.Type
 
-    private var keychainGroup: String? {
-        shouldUseSharedKeychain() ? WPAppKeychainAccessGroup : nil
-    }
-
-    init(shouldUseSharedKeychain: @escaping @autoclosure () -> Bool = FeatureFlag.sharedLogin.enabled,
-         keychainUtils: SFHFKeychainUtils.Type = SFHFKeychainUtils.self) {
-        self.shouldUseSharedKeychain = shouldUseSharedKeychain
+    init(keychainUtils: SFHFKeychainUtils.Type = SFHFKeychainUtils.self) {
         self.keychainUtils = keychainUtils
     }
 
-    func storeUsername(_ username: String, password: String, serviceName: String, accessGroup: String? = nil, updateExisting: Bool) throws {
-        try keychainUtils.storeUsername(
-                username,
-                andPassword: password,
-                forServiceName: serviceName,
-                accessGroup: accessGroup ?? keychainGroup,
-                updateExisting: updateExisting
-        )
-    }
+    func copyKeychain(from sourceAccessGroup: String?,
+                      to destinationAccessGroup: String?,
+                      updateExisting: Bool = true) throws {
+        let sourceItems = try keychainUtils.getAllPasswords(forAccessGroup: sourceAccessGroup)
 
-    func getPasswordForUsername(_ username: String, serviceName: String, accessGroup: String? = nil) throws -> String {
-        try keychainUtils.getPasswordForUsername(
-                username,
-                andServiceName: serviceName,
-                accessGroup: accessGroup ?? keychainGroup
-        )
-    }
-
-    func deleteItem(username: String, serviceName: String, accessGroup: String? = nil) throws {
-        try keychainUtils.deleteItem(
-                forUsername: username,
-                andServiceName: serviceName,
-                accessGroup: accessGroup ?? keychainGroup
-        )
-    }
-
-    func copyKeychainToSharedKeychainIfNeeded() {
-        guard let defaults = UserDefaults(suiteName: WPAppGroupName) else {
-            return
-        }
-
-        guard shouldUseSharedKeychain(),
-              !defaults.bool(forKey: "keychain-copied"),
-              let items = try? keychainUtils.getAllPasswords(forAccessGroup: nil) else {
-            return
-        }
-
-        for item in items {
+        for item in sourceItems {
             guard let username = item["username"],
                   let password = item["password"],
                   let serviceName = item["serviceName"] else {
                 continue
             }
 
-            try? keychainUtils.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: WPAppKeychainAccessGroup, updateExisting: false)
+            try keychainUtils.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: destinationAccessGroup, updateExisting: updateExisting)
         }
-        defaults.set(true, forKey: "keychain-copied")
     }
-
 }

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToAccount.m
@@ -42,10 +42,10 @@
         NSString *newKey = WPComXMLRPCUrl;
 
         NSError *error;
-        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:oldKey accessGroup:nil error:&error];
+        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:oldKey accessGroup:nil error:&error];
         if (password) {
-            if ([KeychainUtils.shared storeUsername:username password:password serviceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
-                [KeychainUtils.shared deleteItemWithUsername:username serviceName:oldKey accessGroup:nil error:&error];
+            if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
+                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:oldKey accessGroup:nil error:&error];
             }
         }
         if (error) {
@@ -112,10 +112,10 @@
             newKey = xmlrpc;
         }
         NSError *error;
-        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:oldKey accessGroup:nil error:&error];
+        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:oldKey accessGroup:nil error:&error];
         if (password) {
-            if ([KeychainUtils.shared storeUsername:username password:password serviceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
-                [KeychainUtils.shared deleteItemWithUsername:username serviceName:oldKey accessGroup:nil error:&error];
+            if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:newKey accessGroup:nil updateExisting:YES error:&error]) {
+                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:oldKey accessGroup:nil error:&error];
             }
         }
         if (error) {

--- a/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
+++ b/WordPress/Classes/Utility/Migrations/10-11/BlogToJetpackAccount.m
@@ -52,10 +52,10 @@ static NSString * const BlogJetpackKeychainPrefix = @"jetpackblog-";
 
         // Migrate passwords
         NSError *error;
-        NSString *password = [KeychainUtils.shared getPasswordForUsername:username serviceName:@"WordPress.com" accessGroup:nil error:&error];
+        NSString *password = [SFHFKeychainUtils getPasswordForUsername:username andServiceName:@"WordPress.com" accessGroup:nil error:nil];
         if (password) {
-            if ([KeychainUtils.shared storeUsername:username password:password serviceName:WPComXMLRPCUrl accessGroup:nil updateExisting:YES error:&error]) {
-                [KeychainUtils.shared deleteItemWithUsername:username serviceName:@"WordPress.com" accessGroup:nil error:&error];
+            if ([SFHFKeychainUtils storeUsername:username andPassword:password forServiceName:WPComXMLRPCUrl accessGroup:nil updateExisting:YES error:&error]) {
+                [SFHFKeychainUtils deleteItemForUsername:username andServiceName:@"WordPress.com" accessGroup:nil error:&error];
             }
         }
         if (error) {
@@ -111,7 +111,7 @@ static NSString * const BlogJetpackKeychainPrefix = @"jetpackblog-";
 - (NSString *)jetpackPasswordForBlog:(NSManagedObject *)blog
 {
     NSError *error = nil;
-    return [KeychainUtils.shared getPasswordForUsername:[self jetpackUsernameForBlog:blog] serviceName:@"WordPress.com" accessGroup:nil error:&error];
+    return [SFHFKeychainUtils getPasswordForUsername:[self jetpackUsernameForBlog:blog] andServiceName:@"WordPress.com" accessGroup:nil error:&error];
 }
 
 @end

--- a/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
+++ b/WordPress/Classes/Utility/Migrations/BlogToBlog32to33.swift
@@ -44,8 +44,8 @@ class BlogToBlog32to33: NSEntityMigrationPolicy {
                 let username = sInstance.value(forKeyPath: "account.username") as! String
 
                 do {
-                    let password = try KeychainUtils.shared.getPasswordForUsername(username, serviceName: accountXmlrpc)
-                    try KeychainUtils.shared.storeUsername(username, password: password, serviceName: blogXmlrpc, updateExisting: true)
+                    let password = try SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: accountXmlrpc)
+                    try SFHFKeychainUtils.storeUsername(username, andPassword: password, forServiceName: blogXmlrpc, updateExisting: true)
                 } catch {
                     DDLogError("Error getting/saving password for \(accountXmlrpc): \(error)")
                 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -464,10 +464,10 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func userAuthenticatedWithAppleUserID(_ appleUserID: String) {
         do {
-            try KeychainUtils.shared.storeUsername(WPAppleIDKeychainUsernameKey,
-                                                   password: appleUserID,
-                                                   serviceName: WPAppleIDKeychainServiceName,
-                                                   updateExisting: true)
+            try SFHFKeychainUtils.storeUsername(WPAppleIDKeychainUsernameKey,
+                                                andPassword: appleUserID,
+                                                forServiceName: WPAppleIDKeychainServiceName,
+                                                updateExisting: true)
         } catch {
             DDLogInfo("Error while saving Apple User ID: \(error)")
         }

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -279,9 +279,9 @@ private extension NotificationService {
     /// - Returns: the token if found; `nil` otherwise
     ///
     func readExtensionToken() -> String? {
-        guard let oauthToken = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
-                                                                                serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                                accessGroup: WPAppKeychainAccessGroup) else {
+        guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainTokenKey,
+                                                                             andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                             accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension OAuth token")
             return nil
         }
@@ -294,9 +294,9 @@ private extension NotificationService {
     /// - Returns: the username if found; `nil` otherwise
     ///
     func readExtensionUsername() -> String? {
-        guard let username = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
-                                                                              serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                              accessGroup: WPAppKeychainAccessGroup) else {
+        guard let username = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUsernameKey,
+                                                                           andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                           accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension username")
             return nil
         }
@@ -309,9 +309,9 @@ private extension NotificationService {
     /// - Returns: the userID if found; `nil` otherwise
     ///
     func readExtensionUserID() -> String? {
-        guard let userID = try? KeychainUtils.shared.getPasswordForUsername(WPNotificationServiceExtensionKeychainUserIDKey,
-                                                                            serviceName: WPNotificationServiceExtensionKeychainServiceName,
-                                                                            accessGroup: WPAppKeychainAccessGroup) else {
+        guard let userID = try? SFHFKeychainUtils.getPasswordForUsername(WPNotificationServiceExtensionKeychainUserIDKey,
+                                                                         andServiceName: WPNotificationServiceExtensionKeychainServiceName,
+                                                                         accessGroup: WPAppKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension userID")
             return nil
         }

--- a/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -30,10 +30,9 @@ class StatsWidgetsService {
         state = .loading
 
         do {
-            let token = try KeychainUtils.shared.getPasswordForUsername(AppConfiguration.Widget.Stats.keychainTokenKey,
-                                                                        serviceName: AppConfiguration.Widget.Stats.keychainServiceName,
-                                                                        accessGroup: WPAppKeychainAccessGroup)
-
+            let token = try SFHFKeychainUtils.getPasswordForUsername(AppConfiguration.Widget.Stats.keychainTokenKey,
+                                                                     andServiceName: AppConfiguration.Widget.Stats.keychainServiceName,
+                                                                     accessGroup: WPAppKeychainAccessGroup)
             let wpApi = WordPressComRestApi(oAuthToken: token)
             let service = StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: widgetData.siteID, siteTimezone: widgetData.timeZone)
 

--- a/WordPress/WordPressTest/KeychainUtilsTests.swift
+++ b/WordPress/WordPressTest/KeychainUtilsTests.swift
@@ -3,129 +3,24 @@ import XCTest
 
 class KeychainUtilsTests: XCTestCase {
 
-    let username = "Username"
-    let password = "Password"
-    let service = "Service"
-    let sharedGroup = WPAppKeychainAccessGroup
-
     override func setUp() {
         super.setUp()
 
         SFHFKeychainUtilsMock.configure(with: [:])
     }
 
-    func testNilAppGroupSavesToSharedGroupWhenFeatureEnabled() {
-        let subject = KeychainUtils(shouldUseSharedKeychain: true, keychainUtils: SFHFKeychainUtilsMock.self)
+    func testCopyingPasswordsBetweenKeychains() {
+        let service = "service"
+        let username = "username"
+        let password = "password"
+        let sharedGroup = WPAppKeychainAccessGroup
+        let subject = KeychainUtils(keychainUtils: SFHFKeychainUtilsMock.self)
+        SFHFKeychainUtilsMock.configure(with: ["default": [service: [username: password]]])
 
-        try? subject.storeUsername(username, password: password, serviceName: service, updateExisting: true)
+        try? subject.copyKeychain(from: nil, to: sharedGroup, updateExisting: true)
 
-        let result = getPassword(username: username, serviceName: service, accessGroup: sharedGroup)
-        XCTAssertEqual(result, password)
-    }
-
-    func testNilAppGroupDoesNotSaveToSharedGroupWhenFeatureDisabled() {
-        let subject = KeychainUtils(shouldUseSharedKeychain: false, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        try? subject.storeUsername(username, password: password, serviceName: service, updateExisting: true)
-
-        let result = getPassword(username: username, serviceName: service, accessGroup: sharedGroup)
-        XCTAssertNotEqual(result, password)
-    }
-
-    func testFeatureFlagChanging() {
-        var enabled = false
-        let subject = KeychainUtils(shouldUseSharedKeychain: enabled, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        enabled = true
-        try? subject.storeUsername(username, password: password, serviceName: service, updateExisting: true)
-
-        let result = getPassword(username: username, serviceName: service, accessGroup: sharedGroup)
-        XCTAssertEqual(result, password)
-    }
-
-    func testNilAppGroupReadsFromSharedGroupWhenFeatureEnabled() {
-        let subject = KeychainUtils(shouldUseSharedKeychain: true, keychainUtils: SFHFKeychainUtilsMock.self)
-        storeUsername(username, password: password, serviceName: service, accessGroup: sharedGroup)
-
-        let result = try? subject.getPasswordForUsername(username, serviceName: service)
-
-        XCTAssertEqual(result, password)
-    }
-
-    func testNilAppGroupDoesNotReadFromSharedGroupWhenFeatureDisabled() {
-        let subject = KeychainUtils(shouldUseSharedKeychain: false, keychainUtils: SFHFKeychainUtilsMock.self)
-        storeUsername(username, password: password, serviceName: service, accessGroup: sharedGroup)
-
-        let result = try? subject.getPasswordForUsername(username, serviceName: service)
-
-        XCTAssertNotEqual(result, password)
-    }
-
-    func testNilAppGroupDeletesFromSharedGroupWhenEnabled() {
-        storeUsername(username, password: password, serviceName: service, accessGroup: sharedGroup)
-        storeUsername(username, password: password, serviceName: service, accessGroup: nil)
-        let subject = KeychainUtils(shouldUseSharedKeychain: true, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        try? subject.deleteItem(username: username, serviceName: service)
-
-        XCTAssertNil(getPassword(username: username, serviceName: service, accessGroup: sharedGroup))
-        XCTAssertEqual(getPassword(username: username, serviceName: service, accessGroup: nil), password)
-    }
-
-    func testNilAppGroupDeletesFromNilGroupWhenDisabled() {
-        storeUsername(username, password: password, serviceName: service, accessGroup: sharedGroup)
-        storeUsername(username, password: password, serviceName: service, accessGroup: nil)
-        let subject = KeychainUtils(shouldUseSharedKeychain: false, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        try? subject.deleteItem(username: username, serviceName: service)
-
-        XCTAssertEqual(getPassword(username: username, serviceName: service, accessGroup: sharedGroup), password)
-        XCTAssertNil(getPassword(username: username, serviceName: service, accessGroup: nil))
-    }
-
-    func testAppGroupIsAPassthroughWhenSaving() {
-        let group = "Test"
-        let subject = KeychainUtils(shouldUseSharedKeychain: true, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        try? subject.storeUsername(username, password: password, serviceName: service, accessGroup: group, updateExisting: true)
-
-        let result = getPassword(username: username, serviceName: service, accessGroup: group)
-        XCTAssertEqual(result, password)
-    }
-
-    func testAppGroupIsAPassthroughWhenReading() {
-        let group = "Test"
-        let subject = KeychainUtils(shouldUseSharedKeychain: true, keychainUtils: SFHFKeychainUtilsMock.self)
-        storeUsername(username, password: password, serviceName: service, accessGroup: group)
-
-        let result = try? subject.getPasswordForUsername(username, serviceName: service, accessGroup: group)
-
-        XCTAssertEqual(result, password)
-    }
-
-    func testAppGroupIsAPassthroughWhenDeleting() {
-        let group = "Test"
-        storeUsername(username, password: password, serviceName: service, accessGroup: group)
-        let subject = KeychainUtils(shouldUseSharedKeychain: false, keychainUtils: SFHFKeychainUtilsMock.self)
-
-        try? subject.deleteItem(username: username, serviceName: service, accessGroup: group)
-
-        XCTAssertNil(getPassword(username: username, serviceName: service, accessGroup: group))
-    }
-
-}
-
-// MARK: - Helper functions
-
-private extension KeychainUtilsTests {
-
-    func getPassword(username: String, serviceName: String, accessGroup: String?) -> String? {
-        let result = (try? SFHFKeychainUtilsMock.getPasswordForUsername(username, andServiceName: serviceName, accessGroup: accessGroup)) ?? ""
-        return result.count > 0 ? result : nil
-    }
-
-    func storeUsername(_ username: String, password: String, serviceName: String, accessGroup: String?) {
-        try? SFHFKeychainUtilsMock.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: accessGroup, updateExisting: true)
+        let sharedPassword = try? SFHFKeychainUtilsMock.getPasswordForUsername(username, andServiceName: service, accessGroup: sharedGroup)
+        XCTAssertEqual(sharedPassword, password)
     }
 
 }
@@ -164,5 +59,28 @@ final private class SFHFKeychainUtilsMock: SFHFKeychainUtils {
     override class func deleteItem(forUsername username: String!, andServiceName serviceName: String!, accessGroup: String!) throws {
         let group = accessGroup ?? "default"
         keychain[group]?[serviceName]?.removeValue(forKey: username)
+    }
+
+    override class func getAllPasswords(forAccessGroup accessGroup: String!) throws -> [[String: String]] {
+        let group = accessGroup ?? "default"
+        var passwords = [[String: String]]()
+        guard let items = keychain[group] else {
+            return passwords
+        }
+
+        for serviceName in items.keys {
+            guard let serviceItems = items[serviceName] else {
+                continue
+            }
+
+            for username in serviceItems.keys {
+                guard let password = serviceItems[username] else {
+                    continue
+                }
+                passwords.append(["username": username, "password": password, "serviceName": serviceName])
+            }
+        }
+
+        return passwords
     }
 }


### PR DESCRIPTION
Resolves #19546 

## Description

Removes the shared keychain code and adds a function to copy the keychain from one access group to another.

## Testing

There isn't a great way to test this. Either rely on the test written for the code or manually call the `copyKeychain` function somewhere and verify it copies to the destination keychain.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
