### PR TITLE
Update WordPress 21.3 release notes with Jetpack migration

### DIFF
--- a/WordPress/Resources/AppStoreStrings.po
+++ b/WordPress/Resources/AppStoreStrings.po
@@ -47,6 +47,8 @@ msgstr ""
 
 msgctxt "v21.3-whats-new"
 msgid ""
+"You can now migrate your site content to the Jetpack app without a hitch.\n"
+"\n"
 "We fixed a small visual issue with the Home and Menu control in the My Site dashboard.\n"
 "\n"
 "We also squashed a bug in My Site. The "Disconnect from WordPress.com” button now disconnects when tapped and will refresh the app.\n"

--- a/WordPress/Resources/release_notes.txt
+++ b/WordPress/Resources/release_notes.txt
@@ -1,3 +1,5 @@
+You can now migrate your site content to the Jetpack app without a hitch.
+
 We fixed a small visual issue with the Home and Menu control in the My Site dashboard.
 
 We also squashed a bug in My Site. The "Disconnect from WordPress.com” button now disconnects when tapped and will refresh the app.


### PR DESCRIPTION
See discussion at https://github.com/wordpress-mobile/WordPress-iOS/pull/19712#discussion_r1039564708

Given the urgency of getting these integrated and sent for translation, I used [the same copy as the Android app](https://github.com/wordpress-mobile/WordPress-Android/blob/0cb9dc18f7ff7bc4f34dbb931af3f4658853517a/WordPress/metadata/release_notes.txt#L1). Likewise, the entry is only in WordPress not in Jetpack, even though the raw `RELEASE-NOTES.txt` item doesn't mention it.