### PR TITLE
Jetpack Focus: Implements actions inside the Jetpack menu card

### DIFF
--- a/WordPress/Classes/Stores/RemoteConfigStore.swift
+++ b/WordPress/Classes/Stores/RemoteConfigStore.swift
@@ -25,6 +25,13 @@ class RemoteConfigStore {
 
     // MARK: Public Functions
 
+    /// Looks up the value for a remote config parameter.
+    /// - Parameters:
+    ///     - key: The key associated with a remote config parameter
+    public func value(for key: String) -> Any? {
+        return cache[key]
+    }
+
     /// Fetches remote config values from the server.
     /// - Parameter callback: An optional callback that can be used to update UI following the fetch. It is not called on the UI thread.
     public func update(then callback: FetchCallback? = nil) {
@@ -49,7 +56,7 @@ extension RemoteConfigStore {
     typealias FetchCallback = () -> Void
 
     /// The local cache stores remote config values between runs so that the most recently fetched set are ready to go as soon as this object is instantiated.
-    private(set) var cache: [String: Any] {
+    private var cache: [String: Any] {
         get {
             // Read from the cache in a thread-safe way
             queue.sync {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfigParameter.swift
@@ -12,7 +12,7 @@ struct RemoteConfigParameter<T> {
     private let store: RemoteConfigStore
 
     private var serverValue: T? {
-        return store.cache[key] as? T
+        return store.value(for: key) as? T
     }
 
     // MARK: Initializer

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -742,7 +742,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }
-    if (JetpackBrandingMenuCardCoordinator.shouldShowCard == YES) {
+    if (self.shouldShowJetpackBrandingMenuCard == YES) {
         [marr addObject:[self jetpackCardSectionViewModel]];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -615,6 +615,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         switch (section.category) {
             case BlogDetailsSectionCategoryQuickAction:
             case BlogDetailsSectionCategoryQuickStart:
+            case BlogDetailsSectionCategoryJetpackBrandingCard:
             case BlogDetailsSectionCategoryDomainCredit: {
                 _restorableSelectedIndexPath = nil;
             }
@@ -700,6 +701,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         switch (section.category) {
             case BlogDetailsSectionCategoryQuickAction:
             case BlogDetailsSectionCategoryQuickStart:
+            case BlogDetailsSectionCategoryJetpackBrandingCard:
             case BlogDetailsSectionCategoryDomainCredit: {
                 BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
                 BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:subsection blog: self.blog];

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -70,6 +70,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
             return Strings.PhaseTwoAndThree.notificationsTitle
         case (.three, .reader):
             return Strings.PhaseTwoAndThree.readerTitle
+        case (.three, _):
+            return Strings.PhaseThree.generalTitle
         default:
             return ""
         }
@@ -110,7 +112,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case .login:
             fallthrough
         case .appOpen:
-            return "" // TODO: Add new animation when ready
+            return Constants.allFeaturesLogosAnimationLtr
         }
     }
 
@@ -127,7 +129,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case .login:
             fallthrough
         case .appOpen:
-            return "" // TODO: Add new animation when ready
+            return Constants.allFeaturesLogosAnimationRtl
         }
     }
 
@@ -175,13 +177,15 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
     }
 
     var continueButtonText: String? {
-        switch source {
-        case .stats:
+        switch (source, phase) {
+        case (.stats, _):
             return Strings.General.statsContinueButtonTitle
-        case .notifications:
+        case (.notifications, _):
             return Strings.General.notificationsContinueButtonTitle
-        case .reader:
+        case (.reader, _):
             return Strings.General.readerContinueButtonTitle
+        case (_, .three):
+            return Strings.PhaseThree.generalContinueButtonTitle
         default:
             return nil
         }
@@ -242,6 +246,8 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
         static let readerLogoAnimationRtl = "JetpackReaderLogoAnimation_rtl"
         static let notificationsLogoAnimationLtr = "JetpackNotificationsLogoAnimation_ltr"
         static let notificationsLogoAnimationRtl = "JetpackNotificationsLogoAnimation_rtl"
+        static let allFeaturesLogosAnimationLtr = "JetpackAllFeaturesLogosAnimation_ltr"
+        static let allFeaturesLogosAnimationRtl = "JetpackAllFeaturesLogosAnimation_rtl"
     }
 
     enum Strings {
@@ -313,6 +319,16 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let footnote = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.footnote",
                                                     value: "Switching is free and only takes a minute.",
                                                     comment: "A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app.")
+        }
+
+        enum PhaseThree {
+            static let generalTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.general.title",
+                                                                  value: "Jetpack features are moving soon.",
+                                                                  comment: "Title of a screen that showcases the Jetpack app.")
+
+            static let generalContinueButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.general.continue.title",
+                                                                            value: "Continue without Jetpack",
+                                                                            comment: "Title of a button that dismisses an overlay that showcases the Jetpack app.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -17,4 +17,9 @@ extension BlogDetailsViewController {
                                          category: .jetpackBrandingCard)
         return section
     }
+
+    func reloadTableView() {
+        configureTableViewData()
+        reloadTableViewPreservingSelection()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -2,6 +2,11 @@ import Foundation
 
 extension BlogDetailsViewController {
 
+    @objc var shouldShowJetpackBrandingMenuCard: Bool {
+        let presenter = JetpackBrandingMenuCardPresenter()
+        return presenter.shouldShowCard()
+    }
+
     @objc func jetpackCardSectionViewModel() -> BlogDetailsSection {
         let row = BlogDetailsRow()
         row.callback = {}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -9,7 +9,9 @@ extension BlogDetailsViewController {
 
     @objc func jetpackCardSectionViewModel() -> BlogDetailsSection {
         let row = BlogDetailsRow()
-        row.callback = {}
+        row.callback = {
+            JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(from: .card, in: self)
+        }
 
         let section = BlogDetailsSection(title: nil,
                                          rows: [row],

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -5,7 +5,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
 
     // MARK: Private Variables
 
-    private weak var viewController: UIViewController?
+    private weak var viewController: BlogDetailsViewController?
     private var presenter: JetpackBrandingMenuCardPresenter
 
     /// Sets the animation based on the language orientation
@@ -189,11 +189,15 @@ private extension JetpackBrandingMenuCardCell {
     // MARK: Actions
 
     private func remindMeLaterTapped() {
-        // TODO: Implement this
+        presenter.remindLaterTapped()
+        viewController?.reloadTableView()
+        // TODO: Track button tapped
     }
 
     private func hideThisTapped() {
-        // TODO: Implement this
+        presenter.hideThisTapped()
+        viewController?.reloadTableView()
+        // TODO: Track button tapped
     }
 }
 
@@ -279,7 +283,7 @@ private extension JetpackBrandingMenuCardCell {
 extension JetpackBrandingMenuCardCell {
 
     @objc(configureWithViewController:)
-    func configure(with viewController: UIViewController) {
+    func configure(with viewController: BlogDetailsViewController) {
         self.viewController = viewController
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -6,6 +6,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Private Variables
 
     private weak var viewController: UIViewController?
+    private var presenter: JetpackBrandingMenuCardPresenter
 
     /// Sets the animation based on the language orientation
     private var animation: Animation? {
@@ -119,11 +120,13 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Initializers
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        presenter = JetpackBrandingMenuCardPresenter()
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         commonInit()
     }
 
     required init?(coder: NSCoder) {
+        presenter = JetpackBrandingMenuCardPresenter()
         super.init(coder: coder)
         commonInit()
     }
@@ -144,7 +147,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
 
     private func setupContent() {
         logosAnimationView.play()
-        let config = JetpackBrandingMenuCardCoordinator.cardConfig
+        let config = presenter.cardConfig()
         descriptionLabel.text = config?.description
         learnMoreSuperview.isHidden = config?.learnMoreButtonURL == nil
     }
@@ -152,7 +155,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Actions
 
     @objc private func learnMoreButtonTapped() {
-        guard let config = JetpackBrandingMenuCardCoordinator.cardConfig,
+        guard let config = presenter.cardConfig(),
               let urlString = config.learnMoreButtonURL,
               let url = URL(string: urlString) else {
             return

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCoordinator.swift
@@ -35,6 +35,11 @@ private extension JetpackBrandingMenuCardCoordinator {
 
 class JetpackBrandingMenuCardPresenter {
 
+    struct Config {
+        let description: String
+        let learnMoreButtonURL: String?
+    }
+
     // MARK: Private Variables
 
     private let remoteConfigStore: RemoteConfigStore
@@ -53,8 +58,20 @@ class JetpackBrandingMenuCardPresenter {
 
     // MARK: Public Functions
 
+    func cardConfig() -> Config? {
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
+        switch phase {
+        case .three:
+            let description = Strings.phaseThreeDescription
+            let url = RemoteConfig(store: remoteConfigStore).phaseThreeBlogPostUrl.value
+            return .init(description: description, learnMoreButtonURL: url)
+        default:
+            return nil
+        }
+    }
+
     func shouldShowCard() -> Bool {
-        return false
+        return cardConfig() != nil
     }
 
     func remindLaterTapped() {
@@ -70,13 +87,6 @@ class JetpackBrandingMenuCardPresenter {
 }
 
 private extension JetpackBrandingMenuCardPresenter {
-    enum Constants {
-        static let secondInDay = 86_400
-        static let remindLaterDurationInDays = 7
-        static let shouldHideCardKey = "JetpackBrandingShouldHideCardKey"
-        static let showCardOnDateKey = "JetpackBrandingShowCardOnDateKey"
-    }
-
     var shouldHideCard: Bool {
         get {
             persistenceStore.bool(forKey: Constants.shouldHideCardKey)
@@ -95,5 +105,20 @@ private extension JetpackBrandingMenuCardPresenter {
         set {
             persistenceStore.set(newValue, forKey: Constants.showCardOnDateKey)
         }
+    }
+}
+
+private extension JetpackBrandingMenuCardPresenter {
+    enum Constants {
+        static let secondInDay = 86_400
+        static let remindLaterDurationInDays = 7
+        static let shouldHideCardKey = "JetpackBrandingShouldHideCardKey"
+        static let showCardOnDateKey = "JetpackBrandingShowCardOnDateKey"
+    }
+
+    enum Strings {
+        static let phaseThreeDescription = NSLocalizedString("jetpack.menuCard.description",
+                                                           value: "Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.",
+                                                           comment: "Description inside a menu card communicating that features are moving to the Jetpack app.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCoordinator.swift
@@ -32,3 +32,68 @@ private extension JetpackBrandingMenuCardCoordinator {
                                                            comment: "Description inside a menu card communicating that features are moving to the Jetpack app.")
     }
 }
+
+class JetpackBrandingMenuCardPresenter {
+
+    // MARK: Private Variables
+
+    private let remoteConfigStore: RemoteConfigStore
+    private let persistenceStore: UserPersistentRepository
+    private let featureFlagStore: RemoteFeatureFlagStore
+
+    // MARK: Initializers
+
+    init(remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
+         featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
+         persistenceStore: UserPersistentRepository = UserDefaults.standard) {
+        self.remoteConfigStore = remoteConfigStore
+        self.featureFlagStore = featureFlagStore
+        self.persistenceStore = persistenceStore
+    }
+
+    // MARK: Public Functions
+
+    func shouldShowCard() -> Bool {
+        return false
+    }
+
+    func remindLaterTapped() {
+        let now = Date()
+        let duration = Constants.remindLaterDurationInDays * Constants.secondInDay
+        let newDate = now.addingTimeInterval(TimeInterval(duration))
+        showCardOnDate = newDate
+    }
+
+    func hideThisTapped() {
+        shouldHideCard = true
+    }
+}
+
+private extension JetpackBrandingMenuCardPresenter {
+    enum Constants {
+        static let secondInDay = 86_400
+        static let remindLaterDurationInDays = 7
+        static let shouldHideCardKey = "JetpackBrandingShouldHideCardKey"
+        static let showCardOnDateKey = "JetpackBrandingShowCardOnDateKey"
+    }
+
+    var shouldHideCard: Bool {
+        get {
+            persistenceStore.bool(forKey: Constants.shouldHideCardKey)
+        }
+
+        set {
+            persistenceStore.set(newValue, forKey: Constants.shouldHideCardKey)
+        }
+    }
+
+    var showCardOnDate: Date? {
+        get {
+            persistenceStore.object(forKey: Constants.showCardOnDateKey) as? Date
+        }
+
+        set {
+            persistenceStore.set(newValue, forKey: Constants.showCardOnDateKey)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -94,7 +94,7 @@ private extension JetpackBrandingMenuCardPresenter {
 
     enum Strings {
         static let phaseThreeDescription = NSLocalizedString("jetpack.menuCard.description",
-                                                           value: "Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.",
+                                                           value: "Stats, Reader, Notifications and other features will move to the Jetpack mobile app soon.",
                                                            comment: "Description inside a menu card communicating that features are moving to the Jetpack app.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -1,38 +1,5 @@
 import Foundation
 
-@objc
-class JetpackBrandingMenuCardCoordinator: NSObject {
-
-    struct Config {
-        let description: String
-        let learnMoreButtonURL: String?
-    }
-
-    static var cardConfig: Config? {
-        let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
-        switch phase {
-        case .three:
-            let description = Strings.phaseThreeDescription
-            let url = RemoteConfig().phaseThreeBlogPostUrl.value
-            return .init(description: description, learnMoreButtonURL: url)
-        default:
-            return nil
-        }
-    }
-
-    @objc static var shouldShowCard: Bool {
-        return cardConfig != nil
-    }
-}
-
-private extension JetpackBrandingMenuCardCoordinator {
-    enum Strings {
-        static let phaseThreeDescription = NSLocalizedString("jetpack.menuCard.description",
-                                                           value: "Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.",
-                                                           comment: "Description inside a menu card communicating that features are moving to the Jetpack app.")
-    }
-}
-
 class JetpackBrandingMenuCardPresenter {
 
     struct Config {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -52,7 +52,7 @@ class JetpackBrandingMenuCardPresenter {
 
     func remindLaterTapped() {
         let now = currentDateProvider.date()
-        let duration = Constants.remindLaterDurationInDays * Constants.secondInDay
+        let duration = Constants.remindLaterDurationInDays * Constants.secondsInDay
         let newDate = now.addingTimeInterval(TimeInterval(duration))
         showCardOnDate = newDate
     }
@@ -86,7 +86,7 @@ private extension JetpackBrandingMenuCardPresenter {
 
 private extension JetpackBrandingMenuCardPresenter {
     enum Constants {
-        static let secondInDay = 86_400
+        static let secondsInDay = 86_400
         static let remindLaterDurationInDays = 7
         static let shouldHideCardKey = "JetpackBrandingShouldHideCardKey"
         static let showCardOnDateKey = "JetpackBrandingShowCardOnDateKey"

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -87,7 +87,7 @@ private extension JetpackBrandingMenuCardPresenter {
 private extension JetpackBrandingMenuCardPresenter {
     enum Constants {
         static let secondsInDay = 86_400
-        static let remindLaterDurationInDays = 7
+        static let remindLaterDurationInDays = 4
         static let shouldHideCardKey = "JetpackBrandingShouldHideCardKey"
         static let showCardOnDateKey = "JetpackBrandingShowCardOnDateKey"
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1577,10 +1577,10 @@
 		80535DB82946C79700873161 /* JetpackBrandingMenuCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DB72946C79700873161 /* JetpackBrandingMenuCardCell.swift */; };
 		80535DBB294ABBF000873161 /* JetpackAllFeaturesLogosAnimation_rtl.json in Resources */ = {isa = PBXBuildFile; fileRef = 80535DB9294ABBEF00873161 /* JetpackAllFeaturesLogosAnimation_rtl.json */; };
 		80535DBC294ABBF000873161 /* JetpackAllFeaturesLogosAnimation_ltr.json in Resources */ = {isa = PBXBuildFile; fileRef = 80535DBA294ABBEF00873161 /* JetpackAllFeaturesLogosAnimation_ltr.json */; };
-		80535DBE294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */; };
+		80535DBE294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBD294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift */; };
 		80535DC0294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */; };
 		80535DC1294BDE1900873161 /* JetpackBrandingMenuCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DB72946C79700873161 /* JetpackBrandingMenuCardCell.swift */; };
-		80535DC2294BDE2500873161 /* JetpackBrandingMenuCardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */; };
+		80535DC2294BDE2500873161 /* JetpackBrandingMenuCardPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBD294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift */; };
 		80535DC3294BDE2B00873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */; };
 		80535DC5294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */; };
 		8058730B28F7B70B00340C11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8058730D28F7B70B00340C11 /* InfoPlist.strings */; };
@@ -6891,7 +6891,7 @@
 		80535DB72946C79700873161 /* JetpackBrandingMenuCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardCell.swift; sourceTree = "<group>"; };
 		80535DB9294ABBEF00873161 /* JetpackAllFeaturesLogosAnimation_rtl.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JetpackAllFeaturesLogosAnimation_rtl.json; sourceTree = "<group>"; };
 		80535DBA294ABBEF00873161 /* JetpackAllFeaturesLogosAnimation_ltr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JetpackAllFeaturesLogosAnimation_ltr.json; sourceTree = "<group>"; };
-		80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardCoordinator.swift; sourceTree = "<group>"; };
+		80535DBD294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardPresenter.swift; sourceTree = "<group>"; };
 		80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+JetpackBrandingMenuCard.swift"; sourceTree = "<group>"; };
 		80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardPresenterTests.swift; sourceTree = "<group>"; };
 		8058730C28F7B70B00340C11 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
@@ -12521,7 +12521,7 @@
 			isa = PBXGroup;
 			children = (
 				80535DB72946C79700873161 /* JetpackBrandingMenuCardCell.swift */,
-				80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */,
+				80535DBD294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift */,
 				80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */,
 			);
 			path = "Menu Card";
@@ -21203,7 +21203,7 @@
 				171096CB270F01EA001BCDD6 /* DomainSuggestionsTableViewController.swift in Sources */,
 				469CE07124BCFB04003BDC8B /* CollapsableHeaderCollectionViewCell.swift in Sources */,
 				7EB5824720EC41B200002702 /* NotificationContentFactory.swift in Sources */,
-				80535DBE294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift in Sources */,
+				80535DBE294AC89200873161 /* JetpackBrandingMenuCardPresenter.swift in Sources */,
 				F53FF3AA23EA725C001AD596 /* SiteIconView.swift in Sources */,
 				FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */,
 				7E7947AD210BAC7B005BB851 /* FormattableNoticonRange.swift in Sources */,
@@ -23017,7 +23017,7 @@
 				98622EA0274C59A400061A5F /* ReaderDetailCommentsTableViewDelegate.swift in Sources */,
 				FABB21EA2602FC2C00C8785C /* RestoreWarningView.swift in Sources */,
 				17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */,
-				80535DC2294BDE2500873161 /* JetpackBrandingMenuCardCoordinator.swift in Sources */,
+				80535DC2294BDE2500873161 /* JetpackBrandingMenuCardPresenter.swift in Sources */,
 				C7D30C652638B07A00A1695B /* JetpackPrologueStyleGuide.swift in Sources */,
 				FABB21EB2602FC2C00C8785C /* GutenbergWebNavigationViewController.swift in Sources */,
 				F4F9D5EC29096CF500502576 /* MigrationHeaderView.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1582,6 +1582,7 @@
 		80535DC1294BDE1900873161 /* JetpackBrandingMenuCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DB72946C79700873161 /* JetpackBrandingMenuCardCell.swift */; };
 		80535DC2294BDE2500873161 /* JetpackBrandingMenuCardCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */; };
 		80535DC3294BDE2B00873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */; };
+		80535DC5294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */; };
 		8058730B28F7B70B00340C11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8058730D28F7B70B00340C11 /* InfoPlist.strings */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
@@ -6892,6 +6893,7 @@
 		80535DBA294ABBEF00873161 /* JetpackAllFeaturesLogosAnimation_ltr.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = JetpackAllFeaturesLogosAnimation_ltr.json; sourceTree = "<group>"; };
 		80535DBD294AC89200873161 /* JetpackBrandingMenuCardCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardCoordinator.swift; sourceTree = "<group>"; };
 		80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+JetpackBrandingMenuCard.swift"; sourceTree = "<group>"; };
+		80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardPresenterTests.swift; sourceTree = "<group>"; };
 		8058730C28F7B70B00340C11 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
 		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
@@ -12510,6 +12512,7 @@
 				8332DD2629259B9700802F7D /* Utility */,
 				803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */,
 				801D951C291ADB7E0051993E /* JetpackOverlayFrequencyTrackerTests.swift */,
+				80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */,
 			);
 			name = Jetpack;
 			sourceTree = "<group>";
@@ -22524,6 +22527,7 @@
 				80EF9284280CFEB60064A971 /* DashboardPostsSyncManagerTests.swift in Sources */,
 				7EC9FE0B22C627DB00C5A888 /* PostEditorAnalyticsSessionTests.swift in Sources */,
 				D88A64A0208D8B7D008AE9BC /* StockPhotosMediaGroupTests.swift in Sources */,
+				80535DC5294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift in Sources */,
 				7EAA66EF22CB36FD00869038 /* TestAnalyticsTracker.swift in Sources */,
 				931D26F619ED7F7000114F17 /* BlogServiceTest.m in Sources */,
 				B5882C471D5297D1008E0EAA /* NotificationTests.swift in Sources */,

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import WordPress
+
+final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
+
+    private var mockUserDefaults: InMemoryUserDefaults!
+    private var remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
+
+    override func setUp() {
+        mockUserDefaults = InMemoryUserDefaults()
+    }
+
+    func testShouldShowCardBasedOnPhase() {
+        // Given
+        let presenter = JetpackBrandingMenuCardPresenter(
+            featureFlagStore: remoteFeatureFlagsStore,
+            persistenceStore: mockUserDefaults)
+
+        // Normal phase
+        XCTAssertFalse(presenter.shouldShowCard())
+
+        // Phase One
+        remoteFeatureFlagsStore.removalPhaseOne = true
+        XCTAssertFalse(presenter.shouldShowCard())
+
+        // Phase Two
+        remoteFeatureFlagsStore.removalPhaseTwo = true
+        XCTAssertFalse(presenter.shouldShowCard())
+
+        // Phase Three
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        XCTAssertTrue(presenter.shouldShowCard())
+
+        // Phase Four
+        remoteFeatureFlagsStore.removalPhaseFour = true
+        XCTAssertFalse(presenter.shouldShowCard())
+
+        // Phase New Users
+        remoteFeatureFlagsStore.removalPhaseNewUsers = true
+        XCTAssertFalse(presenter.shouldShowCard())
+    }
+}
+
+private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
+
+    var removalPhaseOne = false
+    var removalPhaseTwo = false
+    var removalPhaseThree = false
+    var removalPhaseFour = false
+    var removalPhaseNewUsers = false
+
+    override func value(for flag: OverrideableFlag) -> Bool {
+        guard let flag = flag as? WordPress.FeatureFlag else {
+            return false
+        }
+        switch flag {
+        case .jetpackFeaturesRemovalPhaseOne:
+            return removalPhaseOne
+        case .jetpackFeaturesRemovalPhaseTwo:
+            return removalPhaseTwo
+        case .jetpackFeaturesRemovalPhaseThree:
+            return removalPhaseThree
+        case .jetpackFeaturesRemovalPhaseFour:
+            return removalPhaseFour
+        case .jetpackFeaturesRemovalPhaseNewUsers:
+            return removalPhaseNewUsers
+        default:
+            return super.value(for: flag)
+        }
+    }
+}

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -5,6 +5,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
 
     private var mockUserDefaults: InMemoryUserDefaults!
     private var remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
+    private var remoteConfigStore = RemoteConfigStoreMock()
 
     override func setUp() {
         mockUserDefaults = InMemoryUserDefaults()
@@ -39,6 +40,24 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
         remoteFeatureFlagsStore.removalPhaseNewUsers = true
         XCTAssertFalse(presenter.shouldShowCard())
     }
+
+    func testPhaseThreeCardConfig() throws {
+        // Given
+        let presenter = JetpackBrandingMenuCardPresenter(
+            remoteConfigStore: remoteConfigStore,
+            featureFlagStore: remoteFeatureFlagsStore,
+            persistenceStore: mockUserDefaults)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        remoteConfigStore.phaseThreeBlogPostUrl = "example.com"
+
+        // When
+        let config = try XCTUnwrap(presenter.cardConfig())
+
+        // Then
+        XCTAssertEqual(config.description, "Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.")
+        XCTAssertEqual(config.learnMoreButtonURL, "example.com")
+    }
+
 }
 
 private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
@@ -67,5 +86,17 @@ private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
         default:
             return super.value(for: flag)
         }
+    }
+}
+
+private class RemoteConfigStoreMock: RemoteConfigStore {
+
+    var phaseThreeBlogPostUrl: String?
+
+    override func value(for key: String) -> Any? {
+        if key == "phase-three-blog-post" {
+            return phaseThreeBlogPostUrl
+        }
+        return super.value(for: key)
     }
 }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -56,7 +56,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
         let config = try XCTUnwrap(presenter.cardConfig())
 
         // Then
-        XCTAssertEqual(config.description, "Stats, Reader, Notifications and other features will soon move to the Jetpack mobile app.")
+        XCTAssertEqual(config.description, "Stats, Reader, Notifications and other features will move to the Jetpack mobile app soon.")
         XCTAssertEqual(config.learnMoreButtonURL, "example.com")
     }
 
@@ -95,7 +95,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
 
     func testRemindMeLaterTappedAndIntervalPassed() {
         // Given
-        let secondsInSevenDays = TimeInterval(86_400 * 7)
+        let secondsInSevenDays = TimeInterval(86_400 * 4)
         let currentDate = Date()
         let presenter = JetpackBrandingMenuCardPresenter(
             featureFlagStore: remoteFeatureFlagsStore,


### PR DESCRIPTION
Part of #19450

## Description
This PR builds on #19782 and implements the following missing actions: 
- Tapping the card should open up an overlay
- Tapping the ellipsis button and then tapping "Remind me later" should hide the card for 4 days.
- Tapping the ellipsis button and then tapping "Hide this" should hide the card indefinitely.

### Screenshots

| Light Mode | Dark Mode |
| - | - |
|![light](https://user-images.githubusercontent.com/25306722/208017380-58e1d49a-a1e4-4be9-a1fc-4b5b4bc4e0af.png)|![dark](https://user-images.githubusercontent.com/25306722/208017377-56a3cdf1-3b43-4e28-8d80-f974220544f0.png)|

## Testing Instructions

### Display the fullscreen overlay

1. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
2. Kill the app
3. Launch the app
4. Make sure the menu card is displayed
5. Tap anywhere on the card
6. Make sure the overlay is displayed
7. Make sure the overlay matches the design

### Hiding the card

1. Go to `JetpackBrandingMenuCardPresenter.swift` line 90
2. Change the value of `secondsInDay` to any small value, 10, for example
3. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
4. Kill the app
5. Launch the app
6. Make sure the menu card is displayed
7. Tap on the ellipsis button and then tap "Remind me later"
8. Make sure the card is hidden
9. Kill and relaunch the app
10. Make sure the menu card is still not showing
11. Wait for the duration to pass (If you set `secondsInDay` to 10, then wait for 70 seconds)
12. Kill and relaunch the app
13. Make sure the menu card is displayed
14. Tap on the ellipsis button and then tap "Hide this"
15. Make sure the card is hidden
16. Wait for the duration to pass (If you set `secondsInDay` to 10, then wait for 70 seconds)
17. Kill and relaunch the app
18. Make sure the menu card is not showing

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.