### PR TITLE
[Stats Revamp] Fixing Scaling Font (Dynamic Type) issues

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -410,6 +410,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         [defaultActionButton, secondaryActionButton].forEach { (button) in
             button?.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
             button?.titleLabel?.adjustsFontSizeToFitWidth = true
+            button?.titleLabel?.adjustsFontForContentSizeCategory = true
             button?.layer.borderColor = seperator.cgColor
             button?.layer.borderWidth = 1
             button?.layer.cornerRadius = 8
@@ -417,6 +418,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
         primaryActionButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .medium)
         primaryActionButton.titleLabel?.adjustsFontSizeToFitWidth = true
+        primaryActionButton.titleLabel?.adjustsFontForContentSizeCategory = true
         primaryActionButton.backgroundColor = accentColor
         primaryActionButton.layer.cornerRadius = 8
     }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
@@ -99,7 +99,7 @@ class DonutChartView: UIView {
         legendStackView = UIStackView()
         legendStackView.translatesAutoresizingMaskIntoConstraints = false
         legendStackView.spacing = Constants.legendStackViewSpacing
-        legendStackView.distribution = .equalSpacing
+        legendStackView.distribution = .fillEqually
         legendStackView.alignment = .center
 
         addSubview(legendStackView)
@@ -110,6 +110,7 @@ class DonutChartView: UIView {
             chartContainer.leadingAnchor.constraint(equalTo: leadingAnchor),
             chartContainer.trailingAnchor.constraint(equalTo: trailingAnchor),
             chartContainer.topAnchor.constraint(equalTo: topAnchor),
+            chartContainer.heightAnchor.constraint(equalToConstant: Constants.chartHeight),
 
             legendStackView.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
             legendStackView.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
@@ -263,9 +264,11 @@ class DonutChartView: UIView {
         if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
             legendStackView.axis = .vertical
             legendStackView.alignment = .leading
+            legendStackView.subviews.forEach { ($0 as? LegendView)?.isCentered = false }
         } else {
             legendStackView.axis = .horizontal
             legendStackView.alignment = .center
+            legendStackView.subviews.forEach { ($0 as? LegendView)?.isCentered = true }
         }
     }
 
@@ -310,6 +313,7 @@ class DonutChartView: UIView {
         static let titleStackViewSpacing: CGFloat = 8.0
         static let legendStackViewSpacing: CGFloat = 8.0
         static let chartToLegendSpacing: CGFloat = 32.0
+        static let chartHeight: CGFloat = 180.0
 
         // We'll rotate the chart back by 90 degrees so it starts at the top rather than the right
         static let chartRotationDegrees: CGFloat = -90.0
@@ -324,6 +328,17 @@ class DonutChartView: UIView {
 private class LegendView: UIView {
     let segment: DonutChartView.Segment
 
+    var isCentered: Bool {
+        get {
+            return leadingConstraint?.isActive ?? false
+        }
+
+        set {
+            leadingConstraint?.isActive = !newValue
+        }
+    }
+    private var leadingConstraint: NSLayoutConstraint?
+
     init(segment: DonutChartView.Segment) {
         self.segment = segment
 
@@ -337,33 +352,44 @@ private class LegendView: UIView {
     }
 
     private func configureSubviews() {
-        let indicatorContainer = UIView()
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+
         let indicator = UIView()
         indicator.backgroundColor = segment.color
         indicator.layer.cornerRadius = 6.0
         indicator.translatesAutoresizingMaskIntoConstraints = false
-        indicatorContainer.addSubview(indicator)
 
         let titleLabel = UILabel()
-        titleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        titleLabel.font = .preferredFont(forTextStyle: .footnote)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.text = segment.title
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.setContentCompressionResistancePriority(.defaultHigh, for: .horizontal)
 
-        let stackView = UIStackView(arrangedSubviews: [indicatorContainer, titleLabel])
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = 16.0
-        addSubview(stackView)
+        containerView.addSubviews([titleLabel, indicator])
+        addSubview(containerView)
+
+        leadingConstraint = containerView.leadingAnchor.constraint(equalTo: leadingAnchor)
+        leadingConstraint?.priority = .required
 
         NSLayoutConstraint.activate([
             indicator.widthAnchor.constraint(equalToConstant: 12.0),
             indicator.heightAnchor.constraint(equalToConstant: 12.0),
-            indicator.centerXAnchor.constraint(equalTo: indicatorContainer.centerXAnchor),
-            indicator.centerYAnchor.constraint(equalTo: indicatorContainer.centerYAnchor),
+            indicator.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            indicator.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
 
-            stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
-            stackView.topAnchor.constraint(equalTo: topAnchor),
-            stackView.bottomAnchor.constraint(equalTo: bottomAnchor)
+            titleLabel.leadingAnchor.constraint(equalTo: indicator.trailingAnchor, constant: 8),
+            titleLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
+            titleLabel.topAnchor.constraint(greaterThanOrEqualTo: containerView.topAnchor),
+            titleLabel.bottomAnchor.constraint(lessThanOrEqualTo: containerView.bottomAnchor),
+
+            containerView.topAnchor.constraint(equalTo: topAnchor),
+            containerView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            containerView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+            containerView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            containerView.centerXAnchor.constraint(equalTo: centerXAnchor)
         ])
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/DonutChartView.swift
@@ -79,10 +79,12 @@ class DonutChartView: UIView {
         titleLabel = UILabel()
         titleLabel.textAlignment = .center
         titleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        titleLabel.adjustsFontForContentSizeCategory = true
 
         totalCountLabel = UILabel()
         totalCountLabel.textAlignment = .center
         totalCountLabel.font = .preferredFont(forTextStyle: .title1).bold()
+        totalCountLabel.adjustsFontForContentSizeCategory = true
 
         titleStackView = UIStackView(arrangedSubviews: [titleLabel, totalCountLabel])
 
@@ -98,6 +100,7 @@ class DonutChartView: UIView {
         legendStackView.translatesAutoresizingMaskIntoConstraints = false
         legendStackView.spacing = Constants.legendStackViewSpacing
         legendStackView.distribution = .equalSpacing
+        legendStackView.alignment = .center
 
         addSubview(legendStackView)
     }
@@ -252,6 +255,20 @@ class DonutChartView: UIView {
         }
     }
 
+    // MARK: - Dynamic Type
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.preferredContentSizeCategory.isAccessibilityCategory {
+            legendStackView.axis = .vertical
+            legendStackView.alignment = .leading
+        } else {
+            legendStackView.axis = .horizontal
+            legendStackView.alignment = .center
+        }
+    }
+
     // MARK: Helpers
 
     private func makeSegmentLayer(_ segment: Segment) -> CAShapeLayer {
@@ -320,22 +337,28 @@ private class LegendView: UIView {
     }
 
     private func configureSubviews() {
+        let indicatorContainer = UIView()
         let indicator = UIView()
         indicator.backgroundColor = segment.color
         indicator.layer.cornerRadius = 6.0
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        indicatorContainer.addSubview(indicator)
 
         let titleLabel = UILabel()
         titleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.text = segment.title
 
-        let stackView = UIStackView(arrangedSubviews: [indicator, titleLabel])
+        let stackView = UIStackView(arrangedSubviews: [indicatorContainer, titleLabel])
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = 8.0
+        stackView.spacing = 16.0
         addSubview(stackView)
 
         NSLayoutConstraint.activate([
             indicator.widthAnchor.constraint(equalToConstant: 12.0),
             indicator.heightAnchor.constraint(equalToConstant: 12.0),
+            indicator.centerXAnchor.constraint(equalTo: indicatorContainer.centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: indicatorContainer.centerYAnchor),
 
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor),

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -206,7 +206,7 @@ extension WPStyleGuide {
 
         // MARK: - Font Size
 
-        static let maximumChartAxisFontPointSize: CGFloat = 22
+        static let maximumChartAxisFontPointSize: CGFloat = 18
 
         // MARK: - Style Values
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -62,6 +62,7 @@ class InsightsManagementViewController: UITableViewController {
         reloadViewModel()
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
+        tableView.estimatedSectionHeaderHeight = 38
         tableView.accessibilityIdentifier = TextContent.title
 
         if FeatureFlag.statsNewAppearance.enabled {
@@ -83,7 +84,7 @@ class InsightsManagementViewController: UITableViewController {
     // MARK: TableView Data Source / Delegate Overrides
 
     override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 38
+        return UITableView.automaticDimension
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -144,8 +144,17 @@ private extension SiteStatsTableHeaderView {
 
     func applyStyles() {
         backgroundColor = .listForeground
+
         Style.configureLabelAsCellRowTitle(dateLabel)
+        dateLabel.font = Metrics.dateLabelFont
+        dateLabel.adjustsFontForContentSizeCategory = true
+        dateLabel.minimumScaleFactor = Metrics.minimumScaleFactor
+
         Style.configureLabelAsChildRowTitle(timezoneLabel)
+        timezoneLabel.font = Metrics.timezoneFont
+        timezoneLabel.adjustsFontForContentSizeCategory = true
+        timezoneLabel.minimumScaleFactor = Metrics.minimumScaleFactor
+
         Style.configureViewAsSeparator(bottomSeparatorLine)
 
         // Required as the Style separator configure method clears all
@@ -309,5 +318,27 @@ extension SiteStatsTableHeaderView: StatsBarChartViewDelegate {
 
         delegate?.dateChangedTo(self.date)
         reloadView()
+    }
+}
+
+private extension SiteStatsTableHeaderView {
+    enum Metrics {
+        static let dateLabelFontSize: CGFloat = 20
+        static let maximumDateLabelFontSize: CGFloat = 32
+        static let timezoneFontSize: CGFloat = 16
+        static let maximumTimezoneFontSize: CGFloat = 20
+        static let minimumScaleFactor: CGFloat = 0.8
+
+        static var dateLabelFont: UIFont {
+            let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .headline)
+            let font = UIFont(descriptor: fontDescriptor, size: dateLabelFontSize)
+            return UIFontMetrics.default.scaledFont(for: font, maximumPointSize: maximumDateLabelFontSize)
+        }
+
+        static var timezoneFont: UIFont {
+            let fontDescriptor = UIFontDescriptor.preferredFontDescriptor(withTextStyle: .callout)
+            let font = UIFont(descriptor: fontDescriptor, size: timezoneFontSize)
+            return UIFontMetrics.default.scaledFont(for: font, maximumPointSize: maximumTimezoneFontSize)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsFollowersChartViewModel.swift
@@ -15,7 +15,7 @@ struct StatsFollowersChartViewModel {
         let chartView = DonutChartView()
         chartView.configure(title: "", totalCount: CGFloat(totalCount()), segments: segments())
         chartView.translatesAutoresizingMaskIntoConstraints = false
-        chartView.heightAnchor.constraint(equalToConstant: Constants.chartHeight).isActive = true
+        chartView.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.chartHeight).isActive = true
         return chartView
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/StatsReferrersChartViewModel.swift
@@ -53,7 +53,7 @@ struct StatsReferrersChartViewModel {
         let chartView = DonutChartView()
         chartView.configure(title: Constants.chartTitle, totalCount: CGFloat(referrers.totalReferrerViewsCount), segments: segments)
         chartView.translatesAutoresizingMaskIntoConstraints = false
-        chartView.heightAnchor.constraint(equalToConstant: Constants.chartHeight).isActive = true
+        chartView.heightAnchor.constraint(greaterThanOrEqualToConstant: Constants.chartHeight).isActive = true
         return chartView
     }
 


### PR DESCRIPTION
Fixes #19728

## Issues

### The “ACTIVE CARDS” and “INACTIVE CARDS” section headers on the Manage Stats Cards screen overlapping

Fixed by making section height automatic so increasing text sizes would increase section height as well

### The chart legends on the segment (circle) chart on detail screens of the Views & Visitors card clipping

To fix legend titles clipping multiple steps were required to take:
- Rebuild legend UI so the indicator inside a UIStackView wouldn't restrict the title label to grow in size
- Allow legend to be shown vertically and not horizontally when the text grows too large by using `traitCollectionDidChange`
- Use `.fillEqually` instead of `equalCentering` for legend to long labels wouldn't go out of bounds 
- Allow `DonutChatView` to grow in height

### The date pickers used on detail screens to go back and forth between different weeks clipping

Set the maximum size for labels so the date picker header would behave in a similar way as Navigation Bar

### The buttons “Try it now” and “Remind me later” on the “upgraded stats” welcome screen don’t respond to text size changes

Enable `adjustsFontForContentSizeCategory` flag

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags

### Case 1: "Active Cards" and "Inactive Cards" headers not overlapping:
1. Open Stats
2. Click "Settings" on top right
3. Increase font size
4. Confirm "Active Cards" and "Inactive Cards" are not clipping or overlapping

### Case 2: The chart legends on the segment (circle) chart on detail screens of the Views & Visitors card clipping:
1. Open Stats
2. Add "Views & Visitors" or "Total Followers" cards
3. Open details for one of those cards
4. Observe the chart, a legend with labels should be visible
5. Increase font size
6. Confirm the labels not clipping horizontally and eventually be disabled vertically

### Case 3: The date pickers used on detail screens to go back and forth between different weeks.
1. Open Stats
2. Add "Views & Visitors" card
3. Open details
4. Observe the date picker element at the top
5. Increase font size
6. Confirm font increases up to an extent and is not clipped

### Case 4: The buttons “Try it now” and “Remind me later” on the “upgraded stats” welcome screen don’t respond to text size changes
1. Fresh install the app
2. Enable feature flags and kill the app
3. Reopen the app
4. Insights promotion should open
5. Increase font size
6. Confirm button titles change in size

## Regression Notes

1. Potential unintended areas of impact

Already existing functionality of changed views breaking

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



