### PR TITLE
Update logic for GutenbergViewController to fix media upload statuses

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -834,12 +834,14 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
         }
         alertController.addAction(dismissAction)
 
-        if media.remoteStatus == .pushing || media.remoteStatus == .processing {
+        if media.remoteStatus == .failed || media.remoteStatus == .processing || media.remoteStatus == .local || media.remoteStatus == .pushing {
             let cancelUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.stopUploadActionTitle, style: .destructive) { (action) in
                 self.mediaInserterHelper.cancelUploadOf(media: media)
             }
             alertController.addAction(cancelUploadAction)
-        } else if media.remoteStatus == .failed, let error = media.error {
+        }
+
+        if media.remoteStatus == .failed, let error = media.error {
             message = error.localizedDescription
             let retryUploadAction = UIAlertAction(title: MediaAttachmentActionSheet.retryUploadActionTitle, style: .default) { (action) in
                 self.mediaInserterHelper.retryUploadOf(media: media)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5254

To test:
- Tap on the Image block placeholder or edit button in the toolbar
- Tap option ‘Choose from device’ and choose an image
- While the upload is in progress tap on the image thumbnail
- Stop upload button should be present in ActionSheet options

## Regression Notes
1. Potential unintended areas of impact
Gutenberg Editor

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
