### PR TITLE
Fix WordPressKit API breaking changes

### DIFF
--- a/WordPress/Classes/Models/ReaderSiteInfoSubscriptions.swift
+++ b/WordPress/Classes/Models/ReaderSiteInfoSubscriptions.swift
@@ -7,7 +7,7 @@ import CoreData
     @NSManaged open var sendPosts: Bool
 
     class func createOrUpdate(from remoteSiteInfo: RemoteReaderSiteInfo, topic: ReaderSiteTopic, context: NSManagedObjectContext) -> ReaderSiteInfoSubscriptionPost? {
-        guard remoteSiteInfo.postSubscription.wp_isValidObject() else {
+        guard let remotePostSubscription = remoteSiteInfo.postSubscription, remotePostSubscription.wp_isValidObject() else {
             return nil
         }
 
@@ -17,7 +17,7 @@ import CoreData
         }
 
         subscription?.siteTopic = topic
-        subscription?.sendPosts = remoteSiteInfo.postSubscription.sendPosts
+        subscription?.sendPosts = remotePostSubscription.sendPosts
 
         return subscription
     }


### PR DESCRIPTION
### Related PR
The following PR in `WordPressKit` should be merged first to trigger a pod update.
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/566

### Description

This PR fixes a build error due to `WordPressKit` API breaking changes. During the rewrite of `RemoteReaderSiteInfo` from Objective-C to Swift, the `postSubscription` and `emailSubscription` properties are now optional. This PR handles the nullability of those properties.

<img width="1512" alt="CleanShot 2022-12-22 at 12 43 13@2x" src="https://user-images.githubusercontent.com/9609223/209128474-68ea99ff-7754-4d5a-b47d-171fddb4982e.png">

### How to Reproduce
1. Switch to `wpshared-remove-cocoalumberjack` branch
1. Open the Podfile
2. Install latest `WordPressKit` changes
 
```ruby
def wordpress_kit
  # pod 'WordPressKit', '~> 5.0'
  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'trunk'
  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
  # pod 'WordPressKit', :path => '../WordPressKit-iOS'
end
```

3. Open Xcode and try building the app
4. **Expect** the build to fail

### Test Instructions:
1. Switch back to this branch
2. Install latest `WordPressKit` changes
 
```ruby
def wordpress_kit
  # pod 'WordPressKit', '~> 5.0'
  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :tag => ''
  pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :branch => 'trunk'
  # pod 'WordPressKit', :git => 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', :commit => ''
  # pod 'WordPressKit', :path => '../WordPressKit-iOS'
end
```
3. Open Xcode and build the app
4. **Expect** the build to succeed

## Regression Notes
1. Potential unintended areas of impact
None.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

5. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
