### PR TITLE
Run `genstrings` in CI to validate `LocalizedString` usages

### DIFF
--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -11,4 +11,33 @@ mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 
 echo "--- Lint Localized Strings Format"
-bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true
+LOGS=logs.txt
+set +e
+set -o pipefail
+bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
+EXIT_CODE=$?
+set -e
+
+echo $EXIT_CODE
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+  # Strings generation finished with errors, extract the errors in an easy-to-find section
+  echo "--- Report genstrings errors"
+  ERRORS=errors.txt
+  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`*LocalizedStrings\` calls:" | tee $ERRORS
+  echo '' >> $ERRORS
+  # Print the errors inline.
+  #
+  # Notice the second `sed` call that removes the ANSI escape sequences that
+  # Fastlane uses to color the output.
+  grep -e "\[.*\].*genstrings:" $LOGS \
+    | sed -e 's/\[.*\].*genstrings: error: /- /' \
+    | sed -e $'s/\x1b\[[0-9;]*m//g' \
+    | sort \
+    | uniq \
+    | tee -a $ERRORS
+  # Annotate the build with the errors
+  cat $ERRORS | buildkite-agent annotate --style error --context genstrings
+fi
+
+exit $EXIT_CODE

--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+echo "--- :rubygems: Setting up Gems"
+install_gems
+
+echo "--- :cocoapods: Setting up Pods"
+install_cocoapods
+
+echo "--- :writing_hand: Copy Files"
+mkdir -pv ~/.configure/wordpress-ios/secrets
+cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
+
+echo "--- Lint Localized Strings Format"
+bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,3 +123,10 @@ steps:
         plugins: *common_plugins
         agents:
           queue: "android"
+      # Runs the `.strings` generation automation to ensure all the
+      # `LocalizedString` calls in the code can be correctly parsed by Apple's
+      # `genstrings`.
+      - label: "Lint Localized Strings Format"
+        command: .buildkite/commands/lint-localized-strings-format.sh
+        plugins: *common_plugins
+        env: *common_env

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -123,7 +123,7 @@ platform :ios do
   #
   # @called_by complete_code_freeze
   #
-  lane :generate_strings_file_for_glotpress do
+  lane :generate_strings_file_for_glotpress do |options|
     cocoapods
 
     wordpress_en_lproj = File.join('WordPress', 'Resources', 'en.lproj')
@@ -141,7 +141,7 @@ platform :ios do
       destination: File.join(wordpress_en_lproj, 'Localizable.strings')
     )
 
-    git_commit(path: [wordpress_en_lproj], message: 'Update strings for localization', allow_nothing_to_commit: true)
+    git_commit(path: [wordpress_en_lproj], message: 'Update strings for localization', allow_nothing_to_commit: true) unless options[:skip_commit]
   end
 
 


### PR DESCRIPTION
The 21.0 code freeze was delayed because of a `LocalizedString` that didn't use strings literals and therefore failed the `genstrings` execution. See https://github.com/wordpress-mobile/WordPress-iOS/pull/19473.

The change had been in the codebase for a while, but we only found out at code freeze time.

To make the feedback loop faster, this PR adds a new CI step that runs the lane that generates the `.strings` to make sure everything runs fine.

**Important** Once this is merged into `trunk`, we ought to make the check a required one in the GitHub settings for `trunk` and `release/*`. I updated the internal document for this work, pdnsEh-Ly-p2, to remind me about it.

### Implementation Note

This check requires a macOS agent, because of `genstrings`. We can run it in the [“Build for Testing”](https://github.com/wordpress-mobile/WordPress-iOS/blob/0405eb4353b42a19871ed739f898cd4951b44ac2/.buildkite/pipeline.yml#L42-L49) step, before even starting the time consuming build, or in a dedicated step. 

The first option saves resources, the second gives developers more feedback by means of showing whether the app builds and the tests pass regardless of the `genstrings` status.

Since we want to optimize for developer productivity, I opted for a dedicated step instead of making `genstrings` a precondition for "Build for Testing".

## Testing

See #19544 which intentionally introduces a failure

![image](https://user-images.githubusercontent.com/1218433/199399776-c43a275b-c902-4e58-b654-9e9647c75a8a.png)

![image](https://user-images.githubusercontent.com/1218433/199399773-a25fb549-b18f-4306-852c-c8eeead1c371.png)


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**