### PR TITLE
Continue saving fetched posts even if the service instance is released

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService+PostsV2.swift
+++ b/WordPress/Classes/Services/ReaderPostService+PostsV2.swift
@@ -7,11 +7,7 @@ extension ReaderPostService {
         }
 
         let remoteService = ReaderPostServiceRemote.withDefaultApi()
-        remoteService.fetchPosts(for: [topic.slug], page: nextPageHandle, success: { [weak self] posts, pageHandle in
-            guard let self = self else {
-                return
-            }
-
+        remoteService.fetchPosts(for: [topic.slug], page: nextPageHandle, success: { posts, pageHandle in
             self.managedObjectContext.perform {
 
                 if self.managedObjectContext.parent == ContextManager.shared.mainContext {


### PR DESCRIPTION
Fixes #19607.



## Cause

The `ReaderPostService` instances are not longer a stored property of `ReaderStreamViewController` (see https://github.com/wordpress-mobile/WordPress-iOS/pull/19539), instead they are created and discarded inside the fetch post function. This change caused the `fetchPostsV2` function not saving the fetched post and calling the `success` callback. Thus, the fetched post are not displayed on screen.

## Fix

Removing the check of "whether the service instance is released" in `ReaderPostService.fetchPostsV2`—no other functions in `ReaderPostService` perform this check. And, based on what I've noticed so far in other service types, they also do not perform this check. This change aligns with how service types are used in rest of the app—the completion callbacks passed to functions in a service type are called even though the service instance is released.

## Test instructions

Verify #19607 is fixed.

Hi @AliSoftware, just want to let you know this is a bug fix I think should go into 21.2.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
