### PR TITLE
[Jetpack] Content Migration Feature Flag

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentStoreFactory.swift
+++ b/WordPress/Classes/Stores/UserPersistentStoreFactory.swift
@@ -3,12 +3,12 @@ import Foundation
 @objc
 final class UserPersistentStoreFactory: NSObject {
     static func instance() -> UserPersistentRepository {
-        FeatureFlag.sharedUserDefaults.enabled ? UserPersistentStore.standard : UserDefaults.standard
+        FeatureFlag.contentMigration.enabled ? UserPersistentStore.standard : UserDefaults.standard
     }
 
     @objc
     static func userDefaultsInstance() -> UserDefaults {
-        guard FeatureFlag.sharedUserDefaults.enabled, let defaults = UserDefaults(suiteName: WPAppGroupName) else {
+        guard FeatureFlag.contentMigration.enabled, let defaults = UserDefaults(suiteName: WPAppGroupName) else {
             return UserDefaults.standard
         }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -159,7 +159,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func copyToSharedDefaultsIfNeeded() {
-        if !AppConfiguration.isJetpack && FeatureFlag.sharedUserDefaults.enabled && !UserPersistentStore.standard.isOneOffMigrationComplete {
+        if !AppConfiguration.isJetpack && FeatureFlag.contentMigration.enabled && !UserPersistentStore.standard.isOneOffMigrationComplete {
             let dict = UserDefaults.standard.dictionaryRepresentation()
             for (key, value) in dict {
                 UserPersistentStore.standard.set(value, forKey: key)

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -147,7 +147,7 @@ class BloggingRemindersScheduler {
     }
 
     static func handleRemindersMigration() {
-        guard FeatureFlag.sharedLogin.enabled else {
+        guard FeatureFlag.contentMigration.enabled else {
             return
         }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -32,8 +32,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case featureHighlightTooltip
     case jetpackPowered
     case jetpackPoweredBottomSheet
-    case sharedUserDefaults
-    case sharedLogin
+    case contentMigration
     case newJetpackLandingScreen
     case newWordPressLandingScreen
     case newCoreDataContext
@@ -115,9 +114,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .jetpackPoweredBottomSheet:
             return false
-        case .sharedUserDefaults:
-            return false
-        case .sharedLogin:
+        case .contentMigration:
             return false
         case .newJetpackLandingScreen:
             return true
@@ -239,10 +236,8 @@ extension FeatureFlag {
             return "Jetpack powered banners and badges"
         case .jetpackPoweredBottomSheet:
             return "Jetpack powered bottom sheet"
-        case .sharedUserDefaults:
-            return "Shared User Defaults"
-        case .sharedLogin:
-            return "Shared Login"
+        case .contentMigration:
+            return "Content Migration"
         case .newJetpackLandingScreen:
             return "New Jetpack landing screen"
         case .newWordPressLandingScreen:

--- a/WordPress/Classes/Utility/LegacyContextFactory.m
+++ b/WordPress/Classes/Utility/LegacyContextFactory.m
@@ -35,7 +35,7 @@
     NSManagedObjectContext *context = [[NSManagedObjectContext alloc] initWithConcurrencyType:NSPrivateQueueConcurrencyType];
     context.persistentStoreCoordinator = self.container.persistentStoreCoordinator;
     
-    if ([Feature enabled:FeatureFlagSharedLogin]) {
+    if ([Feature enabled:FeatureFlagContentMigration]) {
         context.mergePolicy = NSMergeByPropertyStoreTrumpMergePolicy;
     }
     


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/19633

Merges SharedLogin & SharedDefaults feature flags into a single one `ContentMigration`.

To test:
Pretty straightforward testing here:
1. Set ContentMigration flag to return `true`
2. Log into WP
3. Install JP and verify if you're logged in.


## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
