### PR TITLE
Don't allow editing from a notification when a post is being edited

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -217,6 +217,7 @@ class EditPostViewController: UIViewController {
         }
 
         postPost.setup(post: post)
+        postPost.hideEditButton = isPresentingOverEditor()
         postPost.onClose = {
             self.closePostPost(animated: true)
         }
@@ -226,6 +227,17 @@ class EditPostViewController: UIViewController {
         postPost.preview = {
             self.previewPost()
         }
+    }
+
+    /// - Returns: `true` if `self` was presented over an existing `EditPostViewController`, otherwise `false`.
+    private func isPresentingOverEditor() -> Bool {
+        guard
+            let aztecNavigationController = presentingViewController as? AztecNavigationController,
+            aztecNavigationController.presentingViewController is EditPostViewController
+        else {
+            return false
+        }
+        return true
     }
 
     @objc func shouldShowPostPost(hasChanges: Bool) -> Bool {

--- a/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostPostViewController.swift
@@ -33,6 +33,8 @@ class PostPostViewController: UIViewController {
     @objc var onClose: (() -> ())?
     @objc var reshowEditor: (() -> ())?
     @objc var preview: (() -> ())?
+    /// Set to `true` to hide the edit button from the view.
+    var hideEditButton = false
 
     init() {
         super.init(nibName: nil, bundle: nil)
@@ -175,6 +177,7 @@ class PostPostViewController: UIViewController {
         siteUrlLabel.text = post.blog.displayURL as String?
         siteUrlLabel.accessibilityIdentifier = "siteUrl"
         siteIconView.downloadSiteIcon(for: post.blog)
+        editButton.isHidden = hideEditButton
         let isPrivate = !post.blog.visible
         if isPrivate {
             shareButton.isHidden = true


### PR DESCRIPTION
Fixes #18180

## Description

Currently, users can edit a post directly from the toast notification shown at the bottom of the app when a post is published or updated.

| View tapped | Edit tapped | New editor presented |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/2092798/199614310-30807235-6ffd-4257-8de8-f60096cbb013.png) | ![image](https://user-images.githubusercontent.com/2092798/199614399-1e6f9e51-28dd-4c01-85da-241a3c30c387.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 18 27 56](https://user-images.githubusercontent.com/2092798/199614491-56ca37ed-4ae6-4f80-bd66-d460e54cb13a.png) |

If the user follows this sequence as they revise a post, it can cause multiple editors (all with the same post) to be stacked:

<img width="827" alt="Screen Shot 2022-11-02 at 19 18 30" src="https://user-images.githubusercontent.com/2092798/199620180-28b25306-7cba-4839-898e-d313c6f451b4.png">

Some reasons why this can be problematic:
- High memory usage when multiple editor VCs loaded
- A confusing user experience when the user closes out the stack of editors (see original issue #18180)

**Note about Pages:** This issue should not apply to Pages as we show page previews immediately after tapping "View".

## Options

There are a few routes we can take to improve this:
- **Option A**: 
  - Outside of the editor: Always open a new editor when "Edit Post" is chosen.
  - Inside the editor: Always open a new editor when "Edit Post" is chosen if the post doesn't match the one currently being edited. Otherwise dismiss the prompt to return back to the editor when it's chosen.

- **Option B**: 
  - Outside of the editor: Always open a new editor when "Edit Post" is chosen.
  - Inside the editor: Don't show the "Edit Post" button.

- **Option C**:
  - Remove the ability to edit from the toast notification.

_I'm open to other options!_

## Chosen Solution

I went with **Option B** in this PR. The reasons being:
- It fixes the original issue by preventing multiple editors from stacking.
- It keeps the user focused on one editing session at a time. It seems like a better flow for a user to commit (save a draft / publish) post X before editing post Y.
- Users still have the ability to jump straight into editing outside of the editor.

| When presented while editing | Everywhere else |
| - | - |
| ![image](https://user-images.githubusercontent.com/2092798/199622663-6aca14b4-02c7-4146-86e2-acbee2dead2e.png) | ![Simulator Screen Shot - iPhone 14 - 2022-11-02 at 18 23 31](https://user-images.githubusercontent.com/2092798/199622746-e50b7112-d790-4e90-a5cb-262f3ae7fc55.png) |

## How Android does it

I was able to get a toast notification on Android to show when I was outside the editor, but not while I was inside, so I wasn't able to test this exact scenario.

## Testing

### Responding to a notification inside the editor

1. Create a new Post and publish it.
2. Edit the Post and tap "Update".
3. **Expect** a toast notification to appear from the bottom of the screen.
4. Tap "View".
5. **Expectation:** No "Edit Post" button is shown.

### Responding to a notification outside of the editor

1. Create a new Post.
2. Tap the ellipses at the top right and choose "Save as Draft".
3. Close the post and return to the My Site view.
4. Tap "Posts".
5. Select the "Drafts" tab.
6. Tap "More" and select "Publish Now".
7. Tap "Publish" in the action sheet.
8.  **Expect** a toast notification to appear from the bottom of the screen.
9. Tap "View".
10. **Expectation:** "Edit Post" button is shown and tapping it opens an editor.

#### Known issue

When closing an editor that was spawned, the original prompt isn't dismissed with the animation. This predates this PR and a new issue will be filed if one doesn't already exist.

https://user-images.githubusercontent.com/2092798/199624343-ac8a5c4b-0228-4a35-96ee-1295c8d2fa70.mp4

## Regression Notes
1. Potential unintended areas of impact
It's possible that the detection used in this PR to determine if an editor is opened can create false-positives. It would be good to test responding to these notifications in multiple areas of the app. To do this, a multimedia-heavy post can be published which will take time to upload. This gives the tester enough time to navigate to a different part of the app. One can also synthetically slow their network connection to achieve the same effect.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests above.

3. What automated tests I added (or what prevented me from doing so)
I looked into UI tests but ultimately didn't add any. The biggest risk is that the editor view hierarchy changes in the future, causing editor detection to fail and reverting back to the behavior this fixes.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
