### PR TITLE
[Jetpack Content Migration Flow] Update schemes for Alpha and Internal builds

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
@@ -8,12 +8,14 @@ class JetpackRedirector {
     /// Note: The string values should kept in-sync with Jetpack's URL scheme.
     ///
     static var jetpackDeepLinkScheme: String {
+        /// Important: Multiple compiler flags are set for some builds
+        /// so ordering matters.
         #if DEBUG
         return "jpdebug"
-        #elseif INTERNAL_BUILD
-        return "jpinternal"
         #elseif ALPHA_BUILD
         return "jpalpha"
+        #elseif INTERNAL_BUILD
+        return "jpinternal"
         #else
         return "jetpack"
         #endif

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -466,6 +466,7 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>$(JP_SCHEME)</string>
 		<string>jetpacknotificationmigration</string>
 		<string>org-appextension-feature-password-management</string>
 		<string>twitter</string>

--- a/WordPress/WordPress-Internal-Info.plist
+++ b/WordPress/WordPress-Internal-Info.plist
@@ -443,6 +443,7 @@
 			<string>org.wordpress</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>wordpressmigration+v1</string>
 				<string>wordpressnotificationmigration</string>
 				<string>wordpress-oauth-v2</string>
 				<string>${WPCOM_SCHEME}</string>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -441,6 +441,7 @@
 			<string>org.wordpress</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
+				<string>wordpressmigration+v1</string>
 				<string>wordpressnotificationmigration</string>
 				<string>wordpress-oauth-v2</string>
 				<string>${WPCOM_SCHEME}</string>

--- a/WordPress/Wordpress-Alpha-Info.plist
+++ b/WordPress/Wordpress-Alpha-Info.plist
@@ -465,6 +465,7 @@
 	<false/>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
+		<string>$(JP_SCHEME)</string>
 		<string>jetpacknotificationmigration</string>
 		<string>org-appextension-feature-password-management</string>
 		<string>twitter</string>


### PR DESCRIPTION
This PR fixes and issue where Alpha and Internal WordPress builds (such as ones generated for App Center) didn't declare the migration scheme and couldn't query for the Jetpack app.

**To test:** Initiate the migration flow as defined by the testing steps.

## Regression Notes
1. Potential unintended areas of impact
   - There shouldn't be any.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing of the App Center builds.

3. What automated tests I added (or what prevented me from doing so)
   - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
