### PR TITLE
Fixes a couple of flaky unit and UI tests

### DIFF
--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -39,9 +39,7 @@ public class BlockEditorScreen: ScreenObject {
      */
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
         let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
-        guard titleView.waitForExistence(timeout: 3) else {
-            return self
-        }
+        XCTAssert(titleView.waitForExistence(timeout: 3), "Title View does not exist!")
 
         titleView.tap()
         titleView.typeText(text)

--- a/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -39,6 +39,9 @@ public class BlockEditorScreen: ScreenObject {
      */
     public func enterTextInTitle(text: String) -> BlockEditorScreen {
         let titleView = app.otherElements["Post title. Empty"].firstMatch // Uses a localized string
+        guard titleView.waitForExistence(timeout: 3) else {
+            return self
+        }
 
         titleView.tap()
         titleView.typeText(text)

--- a/WordPress/WordPressTest/MediaURLExporterTests.swift
+++ b/WordPress/WordPressTest/MediaURLExporterTests.swift
@@ -59,7 +59,7 @@ class MediaURLExporterTests: XCTestCase {
             XCTFail("Error: an error occurred testing a URL export: \(error.toNSError())")
             expect.fulfill()
         }
-        waitForExpectations(timeout: 2.0, handler: nil)
+        waitForExpectations(timeout: 3.0, handler: nil)
     }
 
     func testThatURLExportingGIFWorks() {


### PR DESCRIPTION
## Description
This PR fixes a couple of flaky unit and UI tests.
Tests targeted are the least reliable tests based on Buildkite's test analytics.

Targeted tests:
* `MediaURLExporterTests.testThatURLExportingVideoWorks`
* `MediaURLExporterTests.testThatURLExportingVideoWithoutGPSWorks`
* `EditorGutenbergTests.testAddGalleryBlock`

## Testing Instructions

No need for testing. If the CI passes, then we're good to go

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
