### PR TITLE
Jetpack Focus: Fix extensions keychain data not properly migrated

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -784,8 +784,7 @@ extension WordPressAppDelegate {
     @objc fileprivate func handleDefaultAccountChangedNotification(_ notification: NSNotification) {
         // If the notification object is not nil, then it's a login
         if notification.object != nil {
-            setupShareExtensionToken()
-            configureNotificationExtension()
+            setupWordPressExtensions()
             startObservingAppleIDCredentialRevoked()
             AccountService.loadDefaultAccountCookies()
         } else {

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -40,7 +40,7 @@ class JetpackWindowManager: WindowManager {
             switch result {
             case .success:
                 UserPersistentStoreFactory.instance().isJPContentImportComplete = true
-                NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
+                NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: self)
                 self.showMigrationUIIfNeeded(blog)
             case .failure:
                 failureCompletion?()

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -58,11 +58,7 @@ final class SharedDataIssueSolver: NSObject {
         copyShareExtensionDataToJetpack()
     }
 
-    /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
-    ///
-    /// Both WP and JP's extensions are already reading and storing data in the same location, but in case of Today Widget,
-    /// the keys used for Keychain and User Defaults are differentiated to prevent one app overwriting the other.
-    ///
+    /// Copies WP's Today Widget data (in User Defaults and local files) into JP.
     /// Note: This method is not private for unit testing purposes.
     /// It requires time to properly mock the dependencies in `importData`.
     ///
@@ -71,7 +67,7 @@ final class SharedDataIssueSolver: NSObject {
         copyTodayWidgetCacheFiles()
     }
 
-    /// Copies WP's Share extension data (in Keychain and User Defaults) into JP.
+    /// Copies WP's Share extension data (in User Defaults) into JP.
     ///
     /// Note: This method is not private for unit testing purposes.
     /// It requires time to properly mock the dependencies in `importData`.

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -57,7 +57,6 @@ final class SharedDataIssueSolver: NSObject {
 
     func migrateExtensionsKeychainData() {
         copyTodayWidgetKeychain()
-        copyShareExtensionKeychain()
     }
 
     func migrateExtensionsData() {
@@ -84,7 +83,6 @@ final class SharedDataIssueSolver: NSObject {
     /// Note: This method is not private for unit testing purposes.
     /// It requires time to properly mock the dependencies in `importData`.
     func copyShareExtensionDataToJetpack() {
-        copyShareExtensionKeychain()
         copyShareExtensionUserDefaults()
     }
 
@@ -244,19 +242,6 @@ private extension SharedDataIssueSolver {
 
 private extension SharedDataIssueSolver {
 
-    func copyShareExtensionKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPShareExtensionConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPShareExtensionConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPShareExtensionConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPShareExtensionConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
     func copyShareExtensionUserDefaults() {
         let userDefaultKeys: [WPShareExtensionConstants] = [
             .userDefaultsPrimarySiteName,
@@ -274,9 +259,6 @@ private extension SharedDataIssueSolver {
     ///
     enum WPShareExtensionConstants: String, MigratableConstant {
 
-        case keychainUsernameKey = "Username"
-        case keychainTokenKey = "OAuth2Token"
-        case keychainServiceName = "ShareExtension"
         case userDefaultsPrimarySiteName = "WPShareUserDefaultsPrimarySiteName"
         case userDefaultsPrimarySiteID = "WPShareUserDefaultsPrimarySiteID"
         case userDefaultsLastUsedSiteName = "WPShareUserDefaultsLastUsedSiteName"
@@ -286,12 +268,6 @@ private extension SharedDataIssueSolver {
 
         var valueForJetpack: String {
             switch self {
-            case .keychainUsernameKey:
-                return "JPUsername"
-            case .keychainTokenKey:
-                return "JPOAuth2Token"
-            case .keychainServiceName:
-                return "JPShareExtension"
             case .userDefaultsPrimarySiteName:
                 return "JPShareUserDefaultsPrimarySiteName"
             case .userDefaultsPrimarySiteID:

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -58,13 +58,11 @@ final class SharedDataIssueSolver: NSObject {
     func migrateExtensionsKeychainData() {
         copyTodayWidgetKeychain()
         copyShareExtensionKeychain()
-        copyNotificationExtensionKeychain()
     }
 
     func migrateExtensionsData() {
         copyTodayWidgetDataToJetpack()
         copyShareExtensionDataToJetpack()
-        copyNotificationsExtensionDataToJetpack()
     }
 
     /// Copies WP's Today Widget data (in Keychain and User Defaults) into JP.
@@ -88,14 +86,6 @@ final class SharedDataIssueSolver: NSObject {
     func copyShareExtensionDataToJetpack() {
         copyShareExtensionKeychain()
         copyShareExtensionUserDefaults()
-    }
-
-    /// Copies WP's Notifications extension data (in Keychain) into JP.
-    ///
-    /// Note: This method is not private for unit testing purposes.
-    /// It requires time to properly mock the dependencies in `importData`.
-    func copyNotificationsExtensionDataToJetpack() {
-        copyNotificationExtensionKeychain()
     }
 
     private func copySharedDefaults(_ keys: [MigratableConstant]) {
@@ -314,47 +304,6 @@ private extension SharedDataIssueSolver {
                 return "JPShareExtensionMaximumMediaDimensionKey"
             case .recentSitesKey:
                 return "JPShareExtensionRecentSitesKey"
-            }
-        }
-    }
-}
-
-// MARK: - Notifications Extension Helpers
-
-private extension SharedDataIssueSolver {
-
-    func copyNotificationExtensionKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPNotificationsExtensionConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPNotificationsExtensionConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPNotificationsExtensionConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPNotificationsExtensionConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
-    /// Keys relevant for migration, copied from ExtensionConfiguration.
-    ///
-    enum WPNotificationsExtensionConstants: String {
-
-        case keychainServiceName = "NotificationServiceExtension"
-        case keychainTokenKey = "OAuth2Token"
-        case keychainUsernameKey = "Username"
-        case keychainUserIDKey = "UserID"
-
-        var valueForJetpack: String {
-            switch self {
-            case .keychainServiceName:
-                return "JPNotificationServiceExtension"
-            case .keychainTokenKey:
-                return "JPOAuth2Token"
-            case .keychainUsernameKey:
-                return "JPUsername"
-            case .keychainUserIDKey:
-                return "JPUserID"
             }
         }
     }

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -51,12 +51,6 @@ final class SharedDataIssueSolver: NSObject {
                                  password: token,
                                  serviceName: WPAccountConstants.authToken.valueForJetpack,
                                  updateExisting: true)
-
-        migrateExtensionsKeychainData()
-    }
-
-    func migrateExtensionsKeychainData() {
-        copyTodayWidgetKeychain()
     }
 
     func migrateExtensionsData() {
@@ -73,7 +67,6 @@ final class SharedDataIssueSolver: NSObject {
     /// It requires time to properly mock the dependencies in `importData`.
     ///
     func copyTodayWidgetDataToJetpack() {
-        copyTodayWidgetKeychain()
         copyTodayWidgetUserDefaults()
         copyTodayWidgetCacheFiles()
     }
@@ -131,19 +124,6 @@ private extension SharedDataIssueSolver {
 
 private extension SharedDataIssueSolver {
 
-    func copyTodayWidgetKeychain() {
-        guard let authToken = try? keychainUtils.password(for: WPWidgetConstants.keychainTokenKey.rawValue,
-                                                          serviceName: WPWidgetConstants.keychainServiceName.rawValue,
-                                                          accessGroup: WPAppKeychainAccessGroup) else {
-            return
-        }
-
-        try? keychainUtils.store(username: WPWidgetConstants.keychainTokenKey.valueForJetpack,
-                                 password: authToken,
-                                 serviceName: WPWidgetConstants.keychainServiceName.valueForJetpack,
-                                 updateExisting: true)
-    }
-
     func copyTodayWidgetUserDefaults() {
         let userDefaultKeys: [WPWidgetConstants] = [
             .userDefaultsSiteIdKey,
@@ -186,8 +166,6 @@ private extension SharedDataIssueSolver {
     ///
     enum WPWidgetConstants: String, MigratableConstant {
         // Constants for Home Widget
-        case keychainTokenKey = "OAuth2Token"
-        case keychainServiceName = "TodayWidget"
         case userDefaultsSiteIdKey = "WordPressHomeWidgetsSiteId"
         case userDefaultsLoggedInKey = "WordPressHomeWidgetsLoggedIn"
         case todayFilename = "HomeWidgetTodayData.plist" // HomeWidgetTodayData
@@ -205,10 +183,6 @@ private extension SharedDataIssueSolver {
 
         var valueForJetpack: String {
             switch self {
-            case .keychainTokenKey:
-                return "OAuth2Token"
-            case .keychainServiceName:
-                return "JetpackTodayWidget"
             case .userDefaultsSiteIdKey:
                 return "JetpackHomeWidgetsSiteId"
             case .userDefaultsLoggedInKey:

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -26,34 +26,6 @@ class SharedDataIssueSolverTests: XCTestCase {
 
     // MARK: Widget Migration Tests
 
-    func test_widgetMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "OAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JetpackTodayWidget"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_widgetMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        sharedDataIssueSolver.copyTodayWidgetDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
-    }
-
     func test_widgetMigration_userDefaultsShouldMigrateSuccessfully() {
         // Given
         sharedUserDefaults.set("test1", forKey: "WordPressHomeWidgetsSiteId")
@@ -115,34 +87,6 @@ class SharedDataIssueSolverTests: XCTestCase {
 
     // MARK: Share Extension Migration Tests
 
-    func test_shareExtensionMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "JPOAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JPShareExtension"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        sharedDataIssueSolver.copyShareExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_shareExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        sharedDataIssueSolver.copyShareExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
-    }
-
     func test_shareExtensionMigration_userDefaultsShouldMigrateSuccessfully() {
         // Given
         sharedUserDefaults.set("test1", forKey: "WPShareUserDefaultsPrimarySiteName")
@@ -162,36 +106,6 @@ class SharedDataIssueSolverTests: XCTestCase {
         XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareUserDefaultsLastUsedSiteID"), "test4")
         XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionMaximumMediaDimensionKey"), "test5")
         XCTAssertEqual(sharedUserDefaults.string(forKey: "JPShareExtensionRecentSitesKey"), "test6")
-    }
-
-    // MARK: Notifications Extension Migration Tests
-
-    func test_notificationsExtensionMigration_keychainShouldMigrateSuccessfully() {
-        // Given
-        let expectedUsername = "JPOAuth2Token"
-        let expectedPassword = "password"
-        let expectedServiceName = "JPNotificationServiceExtension"
-        keychainUtils.passwordToReturn = expectedPassword
-
-        // When
-        sharedDataIssueSolver.copyNotificationsExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNotNil(keychainUtils.storedPassword)
-        XCTAssertEqual(keychainUtils.storedPassword, expectedPassword)
-        XCTAssertNotNil(keychainUtils.storedUsername)
-        XCTAssertEqual(keychainUtils.storedUsername, expectedUsername)
-        XCTAssertNotNil(keychainUtils.storedServiceName)
-        XCTAssertEqual(keychainUtils.storedServiceName, expectedServiceName)
-        XCTAssertNil(keychainUtils.storedAccessGroup)
-    }
-
-    func test_notificationsExtensionMigration_whenKeychainDoesNotExist_itShouldNotBeCopied() {
-        // When
-        sharedDataIssueSolver.copyNotificationsExtensionDataToJetpack()
-
-        // Then
-        XCTAssertNil(keychainUtils.storedPassword)
     }
 
 }


### PR DESCRIPTION
Ref: https://github.com/wordpress-mobile/WordPress-iOS/pull/19683#issuecomment-1334702379
## Description
This PR fixes an issue where the keychain data for the extensions was not being properly migrated.

## Root Cause
After the migration is complete, we post a `WPAccountDefaultWordPressComAccountChanged` notification from `JetpackWindowManager`, but we don’t pass an object. This leads to `WordPressAppDelegate.handleDefaultAccountChangedNotification()` to treat this as a logout and nukes the extensions’ data.

## Solution
Post the `WPAccountDefaultWordPressComAccountChanged` with an object attached, and then we can depend on `WordPressAppDelegate.handleDefaultAccountChangedNotification()` to configure the extensions keychain data using the correct keys out of the box. In that case, we only need to migrate the user defaults data.

## Testing Instructions

1. Enable the feature flags jetpackPoweredBottomSheet & contentMigration
2. Install WordPress and login
3. Trigger the migration through the bottom banner
4. Install Jetpack
5. Continue through the migration flow until you get to the dashboard
6. Switch to the Photos app
7. Select a photo, then tap the share button
8. Tap on “Save to Jetpack”
9. Make sure that the extension works normally

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

