### PR TITLE
Jetpack Focus: Display phase two/three overlays for Stats, Reader, and Notifications

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -21,11 +21,11 @@ struct RemoteConfig {
     }
 
     var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: "https://jetpack.com/mobile", store: store) // TODO: Revert this
+        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: nil, store: store)
     }
 
     var phaseThreeBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: "https://jetpack.com/mobile", store: store) // TODO: Revert this
+        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: nil, store: store)
     }
 
     var phaseFourBlogPostUrl: RemoteConfigParameter<String> {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -21,11 +21,11 @@ struct RemoteConfig {
     }
 
     var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: "https://jetpack.com/mobile", store: store) // TODO: Revert this
     }
 
     var phaseThreeBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: "https://jetpack.com/mobile", store: store) // TODO: Revert this
     }
 
     var phaseFourBlogPostUrl: RemoteConfigParameter<String> {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -17,7 +17,7 @@ struct RemoteConfig {
     // MARK: Remote Config Parameters
 
     var jetpackDeadline: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: "2022-12-31", store: store) // TODO: Revert this
     }
 
     var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 /// A struct that holds all remote config parameters.
+/// This is where all remote config parameters should be defined.
 struct RemoteConfig {
 
     // MARK: Private Variables
@@ -17,5 +18,25 @@ struct RemoteConfig {
 
     var jetpackDeadline: RemoteConfigParameter<String> {
         RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil, store: store)
+    }
+
+    var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: nil, store: store)
+    }
+
+    var phaseThreeBlogPostUrl: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: nil, store: store)
+    }
+
+    var phaseFourBlogPostUrl: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "phase-four-blog-post", defaultValue: nil, store: store)
+    }
+
+    var phaseNewUsersBlogPostUrl: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "phase-new-users-blog-post", defaultValue: nil, store: store)
+    }
+
+    var phaseSelfHostedBlogPostUrl: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "phase-self-hosted-blog-post", defaultValue: nil, store: store)
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -17,7 +17,7 @@ struct RemoteConfig {
     // MARK: Remote Config Parameters
 
     var jetpackDeadline: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: "2022-12-31", store: store) // TODO: Revert this
+        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil, store: store)
     }
 
     var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
@@ -88,7 +88,7 @@ extension JetpackOverlayFrequencyTracker {
 
         // MARK: Static Variables
         static let defaultConfig = FrequencyConfig(featureSpecificInDays: 0, generalInDays: 0)
-        private static let secondsInDay: TimeInterval = 0 // TODO: Revert this
+        private static let secondsInDay: TimeInterval = 86_400
 
         // MARK: Computed Variables
         var featureSpecificInSeconds: TimeInterval {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
@@ -88,7 +88,7 @@ extension JetpackOverlayFrequencyTracker {
 
         // MARK: Static Variables
         static let defaultConfig = FrequencyConfig(featureSpecificInDays: 0, generalInDays: 0)
-        private static let secondsInDay: TimeInterval = 86_400
+        private static let secondsInDay: TimeInterval = 0 // TODO: Revert this
 
         // MARK: Computed Variables
         var featureSpecificInSeconds: TimeInterval {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -84,6 +84,14 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
             return Strings.PhaseOne.Notifications.subtitle
         case (.one, .reader):
             return Strings.PhaseOne.Reader.subtitle
+
+        // Phase Two
+        case (.two, _):
+            fallthrough
+
+        // Phase Three
+        case (.three, _):
+            return Strings.PhaseTwoAndThree.subtitle // TODO: inject date
         default:
             return ""
         }
@@ -246,6 +254,9 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let notificationsTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.notifications.title",
                                                  value: "Notifications are moving to Jetpack",
                                                  comment: "Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
+            static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.subtitle",
+                                                 value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %@.",
+                                                 comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -144,6 +144,10 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         switch phase {
         case .one:
             return false
+        case .two:
+            return true
+        case .three:
+            return true
         default:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -135,6 +135,10 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         switch phase {
         case .one:
             return nil
+        case .two:
+            return nil
+        case .three:
+            return Strings.PhaseTwoAndThree.footnote
         default:
             return nil
         }
@@ -261,6 +265,9 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.subtitle",
                                                     value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %@.",
                                                     comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed.")
+            static let footnote = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.footnote",
+                                                    value: "Switching is free and only takes a minute.",
+                                                    comment: "A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -214,9 +214,17 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
         guard let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline() else {
             return NSAttributedString(string: Strings.PhaseTwoAndThree.fallbackSubtitle)
         }
+
         let formattedDate = Self.dateFormatter.string(from: deadline)
         let subtitle = String.localizedStringWithFormat(Strings.PhaseTwoAndThree.subtitle, formattedDate)
-        return NSAttributedString(string: subtitle)
+
+        let rangeOfDate = (subtitle as NSString).range(of: formattedDate)
+        let plainFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        let boldFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .bold)
+        let attributedSubtitle = NSMutableAttributedString(string: subtitle, attributes: [.font: plainFont])
+        attributedSubtitle.addAttribute(.font, value: boldFont, range: rangeOfDate)
+
+        return attributedSubtitle
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -250,17 +250,17 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
 
         enum PhaseTwoAndThree {
             static let statsTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.stats.title",
-                                                 value: "Stats are moving to the Jetpack app",
-                                                 comment: "Title of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app.")
+                                                      value: "Stats are moving to the Jetpack app",
+                                                      comment: "Title of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app.")
             static let readerTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.reader.title",
-                                                 value: "Reader is moving to the Jetpack app",
-                                                 comment: "Title of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app.")
+                                                       value: "Reader is moving to the Jetpack app",
+                                                       comment: "Title of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app.")
             static let notificationsTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.notifications.title",
-                                                 value: "Notifications are moving to Jetpack",
-                                                 comment: "Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
+                                                              value: "Notifications are moving to Jetpack",
+                                                              comment: "Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.subtitle",
-                                                 value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %@.",
-                                                 comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed.")
+                                                    value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %@.",
+                                                    comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -161,6 +161,10 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         switch phase {
         case .one:
             return Strings.General.earlyPhasesSwitchButtonTitle
+        case .two:
+            return Strings.General.earlyPhasesSwitchButtonTitle
+        case .three:
+            return Strings.General.latePhasesSwitchButtonTitle
         default:
             return ""
         }
@@ -210,6 +214,9 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
         enum General {
             static let earlyPhasesSwitchButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.early.switch.title",
                                                                         value: "Switch to the new Jetpack app",
+                                                                        comment: "Title of a button that navigates the user to the Jetpack app if installed, or to the app store.")
+            static let latePhasesSwitchButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.late.switch.title",
+                                                                        value: "Switch to the Jetpack app",
                                                                         comment: "Title of a button that navigates the user to the Jetpack app if installed, or to the app store.")
             static let statsContinueButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.stats.continue.title",
                                                                     value: "Continue to Stats",

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -54,6 +54,22 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
             return Strings.PhaseOne.Notifications.title
         case (.one, .reader):
             return Strings.PhaseOne.Reader.title
+
+        // Phase Two
+        case (.two, .stats):
+            return Strings.PhaseTwoAndThree.statsTitle
+        case (.two, .notifications):
+            return Strings.PhaseTwoAndThree.notificationsTitle
+        case (.two, .reader):
+            return Strings.PhaseTwoAndThree.readerTitle
+
+        // Phase Three
+        case (.three, .stats):
+            return Strings.PhaseTwoAndThree.statsTitle
+        case (.three, .notifications):
+            return Strings.PhaseTwoAndThree.notificationsTitle
+        case (.three, .reader):
+            return Strings.PhaseTwoAndThree.readerTitle
         default:
             return ""
         }
@@ -218,6 +234,18 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
                                                      value: "Switch to the Jetpack app to keep recieving real-time notifications on your device.",
                                                      comment: "Subtitle of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
             }
+        }
+
+        enum PhaseTwoAndThree {
+            static let statsTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.stats.title",
+                                                 value: "Stats are moving to the Jetpack app",
+                                                 comment: "Title of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app.")
+            static let readerTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.reader.title",
+                                                 value: "Reader is moving to the Jetpack app",
+                                                 comment: "Title of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app.")
+            static let notificationsTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.notifications.title",
+                                                 value: "Notifications are moving to Jetpack",
+                                                 comment: "Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -91,7 +91,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
 
         // Phase Three
         case (.three, _):
-            return .init(string: Strings.PhaseTwoAndThree.subtitle) // TODO: inject date
+            return phaseTwoAndThreeSubtitle()
         default:
             return .init(string: "")
         }
@@ -201,6 +201,27 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     var onDismiss: JetpackOverlayDismissCallback?
 }
 
+// MARK: Helpers
+
+private extension JetpackFullscreenOverlayGeneralViewModel {
+    static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
+        return formatter
+    }()
+
+    func phaseTwoAndThreeSubtitle() -> NSAttributedString {
+        guard let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline() else {
+            return NSAttributedString(string: Strings.PhaseTwoAndThree.fallbackSubtitle)
+        }
+        let formattedDate = Self.dateFormatter.string(from: deadline)
+        let subtitle = String.localizedStringWithFormat(Strings.PhaseTwoAndThree.subtitle, formattedDate)
+        return NSAttributedString(string: subtitle)
+    }
+}
+
+// MARK: Constants
+
 private extension JetpackFullscreenOverlayGeneralViewModel {
     enum Constants {
         static let statsLogoAnimationLtr = "JetpackStatsLogoAnimation_ltr"
@@ -274,6 +295,9 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.subtitle",
                                                     value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app on %@.",
                                                     comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed.")
+            static let fallbackSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.fallbackSubtitle",
+                                                    value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app soon.",
+                                                    comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app.")
             static let footnote = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.footnote",
                                                     value: "Switching is free and only takes a minute.",
                                                     comment: "A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app.")

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -186,7 +186,9 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     var shouldShowCloseButton: Bool {
         switch phase {
         case .one:
-            return true
+            fallthrough
+        case .two:
+            return true // Only show close button in phases 1 & 2
         default:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -144,16 +144,20 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         }
     }
 
-    var shouldShowLearnMoreButton: Bool {
+    var learnMoreButtonURL: String? {
         switch phase {
         case .one:
-            return false
+            return nil
         case .two:
-            return true
+            return RemoteConfig().phaseTwoBlogPostUrl.value
         case .three:
-            return true
+            return RemoteConfig().phaseThreeBlogPostUrl.value
+        case .four:
+            return RemoteConfig().phaseFourBlogPostUrl.value
+        case .newUsers:
+            return RemoteConfig().phaseNewUsersBlogPostUrl.value
         default:
-            return false
+            return nil
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -75,15 +75,15 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         }
     }
 
-    var subtitle: String {
+    var subtitle: NSAttributedString {
         switch (phase, source) {
         // Phase One
         case (.one, .stats):
-            return Strings.PhaseOne.Stats.subtitle
+            return .init(string: Strings.PhaseOne.Stats.subtitle)
         case (.one, .notifications):
-            return Strings.PhaseOne.Notifications.subtitle
+            return .init(string: Strings.PhaseOne.Notifications.subtitle)
         case (.one, .reader):
-            return Strings.PhaseOne.Reader.subtitle
+            return .init(string: Strings.PhaseOne.Reader.subtitle)
 
         // Phase Two
         case (.two, _):
@@ -91,9 +91,9 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
 
         // Phase Three
         case (.three, _):
-            return Strings.PhaseTwoAndThree.subtitle // TODO: inject date
+            return .init(string: Strings.PhaseTwoAndThree.subtitle) // TODO: inject date
         default:
-            return ""
+            return .init(string: "")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -24,11 +24,11 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.two, .notifications):
             fallthrough
         case (.two, .reader):
-            return false // TODO: Change this to true when other phase 2 tasks are ready
+            return true
 
         // Phase Three: Show all overlays
         case (.three, _):
-            return false // TODO: Change this to true when other phase 3 tasks are ready
+            return true
 
         // Phase Four: Show feature-collection overlays. Features are removed by this point so they are irrelevant.
         case (.four, _):

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -45,8 +45,8 @@ struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayVi
         return nil
     }
 
-    var shouldShowLearnMoreButton: Bool {
-        return false
+    var learnMoreButtonURL: String? {
+        return nil
     }
 
     var switchButtonText: String {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -22,14 +22,14 @@ struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayVi
         return Strings.title
     }
 
-    var subtitle: String {
+    var subtitle: NSAttributedString {
         switch phase {
         case .one:
-            return Strings.phaseOneSubtitle
+            return .init(string: Strings.phaseOneSubtitle)
         case .two:
-            return Strings.phaseTwoSubtitle
+            return .init(string: Strings.phaseTwoSubtitle)
         default:
-            return ""
+            return .init(string: "")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -123,7 +123,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     private func setupContent() {
         animationView.animation = animation
         setTitle()
-        subtitleLabel.text = viewModel.subtitle
+        subtitleLabel.attributedText = viewModel.subtitle
         footnoteLabel.text = viewModel.footnote
         switchButton.setTitle(viewModel.switchButtonText, for: .normal)
         continueButton.setTitle(viewModel.continueButtonText, for: .normal)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -159,7 +159,6 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     private func setupFonts() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
         titleLabel.adjustsFontForContentSizeCategory = true
-        subtitleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         subtitleLabel.adjustsFontForContentSizeCategory = true
         footnoteLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         footnoteLabel.adjustsFontForContentSizeCategory = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -231,7 +231,8 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     }
 
     @IBAction func learnMoreButtonPressed(_ sender: Any) {
-        guard let url = URL(string: Constants.learnMoreURLString) else {
+        guard let urlString = viewModel.learnMoreButtonURL,
+              let url = URL(string: urlString) else {
             return
         }
 
@@ -268,8 +269,6 @@ private extension JetpackFullscreenOverlayViewController {
     }
 
     enum Constants {
-        // TODO: Update link
-        static let learnMoreURLString = "https://jetpack.com/blog/"
         static let closeButtonSystemName = "xmark.circle.fill"
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -9,7 +9,7 @@ protocol JetpackFullscreenOverlayViewModel {
     var animationLtr: String { get }
     var animationRtl: String { get }
     var footnote: String? { get }
-    var shouldShowLearnMoreButton: Bool { get }
+    var learnMoreButtonURL: String? { get }
     var switchButtonText: String { get }
     var continueButtonText: String? { get }
     var shouldShowCloseButton: Bool { get }
@@ -25,7 +25,7 @@ protocol JetpackFullscreenOverlayViewModel {
 
 extension JetpackFullscreenOverlayViewModel {
     var learnMoreButtonIsHidden: Bool {
-        !shouldShowLearnMoreButton
+        learnMoreButtonURL == nil
     }
 
     var footnoteIsHidden: Bool {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -5,7 +5,7 @@ typealias JetpackOverlayDismissCallback = () -> Void
 /// Protocol used to configure `JetpackFullscreenOverlayViewController`
 protocol JetpackFullscreenOverlayViewModel {
     var title: String { get }
-    var subtitle: String { get }
+    var subtitle: NSAttributedString { get }
     var animationLtr: String { get }
     var animationRtl: String { get }
     var footnote: String? { get }


### PR DESCRIPTION
Closes #19593

## Description
This PR displays the feature-specific overlay for phases two and three for Stats, Reader, and Notification.

## Notes
To facilitate testing, these changes have been pushed and will be reverted before merging, hence the "Do not merge" label.
* 3c91594a51292fffb260d164658bbee257f87183: Disable overlay frequency logic
* 79944489bce7b339ba50dff0ec287ef31a712c22: Override remote deadline date to be Dec 31st
* fa56eae8d019212383ba07c1ec7d34ec92d1f0dd: Override remote blog post URLs for phases 2 and 3. The URLs provided are placeholders since the actual blog posts are not ready yet.

### Screenshots

| Phase | Stats | Reader | Notifications |
| - | - | - | - |
|Phase Two Light|![phase-two-stats-light](https://user-images.githubusercontent.com/25306722/205124265-6329299a-ed83-4c2e-8590-e8d4574b2fd3.png)|![phase-two-reader-light](https://user-images.githubusercontent.com/25306722/205124273-f1664212-4f88-40a1-933b-90c046d61f79.png)|![phase-two-notifs-light](https://user-images.githubusercontent.com/25306722/205124282-78b65e15-5e54-41bd-a359-59daef07362e.png)|
|Phase Two Dark|![phase-two-stats-dark](https://user-images.githubusercontent.com/25306722/205124285-0b12cdd7-72f0-4a4b-848f-1e669a40cb4f.png)|![phase-two-reader-dark](https://user-images.githubusercontent.com/25306722/205124291-2858c6dd-5e05-439a-909e-3fc6969d329c.png)|![phase-two-notifs-dark](https://user-images.githubusercontent.com/25306722/205124295-9803c039-40d9-4711-a383-22b612c60d69.png)|
|Phase Three Light|![phase-three-stats-light](https://user-images.githubusercontent.com/25306722/205124490-c8ded3fd-0da6-4a42-8eea-091092c108b0.png)|![phase-three-reader-light](https://user-images.githubusercontent.com/25306722/205124499-40c64e03-50c1-4ee2-a682-6bc381c38ab2.png)|![phase-three-notifs-light](https://user-images.githubusercontent.com/25306722/205124502-107fb203-9e5d-4cc1-b6b1-c51b8fcaf28d.png)|
|Phase Three Dark|![phase-three-stats-dark](https://user-images.githubusercontent.com/25306722/205124506-c507018b-499a-453a-9f3a-1045008e7fbe.png)|![phase-three-reader-dark](https://user-images.githubusercontent.com/25306722/205124508-77b55391-e2ca-42e9-a7b9-2d9f9820a095.png)|![phase-three-notifs-dark](https://user-images.githubusercontent.com/25306722/205124510-a0345d95-8b25-4a2a-b8ca-54420e39b1c4.png)|

## Testing Instructions

### Phase Two

1. Open the app
2. Make sure that only the "Jetpack Features Removal Phase Two" flag is enabled from the debug menu
3. Navigate to stats
4. Make sure the overlay is displayed with the correct content and matches the design
5. Turn on dark mode
6. Make sure the overlay matches the dark mode design
7. Repeat the above steps for Reader and Notifications

### Phase Three

1. Open the app
2. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
3. Navigate to stats
4. Make sure the overlay is displayed with the correct content and matches the design
5. Turn on dark mode
6. Make sure the overlay matches the dark mode design
7. Repeat the above steps for Reader and Notifications


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.