### PR TITLE
Jetpack migration: Copy Today Widget data to JP

### DIFF
--- a/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Prompts/PromptRemindersScheduler.swift
@@ -467,6 +467,12 @@ protocol LocalFileStore {
 
     @discardableResult
     func save(contents: Data, at url: URL) -> Bool
+
+    func containerURL(forAppGroup appGroup: String) -> URL?
+
+    func removeItem(at url: URL) throws
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws
 }
 
 extension LocalFileStore {
@@ -476,6 +482,10 @@ extension LocalFileStore {
 }
 
 extension FileManager: LocalFileStore {
+    func containerURL(forAppGroup appGroup: String) -> URL? {
+        return containerURL(forSecurityApplicationGroupIdentifier: appGroup)
+    }
+
     func fileExists(at url: URL) -> Bool {
         return fileExists(atPath: url.path)
     }

--- a/WordPress/Classes/Utility/KeychainUtils.swift
+++ b/WordPress/Classes/Utility/KeychainUtils.swift
@@ -22,4 +22,16 @@ class KeychainUtils: NSObject {
             try keychainUtils.storeUsername(username, andPassword: password, forServiceName: serviceName, accessGroup: destinationAccessGroup, updateExisting: updateExisting)
         }
     }
+
+    func password(for username: String, serviceName: String, accessGroup: String? = nil) throws -> String? {
+        return try keychainUtils.getPasswordForUsername(username, andServiceName: serviceName, accessGroup: accessGroup)
+    }
+
+    func store(username: String, password: String, serviceName: String, accessGroup: String? = nil, updateExisting: Bool) throws {
+        return try keychainUtils.storeUsername(username,
+                                               andPassword: password,
+                                               forServiceName: serviceName,
+                                               accessGroup: accessGroup,
+                                               updateExisting: updateExisting)
+    }
 }

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -24,7 +24,6 @@ final class DataMigrator {
     enum DataMigratorError: Error {
         case localDraftsNotSynced
         case databaseCopyError
-        case keychainError
         case sharedUserDefaultsNil
     }
 
@@ -62,7 +61,8 @@ final class DataMigrator {
 
     /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
     ///
-    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget, the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
+    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget,
+    /// the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
     ///
     /// Note: This method is not private for unit testing purposes.
     /// It requires time to properly mock the dependencies in `importData`.
@@ -110,17 +110,6 @@ private extension DataMigrator {
             DDLogError("Error restoring database: \(error)")
             return false
         }
-        return true
-    }
-
-    func copyKeychain(from sourceAccessGroup: String?, to destinationAccessGroup: String?) -> Bool {
-        do {
-            try keychainUtils.copyKeychain(from: sourceAccessGroup, to: destinationAccessGroup)
-        } catch {
-            DDLogError("Error copying keychain: \(error)")
-            return false
-        }
-
         return true
     }
 
@@ -211,9 +200,9 @@ private extension DataMigrator {
         case keychainServiceName = "TodayWidget"
         case userDefaultsSiteIdKey = "WordPressHomeWidgetsSiteId"
         case userDefaultsLoggedInKey = "WordPressHomeWidgetsLoggedIn"
-        case todayFilename = "HomeWidgetTodayData.plist"
-        case allTimeFilename = "HomeWidgetAllTimeData.plist"
-        case thisWeekFilename = "HomeWidgetThisWeekData.plist" // HomeWidgetAllTimeData
+        case todayFilename = "HomeWidgetTodayData.plist" // HomeWidgetTodayData
+        case allTimeFilename = "HomeWidgetAllTimeData.plist" // HomeWidgetAllTimeData
+        case thisWeekFilename = "HomeWidgetThisWeekData.plist" // HomeWidgetThisWeekData
 
         // Constants for Stats Widget
         case statsUserDefaultsSiteIdKey = "WordPressTodayWidgetSiteId"

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -5,17 +5,20 @@ final class DataMigrator {
     private let keychainUtils: KeychainUtils
     private let localDefaults: UserDefaults
     private let sharedDefaults: UserDefaults?
+    private let localFileStore: LocalFileStore
 
     init(coreDataStack: CoreDataStack = ContextManager.sharedInstance(),
          backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")?.appendingPathComponent("WordPress.sqlite"),
          keychainUtils: KeychainUtils = KeychainUtils(),
          localDefaults: UserDefaults = UserDefaults.standard,
-         sharedDefaults: UserDefaults? = UserDefaults(suiteName: WPAppGroupName)) {
+         sharedDefaults: UserDefaults? = UserDefaults(suiteName: WPAppGroupName),
+         localFileStore: LocalFileStore = FileManager.default) {
         self.coreDataStack = coreDataStack
         self.backupLocation = backupLocation
         self.keychainUtils = keychainUtils
         self.localDefaults = localDefaults
         self.sharedDefaults = sharedDefaults
+        self.localFileStore = localFileStore
     }
 
     enum DataMigratorError: Error {
@@ -51,10 +54,24 @@ final class DataMigrator {
             completion?(.failure(.sharedUserDefaultsNil))
             return
         }
+
+        copyTodayWidgetDataToJetpack()
         BloggingRemindersScheduler.handleRemindersMigration()
         completion?(.success(()))
     }
 
+    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
+    ///
+    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget, the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    ///
+    func copyTodayWidgetDataToJetpack() {
+        copyTodayWidgetKeychain()
+        copyTodayWidgetUserDefaults()
+        copyTodayWidgetCacheFiles()
+    }
 }
 
 // MARK: - Private Functions
@@ -117,5 +134,127 @@ private extension DataMigrator {
         }
 
         return true
+    }
+}
+
+// MARK: - Today Widget Extension Constants
+
+private extension DataMigrator {
+
+    func copyTodayWidgetKeychain() {
+        guard let authToken = try? keychainUtils.password(for: WPWidgetConstants.keychainTokenKey.rawValue,
+                                                          serviceName: WPWidgetConstants.keychainServiceName.rawValue,
+                                                          accessGroup: WPAppKeychainAccessGroup) else {
+            return
+        }
+
+        try? keychainUtils.store(username: WPWidgetConstants.keychainTokenKey.valueForJetpack(),
+                                 password: authToken,
+                                 serviceName: WPWidgetConstants.keychainServiceName.valueForJetpack(),
+                                 updateExisting: true)
+    }
+
+    func copyTodayWidgetUserDefaults() {
+        guard let sharedDefaults else {
+            return
+        }
+
+        let userDefaultKeys: [WPWidgetConstants] = [
+            .userDefaultsSiteIdKey,
+            .userDefaultsLoggedInKey,
+            .statsUserDefaultsSiteIdKey,
+            .statsUserDefaultsSiteUrlKey,
+            .statsUserDefaultsSiteNameKey,
+            .statsUserDefaultsSiteTimeZoneKey
+        ]
+
+        userDefaultKeys.forEach { key in
+            // go to the next key if there's nothing stored under the current key.
+            guard let objectToMigrate = sharedDefaults.object(forKey: key.rawValue) else {
+                return
+            }
+
+            sharedDefaults.set(objectToMigrate, forKey: key.valueForJetpack())
+        }
+    }
+
+    func copyTodayWidgetCacheFiles() {
+        let fileNames: [WPWidgetConstants] = [
+            .todayFilename,
+            .allTimeFilename,
+            .thisWeekFilename,
+            .statsTodayFilename,
+            .statsThisWeekFilename,
+            .statsAllTimeFilename
+        ]
+
+        fileNames.forEach { fileName in
+            guard let sourceURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.rawValue),
+                  let targetURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.valueForJetpack()),
+                  localFileStore.fileExists(at: sourceURL) else {
+                return
+            }
+
+            if localFileStore.fileExists(at: targetURL) {
+                try? localFileStore.removeItem(at: targetURL)
+            }
+
+            try? localFileStore.copyItem(at: sourceURL, to: targetURL)
+        }
+    }
+
+    /// Keys relevant for migration, copied from WidgetConfiguration.
+    ///
+    enum WPWidgetConstants: String {
+        // Constants for Home Widget
+        case keychainTokenKey = "OAuth2Token"
+        case keychainServiceName = "TodayWidget"
+        case userDefaultsSiteIdKey = "WordPressHomeWidgetsSiteId"
+        case userDefaultsLoggedInKey = "WordPressHomeWidgetsLoggedIn"
+        case todayFilename = "HomeWidgetTodayData.plist"
+        case allTimeFilename = "HomeWidgetAllTimeData.plist"
+        case thisWeekFilename = "HomeWidgetThisWeekData.plist" // HomeWidgetAllTimeData
+
+        // Constants for Stats Widget
+        case statsUserDefaultsSiteIdKey = "WordPressTodayWidgetSiteId"
+        case statsUserDefaultsSiteNameKey = "WordPressTodayWidgetSiteName"
+        case statsUserDefaultsSiteUrlKey = "WordPressTodayWidgetSiteUrl"
+        case statsUserDefaultsSiteTimeZoneKey = "WordPressTodayWidgetTimeZone"
+        case statsTodayFilename = "TodayData.plist" // TodayWidgetStats
+        case statsThisWeekFilename = "ThisWeekData.plist" // ThisWeekWidgetStats
+        case statsAllTimeFilename = "AllTimeData.plist" // AllTimeWidgetStats
+
+        func valueForJetpack() -> String {
+            switch self {
+            case .keychainTokenKey:
+                return "OAuth2Token"
+            case .keychainServiceName:
+                return "JetpackTodayWidget"
+            case .userDefaultsSiteIdKey:
+                return "JetpackHomeWidgetsSiteId"
+            case .userDefaultsLoggedInKey:
+                return "JetpackHomeWidgetsLoggedIn"
+            case .todayFilename:
+                return "JetpackHomeWidgetTodayData.plist"
+            case .allTimeFilename:
+                return "JetpackHomeWidgetAllTimeData.plist"
+            case .thisWeekFilename:
+                return "JetpackHomeWidgetThisWeekData.plist"
+            case .statsUserDefaultsSiteIdKey:
+                return "JetpackTodayWidgetSiteId"
+            case .statsUserDefaultsSiteNameKey:
+                return "JetpackTodayWidgetSiteName"
+            case .statsUserDefaultsSiteUrlKey:
+                return "JetpackTodayWidgetSiteUrl"
+            case .statsUserDefaultsSiteTimeZoneKey:
+                return "JetpackTodayWidgetTimeZone"
+            case .statsTodayFilename:
+                return "JetpackTodayData.plist"
+            case .statsThisWeekFilename:
+                return "JetpackThisWeekData.plist"
+            case .statsAllTimeFilename:
+                return "JetpackAllTimeData.plist"
+            }
+        }
     }
 }

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -308,7 +308,7 @@ private extension NSManagedObjectContext {
 // MARK: - Mock Local File Store
 
 private final class MockLocalFileStore: LocalFileStore {
-    var fileShouldExistClosure: (URL?) -> Bool = { return false }
+    var fileShouldExistClosure: (URL?) -> Bool = { _ in return false }
     var removeItemCallCount: Int = 0
     var copyItemCallCount: Int = 0
 

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -316,7 +316,7 @@ private final class MockLocalFileStore: LocalFileStore {
     var copyShouldThrowError: Bool = false
 
     func fileExists(at url: URL) -> Bool {
-        return fileShouldExistClosure(nil)
+        return fileShouldExistClosure(url)
     }
 
     func save(contents: Data, at url: URL) -> Bool {

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -7,6 +7,7 @@ class DataMigratorTests: XCTestCase {
     private var migrator: DataMigrator!
     private var coreDataStack: CoreDataStackMock!
     private var keychainUtils: KeychainUtilsMock!
+    private var mockLocalStore: MockLocalFileStore!
 
     override func setUp() {
         super.setUp()
@@ -14,7 +15,11 @@ class DataMigratorTests: XCTestCase {
         context = try! createInMemoryContext()
         coreDataStack = CoreDataStackMock(mainContext: context)
         keychainUtils = KeychainUtilsMock()
-        migrator = DataMigrator(coreDataStack: coreDataStack, backupLocation: URL(string: "/dev/null"), keychainUtils: keychainUtils)
+        mockLocalStore = MockLocalFileStore()
+        migrator = DataMigrator(coreDataStack: coreDataStack,
+                                backupLocation: URL(string: "/dev/null"),
+                                keychainUtils: keychainUtils,
+                                localFileStore: mockLocalStore)
     }
 
     func testExportSucceeds() {
@@ -86,17 +91,6 @@ class DataMigratorTests: XCTestCase {
         XCTAssertEqual(migratorError, .localDraftsNotSynced)
     }
 
-//    func testExportFailsWhenKeychainThrows() {
-//        // Given
-//        keychainUtils.shouldThrowError = true
-//
-//        // When
-//        let migratorError = getExportDataMigratorError(migrator)
-//
-//        // Then
-//        XCTAssertEqual(migratorError, .keychainError)
-//    }
-
     func testUserDefaultsCopiesToSharedOnExport() {
         // Given
         let value = "Test"
@@ -131,6 +125,78 @@ class DataMigratorTests: XCTestCase {
         XCTAssertEqual(migratorError, .sharedUserDefaultsNil)
     }
 
+    // MARK: Widget Migration Tests
+
+    func test_widgetMigration_keychainShouldMigrateSuccessfully() {
+        // Given
+        let expectedUsername = "OAuth2Token"
+        let expectedPassword = "password"
+        let expectedServiceName = "JetpackTodayWidget"
+        keychainUtils.passwordToReturn = expectedPassword
+
+        // When
+        migrator.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertNotNil(keychainUtils.storedPassword)
+        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
+        XCTAssertNotNil(keychainUtils.storedUsername)
+        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
+        XCTAssertNotNil(keychainUtils.storedServiceName)
+        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
+        XCTAssertNil(keychainUtils.storedAccessGroup)
+    }
+
+    func test_widgetMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
+        // When
+        migrator.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertNil(keychainUtils.storedPassword)
+    }
+
+    func test_widgetMigration_userDefaultsShouldMigrateSuccessfully() {
+        // TODO: This will be added later.
+    }
+
+    func test_widgetMigration_plistFileShouldMigrateSuccessfully() {
+        // Given
+        let expectedSourceFilename = "HomeWidgetTodayData.plist"
+        mockLocalStore.fileShouldExistClosure = { url in
+            guard let url else {
+                return false
+            }
+            return url.lastPathComponent == expectedSourceFilename
+        }
+
+        // When
+        migrator.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertEqual(mockLocalStore.removeItemCallCount, 0)
+        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
+    }
+
+    func test_widgetMigration_whenTargetPlistFileExists_itShouldBeDeletedFirst() {
+        // Given
+        let expectedSourceFilename = "HomeWidgetTodayData.plist"
+        let expectedTargetFilename = "JetpackHomeWidgetTodayData.plist"
+        mockLocalStore.fileShouldExistClosure = { url in
+            guard let url else {
+                return false
+            }
+            return [expectedSourceFilename, expectedTargetFilename].contains(url.lastPathComponent)
+        }
+
+        // When
+        migrator.copyTodayWidgetDataToJetpack()
+
+        // Then
+        // migrator tries to remove any existing item in the target location first.
+        XCTAssertEqual(mockLocalStore.removeItemCallCount, 1)
+        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
+    }
+
 }
 
 // MARK: - CoreDataStackMock
@@ -158,6 +224,12 @@ private final class KeychainUtilsMock: KeychainUtils {
     var sourceAccessGroup: String?
     var destinationAccessGroup: String?
     var shouldThrowError = false
+    var passwordToReturn: String? = nil
+    var storeShouldThrow = false
+    var storedPassword: String? = nil
+    var storedUsername: String? = nil
+    var storedServiceName: String? = nil
+    var storedAccessGroup: String? = nil
 
     override func copyKeychain(from sourceAccessGroup: String?, to destinationAccessGroup: String?, updateExisting: Bool = true) throws {
         if shouldThrowError {
@@ -166,6 +238,21 @@ private final class KeychainUtilsMock: KeychainUtils {
 
         self.sourceAccessGroup = sourceAccessGroup
         self.destinationAccessGroup = destinationAccessGroup
+    }
+
+    override func password(for username: String, serviceName: String, accessGroup: String? = nil) throws -> String? {
+        return passwordToReturn
+    }
+
+    override func store(username: String, password: String, serviceName: String, accessGroup: String? = nil, updateExisting: Bool) throws {
+        if storeShouldThrow {
+            throw NSError(domain: "", code: 0)
+        }
+
+        storedUsername = username
+        storedPassword = password
+        storedServiceName = serviceName
+        storedAccessGroup = accessGroup
     }
 
 }
@@ -216,4 +303,41 @@ private extension NSManagedObjectContext {
         try! save()
     }
 
+}
+
+// MARK: - Mock Local File Store
+
+private final class MockLocalFileStore: LocalFileStore {
+    var fileShouldExistClosure: (URL?) -> Bool = { return false }
+    var removeItemCallCount: Int = 0
+    var copyItemCallCount: Int = 0
+
+    var removeShouldThrowError: Bool = false
+    var copyShouldThrowError: Bool = false
+
+    func fileExists(at url: URL) -> Bool {
+        return fileShouldExistClosure(nil)
+    }
+
+    func save(contents: Data, at url: URL) -> Bool {
+        return true
+    }
+
+    func containerURL(forAppGroup appGroup: String) -> URL? {
+        return URL(string: "/dev/null")
+    }
+
+    func removeItem(at url: URL) throws {
+        if removeShouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+        removeItemCallCount += 1
+    }
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        if copyShouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+        copyItemCallCount += 1
+    }
 }

--- a/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
+++ b/WordPress/WordPressTest/PromptRemindersSchedulerTests.swift
@@ -514,6 +514,18 @@ private extension PromptRemindersSchedulerTests {
 
             return saveShouldSucceed
         }
+
+        func containerURL(forAppGroup appGroup: String) -> URL? {
+            return nil
+        }
+
+        func removeItem(at url: URL) throws {
+            // no-op
+        }
+
+        func copyItem(at srcURL: URL, to dstURL: URL) throws {
+            // no-op
+        }
     }
 }
 


### PR DESCRIPTION
Refs #19657
Depends on #19660 

Although app extension data is already stored in the same App Group for WP and JP, Today Widget uses a different set of keys for keychain, user defaults, and cache file URLs to prevent conflict between the two apps.

I've also added a new File Manager dependency to `DataMigrator`. The File Manager is abstracted with `LocalFileStore` protocol, so it is unit testable. This is to handle copying cache files within the App Group.

I've also added unit tests for these copy functionalities but left out the part about user defaults to prevent potential conflicts.

## To test

Ensure that the unit tests are passing.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Ensure that unit tests are passing.

3. What automated tests I added (or what prevented me from doing so)
Tests for the copy function.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
