### PR TITLE
Remove ContextManagerMock

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1105,7 +1105,7 @@
 		4AD5656F28E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
 		4AD5657028E413160054C676 /* Blog+History.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656E28E413160054C676 /* Blog+History.swift */; };
 		4AD5657228E543A30054C676 /* BlogQueryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5657128E543A30054C676 /* BlogQueryTests.swift */; };
-		4AFB8FBF2824999500A2F4B2 /* ContextManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */; };
+		4AFB8FBF2824999500A2F4B2 /* ContextManager+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFB8FBE2824999400A2F4B2 /* ContextManager+Helpers.swift */; };
 		4B2DD0F29CD6AC353C056D41 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		4BB2296498BE66D515E3D610 /* Pods_JetpackShareExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 23052F0F1F9B2503E33D0A26 /* Pods_JetpackShareExtension.framework */; };
 		4D520D4F22972BC9002F5924 /* acknowledgements.html in Resources */ = {isa = PBXBuildFile; fileRef = 4D520D4E22972BC9002F5924 /* acknowledgements.html */; };
@@ -6346,7 +6346,7 @@
 		4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPost+Helper.swift"; sourceTree = "<group>"; };
 		4AD5656E28E413160054C676 /* Blog+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+History.swift"; sourceTree = "<group>"; };
 		4AD5657128E543A30054C676 /* BlogQueryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogQueryTests.swift; sourceTree = "<group>"; };
-		4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextManagerMock.swift; sourceTree = "<group>"; };
+		4AFB8FBE2824999400A2F4B2 /* ContextManager+Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "ContextManager+Helpers.swift"; sourceTree = "<group>"; };
 		4D520D4E22972BC9002F5924 /* acknowledgements.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = acknowledgements.html; path = "../Pods/Target Support Files/Pods-Apps-WordPress/acknowledgements.html"; sourceTree = "<group>"; };
 		4D670B9448DF9991366CF42D /* Pods_WordPressStatsWidgets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WordPressStatsWidgets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		51A5F017948878F7E26979A0 /* Pods-Apps-WordPress.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-WordPress.release.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-WordPress/Pods-Apps-WordPress.release.xcconfig"; sourceTree = "<group>"; };
@@ -15421,7 +15421,7 @@
 				E180BD4D1FB4681E00D0D781 /* MockCookieJar.swift */,
 				E1B642121EFA5113001DC6D7 /* ModelTestHelper.swift */,
 				4A17C1A3281A823E0001FFE5 /* NSManagedObject+Fixture.swift */,
-				4AFB8FBE2824999400A2F4B2 /* ContextManagerMock.swift */,
+				4AFB8FBE2824999400A2F4B2 /* ContextManager+Helpers.swift */,
 				933D1F451EA64108009FB462 /* TestingAppDelegate.h */,
 				933D1F461EA64108009FB462 /* TestingAppDelegate.m */,
 				933D1F6B1EA7A3AB009FB462 /* TestingMode.storyboard */,
@@ -22114,7 +22114,7 @@
 				B532ACD31DC3AE1200FFFA57 /* OHHTTPStubs+Helpers.swift in Sources */,
 				E11DF3E420C97F0A00C0B07C /* NotificationCenterObserveOnceTests.swift in Sources */,
 				5960967F1CF7959300848496 /* PostTests.swift in Sources */,
-				4AFB8FBF2824999500A2F4B2 /* ContextManagerMock.swift in Sources */,
+				4AFB8FBF2824999500A2F4B2 /* ContextManager+Helpers.swift in Sources */,
 				3F751D462491A93D0008A2B1 /* ZendeskUtilsTests+Plans.swift in Sources */,
 				F44FB6CB287895AF0001E3CE /* SuggestionsListViewModelTests.swift in Sources */,
 				8BD36E062395CC4400EFFF1C /* MediaEditorOperation+DescriptionTests.swift in Sources */,

--- a/WordPress/WordPressTest/Blog+ObjcTests.m
+++ b/WordPress/WordPressTest/Blog+ObjcTests.m
@@ -2,13 +2,13 @@
 #import "WordPressTest-Swift.h"
 
 @interface Blog_ObjcTests : XCTestCase
-@property (strong, nonatomic) ContextManagerMock *contextManager;
+@property (strong, nonatomic) ContextManager *contextManager;
 @end
 
 @implementation Blog_ObjcTests
 
 - (void)setUp {
-    self.contextManager = [ContextManagerMock new];
+    self.contextManager = [ContextManager forTesting];
     [super setUp];
 }
 

--- a/WordPress/WordPressTest/BlogJetpackTest.m
+++ b/WordPress/WordPressTest/BlogJetpackTest.m
@@ -17,15 +17,14 @@
 
 @property (nonatomic, strong) WPAccount *account;
 @property (nonatomic, strong) Blog *blog;
-@property (nonatomic, strong) ContextManagerMock *testContextManager;
+@property (nonatomic, strong) ContextManager *testContextManager;
 @end
 
 @implementation BlogJetpackTest
 
 - (void)setUp {
     [super setUp];
-    self.testContextManager = [[ContextManagerMock alloc] init];
-    [self.testContextManager useAsSharedInstanceUntilTestFinished:self];
+    self.testContextManager = [ContextManager forTesting];
 
     _blog = (Blog *)[NSEntityDescription insertNewObjectForEntityForName:@"Blog"
                                                   inManagedObjectContext:self.testContextManager.mainContext];

--- a/WordPress/WordPressTest/BlogServiceTest.m
+++ b/WordPress/WordPressTest/BlogServiceTest.m
@@ -12,7 +12,7 @@
 @property (nonatomic, strong) BlogService *blogService;
 @property (nonatomic, strong) id blogServiceMock;
 @property (nonatomic, strong) Blog *blog;
-@property (nonatomic, strong) ContextManagerMock *coreDataStack;
+@property (nonatomic, strong) ContextManager *coreDataStack;
 
 @end
 
@@ -22,7 +22,7 @@
 {
     [super setUp];
 
-    self.coreDataStack = [[ContextManagerMock alloc] init];
+    self.coreDataStack = [ContextManager forTesting];
 
     self.blogService = [[BlogService alloc] initWithManagedObjectContext:[self.coreDataStack mainContext]];
     AccountService *service = [[AccountService alloc] initWithManagedObjectContext:self.coreDataStack.mainContext];

--- a/WordPress/WordPressTest/BlogSiteVisibilityHelperTest.m
+++ b/WordPress/WordPressTest/BlogSiteVisibilityHelperTest.m
@@ -9,7 +9,7 @@
 @end
 
 @interface BlogSiteVisibilityHelperTest ()
-@property (nonatomic, strong) ContextManagerMock *coreDataStack;
+@property (nonatomic, strong) ContextManager *coreDataStack;
 @end
 
 @implementation BlogSiteVisibilityHelperTest
@@ -18,7 +18,7 @@
 {
     [super setUp];
     
-    self.coreDataStack = [ContextManagerMock new];
+    self.coreDataStack = [ContextManager forTesting];
 }
 
 - (void)tearDown

--- a/WordPress/WordPressTest/BlogTimeZoneTests.m
+++ b/WordPress/WordPressTest/BlogTimeZoneTests.m
@@ -5,7 +5,7 @@
 #import "WordPressTest-Swift.h"
 
 @interface BlogTimeZoneTests : XCTestCase
-@property (nonatomic, strong) ContextManagerMock *coreDataStack;
+@property (nonatomic, strong) ContextManager *coreDataStack;
 @property (nonatomic, strong) Blog *blog;
 @end
 
@@ -15,7 +15,7 @@
 {
     [super setUp];
 
-    self.coreDataStack = [[ContextManagerMock alloc] init];
+    self.coreDataStack = [ContextManager forTesting];
 
     AccountService *service = [[AccountService alloc] initWithManagedObjectContext: self.coreDataStack.mainContext];
     WPAccount *account = [service createOrUpdateAccountWithUsername:@"test" authToken:@"token"];

--- a/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/BloggingRemindersSchedulerTests.swift
@@ -54,7 +54,7 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         let schedule = BloggingRemindersScheduler.Schedule.weekdays(days)
         let store: BloggingRemindersStore
 
-        let contextManager = ContextManagerMock()
+        let contextManager = ContextManager.forTesting()
         let context = contextManager.mainContext
         let blog = BlogBuilder(context).build()
 
@@ -93,7 +93,7 @@ class BloggingRemindersSchedulerTests: XCTestCase {
         let cancelExpectation = expectation(description: "The notification is cancelled")
         cancelExpectation.expectedFulfillmentCount = days.count
 
-        let contextManager = ContextManagerMock()
+        let contextManager = ContextManager.forTesting()
         let context = contextManager.mainContext
         let blog = BlogBuilder(context).build()
 

--- a/WordPress/WordPressTest/ContextManager+Helpers.swift
+++ b/WordPress/WordPressTest/ContextManager+Helpers.swift
@@ -2,29 +2,14 @@ import XCTest
 
 @testable import WordPress
 
-class ContextManagerMock: ContextManager {
+extension ContextManager {
 
-    /// Create an in memory database using the current version of the data model.
-    convenience init() {
-        self.init(modelName: ContextManagerModelNameCurrent)
-    }
-
-    /// Create an in memory database using given `modelName`.
+    /// Create an in memory database.
     ///
     /// - SeeAlso `ContextManager`
-    init(modelName: String) {
-        super.init(modelName: modelName, store: ContextManager.inMemoryStoreURL, contextFactory: nil)
-    }
-
-    override func saveContextAndWait(_ context: NSManagedObjectContext) {
-        super.saveContextAndWait(context)
-        // FIXME: Remove this method to use superclass one instead
-        //
-        // This log resolves a deadlock in
-        // `DashboardCardTests.testShouldNotShowQuickStartIfDefaultSectionIsSiteMenu`
-        //
-        // Unfortunately, we're not sure why.
-        NSLog("Context save completed")
+    @objc
+    static func forTesting() -> ContextManager {
+        ContextManager(modelName: ContextManagerModelNameCurrent, store: ContextManager.inMemoryStoreURL, contextFactory: nil)
     }
 
     /// Override `ContextManager.shared` with the mock instance, and un-override it when
@@ -34,7 +19,7 @@ class ContextManagerMock: ContextManager {
     /// `setUp` method.
     ///
     /// - Parameter testCase: The test case to wait for.
-    @objc func useAsSharedInstance(untilTestFinished testCase: XCTestCase) {
+    func useAsSharedInstance(untilTestFinished testCase: XCTestCase) {
         // Create the test observer singleton to add it to `XCTestObservationCenter`.
         _ = AutomaticTeardownTestObserver.instance
 

--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -142,7 +142,7 @@ class ContextManagerTests: XCTestCase {
     }
 
     func testSaveDerivedContextWithChangesInMainContext() throws {
-        let contextManager = ContextManagerMock()
+        let contextManager = ContextManager.forTesting()
         let derivedContext = contextManager.newDerivedContext()
 
         derivedContext.perform {
@@ -179,15 +179,14 @@ class ContextManagerTests: XCTestCase {
         // It's not great to be accessing global state here, but ContextManager accesses this
         // feature flag under the hood and injecting it is out of scope at this point in time.
         if FeatureFlag.newCoreDataContext.enabled == false {
-            // ContextManagerMock subclasses ContextManager, which uses LegacyContextFactory unless
-            // the newCoreDataContext feature flag is on.
+            // ContextManager uses LegacyContextFactory unless the newCoreDataContext feature flag is on.
             XCTExpectFailure("Known issue of `LegacyContextFactory`: the `mainContext` is saved along with the `ContextManager.save` functions")
         }
         expect(try findFirstUser()?.username) == "First User"
     }
 
     func testSaveUsingBlock() async {
-        let contextManager = ContextManagerMock()
+        let contextManager = ContextManager.forTesting()
         let numberOfAccounts: () -> Int = {
             contextManager.mainContext.countObjects(ofType: WPAccount.self)
         }
@@ -233,7 +232,7 @@ class ContextManagerTests: XCTestCase {
     }
 
     func testSaveUsingBlockWithNestedCalls() {
-        let contextManager = ContextManagerMock()
+        let contextManager = ContextManager.forTesting()
         let accounts: () -> Set<String> = {
             let all = (try? contextManager.mainContext.fetch(NSFetchRequest<WPAccount>(entityName: "Account"))) ?? []
             return Set(all.map { $0.username! })

--- a/WordPress/WordPressTest/CoreDataTestCase.swift
+++ b/WordPress/WordPressTest/CoreDataTestCase.swift
@@ -4,8 +4,8 @@ import XCTest
 /// from this class to use the `CoreDataStack` mock instance in your test case.
 class CoreDataTestCase: XCTestCase {
 
-    private(set) lazy var contextManager: ContextManagerMock = {
-        ContextManagerMock()
+    private(set) lazy var contextManager: ContextManager = {
+        ContextManager.forTesting()
     }()
 
     var mainContext: NSManagedObjectContext {

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -12,7 +12,7 @@
 @end
 
 @interface MenusServiceTests : XCTestCase
-@property (nonatomic, strong) ContextManagerMock *manager;
+@property (nonatomic, strong) ContextManager *manager;
 @end
 
 @implementation MenusServiceTests
@@ -20,7 +20,7 @@
 - (void)setUp
 {
     [super setUp];
-    self.manager = [ContextManagerMock new];
+    self.manager = [ContextManager forTesting];
 }
 
 - (void)tearDown

--- a/WordPress/WordPressTest/Notification/Controllers/NotificationsViewControllerTests.swift
+++ b/WordPress/WordPressTest/Notification/Controllers/NotificationsViewControllerTests.swift
@@ -4,11 +4,11 @@ import XCTest
 final class NotificationsViewControllerTests: XCTestCase {
 
     private var controller: NotificationsViewController!
-    private var contextManager: ContextManagerMock!
+    private var contextManager: ContextManager!
     private var utility: NotificationUtility!
 
     override func setUpWithError() throws {
-        contextManager = ContextManagerMock()
+        contextManager = ContextManager.forTesting()
         contextManager.useAsSharedInstance(untilTestFinished: self)
         utility = NotificationUtility(coreDataStack: contextManager)
         controller = NotificationsViewController.loadFromStoryboard()

--- a/WordPress/WordPressTest/PostCategoryServiceTests.m
+++ b/WordPress/WordPressTest/PostCategoryServiceTests.m
@@ -27,7 +27,7 @@
 
 @interface PostCategoryServiceTests : XCTestCase
 
-@property (nonatomic, strong) ContextManagerMock *manager;
+@property (nonatomic, strong) ContextManager *manager;
 @property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) PostCategoryServiceForStubbing *service;
 
@@ -39,7 +39,7 @@
 {
     [super setUp];
 
-    self.manager = [ContextManagerMock new];
+    self.manager = [ContextManager forTesting];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
 
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:self.manager.mainContext];

--- a/WordPress/WordPressTest/PostTagServiceTests.m
+++ b/WordPress/WordPressTest/PostTagServiceTests.m
@@ -27,7 +27,7 @@
 
 @interface PostTagServiceTests : XCTestCase
 
-@property (nonatomic, strong) ContextManagerMock *manager;
+@property (nonatomic, strong) ContextManager *manager;
 @property (nonatomic, strong) Blog *blog;
 @property (nonatomic, strong) PostTagServiceForStubbing *service;
 
@@ -39,7 +39,7 @@
 {
     [super setUp];
 
-    self.manager = [ContextManagerMock new];
+    self.manager = [ContextManager forTesting];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
 
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:self.manager.mainContext];

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -23,7 +23,7 @@ class PromptRemindersSchedulerTests: XCTestCase {
         blog.dotComID!.intValue
     }
 
-    private var contextManager: ContextManagerMock!
+    private var contextManager: ContextManager!
     private var serviceFactory: BloggingPromptsServiceFactory!
     private var notificationScheduler: MockNotificationScheduler!
     private var pushAuthorizer: MockPushNotificationAuthorizer!
@@ -34,7 +34,7 @@ class PromptRemindersSchedulerTests: XCTestCase {
     private var dateProvider: MockCurrentDateProvider!
 
     override func setUp() {
-        contextManager = ContextManagerMock()
+        contextManager = ContextManager.forTesting()
         serviceFactory = BloggingPromptsServiceFactory(contextManager: contextManager)
         notificationScheduler = MockNotificationScheduler()
         pushAuthorizer = MockPushNotificationAuthorizer()

--- a/WordPress/WordPressTest/ReaderPostServiceTest.m
+++ b/WordPress/WordPressTest/ReaderPostServiceTest.m
@@ -34,7 +34,7 @@
 }
 
 - (void)testDeletePostsWithoutATopic {
-    id<CoreDataStack> coreDataStack = [ContextManagerMock new];
+    id<CoreDataStack> coreDataStack = [ContextManager forTesting];
     NSManagedObjectContext *context = [coreDataStack mainContext];
     ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
 

--- a/WordPress/WordPressTest/ReaderPostTest.m
+++ b/WordPress/WordPressTest/ReaderPostTest.m
@@ -5,7 +5,7 @@
 
 @interface ReaderPostTest : XCTestCase
 
-@property (nonatomic, strong) ContextManagerMock *coreDataStack;
+@property (nonatomic, strong) ContextManager *coreDataStack;
 
 @end
 
@@ -15,7 +15,7 @@
 
 - (void)setUp
 {
-    self.coreDataStack = [[ContextManagerMock alloc] init];
+    self.coreDataStack = [ContextManager forTesting];
 }
 
 - (void)tearDown

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -16,7 +16,7 @@
 #pragma mark - Tests
 
 @interface ThemeServiceTests : XCTestCase
-@property (nonatomic, strong) ContextManagerMock *manager;
+@property (nonatomic, strong) ContextManager *manager;
 @end
 
 @implementation ThemeServiceTests
@@ -24,7 +24,7 @@
 - (void)setUp
 {
     [super setUp];
-    self.manager = [ContextManagerMock new];
+    self.manager = [ContextManager forTesting];
 }
 
 - (void)tearDown

--- a/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
+++ b/WordPress/WordPressTest/WPAccount+ObjCLookupTests.m
@@ -3,7 +3,7 @@
 
 @interface WPAccount_ObjCLookupTests : XCTestCase
 
-@property(strong, nonatomic) ContextManagerMock *contextManager;
+@property(strong, nonatomic) ContextManager *contextManager;
 
 @end
 
@@ -11,7 +11,7 @@
 
 - (void) setUp {
     [super setUp];
-    _contextManager = [ContextManagerMock new];
+    _contextManager = [ContextManager forTesting];
 }
 
 - (void) testLookupDefaultWordPressComAccountReturnsNilWhenNoAccountIsSet {


### PR DESCRIPTION
## Changes
`ContextManagerMock` was created solely to workaround the deadlock issue mentioned in the `saveContextAndWait` override. Now that we've switched over to `NSPersistentContainer`(still needs to wait to see if it will introduce any issue in versions 21.1), we no longer need this "mock implementation". This PR deletes it and prepares for the follow up PR, which is deleting the legacy code and completing the `NSPersistentContainer` migration.

- [ ] This PR can be merged if `NSPersistentContainer` doesn't introduce major issue in v21.1.

## Test instructions
All good if CI jobs pass.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
