### PR TITLE
Notifications: Fix filter tab color "leaking" to table view in dark scheme

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -618,7 +618,7 @@ private extension NotificationsViewController {
 
     func setupFilterBar() {
         WPStyleGuide.configureFilterTabBar(filterTabBar)
-        filterTabBar.superview?.backgroundColor = .filterBarBackground
+        filterTabBar.superview?.backgroundColor = .systemBackground
 
         filterTabBar.items = Filter.allCases
         filterTabBar.addTarget(self, action: #selector(selectedFilterDidChange(_:)), for: .valueChanged)


### PR DESCRIPTION
## Description

As titled, this fixes an issue where the background color for the filter tab in Notifications appears as if it's "leaking" to the table view side. See the below image for example:

<img width="371" alt="iphone_before_dark" src="https://user-images.githubusercontent.com/1299411/207366473-d0db2f43-c793-4ca9-9acc-c9be494d2281.png">

The "leaked" space was an incidental bug from #16962, where we added some padding between the filter tab bar and the first table view header. It was a design decision to give some space between the two elements, so they don't feel too cramped visually — especially when the table header is already pretty compact.

Here's how it looks before and after the change in various configurations:

Scenarios | Before | After
-|-|-
iPhone, Dark | <img width="371" alt="iphone_before_dark" src="https://user-images.githubusercontent.com/1299411/207365008-76427449-c23d-45d2-b4dc-0bf3e188d6e4.png"> | <img width="371" alt="iphone_after_dark" src="https://user-images.githubusercontent.com/1299411/207364976-a3be1092-5952-4f46-9459-2b27ef0049a7.png">
iPad, Dark | <img width="326" alt="ipad_before_dark" src="https://user-images.githubusercontent.com/1299411/207365023-c3e62cbf-54e6-4657-86cb-731c1af5a1bc.png"> | <img width="328" alt="ipad_after_dark" src="https://user-images.githubusercontent.com/1299411/207365025-6a76a282-2f7d-4b58-9a4f-75e856de6cec.png">
iPhone, Light | <img width="373" alt="iphone_before_light" src="https://user-images.githubusercontent.com/1299411/207365002-40bc2d81-0d91-473a-bdcf-9156d061b942.png"> | <img width="371" alt="iphone_after_light" src="https://user-images.githubusercontent.com/1299411/207364999-8e76d092-2515-4dff-9418-1241799c03cc.png">
iPad, Light | <img width="328" alt="ipad_before_light" src="https://user-images.githubusercontent.com/1299411/207365013-f20cef94-266f-42f6-a23d-1812b4d95547.png"> | <img width="327" alt="ipad_after_light" src="https://user-images.githubusercontent.com/1299411/207365028-0493faf2-a59d-41c3-a6e8-cf07aa6c0108.png">


## To test

- Open either WordPress or Jetpack app.
- Switch to dark scheme.
- Go to the Notifications tab.
- 🔍 Verify that the filter tab bar's background color is no longer leaking.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
