### PR TITLE
Check all posts remote status instead of just drafts

### DIFF
--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -45,7 +45,7 @@ class ContentMigrationCoordinator {
             return
         }
 
-        guard isLocalDraftsSynced() else {
+        guard isLocalPostsSynced() else {
             completion?(.failure(.localDraftsNotSynced))
             return
         }
@@ -89,10 +89,9 @@ class ContentMigrationCoordinator {
 
 private extension ContentMigrationCoordinator {
 
-    func isLocalDraftsSynced() -> Bool {
+    func isLocalPostsSynced() -> Bool {
         let fetchRequest = NSFetchRequest<Post>(entityName: String(describing: Post.self))
-        fetchRequest.predicate = NSPredicate(format: "status = %@ && (remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@)",
-                                             BasePost.Status.draft.rawValue,
+        fetchRequest.predicate = NSPredicate(format: "remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@ || remoteStatusNumber = %@",
                                              NSNumber(value: AbstractPostRemoteStatus.pushing.rawValue),
                                              NSNumber(value: AbstractPostRemoteStatus.failed.rawValue),
                                              NSNumber(value: AbstractPostRemoteStatus.local.rawValue),

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -76,8 +76,8 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
 
     func test_startAndDo_givenPostWithLocalStatus_shouldReturnFailure() {
         // Given
-        makeDraftPost(remoteStatus: .local)
-        makeDraftPost(remoteStatus: .sync)
+        makePost(remoteStatus: .local)
+        makePost(remoteStatus: .sync)
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in
@@ -94,8 +94,8 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
 
     func test_startAndDo_givenPostWithPushingStatus_shouldReturnFailure() {
         // Given
-        makeDraftPost(remoteStatus: .pushing)
-        makeDraftPost(remoteStatus: .sync)
+        makePost(remoteStatus: .pushing)
+        makePost(remoteStatus: .sync)
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in
@@ -112,8 +112,8 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
 
     func test_startAndDo_givenPostWithPushingMediaStatus_shouldReturnFailure() {
         // Given
-        makeDraftPost(remoteStatus: .pushingMedia)
-        makeDraftPost(remoteStatus: .sync)
+        makePost(remoteStatus: .pushingMedia)
+        makePost(remoteStatus: .sync)
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in
@@ -130,8 +130,8 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
 
     func test_startAndDo_givenPostWithFailedStatus_shouldReturnFailure() {
         // Given
-        makeDraftPost(remoteStatus: .failed)
-        makeDraftPost(remoteStatus: .sync)
+        makePost(remoteStatus: .failed)
+        makePost(remoteStatus: .sync)
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in
@@ -227,9 +227,9 @@ private extension ContentMigrationCoordinatorTests {
                      eligibilityProvider: mockEligibilityProvider)
     }
 
-    func makeDraftPost(remoteStatus: AbstractPostRemoteStatus = .failed) {
+    func makePost(remoteStatus: AbstractPostRemoteStatus = .failed) {
         let _ = PostBuilder(contextManager.mainContext)
-            .drafted()
+            .published()
             .with(remoteStatus: remoteStatus)
             .build()
     }


### PR DESCRIPTION
Ref #19631 

## Description

Updates the local draft check to include all posts to prevent duplicate data.

## Testing

To test:

- Run the`ContentMigrationCoordinatorTests` tests

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
