### PR TITLE
Update Jetpack entitlements on all build types to match WP

### DIFF
--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -12,6 +12,10 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:public-api.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -8,6 +8,10 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:public-api.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/Jetpack/JetpackRelease-Internal.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Internal.entitlements
@@ -8,6 +8,10 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:public-api.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -12,6 +12,10 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>applinks:apps.wordpress.com</string>
+		<string>applinks:wordpress.com</string>
+		<string>applinks:public-api.wordpress.com</string>
+		<string>applinks:links.wp.a8cmail.com</string>
+		<string>applinks:*.wordpress.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>


### PR DESCRIPTION
Updates the entitlements so that Jetpack app reacts to universal links. 

To test:
1. Install Jetpack & Login.
2. Delete WP if already installed.
3. Write a universal link to another app like Notes, Reminders or Shortcuts (not Safari). You can use https://wordpress.com/stats
4. Tap on the link and verify if it opens Jetpack.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
