### PR TITLE
[Jetpack Focus] Add Jetpack banner to People view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1480,7 +1480,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showPeople
 {
-    PeopleViewController *controller = [PeopleViewController controllerWithBlog:self.blog];
+    UIViewController *controller = [PeopleViewController withJPBannerForBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
     [self.presentationDelegate presentBlogDetailsViewController:controller];
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -23,6 +23,7 @@ class JetpackBannerWrapperViewController: UIViewController {
         configureStackView(stackView)
         configureChildVC(stackView)
         configureJetpackBanner(stackView)
+        configureNavigationItem()
     }
 
     // MARK: Configuration
@@ -55,9 +56,12 @@ class JetpackBannerWrapperViewController: UIViewController {
             }
         }
         stackView.addArrangedSubview(jetpackBannerView)
-
         if let childVC = childVC as? JPScrollViewDelegate {
             childVC.addTranslationObserver(jetpackBannerView)
         }
+    }
+
+    private func configureNavigationItem() {
+        navigationItem.title = childVC?.navigationItem.title
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -36,6 +36,7 @@ struct JetpackBrandingAnalyticsHelper {
         case home
         case me
         case notificationsSettings = "notifications_settings"
+        case person
         case readerDetail = "reader_detail"
         case sharing
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -24,6 +24,7 @@ struct JetpackBrandingAnalyticsHelper {
     enum JetpackBannerScreen: String {
         case activityLog = "activity_log"
         case notifications
+        case people
         case reader
         case readerSearch = "reader_search"
         case stats

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+@objc
+extension PeopleViewController {
+    static func withJPBannerForBlog(_ blog: Blog) -> UIViewController? {
+        guard let peopleViewVC = PeopleViewController.controllerWithBlog(blog) else {
+            return nil
+        }
+        return JetpackBannerWrapperViewController(childVC: peopleViewVC, analyticsId: .people)
+    }
+}
+
+extension PeopleViewController: JPScrollViewDelegate {
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        processJetpackBannerVisibility(scrollView)
+    }
+}

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
@@ -6,6 +6,9 @@ extension PeopleViewController {
         guard let peopleViewVC = PeopleViewController.controllerWithBlog(blog) else {
             return nil
         }
+        guard JetpackBrandingCoordinator.shouldShowBannerForJetpackDependentFeatures() else {
+            return peopleViewVC
+        }
         return JetpackBannerWrapperViewController(childVC: peopleViewVC, analyticsId: .people)
     }
 }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Combine
 
 import CocoaLumberjack
 import WordPressShared
@@ -101,6 +102,9 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         frc.delegate = self
         return frc
     }()
+
+    /// Needed for JPScrollViewDelegate conformance.
+    let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
 
     /// Filtering Tab Bar
     ///

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -190,9 +190,12 @@ final class PersonViewController: UITableViewController {
             lastNameIndexPath,
             displayNameIndexPath
         ])
-        model.append([
-            removeIndexPath
-        ])
+
+        if isRemoveEnabled {
+            model.append([
+                removeIndexPath
+            ])
+        }
         return model
     }()
 }

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -604,3 +604,43 @@ private extension PersonViewController {
         }
     }
 }
+
+// MARK: - Jetpack powered badge
+extension PersonViewController {
+
+    private static let jetpackBadgeHeight: CGFloat = 96
+    private static func shouldShowJetpackBadge() -> Bool {
+        JetpackBrandingVisibility.all.enabled &&
+        JetpackBrandingCoordinator.shouldShowBannerForJetpackDependentFeatures()
+    }
+    private var lastSection: Int {
+        viewModel.count - 1
+    }
+
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        guard
+            section == lastSection,
+            Self.shouldShowJetpackBadge()
+        else {
+            return nil
+        }
+
+        return JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+    }
+
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        guard
+            section == lastSection,
+            Self.shouldShowJetpackBadge()
+        else {
+            return UITableView.automaticDimension
+        }
+
+        return Self.jetpackBadgeHeight
+    }
+
+    @objc private func jetpackButtonTapped() {
+        JetpackBrandingCoordinator.presentOverlay(from: self)
+        JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .person)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2630,6 +2630,8 @@
 		C395FB272822148400AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = C395FB252821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift */; };
 		C396C80B280F2401006FE7AC /* SiteDesignTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C396C80A280F2401006FE7AC /* SiteDesignTests.swift */; };
 		C3AB4879292F114A001F7AF8 /* UIApplication+AppAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */; };
+		C3BC86F629528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC86F529528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift */; };
+		C3BC86F729528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3BC86F529528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift */; };
 		C3C21EB928385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
 		C3C21EBA28385EC8002296E2 /* RemoteSiteDesigns.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */; };
 		C3C2F84628AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */; };
@@ -7762,6 +7764,7 @@
 		C396C80A280F2401006FE7AC /* SiteDesignTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDesignTests.swift; sourceTree = "<group>"; };
 		C3AB4878292F114A001F7AF8 /* UIApplication+AppAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+AppAvailability.swift"; sourceTree = "<group>"; };
 		C3ABE791263099F7009BD402 /* WordPress 121.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 121.xcdatamodel"; sourceTree = "<group>"; };
+		C3BC86F529528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PeopleViewController+JetpackBannerViewController.swift"; sourceTree = "<group>"; };
 		C3C21EB828385EC8002296E2 /* RemoteSiteDesigns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteSiteDesigns.swift; sourceTree = "<group>"; };
 		C3C2F84528AC8BC700937E45 /* JetpackBannerScrollVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerScrollVisibilityTests.swift; sourceTree = "<group>"; };
 		C3C2F84728AC8EBF00937E45 /* JetpackBannerScrollVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBannerScrollVisibility.swift; sourceTree = "<group>"; };
@@ -14586,6 +14589,7 @@
 			isa = PBXGroup;
 			children = (
 				E1B912881BB01288003C25B9 /* PeopleViewController.swift */,
+				C3BC86F529528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift */,
 				B59B18741CC7FB8D0055EB7C /* PersonViewController.swift */,
 				B56FEB781CD8E13C00E621F9 /* RoleViewController.swift */,
 				B549BA671CF7447E0086C608 /* InvitePersonViewController.swift */,
@@ -21414,6 +21418,7 @@
 				988FD74A279B75A400C7E814 /* NotificationCommentDetailCoordinator.swift in Sources */,
 				C81CCD83243BF7A600A83E27 /* TenorDataLoader.swift in Sources */,
 				98797DBC222F434500128C21 /* OverviewCell.swift in Sources */,
+				C3BC86F629528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */,
 				1749965F2271BF08007021BD /* WordPressAppDelegate.swift in Sources */,
 				5DA3EE161925090A00294E0B /* MediaService.m in Sources */,
 				8BF9E03327B1A8A800915B27 /* DashboardCard.swift in Sources */,
@@ -23002,6 +23007,7 @@
 				FABB21C92602FC2C00C8785C /* ReaderInterestsStyleGuide.swift in Sources */,
 				FABB21CA2602FC2C00C8785C /* SiteStatsInsightsTableViewController.swift in Sources */,
 				FABB21CB2602FC2C00C8785C /* PostCompactCell.swift in Sources */,
+				C3BC86F729528997005D1A01 /* PeopleViewController+JetpackBannerViewController.swift in Sources */,
 				FABB21CC2602FC2C00C8785C /* MeHeaderView.m in Sources */,
 				FABB21CD2602FC2C00C8785C /* WebProgressView.swift in Sources */,
 				FABB21CE2602FC2C00C8785C /* Restorer.swift in Sources */,


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/19448

## Description
- Adds the Jetpack banner to the People view in the WordPress app if `JetpackBrandingCoordinator.shouldShowBannerForJetpackDependentFeatures()` returns `true`
- Adds the Jetpack badge to the Person view in the WordPress app if `JetpackBrandingCoordinator.shouldShowBannerForJetpackDependentFeatures()` returns `true`

| My Site | People | Person |
| - | - | - |
| ![image](https://user-images.githubusercontent.com/2092798/208796434-f7d7d559-d28a-40c6-9dbd-e5375438b37b.png) | ![image](https://user-images.githubusercontent.com/2092798/210655397-8aa369ca-9325-482c-bf32-b35185010e27.png) | ![image](https://user-images.githubusercontent.com/2092798/210452013-46ea70b4-8fbb-4980-b3a8-c5764acef6bd.png) |


**Known issues:** 

- When testing with three people added to a site and an iPhone 14 in landscape, [this issue occurred](https://github.com/wordpress-mobile/WordPress-iOS/pull/19369).
- For large Dynamic Type sizes extra padding can be added to the right side of the badge.

## Testing

### Banner and badge only appear during phases 2 and 3
Toggle the Jetpack Features Removal feature flags and confirm that:
1. Only when phases Two and / or Three are enabled (and are the **highest phases**) do the banner and badge appear.
2. All other feature flag combinations result in the banner and badge being hidden or the view being inaccessible (e.g. all off, One enabled, Four enabled, New Users).

### Banner appears in the People view in WordPress
1. Load the WordPress app.
2. From My Site, tap People in the Configure section.
3. **Expect:** The Jetpack banner to appear at the bottom of the screen.
4. **Expect:** Tapping on the Jetpack banner shows the Jetpack overlay.
5. **Expect:** The event `🔵 Tracked: jetpack_powered_banner_tapped <screen: people>` to be fired.

### Badge appears in the Person view in WordPress
1. Load the WordPress app.
2. From My Site, tap People in the Configure section.
3. Tap a person in the list.
5. **Expect:** The Jetpack badge to appear at the bottom of the screen.
6. **Expect:** Tapping on the Jetpack badge shows the Jetpack overlay.
7. **Expect:** The event `🔵 Tracked: jetpack_powered_badge_tapped <screen: person>` to be fired.

### Banner and badge do not appear in Jetpack
1. Load the Jetpack app.
2. From My Site, tap People in the Configure section.
3. **Expect:** No Jetpack banner to be shown for any phase combination.
4. Tap a person in the list.
5. **Expect:** No Jetpack badge to be shown for any phase combination.

### Banner visibility behavior
- Initially the banner should be shown when the screen appears.
- Scrolling down hides the banner and the banner reappears only when the view is scrolled to the top.
- If there isn't enough content to scroll, the banner doesn't show / hide on scroll.

### Items to test:
- Light / Dark mode
- Dynamic Type / a11y
- Different screen orientations
- iPhone / iPad

## Regression Notes
1. Potential unintended areas of impact
   - People view functionality.
   - There's a risk I missed something when adding [this conditional](https://github.com/wordpress-mobile/WordPress-iOS/pull/19797/files#r1061009578), but my manual tests all passed. It would be good to test viewing users with different roles so the "Remove" button's visibility is toggled.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing above.

3. What automated tests I added (or what prevented me from doing so)
   - None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
