### PR TITLE
Jetpack Focus: Add analytics tracking for the Jetpack menu card

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -414,6 +414,11 @@ import Foundation
     case jetpackSiteCreationOverlayDisplayed
     case jetpackSiteCreationOverlayButtonTapped
     case jetpackSiteCreationOverlayDismissed
+    case jetpackBrandingMenuCardDisplayed
+    case jetpackBrandingMenuCardTapped
+    case jetpackBrandingMenuCardLinkTapped
+    case jetpackBrandingMenuCardDismissed
+    case jetpackBrandingMenuCardHidden
 
     /// A String that represents the event
     var value: String {
@@ -1123,6 +1128,16 @@ import Foundation
             return "remove_site_creation_overlay_button_tapped"
         case .jetpackSiteCreationOverlayDismissed:
             return "remove_site_creation_overlay_dismissed"
+        case .jetpackBrandingMenuCardDisplayed:
+            return "remove_feature_card_displayed"
+        case .jetpackBrandingMenuCardTapped:
+            return "remove_feature_card_tapped"
+        case .jetpackBrandingMenuCardLinkTapped:
+            return "remove_feature_card_link_tapped"
+        case .jetpackBrandingMenuCardDismissed:
+            return "remove_feature_card_dismissed"
+        case .jetpackBrandingMenuCardHidden:
+            return "remove_feature_card_hidden"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -417,8 +417,8 @@ import Foundation
     case jetpackBrandingMenuCardDisplayed
     case jetpackBrandingMenuCardTapped
     case jetpackBrandingMenuCardLinkTapped
-    case jetpackBrandingMenuCardDismissed
     case jetpackBrandingMenuCardHidden
+    case jetpackBrandingMenuCardRemindLater
 
     /// A String that represents the event
     var value: String {
@@ -1134,10 +1134,10 @@ import Foundation
             return "remove_feature_card_tapped"
         case .jetpackBrandingMenuCardLinkTapped:
             return "remove_feature_card_link_tapped"
-        case .jetpackBrandingMenuCardDismissed:
-            return "remove_feature_card_dismissed"
         case .jetpackBrandingMenuCardHidden:
-            return "remove_feature_card_hidden"
+            return "remove_feature_card_hide"
+        case .jetpackBrandingMenuCardRemindLater:
+            return "remove_feature_card_remind_later"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1136,9 +1136,9 @@ import Foundation
         case .jetpackBrandingMenuCardLinkTapped:
             return "remove_feature_card_link_tapped"
         case .jetpackBrandingMenuCardHidden:
-            return "remove_feature_card_hide"
+            return "remove_feature_card_hide_tapped"
         case .jetpackBrandingMenuCardRemindLater:
-            return "remove_feature_card_remind_later"
+            return "remove_feature_card_remind_later_tapped"
         case .jetpackBrandingMenuCardContextualMenuAccessed:
             return "remove_feature_card_menu_accessed"
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -419,6 +419,7 @@ import Foundation
     case jetpackBrandingMenuCardLinkTapped
     case jetpackBrandingMenuCardHidden
     case jetpackBrandingMenuCardRemindLater
+    case jetpackBrandingMenuCardContextualMenuAccessed
 
     /// A String that represents the event
     var value: String {
@@ -1138,6 +1139,8 @@ import Foundation
             return "remove_feature_card_hide"
         case .jetpackBrandingMenuCardRemindLater:
             return "remove_feature_card_remind_later"
+        case .jetpackBrandingMenuCardContextualMenuAccessed:
+            return "remove_feature_card_menu_accessed"
 
         } // END OF SWITCH
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -10,7 +10,9 @@ extension BlogDetailsViewController {
     @objc func jetpackCardSectionViewModel() -> BlogDetailsSection {
         let row = BlogDetailsRow()
         row.callback = {
+            let presenter = JetpackBrandingMenuCardPresenter()
             JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(from: .card, in: self)
+            presenter.trackCardTapped()
         }
 
         let section = BlogDetailsSection(title: nil,

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -23,8 +23,8 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         frameView.configureButtonContainerStackView()
         frameView.hideHeader()
 
-        frameView.onEllipsisButtonTap = {
-            // TODO: Track menu shown
+        frameView.onEllipsisButtonTap = { [weak self] in
+            self?.presenter.trackContexualMenuAccessed()
         }
         frameView.ellipsisButton.showsMenuAsPrimaryAction = true
         frameView.ellipsisButton.menu = contextMenu

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -134,7 +134,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     private func commonInit() {
         setupViews()
         setupContent()
-        
+
         presenter.trackCardShown()
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -134,7 +134,8 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     private func commonInit() {
         setupViews()
         setupContent()
-        // TODO: Track card shown
+        
+        presenter.trackCardShown()
     }
 
     // MARK: Helpers
@@ -164,7 +165,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         let webViewController = WebViewControllerFactory.controller(url: url, source: Constants.analyticsSource)
         let navController = UINavigationController(rootViewController: webViewController)
         viewController?.present(navController, animated: true)
-        // TODO: Track button tapped
+        presenter.trackLinkTapped()
     }
 }
 
@@ -191,13 +192,11 @@ private extension JetpackBrandingMenuCardCell {
     private func remindMeLaterTapped() {
         presenter.remindLaterTapped()
         viewController?.reloadTableView()
-        // TODO: Track button tapped
     }
 
     private func hideThisTapped() {
         presenter.hideThisTapped()
         viewController?.reloadTableView()
-        // TODO: Track button tapped
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -79,6 +79,10 @@ extension JetpackBrandingMenuCardPresenter {
         WPAnalytics.track(.jetpackBrandingMenuCardTapped, properties: analyticsProperties)
     }
 
+    func trackContexualMenuAccessed() {
+        WPAnalytics.track(.jetpackBrandingMenuCardContextualMenuAccessed, properties: analyticsProperties)
+    }
+
     func trackHideThisTapped() {
         WPAnalytics.track(.jetpackBrandingMenuCardHidden, properties: analyticsProperties)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -12,7 +12,7 @@ class JetpackBrandingMenuCardPresenter {
     private let remoteConfigStore: RemoteConfigStore
     private let persistenceStore: UserPersistentRepository
     private let currentDateProvider: CurrentDateProvider
-    private let phase: JetpackFeaturesRemovalCoordinator.GeneralPhase
+    private let featureFlagStore: RemoteFeatureFlagStore
 
     // MARK: Initializers
 
@@ -23,12 +23,13 @@ class JetpackBrandingMenuCardPresenter {
         self.remoteConfigStore = remoteConfigStore
         self.persistenceStore = persistenceStore
         self.currentDateProvider = currentDateProvider
-        self.phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
+        self.featureFlagStore = featureFlagStore
     }
 
     // MARK: Public Functions
 
     func cardConfig() -> Config? {
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {
         case .three:
             let description = Strings.phaseThreeDescription
@@ -92,7 +93,8 @@ extension JetpackBrandingMenuCardPresenter {
     }
 
     private var analyticsProperties: [String: String] {
-        [Constants.phaseAnalyticsKey: phase.rawValue]
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
+        return [Constants.phaseAnalyticsKey: phase.rawValue]
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -66,27 +66,27 @@ class JetpackBrandingMenuCardPresenter {
 // MARK: Analytics
 
 extension JetpackBrandingMenuCardPresenter {
-    
+
     func trackCardShown() {
         WPAnalytics.track(.jetpackBrandingMenuCardDisplayed, properties: analyticsProperties)
     }
-    
+
     func trackLinkTapped() {
         WPAnalytics.track(.jetpackBrandingMenuCardLinkTapped, properties: analyticsProperties)
     }
-    
+
     func trackCardTapped() {
         WPAnalytics.track(.jetpackBrandingMenuCardTapped, properties: analyticsProperties)
     }
-    
+
     func trackHideThisTapped() {
-        WPAnalytics.track(.jetpackBrandingMenuCardDismissed, properties: analyticsProperties)
-    }
-    
-    func trackRemindMeLaterTapped() {
         WPAnalytics.track(.jetpackBrandingMenuCardHidden, properties: analyticsProperties)
     }
-    
+
+    func trackRemindMeLaterTapped() {
+        WPAnalytics.track(.jetpackBrandingMenuCardRemindLater, properties: analyticsProperties)
+    }
+
     private var analyticsProperties: [String: String] {
         [Constants.phaseAnalyticsKey: phase.rawValue]
     }


### PR DESCRIPTION
Closes #19450

## Description
This PR builds on #19782 and #19785 and implements analytics tracking for the menu card

## Testing Instructions

1. Go to `JetpackBrandingMenuCardPresenter.swift` line 123
2. Change the value of `secondsInDay` to any small value, 1, for example
3. Run the app
4. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
5. Kill the app
6. Launch the app
7. The menu card should be displayed
8. Check logs for the event `remove_feature_card_displayed`
9. Tap anywhere on the card to display the overlay
10. Check logs for the event `remove_feature_card_tapped`
11. Dismiss the overlay
12. Tap on the learn more button
13. Check logs for the event `remove_feature_card_link_tapped`
14. Dismiss the web view
15. Tap on the ellipsis button
16. Check logs for the event `remove_feature_card_menu_accessed`
17. Tap on "Remind me later"
18. Check logs for the event `remove_feature_card_remind_later_tapped`
19. Wait for the duration to pass (If you set `secondsInDay` to 1, then wait for 7 seconds)
20. Kill and relaunch the app
21. The menu card should be displayed
22. Tap on the ellipsis button
23. Tap on "Hide this"
24. Check logs for the event `remove_feature_card_hide_tapped`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.