### PR TITLE
[Stats Widget] Reduce the refresh interval for Stats widgets

### DIFF
--- a/WordPress/WordPressStatsWidgets/SiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/SiteListProvider.swift
@@ -10,7 +10,7 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
     // refresh interval of the widget, in minutes
     let refreshInterval = 30
     // minimum elapsed time, in minutes, before new data are fetched from the backend.
-    let minElapsedTimeToRefresh = 10
+    let minElapsedTimeToRefresh = 1
 
     private var defaultSiteID: Int? {
 

--- a/WordPress/WordPressStatsWidgets/SiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/SiteListProvider.swift
@@ -8,7 +8,7 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
     let widgetKind: StatsWidgetKind
 
     // refresh interval of the widget, in minutes
-    let refreshInterval = 60
+    let refreshInterval = 30
     // minimum elapsed time, in minutes, before new data are fetched from the backend.
     let minElapsedTimeToRefresh = 10
 


### PR DESCRIPTION
Fixes #19685

## Description

We have feedback that Widgets are not refreshing. I could not identify a particular flaw in the code and after waiting a long time my Widgets updated.

However, based on Apple documentation, we could increase the refresh interval:

> A widget’s budget applies to a 24-hour period. WidgetKit tunes the 24-hour window to the user’s daily usage pattern, which means the daily budget doesn’t necessarily reset at exactly midnight. For a widget the user frequently views, a daily budget typically includes from 40 to 70 refreshes. This rate roughly translates to widget reloads every 15 to 60 minutes, but it’s common for these intervals to vary due to the many factors involved.

Frequent users are the ones expecting the Stats widget to refresh most often. Since the system typically allows 40-70 refreshes, by setting the refresh interval to 30 mins we would request updates to the widget 48 times a day.

Additionally, we have `minElapsedTimeToRefresh` which uses cached values if `getTimelines` is called within `minElapsedTimeToRefresh` timeline. For example, `getTimelines` could be called multiple times if we call `refreshTimelines` from our main app code. In this instance, the cached version is the latest one, so it does not make sense to have `minElapsedTimeToRefresh` larger than 1 minute. Also, `reloadTimelines` calls from the code does not consume the budget, so `minElapsedTimeToRefresh` only guards against multiple calls to `API` within a short period of time. 

## To test:

1. Add a widget to display today's views & visitors (any widget should suffice)
3. Configure it to display for a particular site
4. Make note of the view & visitors count displayed on the widget
5. Generate some page views for that site (e.g. load the page in another browser)
6. Return to the widget after waiting 30-60min
7. Notice that the widget's views & visitor values are changed

## Regression Notes
1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
