### PR TITLE
[Jetpack Focus] Add Jetpack banner to Jetpack Backups view

### DIFF
--- a/WordPress/Classes/Utility/ContentCoordinator.swift
+++ b/WordPress/Classes/Utility/ContentCoordinator.swift
@@ -89,7 +89,7 @@ struct DefaultContentCoordinator: ContentCoordinator {
     func displayBackupWithSiteID(_ siteID: NSNumber?) throws {
         guard let siteID = siteID,
               let blog = Blog.lookup(withID: siteID, in: mainContext),
-              let backupListViewController = BackupListViewController(blog: blog)
+              let backupListViewController = BackupListViewController.withJPBannerForBlog(blog)
         else {
             throw DisplayError.missingParameter
         }

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+@objc
+extension BackupListViewController {
+    static func withJPBannerForBlog(_ blog: Blog) -> UIViewController? {
+        guard let backupListVC = BackupListViewController(blog: blog) else {
+            return nil
+        }
+        return JetpackBannerWrapperViewController(childVC: backupListVC)
+    }
+}
+
+extension BackupListViewController: JPScrollViewDelegate {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        super.scrollViewDidScroll(scrollView)
+        processJetpackBannerVisibility(scrollView)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
@@ -6,7 +6,7 @@ extension BackupListViewController {
         guard let backupListVC = BackupListViewController(blog: blog) else {
             return nil
         }
-        return JetpackBannerWrapperViewController(childVC: backupListVC)
+        return JetpackBannerWrapperViewController(childVC: backupListVC, analyticsId: .backup)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -1,6 +1,10 @@
 import Foundation
+import Combine
 
 class BackupListViewController: BaseActivityListViewController {
+    /// Needed for JPScrollViewDelegate conformance.
+    let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
+
     override init(site: JetpackSiteRef, store: ActivityStore, isFreeWPCom: Bool = false) {
         store.onlyRestorableItems = true
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1600,7 +1600,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showBackup
 {
-    BackupListViewController *controller = [[BackupListViewController alloc] initWithBlog:self.blog];
+    UIViewController *controller = [BackupListViewController withJPBannerForBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -23,6 +23,7 @@ struct JetpackBrandingAnalyticsHelper {
 
     enum JetpackBannerScreen: String {
         case activityLog = "activity_log"
+        case backup
         case notifications
         case reader
         case readerSearch = "reader_search"

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2615,6 +2615,8 @@
 		C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
+		C39ABBAE294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39ABBAD294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift */; };
+		C39ABBAF294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C39ABBAD294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift */; };
 		C3AB4879292F114A001F7AF8 /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
 		C3C21EB928385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
 		C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
@@ -7742,6 +7744,7 @@
 		C395FB222821FE4400AE7C11 /* SiteDesignSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignSection.swift; sourceTree = "<group>"; };
 		C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteSiteDesign+Thumbnail.swift"; sourceTree = "<group>"; };
 		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
+		C39ABBAD294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BackupListViewController+JetpackBannerViewController.swift"; sourceTree = "<group>"; };
 		C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+AppAvailability.swift"; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
 		C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSiteDesigns.swift; sourceTree = "<group>"; };
@@ -12951,6 +12954,7 @@
 			isa = PBXGroup;
 			children = (
 				8B36256525A60CCA00D7CCE3 /* BackupListViewController.swift */,
+				C39ABBAD294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift */,
 			);
 			path = Backup;
 			sourceTree = "<group>";
@@ -21598,6 +21602,7 @@
 				08A4E129289D202F001D9EC7 /* UserPersistentStore.swift in Sources */,
 				E1D95EB817A28F5E00A3E9F3 /* WPActivityDefaults.m in Sources */,
 				436D56302117410C00CEAA33 /* RegisterDomainDetailsViewModel+CellIndex.swift in Sources */,
+				C39ABBAE294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */,
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
@@ -24081,6 +24086,7 @@
 				FABB253A2602FC2C00C8785C /* WordPressAppDelegate.swift in Sources */,
 				098B8577275E9765004D299F /* AppLocalizedString.swift in Sources */,
 				FABB253B2602FC2C00C8785C /* MediaService.m in Sources */,
+				C39ABBAF294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */,
 				FEA6517C281C491C002EA086 /* BloggingPromptsService.swift in Sources */,
 				FABB253C2602FC2C00C8785C /* FormattableContentAction.swift in Sources */,
 				3F3DD0B326FD176800F5F121 /* PresentationCard.swift in Sources */,


### PR DESCRIPTION
Part of #19448

## Description
- Adds the Jetpack banner to the Jetpack Backups view in the WordPress app.
- Adds a new analytics event for the Jetpack Backups view.

| My Site | Jetpack Backups |
| - | - |
| ![image](https://user-images.githubusercontent.com/2092798/208783606-c3ad64bd-f168-4b14-bea5-e791a9cbb20c.png) | ![image](https://user-images.githubusercontent.com/2092798/208783658-fd5a551c-24d8-4479-bcf6-e2ddfaa5dff1.png) |


## Testing

**Prerequisite:** Access to a site that has Jetpack Backups enabled. The WordPress.com Business and eCommerce plans [both include this feature](https://wordpress.com/pricing/).

### Banner appears in WordPress
1. Load the WordPress app.
2. From My Site, tap Backup in the Jetpack section.
3. **Expect:** The Jetpack banner to appear at the bottom of the screen.
4. **Expect:** Tapping on the Jetpack banner shows the Jetpack overlay.
5. **Expect:** The event `🔵 Tracked: jetpack_powered_banner_tapped <screen: backup>` to be fired.

### Banner does not appear in Jetpack
1. Load the Jetpack app.
2. From My Site, tap Backup in the Jetpack section.
3. **Expect:** No Jetpack banner to be shown.

### Banner visibility behavior
- Initially the banner should be shown when the screen appears.
- Scrolling down hides the banner and the banner reappears only when the view is scrolled to the top.
- If there isn't enough content to scroll, the banner doesn't show / hide on scroll.

### Items to test:
- Light / Dark mode
- Dynamic Type / a11y
- Different screen orientations
- iPhone / iPad

## Regression Notes
1. Potential unintended areas of impact
    - Functionality of the Jetpack Backups page.
    - Functionality of tapping on the Jetpack banner and viewing the Jetpack overlay.
    - It's supposed to be possible to get a [notification related to backups](https://github.com/wordpress-mobile/WordPress-iOS/blob/1de08a234b2a00ee887b08a19dd627806eadfb7a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift#L94) but I didn't simulate this for testing. Maybe it happens after a restore takes place?

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual tests.

3. What automated tests I added (or what prevented me from doing so)
   - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
