### PR TITLE
Reschedule notifications during migration when the permission is granted

### DIFF
--- a/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
+++ b/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
@@ -152,7 +152,7 @@ final class JetpackNotificationMigrationService: JetpackNotificationMigrationSer
         }
     }
 
-    private func rescheduleLocalNotifications() {
+    func rescheduleLocalNotifications() {
         DispatchQueue.main.async { [weak self] in
             self?.rescheduleWeeklyRoundupNotifications()
             self?.rescheduleBloggingReminderNotifications()

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -101,12 +101,17 @@ private extension JetpackWindowManager {
     func showLoadWordPressUI(schemeUrl: URL) {
         let actions = MigrationLoadWordPressViewModel.Actions()
         let loadWordPressViewModel = MigrationLoadWordPressViewModel(actions: actions)
-        let loadWordPressViewController = MigrationLoadWordPressViewController(viewModel: loadWordPressViewModel)
-        actions.primary = {
+        let loadWordPressViewController = MigrationLoadWordPressViewController(
+            viewModel: loadWordPressViewModel,
+            tracker: migrationTracker
+        )
+        actions.primary = { [weak self] in
+            self?.migrationTracker.track(.loadWordPressScreenOpenTapped)
             UIApplication.shared.open(schemeUrl)
         }
-        actions.secondary = { [weak self] in
-            loadWordPressViewController.dismiss(animated: true) {
+        actions.secondary = { [weak self, weak loadWordPressViewController] in
+            self?.migrationTracker.track(.loadWordPressScreenNoThanksTapped)
+            loadWordPressViewController?.dismiss(animated: true) {
                 self?.showSignInUI()
             }
         }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -9,7 +9,9 @@ class JetpackWindowManager: WindowManager {
     private let migrationTracker = MigrationAnalyticsTracker()
 
     var shouldImportMigrationData: Bool {
-        return !AccountHelper.isLoggedIn && !UserPersistentStoreFactory.instance().isJPContentImportComplete
+        return FeatureFlag.contentMigration.enabled
+        && !AccountHelper.isLoggedIn
+        && !UserPersistentStoreFactory.instance().isJPContentImportComplete
     }
 
     override func showUI(for blog: Blog?) {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
@@ -9,6 +9,22 @@ struct MigrationAnalyticsTracker {
         WPAnalytics.track(event)
     }
 
+    // MARK: - Content Export
+
+    func trackContentExportEligibility(eligible: Bool) {
+        let properties = ["eligible": String(eligible)]
+        self.track(.contentExportEligibility, properties: properties)
+    }
+
+    func trackContentExportSucceeded() {
+        self.track(.contentExportSucceeded)
+    }
+
+    func trackContentExportFailed(reason: String) {
+        let properties = ["error_type": reason]
+        self.track(.contentExportFailed, properties: properties)
+    }
+
     // MARK: - Content Import
 
     func trackContentImportEligibility(eligible: Bool) {

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 enum MigrationEvent: String {
+    // Content Export
+    case contentExportEligibility = "migration_content_export_eligibility"
+    case contentExportSucceeded = "migration_content_export_succeeded"
+    case contentExportFailed = "migration_content_export_failed"
+
     // Content Import
     case contentImportEligibility = "migration_content_import_eligibility"
     case contentImportSucceeded = "migration_content_import_succeeded"
@@ -37,6 +42,11 @@ enum MigrationEvent: String {
     case pleaseDeleteWordPressScreenHelpTapped = "migration_please_delete_wordpress_screen_help_tapped"
     case pleaseDeleteWordPressScreenCloseTapped = "migration_please_delete_wordpress_screen_close_tapped"
 
-    // WordPress Migratable Stat
+    // Load WordPress
+    case loadWordPressScreenShown = "migration_load_wordpress_screen_shown"
+    case loadWordPressScreenOpenTapped = "migration_load_wordpress_screen_open_tapped"
+    case loadWordPressScreenNoThanksTapped = "migration_load_wordpress_screen_no_thanks_tapped"
+
+    // WordPress Migratable State
     case wordPressDetected = "migration_wordpressapp_detected"
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
@@ -5,11 +5,13 @@ class MigrationLoadWordPressViewController: UIViewController {
     // MARK: - Dependencies
 
     private let viewModel: MigrationLoadWordPressViewModel
+    private let tracker: MigrationAnalyticsTracker
 
     // MARK: - Init
 
-    init(viewModel: MigrationLoadWordPressViewModel) {
+    init(viewModel: MigrationLoadWordPressViewModel, tracker: MigrationAnalyticsTracker = .init()) {
         self.viewModel = viewModel
+        self.tracker = tracker
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -31,5 +33,10 @@ class MigrationLoadWordPressViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = MigrationAppearance.backgroundColor
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        self.tracker.track(.loadWordPressScreenShown)
     }
 }

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Notifications Permission/MigrationNotificationsViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Notifications Permission/MigrationNotificationsViewModel.swift
@@ -14,6 +14,10 @@ class MigrationNotificationsViewModel {
                 coordinator?.transitionToNextStep()
                 let event: MigrationEvent = authorized ? .notificationsScreenPermissionGranted : .notificationsScreenPermissionDenied
                 tracker.track(event)
+
+                if authorized {
+                    JetpackNotificationMigrationService.shared.rescheduleLocalNotifications()
+                }
             }
         }
         let secondaryHandler = { [weak coordinator] in


### PR DESCRIPTION
Ref pcdRpT-1i3-p2#comment-2128

## Description

After a user grants the notification permission in Jetpack, we can reschedule their notifications.

## Testing

To test:

- Install WordPress and login
- Set a blogging reminder for a future time and same day
- Kick off the migration with a Jetpack banner
- Install Jetpack
- Finish the migration flow and grant notification permissions when prompted
- Wait for the scheduled time and verify a notification appears for reminders

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.