### PR TITLE
[Jetpack Content Migration] The Migration Flow doesn't disappear when signing out

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/LogOutActionHandler.swift
+++ b/WordPress/Classes/ViewRelated/Support/LogOutActionHandler.swift
@@ -2,12 +2,19 @@ import UIKit
 
 struct LogOutActionHandler {
 
+    private weak var windowManager: WindowManager?
+
+    init(windowManager: WindowManager? = WordPressAppDelegate.shared?.windowManager) {
+        self.windowManager = windowManager
+    }
+
     func logOut(with viewController: UIViewController) {
         let alert  = UIAlertController(title: logOutAlertTitle, message: nil, preferredStyle: .alert)
         alert.addActionWithTitle(Strings.alertCancelAction, style: .cancel)
         alert.addActionWithTitle(Strings.alertLogoutAction, style: .destructive) { [weak viewController] _ in
             viewController?.dismiss(animated: true) {
                 AccountHelper.logOutDefaultWordPressComAccount()
+                windowManager?.showSignInUI()
             }
         }
         viewController.present(alert, animated: true)


### PR DESCRIPTION
## Description

This PR resolves an issue where the Migration Flow doesn't disappear when the user logs out. Reference: pcdRpT-1i3-p2#comment-2059

| Demo |
| ------ |
| <video src="https://user-images.githubusercontent.com/9609223/205039263-977ae9e8-f9c8-4a1a-a07d-3b5e2ef75185.mp4" /> |

## Test Instructions

<details><summary><b>Prerequisites: Enable Feature Flags</b></summary>
<p>

**Via the app**
1. Run Jetpack and WordPress apps then log into your account
2. My Site > Me > App Settings > Debug
3. Enable "Content Migration" Feature Flag on both apps
4. Enable "Jetpack powered bottom sheet" Feature Flag on WordPress app

**Programmatically**
1. Go to `FeatureFlag.swift` file
2. Enable `contentMigration` and `jetpackPoweredBottomSheet` Feature Flags
3. Build and run both WordPress and Jetpack apps

</p>
</details>

1. Run Jetpack app and make sure you're logged out
2. Run WordPress app and make sure you're logged in
3. Go to any Jetpack powered feature. For example, the "Notifications" tab
4. Tap "Jetpack Powered" badge
5. Tap "Try the new Jetpack app"
6. **Expect** the Migration Welcome screen to appear
7. Tap "Me" button
8. Tap "Log Out" button
9. **Expect** the Jetpack Prologue screen to appear

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

4. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.