### PR TITLE
Fix crash when `perform` is called on a context with deprecated concurrency type

### DIFF
--- a/WordPress/Classes/Utility/ContainerContextFactory.swift
+++ b/WordPress/Classes/Utility/ContainerContextFactory.swift
@@ -27,6 +27,13 @@ class ContainerContextFactory: NSObject, ManagedObjectContextFactory {
                 completionBlock?()
             }
         }
+
+        /// Ensure that the `context`'s concurrency type is not `confinementConcurrencyType`, since it will crash if `perform` or `performAndWait` is called.
+        guard context.concurrencyType == .mainQueueConcurrencyType || context.concurrencyType == .privateQueueConcurrencyType else {
+            block()
+            return
+        }
+
         if wait {
             context.performAndWait(block)
         } else {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5209,6 +5209,7 @@
 		FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE2E3729281C839C00A1E82A /* BloggingPromptsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */; };
+		FE320CC5294705990046899B /* ContainerContextFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE320CC4294705990046899B /* ContainerContextFactoryTests.swift */; };
 		FE32E7F12844971000744D80 /* ReminderScheduleCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32E7F02844971000744D80 /* ReminderScheduleCoordinatorTests.swift */; };
 		FE32EFFF275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
 		FE32F000275914390040BE67 /* MenuSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */; };
@@ -8810,6 +8811,7 @@
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
 		FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceTests.swift; sourceTree = "<group>"; };
+		FE320CC4294705990046899B /* ContainerContextFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerContextFactoryTests.swift; sourceTree = "<group>"; };
 		FE32E7F02844971000744D80 /* ReminderScheduleCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinatorTests.swift; sourceTree = "<group>"; };
 		FE32E7F32846A68800744D80 /* WordPress 142.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 142.xcdatamodel"; sourceTree = "<group>"; };
 		FE32EFFE275914390040BE67 /* MenuSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuSheetViewController.swift; sourceTree = "<group>"; };
@@ -9877,7 +9879,7 @@
 			path = Classes;
 			sourceTree = "<group>";
 		};
-		29B97314FDCFA39411CA2CEA = {
+		29B97314FDCFA39411CA2CEA /* CustomTemplate */ = {
 			isa = PBXGroup;
 			children = (
 				3F20FDF3276BF21000DA3CAD /* Packages */,
@@ -14564,6 +14566,7 @@
 				93E9050319E6F242005513C9 /* ContextManagerTests.swift */,
 				B5ECA6CC1DBAAD510062D7E0 /* CoreDataHelperTests.swift */,
 				931D26FF19EDAE8600114F17 /* CoreDataMigrationTests.m */,
+				FE320CC4294705990046899B /* ContainerContextFactoryTests.swift */,
 			);
 			name = "Core Data";
 			sourceTree = "<group>";
@@ -17869,14 +17872,14 @@
 				bg,
 				sk,
 			);
-			mainGroup = 29B97314FDCFA39411CA2CEA;
+			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
 				3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3FC2C33B26C4CF0A00C6D98F /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				17A8858B2757B97F0071FCA3 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
 				3F2B62DA284F4E0B0008CD59 /* XCRemoteSwiftPackageReference "Charts" */,
 				3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */,
-				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */,
+				3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */,
 				3F338B6F289BD3040014ADC5 /* XCRemoteSwiftPackageReference "Nimble" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -22318,6 +22321,7 @@
 				C738CB1128626606001BE107 /* QRLoginVerifyCoordinatorTests.swift in Sources */,
 				FF0B2567237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift in Sources */,
 				FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */,
+				FE320CC5294705990046899B /* ContainerContextFactoryTests.swift in Sources */,
 				F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */,
 				8BC12F72231FEBA1004DDA72 /* PostCoordinatorTests.swift in Sources */,
 				C3C2F84628AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift in Sources */,
@@ -29112,7 +29116,7 @@
 				minimumVersion = 0.3.0;
 			};
 		};
-		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */ = {
+		3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
 			requirement = {
@@ -29185,12 +29189,12 @@
 		};
 		3F411B6E28987E3F002513AE /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3F44DD57289C379C006334CD /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios.git" */;
+			package = 3F411B6D28987E3F002513AE /* XCRemoteSwiftPackageReference "lottie-ios" */;
 			productName = Lottie;
 		};
 		3FC2C33C26C4CF0A00C6D98F /* XCUITestHelpers */ = {

--- a/WordPress/WordPressTest/ContainerContextFactoryTests.swift
+++ b/WordPress/WordPressTest/ContainerContextFactoryTests.swift
@@ -1,0 +1,112 @@
+import XCTest
+
+@testable import WordPress
+
+final class ContainerContextFactoryTests: XCTestCase {
+
+    private var persistentContainer: NSPersistentContainer!
+    private var factory: ContainerContextFactory!
+
+    override func setUp() {
+        super.setUp()
+
+        persistentContainer = makeInMemoryContainer()
+        factory = ContainerContextFactory(persistentContainer: persistentContainer)
+    }
+
+    override func tearDown() {
+        persistentContainer = nil
+        factory = nil
+
+        super.tearDown()
+    }
+
+    // MARK: - `save` Tests
+
+    func test_save_givenMainQueueConcurrencyType_shouldCallPerform() {
+        let context = makeMockContext(concurrencyType: .mainQueueConcurrencyType)
+
+        factory.save(context, andWait: false, withCompletionBlock: nil)
+
+        XCTAssertTrue(context.performCalled)
+        XCTAssertFalse(context.performAndWaitCalled)
+    }
+
+    func test_save_givenMainQueueConcurrencyType_andWaitIsSetToTrue_shouldCallPerformAndWait() {
+        let context = makeMockContext(concurrencyType: .mainQueueConcurrencyType)
+
+        factory.save(context, andWait: true, withCompletionBlock: nil)
+
+        XCTAssertFalse(context.performCalled)
+        XCTAssertTrue(context.performAndWaitCalled)
+    }
+
+    func test_save_givenPrivateQueueConcurrencyType_shouldCallPerform() {
+        let context = makeMockContext(concurrencyType: .privateQueueConcurrencyType)
+
+        factory.save(context, andWait: false, withCompletionBlock: nil)
+
+        XCTAssertTrue(context.performCalled)
+        XCTAssertFalse(context.performAndWaitCalled)
+    }
+
+    func test_save_givenPrivateQueueConcurrencyType_andWaitIsSetToTrue_shouldCallPerformAndWait() {
+        let context = makeMockContext(concurrencyType: .privateQueueConcurrencyType)
+
+        factory.save(context, andWait: true, withCompletionBlock: nil)
+
+        XCTAssertFalse(context.performCalled)
+        XCTAssertTrue(context.performAndWaitCalled)
+    }
+
+    func test_save_givenDeprecatedConcurrencyType_shouldNotCallPerform() {
+        /// creates a context with `.confinementConcurrencyType`. The enum is created from its raw value
+        /// to prevent Xcode from complaining since the enum value is deprecated.
+        let context = makeMockContext(concurrencyType: NSManagedObjectContextConcurrencyType(rawValue: 0)!)
+
+        factory.save(context, andWait: false, withCompletionBlock: nil)
+
+        XCTAssertFalse(context.performCalled)
+        XCTAssertFalse(context.performAndWaitCalled)
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension ContainerContextFactoryTests {
+
+    class MockManagedObjectContext: NSManagedObjectContext {
+
+        var performCalled = false
+        var performAndWaitCalled = false
+
+        override func perform(_ block: @escaping () -> Void) {
+            performCalled = true
+        }
+
+        override func performAndWait(_ block: () -> Void) {
+            performAndWaitCalled = true
+        }
+
+        override func save() throws {
+            // do nothing. let's make sure nothing gets saved.
+        }
+    }
+
+    /// Creates an "in-memory" NSPersistentContainer.
+    /// This follows the approach used in WWDC'18: https://developer.apple.com/videos/play/wwdc2018/224/
+    ///
+    /// - Returns: An instance of NSPersistentContainer that stores data in memory.
+    func makeInMemoryContainer() -> NSPersistentContainer {
+        let container = NSPersistentContainer(name: "WordPress")
+        let description = NSPersistentStoreDescription(url: .init(fileURLWithPath: "/dev/null"))
+        container.persistentStoreDescriptions = [description]
+
+        return container
+    }
+
+    func makeMockContext(concurrencyType: NSManagedObjectContextConcurrencyType) -> MockManagedObjectContext {
+        return MockManagedObjectContext(concurrencyType: concurrencyType)
+    }
+
+}


### PR DESCRIPTION
Refs pcdRpT-1i3-p2#comment-2354

This fixes a crash that happens during the database export process after previously saving a Reader post. Here are some findings during my investigation:

- Saving a post updates a property on the `ReaderPost` managed object, and triggers the `didSave` method that updates another model, `ReaderCard`. The export process makes use of `NSPersistentStoreCoordinator`'s [migratePersistentStore(_:to:options:withType:)](https://developer.apple.com/documentation/coredata/nspersistentstorecoordinator/1468927-migratepersistentstore) method[^2].
- While reading through the stack trace, it seems that the `migratePersistentStore`method creates its own `NSManagedObjectContext` and calls `save`. This call somehow triggers `ReaderPost`'s `didSave` method on the saved post.  Note that I've tried to modify the save post method such that it's persisted in the store before the export process is initiated (i.e., the post's `isUpdated` is `false`), but the `didSave` still gets called during `migratePersistentStore`.

  <details>
  <summary> 📜 <em>Click to see the a snippet of the stack trace</em></summary>

  ```
  Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Can only use -performBlock: on an NSManagedObjectContext that was created with a queue'
  
  Last Exception Backtrace:
  0   CoreFoundation                         0x1d8795e88 __exceptionPreprocess + 164
  1   libobjc.A.dylib                        0x1d1ac38d8 objc_exception_throw + 60
  2   CoreData                               0x1dfff8914 -[NSSQLiteAdapter newCreateTableStatementForEntity:] + 0
  3   WordPress                              0x10585e030 ContainerContextFactory.save(_:andWait:withCompletionBlock:) + 732
  4   WordPress                              0x10585e668 @objc ContainerContextFactory.save(_:andWait:withCompletionBlock:) + 244
  5   WordPress                              0x104ae5aec -[ContextManager saveContext:] + 116
  6   WordPress                              0x104c03840 -[ReaderPost didSave] + 488
  7   CoreData                               0x1dffcde74 -[NSManagedObjectContext _didSaveChanges] + 1664
  8   CoreData                               0x1dfff7308 -[NSManagedObjectContext save:] + 3024
  9   CoreData                               0x1e00feb04 __84-[NSPersistentStoreCoordinator migratePersistentStore:toURL:options:withType:error:]_block_invoke.492 + 2072
  10  CoreData                               0x1e0048840 gutsOfBlockToNSPersistentStoreCoordinatorPerform + 204
  11  libdispatch.dylib                      0x1dfd65fdc _dispatch_client_callout + 20
  12  libdispatch.dylib                      0x1dfd75574 _dispatch_lane_barrier_sync_invoke_and_complete + 56
  13  CoreData                               0x1dffa1bb0 -[NSPersistentStoreCoordinator performBlockAndWait:] + 184
  14  CoreData                               0x1e00fddd0 __84-[NSPersistentStoreCoordinator migratePersistentStore:toURL:options:withType:error:]_block_invoke + 916
  ```

</details>
  
- Within the `ReaderPost`'s `didSave`, there's another `save` call to the managed object context that ends up in `ContainerContextFactory`.

  https://github.com/wordpress-mobile/WordPress-iOS/blob/be75d66eccf451ced90efe45a8ba658131f865d0/WordPress/Classes/Models/ReaderPost.m#L513-L522 

- Finally: in the `ContainerContextFactory`'s `save` method, the completion block is wrapped in a `performBlock`:

  https://github.com/wordpress-mobile/WordPress-iOS/blob/be75d66eccf451ced90efe45a8ba658131f865d0/WordPress/Classes/Utility/ContainerContextFactory.swift#L30-L34

  And this is where the issue is. The `NSManagedObjectContext` that's internally created by the `migratePersistentStore` method is initialized with `.confinementConcurrencyType` — which, apparently, does NOT have a queue (as seen on the stack trace above). So, the solution is to wrap the block with `perform` ONLY when the context has the correct concurrency types.

> **Note**: I'm adding @crazytonyli as a reviewer since this touches the core part of our Core Data setup. That said, I'm quite sure this is safe[^1] since nowhere in our codebase creates `NSManagedObjectContext` with the deprecated concurrency type.

## To test

### Verify that the crash issue is fixed

- Install and run WordPress.
- Log in using any dotcom account.
- Ensure that the `contentMigration` flag is enabled.
- Go to Reader > Discover.
- Save a post or two that has tags/topics on them.
- Go to Notifications tab.
- Tap on the Jetpack-powered banner, and tap on the "Try the new Jetpack app" button.
- 🔍 Verify that the app does not crash.
  - Note: Depending on whether you have the Jetpack app installed, it should either open the Jetpack app or redirect you to the Jetpack page in App Store. but that's out of the scope of this PR.

### Verify that everywhere else is business as usual

Do a light smoke test to ensure that everything works as before and is not impacted by this change:

- Create a post.
- Add a self-hosted site.
- Like a post.
- Write a comment.
- Edit an existing post.
- Moderate a comment.
- Modify selected Topics in Reader settings.
- Save a post.
- View Notifications.
- Like a comment from Notifications.

## Regression Notes
1. Potential unintended areas of impact
There may be some unexpected thread-related issues? But this should be very _very_ unlikely since there's nothing from our side that creates an `NSManagedObjectContext` with the now deprecated `.confinedConcurrencyType`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: Famous last words. 🙃 
[^2]: The method is deprecated, but the [recommended method](https://developer.apple.com/documentation/coredata/nspersistentstorecoordinator/3747534-migratepersistentstore) is only available on iOS 15.0+. We are still supporting iOS 14.