### PR TITLE
Jetpack Migration: Skip copying over private keychain

### DIFF
--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -34,10 +34,6 @@ final class DataMigrator {
             completion?(.failure(.databaseCopyError))
             return
         }
-        guard copyKeychain(from: nil, to: WPAppKeychainAccessGroup) else {
-            completion?(.failure(.keychainError))
-            return
-        }
         guard copyUserDefaults(from: localDefaults, to: sharedDefaults) else {
             completion?(.failure(.sharedUserDefaultsNil))
             return
@@ -49,10 +45,6 @@ final class DataMigrator {
     func importData(completion: ((Result<Void, DataMigratorError>) -> Void)? = nil) {
         guard let backupLocation, restoreDatabase(from: backupLocation) else {
             completion?(.failure(.databaseCopyError))
-            return
-        }
-        guard copyKeychain(from: WPAppKeychainAccessGroup, to: nil) else {
-            completion?(.failure(.keychainError))
             return
         }
         guard copyUserDefaults(from: sharedDefaults, to: localDefaults) else {

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -36,8 +36,6 @@ class DataMigratorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(successful)
-        XCTAssertNil(keychainUtils.sourceAccessGroup)
-        XCTAssertEqual(keychainUtils.destinationAccessGroup, WPAppKeychainAccessGroup)
     }
 
     func testExportFailsWithLocalDrafts() {
@@ -88,16 +86,16 @@ class DataMigratorTests: XCTestCase {
         XCTAssertEqual(migratorError, .localDraftsNotSynced)
     }
 
-    func testExportFailsWhenKeychainThrows() {
-        // Given
-        keychainUtils.shouldThrowError = true
-
-        // When
-        let migratorError = getExportDataMigratorError(migrator)
-
-        // Then
-        XCTAssertEqual(migratorError, .keychainError)
-    }
+//    func testExportFailsWhenKeychainThrows() {
+//        // Given
+//        keychainUtils.shouldThrowError = true
+//
+//        // When
+//        let migratorError = getExportDataMigratorError(migrator)
+//
+//        // Then
+//        XCTAssertEqual(migratorError, .keychainError)
+//    }
 
     func testUserDefaultsCopiesToSharedOnExport() {
         // Given


### PR DESCRIPTION
Refs #19657

Removes the step where WP's private keychain is copied. There's no need to copy WP's keychain since JP is already reading and writing to the same location.

To test:

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ensured all the unit tests were green.

3. What automated tests I added (or what prevented me from doing so)
n/a.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
