### PR TITLE
Address some "deprecated in iOS 14.0, renamed to" warnings

### DIFF
--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -13,7 +13,7 @@ fileprivate let fadeAnimationDuration: TimeInterval = 0.1
 // UIKit glitch.
 extension UINavigationController {
     @objc func pushFullscreenViewController(_ viewController: UIViewController, animated: Bool) {
-        guard let splitViewController = splitViewController, splitViewController.preferredDisplayMode != .primaryHidden else {
+        guard let splitViewController = splitViewController, splitViewController.preferredDisplayMode != .secondaryOnly else {
             pushViewController(viewController, animated: animated)
             return
         }

--- a/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift
@@ -101,7 +101,7 @@ class WPSplitViewController: UISplitViewController {
         super.viewDidLoad()
 
         delegate = self
-        preferredDisplayMode = .allVisible
+        preferredDisplayMode = .oneBesideSecondary
 
         extendedLayoutIncludesOpaqueBars = true
     }
@@ -204,7 +204,7 @@ class WPSplitViewController: UISplitViewController {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if hasHorizontallyCompactView() && preferredDisplayMode == .primaryHidden {
+        if hasHorizontallyCompactView() && preferredDisplayMode == .secondaryOnly {
             setPrimaryViewControllerHidden(false, animated: false)
         }
     }
@@ -377,7 +377,7 @@ class WPSplitViewController: UISplitViewController {
         }
 
         let updateDisplayMode = {
-            self.preferredDisplayMode = (hidden) ? .primaryHidden : .allVisible
+            self.preferredDisplayMode = (hidden) ? .secondaryOnly : .oneBesideSecondary
         }
 
         if animated {
@@ -564,7 +564,7 @@ extension WPSplitViewController: UINavigationControllerDelegate {
         }
 
         let hasFullscreenViewControllersInStack = navigationController.viewControllers.filter({$0 is PrefersFullscreenDisplay}).count > 0
-        let isCurrentlyFullscreen = preferredDisplayMode != .allVisible
+        let isCurrentlyFullscreen = preferredDisplayMode != .oneBesideSecondary
 
         // Handle popping from fullscreen view controllers
         //


### PR DESCRIPTION
Xcode says:

> 'primaryHidden' was deprecated in iOS 14.0: renamed to 'UISplitViewController.DisplayMode.secondaryOnly'
>
> Use 'UISplitViewController.DisplayMode.secondaryOnly' instead

and:

> 'allVisible' was deprecated in iOS 14.0: renamed to 'UISplitViewController.DisplayMode.oneBesideSecondary'
>
> Use 'UISplitViewController.DisplayMode.oneBesideSecondary' instead

## Testing

I haven't tested this as the changes were machine generated by Xcode.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
