### PR TITLE
Remove bounce back to safari code

### DIFF
--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -66,11 +66,6 @@ extension ReaderRoute: NavigationAction {
             return
         }
 
-        // Bounce back to Safari on failure
-        coordinator.failureBlock = {
-            self.failAndBounce(values)
-        }
-
         switch self {
         case .root:
             coordinator.showReaderTab()


### PR DESCRIPTION
Fixes #19755 

Removes the "bounce back" code to safari from Reader. Currently we have the "No Results" screen that communicates to the user the failure and allows them to open the URL in Safari with a button tap. Bouncing back to Safari without giving them a chance to comprehend the failure is not very clear and it was causing the infinite loop since we respond to the same universal links in both apps.

To test:
1. Install both WordPress and Jetpack app.
2. Tap any *.wordpress.com link that leads to a private site (e.g. P2) that you don't have access to.
3. Observe that the app does not redirect between WordPress and Jetpack and remains in the app. 
4. Verify that "Open in Browser" button opens the URL in browser


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
