### PR TITLE
[Jetpack Focus] Revert Jetpack Notifications Disabling Feature Flag and Release Notes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
 21.3
 -----
 * [***] Adds a smooth, opt-in transition to the Jetpack app. [#19714]
-* [*] [internal] When a user migrates to the Jetpack app and allows notifications, WordPress app notifications are disabled. This is released disabled and is behind a feature flag. [#19616, #19611, #19590]
 * [*] Fixed a minor UI issue where the segmented control under My SIte was being clipped when "Home" is selected. [#19595]
 * [*] Fixed an issue where the site wasn't removed and the app wasn't refreshed after disconnecting the site from WordPress.com. [#19634]
 * [*] [internal] Fixed an issue where Jetpack extensions were conflicting with WordPress extensions. [#19665]

--- a/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
+++ b/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
@@ -22,7 +22,7 @@ final class JetpackNotificationMigrationService: JetpackNotificationMigrationSer
     private let jetpackNotificationMigrationDefaultsKey = "jetpackNotificationMigrationDefaultsKey"
 
     private var jetpackMigrationPreventDuplicateNotifications: Bool {
-        return featureFlagStore.value(for: FeatureFlag.jetpackMigrationPreventDuplicateNotifications)
+        return FeatureFlag.jetpackMigrationPreventDuplicateNotifications.enabled
     }
 
     var wordPressNotificationsEnabled: Bool {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -123,7 +123,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newCoreDataContext:
             return true
         case .jetpackMigrationPreventDuplicateNotifications:
-            return true
+            return false
         case .jetpackFeaturesRemovalPhaseOne:
             return false
         case .jetpackFeaturesRemovalPhaseTwo:

--- a/WordPress/WordPressTest/JetpackNotificationMigrationServiceTests.swift
+++ b/WordPress/WordPressTest/JetpackNotificationMigrationServiceTests.swift
@@ -138,7 +138,11 @@ private class RemoteNotificationRegisterMock: RemoteNotificationRegister {
 }
 
 private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
-    var value = false
+    var value = false {
+        didSet {
+            try? FeatureFlagOverrideStore().override(FeatureFlag.jetpackMigrationPreventDuplicateNotifications, withValue: value)
+        }
+    }
 
     override func value(for flag: OverrideableFlag) -> Bool {
         return value


### PR DESCRIPTION
## Description

This PR that disables functionality of "Disable WordPress Notifications" project 

Reverting https://github.com/wordpress-mobile/WordPress-iOS/issues/19619

Internal ref: D94385-code

## Testing instructions

### Prerequisites

Confirm that `prevent_duplicate_notifs_remote_field":false` value exists in https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags

### Case 1: Notifications not disabled on WordPress app
1. Install WordPress app and log in
2. Go to Notification tab on WordPress app and accept iOS notification permission
3. Install Jetpack app and log in
4. Go to Notification tab on Jetpackk app and accept iOS notification permission
5. Jetpack app should not redirect to WordPress app
6. Trigger push notification (write a comment on a blog)
7. Both Jetpack and WordPress apps should receive comments

### Case 2. No "Allow Notifications" switch should be visible on WordPress
1. Install WordPress app and log in
2. Go to Notification tab on WordPress app and accept iOS notification permission
3. Staying on Notifications tab, click Settings icon on a top right corner
4. Confirm that there's no "Allow Notifications" setting at the top of the settings view

## Regression Notes

1. Potential unintended areas of impact

The feature is isolated, there shouldn't be side-effects if we confirm that Jetpack app doesn't turn off WordPress notifications

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

Existing JetpackNotificationMigrationServiceTests continues running and succeeding, that test both enabled and disabled cases

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.