### PR TITLE
Jetpack Content Migration Flow: Add a data migrator class

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -15,8 +15,6 @@ private enum UPRUConstants {
     static let currentAnnouncementsKey = "currentAnnouncements"
     static let currentAnnouncementsDateKey = "currentAnnouncementsDate"
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
-    static let bloggingRemindersCopiedKey = "reminders-copied"
-    static let sharedBloggingRemindersCopiedKey = "shared-reminders-copied"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -164,24 +162,6 @@ extension UserPersistentRepositoryUtility {
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.announcementsVersionDisplayedKey)
-        }
-    }
-
-    var bloggingRemindersCopied: Bool {
-        get {
-            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.bloggingRemindersCopiedKey)
-        }
-        set {
-            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.bloggingRemindersCopiedKey)
-        }
-    }
-
-    var sharedBloggingRemindersCopied: Bool {
-        get {
-            UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.sharedBloggingRemindersCopiedKey)
-        }
-        set {
-            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.sharedBloggingRemindersCopiedKey)
         }
     }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -155,7 +155,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         NotificationCenter.default.post(name: .applicationLaunchCompleted, object: nil)
 
         copyToSharedDefaultsIfNeeded()
-        BloggingRemindersScheduler.handleRemindersMigration()
         return true
     }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -159,8 +159,7 @@ class BloggingRemindersScheduler {
     }
 
     private static func copyStoreToSharedFile() {
-        guard !UserPersistentStoreFactory.instance().bloggingRemindersCopied,
-              let store = try? defaultStore(),
+        guard let store = try? defaultStore(),
               let fileUrl = try? defaultDataFileURL(),
               let sharedFileUrl = sharedDataFileURL() else {
             return
@@ -170,13 +169,10 @@ class BloggingRemindersScheduler {
         if store.configuration.count > 0 {
             try? FileManager.default.copyItem(at: fileUrl, to: sharedFileUrl)
         }
-
-        UserPersistentStoreFactory.instance().bloggingRemindersCopied = true
     }
 
     private static func copyStoreToLocalFile() {
-        guard !UserPersistentStoreFactory.instance().sharedBloggingRemindersCopied,
-              let localStore = try? defaultStore(),
+        guard let localStore = try? defaultStore(),
               let sharedFileUrl = sharedDataFileURL(),
               FileManager.default.fileExists(at: sharedFileUrl),
               let sharedStore = try? BloggingRemindersStore(dataFileURL: sharedFileUrl) else {
@@ -190,8 +186,6 @@ class BloggingRemindersScheduler {
                 try? localStore.save(scheduledReminders: schedule, for: blogIdentifier)
             }
         }
-
-        UserPersistentStoreFactory.instance().sharedBloggingRemindersCopied = true
     }
 
     // MARK: - Initializers

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -271,6 +271,7 @@ extension CoreDataStack {
             throw ContextManager.ContextManagerError.missingDatabase
         }
 
+        mainContext.reset()
         try storeCoordinator.remove(store)
         let databaseReplaced = replaceDatabase(from: databaseLocation, to: currentDatabaseLocation)
 

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -223,6 +223,10 @@ extension CoreDataStack {
     /// Creates a copy of the current open store and saves it to the specified destination
     /// - Parameter backupLocation: Location to save the store copy to
     func createStoreCopy(to backupLocation: URL) throws {
+        let (backupLocation, shmLocation, walLocation) = databaseFiles(for: backupLocation)
+        try? FileManager.default.removeItem(at: backupLocation)
+        try? FileManager.default.removeItem(at: shmLocation)
+        try? FileManager.default.removeItem(at: walLocation)
         guard let storeCoordinator = mainContext.persistentStoreCoordinator,
               let store = storeCoordinator.persistentStores.first else {
             throw ContextManager.ContextManagerError.missingCoordinatorOrStore

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -1,0 +1,129 @@
+final class DataMigrator {
+
+    private let coreDataStack: CoreDataStack
+    private let backupLocation: URL?
+    private let keychainUtils: KeychainUtils
+    private let localDefaults: UserDefaults
+    private let sharedDefaults: UserDefaults?
+
+    init(coreDataStack: CoreDataStack = ContextManager.sharedInstance(),
+         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")?.appendingPathComponent("WordPress.sqlite"),
+         keychainUtils: KeychainUtils = KeychainUtils(),
+         localDefaults: UserDefaults = UserDefaults.standard,
+         sharedDefaults: UserDefaults? = UserDefaults(suiteName: WPAppGroupName)) {
+        self.coreDataStack = coreDataStack
+        self.backupLocation = backupLocation
+        self.keychainUtils = keychainUtils
+        self.localDefaults = localDefaults
+        self.sharedDefaults = sharedDefaults
+    }
+
+    enum DataMigratorError: Error {
+        case localDraftsNotSynced
+        case databaseCopyError
+        case keychainError
+        case sharedUserDefaultsNil
+    }
+
+    func exportData(completion: ((Result<Void, DataMigratorError>) -> Void)? = nil) {
+        guard isLocalDraftsSynced() else {
+            completion?(.failure(.localDraftsNotSynced))
+            return
+        }
+        guard let backupLocation, copyDatabase(to: backupLocation) else {
+            completion?(.failure(.databaseCopyError))
+            return
+        }
+        guard copyKeychain(from: nil, to: WPAppKeychainAccessGroup) else {
+            completion?(.failure(.keychainError))
+            return
+        }
+        guard copyUserDefaults(from: localDefaults, to: sharedDefaults) else {
+            completion?(.failure(.sharedUserDefaultsNil))
+            return
+        }
+        BloggingRemindersScheduler.handleRemindersMigration()
+        completion?(.success(()))
+    }
+
+    func importData(completion: ((Result<Void, DataMigratorError>) -> Void)? = nil) {
+        guard let backupLocation, restoreDatabase(from: backupLocation) else {
+            completion?(.failure(.databaseCopyError))
+            return
+        }
+        guard copyKeychain(from: WPAppKeychainAccessGroup, to: nil) else {
+            completion?(.failure(.keychainError))
+            return
+        }
+        guard copyUserDefaults(from: sharedDefaults, to: localDefaults) else {
+            completion?(.failure(.sharedUserDefaultsNil))
+            return
+        }
+        BloggingRemindersScheduler.handleRemindersMigration()
+        completion?(.success(()))
+    }
+
+}
+
+// MARK: - Private Functions
+
+private extension DataMigrator {
+
+    func isLocalDraftsSynced() -> Bool {
+        let fetchRequest = NSFetchRequest<Post>(entityName: String(describing: Post.self))
+        fetchRequest.predicate = NSPredicate(format: "status = %@ && (remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@)",
+                                             BasePost.Status.draft.rawValue,
+                                             NSNumber(value: AbstractPostRemoteStatus.pushing.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.local.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
+        guard let count = try? coreDataStack.mainContext.count(for: fetchRequest) else {
+            return false
+        }
+
+        return count == 0
+    }
+
+    func copyDatabase(to destination: URL) -> Bool {
+        do {
+            try coreDataStack.createStoreCopy(to: destination)
+        } catch {
+            DDLogError("Error copying database: \(error)")
+            return false
+        }
+        return true
+    }
+
+    func restoreDatabase(from source: URL) -> Bool {
+        do {
+            try coreDataStack.restoreStoreCopy(from: source)
+        } catch {
+            DDLogError("Error restoring database: \(error)")
+            return false
+        }
+        return true
+    }
+
+    func copyKeychain(from sourceAccessGroup: String?, to destinationAccessGroup: String?) -> Bool {
+        do {
+            try keychainUtils.copyKeychain(from: sourceAccessGroup, to: destinationAccessGroup)
+        } catch {
+            DDLogError("Error copying keychain: \(error)")
+            return false
+        }
+
+        return true
+    }
+
+    func copyUserDefaults(from source: UserDefaults?, to destination: UserDefaults?) -> Bool {
+        guard let source, let destination else {
+            return false
+        }
+        let data = source.dictionaryRepresentation()
+        for (key, value) in data {
+            destination.set(value, forKey: key)
+        }
+
+        return true
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1798,6 +1798,9 @@
 		8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8323789828526E6D003F4443 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
 		8323789928526E6E003F4443 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
+		8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
+		8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2329259AE300802F7D /* DataMigrator.swift */; };
+		8332DD2829259BEB00802F7D /* DataMigratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8332DD2729259BEB00802F7D /* DataMigratorTests.swift */; };
 		834CE7341256D0DE0046A4A3 /* CFNetwork.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 834CE7331256D0DE0046A4A3 /* CFNetwork.framework */; };
 		8350E49611D2C71E00A7B073 /* Media.m in Sources */ = {isa = PBXBuildFile; fileRef = 8350E49511D2C71E00A7B073 /* Media.m */; };
 		8355D7D911D260AA00A61362 /* CoreData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8355D7D811D260AA00A61362 /* CoreData.framework */; };
@@ -6862,6 +6865,8 @@
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueAnimator.swift; sourceTree = "<group>"; };
 		8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+BloggingPrompts.swift"; sourceTree = "<group>"; };
+		8332DD2329259AE300802F7D /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
+		8332DD2729259BEB00802F7D /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
 		833AF259114575A50016DE8F /* PostAnnotation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PostAnnotation.h; sourceTree = "<group>"; };
 		833AF25A114575A50016DE8F /* PostAnnotation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PostAnnotation.m; sourceTree = "<group>"; };
 		834CE7331256D0DE0046A4A3 /* CFNetwork.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CFNetwork.framework; path = System/Library/Frameworks/CFNetwork.framework; sourceTree = SDKROOT; };
@@ -12327,6 +12332,7 @@
 		803DE81D29063689007D4E9C /* Jetpack */ = {
 			isa = PBXGroup;
 			children = (
+				8332DD2629259B9700802F7D /* Utility */,
 				803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */,
 			);
 			name = Jetpack;
@@ -12444,6 +12450,22 @@
 				5D6C4AF51B603CA3005E3C43 /* WPTableViewActivityCell.xib */,
 			);
 			path = Cells;
+			sourceTree = "<group>";
+		};
+		8332DD2229259ABA00802F7D /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				8332DD2329259AE300802F7D /* DataMigrator.swift */,
+			);
+			path = Utility;
+			sourceTree = "<group>";
+		};
+		8332DD2629259B9700802F7D /* Utility */ = {
+			isa = PBXGroup;
+			children = (
+				8332DD2729259BEB00802F7D /* DataMigratorTests.swift */,
+			);
+			name = Utility;
 			sourceTree = "<group>";
 		};
 		850BD4531922F95C0032F3AD /* Networking */ = {
@@ -14974,6 +14996,7 @@
 				C72A52CD2649B14B009CA633 /* System */,
 				C7124E4B2638527D00929318 /* NUX */,
 				C7F7ABD5261CED7A00CE547F /* JetpackAuthenticationManager.swift */,
+				8332DD2229259ABA00802F7D /* Utility */,
 				C7F7AC72261CF1C900CE547F /* ViewRelated */,
 			);
 			path = Classes;
@@ -21304,6 +21327,7 @@
 				57AA848F228715DA00D3C2A2 /* PostCardCell.swift in Sources */,
 				FE43DAAF26DFAD1C00CFF595 /* CommentContentTableViewCell.swift in Sources */,
 				8F22804451E5812433733348 /* TimeZoneSearchHeaderView.swift in Sources */,
+				8332DD2429259AE300802F7D /* DataMigrator.swift in Sources */,
 				8F228F2923045666AE456D2C /* TimeZoneSelectorViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -21950,6 +21974,7 @@
 				80EF92932810FA5A0064A971 /* QuickStartFactoryTests.swift in Sources */,
 				D848CBFF20FF010F00A9038F /* FormattableCommentContentTests.swift in Sources */,
 				9123471B221449E200BD9F97 /* GutenbergInformativeDialogTests.swift in Sources */,
+				8332DD2829259BEB00802F7D /* DataMigratorTests.swift in Sources */,
 				C80512FE243FFD4B00B6B04D /* TenorDataSouceTests.swift in Sources */,
 				323F8F3023A22C4C000BA49C /* SiteCreationRotatingMessageViewTests.swift in Sources */,
 				FF1FD02620912AA900186384 /* URL+LinkNormalizationTests.swift in Sources */,
@@ -23053,6 +23078,7 @@
 				FABB234B2602FC2C00C8785C /* UIBarButtonItem+MeBarButton.swift in Sources */,
 				FABB234C2602FC2C00C8785C /* PostSettingsViewController+FeaturedImageUpload.swift in Sources */,
 				F158542E267D3B8A00A2E966 /* BloggingRemindersFlowSettingsViewController.swift in Sources */,
+				8332DD2529259AE300802F7D /* DataMigrator.swift in Sources */,
 				FABB234D2602FC2C00C8785C /* ReaderLikeAction.swift in Sources */,
 				DCF892CD282FA3BB00BB71E1 /* SiteStatsImmuTableRows.swift in Sources */,
 				FABB234E2602FC2C00C8785C /* ReaderMenuAction.swift in Sources */,

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -1,0 +1,221 @@
+import XCTest
+@testable import WordPress
+
+class DataMigratorTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    private var migrator: DataMigrator!
+    private var coreDataStack: CoreDataStackMock!
+    private var keychainUtils: KeychainUtilsMock!
+
+    override func setUp() {
+        super.setUp()
+
+        context = try! createInMemoryContext()
+        coreDataStack = CoreDataStackMock(mainContext: context)
+        keychainUtils = KeychainUtilsMock()
+        migrator = DataMigrator(coreDataStack: coreDataStack, backupLocation: URL(string: "/dev/null"), keychainUtils: keychainUtils)
+    }
+
+    func testExportSucceeds() {
+        // Given
+        context.addDraftPost(remoteStatus: .sync)
+        context.addDraftPost(remoteStatus: .sync)
+
+        // When
+        var successful = false
+        migrator.exportData { result in
+            switch result {
+            case .success:
+                successful = true
+                break
+            case .failure:
+                break
+            }
+        }
+
+        // Then
+        XCTAssertTrue(successful)
+        XCTAssertNil(keychainUtils.sourceAccessGroup)
+        XCTAssertEqual(keychainUtils.destinationAccessGroup, WPAppKeychainAccessGroup)
+    }
+
+    func testExportFailsWithLocalDrafts() {
+        // Given
+        context.addDraftPost(remoteStatus: .local)
+        context.addDraftPost(remoteStatus: .sync)
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .localDraftsNotSynced)
+    }
+
+    func testExportFailsWithPushingDrafts() {
+        // Given
+        context.addDraftPost(remoteStatus: .pushing)
+        context.addDraftPost(remoteStatus: .sync)
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .localDraftsNotSynced)
+    }
+
+    func testExportFailsWithPushingMediaDrafts() {
+        // Given
+        context.addDraftPost(remoteStatus: .pushingMedia)
+        context.addDraftPost(remoteStatus: .sync)
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .localDraftsNotSynced)
+    }
+
+    func testExportFailsWithFailedUploadDrafts() {
+        // Given
+        context.addDraftPost(remoteStatus: .failed)
+        context.addDraftPost(remoteStatus: .sync)
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .localDraftsNotSynced)
+    }
+
+    func testExportFailsWhenKeychainThrows() {
+        // Given
+        keychainUtils.shouldThrowError = true
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .keychainError)
+    }
+
+    func testUserDefaultsCopiesToSharedOnExport() {
+        // Given
+        let value = "Test"
+        let keys = [UUID().uuidString, UUID().uuidString, UUID().uuidString]
+        keys.forEach { key in UserDefaults.standard.set(value, forKey: key) }
+        guard let sharedDefaults = UserDefaults(suiteName: WPAppGroupName) else {
+            XCTFail("Unable to create shared user defaults")
+            return
+        }
+
+        // When
+        migrator.exportData()
+
+        keys.forEach { key in
+            // Then
+            let sharedValue = sharedDefaults.value(forKey: key) as? String
+            XCTAssertEqual(value, sharedValue)
+
+            UserDefaults.standard.removeObject(forKey: key)
+            sharedDefaults.removeObject(forKey: key)
+        }
+    }
+
+    func testExportFailsWhenSharedUserDefaultsNil() {
+        // Given
+        migrator = DataMigrator(coreDataStack: coreDataStack, keychainUtils: keychainUtils, sharedDefaults: nil)
+
+        // When
+        let migratorError = getExportDataMigratorError(migrator)
+
+        // Then
+        XCTAssertEqual(migratorError, .sharedUserDefaultsNil)
+    }
+
+}
+
+// MARK: - CoreDataStackMock
+
+private final class CoreDataStackMock: CoreDataStack {
+    var mainContext: NSManagedObjectContext
+
+    init(mainContext: NSManagedObjectContext) {
+        self.mainContext = mainContext
+    }
+
+    func newDerivedContext() -> NSManagedObjectContext {
+        return mainContext
+    }
+
+    func saveContextAndWait(_ context: NSManagedObjectContext) {}
+    func save(_ context: NSManagedObjectContext) {}
+    func save(_ context: NSManagedObjectContext, withCompletionBlock completionBlock: @escaping () -> Void) {}
+}
+
+// MARK: - KeychainUtilsMock
+
+private final class KeychainUtilsMock: KeychainUtils {
+
+    var sourceAccessGroup: String?
+    var destinationAccessGroup: String?
+    var shouldThrowError = false
+
+    override func copyKeychain(from sourceAccessGroup: String?, to destinationAccessGroup: String?, updateExisting: Bool = true) throws {
+        if shouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+
+        self.sourceAccessGroup = sourceAccessGroup
+        self.destinationAccessGroup = destinationAccessGroup
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension DataMigratorTests {
+
+    func createInMemoryContext() throws -> NSManagedObjectContext {
+        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+        try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+        let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
+
+        return managedObjectContext
+    }
+
+    func getExportDataMigratorError(_ migrator: DataMigrator) -> DataMigrator.DataMigratorError? {
+        var migratorError: DataMigrator.DataMigratorError?
+        migrator.exportData { result in
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                migratorError = error
+            }
+        }
+        return migratorError
+    }
+}
+
+private extension NSManagedObjectContext {
+
+    func createBlog() -> Blog {
+        let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: self) as! Blog
+        blog.url = ""
+        blog.xmlrpc = ""
+        return blog
+    }
+
+    func addDraftPost(remoteStatus: AbstractPostRemoteStatus) {
+        let post = NSEntityDescription.insertNewObject(forEntityName: "Post", into: self) as! Post
+        post.blog = createBlog()
+        post.remoteStatus = remoteStatus
+        post.dateModified = Date()
+        post.status = .draft
+        try! save()
+    }
+
+}


### PR DESCRIPTION
## Description

Collects the various data migration calls into a single export and import method.

## Testing

I used some test code:

<details><summary>SheetActions.swift</summary>
I replaced the story post action with:

```swift
    func makeButton() -> ActionSheetButton {
        return ActionSheetButton(title: NSLocalizedString("Story post", comment: "Create new Story button title"),
                                 image: .gridicon(.story),
                                 identifier: "storyButton",
                                 action: {
            let migrator = DataMigrator()
            migrator.exportData { result in
                switch result {
                case .success:
                    print("CM: Exported data successfully")
                case .failure(let error):
                    print("CM: Error exporting data: \(error)")
                }
            }
            // WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
            // handler()
        })
    }
```

</details>

<details><summary>WordPressAppDelegate.swift</summary>

<pre>
 // MARK: - Application lifecycle

    func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
        KeychainUtils.shared.copyKeychainToSharedKeychainIfNeeded()

        window = UIWindow(frame: UIScreen.main.bounds)
        AppAppearance.overrideAppearance()

        // Start CrashLogging as soon as possible (in case a crash happens during startup)
        try? loggingStack.start()

        // Configure WPCom API overrides
        configureWordPressComApi()

        configureWordPressAuthenticator()

        configureReachability()
        configureSelfHostedChallengeHandler()
        updateFeatureFlags()

        window?.makeKeyAndVisible()

        // Restore a disassociated account prior to fixing tokens.
        AccountService(managedObjectContext: mainContext).restoreDisassociatedAccountIfNecessary()

        customizeAppearance()
        configureAnalytics()

        let solver = WPAuthTokenIssueSolver()
        let isFixingAuthTokenIssue = solver.fixAuthTokenIssueAndDo { [weak self] in
            self?.runStartupSequence(with: launchOptions ?? [:])
        }

        shouldRestoreApplicationState = !isFixingAuthTokenIssue

        <b>let rootViewController = window?.rootViewController
        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleTap))
        tapGesture.numberOfTapsRequired = 3
        tapGesture.numberOfTouchesRequired = 2
        rootViewController?.view.addGestureRecognizer(tapGesture)</b>

        return true
    }

    <b>@objc func handleTap() {
        print("CM: Importing data")
        let migrator = DataMigrator()
        migrator.importData { result in
            switch result {
            case .success:
                print("CM: Imported data successfully")
                // Copied from the startup sequence, probably don't need all of it?
                DispatchQueue.global(qos: .background).async { [weak self] in
                    self?.mergeDuplicateAccountsIfNeeded()
                    MediaCoordinator.shared.refreshMediaStatus()
                    PostCoordinator.shared.refreshPostStatus()
                    MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: nil, onError: nil)
                    self?.uploadsManager.resume()
                }

                self.setupWordPressExtensions()

                self.shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)

                AccountService.loadDefaultAccountCookies()

                self.windowManager.showUI()
            case .failure(let error):
                print("CM: Failed to import data \(error)")
            }
        }
    }</b>
</pre>

</details>

To test:
- Use the test code from ^ or add your own to trigger the two functions
- Login to WordPress
- Trigger the copy (with test code: FAB (+) > Story post)
- Verify the export is successful by looking for the log
- Launch Jetpack
- Trigger the copy (Test code: Triple tap two fingers (option + left click for simulator))
- Verify it imports the data and you are logged in

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
