### PR TITLE
Remove redundant `@available(iOS 12, *)` annotations and checks

### DIFF
--- a/WordPress/Classes/Models/ValueTransformers.swift
+++ b/WordPress/Classes/Models/ValueTransformers.swift
@@ -9,7 +9,6 @@ extension ValueTransformer {
     }
 }
 
-@available(iOS 12.0, *)
 @objc
 final class CoordinateValueTransformer: NSSecureUnarchiveFromDataTransformer {
 
@@ -26,7 +25,6 @@ final class CoordinateValueTransformer: NSSecureUnarchiveFromDataTransformer {
     }
 }
 
-@available(iOS 12.0, *)
 @objc
 final class NSErrorValueTransformer: NSSecureUnarchiveFromDataTransformer {
 
@@ -43,7 +41,6 @@ final class NSErrorValueTransformer: NSSecureUnarchiveFromDataTransformer {
     }
 }
 
-@available(iOS 12.0, *)
 @objc
 final class SetValueTransformer: NSSecureUnarchiveFromDataTransformer {
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -375,11 +375,9 @@ typedef NS_ENUM(NSInteger, SettingsTextSections) {
         requiresSecureTextEntry = YES;
     } else if (newMode == SettingsTextModesNewPassword) {
         requiresSecureTextEntry = YES;
-        if (@available(iOS 12.0, *)) {
-            NSString *passwordDescriptor = @"required: lower; required: upper; required: digit; required: [&)*]]; minlength: 6; maxlength: 24;";
-            self.textField.passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:passwordDescriptor];
-            self.textField.textContentType = UITextContentTypeNewPassword;
-        }
+        NSString *passwordDescriptor = @"required: lower; required: upper; required: digit; required: [&)*]]; minlength: 6; maxlength: 24;";
+        self.textField.passwordRules = [UITextInputPasswordRules passwordRulesWithDescriptor:passwordDescriptor];
+        self.textField.textContentType = UITextContentTypeNewPassword;
     } else if (newMode == SettingsTextModesEmail) {
         keyboardType = UIKeyboardTypeEmailAddress;
         autocapitalizationType = UITextAutocapitalizationTypeNone;


### PR DESCRIPTION
The app targets iOS 14 and above.

## Testing

If CI is green, we're good.

## See also

- https://github.com/wordpress-mobile/WordPress-iOS/pull/19699
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19709

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
