### PR TITLE
[Stats Revamp] VoiceOver improvements

### DIFF
--- a/WordPress/Classes/Utility/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable.swift
@@ -256,7 +256,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
     /// An ImmuTable object representing the table structure.
     open var viewModel = ImmuTable.Empty {
         didSet {
-            if target.isViewLoaded {
+            if target.isViewLoaded && automaticallyReloadTableView {
                 target.tableView.reloadData()
             }
         }
@@ -264,6 +264,9 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     /// Configure the handler to automatically deselect any cell after tapping it.
     @objc var automaticallyDeselectCells = false
+
+    /// Automatically reload table view when view model changes
+    @objc var automaticallyReloadTableView = true
 
     // MARK: UITableViewDataSource
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -315,7 +315,7 @@ private extension InsightsManagementViewController {
             moveRowToInactive(at: index)
         } else if let inactiveIndex = insightsInactive.firstIndex(of: statSection) {
             insightsShown.append(statSection)
-            moveRowToActive(at: index)
+            moveRowToActive(at: inactiveIndex)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -21,6 +21,10 @@ class InsightsManagementViewController: UITableViewController {
         }
     }
 
+    private var insightsInactive: [StatSection] {
+        InsightsManagementViewController.allInsights.filter({ !self.insightsShown.contains($0) })
+    }
+
     private var hasChanges: Bool {
         return insightsShown != originalInsightsShown
     }
@@ -250,7 +254,7 @@ private extension InsightsManagementViewController {
     }
 
     func inactiveCardsSection() -> ImmuTableSection {
-        let rows = InsightsManagementViewController.allInsights.filter({ !self.insightsShown.contains($0) })
+        let rows = insightsInactive
 
         guard rows.count > 0 else {
             return ImmuTableSection(headerText: TextContent.inactiveCardsHeader, rows: [inactivePlaceholderRow])
@@ -310,6 +314,7 @@ private extension InsightsManagementViewController {
         }
 
         reloadViewModel()
+        selectToggledRowForAccessibility(for: statSection)
     }
 
     var placeholderRow: ImmuTableRow {
@@ -374,4 +379,14 @@ private extension InsightsManagementViewController {
         }
     }
 
+}
+
+private extension InsightsManagementViewController {
+    func selectToggledRowForAccessibility(for statSection: StatSection) {
+        if let shownIndex = insightsShown.firstIndex(of: statSection) {
+            UIAccessibility.post(notification: .screenChanged, argument: tableView.cellForRow(at: .init(item: shownIndex, section: 0)))
+        } else if let inactiveIndex = insightsInactive.firstIndex(of: statSection) {
+            UIAccessibility.post(notification: .screenChanged, argument: tableView.cellForRow(at: .init(item: inactiveIndex, section: 1)))
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -259,7 +259,7 @@ private extension InsightsManagementViewController {
         return ImmuTableSection(headerText: TextContent.inactiveCardsHeader,
                                 rows: rows.map {
                                     return AddInsightStatRow(title: $0.insightManagementTitle,
-                                                             enabled: true,
+                                                             enabled: false,
                                                              action: rowActionFor($0)) }
         )
     }

--- a/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Views/NoResultsViewController.swift
@@ -588,11 +588,11 @@ private extension NoResultsViewController {
             view.accessibilityLabel = titleLabel.text
             view.accessibilityTraits = .staticText
         } else {
-            view.accessibilityElements = [noResultsView!, actionButton!]
+            view.accessibilityElements = [labelStackView!, actionButton!]
 
-            noResultsView.isAccessibilityElement = true
-            noResultsView.accessibilityTraits = .staticText
-            noResultsView.accessibilityLabel = [
+            labelStackView.accessibilityTraits = .staticText
+            labelStackView.isAccessibilityElement = true
+            labelStackView.accessibilityLabel = [
                 titleLabel.text,
                 subtitleTextView.isHidden ? nil : subtitleTextView.attributedText.string
             ].compactMap { $0 }.joined(separator: ". ")


### PR DESCRIPTION
Fixes #19727

## Description

- [Made Add Stats Card button visible for voiceover in No Results View](https://github.com/wordpress-mobile/WordPress-iOS/commit/790a638dfff62bf857cebce443efae481390f64b) by using labels stack view as a parent element
- [When adding cards, reading appropriate hints depending on the row being in inactive or active section](https://github.com/wordpress-mobile/WordPress-iOS/commit/fac90e554ceb3649942a5d2bd7ca6243b18d83fd)
- [Reselected row for voiceover when a card is moved from active to inactive section](https://github.com/wordpress-mobile/WordPress-iOS/pull/19773/commits/dae28bfadb9add4822b04357c9d4db3514abf2d7) by using `moveRow`, `insertRow`, `deleteRow` APIs, that voiceover correctly interprets and jumps to the correct cell

Not reproducible:
- On the Views & Visitors card, the “Weeks >” button is inaccessible by VoiceOver
- After the app returns to the Insights tab after a card is added, VoiceOver reads the “Add Stats Card” button instead of reading the card that was added (or not reading anything).

## Testing instructions

See #19727

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### No results view action button visible for voiceover
https://user-images.githubusercontent.com/4062343/207381693-ad87095c-d6f8-4d99-9511-403750bf8a76.mov

### Week button visible for voiceover (issue that wasn't reproduced)
https://user-images.githubusercontent.com/4062343/207381743-fa0b86e2-5e6b-4a90-92aa-a28d46a3dbf3.mov

### Reading appropriate hint depending on a row belonging in an inactive or active section
https://user-images.githubusercontent.com/4062343/207381822-ac83b500-43bd-455c-ab40-b7851ef47c5e.mov

### Reselecting row for voiceover when a card is moved from active to inactive section

https://user-images.githubusercontent.com/4062343/207818131-1e9006f2-c232-4a15-999d-794c17f5491a.mov
https://user-images.githubusercontent.com/4062343/207818177-580cb690-442d-4ab6-9ab7-0722c35ad950.mp4

### Coming back to an empty Insights view - back button selected  (issue that wasn't reproduced)

https://user-images.githubusercontent.com/4062343/207382115-a0be529d-cc95-4815-be17-0e09af0cf3c4.mov




