### PR TITLE
Fix Weekly Update debug instructions

### DIFF
--- a/WordPress/Classes/ViewRelated/Developer/WeeklyRoundupDebugScreen.swift
+++ b/WordPress/Classes/ViewRelated/Developer/WeeklyRoundupDebugScreen.swift
@@ -130,7 +130,7 @@ struct WeeklyRoundupDebugScreen: View {
                     .frame(height: settings.spacerHeight)
             }
 
-            Text("The first number is when the dynamic notification is scheduled at the earliest.  It can take a lot more time to be sent since iOS basically decides when to deliver it.  The second number is for the static notification.  It will be shown if either the App is killed or if the dynamic notification isn't shown by iOS before it.")
+            Text("The first number is when the dynamic notification is scheduled at the earliest.  It can take a lot more time to be sent since iOS basically decides when to deliver it.  The second number is for the static notification which depend on the weeklyRoundupStaticNotification feature flag being enabled.  The static notification will be shown if either the App is killed or if the dynamic notification isn't shown by iOS before it.")
                 .fixedSize(horizontal: false, vertical: true)
                 .padding(settings.defaultPadding)
 


### PR DESCRIPTION
To debug Weekly Roundup using in the app's debug settings, the `weeklyRoundupStaticNotification` feature flag must be enabled for the static fallback notification to work.

### To test
It's not necessary to test (I've tested and this is only an update to debug instructions), however, these would be the testing instructions:
1. Install the WP app via Xcode
2. Log in to a WP.com account with sites with many views (such as A8c sites)
3. Tap profile, App Settings, Debug, Weekly Roundup
4. Enable `Include A8c P2s`
5. Tap `Schedule in 10 sec / 5 min`
6. Kill the app
7. Reopen the app
8. The static notification (titled `Weekly Roundup`, not `Weekly Roundup: <site name>`) is received

## Regression Notes
1. Potential unintended areas of impact

None because this only updates debug instructions

9. What I did to test those areas of impact (or what existing automated tests I relied on)

No tests needed

10. What automated tests I added (or what prevented me from doing so)

No tests needed

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
