### PR TITLE
Add import logic to `JetpackWindowManager`

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -15,6 +15,7 @@ private enum UPRUConstants {
     static let currentAnnouncementsKey = "currentAnnouncements"
     static let currentAnnouncementsDateKey = "currentAnnouncementsDate"
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
+    static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -162,6 +163,15 @@ extension UserPersistentRepositoryUtility {
         }
         set {
             UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.announcementsVersionDisplayedKey)
+        }
+    }
+
+    var isJPContentImportComplete: Bool {
+        get {
+            return UserPersistentStoreFactory.instance().bool(forKey: UPRUConstants.isJPContentImportCompleteKey)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.isJPContentImportCompleteKey)
         }
     }
 }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -196,6 +196,10 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         uploadsManager.resume()
         updateFeatureFlags()
         updateRemoteConfig()
+        if let windowManager = windowManager as? JetpackWindowManager,
+           windowManager.shouldImportMigrationData {
+            windowManager.importAndShowMigrationContent(nil, failureCompletion: nil)
+        }
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -196,10 +196,13 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         uploadsManager.resume()
         updateFeatureFlags()
         updateRemoteConfig()
+
+        #if JETPACK
         if let windowManager = windowManager as? JetpackWindowManager,
            windowManager.shouldImportMigrationData {
             windowManager.importAndShowMigrationContent(nil, failureCompletion: nil)
         }
+        #endif
     }
 
     func applicationWillResignActive(_ application: UIApplication) {

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -53,7 +53,6 @@ class JetpackWindowManager: WindowManager {
         showAppUI(for: blog)
     }
 
-    // TODO: Add logic in here to trigger migration UI if needed
     private var shouldShowMigrationUI: Bool {
         return FeatureFlag.contentMigration.enabled && AccountHelper.isLoggedIn
     }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -27,8 +27,9 @@ class JetpackWindowManager: WindowManager {
                         self.showSignInUI()
                     }
                 }
+            } else {
+                showAppUI(for: blog)
             }
-            return
         }
         // If the user doesn't have any blogs, but they're still logged in, log them out
         // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -4,20 +4,32 @@ import Foundation
 class JetpackWindowManager: WindowManager {
     /// receives migration flow updates in order to dismiss it when needed.
     private var cancellable: AnyCancellable?
-
     override func showUI(for blog: Blog?) {
         // If the user is logged in and has blogs sync'd to their account
         if AccountHelper.isLoggedIn && AccountHelper.hasBlogs {
-            shouldShowMigrationUI ? showMigrationUI(blog) : showAppUI(for: blog)
+            showAppUI(for: blog)
             return
         }
 
-        // Show the sign in UI if the user isn't logged in
         guard AccountHelper.isLoggedIn else {
-            showSignInUI()
+            if shouldImportMigrationData {
+                DataMigrator().importData() { [weak self] result in
+                    guard let self else {
+                        return
+                    }
+
+                    switch result {
+                    case .success:
+                        UserPersistentStoreFactory.instance().isJPContentImportComplete = true
+                        NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+                        self.showMigrationUI(blog)
+                    case .failure:
+                        self.showSignInUI()
+                    }
+                }
+            }
             return
         }
-
         // If the user doesn't have any blogs, but they're still logged in, log them out
         // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
         AccountHelper.logOutDefaultWordPressComAccount()
@@ -43,6 +55,10 @@ class JetpackWindowManager: WindowManager {
 
     // TODO: Add logic in here to trigger migration UI if needed
     private var shouldShowMigrationUI: Bool {
-        return FeatureFlag.contentMigration.enabled
+        return FeatureFlag.contentMigration.enabled && AccountHelper.isLoggedIn
+    }
+
+    private var shouldImportMigrationData: Bool {
+        return !AccountHelper.isLoggedIn && !UserPersistentStoreFactory.instance().isJPContentImportComplete
     }
 }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -4,6 +4,11 @@ import Foundation
 class JetpackWindowManager: WindowManager {
     /// receives migration flow updates in order to dismiss it when needed.
     private var cancellable: AnyCancellable?
+
+    var shouldImportMigrationData: Bool {
+        return !AccountHelper.isLoggedIn && !UserPersistentStoreFactory.instance().isJPContentImportComplete
+    }
+
     override func showUI(for blog: Blog?) {
         // If the user is logged in and has blogs sync'd to their account
         if AccountHelper.isLoggedIn && AccountHelper.hasBlogs {
@@ -13,19 +18,8 @@ class JetpackWindowManager: WindowManager {
 
         guard AccountHelper.isLoggedIn else {
             if shouldImportMigrationData {
-                DataMigrator().importData() { [weak self] result in
-                    guard let self else {
-                        return
-                    }
-
-                    switch result {
-                    case .success:
-                        UserPersistentStoreFactory.instance().isJPContentImportComplete = true
-                        NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
-                        self.showMigrationUI(blog)
-                    case .failure:
-                        self.showSignInUI()
-                    }
+                importAndShowMigrationContent(blog) { [weak self] in
+                    self?.showSignInUI()
                 }
             } else {
                 showAppUI(for: blog)
@@ -37,7 +31,28 @@ class JetpackWindowManager: WindowManager {
         AccountHelper.logOutDefaultWordPressComAccount()
     }
 
-    private func showMigrationUI(_ blog: Blog?) {
+    func importAndShowMigrationContent(_ blog: Blog?, failureCompletion: (() -> ())?) {
+        DataMigrator().importData() { [weak self] result in
+            guard let self else {
+                return
+            }
+
+            switch result {
+            case .success:
+                UserPersistentStoreFactory.instance().isJPContentImportComplete = true
+                NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+                self.showMigrationUIIfNeeded(blog)
+            case .failure:
+                failureCompletion?()
+            }
+        }
+    }
+
+    private func showMigrationUIIfNeeded(_ blog: Blog?) {
+        guard shouldShowMigrationUI else {
+            return
+        }
+
         let container = MigrationDependencyContainer()
         cancellable = container.migrationCoordinator.$currentStep
             .receive(on: DispatchQueue.main)
@@ -57,9 +72,5 @@ class JetpackWindowManager: WindowManager {
 
     private var shouldShowMigrationUI: Bool {
         return FeatureFlag.contentMigration.enabled && AccountHelper.isLoggedIn
-    }
-
-    private var shouldImportMigrationData: Bool {
-        return !AccountHelper.isLoggedIn && !UserPersistentStoreFactory.instance().isJPContentImportComplete
     }
 }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -22,7 +22,7 @@ class JetpackWindowManager: WindowManager {
                     self?.showSignInUI()
                 }
             } else {
-                showAppUI(for: blog)
+                showSignInUI()
             }
             return
         }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -30,6 +30,7 @@ class JetpackWindowManager: WindowManager {
             } else {
                 showAppUI(for: blog)
             }
+            return
         }
         // If the user doesn't have any blogs, but they're still logged in, log them out
         // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/issues/19668

Wiring up the import part in JP App.

To test:
1. Enable content migration & jetpack overlay flags in WP.
2. Tap on "Get Jetpack App" from the overlay.
3. Install JP App and verify if the Migration Sheet appears in JP and flow works correctly.
4. Kill & Launch JP again and verify no Migration Sheet appears again.

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
