### PR TITLE
Remove unnecessary `SchedulingViewControllerProtocol`

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
@@ -26,7 +26,7 @@ class DateCoordinator {
 // MARK: - Date Picker
 
 @available(iOS, introduced: 14.0)
-class SchedulingDatePickerViewController: UIViewController, DatePickerSheet, DateCoordinatorHandler, SchedulingViewControllerProtocol {
+class SchedulingDatePickerViewController: UIViewController, DatePickerSheet, DateCoordinatorHandler, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate {
 
     var coordinator: DateCoordinator? = nil
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingViewControllerPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingViewControllerPresenter.swift
@@ -25,7 +25,7 @@ class PresentableSchedulingViewControllerProvider: PresentableSchedulingViewCont
                                                onDismiss: onDismiss)
     }
 
-    static func wrappedSchedulingViewController(_ schedulingViewController: SchedulingViewControllerProtocol,
+    static func wrappedSchedulingViewController(_ schedulingViewController: SchedulingDatePickerViewController,
                                                 sourceView: UIView?,
                                                 sourceRect: CGRect?,
                                                 transitioningDelegate: UIViewControllerTransitioningDelegate?,
@@ -48,7 +48,7 @@ class PresentableSchedulingViewControllerProvider: PresentableSchedulingViewCont
         return vc
     }
 
-    static func schedulingViewController(with viewModel: PublishSettingsViewModel, updated: @escaping (Date?) -> Void) -> SchedulingViewControllerProtocol {
+    static func schedulingViewController(with viewModel: PublishSettingsViewModel, updated: @escaping (Date?) -> Void) -> SchedulingDatePickerViewController {
         let schedulingViewController = SchedulingDatePickerViewController()
         schedulingViewController.coordinator = DateCoordinator(date: viewModel.date,
                                                                timeZone: viewModel.timeZone,
@@ -57,15 +57,6 @@ class PresentableSchedulingViewControllerProvider: PresentableSchedulingViewCont
                                                                updated: updated)
         return schedulingViewController
     }
-}
-
-// FIXME: This protocol is redundant as of dropping iOS 13.
-//
-// It was used as a facade in between `SchedulingCalendarViewController` (iOS 13) and
-// `SchedulingDatePickerViewController` (iOS 14+). `SchedulingCalendarViewController` has been
-// deleted so we can remove this as well.
-protocol SchedulingViewControllerProtocol: UIViewController, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate {
-    var coordinator: DateCoordinator? { get set }
 }
 
 class SchedulingLightNavigationController: LightNavigationController {


### PR DESCRIPTION
This protocol used to be a facade between `SchedulingDatePickerViewController` and `SchedulingCalendarViewController` but the latter has been removed in a60d3d994d9dd978a5d2f5b65332b449a1586997 during the [iOS 13 Widgets removal](https://github.com/wordpress-mobile/WordPress-iOS/pull/19509) so we can remove the abstraction.

## Testing

If CI builds, we're good to go.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
