### PR TITLE
Fix site icon alert logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -84,8 +84,9 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
 
         NoticesDispatch.lock()
 
-        if !FeatureFlag.siteIconCreator.enabled {
+        guard FeatureFlag.siteIconCreator.enabled else {
             showUpdateSiteIconAlert()
+            return
         }
 
         showSiteIconSelectionAlert()


### PR DESCRIPTION
Addresses https://github.com/wordpress-mobile/WordPress-iOS/pull/19709#discussion_r1037806233

## How to test

1. On My Site tap on your site icon
2. ✅ Validate: the action sheet displays a "create with emoji" option
3. Disable the Site Icon Creator flag via the debug menu - Profile Icon > App Settings > Debug
4. On My Site tap on your site icon
5. ✅ Validate: the action sheet DOES NOT display a "create with emoji" option

Site Icon Creator Enabled | Site Icon Creator Disabled
 -- | --
 <img src="https://user-images.githubusercontent.com/6711616/205888432-dd2c6de4-4058-4369-8ca7-e241b74585eb.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/205888449-acf76064-827f-4d93-81bd-1593cf19c3e8.png" width=200>
 

## Regression Notes
1. Potential unintended areas of impact
n/a

6. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
