### PR TITLE
Track Load WordPress screen events and content export events

### DIFF
--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -101,12 +101,17 @@ private extension JetpackWindowManager {
     func showLoadWordPressUI(schemeUrl: URL) {
         let actions = MigrationLoadWordPressViewModel.Actions()
         let loadWordPressViewModel = MigrationLoadWordPressViewModel(actions: actions)
-        let loadWordPressViewController = MigrationLoadWordPressViewController(viewModel: loadWordPressViewModel)
-        actions.primary = {
+        let loadWordPressViewController = MigrationLoadWordPressViewController(
+            viewModel: loadWordPressViewModel,
+            tracker: migrationTracker
+        )
+        actions.primary = { [weak self] in
+            self?.migrationTracker.track(.loadWordPressScreenOpenTapped)
             UIApplication.shared.open(schemeUrl)
         }
-        actions.secondary = { [weak self] in
-            loadWordPressViewController.dismiss(animated: true) {
+        actions.secondary = { [weak self, weak loadWordPressViewController] in
+            self?.migrationTracker.track(.loadWordPressScreenNoThanksTapped)
+            loadWordPressViewController?.dismiss(animated: true) {
                 self?.showSignInUI()
             }
         }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
@@ -9,6 +9,22 @@ struct MigrationAnalyticsTracker {
         WPAnalytics.track(event)
     }
 
+    // MARK: - Content Export
+
+    func trackContentExportEligibility(eligible: Bool) {
+        let properties = ["eligible": String(eligible)]
+        self.track(.contentExportEligibility, properties: properties)
+    }
+
+    func trackContentExportSucceeded() {
+        self.track(.contentExportSucceeded)
+    }
+
+    func trackContentExportFailed(reason: String) {
+        let properties = ["error_type": reason]
+        self.track(.contentExportFailed, properties: properties)
+    }
+
     // MARK: - Content Import
 
     func trackContentImportEligibility(eligible: Bool) {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 enum MigrationEvent: String {
+    // Content Export
+    case contentExportEligibility = "migration_content_export_eligibility"
+    case contentExportSucceeded = "migration_content_export_succeeded"
+    case contentExportFailed = "migration_content_export_failed"
+
     // Content Import
     case contentImportEligibility = "migration_content_import_eligibility"
     case contentImportSucceeded = "migration_content_import_succeeded"
@@ -37,6 +42,11 @@ enum MigrationEvent: String {
     case pleaseDeleteWordPressScreenHelpTapped = "migration_please_delete_wordpress_screen_help_tapped"
     case pleaseDeleteWordPressScreenCloseTapped = "migration_please_delete_wordpress_screen_close_tapped"
 
-    // WordPress Migratable Stat
+    // Load WordPress
+    case loadWordPressScreenShown = "migration_load_wordpress_screen_shown"
+    case loadWordPressScreenOpenTapped = "migration_load_wordpress_screen_open_tapped"
+    case loadWordPressScreenNoThanksTapped = "migration_load_wordpress_screen_no_thanks_tapped"
+
+    // WordPress Migratable State
     case wordPressDetected = "migration_wordpressapp_detected"
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
@@ -5,11 +5,13 @@ class MigrationLoadWordPressViewController: UIViewController {
     // MARK: - Dependencies
 
     private let viewModel: MigrationLoadWordPressViewModel
+    private let tracker: MigrationAnalyticsTracker
 
     // MARK: - Init
 
-    init(viewModel: MigrationLoadWordPressViewModel) {
+    init(viewModel: MigrationLoadWordPressViewModel, tracker: MigrationAnalyticsTracker = .init()) {
         self.viewModel = viewModel
+        self.tracker = tracker
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -31,5 +33,10 @@ class MigrationLoadWordPressViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = MigrationAppearance.backgroundColor
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.tracker.track(.loadWordPressScreenShown)
     }
 }


### PR DESCRIPTION
Part of #19701 and #19640 

## Description

This PR adds tracking of the following migration events:

- **contentExportEligibility**: Fired on the WordPress side to indicate whether the app can export the content or not.
- **contentExportSucceeded**: Fired on the WordPress side when the content export succeeds
- **contentExportFailed**: Fired on the WordPress side when the content export fails
- **loadWordPressScreenShown**: Fired on the Jetpack side when the "Load WordPress" screen appears
- **loadWordPressScreenOpenTapped**:  Fired on the Jetpack side when the "Load WordPress" screen "Open WordPress" button tapped
- **loadWordPressScreenNoThanksTapped**: Fired on the Jetpack side when the "Load WordPress" screen "No Thanks" button tapped

## Test Instructions

### Load WordPress Screen Events

**Display Load WordPress Screen**
1. Clean install the WordPress app and authenticate.
2. Exit the WordPress app and don't reopen it. (This will prevent the pre-flight sequence from running)
3. Clean install the Jetpack app and keep it attached to the debugger.
4. **Expect:** UI to be shown explaining to the user they can open WordPress
5. **Expect:** These console logs to show up

```
🔵 Tracked: migration_content_export_eligibility <eligible: false>
🔵 Tracked: migration_content_import_eligibility <eligible: true>
🔵 Tracked: migration_wordpressapp_detected <compatible: true>
🔵 Tracked: migration_content_import_failed <error_type: The data wasn't ready to import>
🔵 Tracked: migration_load_wordpress_screen_shown <>
```

<details><summary><b>Case 1: Tapping Open WordPress Button</b></summary>
<p>

1. Tap "Open WordPress" button
2. **Expect:** WordPress to load into the foreground temporarily, and then the Jetpack app is brought back to the foreground.
3. **Expect:** The migration view to be shown in Jetpack.
4. **Expect:** These console logs to show up

```
🔵 Tracked: migration_load_wordpress_screen_open_tapped <>
🔵 Tracked: migration_wordpressapp_detected <compatible: true>
🔵 Tracked: migration_content_import_succeeded <>
🔵 Tracked: migration_email_triggered <>
🔵 Tracked: migration_welcome_screen_shown <>
🔵 Tracked: migration_email_sent <>
```

</p>
</details>

<details><summary><b>Case 2: Tapping No Thanks Button</b></summary>
<p>

1. Tap "No Thanks" button
2. **Expect:** The Jetpack Prologue screen to appear
3. **Expect:** These console logs to show up

```
🔵 Tracked: migration_load_wordpress_screen_no_thanks_tapped <>
```

</p>
</details>

### Content Export Events

1. Build and run WordPress app and keep it attached to debugger
2. Go to any Jetpack powered feature ( e.g Notifications screen )
3. Tap "Jetpack Powered" badge
4. Tap "Try the new Jetpack app"
5. **Expect**: These console logs to show up

```
🔵 Tracked: migration_content_export_succeeded <>
```

## Regression Notes
1. Potential unintended areas of impact
None.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

8. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
