### PR TITLE
My Site Dashboard: Fixes an issue where the segmented control is clipped when the dashboard is selected

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,3 +1,7 @@
+21.3
+-----
+* [*] Fixed a minor UI issue where the segmented control under My SIte was being clipped when "Home" is selected. [#19595]
+
 21.2
 -----
 * [*] [internal] Refactored fetching posts in the Reader tab. [#19539]

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -844,6 +844,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         blogDashboardViewController.update(blog: blog)
         embedChildInStackView(blogDashboardViewController)
         self.blogDashboardViewController = blogDashboardViewController
+        stackView.sendSubviewToBack(blogDashboardViewController.view)
     }
 
     // MARK: - Model Changes


### PR DESCRIPTION
Fixes #19594 

## Description
Fixes an issue where the segmented control is clipped when the dashboard is selected.

## Root Cause
- The segmented control extends outside of its superview by 1 pixel.
- The dashboard view was added in front of the segmented control, clipping its bottom 1 pixel.

## Solution
Send the dashboard view to the back after adding it.

## Screenshots

Home | Menu
-|-
![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 05 32 46](https://user-images.githubusercontent.com/25306722/201820174-cd449182-9eca-4f61-86fb-68c63fa4cc3c.png)|![Simulator Screen Shot - iPhone 14 Pro - 2022-11-15 at 05 32 48](https://user-images.githubusercontent.com/25306722/201820185-3081cb1d-5d1d-48ab-9fe2-4ebd4e65c1c1.png)


## Testing Instructions

1. Run the app
2. Navigate to "Menu"
3. Navigate to "Home"
4. Make sure that the bottom of the segmented control is not clipped when "Home" is selected.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.