### PR TITLE
Fix share extension navigation bar being transparent

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 21.4
 -----
-
+* [*] Share extension navigation bar is no longer transparent [#19700]
 
 21.3
 -----

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -96,8 +96,7 @@ private extension MainShareViewController {
 
         let shareNavController = UINavigationController(rootViewController: editorController)
 
-        if #available(iOS 13, *), editorController.originatingExtension == .saveToDraft {
-            // iOS 13 has proper animations and presentations for share and action sheets. So the `else` case should be removed when iOS 13 is minimum.
+        if editorController.originatingExtension == .saveToDraft {
             // We  need to make sure we don't end up with stacked modal view controllers by using this:
             shareNavController.modalPresentationStyle = .overFullScreen
         } else {

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -77,6 +77,10 @@ private extension MainShareViewController {
             view.backgroundColor = .basicBackground
         }
 
+        // Notice that this will set the apparence of _all_ `UINavigationBar` instances.
+        //
+        // Such a catch-all approach wouldn't be good in the context of a fully fledged application,
+        // but is acceptable here, given we are in an app extension.
         let navigationBarAppearace = UINavigationBar.appearance()
         navigationBarAppearace.isTranslucent = false
         navigationBarAppearace.tintColor = .appBarTint

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -72,11 +72,6 @@ class MainShareViewController: UIViewController {
 private extension MainShareViewController {
     func setupAppearance() {
 
-        if editorController.originatingExtension == .saveToDraft {
-            // This should probably be showing over current context but this just matches previous behavior
-            view.backgroundColor = .basicBackground
-        }
-
         // Notice that this will set the apparence of _all_ `UINavigationBar` instances.
         //
         // Such a catch-all approach wouldn't be good in the context of a fully fledged application,
@@ -86,6 +81,26 @@ private extension MainShareViewController {
         navigationBarAppearace.tintColor = .appBarTint
         navigationBarAppearace.barTintColor = .appBarBackground
         navigationBarAppearace.barStyle = .default
+
+        // Extension-specif settings
+        //
+        // This view controller is shared via target membership by multiple extensions, resulting
+        // in the need to apply some extension-specific settings.
+        //
+        // If we had the time, it would be great to extract all this logic in a standalone
+        // framework or package, and then make the individual extensions import it, and instantiate
+        // and configure the view controller to their liking, without making the code more complex
+        // with branch-logic such as this.
+        switch editorController.originatingExtension {
+        case .saveToDraft:
+            // This should probably be showing over current context but this just matches previous
+            // behavior.
+            view.backgroundColor = .basicBackground
+        case .share:
+            // Without this, the modal view controller will have a semi-transparent bar with a
+            // very low alpha, making it close to fully transparent.
+            navigationBarAppearace.backgroundColor = .basicBackground
+        }
     }
 
     func loadAndPresentNavigationVC() {
@@ -103,9 +118,6 @@ private extension MainShareViewController {
         if editorController.originatingExtension == .saveToDraft {
             // We  need to make sure we don't end up with stacked modal view controllers by using this:
             shareNavController.modalPresentationStyle = .overFullScreen
-        } else {
-            shareNavController.transitioningDelegate = extensionTransitioningManager
-            shareNavController.modalPresentationStyle = .custom
         }
 
         present(shareNavController, animated: true)

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -115,10 +115,8 @@ private extension MainShareViewController {
 
         let shareNavController = UINavigationController(rootViewController: editorController)
 
-        if editorController.originatingExtension == .saveToDraft {
-            // We  need to make sure we don't end up with stacked modal view controllers by using this:
-            shareNavController.modalPresentationStyle = .overFullScreen
-        }
+        // We need to make sure we don't end up with stacked modal view controllers by using this:
+        shareNavController.modalPresentationStyle = .overCurrentContext
 
         present(shareNavController, animated: true)
     }


### PR DESCRIPTION
I came to this PR via https://github.com/wordpress-mobile/WordPress-iOS/pull/19513#discussion_r1007829599.

Originally, it was just a matter of removing the `#available(iOS 13, *)` check, but looking at the code and how it behaves at runtime, it became clear there's some more work to do in regards to the Share Extension. In particular whether I removed the entire `else` branch or I left it as it was, the presentation of the view controller for the share extension always resulted with a close to fully transparent navigation bar (see image below).

The fix I implemented came after a bunch of trial and error and feels a bit like duck-tape. I left a comment with a suggestion for a better fix, but that would need to be a bigger structural-level kind of work.

What my fix consists of is merely changing the color of the navigation bar to match the standard one. 🙃 

It's totally possible I'm misusing UIKit here—UI development is not my strong suit. If that's the case, I'm happy to hand this over to someone more capable than me in this area.

### Before

<img alt="IMG_4741" src="https://user-images.githubusercontent.com/1218433/205047918-33735694-50e5-484a-aa7d-ec67dfc09987.PNG" width=300/>

### After

<table>
<tr>
	<td>
<img width="564" alt="Screenshot 2022-12-01 at 4 55 03 pm" src="https://user-images.githubusercontent.com/1218433/205101429-3584ff78-861c-40d8-a5cd-09749562de38.png">
	</td>
	<td>
<img width="564" alt="Screenshot 2022-12-01 at 4 56 04 pm" src="https://user-images.githubusercontent.com/1218433/205101448-eebe3532-7013-42db-b296-55aab33cd13e.png">
	</td>
</tr>
</table>

## On iPad

I don't know why they don't have the same size, but I think fixing that is out of scope for this PR.

<table>
<tr>
	<td>Share</td>
	</td>Save to Draft</td>
</tr>
<tr>
	<td>
<img alt="Screenshot 2022-12-01 at 5 40 18 pm" src="https://user-images.githubusercontent.com/1218433/205110190-4165d85b-c2d0-4d3c-85cd-2f6b50cef253.png">
	</td>
	<td><img  alt="Screenshot 2022-12-01 at 5 40 25 pm" src="https://user-images.githubusercontent.com/1218433/205110150-5de0360f-c8ef-4c10-ab2f-01e08c3cdd28.png"></td>
</tr>
</table>


## Testing

To test these changes, I launched the app in the Simulator, went out of it (`Shift Cmd H`), opened Safari, and loaded both "Share" and "Save to Draft" extensions to verify the nav bar background color, modal presentation, and scrolling behavior behaved correctly

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
 