### PR TITLE
CMF: Don't present the flow when feature flag is disabled

### DIFF
--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -9,7 +9,9 @@ class JetpackWindowManager: WindowManager {
     private let migrationTracker = MigrationAnalyticsTracker()
 
     var shouldImportMigrationData: Bool {
-        return !AccountHelper.isLoggedIn && !UserPersistentStoreFactory.instance().isJPContentImportComplete
+        return FeatureFlag.contentMigration.enabled
+        && !AccountHelper.isLoggedIn
+        && !UserPersistentStoreFactory.instance().isJPContentImportComplete
     }
 
     override func showUI(for blog: Blog?) {


### PR DESCRIPTION
This PR fixes an issue where the import process runs when the `contentMigration` feature flag is disabled. 

## To test

There are two ways to test this PR:

### Building the PR directly

- Have a compatible WordPress app installed.
- Go to `FeatureFlag.swift` and set the `contentMigration` value to `false`.
- Build & run the Jetpack app.
- 🔎 Verify that the Login screen is shown.

### Using an installable build

- Uninstall WordPress app from your device before installing Jetpack.
- Install Jetpack, and log in with any account.
- Go to App Settings > Debug > Disable Content Migration feature flag.
- Log out.
- Install the WordPress app. No need to log in.
- Open the Jetpack app again.
- 🔎  Verify that the Login screen is shown.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
