### PR TITLE
Add SharedDataIssueSolver class

### DIFF
--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -8,11 +8,6 @@ enum DataMigrationError: Error {
     case sharedUserDefaultsNil
 }
 
-fileprivate protocol MigratableConstant {
-    var rawValue: String { get }
-    var valueForJetpack: String { get }
-}
-
 final class DataMigrator {
 
     /// `DefaultsWrapper` is used to single out a dictionary for the migration process.
@@ -27,51 +22,17 @@ final class DataMigrator {
     private let keychainUtils: KeychainUtils
     private let localDefaults: UserPersistentRepository
     private let sharedDefaults: UserPersistentRepository?
-    private let localFileStore: LocalFileStore
 
     init(coreDataStack: CoreDataStack = ContextManager.sharedInstance(),
          backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")?.appendingPathComponent("WordPress.sqlite"),
          keychainUtils: KeychainUtils = KeychainUtils(),
          localDefaults: UserPersistentRepository = UserDefaults.standard,
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
-         localFileStore: LocalFileStore = FileManager.default) {
+         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName)) {
         self.coreDataStack = coreDataStack
         self.backupLocation = backupLocation
         self.keychainUtils = keychainUtils
         self.localDefaults = localDefaults
         self.sharedDefaults = sharedDefaults
-        self.localFileStore = localFileStore
-    }
-
-    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
-    ///
-    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget,
-    /// the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    ///
-    func copyTodayWidgetDataToJetpack() {
-        copyTodayWidgetKeychain()
-        copyTodayWidgetUserDefaults()
-        copyTodayWidgetCacheFiles()
-    }
-
-    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyShareExtensionDataToJetpack() {
-        copyShareExtensionKeychain()
-        copyShareExtensionUserDefaults()
-    }
-
-    /// Copies WP's Notifications extension data (in Keychain) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyNotificationsExtensionDataToJetpack() {
-        copyNotificationExtensionKeychain()
     }
 }
 
@@ -102,9 +63,6 @@ extension DataMigrator: ContentDataMigrating {
             return
         }
 
-        copyTodayWidgetDataToJetpack()
-        copyShareExtensionDataToJetpack()
-        copyNotificationsExtensionDataToJetpack()
         BloggingRemindersScheduler.handleRemindersMigration()
         completion?(.success(()))
     }
@@ -159,241 +117,5 @@ private extension DataMigrator {
         }
         sharedDefaults.removeObject(forKey: DefaultsWrapper.dictKey)
         return true
-    }
-
-    func copyUserDefaultKeys(_ keys: [MigratableConstant]) {
-        guard let sharedDefaults else {
-            return
-        }
-
-        keys.forEach { key in
-            // go to the next key if there's nothing stored under the current key.
-            guard let objectToMigrate = sharedDefaults.object(forKey: key.rawValue) else {
-                return
-            }
-
-            sharedDefaults.set(objectToMigrate, forKey: key.valueForJetpack)
-        }
-    }
-}
-
-// MARK: - Today Widget Helpers
-
-private extension DataMigrator {
-
-    func copyTodayWidgetKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPWidgetConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPWidgetConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPWidgetConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPWidgetConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
-    func copyTodayWidgetUserDefaults() {
-        let userDefaultKeys: [WPWidgetConstants] = [
-            .userDefaultsSiteIdKey,
-            .userDefaultsLoggedInKey,
-            .statsUserDefaultsSiteIdKey,
-            .statsUserDefaultsSiteUrlKey,
-            .statsUserDefaultsSiteNameKey,
-            .statsUserDefaultsSiteTimeZoneKey
-        ]
-
-        copyUserDefaultKeys(userDefaultKeys)
-    }
-
-    func copyTodayWidgetCacheFiles() {
-        let fileNames: [WPWidgetConstants] = [
-            .todayFilename,
-            .allTimeFilename,
-            .thisWeekFilename,
-            .statsTodayFilename,
-            .statsThisWeekFilename,
-            .statsAllTimeFilename
-        ]
-
-        fileNames.forEach { fileName in
-            guard let sourceURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.rawValue),
-                  let targetURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.valueForJetpack),
-                  localFileStore.fileExists(at: sourceURL) else {
-                return
-            }
-
-            if localFileStore.fileExists(at: targetURL) {
-                try? localFileStore.removeItem(at: targetURL)
-            }
-
-            try? localFileStore.copyItem(at: sourceURL, to: targetURL)
-        }
-    }
-
-    /// Keys relevant for migration, copied from WidgetConfiguration.
-    ///
-    enum WPWidgetConstants: String, MigratableConstant {
-        // Constants for Home Widget
-        case keychainTokenKey = "OAuth2Token"
-        case keychainServiceName = "TodayWidget"
-        case userDefaultsSiteIdKey = "WordPressHomeWidgetsSiteId"
-        case userDefaultsLoggedInKey = "WordPressHomeWidgetsLoggedIn"
-        case todayFilename = "HomeWidgetTodayData.plist" // HomeWidgetTodayData
-        case allTimeFilename = "HomeWidgetAllTimeData.plist" // HomeWidgetAllTimeData
-        case thisWeekFilename = "HomeWidgetThisWeekData.plist" // HomeWidgetThisWeekData
-
-        // Constants for Stats Widget
-        case statsUserDefaultsSiteIdKey = "WordPressTodayWidgetSiteId"
-        case statsUserDefaultsSiteNameKey = "WordPressTodayWidgetSiteName"
-        case statsUserDefaultsSiteUrlKey = "WordPressTodayWidgetSiteUrl"
-        case statsUserDefaultsSiteTimeZoneKey = "WordPressTodayWidgetTimeZone"
-        case statsTodayFilename = "TodayData.plist" // TodayWidgetStats
-        case statsThisWeekFilename = "ThisWeekData.plist" // ThisWeekWidgetStats
-        case statsAllTimeFilename = "AllTimeData.plist" // AllTimeWidgetStats
-
-        var valueForJetpack: String {
-            switch self {
-            case .keychainTokenKey:
-                return "OAuth2Token"
-            case .keychainServiceName:
-                return "JetpackTodayWidget"
-            case .userDefaultsSiteIdKey:
-                return "JetpackHomeWidgetsSiteId"
-            case .userDefaultsLoggedInKey:
-                return "JetpackHomeWidgetsLoggedIn"
-            case .todayFilename:
-                return "JetpackHomeWidgetTodayData.plist"
-            case .allTimeFilename:
-                return "JetpackHomeWidgetAllTimeData.plist"
-            case .thisWeekFilename:
-                return "JetpackHomeWidgetThisWeekData.plist"
-            case .statsUserDefaultsSiteIdKey:
-                return "JetpackTodayWidgetSiteId"
-            case .statsUserDefaultsSiteNameKey:
-                return "JetpackTodayWidgetSiteName"
-            case .statsUserDefaultsSiteUrlKey:
-                return "JetpackTodayWidgetSiteUrl"
-            case .statsUserDefaultsSiteTimeZoneKey:
-                return "JetpackTodayWidgetTimeZone"
-            case .statsTodayFilename:
-                return "JetpackTodayData.plist"
-            case .statsThisWeekFilename:
-                return "JetpackThisWeekData.plist"
-            case .statsAllTimeFilename:
-                return "JetpackAllTimeData.plist"
-            }
-        }
-    }
-}
-
-// MARK: - Share Extension Helpers
-
-private extension DataMigrator {
-
-    func copyShareExtensionKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPShareExtensionConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPShareExtensionConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPShareExtensionConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPShareExtensionConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
-    func copyShareExtensionUserDefaults() {
-        let userDefaultKeys: [WPShareExtensionConstants] = [
-            .userDefaultsPrimarySiteName,
-            .userDefaultsPrimarySiteID,
-            .userDefaultsLastUsedSiteName,
-            .userDefaultsLastUsedSiteID,
-            .maximumMediaDimensionKey,
-            .recentSitesKey
-        ]
-
-        copyUserDefaultKeys(userDefaultKeys)
-    }
-
-    /// Keys relevant for migration, copied from ExtensionConfiguration.
-    ///
-    enum WPShareExtensionConstants: String, MigratableConstant {
-
-        case keychainUsernameKey = "Username"
-        case keychainTokenKey = "OAuth2Token"
-        case keychainServiceName = "ShareExtension"
-        case userDefaultsPrimarySiteName = "WPShareUserDefaultsPrimarySiteName"
-        case userDefaultsPrimarySiteID = "WPShareUserDefaultsPrimarySiteID"
-        case userDefaultsLastUsedSiteName = "WPShareUserDefaultsLastUsedSiteName"
-        case userDefaultsLastUsedSiteID = "WPShareUserDefaultsLastUsedSiteID"
-        case maximumMediaDimensionKey = "WPShareExtensionMaximumMediaDimensionKey"
-        case recentSitesKey = "WPShareExtensionRecentSitesKey"
-
-        var valueForJetpack: String {
-            switch self {
-            case .keychainUsernameKey:
-                return "JPUsername"
-            case .keychainTokenKey:
-                return "JPOAuth2Token"
-            case .keychainServiceName:
-                return "JPShareExtension"
-            case .userDefaultsPrimarySiteName:
-                return "JPShareUserDefaultsPrimarySiteName"
-            case .userDefaultsPrimarySiteID:
-                return "JPShareUserDefaultsPrimarySiteID"
-            case .userDefaultsLastUsedSiteName:
-                return "JPShareUserDefaultsLastUsedSiteName"
-            case .userDefaultsLastUsedSiteID:
-                return "JPShareUserDefaultsLastUsedSiteID"
-            case .maximumMediaDimensionKey:
-                return "JPShareExtensionMaximumMediaDimensionKey"
-            case .recentSitesKey:
-                return "JPShareExtensionRecentSitesKey"
-            }
-        }
-    }
-}
-
-// MARK: - Notifications Extension Helpers
-
-private extension DataMigrator {
-
-    func copyNotificationExtensionKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPNotificationsExtensionConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPNotificationsExtensionConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPNotificationsExtensionConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPNotificationsExtensionConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
-    /// Keys relevant for migration, copied from ExtensionConfiguration.
-    ///
-    enum WPNotificationsExtensionConstants: String {
-
-        case keychainServiceName = "NotificationServiceExtension"
-        case keychainTokenKey = "OAuth2Token"
-        case keychainUsernameKey = "Username"
-        case keychainUserIDKey = "UserID"
-
-        var valueForJetpack: String {
-            switch self {
-            case .keychainServiceName:
-                return "JPNotificationServiceExtension"
-            case .keychainTokenKey:
-                return "JPOAuth2Token"
-            case .keychainUsernameKey:
-                return "JPUsername"
-            case .keychainUserIDKey:
-                return "JPUserID"
-            }
-        }
     }
 }

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -63,6 +63,9 @@ extension DataMigrator: ContentDataMigrating {
             return
         }
 
+        let sharedDataIssueSolver = SharedDataIssueSolver()
+        sharedDataIssueSolver.migrateAuthKey()
+        sharedDataIssueSolver.migrateExtensionsData()
         BloggingRemindersScheduler.handleRemindersMigration()
         completion?(.success(()))
     }

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -1,0 +1,335 @@
+/// TODO
+///
+final class SharedDataIssueSolver {
+
+    private let contextManager: CoreDataStack
+    private let keychainUtils: KeychainUtils
+    private let sharedDefaults: UserPersistentRepository?
+    private let localFileStore: LocalFileStore
+
+    init(contextManager: CoreDataStack = ContextManager.shared,
+         keychainUtils: KeychainUtils = KeychainUtils(),
+         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
+         localFileStore: LocalFileStore = FileManager.default) {
+        self.contextManager = contextManager
+        self.keychainUtils = keychainUtils
+        self.sharedDefaults = sharedDefaults
+        self.localFileStore = localFileStore
+    }
+
+    /// Resolve shared data issue by splitting the keys used to store authentication token and supporting data.
+    /// To be safe, the method only "migrates" the data when the user is logged in, and there's a good chance that
+    /// both apps are logged in with the same account.
+    ///
+    func solveIfNeeded() {
+        guard AppConfiguration.isJetpack,
+              let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext),
+              let username = account.username,
+              let token = try? keychainUtils.password(for: username, serviceName: WPAccountConstants.authToken.rawValue) else {
+            return
+        }
+
+        // If the token has already been migrated, no need to resolve the issue again.
+        // There might also be a possibility that the user logged in to JP by themselves. In which, we won't need to migrate.
+        if let _ = try? keychainUtils.password(for: username, serviceName: WPAccountConstants.authToken.valueForJetpack) {
+            return
+        }
+
+        // if authToken for the account username exists, move it to the authToken location for JP.
+        try? keychainUtils.store(username: username,
+                                 password: token,
+                                 serviceName: WPAccountConstants.authToken.valueForJetpack,
+                                 updateExisting: true)
+
+        migrateExtensionsData()
+    }
+
+    func migrateExtensionsData() {
+        copyTodayWidgetDataToJetpack()
+        copyShareExtensionDataToJetpack()
+        copyNotificationsExtensionDataToJetpack()
+    }
+
+    private func copySharedDefaults(_ keys: [MigratableConstant]) {
+        guard let sharedDefaults else {
+            return
+        }
+
+        keys.forEach { key in
+            // go to the next key if there's nothing stored under the current key.
+            guard let objectToMigrate = sharedDefaults.object(forKey: key.rawValue) else {
+                return
+            }
+
+            sharedDefaults.set(objectToMigrate, forKey: key.valueForJetpack)
+        }
+    }
+
+}
+
+// MARK: - Helpers
+
+fileprivate protocol MigratableConstant {
+    var rawValue: String { get }
+    var valueForJetpack: String { get }
+}
+
+// MARK: - Account Auth Token Helpers
+
+private extension SharedDataIssueSolver {
+
+    enum WPAccountConstants: String, MigratableConstant {
+        case authToken = "public-api.wordpress.com"
+
+        var valueForJetpack: String {
+            switch self {
+            case .authToken:
+                return "jetpack.public-api.wordpress.com"
+            }
+        }
+    }
+
+}
+
+// MARK: - Today Widget Helpers
+
+private extension SharedDataIssueSolver {
+    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
+    ///
+    /// Both WP and JP's extensions are already reading and storing data in the same location,
+    /// but in case of Today Widget, the keys used for Keychain and User Defaults are differentiated
+    /// to prevent one app overwriting the other.
+    ///
+    func copyTodayWidgetDataToJetpack() {
+        copyTodayWidgetKeychain()
+        copyTodayWidgetUserDefaults()
+        copyTodayWidgetCacheFiles()
+    }
+
+    func copyTodayWidgetKeychain() {
+        guard let authToken = try? keychainUtils.password(for: WPWidgetConstants.keychainTokenKey.rawValue,
+                                                          serviceName: WPWidgetConstants.keychainServiceName.rawValue,
+                                                          accessGroup: WPAppKeychainAccessGroup) else {
+            return
+        }
+
+        try? keychainUtils.store(username: WPWidgetConstants.keychainTokenKey.valueForJetpack,
+                                 password: authToken,
+                                 serviceName: WPWidgetConstants.keychainServiceName.valueForJetpack,
+                                 updateExisting: true)
+    }
+
+    func copyTodayWidgetUserDefaults() {
+        let userDefaultKeys: [WPWidgetConstants] = [
+            .userDefaultsSiteIdKey,
+            .userDefaultsLoggedInKey,
+            .statsUserDefaultsSiteIdKey,
+            .statsUserDefaultsSiteUrlKey,
+            .statsUserDefaultsSiteNameKey,
+            .statsUserDefaultsSiteTimeZoneKey
+        ]
+
+        copySharedDefaults(userDefaultKeys)
+    }
+
+    func copyTodayWidgetCacheFiles() {
+        let fileNames: [WPWidgetConstants] = [
+            .todayFilename,
+            .allTimeFilename,
+            .thisWeekFilename,
+            .statsTodayFilename,
+            .statsThisWeekFilename,
+            .statsAllTimeFilename
+        ]
+
+        fileNames.forEach { fileName in
+            guard let sourceURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.rawValue),
+                  let targetURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.valueForJetpack),
+                  localFileStore.fileExists(at: sourceURL) else {
+                return
+            }
+
+            if localFileStore.fileExists(at: targetURL) {
+                try? localFileStore.removeItem(at: targetURL)
+            }
+
+            try? localFileStore.copyItem(at: sourceURL, to: targetURL)
+        }
+    }
+
+    /// Keys relevant for migration, copied from WidgetConfiguration.
+    ///
+    enum WPWidgetConstants: String, MigratableConstant {
+        // Constants for Home Widget
+        case keychainTokenKey = "OAuth2Token"
+        case keychainServiceName = "TodayWidget"
+        case userDefaultsSiteIdKey = "WordPressHomeWidgetsSiteId"
+        case userDefaultsLoggedInKey = "WordPressHomeWidgetsLoggedIn"
+        case todayFilename = "HomeWidgetTodayData.plist" // HomeWidgetTodayData
+        case allTimeFilename = "HomeWidgetAllTimeData.plist" // HomeWidgetAllTimeData
+        case thisWeekFilename = "HomeWidgetThisWeekData.plist" // HomeWidgetThisWeekData
+
+        // Constants for Stats Widget
+        case statsUserDefaultsSiteIdKey = "WordPressTodayWidgetSiteId"
+        case statsUserDefaultsSiteNameKey = "WordPressTodayWidgetSiteName"
+        case statsUserDefaultsSiteUrlKey = "WordPressTodayWidgetSiteUrl"
+        case statsUserDefaultsSiteTimeZoneKey = "WordPressTodayWidgetTimeZone"
+        case statsTodayFilename = "TodayData.plist" // TodayWidgetStats
+        case statsThisWeekFilename = "ThisWeekData.plist" // ThisWeekWidgetStats
+        case statsAllTimeFilename = "AllTimeData.plist" // AllTimeWidgetStats
+
+        var valueForJetpack: String {
+            switch self {
+            case .keychainTokenKey:
+                return "OAuth2Token"
+            case .keychainServiceName:
+                return "JetpackTodayWidget"
+            case .userDefaultsSiteIdKey:
+                return "JetpackHomeWidgetsSiteId"
+            case .userDefaultsLoggedInKey:
+                return "JetpackHomeWidgetsLoggedIn"
+            case .todayFilename:
+                return "JetpackHomeWidgetTodayData.plist"
+            case .allTimeFilename:
+                return "JetpackHomeWidgetAllTimeData.plist"
+            case .thisWeekFilename:
+                return "JetpackHomeWidgetThisWeekData.plist"
+            case .statsUserDefaultsSiteIdKey:
+                return "JetpackTodayWidgetSiteId"
+            case .statsUserDefaultsSiteNameKey:
+                return "JetpackTodayWidgetSiteName"
+            case .statsUserDefaultsSiteUrlKey:
+                return "JetpackTodayWidgetSiteUrl"
+            case .statsUserDefaultsSiteTimeZoneKey:
+                return "JetpackTodayWidgetTimeZone"
+            case .statsTodayFilename:
+                return "JetpackTodayData.plist"
+            case .statsThisWeekFilename:
+                return "JetpackThisWeekData.plist"
+            case .statsAllTimeFilename:
+                return "JetpackAllTimeData.plist"
+            }
+        }
+    }
+}
+
+// MARK: - Share Extension Helpers
+
+private extension SharedDataIssueSolver {
+    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
+    ///
+    func copyShareExtensionDataToJetpack() {
+        copyShareExtensionKeychain()
+        copyShareExtensionUserDefaults()
+    }
+
+    func copyShareExtensionKeychain() {
+        guard let authToken = try? keychainUtils.password(for: WPShareExtensionConstants.keychainTokenKey.rawValue,
+                                                          serviceName: WPShareExtensionConstants.keychainServiceName.rawValue,
+                                                          accessGroup: WPAppKeychainAccessGroup) else {
+            return
+        }
+
+        try? keychainUtils.store(username: WPShareExtensionConstants.keychainTokenKey.valueForJetpack,
+                                 password: authToken,
+                                 serviceName: WPShareExtensionConstants.keychainServiceName.valueForJetpack,
+                                 updateExisting: true)
+    }
+
+    func copyShareExtensionUserDefaults() {
+        let userDefaultKeys: [WPShareExtensionConstants] = [
+            .userDefaultsPrimarySiteName,
+            .userDefaultsPrimarySiteID,
+            .userDefaultsLastUsedSiteName,
+            .userDefaultsLastUsedSiteID,
+            .maximumMediaDimensionKey,
+            .recentSitesKey
+        ]
+
+        copySharedDefaults(userDefaultKeys)
+    }
+
+    /// Keys relevant for migration, copied from ExtensionConfiguration.
+    ///
+    enum WPShareExtensionConstants: String, MigratableConstant {
+
+        case keychainUsernameKey = "Username"
+        case keychainTokenKey = "OAuth2Token"
+        case keychainServiceName = "ShareExtension"
+        case userDefaultsPrimarySiteName = "WPShareUserDefaultsPrimarySiteName"
+        case userDefaultsPrimarySiteID = "WPShareUserDefaultsPrimarySiteID"
+        case userDefaultsLastUsedSiteName = "WPShareUserDefaultsLastUsedSiteName"
+        case userDefaultsLastUsedSiteID = "WPShareUserDefaultsLastUsedSiteID"
+        case maximumMediaDimensionKey = "WPShareExtensionMaximumMediaDimensionKey"
+        case recentSitesKey = "WPShareExtensionRecentSitesKey"
+
+        var valueForJetpack: String {
+            switch self {
+            case .keychainUsernameKey:
+                return "JPUsername"
+            case .keychainTokenKey:
+                return "JPOAuth2Token"
+            case .keychainServiceName:
+                return "JPShareExtension"
+            case .userDefaultsPrimarySiteName:
+                return "JPShareUserDefaultsPrimarySiteName"
+            case .userDefaultsPrimarySiteID:
+                return "JPShareUserDefaultsPrimarySiteID"
+            case .userDefaultsLastUsedSiteName:
+                return "JPShareUserDefaultsLastUsedSiteName"
+            case .userDefaultsLastUsedSiteID:
+                return "JPShareUserDefaultsLastUsedSiteID"
+            case .maximumMediaDimensionKey:
+                return "JPShareExtensionMaximumMediaDimensionKey"
+            case .recentSitesKey:
+                return "JPShareExtensionRecentSitesKey"
+            }
+        }
+    }
+}
+
+// MARK: - Notifications Extension Helpers
+
+private extension SharedDataIssueSolver {
+    /// Copies WP's Notifications extension data (in Keychain) into JP.
+    ///
+    func copyNotificationsExtensionDataToJetpack() {
+        copyNotificationExtensionKeychain()
+    }
+
+    func copyNotificationExtensionKeychain() {
+        guard let authToken = try? keychainUtils.password(for: WPNotificationsExtensionConstants.keychainTokenKey.rawValue,
+                                                          serviceName: WPNotificationsExtensionConstants.keychainServiceName.rawValue,
+                                                          accessGroup: WPAppKeychainAccessGroup) else {
+            return
+        }
+
+        try? keychainUtils.store(username: WPNotificationsExtensionConstants.keychainTokenKey.valueForJetpack,
+                                 password: authToken,
+                                 serviceName: WPNotificationsExtensionConstants.keychainServiceName.valueForJetpack,
+                                 updateExisting: true)
+    }
+
+    /// Keys relevant for migration, copied from ExtensionConfiguration.
+    ///
+    enum WPNotificationsExtensionConstants: String {
+
+        case keychainServiceName = "NotificationServiceExtension"
+        case keychainTokenKey = "OAuth2Token"
+        case keychainUsernameKey = "Username"
+        case keychainUserIDKey = "UserID"
+
+        var valueForJetpack: String {
+            switch self {
+            case .keychainServiceName:
+                return "JPNotificationServiceExtension"
+            case .keychainTokenKey:
+                return "JPOAuth2Token"
+            case .keychainUsernameKey:
+                return "JPUsername"
+            case .keychainUserIDKey:
+                return "JPUserID"
+            }
+        }
+    }
+}

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -67,6 +67,37 @@ final class SharedDataIssueSolver: NSObject {
         copyNotificationsExtensionDataToJetpack()
     }
 
+    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
+    ///
+    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget,
+    /// the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    ///
+    func copyTodayWidgetDataToJetpack() {
+        copyTodayWidgetKeychain()
+        copyTodayWidgetUserDefaults()
+        copyTodayWidgetCacheFiles()
+    }
+
+    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    func copyShareExtensionDataToJetpack() {
+        copyShareExtensionKeychain()
+        copyShareExtensionUserDefaults()
+    }
+
+    /// Copies WP's Notifications extension data (in Keychain) into JP.
+    ///
+    /// Note: This method is not private for unit testing purposes.
+    /// It requires time to properly mock the dependencies in `importData`.
+    func copyNotificationsExtensionDataToJetpack() {
+        copyNotificationExtensionKeychain()
+    }
+
     private func copySharedDefaults(_ keys: [MigratableConstant]) {
         guard let sharedDefaults else {
             return
@@ -111,17 +142,6 @@ private extension SharedDataIssueSolver {
 // MARK: - Today Widget Helpers
 
 private extension SharedDataIssueSolver {
-    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
-    ///
-    /// Both WP and JP's extensions are already reading and storing data in the same location,
-    /// but in case of Today Widget, the keys used for Keychain and User Defaults are differentiated
-    /// to prevent one app overwriting the other.
-    ///
-    func copyTodayWidgetDataToJetpack() {
-        copyTodayWidgetKeychain()
-        copyTodayWidgetUserDefaults()
-        copyTodayWidgetCacheFiles()
-    }
 
     func copyTodayWidgetKeychain() {
         guard let authToken = try? keychainUtils.password(for: WPWidgetConstants.keychainTokenKey.rawValue,
@@ -233,12 +253,6 @@ private extension SharedDataIssueSolver {
 // MARK: - Share Extension Helpers
 
 private extension SharedDataIssueSolver {
-    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
-    ///
-    func copyShareExtensionDataToJetpack() {
-        copyShareExtensionKeychain()
-        copyShareExtensionUserDefaults()
-    }
 
     func copyShareExtensionKeychain() {
         guard let authToken = try? keychainUtils.password(for: WPShareExtensionConstants.keychainTokenKey.rawValue,
@@ -308,11 +322,6 @@ private extension SharedDataIssueSolver {
 // MARK: - Notifications Extension Helpers
 
 private extension SharedDataIssueSolver {
-    /// Copies WP's Notifications extension data (in Keychain) into JP.
-    ///
-    func copyNotificationsExtensionDataToJetpack() {
-        copyNotificationExtensionKeychain()
-    }
 
     func copyNotificationExtensionKeychain() {
         guard let authToken = try? keychainUtils.password(for: WPNotificationsExtensionConstants.keychainTokenKey.rawValue,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1867,6 +1867,7 @@
 		83B1D038282C62620061D911 /* BloggingPromptsAttribution.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */; };
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
+		83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
@@ -20310,6 +20311,7 @@
 				B06378C0253F639D00FD45D2 /* SiteSuggestion+CoreDataClass.swift in Sources */,
 				C7AFF87C283D5CF4000E01DF /* QRLoginVerifyCoordinator.swift in Sources */,
 				FA25FA212609AA9C0005E08F /* AppConfiguration.swift in Sources */,
+				83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */,
 				436D55DB210F862A00CEAA33 /* NibReusable.swift in Sources */,
 				98563DDD21BF30C40006F5E9 /* TabbedTotalsCell.swift in Sources */,
 				82FC61241FA8ADAD00A1757E /* ActivityTableViewCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1868,6 +1868,7 @@
 		83C972E0281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83C972E1281C45AB0049E1FE /* Post+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */; };
 		83EF3D7B2937D703000AF9BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
+		83EF3D7F2937F08C000AF9BF /* SharedDataIssueSolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */; };
 		83F3E26011275E07004CD686 /* MapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E25F11275E07004CD686 /* MapKit.framework */; };
 		83F3E2D311276371004CD686 /* CoreLocation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83F3E2D211276371004CD686 /* CoreLocation.framework */; };
 		83FEFC7611FF6C5A0078B462 /* SiteSettingsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */; };
@@ -6964,6 +6965,7 @@
 		839B150A2795DEE0009F5E77 /* UIView+Margins.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Margins.swift"; sourceTree = "<group>"; };
 		83B1D036282C62620061D911 /* BloggingPromptsAttribution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsAttribution.swift; sourceTree = "<group>"; };
 		83C972DF281C45AB0049E1FE /* Post+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Post+BloggingPrompts.swift"; sourceTree = "<group>"; };
+		83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolverTests.swift; sourceTree = "<group>"; };
 		83F3E25F11275E07004CD686 /* MapKit.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MapKit.framework; path = System/Library/Frameworks/MapKit.framework; sourceTree = SDKROOT; };
 		83F3E2D211276371004CD686 /* CoreLocation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		83FB4D3E122C38F700DB9506 /* MediaPlayer.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MediaPlayer.framework; path = System/Library/Frameworks/MediaPlayer.framework; sourceTree = SDKROOT; };
@@ -12596,6 +12598,7 @@
 			isa = PBXGroup;
 			children = (
 				8332DD2729259BEB00802F7D /* DataMigratorTests.swift */,
+				83EF3D7C2937E969000AF9BF /* SharedDataIssueSolverTests.swift */,
 			);
 			name = Utility;
 			sourceTree = "<group>";
@@ -22200,6 +22203,7 @@
 				400A2C952217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift in Sources */,
 				F151EC832665271200AEA89E /* BloggingRemindersSchedulerTests.swift in Sources */,
 				D81C2F6620F8ACCD002AE1F1 /* FormattableContentFormatterTests.swift in Sources */,
+				83EF3D7F2937F08C000AF9BF /* SharedDataIssueSolverTests.swift in Sources */,
 				8070EB3E28D807CB005C6513 /* InMemoryUserDefaults.swift in Sources */,
 				F93735F822D53C3B00A3C312 /* LoggingURLRedactorTests.swift in Sources */,
 				C738CB1128626606001BE107 /* QRLoginVerifyCoordinatorTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5248,6 +5248,7 @@
 		FECA442F28350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
 		FECA443028350B7800D01F15 /* PromptRemindersScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */; };
 		FECA44322836647100D01F15 /* PromptRemindersSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECA44312836647100D01F15 /* PromptRemindersSchedulerTests.swift */; };
+		FED65D79293511E4008071BF /* SharedDataIssueSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */; };
 		FEDA1AD8269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDA1AD9269D475D0038EC98 /* ListTableViewCell+Comments.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */; };
 		FEDDD46F26A03DE900F8942B /* ListTableViewCell+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */; };
@@ -8817,6 +8818,7 @@
 		FEC26032283FC902003D886A /* WPTabBarController+BloggingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+BloggingPrompt.swift"; sourceTree = "<group>"; };
 		FECA442E28350B7800D01F15 /* PromptRemindersScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersScheduler.swift; sourceTree = "<group>"; };
 		FECA44312836647100D01F15 /* PromptRemindersSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptRemindersSchedulerTests.swift; sourceTree = "<group>"; };
+		FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDataIssueSolver.swift; sourceTree = "<group>"; };
 		FEDA1AD7269D475D0038EC98 /* ListTableViewCell+Comments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Comments.swift"; sourceTree = "<group>"; };
 		FEDDD46E26A03DE900F8942B /* ListTableViewCell+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListTableViewCell+Notifications.swift"; sourceTree = "<group>"; };
 		FEF4DC5428439357003806BE /* ReminderScheduleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinator.swift; sourceTree = "<group>"; };
@@ -12584,6 +12586,7 @@
 			isa = PBXGroup;
 			children = (
 				8332DD2329259AE300802F7D /* DataMigrator.swift */,
+				FED65D78293511E4008071BF /* SharedDataIssueSolver.swift */,
 			);
 			path = Utility;
 			sourceTree = "<group>";
@@ -23280,6 +23283,7 @@
 				FAFC065227D27241002F0483 /* BlogDetailsViewController+Dashboard.swift in Sources */,
 				8B55FAAD2614FC87007D618E /* Text+BoldSubString.swift in Sources */,
 				FABB23382602FC2C00C8785C /* WordPress-22-23.xcmappingmodel in Sources */,
+				FED65D79293511E4008071BF /* SharedDataIssueSolver.swift in Sources */,
 				FABB23392602FC2C00C8785C /* CountriesMap.swift in Sources */,
 				98BC522527F6245700D6E8C2 /* BloggingPromptsFeatureIntroduction.swift in Sources */,
 				FABB233A2602FC2C00C8785C /* RevisionsNavigationController.swift in Sources */,

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -7,7 +7,6 @@ class DataMigratorTests: XCTestCase {
     private var migrator: DataMigrator!
     private var coreDataStack: CoreDataStackMock!
     private var keychainUtils: KeychainUtilsMock!
-    private var mockLocalStore: MockLocalFileStore!
     private var sharedUserDefaults: InMemoryUserDefaults!
     private var localUserDefaults: InMemoryUserDefaults!
 
@@ -17,15 +16,13 @@ class DataMigratorTests: XCTestCase {
         context = try! createInMemoryContext()
         coreDataStack = CoreDataStackMock(mainContext: context)
         keychainUtils = KeychainUtilsMock()
-        mockLocalStore = MockLocalFileStore()
         sharedUserDefaults = InMemoryUserDefaults()
         localUserDefaults = InMemoryUserDefaults()
         migrator = DataMigrator(coreDataStack: coreDataStack,
                                 backupLocation: URL(string: "/dev/null"),
                                 keychainUtils: keychainUtils,
                                 localDefaults: localUserDefaults,
-                                sharedDefaults: sharedUserDefaults,
-                                localFileStore: mockLocalStore)
+                                sharedDefaults: sharedUserDefaults)
     }
 
     func testExportSucceeds() {
@@ -74,176 +71,6 @@ class DataMigratorTests: XCTestCase {
 
         // Then
         XCTAssertEqual(migratorError, .sharedUserDefaultsNil)
-    }
-
-    // MARK: Widget Migration Tests
-
-    func test_widgetMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "OAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JetpackTodayWidget"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        migrator.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_widgetMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        migrator.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
-    }
-
-    func test_widgetMigration_userDefaultsShouldMigrateSuccessfully() {
-        // Given
-        sharedUserDefaults.set("test1", forKey: "WordPressHomeWidgetsSiteId")
-        sharedUserDefaults.set("test2", forKey: "WordPressHomeWidgetsLoggedIn")
-        sharedUserDefaults.set("test3", forKey: "WordPressTodayWidgetSiteId")
-        sharedUserDefaults.set("test4", forKey: "WordPressTodayWidgetSiteName")
-        sharedUserDefaults.set("test5", forKey: "WordPressTodayWidgetSiteUrl")
-        sharedUserDefaults.set("test6", forKey: "WordPressTodayWidgetTimeZone")
-
-        // When
-        migrator.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackHomeWidgetsSiteId"), "test1")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackHomeWidgetsLoggedIn"), "test2")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteId"), "test3")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteName"), "test4")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteUrl"), "test5")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetTimeZone"), "test6")
-    }
-
-    func test_widgetMigration_plistFileShouldMigrateSuccessfully() {
-        // Given
-        let expectedSourceFilename = "HomeWidgetTodayData.plist"
-        mockLocalStore.fileShouldExistClosure = { url in
-            guard let url else {
-                return false
-            }
-            return url.lastPathComponent == expectedSourceFilename
-        }
-
-        // When
-        migrator.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertEqual(mockLocalStore.removeItemCallCount, 0)
-        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
-    }
-
-    func test_widgetMigration_whenTargetPlistFileExists_itShouldBeDeletedFirst() {
-        // Given
-        let expectedSourceFilename = "HomeWidgetTodayData.plist"
-        let expectedTargetFilename = "JetpackHomeWidgetTodayData.plist"
-        mockLocalStore.fileShouldExistClosure = { url in
-            guard let url else {
-                return false
-            }
-            return [expectedSourceFilename, expectedTargetFilename].contains(url.lastPathComponent)
-        }
-
-        // When
-        migrator.copyTodayWidgetDataToJetpack()
-
-        // Then
-        // migrator tries to remove any existing item in the target location first.
-        XCTAssertEqual(mockLocalStore.removeItemCallCount, 1)
-        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
-    }
-
-    // MARK: Share Extension Migration Tests
-
-    func test_shareExtensionMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "JPOAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JPShareExtension"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        migrator.copyShareExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_shareExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        migrator.copyShareExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
-    }
-
-    func test_shareExtensionMigration_userDefaultsShouldMigrateSuccessfully() {
-        // Given
-        sharedUserDefaults.set("test1", forKey: "WPShareUserDefaultsPrimarySiteName")
-        sharedUserDefaults.set("test2", forKey: "WPShareUserDefaultsPrimarySiteID")
-        sharedUserDefaults.set("test3", forKey: "WPShareUserDefaultsLastUsedSiteName")
-        sharedUserDefaults.set("test4", forKey: "WPShareUserDefaultsLastUsedSiteID")
-        sharedUserDefaults.set("test5", forKey: "WPShareExtensionMaximumMediaDimensionKey")
-        sharedUserDefaults.set("test6", forKey: "WPShareExtensionRecentSitesKey")
-
-        // When
-        migrator.copyShareExtensionDataToJetpack()
-
-        // Then
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsPrimarySiteName"), "test1")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsPrimarySiteID"), "test2")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsLastUsedSiteName"), "test3")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsLastUsedSiteID"), "test4")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionMaximumMediaDimensionKey"), "test5")
-        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionRecentSitesKey"), "test6")
-    }
-
-    // MARK: Notifications Extension Migration Tests
-
-    func test_notificationsExtensionMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "JPOAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JPNotificationServiceExtension"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        migrator.copyNotificationsExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_notificationsExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        migrator.copyNotificationsExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
     }
 
 }
@@ -331,42 +158,5 @@ private extension DataMigratorTests {
             }
         }
         return migratorError
-    }
-}
-
-// MARK: - Mock Local File Store
-
-private final class MockLocalFileStore: LocalFileStore {
-    var fileShouldExistClosure: (URL?) -> Bool = { _ in return false }
-    var removeItemCallCount: Int = 0
-    var copyItemCallCount: Int = 0
-
-    var removeShouldThrowError: Bool = false
-    var copyShouldThrowError: Bool = false
-
-    func fileExists(at url: URL) -> Bool {
-        return fileShouldExistClosure(url)
-    }
-
-    func save(contents: Data, at url: URL) -> Bool {
-        return true
-    }
-
-    func containerURL(forAppGroup appGroup: String) -> URL? {
-        return URL(string: "/dev/null")
-    }
-
-    func removeItem(at url: URL) throws {
-        if removeShouldThrowError {
-            throw NSError(domain: "", code: 0)
-        }
-        removeItemCallCount += 1
-    }
-
-    func copyItem(at srcURL: URL, to dstURL: URL) throws {
-        if copyShouldThrowError {
-            throw NSError(domain: "", code: 0)
-        }
-        copyItemCallCount += 1
     }
 }

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -1,0 +1,306 @@
+import XCTest
+@testable import WordPress
+
+class SharedDataIssueSolverTests: XCTestCase {
+
+    private var context: NSManagedObjectContext!
+    private var contextManager: CoreDataStackMock!
+    private var keychainUtils: KeychainUtilsMock!
+    private var sharedUserDefaults: InMemoryUserDefaults!
+    private var mockLocalStore: MockLocalFileStore!
+    private var sharedDataIssueSolver: SharedDataIssueSolver!
+
+    override func setUp() {
+        super.setUp()
+
+        context = try! createInMemoryContext()
+        contextManager = CoreDataStackMock(mainContext: context)
+        keychainUtils = KeychainUtilsMock()
+        sharedUserDefaults = InMemoryUserDefaults()
+        mockLocalStore = MockLocalFileStore()
+        sharedDataIssueSolver = SharedDataIssueSolver(contextManager: contextManager,
+                                                      keychainUtils: keychainUtils,
+                                                      sharedDefaults: sharedUserDefaults,
+                                                      localFileStore: mockLocalStore)
+    }
+
+    // MARK: Widget Migration Tests
+
+    func test_widgetMigration_keychainShouldMigrateSuccessfully() {
+        // Given
+        let expectedUsername = "OAuth2Token"
+        let expectedPassword = "password"
+        let expectedServiceName = "JetpackTodayWidget"
+        keychainUtils.passwordToReturn = expectedPassword
+
+        // When
+        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertNotNil(keychainUtils.storedPassword)
+        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
+        XCTAssertNotNil(keychainUtils.storedUsername)
+        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
+        XCTAssertNotNil(keychainUtils.storedServiceName)
+        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
+        XCTAssertNil(keychainUtils.storedAccessGroup)
+    }
+
+    func test_widgetMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
+        // When
+        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertNil(keychainUtils.storedPassword)
+    }
+
+    func test_widgetMigration_userDefaultsShouldMigrateSuccessfully() {
+        // Given
+        sharedUserDefaults.set("test1", forKey: "WordPressHomeWidgetsSiteId")
+        sharedUserDefaults.set("test2", forKey: "WordPressHomeWidgetsLoggedIn")
+        sharedUserDefaults.set("test3", forKey: "WordPressTodayWidgetSiteId")
+        sharedUserDefaults.set("test4", forKey: "WordPressTodayWidgetSiteName")
+        sharedUserDefaults.set("test5", forKey: "WordPressTodayWidgetSiteUrl")
+        sharedUserDefaults.set("test6", forKey: "WordPressTodayWidgetTimeZone")
+
+        // When
+        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackHomeWidgetsSiteId"), "test1")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackHomeWidgetsLoggedIn"), "test2")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteId"), "test3")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteName"), "test4")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetSiteUrl"), "test5")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JetpackTodayWidgetTimeZone"), "test6")
+    }
+
+    func test_widgetMigration_plistFileShouldMigrateSuccessfully() {
+        // Given
+        let expectedSourceFilename = "HomeWidgetTodayData.plist"
+        mockLocalStore.fileShouldExistClosure = { url in
+            guard let url else {
+                return false
+            }
+            return url.lastPathComponent == expectedSourceFilename
+        }
+
+        // When
+        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
+
+        // Then
+        XCTAssertEqual(mockLocalStore.removeItemCallCount, 0)
+        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
+    }
+
+    func test_widgetMigration_whenTargetPlistFileExists_itShouldBeDeletedFirst() {
+        // Given
+        let expectedSourceFilename = "HomeWidgetTodayData.plist"
+        let expectedTargetFilename = "JetpackHomeWidgetTodayData.plist"
+        mockLocalStore.fileShouldExistClosure = { url in
+            guard let url else {
+                return false
+            }
+            return [expectedSourceFilename, expectedTargetFilename].contains(url.lastPathComponent)
+        }
+
+        // When
+        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
+
+        // Then
+        // migrator tries to remove any existing item in the target location first.
+        XCTAssertEqual(mockLocalStore.removeItemCallCount, 1)
+        XCTAssertEqual(mockLocalStore.copyItemCallCount, 1)
+    }
+
+    // MARK: Share Extension Migration Tests
+
+    func test_shareExtensionMigration_keychainShouldMigrateSuccessfully() {
+        // Given
+        let expectedUsername = "JPOAuth2Token"
+        let expectedPassword = "password"
+        let expectedServiceName = "JPShareExtension"
+        keychainUtils.passwordToReturn = expectedPassword
+
+        // When
+        sharedDataIssueSolver.copyShareExtensionDataToJetpack()
+
+        // Then
+        XCTAssertNotNil(keychainUtils.storedPassword)
+        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
+        XCTAssertNotNil(keychainUtils.storedUsername)
+        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
+        XCTAssertNotNil(keychainUtils.storedServiceName)
+        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
+        XCTAssertNil(keychainUtils.storedAccessGroup)
+    }
+
+    func test_shareExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
+        // When
+        sharedDataIssueSolver.copyShareExtensionDataToJetpack()
+
+        // Then
+        XCTAssertNil(keychainUtils.storedPassword)
+    }
+
+    func test_shareExtensionMigration_userDefaultsShouldMigrateSuccessfully() {
+        // Given
+        sharedUserDefaults.set("test1", forKey: "WPShareUserDefaultsPrimarySiteName")
+        sharedUserDefaults.set("test2", forKey: "WPShareUserDefaultsPrimarySiteID")
+        sharedUserDefaults.set("test3", forKey: "WPShareUserDefaultsLastUsedSiteName")
+        sharedUserDefaults.set("test4", forKey: "WPShareUserDefaultsLastUsedSiteID")
+        sharedUserDefaults.set("test5", forKey: "WPShareExtensionMaximumMediaDimensionKey")
+        sharedUserDefaults.set("test6", forKey: "WPShareExtensionRecentSitesKey")
+
+        // When
+        sharedDataIssueSolver.copyShareExtensionDataToJetpack()
+
+        // Then
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsPrimarySiteName"), "test1")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsPrimarySiteID"), "test2")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsLastUsedSiteName"), "test3")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsLastUsedSiteID"), "test4")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionMaximumMediaDimensionKey"), "test5")
+        XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionRecentSitesKey"), "test6")
+    }
+
+    // MARK: Notifications Extension Migration Tests
+
+    func test_notificationsExtensionMigration_keychainShouldMigrateSuccessfully() {
+        // Given
+        let expectedUsername = "JPOAuth2Token"
+        let expectedPassword = "password"
+        let expectedServiceName = "JPNotificationServiceExtension"
+        keychainUtils.passwordToReturn = expectedPassword
+
+        // When
+        sharedDataIssueSolver.copyNotificationsExtensionDataToJetpack()
+
+        // Then
+        XCTAssertNotNil(keychainUtils.storedPassword)
+        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
+        XCTAssertNotNil(keychainUtils.storedUsername)
+        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
+        XCTAssertNotNil(keychainUtils.storedServiceName)
+        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
+        XCTAssertNil(keychainUtils.storedAccessGroup)
+    }
+
+    func test_notificationsExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
+        // When
+        sharedDataIssueSolver.copyNotificationsExtensionDataToJetpack()
+
+        // Then
+        XCTAssertNil(keychainUtils.storedPassword)
+    }
+
+}
+
+// MARK: - Helpers
+
+private extension SharedDataIssueSolverTests {
+    func createInMemoryContext() throws -> NSManagedObjectContext {
+        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
+        try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+        let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
+
+        return managedObjectContext
+    }
+}
+
+// MARK: - CoreDataStackMock
+
+private final class CoreDataStackMock: CoreDataStack {
+    var mainContext: NSManagedObjectContext
+
+    init(mainContext: NSManagedObjectContext) {
+        self.mainContext = mainContext
+    }
+
+    func newDerivedContext() -> NSManagedObjectContext {
+        return mainContext
+    }
+
+    func saveContextAndWait(_ context: NSManagedObjectContext) {}
+    func save(_ context: NSManagedObjectContext) {}
+    func save(_ context: NSManagedObjectContext, withCompletionBlock completionBlock: @escaping () -> Void) {}
+}
+
+// MARK: - KeychainUtilsMock
+
+private final class KeychainUtilsMock: KeychainUtils {
+
+    var sourceAccessGroup: String?
+    var destinationAccessGroup: String?
+    var shouldThrowError = false
+    var passwordToReturn: String? = nil
+    var storeShouldThrow = false
+    var storedPassword: String? = nil
+    var storedUsername: String? = nil
+    var storedServiceName: String? = nil
+    var storedAccessGroup: String? = nil
+
+    override func copyKeychain(from sourceAccessGroup: String?, to destinationAccessGroup: String?, updateExisting: Bool = true) throws {
+        if shouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+
+        self.sourceAccessGroup = sourceAccessGroup
+        self.destinationAccessGroup = destinationAccessGroup
+    }
+
+    override func password(for username: String, serviceName: String, accessGroup: String? = nil) throws -> String? {
+        return passwordToReturn
+    }
+
+    override func store(username: String, password: String, serviceName: String, accessGroup: String? = nil, updateExisting: Bool) throws {
+        if storeShouldThrow {
+            throw NSError(domain: "", code: 0)
+        }
+
+        storedUsername = username
+        storedPassword = password
+        storedServiceName = serviceName
+        storedAccessGroup = accessGroup
+    }
+
+}
+
+// MARK: - Mock Local File Store
+
+private final class MockLocalFileStore: LocalFileStore {
+    var fileShouldExistClosure: (URL?) -> Bool = { _ in return false }
+    var removeItemCallCount: Int = 0
+    var copyItemCallCount: Int = 0
+
+    var removeShouldThrowError: Bool = false
+    var copyShouldThrowError: Bool = false
+
+    func fileExists(at url: URL) -> Bool {
+        return fileShouldExistClosure(url)
+    }
+
+    func save(contents: Data, at url: URL) -> Bool {
+        return true
+    }
+
+    func containerURL(forAppGroup appGroup: String) -> URL? {
+        return URL(string: "/dev/null")
+    }
+
+    func removeItem(at url: URL) throws {
+        if removeShouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+        removeItemCallCount += 1
+    }
+
+    func copyItem(at srcURL: URL, to dstURL: URL) throws {
+        if copyShouldThrowError {
+            throw NSError(domain: "", code: 0)
+        }
+        copyItemCallCount += 1
+    }
+}


### PR DESCRIPTION
Refs https://github.com/wordpress-mobile/WordPress-iOS/pull/19666#discussion_r1033086291

Through #19666, we've differentiated the keys to store App Extension data in Keychain and User Defaults. Also included in that PR, we tried to map the values stored under the WP keys and copy them into the new keys for JP.

**However, we have a problem.** We are only mapping the value when `DataMigrator.importData` is called — which is, when the JP app is logged out. Starting 21.3, JP will start reading from these new keys, and users already logged in to JP will experience extension issues due to their data not being migrated.

This PR attempts to solve the issue by introducing a second migration layer (on top of the Content Migration Flow).

### Auth token
Some simulation for auth token migration:

Scenario | Migrate account auth token?
-|-
JP logged in |  ✅ Migrate. We don't know if WP is logged in or whether it's using the same or different account from JP. But we should, regardless, move the auth token in JP to the new key.
JP logged out | 🚫 No need to migrate. There's nothing to migrate.


### Extensions
As for extensions data, it is a bit tricky because regardless of account username, it is stored under the same `username` and `serviceName` value. We don't know which account the auth token belongs to since this depends on which app is opened last. Note that extensions' auth tokens are always refreshed/overwritten during app launch. This is why which app breaks depends on which app is opened last. However: extensions store other stuff in user defaults. 

Regardless, here's a table:

Scenario | Migrate app extensions data?
-|-
JP logged in |  ✅  Migrate? We can't really check if WP and JP are logged in to different accounts. Regardless of which app had the extension issue, it will still be in the same state after the migration. Also, the app will fix itself (by overwriting the auth token for the extensions) during app launch
JP logged out | 🚫 Do not migrate.

## Tasks

- [x] Extract the extensions' data migration into a separate class.
- [x] Let's also migrate the user's auth token while we're at it.
- [x] Conditions for the migration:
  - [x] Likely needs to happen very early.
  - [x] Should only be triggered from the JP app.
  - [x] The user must be logged in.
  - [x] The migration should only be allowed to run once.

## To Test

### Scenario 1

An existing Jetpack user who is upgrading their app. We need to copy their auth token to the new location.

- Install a Jetpack version other than this branch (`trunk` or `release/21.3` should be fine)
- Login to the app
- Install this branch's Jetpack
- Verify you are still logged in and API calls are successful

### Scenario 2

A user who is migrating from WordPress to Jetpack. The new values need to be copied on the data import step.

- Enable the feature flags `jetpackPoweredBottomSheet` & `contentMigration`
- Install WordPress and login
- Trigger the migration through the bottom banner
- Install Jetpack
- Continue through the migration flow until you get to the dashboard
- Verify you are still logged in and API calls are successful

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
