### PR TITLE
Jetpack Focus: Add convenience method for retrieving the removal deadline

### DIFF
--- a/WordPress/Classes/Stores/RemoteConfigStore.swift
+++ b/WordPress/Classes/Stores/RemoteConfigStore.swift
@@ -1,22 +1,24 @@
 import Foundation
 
+fileprivate extension DispatchQueue {
+    static let remoteConfigStoreQueue = DispatchQueue(label: "remote-config-store-queue")
+}
+
 class RemoteConfigStore {
-
-    // MARK: Shared Instance
-
-    public static let shared = RemoteConfigStore()
 
     // MARK: Private Variables
 
     /// Thread Safety Coordinator
-    private let queue: DispatchQueue = DispatchQueue(label: "remote-config-store-queue")
+    private let queue: DispatchQueue
     private let remote: RemoteConfigRemote
     private let persistenceStore: UserPersistentRepository
 
     // MARK: Initializer
 
-    init(remote: RemoteConfigRemote = RemoteConfigRemote(wordPressComRestApi: .defaultApi()),
+    init(queue: DispatchQueue = .remoteConfigStoreQueue,
+         remote: RemoteConfigRemote = RemoteConfigRemote(wordPressComRestApi: .defaultApi()),
          persistenceStore: UserPersistentRepository = UserDefaults.standard) {
+        self.queue = queue
         self.remote = remote
         self.persistenceStore = persistenceStore
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -44,6 +44,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     private var noticePresenter: NoticePresenter?
     private var bgTask: UIBackgroundTaskIdentifier? = nil
     private let remoteFeatureFlagStore = RemoteFeatureFlagStore()
+    private let remoteConfigStore = RemoteConfigStore()
 
     private var mainContext: NSManagedObjectContext {
         return ContextManager.shared.mainContext
@@ -667,7 +668,7 @@ extension WordPressAppDelegate {
     }
 
     func updateRemoteConfig() {
-        RemoteConfigStore.shared.update()
+        remoteConfigStore.update()
     }
 }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -9,7 +9,7 @@ struct RemoteConfig {
 
     // MARK: Initializer
 
-    init(store: RemoteConfigStore = .shared) {
+    init(store: RemoteConfigStore = RemoteConfigStore()) {
         self.store = store
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -2,5 +2,20 @@ import Foundation
 
 /// A struct that holds all remote config parameters.
 struct RemoteConfig {
-    static let jetpackDeadline = RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil)
+
+    // MARK: Private Variables
+
+    private var store: RemoteConfigStore
+
+    // MARK: Initializer
+
+    init(store: RemoteConfigStore = .shared) {
+        self.store = store
+    }
+
+    // MARK: Remote Config Parameters
+
+    var jetpackDeadline: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil, store: store)
+    }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -17,7 +17,7 @@ struct RemoteConfigParameter<T> {
 
     // MARK: Initializer
 
-    init(key: String, defaultValue: T?, store: RemoteConfigStore = .shared) {
+    init(key: String, defaultValue: T?, store: RemoteConfigStore) {
         self.key = key
         self.defaultValue = defaultValue
         self.store = store

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -84,6 +84,15 @@ class JetpackFeaturesRemovalCoordinator {
         return .normal
     }
 
+    static func removalDeadline(remoteConfigStore: RemoteConfigStore = .shared) -> Date? {
+        guard let dateString = RemoteConfig(store: remoteConfigStore).jetpackDeadline.value else {
+            return nil
+        }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: dateString)
+    }
+
     /// Used to display feature-specific or feature-collection overlays.
     /// - Parameters:
     ///   - source: The source that triggers the display of the overlay.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -84,7 +84,7 @@ class JetpackFeaturesRemovalCoordinator {
         return .normal
     }
 
-    static func removalDeadline(remoteConfigStore: RemoteConfigStore = .shared) -> Date? {
+    static func removalDeadline(remoteConfigStore: RemoteConfigStore = RemoteConfigStore()) -> Date? {
         guard let dateString = RemoteConfig(store: remoteConfigStore).jetpackDeadline.value else {
             return nil
         }

--- a/WordPress/WordPressTest/InMemoryUserDefaults.swift
+++ b/WordPress/WordPressTest/InMemoryUserDefaults.swift
@@ -43,7 +43,7 @@ class InMemoryUserDefaults: UserPersistentRepository {
     }
 
     func dictionaryRepresentation() -> [String: Any] {
-        return dictionary
+        return dictionary as [String: Any]
     }
 
     func set(_ value: Any?, forKey key: String) {

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -245,6 +245,31 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
         XCTAssertEqual(phase, .two)
     }
 
+    // MARK: Removal Deadline
+
+    func testFetchingRemovalDeadline() {
+        // Given
+        let remoteConfigStore = RemoteConfigStore(persistenceStore: mockUserDefaults)
+        mockUserDefaults.set(["jp-deadline": "2022-10-10"], forKey: RemoteConfigStore.Constants.CachedResponseKey)
+
+        // When
+        let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline(remoteConfigStore: remoteConfigStore)
+
+        XCTAssertEqual(deadline?.components.year, 2022)
+        XCTAssertEqual(deadline?.components.month, 10)
+        XCTAssertEqual(deadline?.components.day, 10)
+    }
+
+    func testRemovalDeadlineDoesNotExist() {
+        // Given
+        let remoteConfigStore = RemoteConfigStore(persistenceStore: mockUserDefaults)
+
+        // When
+        let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline(remoteConfigStore: remoteConfigStore)
+
+        XCTAssertNil(deadline)
+    }
+
     // MARK: Helpers
 
     private func generateFlags(phaseOne: Bool,
@@ -259,5 +284,12 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseFour.remoteKey ?? "", value: phaseFour),
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.remoteKey ?? "", value: phaseNewUsers),
         ]
+    }
+}
+
+private extension Date {
+    var components: DateComponents {
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute, .second],
+                                               from: self)
     }
 }


### PR DESCRIPTION
Part of #19593

## Description
This PR adds a convenience function for retrieving the removal deadline remotely.
This will be used in #19593, #19451, and #19449.

## Testing Instructions

Ensure that the unit tests are passing.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
Added a couple of tests to `JetpackFeaturesRemovalCoordinatorTests` to cover the new function.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
