### PR TITLE
[Bugfix] Localize Blogging Prompts Answer Button

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -58,7 +58,7 @@ private extension BloggingPromptsHeaderView {
     func configureStrings() {
         titleLabel.text = Strings.title
         infoButton.accessibilityLabel = Strings.infoButtonAccessibilityLabel
-        answerPromptButton.titleLabel?.text = Strings.answerButtonTitle
+        answerPromptButton.setTitle(Strings.answerButtonTitle, for: .normal)
         answeredLabel.text = Strings.answeredLabelTitle
         shareButton.titleLabel?.text = Strings.shareButtonTitle
     }


### PR DESCRIPTION
Fixes #19487

This button was never localized because the button title was being set via `titleLabel?.text = ` API which won't work. It was using the value from the xib file. I replaced that line with `setTitle` function.

To test:
1. Change the device language to Turkish (or any non-English language).
2. Launch the Jetpack app.
3. Tap the green create blog button at the bottom of the screen.
4. Verify "Answer Prompt" label is localized.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
