### PR TITLE
Use bash-cache command for `.strings` validation

### DIFF
--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,43 +1,7 @@
 #!/bin/bash -eu
 
-echo "--- :rubygems: Setting up Gems"
-install_gems
-
-echo "--- :cocoapods: Setting up Pods"
-install_cocoapods
-
 echo "--- :writing_hand: Copy Files"
 mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env
 
-echo "--- Lint Localized Strings Format"
-LOGS=logs.txt
-set +e
-set -o pipefail
-bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true | tee $LOGS
-EXIT_CODE=$?
-set -e
-
-echo $EXIT_CODE
-
-if [[ $EXIT_CODE -ne 0 ]]; then
-  # Strings generation finished with errors, extract the errors in an easy-to-find section
-  echo "--- Report genstrings errors"
-  ERRORS=errors.txt
-  echo "Found errors when trying to run \`genstrings\` to generate the \`.strings\` files from \`*LocalizedStrings\` calls:" | tee $ERRORS
-  echo '' >> $ERRORS
-  # Print the errors inline.
-  #
-  # Notice the second `sed` call that removes the ANSI escape sequences that
-  # Fastlane uses to color the output.
-  grep -e "\[.*\].*genstrings:" $LOGS \
-    | sed -e 's/\[.*\].*genstrings: error: /- /' \
-    | sed -e $'s/\x1b\[[0-9;]*m//g' \
-    | sort \
-    | uniq \
-    | tee -a $ERRORS
-  # Annotate the build with the errors
-  cat $ERRORS | buildkite-agent annotate --style error --context genstrings
-fi
-
-exit $EXIT_CODE
+lint_localized_strings_format

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/bash-cache#2.8.0
+    - automattic/bash-cache#2.12.0
     - automattic/git-s3-cache#v1.1.3:
         bucket: "a8c-repo-mirrors"
         repo: "wordpress-mobile/wordpress-ios/"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -123,10 +123,7 @@ steps:
         plugins: *common_plugins
         agents:
           queue: "android"
-      # Runs the `.strings` generation automation to ensure all the
-      # `LocalizedString` calls in the code can be correctly parsed by Apple's
-      # `genstrings`.
-      - label: "Lint Localized Strings Format"
+      - label: ":sleuth_or_spy: Lint Localized Strings Format"
         command: .buildkite/commands/lint-localized-strings-format.sh
         plugins: *common_plugins
         env: *common_env


### PR DESCRIPTION
The work from https://github.com/wordpress-mobile/WordPress-iOS/pull/19553 is now part of `bash-cache`.

## Testing

CI is green in this step, which validates the happy path. I recycled the [same test PR as #19553](https://github.com/wordpress-mobile/WordPress-iOS/pull/19544) by force pushing and you can see it still [fails](https://buildkite.com/automattic/wordpress-ios/builds/11042#0184ad66-dc52-4840-b4d9-d2445f5b5455)

![image](https://user-images.githubusercontent.com/1218433/205226527-8d36a789-4edf-4cde-ba55-f6f37fa603e0.png)

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**