### PR TITLE
Jetpack migration: Wire up export function to the UI in WordPress

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -320,6 +320,12 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         setupWordPressExtensions()
 
+        // Start proactively exporting WP data in the background if the conditions are fulfilled.
+        // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
+        DispatchQueue.global().async {
+            ContentMigrationCoordinator.shared.startOnceIfNeeded()
+        }
+
         shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)
 
         AccountService.loadDefaultAccountCookies()

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -1,0 +1,98 @@
+/// Encapsulates logic related to content migration from WordPress to Jetpack.
+///
+class ContentMigrationCoordinator {
+
+    static let shared: ContentMigrationCoordinator = .init()
+
+    // MARK: Dependencies
+
+    private let dataMigrator: ContentDataMigrating
+    private let keyValueDatabase: KeyValueDatabase
+    private let eligibilityProvider: ContentMigrationEligibilityProvider
+
+    init(dataMigrator: ContentDataMigrating = DataMigrator(),
+         keyValueDatabase: KeyValueDatabase = UserDefaults.standard,
+         eligibilityProvider: ContentMigrationEligibilityProvider = AppConfiguration()) {
+        self.dataMigrator = dataMigrator
+        self.keyValueDatabase = keyValueDatabase
+        self.eligibilityProvider = eligibilityProvider
+    }
+
+    enum ContentMigrationCoordinatorError: Error {
+        case ineligible
+        case exportFailure
+    }
+
+    // MARK: Methods
+
+    /// Starts the content migration process of exporting app data to the shared location
+    /// that will be accessible by the Jetpack app.
+    ///
+    /// The completion block is intentionally called regardless of whether the export process
+    /// succeeds or fails. Since the export process consists of local file operations, we should
+    /// just let the user continue with the original intent in case of failure.
+    ///
+    /// - Parameter completion: Closure called after the export process completes.
+    func startAndDo(completion: ((Result<Void, ContentMigrationCoordinatorError>) -> Void)? = nil) {
+        guard eligibilityProvider.isEligibleForMigration else {
+            completion?(.failure(.ineligible))
+            return
+        }
+
+        // TODO: Sync local post drafts here.
+
+        dataMigrator.exportData { result in
+            if case let .failure(error) = result {
+                DDLogError("[Jetpack Migration] Error exporting data: \(error)")
+                completion?(.failure(.exportFailure))
+                return
+            }
+
+            completion?(.success(()))
+        }
+    }
+
+    /// Starts the content migration process once per installation.
+    ///
+    func startOnce(completion: (() -> Void)? = nil) {
+        if keyValueDatabase.bool(forKey: .oneOffMigrationKey) {
+            return
+        }
+
+        startAndDo { [weak self] result in
+            guard case .success = result else {
+                return
+            }
+
+            self?.keyValueDatabase.set(true, forKey: .oneOffMigrationKey)
+        }
+    }
+}
+
+// MARK: - Content Migrating
+
+
+protocol ContentDataMigrating {
+    func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)
+    func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)
+}
+
+extension DataMigrator: ContentDataMigrating {}
+
+// MARK: - Content Migration Eligibility Provider
+
+protocol ContentMigrationEligibilityProvider {
+    var isEligibleForMigration: Bool { get }
+}
+
+extension AppConfiguration: ContentMigrationEligibilityProvider {
+    var isEligibleForMigration: Bool {
+        FeatureFlag.contentMigration.enabled && Self.isWordPress && AccountHelper.isLoggedIn && AccountHelper.hasBlogs
+    }
+}
+
+// MARK: - Constants
+
+private extension String {
+    static let oneOffMigrationKey = "wordpress_one_off_export"
+}

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -7,14 +7,14 @@ class ContentMigrationCoordinator {
     // MARK: Dependencies
 
     private let dataMigrator: ContentDataMigrating
-    private let keyValueDatabase: KeyValueDatabase
+    private let userPersistentRepository: UserPersistentRepository
     private let eligibilityProvider: ContentMigrationEligibilityProvider
 
     init(dataMigrator: ContentDataMigrating = DataMigrator(),
-         keyValueDatabase: KeyValueDatabase = UserDefaults.standard,
+         userPersistentRepository: UserPersistentRepository = UserDefaults.standard,
          eligibilityProvider: ContentMigrationEligibilityProvider = AppConfiguration()) {
         self.dataMigrator = dataMigrator
-        self.keyValueDatabase = keyValueDatabase
+        self.userPersistentRepository = userPersistentRepository
         self.eligibilityProvider = eligibilityProvider
     }
 
@@ -60,7 +60,7 @@ class ContentMigrationCoordinator {
     /// again on the next call.
     ///
     func startOnceIfNeeded(completion: (() -> Void)? = nil) {
-        if keyValueDatabase.bool(forKey: .oneOffMigrationKey) {
+        if userPersistentRepository.bool(forKey: .oneOffMigrationKey) {
             completion?()
             return
         }
@@ -71,7 +71,7 @@ class ContentMigrationCoordinator {
                 return
             }
 
-            self?.keyValueDatabase.set(true, forKey: .oneOffMigrationKey)
+            self?.userPersistentRepository.set(true, forKey: .oneOffMigrationKey)
             completion?()
         }
     }

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -52,9 +52,14 @@ class ContentMigrationCoordinator {
         }
     }
 
-    /// Starts the content migration process once per installation.
+    /// Silently starts the content migration process from WordPress to Jetpack.
+    /// This operation is only executed once per installation, and only performed
+    /// when all the conditions are fulfilled.
     ///
-    func startOnce(completion: (() -> Void)? = nil) {
+    /// Note: If the conditions are not fulfilled, this method will attempt to migrate
+    /// again on the next call.
+    ///
+    func startOnceIfNeeded(completion: (() -> Void)? = nil) {
         if keyValueDatabase.bool(forKey: .oneOffMigrationKey) {
             completion?()
             return

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -79,7 +79,6 @@ class ContentMigrationCoordinator {
 
 // MARK: - Content Migrating
 
-
 protocol ContentDataMigrating {
     func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)
     func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -56,15 +56,18 @@ class ContentMigrationCoordinator {
     ///
     func startOnce(completion: (() -> Void)? = nil) {
         if keyValueDatabase.bool(forKey: .oneOffMigrationKey) {
+            completion?()
             return
         }
 
         startAndDo { [weak self] result in
             guard case .success = result else {
+                completion?()
                 return
             }
 
             self?.keyValueDatabase.set(true, forKey: .oneOffMigrationKey)
+            completion?()
         }
     }
 }

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -77,15 +77,6 @@ class ContentMigrationCoordinator {
     }
 }
 
-// MARK: - Content Migrating
-
-protocol ContentDataMigrating {
-    func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)
-    func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)?)
-}
-
-extension DataMigrator: ContentDataMigrating {}
-
 // MARK: - Content Migration Eligibility Provider
 
 protocol ContentMigrationEligibilityProvider {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -6,7 +6,10 @@ class JetpackBrandingCoordinator {
     static func presentOverlay(from viewController: UIViewController, redirectAction: (() -> Void)? = nil) {
 
         let action = redirectAction ?? {
-            JetpackRedirector.redirectToJetpack()
+            // Try to export WordPress data to a shared location before redirecting the user.
+            ContentMigrationCoordinator.shared.startAndDo { _ in
+                JetpackRedirector.redirectToJetpack()
+            }
         }
 
         let jetpackOverlayViewController = JetpackOverlayViewController(viewFactory: makeJetpackOverlayView, redirectAction: action)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -218,8 +218,11 @@ class JetpackFullscreenOverlayViewController: UIViewController {
 
 
     @IBAction func switchButtonPressed(_ sender: Any) {
-        JetpackRedirector.redirectToJetpack()
-        viewModel.trackSwitchButtonTapped()
+        // Try to export WordPress data to a shared location before redirecting the user.
+        ContentMigrationCoordinator.shared.startAndDo { [weak self] _ in
+            JetpackRedirector.redirectToJetpack()
+            self?.viewModel.trackSwitchButtonTapped()
+        }
     }
 
     @IBAction func continueButtonPressed(_ sender: Any) {

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -57,6 +57,23 @@ final class DataMigrator {
         copyTodayWidgetUserDefaults()
         copyTodayWidgetCacheFiles()
     }
+
+    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    func copyShareExtensionDataToJetpack() {
+        copyShareExtensionKeychain()
+        copyShareExtensionUserDefaults()
+    }
+
+    /// Copies WP's Notifications extension data (in Keychain) into JP.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    func copyNotificationsExtensionDataToJetpack() {
+        copyNotificationExtensionKeychain()
+    }
 }
 
 // MARK: - Content Data Migrating
@@ -96,36 +113,6 @@ extension DataMigrator: ContentDataMigrating {
         BloggingRemindersScheduler.handleRemindersMigration()
         completion?(.success(()))
     }
-<<<<<<< HEAD
-=======
-
-    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyTodayWidgetDataToJetpack() {
-        copyTodayWidgetKeychain()
-        copyTodayWidgetUserDefaults()
-        copyTodayWidgetCacheFiles()
-    }
-
-    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyShareExtensionDataToJetpack() {
-        copyShareExtensionKeychain()
-        copyShareExtensionUserDefaults()
-    }
-
-    /// Copies WP's Notifications extension data (in Keychain) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyNotificationsExtensionDataToJetpack() {
-        copyNotificationExtensionKeychain()
-    }
->>>>>>> origin/trunk
 }
 
 // MARK: - Private Functions

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5204,6 +5204,9 @@
 		FE43DAB126DFAD1C00CFF595 /* CommentContentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */; };
 		FE43DAB226DFAD1C00CFF595 /* CommentContentTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */; };
 		FE4C46FF27FAE61700285F35 /* DashboardPromptsCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE18495727F5ACBA00D26879 /* DashboardPromptsCardCell.swift */; };
+		FE6BB143293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
+		FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */; };
+		FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */; };
 		FE9CC71A26D7A2A40026AEF3 /* CommentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9CC71926D7A2A40026AEF3 /* CommentDetailViewController.swift */; };
 		FE9CC71B26D7A2A40026AEF3 /* CommentDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9CC71926D7A2A40026AEF3 /* CommentDetailViewController.swift */; };
 		FEA088012696E7F600193358 /* ListTableHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA088002696E7F600193358 /* ListTableHeaderView.swift */; };
@@ -8766,6 +8769,8 @@
 		FE43DAAD26DFAD1C00CFF595 /* CommentContentTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentContentTableViewCell.swift; sourceTree = "<group>"; };
 		FE43DAAE26DFAD1C00CFF595 /* CommentContentTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CommentContentTableViewCell.xib; sourceTree = "<group>"; };
 		FE59DA9527D1FD0700624D26 /* WordPress 138.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 138.xcdatamodel"; sourceTree = "<group>"; };
+		FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinator.swift; sourceTree = "<group>"; };
+		FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentMigrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		FE97BC13274FCE7A00CF08F9 /* WordPress 137.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 137.xcdatamodel"; sourceTree = "<group>"; };
 		FE9CC71926D7A2A40026AEF3 /* CommentDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentDetailViewController.swift; sourceTree = "<group>"; };
 		FEA088002696E7F600193358 /* ListTableHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListTableHeaderView.swift; sourceTree = "<group>"; };
@@ -12629,6 +12634,7 @@
 				F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */,
 				F565190223CF6D1D003FACAF /* WKCookieJarTests.swift */,
 				1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */,
+				FE6BB1452932289B001E5F7A /* ContentMigrationCoordinatorTests.swift */,
 				93B853211B44165B0064FE72 /* Analytics */,
 				DC06DFF727BD52A100969974 /* BackgroundTasks */,
 				FE32E7EF284496F500744D80 /* Blogging Prompts */,
@@ -12692,6 +12698,7 @@
 		8584FDB4192437160019C02E /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				FE6BB14129322798001E5F7A /* Migration */,
 				8B85AED8259230C500ADBEC9 /* AB Testing */,
 				FA25FB242609B98E0005E08F /* App Configuration */,
 				F181EDE326B2AC3100C61241 /* BackgroundTasks */,
@@ -17046,6 +17053,14 @@
 			name = Sharing;
 			sourceTree = "<group>";
 		};
+		FE6BB14129322798001E5F7A /* Migration */ = {
+			isa = PBXGroup;
+			children = (
+				FE6BB142293227AC001E5F7A /* ContentMigrationCoordinator.swift */,
+			);
+			path = Migration;
+			sourceTree = "<group>";
+		};
 		FEA087FB2696DDE900193358 /* List */ = {
 			isa = PBXGroup;
 			children = (
@@ -19931,6 +19946,7 @@
 				3F662C4A24DC9FAC00CAEA95 /* WhatIsNewViewController.swift in Sources */,
 				7EFF208C20EADF68009C4699 /* FormattableCommentContent.swift in Sources */,
 				17EFD3742578201100AB753C /* ValueTransformers.swift in Sources */,
+				FE6BB143293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */,
 				8B85AEDA259230FC00ADBEC9 /* ABTest.swift in Sources */,
 				178DDD06266D68A3006C68C4 /* BloggingRemindersFlowIntroViewController.swift in Sources */,
 				E1E5EE37231E47A80018E9E3 /* ContextManager+ErrorHandling.swift in Sources */,
@@ -22133,6 +22149,7 @@
 				F1BB660C274E704D00A319BE /* LikeUserHelperTests.swift in Sources */,
 				436D5655212209D600CEAA33 /* RegisterDomainDetailsServiceProxyMock.swift in Sources */,
 				F1450CF92437EEBB00A28BFE /* MediaRequestAuthenticatorTests.swift in Sources */,
+				FE6BB1462932289B001E5F7A /* ContentMigrationCoordinatorTests.swift in Sources */,
 				D821C817210036D9002ED995 /* ActivityContentFactoryTests.swift in Sources */,
 				931D26F719ED7F7500114F17 /* ReaderPostServiceTest.m in Sources */,
 				B5772AC61C9C84900031F97E /* GravatarServiceTests.swift in Sources */,
@@ -22411,6 +22428,7 @@
 				FABB20DA2602FC2C00C8785C /* GutenbergRollout.swift in Sources */,
 				FABB20DB2602FC2C00C8785C /* Routes+MySites.swift in Sources */,
 				FABB20DC2602FC2C00C8785C /* WPAppAnalytics+Media.swift in Sources */,
+				FE6BB144293227AC001E5F7A /* ContentMigrationCoordinator.swift in Sources */,
 				FABB20DD2602FC2C00C8785C /* Post.swift in Sources */,
 				FA8E2FE127C6377000DA0982 /* DashboardQuickStartCardCell.swift in Sources */,
 				FABB20DE2602FC2C00C8785C /* GutenbergWebViewController.swift in Sources */,

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -122,12 +122,12 @@ private extension ContentMigrationCoordinatorTests {
     }
 
     final class MockDataMigrator: ContentDataMigrating {
-        var exportErrorToReturn: DataMigrator.DataMigratorError? = nil
+        var exportErrorToReturn: DataMigrationError? = nil
         var exportCalled = false
-        var importErrorToReturn: DataMigrator.DataMigratorError? = nil
+        var importErrorToReturn: DataMigrationError? = nil
         var importCalled = false
 
-        func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+        func exportData(completion: ((Result<Void, DataMigrationError>) -> Void)? = nil) {
             exportCalled = true
             guard let exportErrorToReturn else {
                 completion?(.success(()))
@@ -136,7 +136,7 @@ private extension ContentMigrationCoordinatorTests {
             completion?(.failure(exportErrorToReturn))
         }
 
-        func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+        func importData(completion: ((Result<Void, DataMigrationError>) -> Void)? = nil) {
             importCalled = true
             guard let importErrorToReturn else {
                 completion?(.success(()))

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -8,7 +8,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
 
     private var mockEligibilityProvider: MockEligibilityProvider!
     private var mockDataMigrator: MockDataMigrator!
-    private var mockKeyValueDatabase: EphemeralKeyValueDatabase!
+    private var mockPersistentRepository: InMemoryUserDefaults!
     private var coordinator: ContentMigrationCoordinator!
 
     override func setUp() {
@@ -16,14 +16,14 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
 
         mockEligibilityProvider = MockEligibilityProvider()
         mockDataMigrator = MockDataMigrator()
-        mockKeyValueDatabase = EphemeralKeyValueDatabase()
+        mockPersistentRepository = InMemoryUserDefaults()
         coordinator = makeCoordinator()
     }
 
     override func tearDown() {
         mockEligibilityProvider = nil
         mockDataMigrator = nil
-        mockKeyValueDatabase = nil
+        mockPersistentRepository = nil
         coordinator = nil
 
         super.tearDown()
@@ -78,7 +78,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
         let expect = expectation(description: "Content migration should succeed")
         coordinator.startOnceIfNeeded { [unowned self] in
             XCTAssertTrue(mockDataMigrator.exportCalled)
-            XCTAssertTrue(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
+            XCTAssertTrue(mockPersistentRepository.bool(forKey: userDefaultsKey))
             expect.fulfill()
         }
         wait(for: [expect], timeout: timeout)
@@ -90,14 +90,14 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
         let expect = expectation(description: "Content migration should succeed")
         coordinator.startOnceIfNeeded { [unowned self] in
             XCTAssertTrue(mockDataMigrator.exportCalled)
-            XCTAssertFalse(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
+            XCTAssertFalse(mockPersistentRepository.bool(forKey: userDefaultsKey))
             expect.fulfill()
         }
         wait(for: [expect], timeout: timeout)
     }
 
     func test_startOnce_whenUserDefaultsExists_shouldNotMigrate() {
-        mockKeyValueDatabase.set(true, forKey: userDefaultsKey)
+        mockPersistentRepository.set(true, forKey: userDefaultsKey)
 
         let expect = expectation(description: "Content migration should not be called")
         coordinator.startOnceIfNeeded { [unowned self] in
@@ -148,7 +148,7 @@ private extension ContentMigrationCoordinatorTests {
 
     func makeCoordinator() -> ContentMigrationCoordinator {
         return .init(dataMigrator: mockDataMigrator,
-                     keyValueDatabase: mockKeyValueDatabase,
+                     userPersistentRepository: mockPersistentRepository,
                      eligibilityProvider: mockEligibilityProvider)
     }
 

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -76,7 +76,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
 
     func test_startOnce_whenUserDefaultsDoesNotExist_shouldMigrate() {
         let expect = expectation(description: "Content migration should succeed")
-        coordinator.startOnce { [unowned self] in
+        coordinator.startOnceIfNeeded { [unowned self] in
             XCTAssertTrue(mockDataMigrator.exportCalled)
             XCTAssertTrue(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
             expect.fulfill()
@@ -88,7 +88,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
         mockDataMigrator.exportErrorToReturn = .localDraftsNotSynced
 
         let expect = expectation(description: "Content migration should succeed")
-        coordinator.startOnce { [unowned self] in
+        coordinator.startOnceIfNeeded { [unowned self] in
             XCTAssertTrue(mockDataMigrator.exportCalled)
             XCTAssertFalse(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
             expect.fulfill()
@@ -100,7 +100,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
         mockKeyValueDatabase.set(true, forKey: userDefaultsKey)
 
         let expect = expectation(description: "Content migration should not be called")
-        coordinator.startOnce { [unowned self] in
+        coordinator.startOnceIfNeeded { [unowned self] in
             XCTAssertFalse(mockDataMigrator.exportCalled)
             expect.fulfill()
         }

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+
+@testable import WordPress
+
+final class ContentMigrationCoordinatorTests: XCTestCase {
+
+    private let timeout: TimeInterval = 1
+
+    private var mockEligibilityProvider: MockEligibilityProvider!
+    private var mockDataMigrator: MockDataMigrator!
+    private var mockKeyValueDatabase: EphemeralKeyValueDatabase!
+    private var coordinator: ContentMigrationCoordinator!
+
+    override func setUp() {
+        super.setUp()
+
+        mockEligibilityProvider = MockEligibilityProvider()
+        mockDataMigrator = MockDataMigrator()
+        mockKeyValueDatabase = EphemeralKeyValueDatabase()
+        coordinator = makeCoordinator()
+    }
+
+    override func tearDown() {
+        mockEligibilityProvider = nil
+        mockDataMigrator = nil
+        mockKeyValueDatabase = nil
+        coordinator = nil
+
+        super.tearDown()
+    }
+
+    // MARK: `startAndDo` tests
+
+    func test_startAndDo_givenEligibleAccount_shouldMigrateContent() {
+        let expect = expectation(description: "Content migration should succeed")
+        coordinator.startAndDo { result in
+            guard case .success = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertTrue(self.mockDataMigrator.exportCalled)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startAndDo_whenAccountNotEligible_shouldNotMigrateContent() {
+        mockEligibilityProvider.isEligibleForMigration = false
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { result in
+            guard case .failure = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertFalse(self.mockDataMigrator.exportCalled)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startAndDo_givenExportError_shouldInvokeClosureWithError() {
+        mockDataMigrator.exportErrorToReturn = .databaseCopyError
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { _ in
+            XCTAssertTrue(self.mockDataMigrator.exportCalled)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    // MARK: `startOnce` tests
+
+    func test_startOnce_whenUserDefaultsDoesNotExist_shouldMigrate() {
+        let expect = expectation(description: "Content migration should succeed")
+        coordinator.startOnce { [unowned self] in
+            XCTAssertTrue(mockDataMigrator.exportCalled)
+            XCTAssertTrue(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startOnce_givenErrorResult_shouldNotSaveUserDefaults() {
+        mockDataMigrator.exportErrorToReturn = .localDraftsNotSynced
+
+        let expect = expectation(description: "Content migration should succeed")
+        coordinator.startOnce { [unowned self] in
+            XCTAssertTrue(mockDataMigrator.exportCalled)
+            XCTAssertFalse(mockKeyValueDatabase.bool(forKey: userDefaultsKey))
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startOnce_whenUserDefaultsExists_shouldNotMigrate() {
+        mockKeyValueDatabase.set(true, forKey: userDefaultsKey)
+
+        let expect = expectation(description: "Content migration should not be called")
+        coordinator.startOnce { [unowned self] in
+            XCTAssertFalse(mockDataMigrator.exportCalled)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension ContentMigrationCoordinatorTests {
+
+    var userDefaultsKey: String {
+        "wordpress_one_off_export"
+    }
+
+    final class MockEligibilityProvider: ContentMigrationEligibilityProvider {
+        var isEligibleForMigration: Bool = true
+    }
+
+    final class MockDataMigrator: ContentDataMigrating {
+        var exportErrorToReturn: DataMigrator.DataMigratorError? = nil
+        var exportCalled = false
+        var importErrorToReturn: DataMigrator.DataMigratorError? = nil
+        var importCalled = false
+
+        func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+            guard let exportErrorToReturn else {
+                exportCalled = true
+                completion?(.success(()))
+                return
+            }
+            completion?(.failure(exportErrorToReturn))
+        }
+
+        func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+            guard let importErrorToReturn else {
+                importCalled = true
+                completion?(.success(()))
+                return
+            }
+            completion?(.failure(importErrorToReturn))
+        }
+    }
+
+    func makeCoordinator() -> ContentMigrationCoordinator {
+        return .init(dataMigrator: mockDataMigrator,
+                     keyValueDatabase: mockKeyValueDatabase,
+                     eligibilityProvider: mockEligibilityProvider)
+    }
+
+}

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -128,8 +128,8 @@ private extension ContentMigrationCoordinatorTests {
         var importCalled = false
 
         func exportData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+            exportCalled = true
             guard let exportErrorToReturn else {
-                exportCalled = true
                 completion?(.success(()))
                 return
             }
@@ -137,8 +137,8 @@ private extension ContentMigrationCoordinatorTests {
         }
 
         func importData(completion: ((Result<Void, DataMigrator.DataMigratorError>) -> Void)? = nil) {
+            importCalled = true
             guard let importErrorToReturn else {
-                importCalled = true
                 completion?(.success(()))
                 return
             }

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -272,8 +272,8 @@ private extension DataMigratorTests {
         return managedObjectContext
     }
 
-    func getExportDataMigratorError(_ migrator: DataMigrator) -> DataMigrator.DataMigratorError? {
-        var migratorError: DataMigrator.DataMigratorError?
+    func getExportDataMigratorError(_ migrator: DataMigrator) -> DataMigrationError? {
+        var migratorError: DataMigrationError?
         migrator.exportData { result in
             switch result {
             case .success:


### PR DESCRIPTION
Refs #19668 

- Adds a `ContentMigrationCoordinator` to be called from the WP side. This class handles checking the migration condition and calling the relevant migration methods.
- Wire up the coordinator object to the Jetpack overlay sheets.
- Wire up the coordinator to App Delegate, to be called once upon app launch. If the export process is successful, it will not be called again unless the app is reinstalled.

## To test:

### Unit test
- Ensure that the unit tests are passing.

### Manual test

_Note: To test this manually, you will need some tools to help verify the exported data. The easiest would be to run the app in a simulator and use a simulator observer tool such as [SimSim](https://github.com/dsmelov/simsim) so you can easily access the shared folder used by the app. And also [SQLite Browser](https://sqlitebrowser.org/) to inspect the copied database file._

#### Scenario 1: Export once

- Launch the WordPress app.
- Login to an account that has blogs.
- Enable the content migration and the Jetpack-powered bottom sheet feature flags.
- Relaunch the app.
- The export function should get called here once.
- Verify that the data export process succeeds:
  - Open the `group.org.wordpress` App Group folder.
  - Verify that the database file has been backed up.
  - Verify that the user defaults are backed up.

#### Scenario 2: Don't export for the second time during app launch

- Using the previous session, add a self-hosted app.
- Relaunch the app.
- The export function should NOT be called again here (provided that the first export succeeded). To verify:
  - Open the `group.org.wordpress` App Group folder.
  - Open the database backup file with SQLite Browser.
  - Verify that the self-hosted site is not there by looking at the records in the `Blog` schema.

#### Scenario 3: Tapping on the Jetpack button exports WP data.

- While logged-in, add a self-hosted site.
- Go to any section with the Jetpack powered badge, and tap it.
- Tap on the Try the new Jetpack app.
- It doesn't matter whether JP is installed or not, the data export will be performed.
- Verify that the data has been exported:
  - Go to the `group.org.wordpress` App Group folder.
  - Open the database file.
  - Verify that the self-hosted site is in the `Blog` schema.

## Regression Notes
1. Potential unintended areas of impact
Should be none. It's not released yet.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Added unit tests.

3. What automated tests I added (or what prevented me from doing so)
Added tests for `ContentMigrationCoordinator`.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
