### PR TITLE
[Tooling] Use explicit title for Beta/Release builds on Buildkite UI

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -184,7 +184,8 @@ def trigger_buildkite_release_build(branch:, beta:)
     buildkite_pipeline: 'wordpress-ios',
     branch: branch,
     environment: { BETA_RELEASE: beta },
-    pipeline_file: 'release-builds.yml'
+    pipeline_file: 'release-builds.yml',
+    message: beta ? 'Beta Builds' : 'Release Builds'
   )
 end
 


### PR DESCRIPTION
This is a small improvement which takes advantage of a [recent(-ish) addition to `buildkite_trigger_build` in the `release-toolkit`](https://github.com/wordpress-mobile/release-toolkit/pull/392) so that Beta and Release builds have a nice explicit title for their builds on the Buildkite UI

This is a replication of [what was done on WPAndroid here](https://github.com/wordpress-mobile/WordPress-Android/pull/17013) a while ago.

## To Test

 - Run `bundle exec fastlane trigger_beta_build` (or alternatively, `bundle exec fastlane trigger_beta_build branch:$somebranch`)
 - Check on Buildkite's dashboard that the build triggered shows up with an explicit "Beta Builds" title, as opposed to it using the commit message of the HEAD commit of the branch being built.
 - Cancel the beta build once you validated the title was correct, to spare CI minutes and free Mac agents
 - Optional: repeat the test with `trigger_release_build` lane. Better be ready to cancel that one soon after it gets triggered tho, to avoid side effects.