### PR TITLE
Jetpack Focus: Display phase three feature collection overlay on app open

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -162,6 +162,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         subscribeToPostPublished()
         startObservingQuickStart()
         startObservingOnboardingPrompt()
+        subscribeToWillEnterForeground()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -262,6 +263,13 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     private func subscribeToPostPublished() {
         NotificationCenter.default.addObserver(self, selector: #selector(handlePostPublished), name: .newPostPublished, object: nil)
+    }
+
+    private func subscribeToWillEnterForeground() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(displayOverlayIfNeeded),
+                                               name: UIApplication.willEnterForegroundNotification,
+                                               object: nil)
     }
 
     func updateNavigationTitle(for blog: Blog) {
@@ -1030,7 +1038,9 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
 // MARK: Jetpack Features Removal
 
 private extension MySiteViewController {
-    func displayOverlayIfNeeded() {
-        JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(from: .appOpen, in: self)
+    @objc func displayOverlayIfNeeded() {
+        if isViewOnScreen() {
+            JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(from: .appOpen, in: self)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -184,6 +184,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        displayOverlayIfNeeded()
+
         workaroundLargeTitleCollapseBug()
 
         if AppConfiguration.showsWhatIsNew {
@@ -1022,5 +1024,13 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
         case .none:
             return
         }
+    }
+}
+
+// MARK: Jetpack Features Removal
+
+private extension MySiteViewController {
+    func displayOverlayIfNeeded() {
+        JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(from: .appOpen, in: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -41,6 +41,9 @@ class JetpackFeaturesRemovalCoordinator {
         case login
         case appOpen = "app_open"
 
+        /// Used to differentiate between last saved dates for different phases.
+        /// Should return a dynamic value if each phase should be treated differently.
+        /// Should return a static value (empty string for example) if all phases should be treated the same.
         func frequencyTrackerPhaseString(phase: GeneralPhase) -> String {
             switch self {
             case .login:
@@ -48,7 +51,7 @@ class JetpackFeaturesRemovalCoordinator {
             case .appOpen:
                 return phase.rawValue // Shown once per phase
             default:
-                return "" // Phase is irrelevant, it just affects the frequency.
+                return "" // Phase is irrelevant.
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -40,6 +40,17 @@ class JetpackFeaturesRemovalCoordinator {
         case card
         case login
         case appOpen = "app_open"
+
+        func frequencyTrackerPhaseString(phase: GeneralPhase) -> String {
+            switch self {
+            case .login:
+                fallthrough
+            case .appOpen:
+                return phase.rawValue // Shown once per phase
+            default:
+                return "" // Phase is irrelevant, it just affects the frequency.
+            }
+        }
     }
 
     static func generalPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> GeneralPhase {
@@ -100,8 +111,11 @@ class JetpackFeaturesRemovalCoordinator {
     static func presentOverlayIfNeeded(from source: OverlaySource, in viewController: UIViewController) {
         let phase = generalPhase()
         let frequencyConfig = phase.frequencyConfig
+        let frequencyTrackerPhaseString = source.frequencyTrackerPhaseString(phase: phase)
         let viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source)
-        let frequencyTracker = JetpackOverlayFrequencyTracker(frequencyConfig: frequencyConfig, source: source)
+        let frequencyTracker = JetpackOverlayFrequencyTracker(frequencyConfig: frequencyConfig,
+                                                              phaseString: frequencyTrackerPhaseString,
+                                                              source: source)
         guard viewModel.shouldShowOverlay, frequencyTracker.shouldShow() else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -43,15 +43,15 @@ class JetpackFeaturesRemovalCoordinator {
 
         /// Used to differentiate between last saved dates for different phases.
         /// Should return a dynamic value if each phase should be treated differently.
-        /// Should return a static value (empty string for example) if all phases should be treated the same.
-        func frequencyTrackerPhaseString(phase: GeneralPhase) -> String {
+        /// Should return nil if all phases should be treated the same.
+        func frequencyTrackerPhaseString(phase: GeneralPhase) -> String? {
             switch self {
             case .login:
                 fallthrough
             case .appOpen:
                 return phase.rawValue // Shown once per phase
             default:
-                return "" // Phase is irrelevant.
+                return nil // Phase is irrelevant.
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
@@ -3,9 +3,16 @@ import Foundation
 class JetpackOverlayFrequencyTracker {
 
     private let frequencyConfig: FrequencyConfig
-    private let phaseString: String
+    private let phaseString: String?
     private let source: JetpackFeaturesRemovalCoordinator.OverlaySource
     private let persistenceStore: UserPersistentRepository
+
+    private var sourceDateKey: String {
+        guard let phaseString = phaseString else {
+            return "\(Constants.lastDateKeyPrefix)-\(source.rawValue)"
+        }
+        return "\(Constants.lastDateKeyPrefix)-\(source.rawValue)-\(phaseString)"
+    }
 
     private var lastSavedGenericDate: Date? {
         get {
@@ -20,17 +27,15 @@ class JetpackOverlayFrequencyTracker {
 
     private var lastSavedSourceDate: Date? {
         get {
-            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)-\(phaseString)"
-            return persistenceStore.object(forKey: sourceKey) as? Date
+            return persistenceStore.object(forKey: sourceDateKey) as? Date
         }
         set {
-            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)-\(phaseString)"
-            persistenceStore.set(newValue, forKey: sourceKey)
+            persistenceStore.set(newValue, forKey: sourceDateKey)
         }
     }
 
     init(frequencyConfig: FrequencyConfig = .defaultConfig,
-         phaseString: String = "",
+         phaseString: String? = nil,
          source: JetpackFeaturesRemovalCoordinator.OverlaySource,
          persistenceStore: UserPersistentRepository = UserDefaults.standard) {
         self.frequencyConfig = frequencyConfig

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
@@ -3,6 +3,7 @@ import Foundation
 class JetpackOverlayFrequencyTracker {
 
     private let frequencyConfig: FrequencyConfig
+    private let phaseString: String
     private let source: JetpackFeaturesRemovalCoordinator.OverlaySource
     private let persistenceStore: UserPersistentRepository
 
@@ -19,19 +20,21 @@ class JetpackOverlayFrequencyTracker {
 
     private var lastSavedSourceDate: Date? {
         get {
-            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)"
+            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)-\(phaseString)"
             return persistenceStore.object(forKey: sourceKey) as? Date
         }
         set {
-            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)"
+            let sourceKey = "\(Constants.lastDateKeyPrefix)-\(source.rawValue)-\(phaseString)"
             persistenceStore.set(newValue, forKey: sourceKey)
         }
     }
 
     init(frequencyConfig: FrequencyConfig = .defaultConfig,
+         phaseString: String = "",
          source: JetpackFeaturesRemovalCoordinator.OverlaySource,
          persistenceStore: UserPersistentRepository = UserDefaults.standard) {
         self.frequencyConfig = frequencyConfig
+        self.phaseString = phaseString
         self.source = source
         self.persistenceStore = persistenceStore
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -146,7 +146,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     }
 
     private func setupContent() {
-        logosAnimationView.play()
+        logosAnimationView.currentProgress = 1.0
         let config = presenter.cardConfig()
         descriptionLabel.text = config?.description
         learnMoreSuperview.isHidden = config?.learnMoreButtonURL == nil

--- a/WordPress/WordPressTest/JetpackOverlayFrequencyTrackerTests.swift
+++ b/WordPress/WordPressTest/JetpackOverlayFrequencyTrackerTests.swift
@@ -18,7 +18,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testTrackingOverlay() throws {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .stats, persistenceStore: mockUserDefaults)
 
@@ -37,7 +37,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testAlwaysShowCardOverlays() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-card-"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-card"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .card, persistenceStore: mockUserDefaults)
         mockUserDefaults.set(Date(), forKey: key)
@@ -49,9 +49,11 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testShowLoginOverlayOnlyOnce() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-login-"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-login-phaseString"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
-        let tracker = JetpackOverlayFrequencyTracker(source: .login, persistenceStore: mockUserDefaults)
+        let tracker = JetpackOverlayFrequencyTracker(phaseString: "phaseString",
+                                                     source: .login,
+                                                     persistenceStore: mockUserDefaults)
 
         // When & Then
         XCTAssertTrue(tracker.shouldShow())
@@ -67,9 +69,11 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testShowAppOpenOverlayOnlyOnce() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-app_open-"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-app_open-phaseString"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
-        let tracker = JetpackOverlayFrequencyTracker(source: .appOpen, persistenceStore: mockUserDefaults)
+        let tracker = JetpackOverlayFrequencyTracker(phaseString: "phaseString",
+                                                     source: .appOpen,
+                                                     persistenceStore: mockUserDefaults)
 
         // When & Then
         XCTAssertTrue(tracker.shouldShow())
@@ -85,7 +89,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testFeatureSpecificFrequency() {
         // Given
-        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
+        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(frequencyConfig: Constants.frequencyConfig,
                                                      source: .stats,
@@ -113,7 +117,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testGeneralFrequency() {
         // Given
-        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
+        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let statsTracker = JetpackOverlayFrequencyTracker(frequencyConfig: Constants.frequencyConfig,
                                                           source: .stats,

--- a/WordPress/WordPressTest/JetpackOverlayFrequencyTrackerTests.swift
+++ b/WordPress/WordPressTest/JetpackOverlayFrequencyTrackerTests.swift
@@ -18,7 +18,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testTrackingOverlay() throws {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .stats, persistenceStore: mockUserDefaults)
 
@@ -37,7 +37,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testAlwaysShowCardOverlays() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-card"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-card-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .card, persistenceStore: mockUserDefaults)
         mockUserDefaults.set(Date(), forKey: key)
@@ -49,7 +49,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testShowLoginOverlayOnlyOnce() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-login"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-login-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .login, persistenceStore: mockUserDefaults)
 
@@ -67,7 +67,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testShowAppOpenOverlayOnlyOnce() {
         // Given
-        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-app_open"
+        let key = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-app_open-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(source: .appOpen, persistenceStore: mockUserDefaults)
 
@@ -85,7 +85,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testFeatureSpecificFrequency() {
         // Given
-        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
+        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let tracker = JetpackOverlayFrequencyTracker(frequencyConfig: Constants.frequencyConfig,
                                                      source: .stats,
@@ -113,7 +113,7 @@ final class JetpackOverlayFrequencyTrackerTests: XCTestCase {
 
     func testGeneralFrequency() {
         // Given
-        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats"
+        let statsKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix + "-stats-"
         let genericKey = JetpackOverlayFrequencyTracker.Constants.lastDateKeyPrefix
         let statsTracker = JetpackOverlayFrequencyTracker(frequencyConfig: Constants.frequencyConfig,
                                                           source: .stats,


### PR DESCRIPTION
Closes #19451

## Description
This PR displays the feature collection overlay for phase 3. The overlay is displayed upon opening the app. It is the same overlay that's displayed when tapping the menu card. It should be displayed only once during phase 3.

The PR also has a small tweak to the menu card c4376c6532d9d5a4d30e4439b4df8e685239cf17 that was found during development.

### Screenshots

| Light Mode | Dark Mode |
| - | - |
|![light](https://user-images.githubusercontent.com/25306722/208017380-58e1d49a-a1e4-4be9-a1fc-4b5b4bc4e0af.png)|![dark](https://user-images.githubusercontent.com/25306722/208017377-56a3cdf1-3b43-4e28-8d80-f974220544f0.png)|

## Testing Instructions

1. Open the app
2. Make sure that none of the Jetpack removal flags are enabled from the debug menu
3. Navigate to My Site
4. Close and re-open the app
5. Make sure the overlay is not displayed
6. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
7. Navigate to My Site
8. Close and re-open the app
9. Make sure the overlay is displayed with the correct content and matches the design
10. Close and re-open the app
11. Make sure the overlay is not displayed again

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.