### PR TITLE
Jetpack Focus: Update remote config keys

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -17,26 +17,26 @@ struct RemoteConfig {
     // MARK: Remote Config Parameters
 
     var jetpackDeadline: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "jp-deadline", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "jp_deadline", defaultValue: nil, store: store)
     }
 
     var phaseTwoBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-two-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase_two_blog_post", defaultValue: nil, store: store)
     }
 
     var phaseThreeBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-three-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase_three_blog_post", defaultValue: nil, store: store)
     }
 
     var phaseFourBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-four-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase_four_blog_post", defaultValue: nil, store: store)
     }
 
     var phaseNewUsersBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-new-users-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase_new_users_blog_post", defaultValue: nil, store: store)
     }
 
     var phaseSelfHostedBlogPostUrl: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "phase-self-hosted-blog-post", defaultValue: nil, store: store)
+        RemoteConfigParameter<String>(key: "phase_self_hosted_blog_post", defaultValue: nil, store: store)
     }
 }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -148,7 +148,7 @@ private class RemoteConfigStoreMock: RemoteConfigStore {
     var phaseThreeBlogPostUrl: String?
 
     override func value(for key: String) -> Any? {
-        if key == "phase-three-blog-post" {
+        if key == "phase_three_blog_post" {
             return phaseThreeBlogPostUrl
         }
         return super.value(for: key)

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -250,7 +250,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
     func testFetchingRemovalDeadline() {
         // Given
         let remoteConfigStore = RemoteConfigStore(persistenceStore: mockUserDefaults)
-        mockUserDefaults.set(["jp-deadline": "2022-10-10"], forKey: RemoteConfigStore.Constants.CachedResponseKey)
+        mockUserDefaults.set(["jp_deadline": "2022-10-10"], forKey: RemoteConfigStore.Constants.CachedResponseKey)
 
         // When
         let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline(remoteConfigStore: remoteConfigStore)


### PR DESCRIPTION
Closes #19804
Ref: p1671444151901629-slack-C04564QS0V7

## Description
This PR updates the remote config keys to match the updated keys in the endpoint. We simply replaced the dashes with underscores.

## Testing Instructions

1. Run the app
2. Make sure that only the "Jetpack Features Removal Phase Three" flag is enabled from the debug menu
3. Kill the app
4. Launch the app
5. The menu card should be displayed
6. Tap anywhere on the card to display the overlay
7. Make sure the deadline "February 22, 2023" is displayed.
8. Make sure the learn more button is visible. (P.S: The link currently returned from the endpoint is faulty as it's missing the https protocol, so tapping the link doesn't load a webpage successfully.)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.