### PR TITLE
Remove redundant `available(iOS 14, *)` annotations and checks

### DIFF
--- a/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
+++ b/WordPress/Classes/Extensions/UITextField+WorkaroundContinueIssue.swift
@@ -9,11 +9,7 @@ extension UITextField {
     /// Once we drop support for iOS 14, we could remove this extension entirely.
     ///
     public class func shouldActivateWorkaroundForBulgarianKeyboardCrash() -> Bool {
-        if #available(iOS 14.0, *) {
-            return true
-        }
-
-        return false
+        return true
     }
 
     /// We're swizzling `UITextField.becomeFirstResponder()` so that we can fix an issue with

--- a/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
+++ b/WordPress/Classes/Services/Stories/WPMediaPicker+MediaPicker.swift
@@ -60,8 +60,7 @@ class WPMediaPickerForKanvas: WPNavigationMediaPickerViewController, MediaPicker
         photoPicker.dataSource = WPPHAssetDataSource.sharedInstance()
         photoPicker.tabBarItem = UITabBarItem(title: Constants.photosTabBarTitle, image: Constants.photosTabBarIcon, tag: 0)
 
-        if #available(iOS 14.0, *),
-           FeatureFlag.mediaPickerPermissionsNotice.enabled {
+        if FeatureFlag.mediaPickerPermissionsNotice.enabled {
             photoPicker.mediaPicker.registerClass(forCustomHeaderView: DeviceMediaPermissionsHeader.self)
         }
 
@@ -182,8 +181,7 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerShouldShowCustomHeaderView(_ picker: WPMediaPickerViewController) -> Bool {
-        guard #available(iOS 14.0, *),
-              FeatureFlag.mediaPickerPermissionsNotice.enabled,
+        guard FeatureFlag.mediaPickerPermissionsNotice.enabled,
               picker.dataSource is WPPHAssetDataSource else {
             return false
         }
@@ -192,10 +190,6 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerReferenceSize(forCustomHeaderView picker: WPMediaPickerViewController) -> CGSize {
-        guard #available(iOS 14.0, *) else {
-            return .zero
-        }
-
         let header = DeviceMediaPermissionsHeader()
         header.translatesAutoresizingMaskIntoConstraints = false
 
@@ -203,8 +197,7 @@ class MediaPickerDelegate: NSObject, WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, configureCustomHeaderView headerView: UICollectionReusableView) {
-        guard #available(iOS 14.0, *),
-              let headerView = headerView as? DeviceMediaPermissionsHeader else {
+        guard let headerView = headerView as? DeviceMediaPermissionsHeader else {
             return
         }
 

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -18,34 +18,22 @@ class StatsWidgetsStore {
 
         if let newTodayData = refreshStats(type: HomeWidgetTodayData.self) {
             HomeWidgetTodayData.write(items: newTodayData)
-
-            if #available(iOS 14.0, *) {
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
-            }
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.todayKind)
         }
 
         if let newAllTimeData = refreshStats(type: HomeWidgetAllTimeData.self) {
             HomeWidgetAllTimeData.write(items: newAllTimeData)
-
-            if #available(iOS 14.0, *) {
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
-            }
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.allTimeKind)
         }
 
         if let newThisWeekData = refreshStats(type: HomeWidgetThisWeekData.self) {
             HomeWidgetThisWeekData.write(items: newThisWeekData)
-
-            if #available(iOS 14.0, *) {
-                WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
-            }
+            WidgetCenter.shared.reloadTimelines(ofKind: AppConfiguration.Widget.Stats.thisWeekKind)
         }
     }
 
     /// Initialize the local cache for widgets, if it does not exist
     func initializeStatsWidgetsIfNeeded() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
         if HomeWidgetTodayData.read() == nil {
             DDLogInfo("StatsWidgets: Writing initialization data into HomeWidgetTodayData.plist")
             HomeWidgetTodayData.write(items: initializeHomeWidgetData(type: HomeWidgetTodayData.self))
@@ -70,8 +58,7 @@ class StatsWidgetsStore {
     ///   - widgetType: concrete type of the widget
     ///   - stats: stats to be stored
     func storeHomeWidgetData<T: HomeWidgetData>(widgetType: T.Type, stats: Codable) {
-        guard #available(iOS 14.0, *),
-              let siteID = SiteStatsInformation.sharedInstance.siteID else {
+        guard let siteID = SiteStatsInformation.sharedInstance.siteID else {
             return
         }
 
@@ -243,9 +230,6 @@ private extension StatsWidgetsStore {
 // MARK: - Extract this week data
 extension StatsWidgetsStore {
     func updateThisWeekHomeWidget(summary: StatsSummaryTimeIntervalData?) {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
         switch summary?.period {
         case .day:
             guard summary?.periodEndDate == StatsDataHelper.currentDateForSite().normalizedDate() else {
@@ -269,10 +253,6 @@ private extension StatsWidgetsStore {
     /// Observes WPAccountDefaultWordPressComAccountChanged notification and reloads widget data based on the state of account.
     /// The site data is not yet loaded after this notification and widget data cannot be cached for newly signed in account.
     func observeAccountChangesForWidgets() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-
         NotificationCenter.default.addObserver(forName: .WPAccountDefaultWordPressComAccountChanged,
                                                object: nil,
                                                queue: nil) { notification in
@@ -294,10 +274,6 @@ private extension StatsWidgetsStore {
     /// Observes WPSigninDidFinishNotification notification and initializes the widget.
     /// The site data is loaded after this notification and widget data can be cached.
     func observeAccountSignInForWidgets() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-
         NotificationCenter.default.addObserver(forName: NSNotification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification),
                                                object: nil,
                                                queue: nil) { [weak self] _ in
@@ -307,10 +283,6 @@ private extension StatsWidgetsStore {
 
     /// Observes applicationLaunchCompleted notification and runs migration.
     func observeApplicationLaunched() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-
         NotificationCenter.default.addObserver(forName: NSNotification.Name.applicationLaunchCompleted,
                                                object: nil,
                                                queue: nil) { [weak self] _ in

--- a/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/InteractiveNotificationsManager.swift
@@ -619,11 +619,7 @@ extension InteractiveNotificationsManager: UNUserNotificationCenterDelegate {
         if notification.request.content.categoryIdentifier == NoteCategoryDefinition.bloggingReminderWeekly.rawValue
             || notification.request.content.categoryIdentifier == NoteCategoryDefinition.weeklyRoundup.rawValue {
 
-            if #available(iOS 14.0, *) {
-                completionHandler([.banner, .list, .sound])
-            } else {
-                completionHandler([.alert, .sound])
-            }
+            completionHandler([.banner, .list, .sound])
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -636,8 +636,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
         // Required to work around an issue present in iOS 14 beta 2
         // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
-        if #available(iOS 14.0, *),
-            presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
+        if presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
             dismiss(animated: true)
         }
     }
@@ -1326,8 +1325,7 @@ private extension AztecPostViewController {
 
         alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle)
 
-        if #available(iOS 14.0, *),
-            let button = navigationBarManager.moreBarButtonItem.customView {
+        if let button = navigationBarManager.moreBarButtonItem.customView {
             // Required to work around an issue present in iOS 14 beta 2
             // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
             alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteIconPickerView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteIconPickerView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 import UIKit
 
-@available(iOS 14.0, *)
 struct SiteIconPickerView: View {
     private let initialIcon = Image("blavatar-default")
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController+SiteIcon.swift
@@ -92,10 +92,6 @@ extension SitePickerViewController {
     }
 
     func showEmojiPicker() {
-        guard #available(iOS 14.0, *) else {
-            return
-        }
-
         var pickerView = SiteIconPickerView()
 
         pickerView.onCompletion = { [weak self] image in

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -88,11 +88,7 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
             showUpdateSiteIconAlert()
         }
 
-        if #available(iOS 14.0, *) {
-            showSiteIconSelectionAlert()
-        } else {
-            showUpdateSiteIconAlert()
-        }
+        showSiteIconSelectionAlert()
     }
 
     func siteIconReceivedDroppedImage(_ image: UIImage?) {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergMediaPickerHelper.swift
@@ -68,8 +68,7 @@ class GutenbergMediaPickerHelper: NSObject {
         picker.delegate = self
         picker.mediaPicker.registerClass(forReusableCellOverlayViews: DisabledVideoOverlay.self)
 
-        if #available(iOS 14.0, *),
-           FeatureFlag.mediaPickerPermissionsNotice.enabled {
+        if FeatureFlag.mediaPickerPermissionsNotice.enabled {
             picker.mediaPicker.registerClass(forCustomHeaderView: DeviceMediaPermissionsHeader.self)
         }
 
@@ -137,8 +136,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerShouldShowCustomHeaderView(_ picker: WPMediaPickerViewController) -> Bool {
-        guard #available(iOS 14.0, *),
-              FeatureFlag.mediaPickerPermissionsNotice.enabled,
+        guard FeatureFlag.mediaPickerPermissionsNotice.enabled,
               picker !== cameraPicker else {
             return false
         }
@@ -147,10 +145,6 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerReferenceSize(forCustomHeaderView picker: WPMediaPickerViewController) -> CGSize {
-        guard #available(iOS 14.0, *) else {
-            return .zero
-        }
-
         let header = DeviceMediaPermissionsHeader()
         header.translatesAutoresizingMaskIntoConstraints = false
 
@@ -158,8 +152,7 @@ extension GutenbergMediaPickerHelper: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, configureCustomHeaderView headerView: UICollectionReusableView) {
-        guard #available(iOS 14.0, *),
-              let headerView = headerView as? DeviceMediaPermissionsHeader else {
+        guard let headerView = headerView as? DeviceMediaPermissionsHeader else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -73,8 +73,7 @@ extension GutenbergViewController {
             ActionDispatcher.dispatch(NoticeAction.unlock)
         }
 
-        if #available(iOS 14.0, *),
-            let button = navigationBarManager.moreBarButtonItem.customView {
+        if let button = navigationBarManager.moreBarButtonItem.customView {
             // Required to work around an issue present in iOS 14 beta 2
             // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
             alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -402,8 +402,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
         // Required to work around an issue present in iOS 14 beta 2
         // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
-        if #available(iOS 14.0, *),
-            presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
+        if presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
             dismiss(animated: true)
         }
     }

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -74,20 +74,16 @@ extension Gutenberg.MediaType {
     private func getTypesFrom(_ allTypes: [String], conformingTo uttype: CFString) -> [String] {
 
         return allTypes.filter {
-            if #available(iOS 14.0, *) {
-                guard let allowedType = UTType($0), let requiredType = UTType(uttype as String) else {
-                    return false
-                }
-                // Sometimes the compared type could be a supertype
-                // For example a self-hosted site without Jetpack may have "public.content" as allowedType
-                // Although "public.audio" conforms to "public.content", it's not true the other way around
-                if allowedType.isSupertype(of: requiredType) {
-                    return true
-                }
-                return allowedType.conforms(to: requiredType)
-            } else {
-                return UTTypeConformsTo($0 as CFString, uttype)
+            guard let allowedType = UTType($0), let requiredType = UTType(uttype as String) else {
+                return false
             }
+            // Sometimes the compared type could be a supertype
+            // For example a self-hosted site without Jetpack may have "public.content" as allowedType
+            // Although "public.audio" conforms to "public.content", it's not true the other way around
+            if allowedType.isSupertype(of: requiredType) {
+                return true
+            }
+            return allowedType.conforms(to: requiredType)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Media/DeviceMediaPermissionsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Media/DeviceMediaPermissionsHeader.swift
@@ -4,7 +4,6 @@ import PhotosUI
 /// Displays a notice at the top of a media picker view in the event that the user has only given the app
 /// limited photo library permissions. Contains buttons allowing the user to select more images or review their settings.
 ///
-@available(iOS 14.0, *)
 class DeviceMediaPermissionsHeader: UICollectionReusableView {
 
     weak var presenter: UIViewController?

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryPicker.swift
@@ -24,8 +24,7 @@ final class MediaLibraryPicker: NSObject {
         picker.delegate = delegate
         picker.mediaPicker.registerClass(forReusableCellOverlayViews: DisabledVideoOverlay.self)
 
-        if #available(iOS 14.0, *),
-           FeatureFlag.mediaPickerPermissionsNotice.enabled {
+        if FeatureFlag.mediaPickerPermissionsNotice.enabled {
             picker.mediaPicker.registerClass(forCustomHeaderView: DeviceMediaPermissionsHeader.self)
         }
 

--- a/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaLibraryViewController.swift
@@ -573,8 +573,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerShouldShowCustomHeaderView(_ picker: WPMediaPickerViewController) -> Bool {
-        guard #available(iOS 14.0, *),
-              FeatureFlag.mediaPickerPermissionsNotice.enabled,
+        guard FeatureFlag.mediaPickerPermissionsNotice.enabled,
               picker != self else {
             return false
         }
@@ -584,10 +583,6 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerControllerReferenceSize(forCustomHeaderView picker: WPMediaPickerViewController) -> CGSize {
-        guard #available(iOS 14.0, *) else {
-            return .zero
-        }
-
         let header = DeviceMediaPermissionsHeader()
         header.translatesAutoresizingMaskIntoConstraints = false
 
@@ -595,8 +590,7 @@ extension MediaLibraryViewController: WPMediaPickerViewControllerDelegate {
     }
 
     func mediaPickerController(_ picker: WPMediaPickerViewController, configureCustomHeaderView headerView: UICollectionReusableView) {
-        guard #available(iOS 14.0, *),
-              let headerView = headerView as? DeviceMediaPermissionsHeader else {
+        guard let headerView = headerView as? DeviceMediaPermissionsHeader else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/SchedulingDatePickerViewController.swift
@@ -25,7 +25,6 @@ class DateCoordinator {
 
 // MARK: - Date Picker
 
-@available(iOS, introduced: 14.0)
 class SchedulingDatePickerViewController: UIViewController, DatePickerSheet, DateCoordinatorHandler, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate {
 
     var coordinator: DateCoordinator? = nil
@@ -129,7 +128,6 @@ class SchedulingDatePickerViewController: UIViewController, DatePickerSheet, Dat
     }
 }
 
-@available(iOS 14.0, *)
 extension SchedulingDatePickerViewController {
     @objc func presentationController(forPresented presented: UIViewController, presenting: UIViewController?, source: UIViewController) -> UIPresentationController? {
         let presentationController = PartScreenPresentationController(presentedViewController: presented, presenting: presenting)
@@ -143,7 +141,7 @@ extension SchedulingDatePickerViewController {
 }
 
 // MARK: Accessibility
-@available(iOS 14.0, *)
+
 private extension SchedulingDatePickerViewController {
     func setupForAccessibility() {
         let notificationNames = [

--- a/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderTableCardCell.swift
@@ -34,11 +34,9 @@ class ReaderTopicsTableCardCell: UITableViewCell {
         setupTableView()
         applyStyles()
 
-        // iOS 14 puts the contentView in the top of the view hierarchy
-        // This conflicts with the tableView interaction, so we disable it
-        if #available(iOS 14, *) {
-            contentView.isUserInteractionEnabled = false
-        }
+        // Since iOS 14, the contentView is in the top of the view hierarchy.
+        // This conflicts with the tableView interaction, so we disable it.
+        contentView.isUserInteractionEnabled = false
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/ActionSheetViewController.swift
@@ -148,15 +148,7 @@ class ActionSheetViewController: UIViewController {
     }
 
     private func createButton(_ handler: @escaping () -> Void) -> UIButton {
-        let button: UIButton
-        if #available(iOS 14.0, *) {
-            button = UIButton(type: .custom, primaryAction: UIAction(handler: { _ in handler() }))
-        } else {
-            button = ClosureButton(frame: .zero, closure: {
-                handler()
-            })
-        }
-
+        let button = UIButton(type: .custom, primaryAction: UIAction(handler: { _ in handler() }))
         button.titleLabel?.font = Constants.Button.font
         button.setTitleColor(Constants.Button.textColor, for: .normal)
         button.imageView?.tintColor = Constants.Button.imageTintColor

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -18,12 +18,7 @@ extension XCTestCase {
         app.activate()
 
         // Media permissions alert handler
-        let alertButtonTitle: String
-        if #available(iOS 14.0, *) {
-            alertButtonTitle = "Allow Access to All Photos"
-        } else {
-            alertButtonTitle = "OK"
-        }
+        let alertButtonTitle = "Allow Access to All Photos"
         systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
     }
 


### PR DESCRIPTION
The app targets iOS 14.0+ making them always true.

## Testing

If CI builds, we're good.

## See also

- https://github.com/wordpress-mobile/WordPress-iOS/pull/19699
- https://github.com/wordpress-mobile/WordPress-iOS/pull/19707

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
