### PR TITLE
[Jetpack Content Migration Flow] [Load WordPress view] Secondary description key

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewModel.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewModel.swift
@@ -40,7 +40,7 @@ final class MigrationLoadWordPressViewModel {
             comment: "The description in the Load WordPress screen"
         )
         static let secondaryDescription = NSLocalizedString(
-            "migration.loadWordpress.description",
+            "migration.loadWordpress.secondaryDescription",
             value: "Would you like to transfer your data from the WordPress app and sign in automatically?",
             comment: "The secondary description in the Load WordPress screen"
         )


### PR DESCRIPTION
## Description

This PR resolves an issue where text is duplicated on the "Open WordPress" view when launching Jetpack. This was due to a duplicate localization key.

| Before | After |
| - | - |
| ![IMG_0317](https://user-images.githubusercontent.com/2092798/208811553-347c778a-0e51-4f5b-be53-7c366ca73a1a.PNG) | ![IMG_0319](https://user-images.githubusercontent.com/2092798/208811853-8246bece-3576-42c8-8f27-0e5dcdff5eed.PNG) |

## Testing

The "Open WordPress" view will appears in Jetpack when a compatible (`21.4`) version of WordPress is installed but it's never been opened.

1. Install WordPress `21.2`
2. Upgrade WordPress to `21.4` but **do not open it**
3. Install and run Jetpack `21.4`
4. **Expect** to see the "Open WordPress" view above without duplicated strings.

**Important note:** Since this changes the localization key for the string, it will only appear in English until a translation has been created.

## Regression Notes
1. Potential unintended areas of impact
   - None identified

2. What I did to test those areas of impact (or what existing automated tests I relied on)
   - Manual testing above

3. What automated tests I added (or what prevented me from doing so)
   - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
