### PR TITLE
Post / Page creation: Don't send default Post.authorID to the API

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 21.4
 -----
+* [*] Fixed an issue where publishing Posts and Pages could fail under certain conditions. [#19717]
 * [*] Share extension navigation bar is no longer transparent [#19700]
 
 21.3

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -160,6 +160,13 @@ forceDraftIfCreating:(BOOL)forceDraftIfCreating
            success:(nullable void (^)(void))success
            failure:(void (^)(NSError * _Nullable error))failure;
 
+/**
+ Creates a RemotePost from an AbstractPost to be used for API calls.
+
+ @param post The AbstractPost used to create the RemotePost
+ */
+- (RemotePost *)remotePostWithPost:(AbstractPost *)post;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -814,7 +814,11 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
     remotePost.password = post.password;
     remotePost.type = @"post";
     remotePost.authorAvatarURL = post.authorAvatarURL;
-    remotePost.authorID = post.authorID;
+    // If a Post's authorID is 0 (the default Core Data value)
+    // or nil, don't send it to the API.
+    if (post.authorID.integerValue != 0) {
+        remotePost.authorID = post.authorID;
+    }
     remotePost.excerpt = post.mt_excerpt;
     remotePost.slug = post.wp_slug;
 

--- a/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
+++ b/WordPress/WordPressTest/Services/PostServiceWPComTests.swift
@@ -293,6 +293,49 @@ class PostServiceWPComTests: CoreDataTestCase {
         wait(for: [expectation], timeout: timeout)
     }
 
+    /// The default `Post.authorID` value (currently 0 in the Core Data model) should
+    /// be `nil` for `RemotePost`s.
+    func testRemotePostAuthorIDNilForDefaultPostAuthorID() {
+        // Given
+        let post = PostBuilder(mainContext).build()
+        try! mainContext.save()
+
+        // When
+        let remotePost = self.service.remotePost(with: post)
+
+        // Then
+        XCTAssertNil(remotePost.authorID)
+    }
+
+    /// `Post.authorID`s set to `nil` should be `nil` for `RemotePost`s.
+    func testRemotePostAuthorIDNilForNilPostAuthorID() {
+        // Given
+        let post = PostBuilder(mainContext).build()
+        post.authorID = nil
+        try! mainContext.save()
+
+        // When
+        let remotePost = self.service.remotePost(with: post)
+
+        // Then
+        XCTAssertNil(remotePost.authorID)
+    }
+
+    /// `Post.authorID`s set to a valid value should be reflected in `RemotePost`s.
+    func testRemotePostAuthorSetForValidPostAuthorID() {
+        // Given
+        let expectedAuthorID: NSNumber = 1
+        let post = PostBuilder(mainContext).build()
+        post.authorID = expectedAuthorID
+        try! mainContext.save()
+
+        // When
+        let remotePost = self.service.remotePost(with: post)
+
+        // Then
+        XCTAssertEqual(remotePost.authorID, expectedAuthorID)
+    }
+
     private func createRemotePost(_ status: BasePost.Status = .draft) -> RemotePost {
         let remotePost = RemotePost(siteID: 1,
                                     status: status.rawValue,


### PR DESCRIPTION
Fixes #19589

## Description

This PR resolves an issue where the app could send an invalid author ID for Posts and Pages.

### Problem

When the app doesn't have a `Blog.userID` set and the user creates a new Post or Page, the app is setting the author ID to `0`, which is the default value for a `BasePost`'s author ID in the Core Data model. This `0` gets sent to the API which is an invalid author ID.

The main reason `Blog.userID` might not be set is because the [`updateMultiAuthor` method of `BlogService`](https://github.com/wordpress-mobile/WordPress-iOS/blob/466c3f7e5c2a8719b6452f27318f72d9e4c917b2/WordPress/Classes/Services/BlogService.m#L756) hasn't ran, or had a failure on the server side.

<details>
<summary>See technical summary</summary>

There currently exists a race where a new Post or Page can be created before the blog's user ID is populated. The call can also just outright fail, like any API call:

https://github.com/wordpress-mobile/WordPress-iOS/blob/466c3f7e5c2a8719b6452f27318f72d9e4c917b2/WordPress/Classes/Services/BlogService.m#L788-L790

If a new Post or Page is created before the blog's user ID is populated, the post's author ID never gets set

https://github.com/wordpress-mobile/WordPress-iOS/blob/bff014b290251b33c7ec021922dc3a9dbe47f427/WordPress/Classes/Models/Blog%2BPost.swift#L58-L61

So it sticks with the default value assigned when instantiating (in this case) the Post:

https://github.com/wordpress-mobile/WordPress-iOS/blob/bff014b290251b33c7ec021922dc3a9dbe47f427/WordPress/Classes/Models/Blog%2BPost.swift#L45

**At first glance this doesn't appear to be a problem, since:**
- It's OK to not send an author to the API - it will default to the authenticated user creating the post
- The Post / Page's `authorID` [is an optional](https://github.com/wordpress-mobile/WordPress-iOS/blob/466c3f7e5c2a8719b6452f27318f72d9e4c917b2/WordPress/Classes/Models/BasePost.h#L12) `NSNumber`, so we assume it would default to `nil`
- Author IDs that aren't set aren't sent to the API [[REST](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/146821b4364723b00392cbdcdb452f2036f158f6/WordPressKit/PostServiceRemoteREST.m#L548)] [[XML-RPC](https://github.com/wordpress-mobile/WordPressKit-iOS/blob/146821b4364723b00392cbdcdb452f2036f158f6/WordPressKit/PostServiceRemoteXMLRPC.m#L386)]

The issue is that `BasePost.authorID` defaults to `0` in the [Core Data model](https://github.com/wordpress-mobile/WordPress-iOS/tree/eb7da677caf8256a881e8037034900b7eb8117dc/WordPress/Classes/WordPress.xcdatamodeld/WordPress%20145.xcdatamodel).

So in these cases we're sending a `0` for the author ID instead of not sending the value, which can result in errors like:

```
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>404</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>Invalid author ID.</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```

What worsens the issue is that once a Post or Page has been created by the app, the invalid author ID of `0` is stuck to it. Even if the blog's user ID is synced later on, it will only fix the issue for _new_ Posts and Pages.

Another potential solution would be to remove the default value of `0` from the Core Data model, but this could introduce risk to [existing logic](https://github.com/wordpress-mobile/WordPress-iOS/blob/2e9e096c03ce8450615e1ad01519c17cc0f41957/WordPress/Classes/ViewRelated/Post/PostListViewController.swift#L509).

</details>

### Potential workarounds

- Add another user to the site so it becomes multi-author and unlocks the author picker in the Post and Page settings. Selecting the correct author should update the value and allow the user to publish.
- For user roles who can't query other authors (lower than Editor), temporarily elevate their permissions.

### Solution

If a Post or Page's author ID hasn't been set locally, we shouldn't send a value to the API.

## Testing

_Both the WordPress and Jetpack apps should be tested._

### Self-hosted site publishing
1. Clean install the app
2. Spin up a new self-hosted site, not connected to Jetpack
3. Quickly create a Post or Page after logging into the site in the app
4. Publish it
5. **Expect** the Post or Page to successfully publish

### Self-hosted site connected to Jetpack
1. Clean install the app
2. Quickly create a Post or Page after logging into the site in the app
3. Publish it
4. **Expect** the Post or Page to successfully publish

### WordPress.com site
1. Clean install the app
2. Quickly create a Post or Page after logging into the site in the app
4. Publish it
5. **Expect** the Post or Page to successfully publish

### Multi-user sites as an Admin or Editor role
This test should be ran with an Admin or Editor role.
- [.com roles](https://wordpress.com/support/user-roles/)
- [.org roles](https://wordpress.org/support/article/roles-and-capabilities/)

1. On a site with multiple users, create a new Post or Page (If a site only has one user, add at least one more)
2. In the settings for the Page or Post, change the author and publish it
3. **Expect** the Post or Page to successfully publish
4. **Expect** the Post or Page to be assigned to the author in step 2

### Multi-user sites as an Author or Contributor role
This test should be ran with an Author or Contributor role.
- [.com roles](https://wordpress.com/support/user-roles/)
- [.org roles](https://wordpress.org/support/article/roles-and-capabilities/)

1. On a site with multiple users, create a new Post or Page (If a site only has one user, add at least one more)
2. **Expect** to not see the option to change the author in the Post or Page settings
3. **Expect** the Post or Page to successfully publish if user is an Author (**note:** Contributors cannot publish)

## Regression Notes
1. Potential unintended areas of impact
   - Publishing Posts and Pages
   - Author selection in Post / Page settings for multi-author sites

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing and existing automated tests.

3. What automated tests I added (or what prevented me from doing so)
   - Added tests for constructing a `RemotePost` (e905ae561012158fe42f3131b4821b8ec676751f)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
