### PR TITLE
Move a `guard let` conditional outside of a loop, so it runs only once

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergFilesAppMediaSource.swift
@@ -72,9 +72,12 @@ extension Gutenberg.MediaType {
     }
 
     private func getTypesFrom(_ allTypes: [String], conformingTo uttype: CFString) -> [String] {
+        guard let requiredType = UTType(uttype as String) else {
+            return []
+        }
 
         return allTypes.filter {
-            guard let allowedType = UTType($0), let requiredType = UTType(uttype as String) else {
+            guard let allowedType = UTType($0) else {
                 return false
             }
             // Sometimes the compared type could be a supertype


### PR DESCRIPTION
The app targets iOS 14.0+ making them always true.

Hat tip @crazytonyli for the suggestion. See https://github.com/wordpress-mobile/WordPress-iOS/pull/19709/files#r1040308672

## Testing

I briefly considered writing a unit test for this but didn't go down that path because of lack of pre-existing testing harness. 

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
