### PR TITLE
[Jetpack Content Migration Flow] Put the ContentMigrationCoordinator behind feature flag

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -328,10 +328,12 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         setupWordPressExtensions()
 
-        // Start proactively exporting WP data in the background if the conditions are fulfilled.
-        // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
-        DispatchQueue.global().async {
-            ContentMigrationCoordinator.shared.startOnceIfNeeded()
+        if FeatureFlag.contentMigration.enabled {
+            // Start proactively exporting WP data in the background if the conditions are fulfilled.
+            // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
+            DispatchQueue.global().async {
+                ContentMigrationCoordinator.shared.startOnceIfNeeded()
+            }
         }
 
         shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -15,21 +15,25 @@ class JetpackWindowManager: WindowManager {
     }
 
     override func showUI(for blog: Blog?) {
-        // If the user is logged in and has blogs sync'd to their account
-        if AccountHelper.isLoggedIn && AccountHelper.hasBlogs {
-            showAppUI(for: blog)
+        if AccountHelper.isLoggedIn {
+            if AccountHelper.hasBlogs {
+                // If the user is logged in and has blogs sync'd to their account
+                showAppUI(for: blog)
+            } else {
+                // If the user doesn't have any blogs, but they're still logged in, log them out
+                // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
+                AccountHelper.logOutDefaultWordPressComAccount()
+            }
             return
         }
 
-        guard AccountHelper.isLoggedIn else {
-            self.migrationTracker.trackContentImportEligibility(eligible: shouldImportMigrationData)
-            shouldImportMigrationData ? importAndShowMigrationContent(blog) : showSignInUI()
+        guard FeatureFlag.contentMigration.enabled else {
+            showSignInUI()
             return
         }
 
-        // If the user doesn't have any blogs, but they're still logged in, log them out
-        // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
-        AccountHelper.logOutDefaultWordPressComAccount()
+        self.migrationTracker.trackContentImportEligibility(eligible: shouldImportMigrationData)
+        shouldImportMigrationData ? importAndShowMigrationContent(blog) : showSignInUI()
     }
 
     func importAndShowMigrationContent(_ blog: Blog? = nil) {

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -19,12 +19,13 @@ class JetpackWindowManager: WindowManager {
             if AccountHelper.hasBlogs {
                 // If the user is logged in and has blogs sync'd to their account
                 showAppUI(for: blog)
+                return
             } else {
                 // If the user doesn't have any blogs, but they're still logged in, log them out
                 // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
                 AccountHelper.logOutDefaultWordPressComAccount()
+                return
             }
-            return
         }
 
         guard FeatureFlag.contentMigration.enabled else {


### PR DESCRIPTION
## Description

This PR puts the ContentMigrationCoordinator `startOnceIfNeeded` call in the App Delegate behind a feature flag so it should only run when the `contentMigration` feature flag is enabled.

Related PR: https://github.com/wordpress-mobile/WordPress-iOS/pull/19674

## Testing

### Jetpack: Logged in user with blogs sees the authenticated interface on cold start
1. Authenticate with WordPress.com or a self-hosted site using the Jetpack app.
2. Restart the app.
3. **Expect** the user to be authenticated inside the app and can access My Site, Reader, Notifications, etc.

### Jetpack: Logged in user without any blogs sees the login screen on cold start
1. Sign up for a new WP.com account from the Jetpack app.
2. Don't create any blogs.
3. Restart the app.
4. **Expect** the Jetpack prologue / login view to be shown.

### Jetpack: Logged out user sees the login screen on cold start
1. Make sure the user is logged out of the Jetpack app
2. Restart the app.
3. **Expect** the Jetpack prologue / login view to be shown.

### Flag enabled (requires debug build)
1. Enable the content migration feature flag.
4. **Expect** the ContentMigrationCoordinator `startOnceIfNeeded` call in the App Delegate to run.

### Flag disabled (requires debug build)
1. Disable the content migration feature flag.
2. **Expect** the ContentMigrationCoordinator `startOnceIfNeeded` call in the App Delegate to **not** to run.

## Regression Notes
1. Potential unintended areas of impact
    - Jetpack flows on app cold start:
      1. Authenticated user with blogs (should be shown logged in interface - My Site, Reader, etc.)
      2. Authenticated user without blogs should see the login screen
      5. Unauthenticated user should see the login screen

6. What I did to test those areas of impact (or what existing automated tests I relied on)
    I manually ran the build while connected to the Xcode debugger.

8. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
