### PR TITLE
[Reader] Scroll to the top if the tab bar button is tapped

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [***] You can now migrate your site content to the Jetpack app without a hitch. [#19759]
 * [**] [internal] Upgrade React Native from 0.66.2 to 0.69.4 [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5193]
 * [*] [internal] When a user migrates to the Jetpack app and allows notifications, WordPress app notifications are disabled. [#19616, #19611, #19590]
+* [*] Reader now scrolls to the top if the tab bar button is tapped. [#19769]
 
 21.3
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -198,3 +198,14 @@ extension ReaderTabViewController {
         static let spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
     }
 }
+
+// MARK: - WPScrollableViewController conformance
+extension ReaderTabViewController: WPScrollableViewController {
+    /// Scrolls the first child VC to the top if it's a `ReaderStreamViewController`.
+    func scrollViewToTop() {
+        guard let readerStreamVC = children.first as? ReaderStreamViewController else {
+            return
+        }
+        readerStreamVC.scrollViewToTop()
+    }
+}


### PR DESCRIPTION
Fixes #17021

## Description

This PR scrolls Reader to the top when the tab bar button is tapped.

## Testing
1. In the Jetpack and WordPress apps, load Reader and scroll down some.
2. Tap the Reader tab bar button at the bottom, in the center.
3. **Expect:** Reader to scroll to the top.

## Regression Notes
1. Potential unintended areas of impact
     - This only adds the functionality to `ReaderStreamViewController`s. It's possible I missed another type that needs to scroll.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Manual testing above.

3. What automated tests I added (or what prevented me from doing so)
    - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
