### PR TITLE
Tweak atomic site account deletion error message to give more info

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -359,7 +359,7 @@ private class AccountSettingsController: SettingsController {
         // Based on https://github.com/Automattic/wp-calypso/pull/65780
         NSLocalizedString(
             "accountSettings.closeAccount.error.atomicSite",
-            value: "This user account cannot be closed because it has active purchases. Please contact our support team.",
+            value: "This user account cannot be closed immediately because it has active purchases. Please contact our support team to finish deleting the account.",
             comment: "Error message displayed when unable to close user account due to having active atomic site."
         )
     }

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -356,9 +356,10 @@ private class AccountSettingsController: SettingsController {
     }
 
     private var localizedErrorMessageForAtomicSites: String {
+        // Based on https://github.com/Automattic/wp-calypso/pull/65780
         NSLocalizedString(
             "accountSettings.closeAccount.error.atomicSite",
-            value: "To close this account now, contact our support team.",
+            value: "This user account cannot be closed because it has active purchases. Please contact our support team.",
             comment: "Error message displayed when unable to close user account due to having active atomic site."
         )
     }

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -356,8 +356,11 @@ private class AccountSettingsController: SettingsController {
     }
 
     private var localizedErrorMessageForAtomicSites: String {
-        NSLocalizedString("To close this account now, contact our support team.",
-                                 comment: "Error message displayed when unable to close user account due to having active atomic site.")
+        NSLocalizedString(
+            "accountSettings.closeAccount.error.atomicSite",
+            value: "To close this account now, contact our support team.",
+            comment: "Error message displayed when unable to close user account due to having active atomic site."
+        )
     }
 
     private var contactSupportAction: ((UIAlertAction) -> Void) {

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -459,6 +459,9 @@
    Link to Account Settings section */
 "Account Settings" = "Account Settings";
 
+/* Error message displayed when unable to close user account due to having active atomic site. */
+"accountSettings.closeAccount.error.atomicSite" = "This user account cannot be closed immediately because it has active purchases. Please contact our support team to finish deleting the account.";
+
 /* Title of button that displays the App's acknoledgements */
 "Acknowledgements" = "Acknowledgements";
 
@@ -8314,9 +8317,6 @@
 
 /* Error popup message to indicate that there was no category title filled in. */
 "Title for a category is mandatory." = "Title for a category is mandatory.";
-
-/* Error message displayed when unable to close user account due to having active atomic site. */
-"To close this account now, contact our support team." = "To close this account now, contact our support team.";
 
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "To continue please enter your email address and name.";


### PR DESCRIPTION
Jetpack iOS 21.1 has been rejected because the reviewer didn't find the account deletion error message they got on an account with Atomic sites satisfactory.

While we work on improving the flow, this copy tweak might be just enough to comply with Apple's guidelines.