### PR TITLE
Sync Weekly Roundup and notifications switch state

### DIFF
--- a/WordPress/Classes/Models/Notifications/NotificationSettings.swift
+++ b/WordPress/Classes/Models/Notifications/NotificationSettings.swift
@@ -139,7 +139,7 @@ open class NotificationSettings {
     }
 
     // MARK: - Private Properties
-    fileprivate let blogPreferenceKeys: [String] = {
+    fileprivate var blogPreferenceKeys: [String] {
         var keys = [Keys.commentAdded, Keys.commentLiked, Keys.postLiked, Keys.follower, Keys.achievement, Keys.mention]
 
         if Feature.enabled(.weeklyRoundup) {
@@ -147,7 +147,7 @@ open class NotificationSettings {
         }
 
         return keys
-    }()
+    }
     fileprivate let blogEmailPreferenceKeys = [Keys.commentAdded, Keys.commentLiked, Keys.postLiked, Keys.follower, Keys.mention]
     fileprivate let otherPreferenceKeys     = [Keys.commentLiked, Keys.commentReplied]
     fileprivate let wpcomPreferenceKeys     = [Keys.marketing, Keys.research, Keys.community]


### PR DESCRIPTION
Ref https://github.com/wordpress-mobile/WordPress-iOS/issues/19560

This fixes a bug where the notifications switch could be off but Weekly Roundup was still showing up in the app's UI. https://github.com/wordpress-mobile/WordPress-iOS/pull/19590 hid Weekly Roundup when the switch was off. I noticed that toggling the switch wouldn't always toggle Weekly Roundup's visibility. I would need to close and re-open the Notifications Settings screen for the switch's state to take effect.

This PR fixes it by checking if notifications is on every time the screen is shown, not just the first time. I don't think this causes any performance issues.

### To test
1. Turn the `Disable WordPress app notifications when Jetpack is installed` feature flag on
2. On the Notifications tab, tap the gear icon
3. Turn the Allow Notifications switch is OFF
4. Tap any site under "YOUR SITES"
5. Tap "Push Notifications"
6. Verify that "Weekly Roundup" is not shown
7. Go back two screens to the "Notifications Settings" screen
8. Turn the Allow Notifications switch is ON
9. Tap any site under "YOUR SITES"
5. Tap "Push Notifications"
6. Verify that "Weekly Roundup" is shown (prior to this PR, it still would not be shown)

## Regression Notes
1. Potential unintended areas of impact

This PR could cause an unintended bug on the "YOUR SITES" → "Push Notifications" screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of the screen

10. What automated tests I added (or what prevented me from doing so)

I don't think it's worthwhile to add a test to ensure that Weekly Roundup's visibility is kept in sync with the switch. The switch isn't permanent, it will only be available while the `Disable WordPress app notifications when Jetpack is installed` is true (it won't be needed after the migration). Also, it's not clear if we need to hide Weekly Roundup when WP notifications are disabled (see https://github.com/wordpress-mobile/WordPress-iOS/pull/19590#issuecomment-1317733413).

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
