### PR TITLE
[Stats Revamp] Fix Country card does not have any title in details

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class CountriesCell: UITableViewCell, NibLoadable {
+class CountriesCell: StatsBaseCell, NibLoadable {
 
     // MARK: - Properties
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,16 +18,16 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="WGt-7n-PjC" userLabel="Subtitles Stack View">
-                        <rect key="frame" x="16" y="7.5" width="323" height="16"/>
+                        <rect key="frame" x="16" y="7.666666666666667" width="323" height="15.666666666666664"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5E0-WK-AUD">
-                                <rect key="frame" x="0.0" y="0.0" width="161.5" height="16"/>
+                                <rect key="frame" x="0.0" y="0.0" width="161.66666666666666" height="15.666666666666666"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Subtitle" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2jM-Bl-1PY">
-                                <rect key="frame" x="161.5" y="0.0" width="161.5" height="16"/>
+                                <rect key="frame" x="161.66666666666663" y="0.0" width="161.33333333333337" height="15.666666666666666"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -38,17 +38,17 @@
                         </constraints>
                     </stackView>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="UCQ-gq-RrN" userLabel="Rows Stack View">
-                        <rect key="frame" x="0.0" y="0.5" width="355" height="416.5"/>
+                        <rect key="frame" x="0.0" y="0.66666666666665719" width="355" height="416.33333333333337"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OxT-ul-sgW" userLabel="Top Seperator Line">
-                        <rect key="frame" x="0.0" y="0.0" width="355" height="0.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="355" height="0.66666666666666663"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="tep-qB-gA1"/>
                         </constraints>
                     </view>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4PI-2u-gGF" userLabel="Bottom Seperator Line">
-                        <rect key="frame" x="0.0" y="416.5" width="355" height="0.5"/>
+                        <rect key="frame" x="0.0" y="416.66666666666669" width="355" height="0.33333333333331439"/>
                         <color key="backgroundColor" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="height" constant="0.5" id="RQD-WP-JN5"/>
@@ -80,6 +80,7 @@
                 <outlet property="rowsStackViewTopConstraint" destination="Usf-7v-7m6" id="Res-MH-gOh"/>
                 <outlet property="subtitleStackView" destination="WGt-7n-PjC" id="5JN-Yn-YM9"/>
                 <outlet property="subtitlesStackViewTopConstraint" destination="u2O-MU-b7v" id="ya9-A4-B6Y"/>
+                <outlet property="topConstraint" destination="Ilj-Ck-ryH" id="pmE-rQ-UDq"/>
                 <outlet property="topSeparatorLine" destination="OxT-ul-sgW" id="qjZ-f6-e57"/>
                 <outlet property="topSeparatorLineHeightConstraint" destination="tep-qB-gA1" id="7JT-Pm-BKH"/>
             </connections>

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class CountriesMapCell: UITableViewCell, NibLoadable, Accessible {
+class CountriesMapCell: StatsBaseCell, NibLoadable, Accessible {
     private let countriesMapView = CountriesMapView.loadFromNib()
     private typealias Style = WPStyleGuide.Stats
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.xib
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.xib
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -16,11 +14,11 @@
             <rect key="frame" x="0.0" y="0.0" width="320" height="284"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="283.5"/>
+                <rect key="frame" x="0.0" y="0.0" width="320" height="284"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xGz-qQ-24V">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="283.5"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="284"/>
                     </stackView>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="9qC-oR-E6W">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="0.5"/>
@@ -44,6 +42,7 @@
             <connections>
                 <outlet property="countriesMapContainer" destination="xGz-qQ-24V" id="6Gf-JD-vv0"/>
                 <outlet property="separatorLine" destination="9qC-oR-E6W" id="Coq-Qn-X3j"/>
+                <outlet property="topConstraint" destination="aHU-mj-i0K" id="BXa-2B-3Tn"/>
             </connections>
             <point key="canvasLocation" x="153.62318840579712" y="187.5"/>
         </tableViewCell>

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -280,7 +280,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
 
                     // Countries
-                    let map = countriesMap()
+                    let map = countriesMap(topCountries: viewsAndVisitorsData.topCountries)
                     let isMapShown = !map.data.isEmpty
                     if isMapShown {
                         rows.append(CountriesMapRow(countriesMap: map, statSection: .periodCountries))
@@ -446,7 +446,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
         case .periodCountries:
             return periodImmuTable(for: periodStore.topCountriesStatus) { status in
                 var rows = [ImmuTableRow]()
-                let map = countriesMap()
+                let map = countriesMap(topCountries: periodStore.getTopCountries())
                 if !map.data.isEmpty {
                     rows.append(CountriesMapRow(countriesMap: map))
                 }
@@ -1012,8 +1012,8 @@ private extension SiteStatsInsightsDetailsViewModel {
                 ?? []
     }
 
-    func countriesMap() -> CountriesMap {
-        let countries = periodStore.getTopCountries()?.countries ?? []
+    func countriesMap(topCountries: StatsTopCountryTimeIntervalData?) -> CountriesMap {
+        let countries = topCountries?.countries ?? []
         return CountriesMap(minViewsCount: countries.last?.viewsCount ?? 0,
                 maxViewsCount: countries.first?.viewsCount ?? 0,
                 data: countries.reduce([String: NSNumber]()) { (dict, country) in

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -299,11 +299,13 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
                     // Countries
                     let map = countriesMap()
-                    if !map.data.isEmpty {
-                        rows.append(CountriesMapRow(countriesMap: map))
+                    let isMapShown = !map.data.isEmpty
+                    if isMapShown {
+                        rows.append(CountriesMapRow(countriesMap: map, statSection: .periodCountries))
                     }
                     rows.append(CountriesStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
                                                   dataSubtitle: StatSection.periodCountries.dataSubtitle,
+                                                  statSection: isMapShown ? nil : .periodCountries,
                                                   dataRows: countriesRowData(),
                                                   siteStatsPeriodDelegate: nil,
                                                   siteStatsInsightsDetailsDelegate: insightsDetailsDelegate))

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -488,6 +488,7 @@ struct CountriesStatsRow: ImmuTableRow {
 
     let itemSubtitle: String
     let dataSubtitle: String
+    var statSection: StatSection?
     let dataRows: [StatsTotalRowData]
     weak var siteStatsPeriodDelegate: SiteStatsPeriodDelegate?
     weak var siteStatsInsightsDetailsDelegate: SiteStatsInsightsDelegate?
@@ -504,12 +505,14 @@ struct CountriesStatsRow: ImmuTableRow {
                        dataRows: dataRows,
                        siteStatsPeriodDelegate: siteStatsPeriodDelegate,
                        siteStatsInsightsDetailsDelegate: siteStatsInsightsDetailsDelegate)
+        cell.statSection = statSection
     }
 }
 
 struct CountriesMapRow: ImmuTableRow {
     let action: ImmuTableAction? = nil
     let countriesMap: CountriesMap
+    var statSection: StatSection?
 
     typealias CellType = CountriesMapCell
 
@@ -522,6 +525,7 @@ struct CountriesMapRow: ImmuTableRow {
             return
         }
         cell.configure(with: countriesMap)
+        cell.statSection = statSection
     }
 }
 


### PR DESCRIPTION
Fixes #19429

## Description

`CountriesCell` and `CountriesMapCell` do not show titles. The problem is that they did not inherit from `StatsBaseCell` and `statSection` wasn't set.

**Additionally**, fixing countries map being colored for the day and not for the week [by using StatsRevampStore data](https://github.com/wordpress-mobile/WordPress-iOS/pull/19757).

## Testing instructions

### Case 1 Countries Card Title:
1. Enable "New appearance for Stats" & "New cards for Stats insights" in App Settings -> Debug
2. Open Stats
3. Add Views & Visitors card (Settings on top right)
4. Click "Week"
5. Confirm that Countries card has a title

### Case 2 Countries Map is colored for the week:
1. Enable "New appearance for Stats" & "New cards for Stats insights" in App Settings -> Debug
2. Open Stats
3. Add Views & Visitors card (Settings on top right)
4. Click "Week"
5. Confirm that Countries map is colored according to numbers on the table

## Regression Notes

1. Potential unintended areas of impact

Old design of Country Cell would appear with a title

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos
![image](https://user-images.githubusercontent.com/4062343/209160356-90680d5f-eaaa-430b-ac96-d11d3cab2280.png)
<img width="363" alt="image" src="https://user-images.githubusercontent.com/4062343/209160401-dbb5d5c8-9070-4f07-8952-4fe911726ae9.png">
![image](https://user-images.githubusercontent.com/4062343/209160469-943da15f-0a76-442c-8e31-375ac8303692.png)




