### PR TITLE
[Jetpack Content Migration] Toggle Success Card visibility depending on WordPress installation state and migration completion state

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigratableStateTracker.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigratableStateTracker.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+struct MigratableStateTracker {
+
+    private static let eventName = "migration_wordpressapp_detected"
+
+    private func track(_ event: AnalyticsEvent) {
+        WPAnalytics.track(event)
+    }
+
+    private func event(_ eventName: String, properties: [String: String]) -> AnalyticsEvent {
+        AnalyticsEvent(name: eventName, properties: properties)
+    }
+
+    /// Tracks an event representing the WordPress migratable state.
+    /// If WordPress is not installed, nothing is tracked.
+    func track() {
+        let installationState = MigrationAppDetection.getWordPressInstallationState()
+        switch installationState {
+        case .wordPressInstalledAndMigratable:
+            self.trackMigratable()
+        case .wordPressInstalledNotMigratable:
+            self.trackNotMigratable()
+        default:
+            break
+        }
+    }
+
+    private func trackMigratable() {
+        track(event(Self.eventName, properties: ["compatible": "true"]))
+    }
+
+    private func trackNotMigratable() {
+        track(event(Self.eventName, properties: ["compatible": "false"]))
+    }
+}

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
@@ -13,39 +13,14 @@ enum WordPressInstallationState {
 struct MigrationAppDetection {
 
     static func getWordPressInstallationState() -> WordPressInstallationState {
-        let tracker = MigratatableStateTracker()
-
         if UIApplication.shared.canOpen(app: .wordpressMigrationV1) {
-            tracker.trackMigratable()
             return .wordPressInstalledAndMigratable
         }
 
         if UIApplication.shared.canOpen(app: .wordpress) {
-            tracker.trackNotMigratable()
             return .wordPressInstalledNotMigratable
         }
 
         return .wordPressNotInstalled
-    }
-}
-
-struct MigratatableStateTracker {
-
-    private static let eventName = "jpmigration_wordpressapp_detected"
-
-    private func track(_ event: AnalyticsEvent) {
-        WPAnalytics.track(event)
-    }
-
-    private func event(_ eventName: String, properties: [String: String]) -> AnalyticsEvent {
-        AnalyticsEvent(name: eventName, properties: properties)
-    }
-
-    func trackMigratable() {
-        track(event(Self.eventName, properties: ["compatible": "true"]))
-    }
-
-    func trackNotMigratable() {
-        track(event(Self.eventName, properties: ["compatible": "false"]))
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
@@ -4,6 +4,10 @@ enum WordPressInstallationState {
     case wordPressNotInstalled
     case wordPressInstalledNotMigratable
     case wordPressInstalledAndMigratable
+
+    var isWordPressInstalled: Bool {
+        return self != .wordPressNotInstalled
+    }
 }
 
 struct MigrationAppDetection {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
@@ -80,13 +80,10 @@ class MigrationSuccessCardView: UIView {
 extension MigrationSuccessCardView {
 
     @objc static var shouldShowMigrationSuccessCard: Bool {
-        #if JETPACK
+        let isJetpack = AppConfiguration.isJetpack
         let isFeatureFlagEnabled = FeatureFlag.contentMigration.enabled
         let isWordPressInstalled = MigrationAppDetection.getWordPressInstallationState().isWordPressInstalled
         let isMigrationCompleted = UserPersistentStoreFactory.instance().isJPContentImportComplete
-        return isFeatureFlagEnabled && isWordPressInstalled && isMigrationCompleted
-        #else
-        return false
-        #endif
+        return isJetpack && isFeatureFlagEnabled && isWordPressInstalled && isMigrationCompleted
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
@@ -81,9 +81,10 @@ extension MigrationSuccessCardView {
 
     @objc static var shouldShowMigrationSuccessCard: Bool {
         #if JETPACK
+        let isFeatureFlagEnabled = FeatureFlag.contentMigration.enabled
         let isWordPressInstalled = MigrationAppDetection.getWordPressInstallationState().isWordPressInstalled
         let isMigrationCompleted = UserPersistentStoreFactory.instance().isJPContentImportComplete
-        return isWordPressInstalled && isMigrationCompleted
+        return isFeatureFlagEnabled && isWordPressInstalled && isMigrationCompleted
         #else
         return false
         #endif

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Success card/MigrationSuccessCardView.swift
@@ -73,13 +73,19 @@ class MigrationSuccessCardView: UIView {
     }
 }
 
-// TODO: This extension is temporary, and should be replaced by the actual condition to check, and placed in the proper location
+// Ideally, this logic should be handled elsewhere. But since the whole migration feature is temporary
+// Perhaps that's not worth the trouble.
+//
+// TODO: Remove `shouldShowMigrationSuccessCard` when the migration feature is no longer needed
 extension MigrationSuccessCardView {
-    @objc
-    static var shouldShowMigrationSuccessCard: Bool {
 
-        AppConfiguration.isJetpack && showCard
+    @objc static var shouldShowMigrationSuccessCard: Bool {
+        #if JETPACK
+        let isWordPressInstalled = MigrationAppDetection.getWordPressInstallationState().isWordPressInstalled
+        let isMigrationCompleted = UserPersistentStoreFactory.instance().isJPContentImportComplete
+        return isWordPressInstalled && isMigrationCompleted
+        #else
+        return false
+        #endif
     }
-
-    private static let showCard = false
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3410,6 +3410,7 @@
 		F49B99FF2937C9B4000CEFCE /* MigrationEmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */; };
 		F49B9A0029393049000CEFCE /* MigrationAppDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33A5ADB2935848F00961E3A /* MigrationAppDetection.swift */; };
 		F49B9A0129393097000CEFCE /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
+		F49B9A032939373E000CEFCE /* MigratableStateTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B9A022939373E000CEFCE /* MigratableStateTracker.swift */; };
 		F4BECD1B288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4BECD1C288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4CBE3D429258AE1004FFBB6 /* MeHeaderViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */; };
@@ -8569,6 +8570,7 @@
 		F465980728E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "white-on-blue-icon-app-83.5@2x.png"; sourceTree = "<group>"; };
 		F478B151292FC1BC00AA8645 /* MigrationAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationAppearance.swift; sourceTree = "<group>"; };
 		F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MigrationEmailService.swift; sourceTree = "<group>"; };
+		F49B9A022939373E000CEFCE /* MigratableStateTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigratableStateTracker.swift; sourceTree = "<group>"; };
 		F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SuggestionsViewModelType.swift; sourceTree = "<group>"; };
 		F4CBE3D329258AD6004FFBB6 /* MeHeaderView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MeHeaderView.h; sourceTree = "<group>"; };
 		F4CBE3D5292597E3004FFBB6 /* SupportTableViewControllerConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportTableViewControllerConfiguration.swift; sourceTree = "<group>"; };
@@ -11028,6 +11030,7 @@
 				F4F9D5EE29096D0400502576 /* Views */,
 				F478B151292FC1BC00AA8645 /* MigrationAppearance.swift */,
 				C33A5ADB2935848F00961E3A /* MigrationAppDetection.swift */,
+				F49B9A022939373E000CEFCE /* MigratableStateTracker.swift */,
 			);
 			path = Common;
 			sourceTree = "<group>";
@@ -23882,6 +23885,7 @@
 				FABB250D2602FC2C00C8785C /* ReaderCrossPostCell.swift in Sources */,
 				93E6336A272AC532009DACF8 /* LoginEpilogueChooseSiteTableViewCell.swift in Sources */,
 				C7234A4F2832C47D0045C63F /* QRLoginVerifyAuthorizationViewController.swift in Sources */,
+				F49B9A032939373E000CEFCE /* MigratableStateTracker.swift in Sources */,
 				FABB250E2602FC2C00C8785C /* Role.swift in Sources */,
 				FABB250F2602FC2C00C8785C /* SuggestionsTableView.swift in Sources */,
 				FABB25102602FC2C00C8785C /* MenuItemSourceResultsViewController.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3408,6 +3408,8 @@
 		F465980C28E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = F465980728E66A5B00D5F49A /* white-on-blue-icon-app-83.5@2x.png */; };
 		F478B152292FC1BC00AA8645 /* MigrationAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = F478B151292FC1BC00AA8645 /* MigrationAppearance.swift */; };
 		F49B99FF2937C9B4000CEFCE /* MigrationEmailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49B99FE2937C9B4000CEFCE /* MigrationEmailService.swift */; };
+		F49B9A0029393049000CEFCE /* MigrationAppDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C33A5ADB2935848F00961E3A /* MigrationAppDetection.swift */; };
+		F49B9A0129393097000CEFCE /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
 		F4BECD1B288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4BECD1C288EE5220078391A /* SuggestionsViewModelType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4BECD1A288EE5220078391A /* SuggestionsViewModelType.swift */; };
 		F4CBE3D429258AE1004FFBB6 /* MeHeaderViewConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4FB0ACC292587D500F651F9 /* MeHeaderViewConfiguration.swift */; };
@@ -20109,6 +20111,7 @@
 				830A58D82793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */,
 				08216FD51CDBF96000304BA7 /* MenuItemTypeViewController.m in Sources */,
 				B526DC291B1E47FC002A8C5F /* WPStyleGuide+WebView.m in Sources */,
+				F49B9A0029393049000CEFCE /* MigrationAppDetection.swift in Sources */,
 				3F6DA04125646F96002AB88F /* HomeWidgetData.swift in Sources */,
 				B089140D27E1255D00CF468B /* SiteIntentViewController.swift in Sources */,
 				82FC61271FA8ADAD00A1757E /* WPStyleGuide+Activity.swift in Sources */,
@@ -21343,6 +21346,7 @@
 				9A38DC6D218899FB006A409B /* DiffAbstractValue.swift in Sources */,
 				17B7C8C120EE2A870042E260 /* Routes+Notifications.swift in Sources */,
 				7E92A1FB233CB1B7006D281B /* Autosaver.swift in Sources */,
+				F49B9A0129393097000CEFCE /* UIApplication+AppAvailability.swift in Sources */,
 				9A341E5621997A340036662E /* BlogAuthor.swift in Sources */,
 				C7234A3A2832BA240045C63F /* QRLoginCoordinator.swift in Sources */,
 				9A341E5721997A340036662E /* Blog+BlogAuthors.swift in Sources */,


### PR DESCRIPTION
Fixes #19678

## Description

This PR shows the "Success Card" when these conditions are true:
1. WordPress is installed
2. Migration Completed
3. Content Migration Feature Flag enabled

| WordPress Installation Condition | Migration Completion Condition |
| ------------------------------ | --------------------------------
| <video src="https://user-images.githubusercontent.com/9609223/205050642-f606aff9-4b6b-4eb1-9026-c598efbfacda.mp4" /> | <video src="https://user-images.githubusercontent.com/9609223/205057152-997c3398-02e2-4adb-8e62-f92b61ccfa2b.mp4" /> |

## Test Instructions

<details><summary><b>Prerequisites: Enable Feature Flags</b></summary>
<p>

**Via the app**
1. Run Jetpack and WordPress apps then log into your account
2. My Site > Me > App Settings > Debug
4. Enable "Content Migration" Feature Flag on both apps
5. Enable "Jetpack powered bottom sheet" Feature Flag on WordPress app

**Programmatically**
1. Go to `FeatureFlag.swift` file
2. Enable `contentMigration` and `jetpackPoweredBottomSheet` Feature Flags
3. Build and run both WordPress and Jetpack apps

</p>
</details>

#### WordPress Installed / Not Installed Condition
1. Run Jetpack app and make sure you're logged out
2. Run WordPress app and make sure you're logged in
3. Go to any Jetpack powered feature. For example, the "Notifications" tab
4. Tap "Jetpack Powered" badge
6. Tap "Try the new Jetpack app"
7. **Expect** the Migration Welcome screen to appear
8. Go through the migration flow
9. **Expect** "My Site" screen to appear
10. **Expect** the "Please delete WordPress app" message to be visible under both "Home" and "Menu" tabs
11. Delete the WordPress app
12. **Expect** the "Please delete WordPress app" message to disappear under both "Home" and "Menu" tabs
13. Re-install WordPress app, and **Expect** the "Please delete WordPress app" message to show up again

#### Migration Not Completed Condition
1. Delete both WordPress and Jetpack apps
2. Re-install Jetpack app only 
3. Make sure "Content Migration" Feature Flag is enabled ( see **prerequisites** )
4. Log into your account
5. **Expect** "My Site" screen to appear
6. **Verify** the "Please delete WordPress app" message is not visible

## Regression Notes
1. Potential unintended areas of impact
None.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

8. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
