### PR TITLE
[Jetpack Content Migration Flow] Enable feature flags

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 21.4
 -----
 * [*] Share extension navigation bar is no longer transparent [#19700]
+* [***] [Jetpack-only] Adds a smooth, opt-in transition to the Jetpack app. [#19759]
+* [***] You can now migrate your site content to the Jetpack app without a hitch. [#19759]
 
 21.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 21.4
 -----
 * [*] Share extension navigation bar is no longer transparent [#19700]
-* [***] [Jetpack-only] Adds a smooth, opt-in transition to the Jetpack app. [#19759]
+* [***] [Jetpack-only] Adds a smooth, opt-in transition to the Jetpack app for users migrating from the WordPress app. [#19759]
 * [***] You can now migrate your site content to the Jetpack app without a hitch. [#19759]
 * [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -113,9 +113,9 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackPowered:
             return true
         case .jetpackPoweredBottomSheet:
-            return false
+            return true
         case .contentMigration:
-            return false
+            return true
         case .newJetpackLandingScreen:
             return true
         case .newWordPressLandingScreen:
@@ -123,7 +123,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newCoreDataContext:
             return true
         case .jetpackMigrationPreventDuplicateNotifications:
-            return false
+            return true
         case .jetpackFeaturesRemovalPhaseOne:
             return false
         case .jetpackFeaturesRemovalPhaseTwo:


### PR DESCRIPTION
## Description

This PR enables the following feature flags for the Content Migration Flow project:
- `jetpackPoweredBottomSheet`
- `contentMigration`
- `jetpackMigrationPreventDuplicateNotifications`

## Testing

To test, follow the project's test plan.

Internal ref: pcdRpT-1i3-p2

## Regression Notes
1. Potential unintended areas of impact
   - N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - N/A

3. What automated tests I added (or what prevented me from doing so)
   - N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.