### PR TITLE
Fix a `NSLocalizedStrings` not using a literal value, leading to an export issue

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
@@ -101,14 +101,18 @@ private extension MigrationHeaderConfiguration {
                                                                          comment: "Secondary description in the migration notifications screen")
 
         static func welcomeSecondaryDescription(plural: Bool) -> String {
-            let siteWord = plural ? "sites" : "site"
-            let value = "We found your \(siteWord). Continue to transfer all your data and sign in to Jetpack automatically."
             if plural {
-                let comment = "The plural form of the secondary description in the migration welcome screen"
-                return NSLocalizedString("migration.welcome.secondaryDescription.plural", value: value, comment: comment)
+                return NSLocalizedString(
+                    "migration.welcome.secondaryDescription.plural",
+                    value: "We found your sites. Continue to transfer all your data and sign in to Jetpack automatically.",
+                    comment: "The plural form of the secondary description in the migration welcome screen"
+                )
             } else {
-                let comment = "The singular form of the secondary description in the migration welcome screen"
-                return NSLocalizedString("migration.welcome.secondaryDescription.singular", value: value, comment: comment)
+                return NSLocalizedString(
+                    "migration.welcome.secondaryDescription.singular",
+                    value: "We found your site. Continue to transfer all your data and sign in to Jetpack automatically.",
+                    comment: "The singular form of the secondary description in the migration welcome screen"
+                )
             }
         }
     }

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -4818,11 +4818,11 @@
 /* The primary description in the migration welcome screen */
 "migration.welcome.primaryDescription" = "It looks like you’re switching from the WordPress app.";
 
-/* No comment provided by engineer. */
-"migration.welcome.secondaryDescription.plural" = "migration.welcome.secondaryDescription.plural";
+/* The plural form of the secondary description in the migration welcome screen */
+"migration.welcome.secondaryDescription.plural" = "We found your sites. Continue to transfer all your data and sign in to Jetpack automatically.";
 
-/* No comment provided by engineer. */
-"migration.welcome.secondaryDescription.singular" = "migration.welcome.secondaryDescription.singular";
+/* The singular form of the secondary description in the migration welcome screen */
+"migration.welcome.secondaryDescription.singular" = "We found your site. Continue to transfer all your data and sign in to Jetpack automatically.";
 
 /* The title in the migration welcome screen */
 "migration.welcome.title" = "Welcome to Jetpack!";


### PR DESCRIPTION
The `value` parameter of two `NSLocalizedString` calls (that were added in https://github.com/wordpress-mobile/WordPress-iOS/pull/19563) was not a string literal, which made those entries not being extracted properly by `genstrings`/`generate_strings_file_for_glotpress` into the `Localizable.strings` during code freeze, and thus led to the original / English copy exported to GlotPress to be the same as the semantic key, instead of being the expected English copy.

<img width="1197" alt="image" src="https://user-images.githubusercontent.com/216089/202178725-01315b4e-80b1-49e5-9599-4920a62a1ecb.png">

This was [reported to us by a polyglot in the Making WordPress Slack here](https://wordpress.slack.com/archives/C02RQC4LY/p1668597413000499).

To test:
 - Ensure that the screen that uses that string still shows the proper copy to the end user in the UI.

## Regression Notes

1. Potential unintended areas of impact:

None

3. What I did to test those areas of impact (or what existing automated tests I relied on)

I haven't launched the app to test that those changes don't affect the copy presented to the end user (also because I didn't know how to reproduce the right context to navigate to that migration screen in the app and test it).
Feel free to test it yourself if you feel it's worth it — though the code diff is pretty straightforward I think.

4. What automated tests I added (or what prevented me from doing so)

N/A


PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] ~I have considered adding unit tests for my changes~.
- [x] ~I have considered adding accessibility improvements for my changes~.
- [x] ~I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary~.
