### PR TITLE
Export and import blogging reminders using the blog's url

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -160,14 +160,22 @@ class BloggingRemindersScheduler {
 
     private static func copyStoreToSharedFile() {
         guard let store = try? defaultStore(),
-              let fileUrl = try? defaultDataFileURL(),
               let sharedFileUrl = sharedDataFileURL() else {
             return
         }
 
-        // Only copy the file if we have at least one reminder schedule
-        if store.configuration.count > 0 {
-            try? FileManager.default.copyItem(at: fileUrl, to: sharedFileUrl)
+        var configuration = [String: ScheduledReminders]()
+        for (blogIdentifier, schedule) in store.configuration {
+            guard let objectID = ContextManager.shared.mainContext.persistentStoreCoordinator?.managedObjectID(forURIRepresentation: blogIdentifier),
+                  let blog = ContextManager.shared.mainContext.object(with: objectID) as? Blog,
+                  let url = blog.url else {
+                continue
+            }
+            configuration[url] = schedule
+        }
+
+        if configuration.count > 0 {
+            try? PropertyListEncoder().encode(configuration).write(to: sharedFileUrl)
         }
     }
 
@@ -175,16 +183,21 @@ class BloggingRemindersScheduler {
         guard let localStore = try? defaultStore(),
               let sharedFileUrl = sharedDataFileURL(),
               FileManager.default.fileExists(at: sharedFileUrl),
-              let sharedStore = try? BloggingRemindersStore(dataFileURL: sharedFileUrl) else {
+              let data = try? Data(contentsOf: sharedFileUrl),
+              let sharedConfig = try? PropertyListDecoder().decode([String: ScheduledReminders].self, from: data) else {
             return
         }
 
         // Only copy if the existing local store contains no schedules
         if localStore.configuration.count == 0 {
-            for blogIdentifier in sharedStore.configuration.keys {
-                let schedule = sharedStore.scheduledReminders(for: blogIdentifier)
+            for (blogUrl, schedule) in sharedConfig {
+                guard let blog = try? BlogQuery().hostname(matching: blogUrl).blog(in: ContextManager.shared.mainContext) else {
+                    continue
+                }
+                let blogIdentifier = blog.objectID.uriRepresentation()
                 try? localStore.save(scheduledReminders: schedule, for: blogIdentifier)
             }
+            try? FileManager.default.removeItem(at: sharedFileUrl)
         }
     }
 


### PR DESCRIPTION
Ref pcdRpT-1i3-p2#comment-2128

## Description

Uses the blog's URL as the key when exporting/importing the blogging reminder schedules instead of the object ID.

## Testing

To test:

- Enable the feature flags `jetpackPoweredBottomSheet` & `contentMigration`
- Install WordPress and login
- Set a blogging reminder on a site or multiple sites
- Trigger the migration with a Jetpack banner
- Install Jetpack
- Go through the data migration screens
- Verify the blogging reminder schedules are there for the same site(s) (Note: if you have reminders set with blogging prompts in Jetpack, those will take precedence over a local schedule)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.