### PR TITLE
[Tooling] Update App Center Distribution Group used by Installable Builds

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -278,7 +278,7 @@ platform :ios do
       app_name: 'WPiOS-One-Offs',
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
-      destinations: 'All-users-of-WPiOS-One-Offs',
+      destinations: 'Collaborators',
       notify_testers: false
     )
 


### PR DESCRIPTION
> **Note**: This is a replication of [a similar PR done on WooCommerce-iOS a while ago](https://github.com/woocommerce/woocommerce-ios/pull/8125)

> **Note**: See internal request pdnsEh-Of-p2

### Description

This PR should resolve access issues by distributing prototype builds to the `Collaborators` group on App Center, which is the group associated with our internal automation.

 - `WPiOS-One-Offs` app (line 274): this PR updates the `destinations` parameter of the `appcenter_upload` call to `"Collaborators"`
 - `jetpack-installable-builds` app (line 327): No change. The `appcenter_upload` call already specified `"Collaborators"` for its `destinations` parameter
 - `WP-Internal` app (line 225): No change. The `appcenter_upload` call didn't specify a `destinations` parameter at all, hence defaulting to "Collaborators" already.

### Testing instructions

Note that the build associated with this PR is distributed to the `Collaborators` group.