### PR TITLE
Fix missing photo permission message in image block

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 21.2
 -----
 * [*] [internal] Refactored fetching posts in the Reader tab. [#19539]
+* [*] [Block Editor] Fixed image block issue where no message was shown when permission to the device photos was not granted [#19577]
 
 
 21.1

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -125,12 +125,6 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
         }
     }
 
-    open func mediaPickerController(_ picker: WPMediaPickerViewController, handleError error: Error) -> Bool {
-        let alert = WPMediaPickerAlertHelper.buildAlertControllerWithError(error)
-        context.present(alert, animated: true)
-        return true
-    }
-
     func mediaPickerControllerDidCancel(_ picker: WPMediaPickerViewController) {
         mediaLibraryDataSource.searchCancelled()
         context.dismiss(animated: true, completion: { self.invokeMediaPickerCallback(asset: nil) })


### PR DESCRIPTION
Fixes #19576

MediaPicker-iOS handles the display of a message when the app lacks photo permission. By implementing a delegate method, the app was overriding this and presenting the prompt from the block editor screen which is hidden behind the media picker screen, leading to this error:

```
2022-11-10 00:01:35.281384-0700 Jetpack[7225:42366] [Presentation] Attempt to present <UIAlertController: 0x7fa85aa9d200> on <WordPress.AztecNavigationController: 0x7fa849195400> (from <WordPress.GutenbergViewController: 0x7fa849030800>) whose view is not in the window hierarchy.
```

To fix this, I removed the delegate method. This means that the media picker doesn't try to call the delegate method ([see code](https://github.com/wordpress-mobile/MediaPicker-iOS/blob/d1e5dbab94a013f23d6b784ef98699b05c536d77/Pod/Classes/WPMediaPickerViewController.m#L790-L794) and instead calls [`wpm_showAlertWithError`](https://github.com/wordpress-mobile/MediaPicker-iOS/blob/d1e5dbab94a013f23d6b784ef98699b05c536d77/Pod/Classes/WPMediaPickerViewController.m#L795), which in turn shows the same permission alert that's shown when adding media via My Site → Menu → Media ([which presents the alert on the media picker view controller](https://github.com/wordpress-mobile/MediaPicker-iOS/blob/ce1e610ca42279dacc13d9b65f4c1c4ab1423655/Pod/Classes/UIViewController%2BMediaAdditions.m#L9), which is on-screen).

To test:
1. Ensure the app does not have access to photos:
  a. Go My Site tab → Menu → Media
  b. Go to add media, but deny the app permission
2. Now open a new post
3. Add the image block
4. Tap "Choose from device"
5. Notice the app now shows an alert prompting users to enable the missing permission

## Regression Notes
1. Potential unintended areas of impact

Image block error handling could be inadvertently affected by this change.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested adding images via the image block both with and without the photo permission.

3. What automated tests I added (or what prevented me from doing so)

There were no existing tests I could easily build upon.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
