### PR TITLE
Jetpack Focus: Disable notifications - always access isRegisteredForRemoteNotifications from main thread

### DIFF
--- a/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
+++ b/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
@@ -25,7 +25,16 @@ final class JetpackNotificationMigrationService: JetpackNotificationMigrationSer
 
     var wordPressNotificationsEnabled: Bool {
         get {
-            return remoteNotificationRegister.isRegisteredForRemoteNotifications
+            /// UIApplication.shared.isRegisteredForRemoteNotifications should be always accessed from main thread
+            if Thread.isMainThread {
+                return remoteNotificationRegister.isRegisteredForRemoteNotifications
+            } else {
+                var isRegisteredForRemoteNotifications = false
+                DispatchQueue.main.sync {
+                    isRegisteredForRemoteNotifications = remoteNotificationRegister.isRegisteredForRemoteNotifications
+                }
+                return isRegisteredForRemoteNotifications
+            }
         }
 
         set {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -123,7 +123,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newCoreDataContext:
             return true
         case .jetpackMigrationPreventDuplicateNotifications:
-            return false
+            return true
         case .jetpackFeaturesRemovalPhaseOne:
             return false
         case .jetpackFeaturesRemovalPhaseTwo:

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsPinnedItemStore.swift
@@ -5,7 +5,7 @@ protocol SiteStatsPinnable { /* not implemented */ }
 
 final class SiteStatsPinnedItemStore {
     private(set) lazy var items: [SiteStatsPinnable] = {
-        let presentBloggingReminders = Feature.enabled(.bloggingReminders) && JetpackNotificationMigrationService.shared.shouldPresentNotifications()
+        let presentBloggingReminders = Feature.enabled(.bloggingReminders) && jetpackNotificationMigrationService.shouldPresentNotifications()
         return presentBloggingReminders ?
             [GrowAudienceCell.HintType.social,
              GrowAudienceCell.HintType.bloggingReminders,


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/19619

## Description

`JetpackNotificationMigrationService. shouldPresentNotifications()` is accessed from the background thread in some cases, for example, background tasks.  `shouldPresentNotifications` uses `UIApplication.shared.isRegisteredForRemoteNotifications` which should always be accessed from the main thread.

## Solution

Using `DispatchQueue.main.sync` when the variable is accessed from a background thread. It waits in background thread to access `isRegisteredForRemoteNotifications` value.

## Testing instructions

### Case 1:
1. Launch application with a debugger and login 
2. Profile
3. App Settings
4. Debug
5. Weekly Roundup
6. Schedule Immediately
7. Debugger shouldn't throw a warning about the code being accessed not from the main thread

## Regression Notes

1. Potential unintended areas of impact

Functionality of disabling notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Retesting scenarios of running background tasks through command line, confirming that the correct `isRegisteredForRemoteNotifications` value is taken and accessed from the main thread.

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

### Videos & Photos:

1. Allow notifications
2. Background app and bg task gets executed
3. Notifications appear
4. Come back to app
5. Disable notifications
6. Background app and bg task gets executed
7. No notifications appear
8. Allow notifications again
9. Background app and bg task gets executed
10. Notifications appear

Executing `e -l objc -- (void)[[BGTaskScheduler sharedScheduler] _simulateLaunchForTaskWithIdentifier:@"org.wordpress.bgtask.weeklyroundup"]` every time the app goes into the background. No warnings were received, and the functionality continues working.

https://user-images.githubusercontent.com/4062343/203997620-f2906269-109b-4c18-8ac2-3fb951e1ee0a.MP4


