### PR TITLE
Update blogging prompts answer label color to secondaryLabel

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+BloggingPrompts.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+BloggingPrompts.swift
@@ -4,7 +4,7 @@ extension WPStyleGuide {
     public struct BloggingPrompts {
         static let promptContentFont = WPStyleGuide.serifFontForTextStyle(.headline, fontWeight: .semibold)
         static let answerInfoLabelFont = WPStyleGuide.fontForTextStyle(.caption1)
-        static let answerInfoLabelColor = UIColor.primary
+        static let answerInfoLabelColor = UIColor.textSubtle
         static let buttonTitleFont = WPStyleGuide.fontForTextStyle(.subheadline)
         static let buttonTitleColor = UIColor.primary
         static let answeredLabelColor = UIColor.muriel(name: .green, .shade50)


### PR DESCRIPTION
Refs pcdRpT-16E-p2#comment-1372

This updates the label color of the answer info label (i.e., the number of answers) to a `secondaryLabel`. This is to reduce the expectation that the label can be tapped.

• | Before | After
-|-|-
Light | <img width="369" alt="answerinfo_before_light" src="https://user-images.githubusercontent.com/1299411/199536958-07cbb8ea-f1ad-4316-8f1e-aec4c9844c66.png"> | <img width="375" alt="answerinfo_after_light" src="https://user-images.githubusercontent.com/1299411/199536988-db99370f-9c63-4576-bbf6-6630546a61a1.png">
Dark | <img width="368" alt="answerinfo_before_dark" src="https://user-images.githubusercontent.com/1299411/199536975-bcf3e37c-7f8d-4762-83a9-c504f5c035e0.png"> | <img width="375" alt="answerinfo_after_dark" src="https://user-images.githubusercontent.com/1299411/199536984-59fabd7f-afe4-4c27-a345-05b428641ee6.png">

## To test

- Open the app with an account that has the Blogging Prompts feature enabled.
- 🔍 Verify that the answer info label is displayed in `secondaryLabel` (or `textSubtle`) color.
- Go to Menu > App Settings > Appearance, and switch the color theme.
- 🔍  Verify that the label color is also updated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.