### PR TITLE
Use a unique key for `safariButtonAccessibilityLabel`

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1112,7 +1112,7 @@ extension ReaderDetailViewController {
             comment: "Spoken accessibility label"
         )
         static let safariButtonAccessibilityLabel = NSLocalizedString(
-            "readerDetail.backButton.accessibilityLabel",
+            "readerDetail.safariButton.accessibilityLabel",
             value: "Open in Safari",
             comment: "Spoken accessibility label"
         )


### PR DESCRIPTION
While testing the syntax for https://github.com/Automattic/bash-cache-buildkite-plugin/pull/36, I noticed that `ios_generate_strings_file_from_code` on `trunk` (`33e65ab7e9`) printed:

```
Key "readerDetail.backButton.accessibilityLabel" used with multiple values.
  Value "Back" kept. Value "Open in Safari" ignored.`
```

This is my fault from #19635 🤦‍♂️ . Double, because I thought to run the command but clearly didn't do it before the final merge.

But, it reveals an interesting thing about `genstrings` and our ongoing effort to lint strings in CI (see https://github.com/Automattic/bash-cache-buildkite-plugin/pull/36, #19624, https://github.com/wordpress-mobile/WordPress-iOS/pull/19553), namely yet another piece of early feedback point we can give to developers.

The current implementation, evidently, doesn't pick this up, because `genstrings` doesn't throw this as an error. At least, I'm pretty sure that's the explanation because if `genstrings` failed so would the action. cc @AliSoftware  I think we should update the action to capture this particular case and treat it as an error. What do you think? If that sounds good, I'll add it to my list.

## Testing

Running `bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true` on this branch should not print any warning.

<img width="956" alt="image" src="https://user-images.githubusercontent.com/1218433/203626465-368a6492-b14f-465c-8a4a-7a9a66fbf90d.png">


## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
