### PR TITLE
Call `AVCaptureSession` `startRunning` from a background thread

### DIFF
--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
@@ -3,6 +3,12 @@ import AVFoundation
 
 class QRLoginCameraSession: NSObject, QRCodeScanningSession {
     var session: AVCaptureSession?
+    // > Delegate any interaction with the AVCaptureSession—including its inputs and outputs—to a
+    // > dedicated serial dispatch queue, so that the interaction doesn’t block the main queue.
+    // >
+    // > – https://developer.apple.com/documentation/avfoundation/capture_setup/avcam_building_a_camera_app
+    let sessionQueue = DispatchQueue(label: "qrlogincamerasession.queue.serial")
+
     var cameraDevice: AVCaptureDevice?
 
     var hasCamera: Bool {
@@ -24,23 +30,29 @@ class QRLoginCameraSession: NSObject, QRCodeScanningSession {
     }
 
     func start() {
-        DispatchQueue.global(qos: .background).async { [weak self] in
+        sessionQueue.async { [weak self] in
             self?.session?.startRunning()
         }
     }
 
     func stop() {
-        session?.stopRunning()
+        sessionQueue.async { [weak self] in
+            self?.session?.stopRunning()
+        }
     }
 }
 
 private extension QRLoginCameraSession {
     func startCameraSession() {
-        session?.startRunning()
+        sessionQueue.async { [weak self] in
+            self?.session?.startRunning()
+        }
     }
 
     func stopCameraSession() {
-        session?.stopRunning()
+        sessionQueue.async { [weak self] in
+            self?.session?.stopRunning()
+        }
     }
 
     func configureCamera() {

--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraSession.swift
@@ -24,7 +24,9 @@ class QRLoginCameraSession: NSObject, QRCodeScanningSession {
     }
 
     func start() {
-        session?.startRunning()
+        DispatchQueue.global(qos: .background).async { [weak self] in
+            self?.session?.startRunning()
+        }
     }
 
     func stop() {


### PR DESCRIPTION
While working on #19635, Xcode reported:

> Thread Performance Checker: `-[AVCaptureSession startRunning]` should be called from background thread. Calling it on the main thread can lead to UI unresponsiveness

![image](https://user-images.githubusercontent.com/1218433/203373950-e7abb3b4-c7f3-45cc-9601-d5482e26c6b5.png)

## Testing

I applied the code and run through the Scan QR code flow (visit [this page](https://wordpress.com/log-in/qr?redirect_to=https%3A%2F%2Fwordpress.com%2F) on the desktop browser) and verified the TSAN warning was gone.

~~As an aside, I've been getting the following error, but I'm 99.9% sure it's unrelated to the code change:~~ **Update** The reason was that I was using an A8c account, for which QR code login doesn't work.

<details>
<summary>Error screenshot</summary>

<img alt="IMG_54F528C80EF2-1" src="https://user-images.githubusercontent.com/1218433/203374970-a2b2caa2-d0c4-49b5-acec-83c6fe9b383f.jpeg" width=300/>

</details>


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
