### PR TITLE
[Jetpack Focus] Reenable Jetpack Notifications Disabling Feature Flag and Release Notes 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Share extension navigation bar is no longer transparent [#19700]
 * [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
+* [*] [internal] When a user migrates to the Jetpack app and allows notifications, WordPress app notifications are disabled. [#19616, #19611, #19590]
 
 21.3
 -----

--- a/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
+++ b/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
@@ -22,7 +22,7 @@ final class JetpackNotificationMigrationService: JetpackNotificationMigrationSer
     private let jetpackNotificationMigrationDefaultsKey = "jetpackNotificationMigrationDefaultsKey"
 
     private var jetpackMigrationPreventDuplicateNotifications: Bool {
-        return FeatureFlag.jetpackMigrationPreventDuplicateNotifications.enabled
+        return featureFlagStore.value(for: FeatureFlag.jetpackMigrationPreventDuplicateNotifications)
     }
 
     private var notificationSettingsService: NotificationSettingsService?

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -123,7 +123,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .newCoreDataContext:
             return true
         case .jetpackMigrationPreventDuplicateNotifications:
-            return false
+            return true
         case .jetpackFeaturesRemovalPhaseOne:
             return false
         case .jetpackFeaturesRemovalPhaseTwo:


### PR DESCRIPTION
Revert https://github.com/wordpress-mobile/WordPress-iOS/pull/19735 to reenable disable notifications feature

## Description

Re-enabling already tested disable-notifications functionality https://github.com/wordpress-mobile/WordPress-iOS/issues/19619

## Testing instructions

Confirm that `prevent_duplicate_notifs_remote_field":true` value exists in https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags

### Case 1: Notifications disabled on WordPress app
1. Install WordPress app and log in
2. Go to Notification tab on WordPress app and accept iOS notification permission
3. Install Jetpack app and log in
4. Go to Notification tab on Jetpack app and accept iOS notification permission
5. Jetpack app should redirect to WordPress app
6. Trigger push notification (write a comment on a blog)
7. Jetpack should receive a notification. WordPress app should not receive a notification.

### Case 2 "Allow Notifications" switch should be visible on WordPress
1. Install WordPress app and log in
2. Go to Notification tab on WordPress app and accept iOS notification permission
3. Staying on Notifications tab, click Settings icon on a top right corner
4. Allow Notifications switch should be visible.

## Regression Notes

1. Potential unintended areas of impact

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




