### PR TITLE
[Jetpack Content Migration] Disable Content Migration Flow

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 
 21.3
 -----
-* [***] Adds a smooth, opt-in transition to the Jetpack app. [#19714]
 * [*] [internal] When a user migrates to the Jetpack app and allows notifications, WordPress app notifications are disabled. This is released disabled and is behind a feature flag. [#19616, #19611, #19590]
 * [*] Fixed a minor UI issue where the segmented control under My SIte was being clipped when "Home" is selected. [#19595]
 * [*] Fixed an issue where the site wasn't removed and the app wasn't refreshed after disconnecting the site from WordPress.com. [#19634]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -113,9 +113,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackPowered:
             return true
         case .jetpackPoweredBottomSheet:
-            return true
+            return false
         case .contentMigration:
-            return true
+            return false
         case .newJetpackLandingScreen:
             return true
         case .newWordPressLandingScreen:


### PR DESCRIPTION
This PR reverts the commits from #19714 to disable the Content Migration Flow.

Related: https://github.com/wordpress-mobile/WordPress-iOS/pull/19735

## Testing

### Tapping a banner or badge in the WordPress app should _not_ show the Jetpack overlay

1. Load the WordPress app with an account authenticated into WordPress.com
2. Locate any view that has a Jetpack badge or banner (Notifications, Reader, etc.)
3. Tap the badge or banner
4. **Expect:** No Jetpack overlay view to be shown and no prompts to start a migration

### Loading the Jetpack app should not kick off a migration from the WordPress app 
Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19710

1. Clean install the WordPress app and authenticate.
2. Exit the WordPress app and don't reopen it. (This will prevent the pre-flight sequence from running)
3. Clean install the Jetpack app and load it.
4. **Expect**: To see the Jetpack landing / prologue login screen.

### Local build tests using Xcode debugger

1. Run the WordPress and Jetpack apps from local builds attached to the Xcode debugger
2. Monitor the debugger output for any messages related to the Jetpack migration

## Regression Notes
1. Potential unintended areas of impact
    - All features related to the migration should be behind feature flags, so thorough testing should be completed to confirm.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Testing steps above.

5. What automated tests I added (or what prevented me from doing so)
   - Automated tests added as part of the Jetpack Content Migration Flow.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
