### PR TITLE
Jetpack Focus: Display Site Creation overlay

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
@@ -1,11 +1,18 @@
 extension BlogListViewController {
     @objc
     func launchSiteCreation() {
-        let wizardLauncher = SiteCreationWizardLauncher()
-        guard let wizard = wizardLauncher.ui else {
-            return
+        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self) {
+            guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
+                return
+            }
+
+            // Display site creation flow if not in phase two
+            let wizardLauncher = SiteCreationWizardLauncher()
+            guard let wizard = wizardLauncher.ui else {
+                return
+            }
+            self.present(wizard, animated: true)
+            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "my_sites"])
         }
-        present(wizard, animated: true)
-        WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "my_sites"])
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -696,12 +696,19 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     func launchSiteCreation(source: String) {
-        let wizardLauncher = SiteCreationWizardLauncher()
-        guard let wizard = wizardLauncher.ui else {
-            return
+        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self) {
+            guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
+                return
+            }
+
+            // Display site creation flow if not in phase two
+            let wizardLauncher = SiteCreationWizardLauncher()
+            guard let wizard = wizardLauncher.ui else {
+                return
+            }
+            self.present(wizard, animated: true)
+            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
         }
-        present(wizard, animated: true)
-        WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": source])
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -100,6 +100,18 @@ class JetpackFeaturesRemovalCoordinator {
         frequencyTracker.track()
     }
 
+    /// Used to display Site Creation overlays.
+    /// - Parameters:
+    ///   - viewController: View controller where the overlay should be presented in.
+    static func presentSiteCreationOverlayIfNeeded(in viewController: UIViewController) {
+        let phase = siteCreationPhase()
+        let viewModel = JetpackFullscreenOverlaySiteCreationViewModel(phase: phase)
+        guard viewModel.shouldShowOverlay else {
+            return
+        }
+        createAndPresentOverlay(with: viewModel, in: viewController)
+    }
+
     private static func createAndPresentOverlay(with viewModel: JetpackFullscreenOverlayViewModel, in viewController: UIViewController) {
         let overlay = JetpackFullscreenOverlayViewController(with: viewModel)
         let navigationViewController = UINavigationController(rootViewController: overlay)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -103,10 +103,12 @@ class JetpackFeaturesRemovalCoordinator {
     /// Used to display Site Creation overlays.
     /// - Parameters:
     ///   - viewController: View controller where the overlay should be presented in.
-    static func presentSiteCreationOverlayIfNeeded(in viewController: UIViewController) {
+    static func presentSiteCreationOverlayIfNeeded(in viewController: UIViewController, onDismiss: JetpackOverlayDismissCallback? = nil) {
         let phase = siteCreationPhase()
-        let viewModel = JetpackFullscreenOverlaySiteCreationViewModel(phase: phase)
+        var viewModel = JetpackFullscreenOverlaySiteCreationViewModel(phase: phase)
+        viewModel.onDismiss = onDismiss
         guard viewModel.shouldShowOverlay else {
+            onDismiss?()
             return
         }
         createAndPresentOverlay(with: viewModel, in: viewController)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -103,7 +103,8 @@ class JetpackFeaturesRemovalCoordinator {
     /// Used to display Site Creation overlays.
     /// - Parameters:
     ///   - viewController: View controller where the overlay should be presented in.
-    static func presentSiteCreationOverlayIfNeeded(in viewController: UIViewController, onDismiss: JetpackOverlayDismissCallback? = nil) {
+    static func presentSiteCreationOverlayIfNeeded(in viewController: UIViewController,
+                                                   onDismiss: JetpackOverlayDismissCallback? = nil) {
         let phase = siteCreationPhase()
         var viewModel = JetpackFullscreenOverlaySiteCreationViewModel(phase: phase)
         viewModel.onDismiss = onDismiss

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -159,6 +159,10 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     var analyticsSource: String {
         return source.rawValue
     }
+
+    var titleLabelMaxNumberOfLines: Int {
+        return 2
+    }
 }
 
 private extension JetpackFullscreenOverlayGeneralViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -163,6 +163,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     var titleLabelMaxNumberOfLines: Int {
         return 2
     }
+
+    var onDismiss: JetpackOverlayDismissCallback?
 }
 
 private extension JetpackFullscreenOverlayGeneralViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -161,7 +161,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     }
 
     var titleLabelMaxNumberOfLines: Int {
-        return 2
+        return Constants.titleLabelMaxNumberOfLines
     }
 
     var onDismiss: JetpackOverlayDismissCallback?
@@ -175,6 +175,7 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
         static let readerLogoAnimationRtl = "JetpackReaderLogoAnimation_rtl"
         static let notificationsLogoAnimationLtr = "JetpackNotificationsLogoAnimation_ltr"
         static let notificationsLogoAnimationRtl = "JetpackNotificationsLogoAnimation_rtl"
+        static let titleLabelMaxNumberOfLines: Int = 2
     }
 
     enum Strings {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
@@ -1,0 +1,27 @@
+import Foundation
+import AutomatticTracks
+
+extension JetpackFullscreenOverlaySiteCreationViewModel {
+
+    // MARK: Analytics Implementation
+
+    func trackOverlayDisplayed() {
+        // TODO: Implement this
+    }
+
+    func trackLearnMoreTapped() {
+        // TODO: Implement this
+    }
+
+    func trackSwitchButtonTapped() {
+        // TODO: Implement this
+    }
+
+    func trackCloseButtonTapped() {
+        // TODO: Implement this
+    }
+
+    func trackContinueButtonTapped() {
+        // TODO: Implement this
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -71,7 +71,7 @@ struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayVi
     }
 
     var titleLabelMaxNumberOfLines: Int {
-        return 2
+        return 3
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+/// Dynamic implementation of `JetpackFullscreenOverlayViewModel` based on the site creation phase
+/// Should be used for Site Creation overlays.
+struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayViewModel {
+
+    let phase: JetpackFeaturesRemovalCoordinator.SiteCreationPhase
+
+    var shouldShowOverlay: Bool {
+        switch phase {
+        case .normal:
+            return false
+        case .one:
+            fallthrough
+        case .two:
+            return true
+        }
+    }
+
+    var title: String {
+        return Strings.title
+    }
+
+    var subtitle: String {
+        switch phase {
+        case .one:
+            return Strings.phaseOneSubtitle
+        case .two:
+            return Strings.phaseTwoSubtitle
+        default:
+            return ""
+        }
+    }
+
+    var animationLtr: String {
+        return Constants.wpJetpackLogoAnimationLtr
+    }
+
+    var animationRtl: String {
+        return Constants.wpJetpackLogoAnimationRtl
+    }
+
+    var footnote: String? {
+        return nil
+    }
+
+    var shouldShowLearnMoreButton: Bool {
+        return false
+    }
+
+    var switchButtonText: String {
+        return Strings.switchButtonTitle
+    }
+
+    var continueButtonText: String? {
+        switch phase {
+        // Show only in phase one
+        case .one:
+            return Strings.continueButtonTitle
+        default:
+            return nil
+        }
+    }
+
+    var shouldShowCloseButton: Bool {
+        return true
+    }
+
+    var analyticsSource: String {
+        return Constants.analyticsSource
+    }
+
+    var titleLabelMaxNumberOfLines: Int {
+        return 2
+    }
+}
+
+private extension JetpackFullscreenOverlaySiteCreationViewModel {
+    enum Constants {
+        static let wpJetpackLogoAnimationLtr = "JetpackWordPressLogoAnimation_ltr"
+        static let wpJetpackLogoAnimationRtl = "JetpackWordPressLogoAnimation_rtl"
+        static let analyticsSource = "site_creation"
+    }
+
+    enum Strings {
+        static let title = NSLocalizedString("jetpack.fullscreen.overlay.siteCreation.title",
+                                             value: "Create a new WordPress site with the Jetpack app",
+                                             comment: "Title of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app.")
+        static let phaseOneSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseOne.siteCreation.subtitle",
+                                             value: "Jetpack provides stats, notifications and more to help you build and grow the WordPress site of your dreams.",
+                                             comment: "Subtitle of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app.")
+        static let phaseTwoSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwo.siteCreation.subtitle",
+                                             value: "Jetpack provides stats, notifications and more to help you build and grow the WordPress site of your dreams.\n\nThe WordPress app no longer supports creating a new site.",
+                                             comment: "Subtitle of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app.")
+        static let switchButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.siteCreation.switch.title",
+                                                                    value: "Try the new Jetpack app",
+                                                                    comment: "Title of a button that navigates the user to the Jetpack app if installed, or to the app store.")
+        static let continueButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.siteCreation.continue.title",
+                                                                    value: "Continue without Jetpack",
+                                                                    comment: "Title of a button that navigates the user to the Jetpack app if installed, or to the app store.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -71,7 +71,7 @@ struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayVi
     }
 
     var titleLabelMaxNumberOfLines: Int {
-        return 3
+        return Constants.titleLabelMaxNumberOfLines
     }
 
     var onDismiss: JetpackOverlayDismissCallback?
@@ -82,6 +82,7 @@ private extension JetpackFullscreenOverlaySiteCreationViewModel {
         static let wpJetpackLogoAnimationLtr = "JetpackWordPressLogoAnimation_ltr"
         static let wpJetpackLogoAnimationRtl = "JetpackWordPressLogoAnimation_rtl"
         static let analyticsSource = "site_creation"
+        static let titleLabelMaxNumberOfLines: Int = 3
     }
 
     enum Strings {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -73,6 +73,8 @@ struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayVi
     var titleLabelMaxNumberOfLines: Int {
         return 3
     }
+
+    var onDismiss: JetpackOverlayDismissCallback?
 }
 
 private extension JetpackFullscreenOverlaySiteCreationViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -211,6 +211,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     @objc private func closeButtonPressed(sender: UIButton) {
         dismiss(animated: true, completion: nil)
         viewModel.trackCloseButtonTapped()
+        viewModel.onDismiss?()
     }
 
 
@@ -222,6 +223,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     @IBAction func continueButtonPressed(_ sender: Any) {
         dismiss(animated: true, completion: nil)
         viewModel.trackContinueButtonTapped()
+        viewModel.onDismiss?()
     }
 
     @IBAction func learnMoreButtonPressed(_ sender: Any) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -117,7 +117,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         let ratio = animationSize.width / animationSize.height
         animationView.widthAnchor.constraint(equalTo: animationView.heightAnchor, multiplier: ratio).isActive = true
 
-        // Buttons bottom constraints
+        // Buttons bottom constraint
         buttonsSuperViewBottomConstraint.constant = viewModel.continueButtonIsHidden ? Metrics.singleButtonBottomSpacing : Metrics.buttonsNormalBottomSpacing
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -52,6 +52,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     @IBOutlet weak var learnMoreButton: UIButton!
     @IBOutlet weak var switchButton: UIButton!
     @IBOutlet weak var continueButton: UIButton!
+    @IBOutlet weak var buttonsSuperViewBottomConstraint: NSLayoutConstraint!
 
     // MARK: Initializers
 
@@ -72,7 +73,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         self.isModalInPresentation = true
         configureNavigationBar()
         applyStyles()
-        addConstraints()
+        setupConstraints()
         setupContent()
         setupColors()
         setupFonts()
@@ -110,10 +111,14 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         titleLabel.numberOfLines = viewModel.titleLabelMaxNumberOfLines
     }
 
-    private func addConstraints() {
+    private func setupConstraints() {
+        // Animation constraint
         let animationSize = animation?.size ?? .init(width: 1, height: 1)
         let ratio = animationSize.width / animationSize.height
         animationView.widthAnchor.constraint(equalTo: animationView.heightAnchor, multiplier: ratio).isActive = true
+
+        // Buttons bottom constraints
+        buttonsSuperViewBottomConstraint.constant = viewModel.continueButtonIsHidden ? Metrics.singleButtonBottomSpacing : Metrics.buttonsNormalBottomSpacing
     }
 
     private func setupContent() {
@@ -252,6 +257,8 @@ private extension JetpackFullscreenOverlayViewController {
         static let switchButtonCornerRadius: CGFloat = 6
         static let titleLineHeightMultiple: CGFloat = 0.88
         static let titleKern: CGFloat = 0.37
+        static let buttonsNormalBottomSpacing: CGFloat = 30
+        static let singleButtonBottomSpacing: CGFloat = 60
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -107,6 +107,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
 
     private func applyStyles() {
         switchButton.layer.cornerRadius = Metrics.switchButtonCornerRadius
+        titleLabel.numberOfLines = viewModel.titleLabelMaxNumberOfLines
     }
 
     private func addConstraints() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -12,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="JetpackFullscreenOverlayViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
                 <outlet property="animationView" destination="v3d-AD-Jsf" id="8wg-bB-WH5"/>
+                <outlet property="buttonsSuperViewBottomConstraint" destination="zhh-p2-mZx" id="4cZ-ra-9SF"/>
                 <outlet property="contentStackView" destination="TTg-Z6-h4X" id="rbe-WF-3kb"/>
                 <outlet property="continueButton" destination="hPW-8A-Di4" id="fym-yu-QBz"/>
                 <outlet property="footnoteLabel" destination="1l4-qY-6ZA" id="Szg-6d-q2E"/>
@@ -34,7 +35,7 @@
                             <rect key="frame" x="0.0" y="0.0" width="375" height="514"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="TTg-Z6-h4X" userLabel="Content Stack View">
-                                    <rect key="frame" x="30" y="115.5" width="315" height="283"/>
+                                    <rect key="frame" x="30" y="115.66666666666666" width="315" height="282.66666666666674"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bUe-f2-zzc" userLabel="Icon Super View">
                                             <rect key="frame" x="0.0" y="0.0" width="315" height="75"/>
@@ -57,28 +58,28 @@
                                             </constraints>
                                         </view>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.59999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="EqD-nO-Q6T">
-                                            <rect key="frame" x="0.0" y="95" width="315" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="94.999999999999986" width="315" height="20.333333333333329"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" minimumScaleFactor="0.59999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="n6H-KY-dMw">
-                                            <rect key="frame" x="0.0" y="135.5" width="315" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="135.33333333333331" width="315" height="20.333333333333343"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Footnote Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumScaleFactor="0.59999999999999998" translatesAutoresizingMaskIntoConstraints="NO" id="1l4-qY-6ZA">
-                                            <rect key="frame" x="0.0" y="176" width="315" height="20.5"/>
+                                            <rect key="frame" x="0.0" y="175.66666666666663" width="315" height="20.333333333333343"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0z9-x4-AgY" userLabel="Learn More Super View">
-                                            <rect key="frame" x="0.0" y="216.5" width="315" height="66.5"/>
+                                            <rect key="frame" x="0.0" y="216" width="315" height="66.666666666666686"/>
                                             <subviews>
                                                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="n55-iX-u43">
-                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="66.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="128" height="66.666666666666671"/>
                                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                     <state key="normal" title="Learn More Button"/>
                                                     <connections>
@@ -116,7 +117,7 @@
                     </constraints>
                 </scrollView>
                 <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="354" placeholderIntrinsicHeight="166" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vcE-wc-fHe">
-                    <rect key="frame" x="10.5" y="529" width="354" height="108"/>
+                    <rect key="frame" x="10.666666666666657" y="529" width="354" height="108"/>
                     <subviews>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VGE-FS-gsd">
                             <rect key="frame" x="0.0" y="0.0" width="354" height="50"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -12,6 +12,7 @@ protocol JetpackFullscreenOverlayViewModel {
     var continueButtonText: String? { get }
     var shouldShowCloseButton: Bool { get }
     var analyticsSource: String { get }
+    var titleLabelMaxNumberOfLines: Int { get }
 
     func trackOverlayDisplayed()
     func trackLearnMoreTapped()

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -1,5 +1,7 @@
 import Foundation
 
+typealias JetpackOverlayDismissCallback = () -> Void
+
 /// Protocol used to configure `JetpackFullscreenOverlayViewController`
 protocol JetpackFullscreenOverlayViewModel {
     var title: String { get }
@@ -13,6 +15,7 @@ protocol JetpackFullscreenOverlayViewModel {
     var shouldShowCloseButton: Bool { get }
     var analyticsSource: String { get }
     var titleLabelMaxNumberOfLines: Int { get }
+    var onDismiss: JetpackOverlayDismissCallback? { get }
 
     func trackOverlayDisplayed()
     func trackLearnMoreTapped()

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -385,13 +385,20 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
         let onDismissQuickStartPromptForNewSiteHandler = onDismissQuickStartPromptHandler(type: .newSite, onDismiss: onDismiss)
 
         epilogueViewController.onCreateNewSite = {
-            let wizardLauncher = SiteCreationWizardLauncher(onDismiss: onDismissQuickStartPromptForNewSiteHandler)
-            guard let wizard = wizardLauncher.ui else {
-                return
-            }
+            JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: navigationController) {
+                guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
+                    return
+                }
 
-            navigationController.present(wizard, animated: true)
-            WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "login_epilogue"])
+                // Display site creation flow if not in phase two
+                let wizardLauncher = SiteCreationWizardLauncher(onDismiss: onDismissQuickStartPromptForNewSiteHandler)
+                guard let wizard = wizardLauncher.ui else {
+                    return
+                }
+
+                navigationController.present(wizard, animated: true)
+                WPAnalytics.track(.enhancedSiteCreationAccessed, withProperties: ["source": "login_epilogue"])
+            }
         }
 
         navigationController.delegate = epilogueViewController

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1529,6 +1529,10 @@
 		7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */; };
 		800035BD291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800035BC291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift */; };
 		800035BE291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800035BC291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift */; };
+		8000361D292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8000361C292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift */; };
+		8000361E292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8000361C292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift */; };
+		8000362029246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8000361F29246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift */; };
+		8000362129246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8000361F29246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift */; };
 		801D94EF2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801D94EE2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift */; };
 		801D94F02919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 801D94EE2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift */; };
 		801D950D291AB3CF0051993E /* JetpackReaderLogoAnimation_ltr.json in Resources */ = {isa = PBXBuildFile; fileRef = 801D9507291AB3CD0051993E /* JetpackReaderLogoAnimation_ltr.json */; };
@@ -6793,6 +6797,8 @@
 		7EFF208920EADCB6009C4699 /* NotificationTextContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTextContent.swift; sourceTree = "<group>"; };
 		7EFF208B20EADF68009C4699 /* FormattableCommentContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormattableCommentContent.swift; sourceTree = "<group>"; };
 		800035BC291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JetpackFullscreenOverlayGeneralViewModel+Analytics.swift"; sourceTree = "<group>"; };
+		8000361C292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackFullscreenOverlaySiteCreationViewModel.swift; sourceTree = "<group>"; };
+		8000361F29246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift"; sourceTree = "<group>"; };
 		801D94EE2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackFullscreenOverlayGeneralViewModel.swift; sourceTree = "<group>"; };
 		801D9507291AB3CD0051993E /* JetpackReaderLogoAnimation_ltr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JetpackReaderLogoAnimation_ltr.json; sourceTree = "<group>"; };
 		801D9508291AB3CD0051993E /* JetpackReaderLogoAnimation_rtl.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JetpackReaderLogoAnimation_rtl.json; sourceTree = "<group>"; };
@@ -12351,6 +12357,8 @@
 				809101972908DE8500FCB4EA /* JetpackFullscreenOverlayViewModel.swift */,
 				801D94EE2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift */,
 				800035BC291DD0D7007D2D26 /* JetpackFullscreenOverlayGeneralViewModel+Analytics.swift */,
+				8000361C292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift */,
+				8000361F29246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift */,
 			);
 			path = "Fullscreen Overlay";
 			sourceTree = "<group>";
@@ -20145,6 +20153,7 @@
 				98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */,
 				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,
 				435D101A2130C2AB00BB2AA8 /* BlogDetailsViewController+FancyAlerts.swift in Sources */,
+				8000361D292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */,
 				F1E72EBA267790110066FF91 /* UIViewController+Dismissal.swift in Sources */,
 				F532AD61253B81320013B42E /* StoriesIntroDataSource.swift in Sources */,
 				E1ECE34F1FA88DA2007FA37A /* StoreContainer.swift in Sources */,
@@ -21210,6 +21219,7 @@
 				5D6C4B121B604190005E3C43 /* RichTextView.swift in Sources */,
 				3F43602F23F31D48001DEE70 /* ScenePresenter.swift in Sources */,
 				9A4E271D22EF33F5001F6A6B /* AccountSettingsStore.swift in Sources */,
+				8000362029246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift in Sources */,
 				4319AADE2090F00C0025D68E /* FancyAlertViewController+NotificationPrimer.swift in Sources */,
 				73FF7032221F469100541798 /* Charts+Support.swift in Sources */,
 				F16601C423E9E783007950AE /* SharingAuthorizationWebViewController.swift in Sources */,
@@ -22609,6 +22619,7 @@
 				9804A098263780B500354097 /* LikeUserHelpers.swift in Sources */,
 				FABB21C02602FC2C00C8785C /* AppRatingUtilityType.swift in Sources */,
 				FABB21C12602FC2C00C8785C /* MenuItemSourceFooterView.m in Sources */,
+				8000361E292468D4007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel.swift in Sources */,
 				FABB21C22602FC2C00C8785C /* JetpackRestoreFailedViewController.swift in Sources */,
 				8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */,
 				FABB21C32602FC2C00C8785C /* ActionSheetViewController.swift in Sources */,
@@ -23969,6 +23980,7 @@
 				FABB25F92602FC2C00C8785C /* PostServiceUploadingList.swift in Sources */,
 				FABB25FA2602FC2C00C8785C /* ImmuTable.swift in Sources */,
 				FABB25FB2602FC2C00C8785C /* PersonViewController.swift in Sources */,
+				8000362129246956007D2D26 /* JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift in Sources */,
 				FABB25FC2602FC2C00C8785C /* StreakInsightStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB25FD2602FC2C00C8785C /* JetpackRemoteInstallState.swift in Sources */,
 				FABB25FE2602FC2C00C8785C /* Scheduler.swift in Sources */,


### PR DESCRIPTION
Part of #19585

## Description
This PR displays the Site Creation overlay for the Site Creation phases one and two.

## Notes

- Track events will be handled in a future PR.
- The action for the Switch button is still not implemented. It will be implemented under another project.

### Screenshots

| / | Phase One | Phase Two |
| - | - | - |
| Light Mode |![phase-one-light](https://user-images.githubusercontent.com/25306722/202073348-953929ce-d9ac-46eb-8db4-a6c1b481a207.png)|![phase-two-light](https://user-images.githubusercontent.com/25306722/202073277-c09629dd-cf3f-41ef-b1b2-fae04a4b17dd.png)|
| Dark Mode |![phase-one-dark](https://user-images.githubusercontent.com/25306722/202073352-bd63cfa0-136c-4259-9d94-04df23e989a5.png)|![phase-two-dark](https://user-images.githubusercontent.com/25306722/202073337-f563046b-d8f2-4185-b907-d23dc4982551.png)|

## Recordings

**Phase One**

https://user-images.githubusercontent.com/25306722/202073356-9d505059-98e6-44a2-986d-a1dde25c4995.mp4

**Phase Two**

https://user-images.githubusercontent.com/25306722/202073408-0b57810d-a27c-4bfd-9051-4f050738325d.mp4

## Testing Instructions
Site creation has three possible phases. Here's how to enable each one of them.
* Normal phase
    * This is the phase where no overlays should be displayed
    * Enable this phase by making sure all jetpack removal flags are disabled
* Phase One
    * This is the phase where we show an overlay but don't fully disable site creation
    * Enable this phase by making sure the "Jetpack Features Removal Phase one" flag is enabled
* Phase Two
    * This is the phase where we show an overlay and fully disable site creation
    * Enable this phase by making sure the "Jetpack Features Removal Phase four" flag is enabled

Please test the following three flows in each phase.

### Site List flow

1. Open the app
2. Navigate to Sites list
3. Tap plus button
4. Tap "Create WordPress.com site"
5. If in the normal phase, make sure no overlay is displayed and the site creation flow starts normally
6. If in phase one, make sure an overlay is displayed with a continue button visible, and upon dismissing the overlay, the site creation flow starts
7. If in phase two, make sure an overlay is displayed without a continue button visible, and upon dismissing the overlay, nothing happens

### Login flow

1. Open the app
2. Logout
3. Login using any method
4. Tap "Create a new site"
5. If in the normal phase, make sure no overlay is displayed and the site creation flow starts normally
6. If in phase one, make sure an overlay is displayed with a continue button visible, and upon dismissing the overlay, the site creation flow starts
7. If in phase two, make sure an overlay is displayed without a continue button visible, and upon dismissing the overlay, nothing happens

### Signup flow

1. Open the app
2. Logout
3. Sign up for a new account
4. Tap "Create a new site"
5. If in the normal phase, make sure no overlay is displayed and the site creation flow starts normally
6. If in phase one, make sure an overlay is displayed with a continue button visible, and upon dismissing the overlay, the site creation flow starts
7. If in phase two, make sure an overlay is displayed without a continue button visible, and upon dismissing the overlay, nothing happens

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.