### PR TITLE
Update comments to Jetpack from JetPack.

### DIFF
--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -832,7 +832,7 @@ typedef void (^AutosaveSuccessBlock)(RemotePost *post, NSString *previewURL);
         remotePost.categories = [self remoteCategoriesForPost:postPost];
         remotePost.metadata = [self remoteMetadataForPost:postPost];
 
-        // Because we can't get what's the self-hosted non JetPack site capabilities
+        // Because we can't get what's the self-hosted non Jetpack site capabilities
         // only Admin users are allowed to set a post as sticky.
         // This doesn't affect WPcom sites.
         //

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -357,8 +357,8 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
 
     func run(onError: @escaping (Error) -> Void, completion: @escaping (Bool) -> Void) {
 
-        // This will no longer run for WordPress as part of JetPack migration.
-        // This can be removed once JetPack migration is complete.
+        // This will no longer run for WordPress as part of Jetpack migration.
+        // This can be removed once Jetpack migration is complete.
         guard JetpackNotificationMigrationService.shared.shouldPresentNotifications() else {
             notificationScheduler.cancellAll()
             notificationScheduler.cancelStaticNotification()

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -365,7 +365,7 @@ FeaturedImageViewControllerDelegate>
                                   stickyPostSection,
                                   @(PostSettingsSectionShare),
                                   @(PostSettingsSectionMoreOptions) ] mutableCopy];
-    // Remove sticky post section for self-hosted non JetPack site
+    // Remove sticky post section for self-hosted non Jetpack site
     // and non admin user
     //
     if (![self.apost.blog supports:BlogFeatureWPComRESTAPI] && !self.apost.blog.isAdmin) {


### PR DESCRIPTION
Fixes various comments that say "JetPack" rather than "Jetpack". 😄 

I've also [sent translation suggestions](https://translate.wordpress.org/projects/apps/ios/dev/) for the following languages where the string "JetPack" was found:

- German
- French
- Turkish
- Indonesian
- Portuguese

## Regression Notes
1. Potential unintended areas of impact
   - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - N/A

3. What automated tests I added (or what prevented me from doing so)
   - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
