### PR TITLE
Prevent multiple threads exporting data at the same time

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -333,10 +333,14 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             // To prevent race condition, initialize the shared instance synchronously so it can listen to account change notifications.
             let _ = ContentMigrationCoordinator.shared
 
-            // Start proactively exporting WP data in the background if the conditions are fulfilled.
-            // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
-            DispatchQueue.global().async {
-                ContentMigrationCoordinator.shared.startOnceIfNeeded()
+            let launchUrl = launchOptions[.url] as? URL
+            let exportUrl = URL(string: "\(AppScheme.wordpressMigrationV1.rawValue)\(WordPressExportRoute().path.removingPrefix("/"))")
+            if launchUrl != exportUrl {
+                // Start proactively exporting WP data in the background if the conditions are fulfilled.
+                // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
+                DispatchQueue.global().async {
+                    ContentMigrationCoordinator.shared.startOnceIfNeeded()
+                }
             }
         }
 


### PR DESCRIPTION
Fixes "Open WordPress" crash from https://github.com/wordpress-mobile/WordPress-iOS/pull/19787#issuecomment-1356025562

## Description

When WordPress launches, it tries to export data automatically during the startup sequence. The deep link from Jetpack that opens WordPress also tries to export data. I think this can cause a crash when multiple threads are exporting data at the same time.

![Screen Shot 2022-12-19 at 12 16 27 PM](https://user-images.githubusercontent.com/2454408/208524960-b071ba43-b79a-41f1-a0e9-5b34c5c952db.png)

## Testing

### Setup

To get both apps to kick off the export at the same time:

- Comment out [this code](https://github.com/wordpress-mobile/WordPress-iOS/blob/release/21.4/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift#L97-L100) and install WordPress
- Login

**OR**

- Install an older WordPress such as 21.2 first from TestFlight (so the data export flag isn't set yet)
- Login
- Install over that version with a newer build with the automatic launch off (Edit scheme... > Run > Launch = "Wait for the executable to be launched")

### Steps

To test:

- Setup WordPress following one of the steps from above ^
- Install Jetpack
- Tap on "Open WordPress" when the popup appears
- Verify no crash happens when WordPress opens
- Attempt multiple times since race conditions are fun like that 🙃

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
