### PR TITLE
Fix the app not being refreshed after disconnecting from WordPress.com in Jetpack Settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] [internal] Blogging Reminders notifications and scheduling can be turned off for WordPress as part of Jetpack focus behind a feature flag. [#19611]
 * [*] [internal] Weekly Roundup notifications and scheduling can be turned off for WordPress as part of Jetpack focus behind a feature flag. [#19590]
 * [*] Fixed a minor UI issue where the segmented control under My SIte was being clipped when "Home" is selected. [#19595]
+* [*] Fixed an issue where the site wasn't removed and the app wasn't refreshed after disconnecting the site from WordPress.com. [#19634]
 
 21.2
 -----

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -962,7 +962,7 @@ extension MySiteViewController: WPSplitViewControllerDetailProvider {
         return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)
     }
 
-    /// Removes all view controllers from the details view controller stack and leaves splti view details in an empty state.
+    /// Removes all view controllers from the details view controller stack and leaves split view details in an empty state.
     ///
     private func hideSplitDetailsView() {
         if let splitViewController = splitViewController as? WPSplitViewController,

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -547,6 +547,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
 
         hideBlogDetails()
+        hideSplitDetailsView()
         blogDetailsViewController = nil
 
         guard noResultsViewController.view.superview == nil else {
@@ -959,6 +960,16 @@ extension MySiteViewController: WPSplitViewControllerDetailProvider {
         }
 
         return blogDetailsViewController.initialDetailViewControllerForSplitView(splitView)
+    }
+
+    /// Removes all view controllers from the details view controller stack and leaves splti view details in an empty state.
+    ///
+    private func hideSplitDetailsView() {
+        if let splitViewController = splitViewController as? WPSplitViewController,
+           splitViewController.viewControllers.count > 1,
+           let detailsNavigationController = splitViewController.viewControllers.last as? UINavigationController {
+            detailsNavigationController.setViewControllers([], animated: false)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -106,11 +106,9 @@ open class JetpackConnectionViewController: UITableViewController {
                                                success: { [weak self] in
                                                    self?.stopLoading()
                                                    if let blog = self?.blog {
-                                                       // Jetpack was successfully disconnected, lets hide the blog,
-                                                       // it should become unavailable the next time blogs are fetched
                                                        let context = ContextManager.sharedInstance().mainContext
-                                                       let service = AccountService(managedObjectContext: context)
-                                                       service.setVisibility(false, forBlogs: [blog])
+                                                       let service = BlogService(managedObjectContext: context)
+                                                       service.remove(blog)
                                                        try? context.save()
                                                        self?.delegate?.jetpackDisconnectedForBlog(blog)
                                                    } else {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -338,6 +338,9 @@ open class JetpackSettingsViewController: UITableViewController {
     fileprivate func refreshSettings() {
         service.syncJetpackSettingsForBlog(blog,
                                            success: { [weak self] in
+                                               guard self?.blog?.settings != nil else {
+                                                   return
+                                               }
                                                self?.reloadViewModel()
                                                DDLogInfo("Reloaded Jetpack Settings")
                                            },


### PR DESCRIPTION
Fixes #19501

## Description

When My Site → Jetpack Settings → Manage Connection → "Disconnect from WordPress.com button" is tapped, the site is not removed immediately causing subsequent errors.

## Solution

- Immediately delete a blog, instead of setting `visible = false` and waiting for an app refresh
- Show loading indicator and don't allow to navigate back from the view while loading is happening, it allows avoiding the app ending up in an undetermined state
- Additionally fix an issue with split view keeping the state when the last remaining blog is removed

## Testing instructions

Test on both iPhone and iPad. Some specific changed were made to support split view

### Case 1 Multi-site account (iPhone and iPad):
1. Launch the WP app.
2. Select a site with Jetpack plugin installed.
3. Tap My Site → Jetpack Settings → Manage Connection → "Disconnect from WordPress.com button".
4. Loading indicator should be shown
5. The app should not respond to interactions
6. After loading is done, the app should return to the main view and the main blog should be selected

### Case 2 Single-site account (iPhone and iPad):
1. Launch the WP app.
2. Have a site with Jetpack plugin installed.
3. Tap My Site → Jetpack Settings → Manage Connection → "Disconnect from WordPress.com button".
4. Loading indicator should be shown
5. The app should not respond to interactions
6. After loading is done, the app should show "Create a site" message

## Regression Notes

1. Potential unintended areas of impact

Additional issues raising when immediately removing the site, instead of making it invisible and waiting for the refresh

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Single-site - iPhone
https://user-images.githubusercontent.com/4062343/203344563-daf51d8f-57f9-4213-be07-98e5519e4f07.mp4

### Single-site - iPad
https://user-images.githubusercontent.com/4062343/203345162-b209581b-8364-439d-8af2-15df8a5f1f8f.mov

### Multi-site - iPad
https://user-images.githubusercontent.com/4062343/203347985-04d5bbba-fc60-430b-91b8-c20198cf7d1b.mov



