### PR TITLE
Move local drafts check to ContentMigrationCoordinator

### DIFF
--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -8,13 +8,16 @@ class ContentMigrationCoordinator {
 
     // MARK: Dependencies
 
+    private let coreDataStack: CoreDataStack
     private let dataMigrator: ContentDataMigrating
     private let userPersistentRepository: UserPersistentRepository
     private let eligibilityProvider: ContentMigrationEligibilityProvider
 
-    init(dataMigrator: ContentDataMigrating = DataMigrator(),
+    init(coreDataStack: CoreDataStack = ContextManager.shared,
+         dataMigrator: ContentDataMigrating = DataMigrator(),
          userPersistentRepository: UserPersistentRepository = UserDefaults.standard,
          eligibilityProvider: ContentMigrationEligibilityProvider = AppConfiguration()) {
+        self.coreDataStack = coreDataStack
         self.dataMigrator = dataMigrator
         self.userPersistentRepository = userPersistentRepository
         self.eligibilityProvider = eligibilityProvider
@@ -23,6 +26,7 @@ class ContentMigrationCoordinator {
     enum ContentMigrationCoordinatorError: Error {
         case ineligible
         case exportFailure
+        case localDraftsNotSynced
     }
 
     // MARK: Methods
@@ -41,7 +45,10 @@ class ContentMigrationCoordinator {
             return
         }
 
-        // TODO: Sync local post drafts here.
+        guard isLocalDraftsSynced() else {
+            completion?(.failure(.localDraftsNotSynced))
+            return
+        }
 
         dataMigrator.exportData { result in
             switch result {
@@ -76,6 +83,27 @@ class ContentMigrationCoordinator {
             completion?()
         }
     }
+}
+
+// MARK: - Preflights Local Draft Check
+
+private extension ContentMigrationCoordinator {
+
+    func isLocalDraftsSynced() -> Bool {
+        let fetchRequest = NSFetchRequest<Post>(entityName: String(describing: Post.self))
+        fetchRequest.predicate = NSPredicate(format: "status = %@ && (remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@)",
+                                             BasePost.Status.draft.rawValue,
+                                             NSNumber(value: AbstractPostRemoteStatus.pushing.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.local.rawValue),
+                                             NSNumber(value: AbstractPostRemoteStatus.pushingMedia.rawValue))
+        guard let count = try? coreDataStack.mainContext.count(for: fetchRequest) else {
+            return false
+        }
+
+        return count == 0
+    }
+
 }
 
 // MARK: - Content Migration Eligibility Provider

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import WordPress
 
-final class ContentMigrationCoordinatorTests: XCTestCase {
+final class ContentMigrationCoordinatorTests: CoreDataTestCase {
 
     private let timeout: TimeInterval = 1
 
@@ -72,6 +72,80 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
         wait(for: [expect], timeout: timeout)
     }
 
+    // MARK: Local draft checking tests
+
+    func test_startAndDo_givenPostWithLocalStatus_shouldReturnFailure() {
+        // Given
+        makeDraftPost(remoteStatus: .local)
+        makeDraftPost(remoteStatus: .sync)
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { result in
+            guard case .failure(let error) = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(error, .localDraftsNotSynced)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startAndDo_givenPostWithPushingStatus_shouldReturnFailure() {
+        // Given
+        makeDraftPost(remoteStatus: .pushing)
+        makeDraftPost(remoteStatus: .sync)
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { result in
+            guard case .failure(let error) = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(error, .localDraftsNotSynced)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startAndDo_givenPostWithPushingMediaStatus_shouldReturnFailure() {
+        // Given
+        makeDraftPost(remoteStatus: .pushingMedia)
+        makeDraftPost(remoteStatus: .sync)
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { result in
+            guard case .failure(let error) = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(error, .localDraftsNotSynced)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
+    func test_startAndDo_givenPostWithFailedStatus_shouldReturnFailure() {
+        // Given
+        makeDraftPost(remoteStatus: .failed)
+        makeDraftPost(remoteStatus: .sync)
+
+        let expect = expectation(description: "Content migration should fail")
+        coordinator.startAndDo { result in
+            guard case .failure(let error) = result else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(error, .localDraftsNotSynced)
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: timeout)
+    }
+
     // MARK: `startOnce` tests
 
     func test_startOnce_whenUserDefaultsDoesNotExist_shouldMigrate() {
@@ -85,7 +159,7 @@ final class ContentMigrationCoordinatorTests: XCTestCase {
     }
 
     func test_startOnce_givenErrorResult_shouldNotSaveUserDefaults() {
-        mockDataMigrator.exportErrorToReturn = .localDraftsNotSynced
+        mockDataMigrator.exportErrorToReturn = .databaseCopyError
 
         let expect = expectation(description: "Content migration should succeed")
         coordinator.startOnceIfNeeded { [unowned self] in
@@ -147,9 +221,17 @@ private extension ContentMigrationCoordinatorTests {
     }
 
     func makeCoordinator() -> ContentMigrationCoordinator {
-        return .init(dataMigrator: mockDataMigrator,
+        return .init(coreDataStack: contextManager,
+                     dataMigrator: mockDataMigrator,
                      userPersistentRepository: mockPersistentRepository,
                      eligibilityProvider: mockEligibilityProvider)
+    }
+
+    func makeDraftPost(remoteStatus: AbstractPostRemoteStatus = .failed) {
+        let _ = PostBuilder(contextManager.mainContext)
+            .drafted()
+            .with(remoteStatus: remoteStatus)
+            .build()
     }
 
 }

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -29,10 +29,6 @@ class DataMigratorTests: XCTestCase {
     }
 
     func testExportSucceeds() {
-        // Given
-        context.addDraftPost(remoteStatus: .sync)
-        context.addDraftPost(remoteStatus: .sync)
-
         // When
         var successful = false
         migrator.exportData { result in
@@ -47,54 +43,6 @@ class DataMigratorTests: XCTestCase {
 
         // Then
         XCTAssertTrue(successful)
-    }
-
-    func testExportFailsWithLocalDrafts() {
-        // Given
-        context.addDraftPost(remoteStatus: .local)
-        context.addDraftPost(remoteStatus: .sync)
-
-        // When
-        let migratorError = getExportDataMigratorError(migrator)
-
-        // Then
-        XCTAssertEqual(migratorError, .localDraftsNotSynced)
-    }
-
-    func testExportFailsWithPushingDrafts() {
-        // Given
-        context.addDraftPost(remoteStatus: .pushing)
-        context.addDraftPost(remoteStatus: .sync)
-
-        // When
-        let migratorError = getExportDataMigratorError(migrator)
-
-        // Then
-        XCTAssertEqual(migratorError, .localDraftsNotSynced)
-    }
-
-    func testExportFailsWithPushingMediaDrafts() {
-        // Given
-        context.addDraftPost(remoteStatus: .pushingMedia)
-        context.addDraftPost(remoteStatus: .sync)
-
-        // When
-        let migratorError = getExportDataMigratorError(migrator)
-
-        // Then
-        XCTAssertEqual(migratorError, .localDraftsNotSynced)
-    }
-
-    func testExportFailsWithFailedUploadDrafts() {
-        // Given
-        context.addDraftPost(remoteStatus: .failed)
-        context.addDraftPost(remoteStatus: .sync)
-
-        // When
-        let migratorError = getExportDataMigratorError(migrator)
-
-        // Then
-        XCTAssertEqual(migratorError, .localDraftsNotSynced)
     }
 
     func testUserDefaultsCopiesToSharedOnExport() {
@@ -384,26 +332,6 @@ private extension DataMigratorTests {
         }
         return migratorError
     }
-}
-
-private extension NSManagedObjectContext {
-
-    func createBlog() -> Blog {
-        let blog = NSEntityDescription.insertNewObject(forEntityName: "Blog", into: self) as! Blog
-        blog.url = ""
-        blog.xmlrpc = ""
-        return blog
-    }
-
-    func addDraftPost(remoteStatus: AbstractPostRemoteStatus) {
-        let post = NSEntityDescription.insertNewObject(forEntityName: "Post", into: self) as! Post
-        post.blog = createBlog()
-        post.remoteStatus = remoteStatus
-        post.dateModified = Date()
-        post.status = .draft
-        try! save()
-    }
-
 }
 
 // MARK: - Mock Local File Store


### PR DESCRIPTION
Refs #19631

This moves the local drafts check to the `ContentMigrationCoordinator` (along with the unit tests). This should help if we want to perform an actual sync for local posts later.

Originally, I planned to sync any local posts here if there are any, show an activity indicator over the Jetpack button, and redirect them to JP once the sync is completed. 

However, the app is already attempting to upload all these local posts asynchronously on `willEnterForeground` — including retries, in case the upload fails the first time (see: `PostCoordinator#resume`). The current state already tries to sync local posts aggressively, so I believe force syncing again on the Jetpack button is unnecessary.

Note that we will still redirect the user to JP even in case of failure. However, they will see the login prologue instead of the migration UI.

## To test

- Open the WP app and log in to a WP.com account.
- Enable the `contentMigration` flag.
- Switch the device to airplane mode (or turn off Wi-Fi).
- Create a post on the device, and save it as a draft. You can also publish or schedule it for variance.
- Tap on the Jetpack button.
- Verify that the data is not exported.
  - You can refer to this PR https://github.com/wordpress-mobile/WordPress-iOS/pull/19674 on how to verify the exported data.

## Regression Notes
1. Potential unintended areas of impact
Should be none. Feature is not released yet.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
Added unit tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
