### PR TITLE
Remove self-hosted credentials from keychain when the site is removed

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -105,6 +105,11 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 {
     [super prepareForDeletion];
 
+    // delete stored password in the keychain for self-hosted sites.
+    if ([self.username length] > 0 && [self.xmlrpc length] > 0) {
+        self.password = nil;
+    }
+
     [_xmlrpcApi invalidateAndCancelTasks];
     [_wordPressOrgRestApi invalidateAndCancelTasks];
 }


### PR DESCRIPTION
## Description

Since the beginning, we have stored credentials for self-hosted sites in the keychain but don't delete them when the site is removed. This PR fixes that by wiping the stored credentials on the `Blog`'s `prepareForDeletion`. 

I've checked the file history to see if there's a specific edge case we tried to work around by not removing the credentials, but I couldn't find any. I've also smoke-tested the app, and it works fine.

## To test

There's no way to test this manually without modifying the source code. Before running the app on the Simulator, add this debug code on the `WordPressAppDelegate#willEnterForeground`. 

```swift
// WordPressAppDelegate.swift

func applicationWillEnterForeground(_ application: UIApplication) {
    DDLogInfo("\(self) \(#function)")

    // TODO: Remove this once you're done!
    let username = "<your self-hosted username>"
    let xmlrpc = "https://<your self-hosted site>/xmlrpc.php"
    if let _ = try? SFHFKeychainUtils.getPasswordForUsername(username, andServiceName: xmlrpc) {
        print("<<DEBUG>> ⚠️ Password detected in keychain for username: \(username) in blog: \(xmlrpc)")
    } else {
        print("<<DEBUG>> ✅ Password is not found for username: \(username) in blog: \(xmlrpc)")
    }

    ...
```

> **Warning** Don't forget to replace the placeholders with your actual self-hosted credentials! 🙂 

- Run the WP app with the debug code in place.
- Log in to a dotcom account.
- Go to the Blog List screen > Add a self-hosted site.
- Enter the credentials matching the one added in the debug code.
- Verify that the self-hosted site is now displayed in My Site.
- Scroll down and tap Remove Site to remove the self-hosted site from the app.
- Minimize the app.
- Verify that this shows up in the console: `<<DEBUG>> ✅ Password is not found for username: ...`

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
