### PR TITLE
Stats Revamp: Change follower details to be the same behaviour as Android

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -422,7 +422,7 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
 
         if FeatureFlag.statsNewInsights.enabled {
             switch statSection {
-            case .insightsViewsVisitors, .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
+            case .insightsViewsVisitors, .insightsFollowerTotals, .insightsLikesTotals, .insightsCommentsTotals:
                 segueToInsightsDetails(statSection: statSection, selectedDate: selectedDate)
             default:
                 segueToDetails(statSection: statSection, selectedDate: selectedDate)


### PR DESCRIPTION
This PR adds functionality to bring iOS app + followers details screens to parity with Android.

I reviewed the original stats revamp designs from the designer and I had made an assumption about what Followers details should be as the stats revamp design(s) did not have any information on what should be done on the followers card.  As a result, I've implemented a change so that iOS has parity with Android

Fixes #19763

To test:
1. Enable new stats feature flags
2. Go to Stats screen -> Insights
3. Tap Total Followers.  You should be navigated to the Total Followers screen
<img width="300" alt="image" src="https://user-images.githubusercontent.com/88816724/207113926-7dd6d236-0ea8-4c0a-a1de-dfa44a69a1aa.png">

4. Navigate back to Insights main screen
5. Go to the Followers card and tap "View more".  You should be navigated to the following screen
<img width="410" alt="image" src="https://user-images.githubusercontent.com/88816724/207114056-4fffbbac-3245-4ba8-a9d5-9d27896e8e2e.png">



## Regression Notes
1. Potential unintended areas of impact
Stats revamp

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested

3. What automated tests I added (or what prevented me from doing so)
N/A
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
