### PR TITLE
Add step to load pods in cache before building and testing

### DIFF
--- a/.buildkite/commands/load-pods.sh
+++ b/.buildkite/commands/load-pods.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Set up Gems"
+install_gems
+
+echo "--- :cocoapods: Set up Pods and cache them if needed"
+install_cocoapods

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,6 +13,15 @@ common_params:
 # This is the default pipeline – it will build and test the app
 steps:
 
+  # Make sure there is a cached version of the pods avaialble before testing
+  # the app or deploying installable builds to avoid parallel steps wasting
+  # time building the same `Podfile.lock` from scratch.
+  - label: ':cocoapods: Pre-load Pods'
+    key: pods
+    command: .buildkite/commands/load-pods.sh
+    env: *common_env
+    plugins: *common_plugins
+
   #################
   # Create Installable Builds for WP and JP
   #################
@@ -20,6 +29,7 @@ steps:
     steps:
       - label: "🛠 WordPress Installable Build"
         command: ".buildkite/commands/installable-build-wordpress.sh"
+        depends_on: "pods"
         env: *common_env
         plugins: *common_plugins
         if: "build.pull_request.id != null || build.pull_request.draft"
@@ -29,6 +39,7 @@ steps:
 
       - label: "🛠 Jetpack Installable Build"
         command: ".buildkite/commands/installable-build-jetpack.sh"
+        depends_on: "pods"
         env: *common_env
         plugins: *common_plugins
         if: "build.pull_request.id != null || build.pull_request.draft"
@@ -42,6 +53,7 @@ steps:
   - label: "🛠 Build for Testing"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
+    depends_on: "pods"
     env: *common_env
     plugins: *common_plugins
     notify:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -14,8 +14,18 @@ common_params:
 
 steps:
 
+  # Make sure there is a cached version of the pods avaialble before testing
+  # the app or deploying installable builds to avoid parallel steps wasting
+  # time building the same `Podfile.lock` from scratch.
+  - label: ':cocoapods: Pre-load Pods'
+    key: pods
+    command: .buildkite/commands/load-pods.sh
+    env: *common_env
+    plugins: *common_plugins
+
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
+    depends_on: "pods"
     env: *common_env
     plugins: *common_plugins
     notify:
@@ -23,6 +33,7 @@ steps:
 
   - label: ":wordpress: :appcenter: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
+    depends_on: "pods"
     env: *common_env
     plugins: *common_plugins
     notify:
@@ -30,6 +41,7 @@ steps:
 
   - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
+    depends_on: "pods"
     env: *common_env
     plugins: *common_plugins
     notify:


### PR DESCRIPTION
It occurred to me, because of our steps parallelism, we can run in situations where a commit that changes the `Podfile.lock` results in multiple steps in the same CI build installing the pods from scratch. For example, see this build where all three IPA deployment steps spend 15+ minutes in the CocoaPods part of the build because there was no cached version of the pods available,
https://buildkite.com/automattic/wordpress-ios/builds/10636.

By introducing a step at the start of the pipeline, on which the following steps depend upon, to install the pods we can make sure parallel steps won't waste time building the same new version of the Pods.

## Testing

_I'll add a few example builds here if we decide to move forward with this idea_

- https://buildkite.com/automattic/wordpress-ios/builds/10660

## RFC – Is this worth it & How to improve it

Based on the crude build time numbers mentioned above, on a release CI build that doesn't have a cached `Pods/` available, this could save ~30 minutes – 15 minutes for the cache, then run 3 app builds with the cache available vs. run 3 app builds each building the cache. The savings should be similar on the regular pipeline, where we have 2 installable build steps plus the one that builds the app for testing. We'll also soon have the step to validate the `.strings` generation, which will run CocoaPods, too.

However, on builds that do have a cache available, this will introduce a ~4 minutes delay.

That means that will have caught up with the saving on non-cached builds every 7-8 cached builds. I don't have stats but, intuitively, I don't think we change the `Podfile.lock` that frequently.

The time saved might even be less that ~30 mins on a 3 steps build because, let's not forget, each step will still need to download the cache.

So, I wonder whether this is worth pursuing. From one point of view, I "can't unsee" the time waste that occurs when the cache is not available. From the other, my back of the napkin math points to the time saving becoming irrelevant once we take into account `Podfile.lock` doesn't change that often.

Improvement ideas:

- I estimate we could make the pre-load step twice as fast by checking if the cache is available _before_ running `install_gems` and `install_pods`. To do so, we'd have to extract the [logic that checks that](https://github.com/Automattic/bash-cache-buildkite-plugin/blob/688461e48115844a2e71099b69d4b4e7d7bb6f3e/bin/save_cache#L47) in a dedicated command at the `bash-cache` level.
- `Podfile.lock` doesn't change often in development builds, but the build-to-change ratio is much higher in for release builds. The code freeze build will almost always change the pods. We always run at least two additional CI release builds: localization smoke testing and release finalization. On top of those, we may or may not have additional betas to ship. Even accounting for 3 additional betas, the number of CI release builds after the cache is still such that ....

_I need a break! I'll finish this later because I'm becoming more and more unsure of my math_

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
