### PR TITLE
Jetpack Migration: Use app group constant instead of hardcoded value

### DIFF
--- a/WordPress/Classes/System/Constants.m
+++ b/WordPress/Classes/System/Constants.m
@@ -22,17 +22,17 @@ NSString *const WPComDomain                                         = @"wordpres
 
 /// Keychain Constants
 ///
-#ifdef INTERNAL_BUILD
+/// Note: Multiple compiler flags are set for some builds, so conditional ordering matters.
+///
+#if defined(ALPHA_BUILD)
+NSString *const WPAppGroupName                                      = @"group.org.wordpress.alpha";
+NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.alpha";
+#elif defined(INTERNAL_BUILD)
 NSString *const WPAppGroupName                                      = @"group.org.wordpress.internal";
 NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.internal";
 #else
-#if ALPHA_BUILD
-NSString *const WPAppGroupName                                      = @"group.org.wordpress.alpha";
-NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.alpha";
-#else
 NSString *const WPAppGroupName                                      = @"group.org.wordpress";
 NSString *const WPAppKeychainAccessGroup                            = @"3TMU3BH3NK.org.wordpress";
-#endif
 #endif
 
 /// Notification Content Extension Constants

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -142,7 +142,7 @@ class BloggingRemindersScheduler {
     }
 
     private static func sharedDataFileURL() -> URL? {
-        let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")
+        let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName)
         return sharedDirectory?.appendingPathComponent(defaultDataFileName)
     }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -35,7 +35,7 @@ final class DataMigrator {
     private let sharedDefaults: UserPersistentRepository?
 
     init(coreDataStack: CoreDataStack = ContextManager.sharedInstance(),
-         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: "group.org.wordpress")?.appendingPathComponent("WordPress.sqlite"),
+         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName)?.appendingPathComponent("WordPress.sqlite"),
          keychainUtils: KeychainUtils = KeychainUtils(),
          localDefaults: UserPersistentRepository = UserDefaults.standard,
          sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName)) {


### PR DESCRIPTION
Refs p1671051139662589-slack-C046L7LPV0F

⚠️ **NOTE: Auto-merge is enabled!** ⚠️ 

This fixes an issue where the export process kept failing due to the App Group not being accessible for Alpha or Internal builds.

To test:

- Install WP and JP from this PR's installable build.
- Open WP > Log in > Go to Notifications > tap the "Try the new Jetpack app" button.
- 🔍 Verify that JP opens and the data is migrated.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes, but it should be verified through the installable builds since Debug builds are working fine.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.