### PR TITLE
[Fix] Jetpack force logout on accounts with no sites

### DIFF
--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -16,16 +16,8 @@ class JetpackWindowManager: WindowManager {
 
     override func showUI(for blog: Blog?) {
         if AccountHelper.isLoggedIn {
-            if AccountHelper.hasBlogs {
-                // If the user is logged in and has blogs sync'd to their account
-                showAppUI(for: blog)
-                return
-            } else {
-                // If the user doesn't have any blogs, but they're still logged in, log them out
-                // the `logOutDefaultWordPressComAccount` method will trigger the `showSignInUI` automatically
-                AccountHelper.logOutDefaultWordPressComAccount()
-                return
-            }
+            showAppUI(for: blog)
+            return
         }
 
         guard FeatureFlag.contentMigration.enabled else {


### PR DESCRIPTION
Fixes #19426

Fixes the issue where user with no sites would be logged out on Jetpack every time they killed the app.

To test:
1. Get a WP.com account with no blogs.
2. Sign in to the Jetpack app using the account.
3. Kill the app after signed in.
4. Launch the app again.
5. User should still be logged in.

## Regression Notes
1. Potential unintended areas of impact
[This issue](https://github.com/wordpress-mobile/WordPress-iOS/pull/16462) could be affected as it reverts the condition added in that PR.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I confirmed that case is no longer valid as now we offer Site Creating in Jetpack as well. So the "no sites message" with "Try Again" button is not shown anymore.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
