### PR TITLE
Stats Revamp: Show Total Likes details data for this week instead of last 7 days

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -19,12 +19,16 @@ struct StatsTotalInsightsData {
         return StatsTotalInsightsData(count: insightsStore.getTotalFollowerCount())
     }
 
-    public static func createTotalInsightsData(periodStore: StatsPeriodStore, insightsStore: StatsInsightsStore, statsSummaryType: StatsSummaryType, guideText: NSAttributedString? = nil) -> StatsTotalInsightsData {
+    public static func createTotalInsightsData(periodStore: StatsPeriodStore,
+                                               insightsStore: StatsInsightsStore,
+                                               statsSummaryType: StatsSummaryType,
+                                               guideText: NSAttributedString? = nil,
+                                               periodEndDate: Date? = nil) -> StatsTotalInsightsData {
         guard let periodSummary = periodStore.getSummary() else {
             return StatsTotalInsightsData(count: 0)
         }
 
-        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(periodSummary)
+        let splitSummaryTimeIntervalData = SiteStatsInsightsViewModel.splitStatsSummaryTimeIntervalData(periodSummary, periodEndDate: periodEndDate)
 
         var countKey: KeyPath<StatsSummaryData, Int>
         switch statsSummaryType {
@@ -37,7 +41,7 @@ struct StatsTotalInsightsData {
         }
 
         let sparklineData: [Int] = makeSparklineData(countKey: countKey, splitSummaryTimeIntervalData: splitSummaryTimeIntervalData)
-        let data = SiteStatsInsightsViewModel.intervalData(periodSummary, summaryType: statsSummaryType)
+        let data = SiteStatsInsightsViewModel.intervalData(periodSummary, summaryType: statsSummaryType, periodEndDate: periodEndDate)
         let guideText = makeTotalInsightsGuideText(lastPostInsight: insightsStore.getLastPostInsight(), statsSummaryType: statsSummaryType)
         let guideURL: URL? = statsSummaryType == .likes ? insightsStore.getLastPostInsight()?.url : nil
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -276,17 +276,14 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     let referrersData = referrersRowData()
                     let chartViewModel = StatsReferrersChartViewModel(referrers: referrers)
                     let chartView: UIView? = referrers.totalReferrerViewsCount > 0 ?  chartViewModel.makeReferrersChartView() : nil
-                    let week = StatsPeriodHelper().weekIncludingDate(periodSummary.periodEndDate)
 
                     // Views Visitors
-                    // when selectedDate is < end of the week we pad forward days to match the weeks view on WordPress.com
-                    if let weekEnd = week?.weekEnd, weekEnd > periodSummary.periodEndDate {
-                        rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!, periodEndDate: weekEnd,
-                                                                                                 statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
-                    } else {
-                        rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary, periodDate: selectedDate!,
-                                                                                                 statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil))
-                    }
+                    let weekEnd = futureEndOfWeekDate(for: periodSummary)
+                    rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary,
+                                                                                             periodDate: selectedDate!,
+                                                                                             periodEndDate: weekEnd,
+                                                                                             statsLineChartViewDelegate: nil,
+                                                                                             siteStatsInsightsDelegate: nil))
 
                     // Referrers
                     var referrersRow = TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
@@ -1330,6 +1327,22 @@ private extension SiteStatsInsightsDetailsViewModel {
             static let minRowCount = 1
             static let maxRowCount = 5
             static let rows = 0...maxRowCount
+        }
+    }
+
+    // Return the future end of the week date if current period end date is not an end of the week
+    func futureEndOfWeekDate(for summary: StatsSummaryTimeIntervalData?) -> Date? {
+        guard let summary = summary else {
+            return nil
+        }
+
+        /// When selectedDate is < end of the week we pad forward days to match the weeks view on WordPress.com
+        let week = StatsPeriodHelper().weekIncludingDate(summary.periodEndDate)
+
+        if let weekEnd = week?.weekEnd, weekEnd > summary.periodEndDate {
+            return weekEnd
+        } else {
+            return nil
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -505,7 +505,11 @@ class SiteStatsInsightsDetailsViewModel: Observable {
     }
 
     func createLikesTotalInsightsRow() -> StatsTotalInsightsData {
-        var data = StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore, insightsStore: insightsStore, statsSummaryType: .likes)
+        let weekEnd = futureEndOfWeekDate(for: periodStore.getSummary())
+        var data = StatsTotalInsightsData.createTotalInsightsData(periodStore: periodStore,
+                                                                  insightsStore: insightsStore,
+                                                                  statsSummaryType: .likes,
+                                                                  periodEndDate: weekEnd)
         // We don't show guide text at the detail level
         data.guideText = nil
         return data


### PR DESCRIPTION
Fixes #19781

## Description

Total Likes details view shows the data for "the last 7 days", instead of showing the data for the current week (from the start to the end of the week).

This is the exactly same issue that was already fixed [for Views and Visitors](https://github.com/wordpress-mobile/WordPress-iOS/pull/19393). Applying the same bug fix for Total Likes by reusing the built functionality.

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags

### Case 1:
1. Open Stats
2. Click Settings icon on the top right
3. Add "Total Likes card"
4. Observe the total likes number on the card. It should show numbers for "last 7 days"
5. Click "Week >"
6. Observe the total likes number on the card. It should show number for "this week". So if the week hasn't ended yet, it should show totals for less than 7 days. Compare the numbers with the web

## Regression Notes

1. Potential unintended areas of impact

Breaking Views & Visitors details functionality

2. What I did do to test those areas of impact (or what existing automated tests I relied on)

Manual testing, comparing numbers with Web

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

https://user-images.githubusercontent.com/4062343/208902473-7d862140-3cbd-4705-92a2-b4e6bb0e603a.mov


