### PR TITLE
[Jetpack Content Migration] Enable Content Migration Flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 
 21.3
 -----
+* [***] Adds a smooth, opt-in transition to the Jetpack app. [#19714]
 * [*] [internal] When a user migrates to the Jetpack app and allows notifications, WordPress app notifications are disabled. This is released disabled and is behind a feature flag. [#19616, #19611, #19590]
 * [*] Fixed a minor UI issue where the segmented control under My SIte was being clipped when "Home" is selected. [#19595]
 * [*] Fixed an issue where the site wasn't removed and the app wasn't refreshed after disconnecting the site from WordPress.com. [#19634]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -113,9 +113,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackPowered:
             return true
         case .jetpackPoweredBottomSheet:
-            return false
+            return true
         case .contentMigration:
-            return false
+            return true
         case .newJetpackLandingScreen:
             return true
         case .newWordPressLandingScreen:


### PR DESCRIPTION
Closes #19659

## Description

Activates the Jetpack migration flow by enabling the following feature flags:
- `jetpackPoweredBottomSheet`
- `contentMigration`

## Regression Notes
1. Potential unintended areas of impact
    - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing

3. What automated tests I added (or what prevented me from doing so)
    - Tests were added during feature development

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
