### PR TITLE
Jetpack migration flow - add tracks for migratable and not migratable statuses

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
@@ -9,14 +9,39 @@ enum WordPressInstallationState {
 struct MigrationAppDetection {
 
     static func getWordPressInstallationState() -> WordPressInstallationState {
+        let tracker = MigratatableStateTracker()
+
         if UIApplication.shared.canOpen(app: .wordpressMigrationV1) {
+            tracker.trackMigratable()
             return .wordPressInstalledAndMigratable
         }
 
         if UIApplication.shared.canOpen(app: .wordpress) {
+            tracker.trackNotMigratable()
             return .wordPressInstalledNotMigratable
         }
 
         return .wordPressNotInstalled
+    }
+}
+
+struct MigratatableStateTracker {
+
+    static let eventName = "jpmigration_wordpressapp_detected"
+
+    private func track(_ event: AnalyticsEvent) {
+        WPAnalytics.track(event)
+    }
+
+    private func event(_ eventName: String, properties: [String: String]) -> AnalyticsEvent {
+        AnalyticsEvent(name: eventName, properties: properties)
+    }
+
+    func trackMigratable() {
+        track(event(Self.eventName, properties: ["compatible": "true"]))
+    }
+
+    func trackNotMigratable() {
+        track(event(Self.eventName, properties: ["compatible": "false"]))
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
@@ -27,7 +27,7 @@ struct MigrationAppDetection {
 
 struct MigratatableStateTracker {
 
-    static let eventName = "jpmigration_wordpressapp_detected"
+    private static let eventName = "jpmigration_wordpressapp_detected"
 
     private func track(_ event: AnalyticsEvent) {
         WPAnalytics.track(event)


### PR DESCRIPTION
This PR tracks if the WordPress version is compatible or not compatible with the migration to Jetpack
Fixes #19682

To test:

- Follow the same test instructions in #19680 
    - you can omit the print statements in the patch
    - you can skip the "WordPress not installed" scenario
- In the "WordPress installed and migratable" scenario, verify that in the Xcode console you see the following line:
`🔵 Tracked: jpmigration_wordpressapp_detected <compatible: true>`
- In the "WordPress installed and NOT migratable" scenario, verify that in the Xcode console you see the following line:
`🔵 Tracked: jpmigration_wordpressapp_detected <compatible: false>`
- Optionally, open the tracks live view and make sure you see these tracks in there (there's usually a 5+ minutes delay)

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
