### PR TITLE
Fix VoiceOver crash when initial screen is Home

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/DynamicHeightCollectionView.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-class DynamicHeightCollectionView: AccessibleCollectionView {
+class DynamicHeightCollectionView: UICollectionView {
     override func layoutSubviews() {
         super.layoutSubviews()
 

--- a/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tags View/TopicsCollectionView.swift
@@ -37,6 +37,14 @@ class TopicsCollectionView: DynamicHeightCollectionView {
     func collapse() {
         coordinator?.changeState(.collapsed)
     }
+
+    override func accessibilityElementCount() -> Int {
+        guard let dataSource else {
+            return 0
+        }
+
+        return dataSource.collectionView(self, numberOfItemsInSection: 0)
+    }
 }
 
 extension TopicsCollectionView: ReaderTopicCollectionViewCoordinatorDelegate {


### PR DESCRIPTION
Fixes #19609

## Description

Fixes a crash on the dashboard when VoiceOver is enabled.

One class inherits from `DynamicHeightCollectionView` and the dashboard uses it. The accessibility code has been added to `TopicsCollectionView` so it continues to work properly with VoiceOver.

## Testing

To test:

### Testing the launch crash

- Use a real device and login
- Set/verify initial screen is set to `Home` (`Me` → `App Settings` → `Initial Screen`)
- Close the app
- Enable VoiceOver
- Launch the app
- Verify it does not crash

### Reader topics

- Use a real device and enable VoiceOver
- Login
- Navigate to the Reader tab
- Tap on Discover
- Select topics if necessary and hit 'Done'
- Find a post with many tags (Should have an `N+` tag like `4+`)
- Expand the tags
- Swipe left and verify it voices each tag

## Regression Notes
1. Potential unintended areas of impact
Reader topic VoiceOver

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
