### PR TITLE
Update various localized strings to use reverse-DNS keys

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+FeaturedImageUpload.swift
@@ -118,10 +118,26 @@ extension PostSettingsViewController {
     }
 
     struct FeaturedImageActionSheet {
-        static let title = NSLocalizedString("Featured Image Options", comment: "Title for action sheet with featured media options.")
-        static let dismissActionTitle = NSLocalizedString("Dismiss", comment: "User action to dismiss featured media options.")
-        static let retryUploadActionTitle = NSLocalizedString("Retry", comment: "User action to retry featured media upload.")
-        static let removeActionTitle = NSLocalizedString("Remove", comment: "User action to remove featured media.")
+        static let title = NSLocalizedString(
+            "postSettings.featuredImageUploadActionSheet.title",
+            value: "Featured Image Options",
+            comment: "Title for action sheet with featured media options."
+        )
+        static let dismissActionTitle = NSLocalizedString(
+            "postSettings.featuredImageUploadActionSheet.dismiss",
+            value: "Dismiss",
+            comment: "User action to dismiss featured media options."
+        )
+        static let retryUploadActionTitle = NSLocalizedString(
+            "postSettings.featuredImageUploadActionSheet.retryUpload",
+            value: "Retry",
+            comment: "User action to retry featured media upload."
+        )
+        static let removeActionTitle = NSLocalizedString(
+            "postSettings.featuredImageUploadActionSheet.remove",
+            value: "Remove",
+            comment: "User action to remove featured media."
+        )
     }
 
 }

--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
@@ -201,16 +201,17 @@ extension QRLoginVerifyAuthorizationViewController {
                 value: "You're logged in!",
                 comment: "Title for the success view when the user has successfully logged in"
             )
-            static let subtitle = NSLocalizedString(
+            private static let subtitleFormat = NSLocalizedString(
                 "qrLoginVerifyAuthorization.completedInstructions.subtitle",
-                value: "Tap dismiss and head back to your web browser to continue.",
-                comment: "Subtitle instructing the user to tap the dismiss button to leave the log in flow"
+                value: "Tap '%@' and head back to your web browser to continue.",
+                comment: "Subtitle instructing the user to tap the dismiss button to leave the log in flow. %@ is a placeholder for the dismiss button name."
             )
             static let confirmButton = NSLocalizedString(
                 "qrLoginVerifyAuthorization.completedInstructions.dismiss",
                 value: "Dismiss",
                 comment: "Button label that dismisses the qr log in flow and returns the user back to the previous screen"
             )
+            static let subtitle = String(format: subtitleFormat, Self.confirmButton)
         }
 
         enum noConnection {

--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
@@ -196,9 +196,21 @@ extension QRLoginVerifyAuthorizationViewController {
 
         enum completed {
             static let imageName = "domains-success"
-            static let title = NSLocalizedString("You're logged in!", comment: "Title for the success view when the user has successfully logged in")
-            static let subtitle = NSLocalizedString("Tap dismiss and head back to your web browser to continue.", comment: "Subtitle instructing the user to tap the dismiss button to leave the log in flow")
-            static let confirmButton = NSLocalizedString("Dismiss", comment: "Button label that dismisses the qr log in flow and returns the user back to the previous screen")
+            static let title = NSLocalizedString(
+                "qrLoginVerifyAuthorization.completedInstructions.title",
+                value: "You're logged in!",
+                comment: "Title for the success view when the user has successfully logged in"
+            )
+            static let subtitle = NSLocalizedString(
+                "qrLoginVerifyAuthorization.completedInstructions.subtitle",
+                value: "Tap dismiss and head back to your web browser to continue.",
+                comment: "Subtitle instructing the user to tap the dismiss button to leave the log in flow"
+            )
+            static let confirmButton = NSLocalizedString(
+                "qrLoginVerifyAuthorization.completedInstructions.dismiss",
+                value: "Dismiss",
+                comment: "Button label that dismisses the qr log in flow and returns the user back to the previous screen"
+            )
         }
 
         enum noConnection {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1101,20 +1101,61 @@ extension ReaderDetailViewController: UIViewControllerRestoration {
 // MARK: - Strings
 extension ReaderDetailViewController {
     private struct Strings {
-        static let backButtonAccessibilityLabel = NSLocalizedString("Back", comment: "Spoken accessibility label")
-        static let dismissButtonAccessibilityLabel = NSLocalizedString("Dismiss", comment: "Spoken accessibility label")
-        static let safariButtonAccessibilityLabel = NSLocalizedString("Open in Safari", comment: "Spoken accessibility label")
-        static let shareButtonAccessibilityLabel = NSLocalizedString("Share", comment: "Spoken accessibility label")
-        static let moreButtonAccessibilityLabel = NSLocalizedString("More", comment: "Spoken accessibility label")
-        static let localPostsSectionTitle = NSLocalizedString("More from %1$@", comment: "Section title for local related posts. %1$@ is a placeholder for the blog display name.")
-        static let globalPostsSectionTitle = NSLocalizedString("More on WordPress.com", comment: "Section title for global related posts.")
-        static let tooltipTitle = NSLocalizedString("Follow the conversation", comment: "Title of follow conversations tooltip.")
+        static let backButtonAccessibilityLabel = NSLocalizedString(
+            "readerDetail.backButton.accessibilityLabel",
+            value: "Back",
+            comment: "Spoken accessibility label"
+        )
+        static let dismissButtonAccessibilityLabel = NSLocalizedString(
+            "readerDetail.dismissButton.accessibilityLabel",
+            value: "Dismiss",
+            comment: "Spoken accessibility label"
+        )
+        static let safariButtonAccessibilityLabel = NSLocalizedString(
+            "readerDetail.backButton.accessibilityLabel",
+            value: "Open in Safari",
+            comment: "Spoken accessibility label"
+        )
+        static let shareButtonAccessibilityLabel = NSLocalizedString(
+            "readerDetail.shareButton.accessibilityLabel",
+            value: "Share",
+            comment: "Spoken accessibility label"
+        )
+        static let moreButtonAccessibilityLabel = NSLocalizedString(
+            "readerDetail.moreButton.accessibilityLabel",
+            value: "More",
+            comment: "Spoken accessibility label"
+        )
+        static let localPostsSectionTitle = NSLocalizedString(
+            "readerDetail.localPostsSection.accessibilityLabel",
+            value: "More from %1$@",
+            comment: "Section title for local related posts. %1$@ is a placeholder for the blog display name."
+        )
+        static let globalPostsSectionTitle = NSLocalizedString(
+            "readerDetail.globalPostsSection.accessibilityLabel",
+            value: "More on WordPress.com",
+            comment: "Section title for global related posts."
+        )
+        static let tooltipTitle = NSLocalizedString(
+            "readerDetail.followConversationTooltipTitle.accessibilityLabel",
+            value: "Follow the conversation",
+            comment: "Title of follow conversations tooltip."
+        )
         static let tooltipMessage = NSLocalizedString(
-            "Get notified when new comments are added to this post.",
+            "readerDetail.followConversationTooltipMessage.accessibilityLabel",
+            value: "Get notified when new comments are added to this post.",
             comment: "Message for the follow conversations tooltip."
         )
-        static let tooltipButtonTitle = NSLocalizedString("Got it", comment: "Button title for the follow conversations tooltip.")
-        static let tooltipAnchorTitle = NSLocalizedString("New", comment: "Title for the tooltip anchor.")
+        static let tooltipButtonTitle = NSLocalizedString(
+            "readerDetail.followConversationTooltipButton.accessibilityLabel",
+            value: "Got it",
+            comment: "Button title for the follow conversations tooltip."
+        )
+        static let tooltipAnchorTitle = NSLocalizedString(
+            "readerDetail.tooltipAnchorTitle.accessibilityLabel",
+            value: "New",
+            comment: "Title for the tooltip anchor."
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/CustomizeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/CustomizeInsightsCell.swift
@@ -75,12 +75,36 @@ private extension CustomizeInsightsCell {
     // MARK: - Constants
 
     struct Labels {
-        static let title = NSLocalizedString("Customize your insights", comment: "Customize Insights title")
-        static let content = NSLocalizedString("Create your own customized dashboard and choose what reports to see. Focus on the data you care most about.", comment: "Customize Insights description")
-        static let tryIt = NSLocalizedString("Try it now", comment: "Customize Insights button title")
-        static let dismiss = NSLocalizedString("Dismiss", comment: "Customize Insights button title")
-        static let dismissHint = NSLocalizedString("Tap to dismiss this card", comment: "Accessibility hint")
-        static let tryItHint = NSLocalizedString("Tap to customize insights", comment: "Accessibility hint")
+        static let title = NSLocalizedString(
+            "customizeInsightsCell.title",
+            value: "Customize your insights",
+            comment: "Customize Insights title"
+        )
+        static let content = NSLocalizedString(
+            "customizeInsightsCell.content",
+            value: "Create your own customized dashboard and choose what reports to see. Focus on the data you care most about.",
+            comment: "Customize Insights description"
+        )
+        static let tryIt = NSLocalizedString(
+            "customizeInsightsCell.tryItButton.title",
+            value: "Try it now",
+            comment: "Customize Insights button title"
+        )
+        static let dismiss = NSLocalizedString(
+            "customizeInsightsCell.dismissButton.title",
+            value: "Dismiss",
+            comment: "Customize Insights button title"
+        )
+        static let dismissHint = NSLocalizedString(
+            "customizeInsightsCell.dismissButton.accessibilityHint",
+            value: "Tap to dismiss this card",
+            comment: "Accessibility hint"
+        )
+        static let tryItHint = NSLocalizedString(
+            "customizeInsightsCell.tryItButton.accessibilityHint",
+            value: "Tap to customize insights",
+            comment: "Accessibility hint"
+        )
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -144,22 +144,26 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
     private enum Strings {
 
         static let viewsCountDescriptionSingular = NSLocalizedString(
-            "View to your site so far",
+            "growAudienceCell.viewsCount.singular",
+            value: "View to your site so far",
             comment: "Description for view count. Singular."
         )
 
         static let viewsCountDescriptionPlural = NSLocalizedString(
-            "Views to your site so far",
+            "growAudienceCell.viewsCount.plural",
+            value: "Views to your site so far",
             comment: "Description for view count. Singular."
         )
 
         static let tipTitle = NSLocalizedString(
-            "A tip to grow your audience",
+            "growAudienceCell.tip",
+            value: "A tip to grow your audience",
             comment: "A hint to users about growing the audience for their site, when their site doesn't have many views yet."
         )
 
         static let dismissButtonTitle = NSLocalizedString(
-            "Dismiss",
+            "growAudienceCell.dismiss",
+            value: "Dismiss",
             comment: "Title for button that will dismiss the Grow Your Audience card."
         )
 
@@ -174,81 +178,96 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
         enum Social {
             static let detailsTitle = NSLocalizedString(
-                "Automatically share new posts to your social media to start bringing that audience over to your site.",
+                "growAudienceCell.social.title",
+                value: "Automatically share new posts to your social media to start bringing that audience over to your site.",
                 comment: "A detailed message to users about growing the audience for their site through enabling post sharing."
             )
 
             static let actionButtonTitle = NSLocalizedString(
-                "Enable post sharing",
+                "growAudienceCell.social.actionButton",
+                value: "Enable post sharing",
                 comment: "Title for button that will open up the social media Sharing screen."
             )
 
             static let completedTipTitle = NSLocalizedString(
-                "Sharing is set up!",
+                "growAudienceCell.social.completed.title",
+                value: "Sharing is set up!",
                 comment: "A hint to users that they've set up post sharing."
             )
 
             static let completedDetailsTitle = NSLocalizedString(
-                "When you publish your next post it will be automatically shared to your connected networks.",
+                "growAudienceCell.social.completed.details",
+                value: "When you publish your next post it will be automatically shared to your connected networks.",
                 comment: "A detailed message to users indicating that they've set up post sharing."
             )
 
             static let completedActionButtonTitle = NSLocalizedString(
-                "Connect more networks",
+                "growAudienceCell.social.completed.button",
+                value: "Connect more networks",
                 comment: "Title for button that will open up the social media Sharing screen."
             )
         }
 
         enum BloggingReminders {
             static let detailsTitle = NSLocalizedString(
-                "Posting regularly can help build an audience. Reminders help keep you on track.",
+                "growAudienceCell.bloggingReminders.details",
+                value: "Posting regularly can help build an audience. Reminders help keep you on track.",
                 comment: "A detailed message to users about growing the audience for their site through blogging reminders."
             )
 
             static let actionButtonTitle = NSLocalizedString(
-                "Set up blogging reminders",
+                "growAudienceCell.bloggingReminders.actionButton",
+                value: "Set up blogging reminders",
                 comment: "Title for button that will open up the blogging reminders screen."
             )
 
             static let completedTipTitle = NSLocalizedString(
-                "You set up blogging reminders",
+                "growAudienceCell.bloggingReminders.completed.tip",
+                value: "You set up blogging reminders",
                 comment: "A hint to users that they've set up blogging reminders."
             )
 
             static let completedDetailsTitle = NSLocalizedString(
-                "Keep blogging and check back to see visitors arriving at your site.",
+                "growAudienceCell.bloggingReminders.completed.details",
+                value: "Keep blogging and check back to see visitors arriving at your site.",
                 comment: "A detailed message to users indicating that they've set up blogging reminders."
             )
 
             static let completedActionButtonTitle = NSLocalizedString(
-                "Edit reminders",
+                "growAudienceCell.bloggingReminders.completed.actionButton",
+                value: "Edit reminders",
                 comment: "Title for button that will open up the blogging reminders screen."
             )
         }
 
         enum ReaderDiscover {
             static let detailsTitle = NSLocalizedString(
-                "Connect with other bloggers by following, liking and commenting on their posts.",
+                "growAudienceCell.readerDiscover.details",
+                value: "Connect with other bloggers by following, liking and commenting on their posts.",
                 comment: "A detailed message to users about growing the audience for their site through reader discover."
             )
 
             static let actionButtonTitle = NSLocalizedString(
-                "Discover blogs to follow",
+                "growAudienceCell.readerDiscover.actionButton",
+                value: "Discover blogs to follow",
                 comment: "Title for button that will open up the follow topics screen."
             )
 
             static let completedTipTitle = NSLocalizedString(
-                "You've connected with other blogs",
+                "growAudienceCell.readerDiscover.completed.tip",
+                value: "You've connected with other blogs",
                 comment: "A hint to users that they've set up reader discover."
             )
 
             static let completedDetailsTitle = NSLocalizedString(
-                "Keep going! Liking and commenting is a good way to build a network. Go to Reader to find more posts.",
+                "growAudienceCell.readerDiscover.completed.details",
+                value: "Keep going! Liking and commenting is a good way to build a network. Go to Reader to find more posts.",
                 comment: "A detailed message to users indicating that they've set up reader discover."
             )
 
             static let completedActionButtonTitle = NSLocalizedString(
-                "Do it again",
+                "growAudienceCell.readerDiscover.completed.action",
+                value: "Do it again",
                 comment: "Title for button that will open up the follow topics screen."
             )
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -143,18 +143,25 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
 
     private enum Strings {
 
-        static let viewsCountDescriptionSingular =
-            NSLocalizedString("View to your site so far", comment: "Description for view count. Singular.")
+        static let viewsCountDescriptionSingular = NSLocalizedString(
+            "View to your site so far",
+            comment: "Description for view count. Singular."
+        )
 
-        static let viewsCountDescriptionPlural =
-            NSLocalizedString("Views to your site so far", comment: "Description for view count. Singular.")
+        static let viewsCountDescriptionPlural = NSLocalizedString(
+            "Views to your site so far",
+            comment: "Description for view count. Singular."
+        )
 
-        static let tipTitle =
-            NSLocalizedString("A tip to grow your audience",
-                              comment: "A hint to users about growing the audience for their site, when their site doesn't have many views yet.")
+        static let tipTitle = NSLocalizedString(
+            "A tip to grow your audience",
+            comment: "A hint to users about growing the audience for their site, when their site doesn't have many views yet."
+        )
 
-        static let dismissButtonTitle =
-            NSLocalizedString("Dismiss", comment: "Title for button that will dismiss the Grow Your Audience card.")
+        static let dismissButtonTitle = NSLocalizedString(
+            "Dismiss",
+            comment: "Title for button that will dismiss the Grow Your Audience card."
+        )
 
         static func getViewsCountDescription(viewsCount: Int) -> String {
             return viewsCount == 1 ? viewsCountDescriptionSingular : viewsCountDescriptionPlural
@@ -166,63 +173,84 @@ class GrowAudienceCell: UITableViewCell, NibLoadable {
         }
 
         enum Social {
-            static let detailsTitle =
-                NSLocalizedString("Automatically share new posts to your social media to start bringing that audience over to your site.",
-                                  comment: "A detailed message to users about growing the audience for their site through enabling post sharing.")
+            static let detailsTitle = NSLocalizedString(
+                "Automatically share new posts to your social media to start bringing that audience over to your site.",
+                comment: "A detailed message to users about growing the audience for their site through enabling post sharing."
+            )
 
-            static let actionButtonTitle =
-                NSLocalizedString("Enable post sharing", comment: "Title for button that will open up the social media Sharing screen.")
+            static let actionButtonTitle = NSLocalizedString(
+                "Enable post sharing",
+                comment: "Title for button that will open up the social media Sharing screen."
+            )
 
-            static let completedTipTitle =
-                NSLocalizedString("Sharing is set up!",
-                                  comment: "A hint to users that they've set up post sharing.")
+            static let completedTipTitle = NSLocalizedString(
+                "Sharing is set up!",
+                comment: "A hint to users that they've set up post sharing."
+            )
 
-            static let completedDetailsTitle =
-                NSLocalizedString("When you publish your next post it will be automatically shared to your connected networks.",
-                                  comment: "A detailed message to users indicating that they've set up post sharing.")
+            static let completedDetailsTitle = NSLocalizedString(
+                "When you publish your next post it will be automatically shared to your connected networks.",
+                comment: "A detailed message to users indicating that they've set up post sharing."
+            )
 
-            static let completedActionButtonTitle =
-                NSLocalizedString("Connect more networks", comment: "Title for button that will open up the social media Sharing screen.")
+            static let completedActionButtonTitle = NSLocalizedString(
+                "Connect more networks",
+                comment: "Title for button that will open up the social media Sharing screen."
+            )
         }
 
         enum BloggingReminders {
-            static let detailsTitle =
-                NSLocalizedString("Posting regularly can help build an audience. Reminders help keep you on track.",
-                                  comment: "A detailed message to users about growing the audience for their site through blogging reminders.")
+            static let detailsTitle = NSLocalizedString(
+                "Posting regularly can help build an audience. Reminders help keep you on track.",
+                comment: "A detailed message to users about growing the audience for their site through blogging reminders."
+            )
 
-            static let actionButtonTitle =
-                NSLocalizedString("Set up blogging reminders", comment: "Title for button that will open up the blogging reminders screen.")
+            static let actionButtonTitle = NSLocalizedString(
+                "Set up blogging reminders",
+                comment: "Title for button that will open up the blogging reminders screen."
+            )
 
-            static let completedTipTitle =
-                NSLocalizedString("You set up blogging reminders",
-                                  comment: "A hint to users that they've set up blogging reminders.")
+            static let completedTipTitle = NSLocalizedString(
+                "You set up blogging reminders",
+                comment: "A hint to users that they've set up blogging reminders."
+            )
 
-            static let completedDetailsTitle =
-                NSLocalizedString("Keep blogging and check back to see visitors arriving at your site.",
-                                  comment: "A detailed message to users indicating that they've set up blogging reminders.")
+            static let completedDetailsTitle = NSLocalizedString(
+                "Keep blogging and check back to see visitors arriving at your site.",
+                comment: "A detailed message to users indicating that they've set up blogging reminders."
+            )
 
-            static let completedActionButtonTitle =
-                NSLocalizedString("Edit reminders", comment: "Title for button that will open up the blogging reminders screen.")
+            static let completedActionButtonTitle = NSLocalizedString(
+                "Edit reminders",
+                comment: "Title for button that will open up the blogging reminders screen."
+            )
         }
 
         enum ReaderDiscover {
-            static let detailsTitle =
-                NSLocalizedString("Connect with other bloggers by following, liking and commenting on their posts.",
-                                  comment: "A detailed message to users about growing the audience for their site through reader discover.")
+            static let detailsTitle = NSLocalizedString(
+                "Connect with other bloggers by following, liking and commenting on their posts.",
+                comment: "A detailed message to users about growing the audience for their site through reader discover."
+            )
 
-            static let actionButtonTitle =
-                NSLocalizedString("Discover blogs to follow", comment: "Title for button that will open up the follow topics screen.")
+            static let actionButtonTitle = NSLocalizedString(
+                "Discover blogs to follow",
+                comment: "Title for button that will open up the follow topics screen."
+            )
 
-            static let completedTipTitle =
-                NSLocalizedString("You've connected with other blogs",
-                                  comment: "A hint to users that they've set up reader discover.")
+            static let completedTipTitle = NSLocalizedString(
+                "You've connected with other blogs",
+                comment: "A hint to users that they've set up reader discover."
+            )
 
-            static let completedDetailsTitle =
-                NSLocalizedString("Keep going! Liking and commenting is a good way to build a network. Go to Reader to find more posts.",
-                                  comment: "A detailed message to users indicating that they've set up reader discover.")
+            static let completedDetailsTitle = NSLocalizedString(
+                "Keep going! Liking and commenting is a good way to build a network. Go to Reader to find more posts.",
+                comment: "A detailed message to users indicating that they've set up reader discover."
+            )
 
-            static let completedActionButtonTitle =
-                NSLocalizedString("Do it again", comment: "Title for button that will open up the follow topics screen.")
+            static let completedActionButtonTitle = NSLocalizedString(
+                "Do it again",
+                comment: "Title for button that will open up the follow topics screen."
+            )
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -235,7 +235,11 @@ import Reachability
     /// Accepts an optional title, if none is provided, will default to 'Dismiss'
     func showDismissButton(title: String? = nil) {
         navigationItem.hidesBackButton = true
-        let buttonTitle = title ?? AppLocalizedString("Dismiss", comment: "Dismiss button title.")
+        let buttonTitle = title ?? AppLocalizedString(
+            "noResultsViewController.dismissButton",
+            value: "Dismiss",
+            comment: "Dismiss button title."
+        )
 
         let dismissButton = UIBarButtonItem(title: buttonTitle,
                                             style: .done,

--- a/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionEditorViewController.swift
@@ -944,23 +944,39 @@ extension ShareExtensionEditorViewController {
 
     func displayActions(forAttachment attachment: MediaAttachment, position: CGPoint) {
         let mediaID = attachment.identifier
-        let title: String = AppLocalizedString("Media Options", comment: "Title for action sheet with media options.")
+        let title: String = AppLocalizedString(
+            "shareExtension.editor.attachmentActions.title",
+            value: "Media Options",
+            comment: "Title for action sheet with media options."
+        )
         let alertController = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
-        alertController.addActionWithTitle(AppLocalizedString("Dismiss", comment: "User action to dismiss media options."),
-                                           style: .cancel,
-                                           handler: { (action) in
-                                            if attachment == self.currentSelectedAttachment {
-                                                self.currentSelectedAttachment = nil
-                                                self.resetMediaAttachmentOverlay(attachment)
-                                                self.richTextView.refresh(attachment)
-                                            }
-        })
+        alertController.addActionWithTitle(
+            AppLocalizedString(
+                "shareExtension.editor.attachmentActions.dismiss",
+                value: "Dismiss",
+                comment: "User action to dismiss media options."
+            ),
+            style: .cancel,
+            handler: { (action) in
+                if attachment == self.currentSelectedAttachment {
+                    self.currentSelectedAttachment = nil
+                    self.resetMediaAttachmentOverlay(attachment)
+                    self.richTextView.refresh(attachment)
+                }
+            }
+        )
         if attachment is ImageAttachment {
-            alertController.addActionWithTitle(AppLocalizedString("Remove", comment: "User action to remove media."),
-                                               style: .destructive,
-                                               handler: { (action) in
-                                                self.richTextView.remove(attachmentID: mediaID)
-            })
+            alertController.addActionWithTitle(
+                AppLocalizedString(
+                    "shareExtension.editor.attachmentActions.remove",
+                    value: "Remove",
+                    comment: "User action to remove media."
+                ),
+                style: .destructive,
+                handler: { (action) in
+                    self.richTextView.remove(attachmentID: mediaID)
+                }
+            )
         }
 
         alertController.title = title

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -884,21 +884,25 @@ fileprivate extension ShareModularViewController {
 
     func showRetryAlert() {
         let title: String = AppLocalizedString(
-            "Sharing Error",
+            "shareModularViewController.retryAlert.title",
+            value: "Sharing Error",
             comment: "Share extension error dialog title."
         )
         let message: String = AppLocalizedString(
-            "Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.",
+            "shareModularViewController.retryAlert.message",
+            value: "Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.",
             comment: "Share extension error dialog text."
         )
         let dismiss: String = AppLocalizedString(
-            "Dismiss",
+            "shareModularViewController.retryAlert.dismiss",
+            value: "Dismiss",
             comment: "Share extension error dialog cancel button label."
         )
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
         let acceptButtonText = AppLocalizedString(
-            "Try again",
+            "shareModularViewController.retryAlert.accept",
+            value: "Try again",
             comment: "Share extension error dialog retry button label."
         )
         let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in

--- a/WordPress/WordPressShareExtension/ShareModularViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareModularViewController.swift
@@ -883,12 +883,24 @@ fileprivate extension ShareModularViewController {
     }
 
     func showRetryAlert() {
-        let title: String = AppLocalizedString("Sharing Error", comment: "Share extension error dialog title.")
-        let message: String = AppLocalizedString("Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.", comment: "Share extension error dialog text.")
-        let dismiss: String = AppLocalizedString("Dismiss", comment: "Share extension error dialog cancel button label.")
+        let title: String = AppLocalizedString(
+            "Sharing Error",
+            comment: "Share extension error dialog title."
+        )
+        let message: String = AppLocalizedString(
+            "Whoops, something went wrong while sharing. You can try again, maybe it was a glitch.",
+            comment: "Share extension error dialog text."
+        )
+        let dismiss: String = AppLocalizedString(
+            "Dismiss",
+            comment: "Share extension error dialog cancel button label."
+        )
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        let acceptButtonText = AppLocalizedString("Try again", comment: "Share extension error dialog retry button label.")
+        let acceptButtonText = AppLocalizedString(
+            "Try again",
+            comment: "Share extension error dialog retry button label."
+        )
         let acceptAction = UIAlertAction(title: acceptButtonText, style: .default) { (action) in
             self.savePostToRemoteSite()
         }


### PR DESCRIPTION
See #19028.

In previous PRs, I only touched the "Dismiss" localized string. In this one, I tried to set a better example and update all the localized strings usages in the context where the "Dismiss" one was. 

This should be the last PR in the #19028 series. 

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
