### PR TITLE
[Jetpack Content Migration] Success Card Actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -66,6 +66,7 @@ class BlogDashboardViewModel {
             case .migrationSuccess:
                 let cellType = DashboardMigrationSuccessCell.self
                 let cell = collectionView.dequeueReusableCell(withReuseIdentifier: cellType.defaultReuseID, for: indexPath) as? DashboardMigrationSuccessCell
+                cell?.configure(with: viewController)
                 return cell
             }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1162,6 +1162,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if (section.category == BlogDetailsSectionCategoryMigrationSuccess && MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
         MigrationSuccessCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsMigrationSuccessCellIdentifier];
+        [cell configureWithViewController:self];
         return cell;
     }
 

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
@@ -1,12 +1,14 @@
 struct MigrationActionsViewConfiguration {
-    let step: MigrationStep
+    
     let primaryTitle: String?
     let secondaryTitle: String?
     let primaryHandler: (() -> Void)?
     let secondaryHandler: (() -> Void)?
+}
+
+extension MigrationActionsViewConfiguration {
 
     init(step: MigrationStep, primaryHandler: (() -> Void)? = nil, secondaryHandler: (() -> Void)? = nil) {
-        self.step = step
         self.primaryHandler = primaryHandler
         self.secondaryHandler = secondaryHandler
         self.primaryTitle = Appearance.primaryTitle(for: step)

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationActionsConfiguration.swift
@@ -1,5 +1,5 @@
 struct MigrationActionsViewConfiguration {
-    
+
     let primaryTitle: String?
     let secondaryTitle: String?
     let primaryHandler: (() -> Void)?

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationCenterViewConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationCenterViewConfiguration.swift
@@ -1,6 +1,9 @@
 struct MigrationCenterViewConfiguration {
 
     let attributedText: NSAttributedString
+}
+
+extension MigrationCenterViewConfiguration {
 
     init(step: MigrationStep) {
         self.attributedText = Appearance.highlightText(Appearance.highlightedText(for: step), inString: Appearance.text(for: step))

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/Configuration/MigrationHeaderConfiguration.swift
@@ -1,14 +1,14 @@
 struct MigrationHeaderConfiguration {
 
-    let step: MigrationStep
     let title: String?
     let image: UIImage?
     let primaryDescription: String?
     let secondaryDescription: String?
+}
+
+extension MigrationHeaderConfiguration {
 
     init(step: MigrationStep, multiSite: Bool = false) {
-        self.step = step
-
         image = Appearance.image(for: step)
         title = Appearance.title(for: step)
         primaryDescription = Appearance.primaryDescription(for: step)

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
@@ -2,6 +2,17 @@ import UIKit
 
 class MigrationStepView: UIView {
 
+    // MARK: - Configuration
+
+    var additionalContentInset = UIEdgeInsets(
+        top: Constants.topContentInset,
+        left: 0,
+        bottom: Constants.additionalBottomContentInset,
+        right: 0
+    )
+
+    // MARK: - Views
+
     private let headerView: MigrationHeaderView
     private let centerView: UIView
     private let actionsView: MigrationActionsView
@@ -33,6 +44,8 @@ class MigrationStepView: UIView {
         scrollView.addSubview(contentView)
         return scrollView
     }()
+
+    // MARK: - Init
 
     init(headerView: MigrationHeaderView,
          actionsView: MigrationActionsView,
@@ -79,9 +92,13 @@ class MigrationStepView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         let bottomInset = actionsView.frame.size.height - safeAreaInsets.bottom
-        mainScrollView.contentInset.bottom = bottomInset + Constants.additionalBottomContentInset
+        mainScrollView.contentInset = .init(
+            top: additionalContentInset.top,
+            left: additionalContentInset.left,
+            bottom: bottomInset + additionalContentInset.bottom,
+            right: additionalContentInset.right
+        )
         mainScrollView.verticalScrollIndicatorInsets.bottom = bottomInset
-        mainScrollView.contentInset.top = Constants.topContentInset
     }
 
     private enum Constants {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewController.swift
@@ -1,0 +1,90 @@
+import UIKit
+
+final class MigrationDeleteWordPressViewController: UIViewController {
+
+    // MARK: - Dependencies
+
+    private let viewModel: MigrationDeleteWordPressViewModel
+
+    // MARK: - Init
+
+    init(viewModel: MigrationDeleteWordPressViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    convenience init() {
+        let actions = MigrationDeleteWordPressViewModel.Actions()
+        self.init(viewModel: MigrationDeleteWordPressViewModel(actions: actions))
+        actions.primary = { [weak self] in
+            self?.primaryButtonTapped()
+        }
+        actions.secondary = { [weak self] in
+            self?.secondaryButtonTapped()
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - View Lifecycle
+
+    override func loadView() {
+        let centerContentView = MigrationDoneCenterView()
+        let centerView = MigrationCenterView(
+            contentView: centerContentView,
+            configuration: viewModel.content
+        )
+        let migrationView = MigrationStepView(
+            headerView: MigrationHeaderView(configuration: viewModel.header),
+            actionsView: MigrationActionsView(configuration: viewModel.actions),
+            centerView: centerView
+        )
+        migrationView.additionalContentInset.top = 0
+        self.view = migrationView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.setupNavigationBar()
+        self.setupDismissButton()
+    }
+
+    // MARK: - Setup
+
+    private func setupNavigationBar() {
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithTransparentBackground()
+        appearance.backgroundColor = MigrationAppearance.backgroundColor
+        navigationItem.standardAppearance = appearance
+        navigationItem.scrollEdgeAppearance = appearance
+        navigationItem.compactAppearance = appearance
+        if #available(iOS 15.0, *) {
+            navigationItem.compactScrollEdgeAppearance = appearance
+        }
+    }
+
+    private func setupDismissButton() {
+        let closeButton = UIButton.makeCloseButton()
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        let item = UIBarButtonItem(customView: closeButton)
+        self.navigationItem.rightBarButtonItem = item
+    }
+
+    // MARK: - User Interaction
+
+    @objc private func closeButtonTapped() {
+        self.dismiss(animated: true)
+    }
+
+    private func primaryButtonTapped() {
+        self.dismiss(animated: true)
+    }
+
+    private func secondaryButtonTapped() {
+        let destination = SupportTableViewController()
+        self.present(UINavigationController(rootViewController: destination), animated: true)
+    }
+}
+

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewController.swift
@@ -87,4 +87,3 @@ final class MigrationDeleteWordPressViewController: UIViewController {
         self.present(UINavigationController(rootViewController: destination), animated: true)
     }
 }
-

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewModel.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+final class MigrationDeleteWordPressViewModel {
+
+    // MARK: - Configuration
+
+    let header: MigrationHeaderConfiguration
+    let content: MigrationCenterViewConfiguration
+    let actions: MigrationActionsViewConfiguration
+
+    // MARK: - Init
+
+    init(actions: Actions) {
+        self.header = .init(
+            title: Strings.title,
+            image: UIImage(named: "wp-migration-welcome"),
+            primaryDescription: Strings.description,
+            secondaryDescription: nil
+        )
+        self.content = .init(step: .done)
+        self.actions = .init(
+            primaryTitle: Strings.primaryAction,
+            secondaryTitle: Strings.secondaryAction,
+            primaryHandler: { actions.primary?() },
+            secondaryHandler: { actions.secondary?() }
+        )
+    }
+
+    // MARK: - Types
+
+    enum Strings {
+        static let title = NSLocalizedString(
+            "migration.deleteWordpress.title",
+            value: "You no longer need the WordPress app",
+            comment: "The title in the Delete WordPress screen"
+        )
+        static let description = NSLocalizedString(
+            "migration.deleteWordpress.description",
+            value: "It looks like you still have the WordPress app installed. We recommend you delete the WordPress app to avoid data conflicts.",
+            comment: "The description in the Delete WordPress screen"
+        )
+        static let primaryAction = NSLocalizedString(
+            "migration.deleteWordpress.primaryButton",
+            value: "Got it",
+            comment: "The primary button title in the Delete WordPress screen"
+        )
+        static let secondaryAction = NSLocalizedString(
+            "Need help?",
+            value: "Need help?",
+            comment: "The secondary button title in the Delete WordPress screen"
+        )
+    }
+
+    class Actions {
+        var primary: (() -> Void)?
+        var secondary: (() -> Void)?
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/MigrationDeleteWordPressViewModel.swift
@@ -45,7 +45,7 @@ final class MigrationDeleteWordPressViewModel {
             comment: "The primary button title in the Delete WordPress screen"
         )
         static let secondaryAction = NSLocalizedString(
-            "Need help?",
+            "migration.deleteWordpress.secondaryButton",
             value: "Need help?",
             comment: "The secondary button title in the Delete WordPress screen"
         )

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/UIButton+Dismiss.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Delete WordPress/UIButton+Dismiss.swift
@@ -1,0 +1,43 @@
+import UIKit
+
+extension UIButton {
+
+    private static var closeButtonImage: UIImage {
+        let fontForSystemImage = UIFont.systemFont(ofSize: Metrics.closeButtonRadius)
+        let configuration = UIImage.SymbolConfiguration(font: fontForSystemImage)
+
+        // fallback to the gridicon if for any reason the system image fails to render
+        return UIImage(systemName: Constants.closeButtonSystemName, withConfiguration: configuration) ??
+        UIImage.gridicon(.crossCircle, size: CGSize(width: Metrics.closeButtonRadius, height: Metrics.closeButtonRadius))
+    }
+
+    static func makeCloseButton() -> UIButton {
+        let closeButton = CircularImageButton()
+
+        closeButton.setImage(closeButtonImage, for: .normal)
+        closeButton.tintColor = Colors.closeButtonTintColor
+        closeButton.setImageBackgroundColor(UIColor(light: .black, dark: .white))
+
+        NSLayoutConstraint.activate([
+            closeButton.widthAnchor.constraint(equalToConstant: Metrics.closeButtonRadius),
+            closeButton.heightAnchor.constraint(equalTo: closeButton.widthAnchor)
+        ])
+
+        return closeButton
+    }
+
+    private enum Constants {
+        static let closeButtonSystemName = "xmark.circle.fill"
+    }
+
+    private enum Metrics {
+        static let closeButtonRadius: CGFloat = 30
+    }
+
+    private enum Colors {
+        static let closeButtonTintColor = UIColor(
+            light: .muriel(color: .gray, .shade5),
+            dark: .muriel(color: .jetpackGreen, .shade90)
+        )
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell+Jetpack.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell+Jetpack.swift
@@ -1,0 +1,14 @@
+import UIKit
+
+extension DashboardMigrationSuccessCell {
+
+    func configure(with viewController: UIViewController) {
+        self.onTap = { [weak viewController] in
+            guard let viewController else {
+                return
+            }
+            let handler = MigrationSuccessActionHandler()
+            handler.showDeleteWordPressOverlay(with: viewController)
+        }
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell+WordPress.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell+WordPress.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension DashboardMigrationSuccessCell {
+
+    func configure(with viewController: UIViewController) {
+        // Adding an empty implementation of this method so Xcode doesn't complain.
+        // The whole `DashboardMigrationSuccessCell` shouldn't exist in WordPress. It's only needed for Jetpack.
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Collection View/DashboardMigrationSuccessCell.swift
@@ -2,6 +2,8 @@ import UIKit
 
 class DashboardMigrationSuccessCell: UICollectionViewCell, Reusable {
 
+    var onTap: (() -> Void)?
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setup()
@@ -13,7 +15,7 @@ class DashboardMigrationSuccessCell: UICollectionViewCell, Reusable {
 
     private func setup() {
         let view = MigrationSuccessCardView() {
-            // TODO: add card presentation logic here
+            self.onTap?()
         }
         view.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(view)

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessActionHandler.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessActionHandler.swift
@@ -1,0 +1,9 @@
+import UIKit
+
+@objcMembers final class MigrationSuccessActionHandler {
+
+    func showDeleteWordPressOverlay(with viewController: UIViewController) {
+        let destination = MigrationDeleteWordPressViewController()
+        viewController.present(UINavigationController(rootViewController: destination), animated: true)
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell+Jetpack.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell+Jetpack.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+extension MigrationSuccessCell {
+
+    @objc(configureWithViewController:)
+    func configure(with viewController: UIViewController) {
+        self.onTap = { [weak viewController] in
+            guard let viewController else {
+                return
+            }
+            let handler = MigrationSuccessActionHandler()
+            handler.showDeleteWordPressOverlay(with: viewController)
+        }
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell+WordPress.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell+WordPress.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+extension MigrationSuccessCell {
+
+    @objc(configureWithViewController:)
+    func configure(with viewController: UIViewController) {
+        // Adding an empty implementation of this method so Xcode doesn't complain.
+        // The whole `MigrationSuccessCell` shouldn't exist in WordPress. It's only needed for Jetpack.
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/Table View/MigrationSuccessCell.swift
@@ -3,6 +3,8 @@ import UIKit
 @objc
 class MigrationSuccessCell: UITableViewCell {
 
+    var onTap: (() -> Void)?
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         setup()
@@ -14,7 +16,7 @@ class MigrationSuccessCell: UITableViewCell {
 
     private func setup() {
         let view = MigrationSuccessCardView() {
-            // TODO: add card presentation logic here
+            self.onTap?()
         }
         view.translatesAutoresizingMaskIntoConstraints = false
         contentView.addSubview(view)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3402,6 +3402,14 @@
 		F4CBE3D7292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */; };
 		F4CBE3D929265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
 		F4CBE3DA29265BC8004FFBB6 /* LogOutActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */; };
+		F4D829622930E9F300038726 /* MigrationDeleteWordPressViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */; };
+		F4D829642930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829632930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift */; };
+		F4D829662931046F00038726 /* UIButton+Dismiss.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829652931046F00038726 /* UIButton+Dismiss.swift */; };
+		F4D829682931059000038726 /* MigrationSuccessActionHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829672931059000038726 /* MigrationSuccessActionHandler.swift */; };
+		F4D8296A2931083000038726 /* MigrationSuccessCell+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D829692931083000038726 /* MigrationSuccessCell+WordPress.swift */; };
+		F4D8296C2931087100038726 /* MigrationSuccessCell+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D8296B2931087100038726 /* MigrationSuccessCell+Jetpack.swift */; };
+		F4D829702931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D8296F2931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift */; };
+		F4D82972293109A600038726 /* DashboardMigrationSuccessCell+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D82971293109A600038726 /* DashboardMigrationSuccessCell+Jetpack.swift */; };
 		F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */; };
 		F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */; };
 		F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */; };
@@ -8541,6 +8549,14 @@
 		F4CBE3D329258AD6004FFBB6 /* MeHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeHeaderView.h; sourceTree = "<group>"; };
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
 		F4CBE3D829265BC8004FFBB6 /* LogOutActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogOutActionHandler.swift; sourceTree = "<group>"; };
+		F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeleteWordPressViewController.swift; sourceTree = "<group>"; };
+		F4D829632930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationDeleteWordPressViewModel.swift; sourceTree = "<group>"; };
+		F4D829652931046F00038726 /* UIButton+Dismiss.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Dismiss.swift"; sourceTree = "<group>"; };
+		F4D829672931059000038726 /* MigrationSuccessActionHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationSuccessActionHandler.swift; sourceTree = "<group>"; };
+		F4D829692931083000038726 /* MigrationSuccessCell+WordPress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MigrationSuccessCell+WordPress.swift"; sourceTree = "<group>"; };
+		F4D8296B2931087100038726 /* MigrationSuccessCell+Jetpack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MigrationSuccessCell+Jetpack.swift"; sourceTree = "<group>"; };
+		F4D8296F2931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardMigrationSuccessCell+WordPress.swift"; sourceTree = "<group>"; };
+		F4D82971293109A600038726 /* DashboardMigrationSuccessCell+Jetpack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DashboardMigrationSuccessCell+Jetpack.swift"; sourceTree = "<group>"; };
 		F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModelTests.swift; sourceTree = "<group>"; };
 		F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTableViewTests.swift; sourceTree = "<group>"; };
 		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
@@ -10780,9 +10796,10 @@
 		3F8B459E29283D3800730FA4 /* Success card */ = {
 			isa = PBXGroup;
 			children = (
-				3F8B459F29283D6C00730FA4 /* DashboardMigrationSuccessCell.swift */,
+				F4D8296E2931092800038726 /* Collection View */,
+				F4D8296D2931091B00038726 /* Table View */,
 				3F8B45A6292C1A2300730FA4 /* MigrationSuccessCardView.swift */,
-				3F8B45AA292C42CC00730FA4 /* MigrationSuccessCell.swift */,
+				F4D829672931059000038726 /* MigrationSuccessActionHandler.swift */,
 			);
 			path = "Success card";
 			sourceTree = "<group>";
@@ -16531,9 +16548,40 @@
 			path = "white-on-pink";
 			sourceTree = "<group>";
 		};
+		F4D829602930E9DD00038726 /* Delete WordPress */ = {
+			isa = PBXGroup;
+			children = (
+				F4D829612930E9F300038726 /* MigrationDeleteWordPressViewController.swift */,
+				F4D829632930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift */,
+				F4D829652931046F00038726 /* UIButton+Dismiss.swift */,
+			);
+			path = "Delete WordPress";
+			sourceTree = "<group>";
+		};
+		F4D8296D2931091B00038726 /* Table View */ = {
+			isa = PBXGroup;
+			children = (
+				3F8B45AA292C42CC00730FA4 /* MigrationSuccessCell.swift */,
+				F4D829692931083000038726 /* MigrationSuccessCell+WordPress.swift */,
+				F4D8296B2931087100038726 /* MigrationSuccessCell+Jetpack.swift */,
+			);
+			path = "Table View";
+			sourceTree = "<group>";
+		};
+		F4D8296E2931092800038726 /* Collection View */ = {
+			isa = PBXGroup;
+			children = (
+				3F8B459F29283D6C00730FA4 /* DashboardMigrationSuccessCell.swift */,
+				F4D8296F2931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift */,
+				F4D82971293109A600038726 /* DashboardMigrationSuccessCell+Jetpack.swift */,
+			);
+			path = "Collection View";
+			sourceTree = "<group>";
+		};
 		F4F9D5E82909615D00502576 /* WordPress-to-Jetpack Migration */ = {
 			isa = PBXGroup;
 			children = (
+				F4D829602930E9DD00038726 /* Delete WordPress */,
 				3FFDEF7D29177F4200B625CE /* Common */,
 				F4F9D5ED29096CFC00502576 /* Welcome */,
 				3F00739D2915BAA100A37FD1 /* Notifications Permission */,
@@ -20846,6 +20894,7 @@
 				E1BB92321FDAAFFA00F2D817 /* TextWithAccessoryButtonCell.swift in Sources */,
 				C81CCD70243AFAE600A83E27 /* TenorResponse.swift in Sources */,
 				FAB8F78C25AD785400D5D54A /* BaseRestoreStatusViewController.swift in Sources */,
+				F4D8296A2931083000038726 /* MigrationSuccessCell+WordPress.swift in Sources */,
 				9872CB30203B8A730066A293 /* SignupEpilogueTableViewController.swift in Sources */,
 				E1B23B081BFB3B370006559B /* MyProfileViewController.swift in Sources */,
 				F532AE1C253E55D40013B42E /* CreateButtonActionSheet.swift in Sources */,
@@ -21254,6 +21303,7 @@
 				9A341E5621997A340036662E /* BlogAuthor.swift in Sources */,
 				C7234A3A2832BA240045C63F /* QRLoginCoordinator.swift in Sources */,
 				9A341E5721997A340036662E /* Blog+BlogAuthors.swift in Sources */,
+				F4D829702931097900038726 /* DashboardMigrationSuccessCell+WordPress.swift in Sources */,
 				7E3AB3DB20F52654001F33B6 /* ActivityContentStyles.swift in Sources */,
 				469CE06D24BCED75003BDC8B /* CategorySectionTableViewCell.swift in Sources */,
 				809101982908DE8500FCB4EA /* JetpackFullscreenOverlayViewModel.swift in Sources */,
@@ -22486,6 +22536,7 @@
 				836498CF281735CC00A2C170 /* BloggingPromptsHeaderView.swift in Sources */,
 				FABB21162602FC2C00C8785C /* WPBlogTableViewCell.m in Sources */,
 				FABB21172602FC2C00C8785C /* JetpackBackupOptionsViewController.swift in Sources */,
+				F4D829682931059000038726 /* MigrationSuccessActionHandler.swift in Sources */,
 				FABB21182602FC2C00C8785C /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB21192602FC2C00C8785C /* NotificationContentRangeFactory.swift in Sources */,
 				FABB211A2602FC2C00C8785C /* SiteInfo.swift in Sources */,
@@ -22652,6 +22703,7 @@
 				FE4C46FF27FAE61700285F35 /* DashboardPromptsCardCell.swift in Sources */,
 				FABB21972602FC2C00C8785C /* MenusViewController.m in Sources */,
 				FABB21982602FC2C00C8785C /* UIViewController+Notice.swift in Sources */,
+				F4D8296C2931087100038726 /* MigrationSuccessCell+Jetpack.swift in Sources */,
 				F4CBE3D7292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift in Sources */,
 				FABB21992602FC2C00C8785C /* GutenbergFileUploadProcessor.swift in Sources */,
 				FABB219A2602FC2C00C8785C /* EventLoggingDataProvider.swift in Sources */,
@@ -23272,6 +23324,7 @@
 				FABB23802602FC2C00C8785C /* ReaderCommentsViewController.m in Sources */,
 				FABB23812602FC2C00C8785C /* MySiteViewController.swift in Sources */,
 				46F584B92624E6380010A723 /* BlockEditorSettings+GutenbergEditorSettings.swift in Sources */,
+				F4D829622930E9F300038726 /* MigrationDeleteWordPressViewController.swift in Sources */,
 				FABB23822602FC2C00C8785C /* FooterContentGroup.swift in Sources */,
 				FABB23832602FC2C00C8785C /* BasePageListCell.m in Sources */,
 				F163541726DE2ECE008B625B /* NotificationEventTracker.swift in Sources */,
@@ -23493,6 +23546,7 @@
 				B0CD27D0286F8858009500BF /* JetpackBannerView.swift in Sources */,
 				AE2F3126270B6DA000B2A9C2 /* Scanner+QuotedText.swift in Sources */,
 				C7AFF878283C2623000E01DF /* QRLoginScanningCoordinator.swift in Sources */,
+				F4D829642930EA4C00038726 /* MigrationDeleteWordPressViewModel.swift in Sources */,
 				FABB243C2602FC2C00C8785C /* StockPhotosService.swift in Sources */,
 				086F2481284F52DB00032F39 /* TooltipPresenter.swift in Sources */,
 				FABB243D2602FC2C00C8785C /* Blog+Analytics.swift in Sources */,
@@ -23713,6 +23767,7 @@
 				FABB24E52602FC2C00C8785C /* CoreDataIterativeMigrator.swift in Sources */,
 				8B55F9CA2614D8BC007D618E /* RoundRectangleView.swift in Sources */,
 				FABB24E62602FC2C00C8785C /* ReaderSiteSearchViewController.swift in Sources */,
+				F4D82972293109A600038726 /* DashboardMigrationSuccessCell+Jetpack.swift in Sources */,
 				FABB24E72602FC2C00C8785C /* TopViewedVideoStatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB24E82602FC2C00C8785C /* ReaderPost.m in Sources */,
 				FABB24E92602FC2C00C8785C /* MediaLibraryMediaPickingCoordinator.swift in Sources */,
@@ -23820,6 +23875,7 @@
 				FABB25372602FC2C00C8785C /* ActivityContentFactory.swift in Sources */,
 				FABB25382602FC2C00C8785C /* TenorDataLoader.swift in Sources */,
 				FABB25392602FC2C00C8785C /* OverviewCell.swift in Sources */,
+				F4D829662931046F00038726 /* UIButton+Dismiss.swift in Sources */,
 				FABB253A2602FC2C00C8785C /* WordPressAppDelegate.swift in Sources */,
 				098B8577275E9765004D299F /* AppLocalizedString.swift in Sources */,
 				FABB253B2602FC2C00C8785C /* MediaService.m in Sources */,


### PR DESCRIPTION
Fixes #19613

## Description

This PR adds the Delete WordPress screen that shows up when the Success Card is tapped.

| iPhone | iPad |
| ------- | ---- |
|  <video src="https://user-images.githubusercontent.com/9609223/204020367-d298a831-9a38-4963-9819-8b8a125598f4.mp4" /> |  <video src="https://user-images.githubusercontent.com/9609223/204023943-a8c874bb-df59-4197-8f52-c8688a59b454.mp4"/> |

_Figma Design:_ qk5s4q4mZsXknwhMWo2vIY-fi-5760%3A21600&t=0MJNg0O8l3lDZWNc-4

## Test Instructions

<details><summary>Prerequisites</summary>
<p>

**Enable Success Card**
1. Go to `MigrationSuccessCardView.swift`
2. Change `showCard` value to `true`
3. Build and run Jetpack

</p>
</details>

1. Log into your account.
2. Tap "My Site" tab.
3. **Expect** to see **"Please delete the WordPress app"** button under "Home" tab and "Menu" tab.
4. Tap the **"Please delete the WordPress app"** button.
5. **Expect** to see **"You no longer need the WordPress app"** screen. 
6. **Verify** it matches the design and screen recordings.
7. Tap "Need help?" button.
8. **Expect** to see Support Screen.
9. Dismiss Support Screen then tap **"Got it"** button.
10. **Expect** the **"Delete WordPress"** screen to disappear.

## Regression Notes

1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

4. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.