### PR TITLE
[Stats Revamp] Show "View More" CTA instead of "Week" CTA for Total Comments card 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -117,9 +117,9 @@ class StatsBaseCell: UITableViewCell {
             showDetailsButton.isHidden = false
 
             switch statSection {
-            case .insightsViewsVisitors, .insightsLikesTotals, .insightsCommentsTotals:
+            case .insightsViewsVisitors, .insightsLikesTotals:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleThisWeek, for: .normal)
-            case .insightsFollowerTotals:
+            case .insightsFollowerTotals, .insightsCommentsTotals:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleViewMore, for: .normal)
             default:
                 showDetailsButton.setTitle("", for: .normal)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -22,7 +22,6 @@ struct StatsTotalInsightsData {
     public static func createTotalInsightsData(periodSummary: StatsSummaryTimeIntervalData?,
                                                insightsStore: StatsInsightsStore,
                                                statsSummaryType: StatsSummaryType,
-                                               guideText: NSAttributedString? = nil,
                                                periodEndDate: Date? = nil) -> StatsTotalInsightsData {
 
         guard let periodSummary = periodSummary else {
@@ -115,7 +114,8 @@ class StatsTotalInsightsCell: StatsBaseCell {
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
     private var lastPostInsight: StatsLastPostInsight?
     private var statsSummaryType: StatsSummaryType?
-    private var guideURL: URL? = nil
+    private var guideURL: URL?
+    private var guideText: NSAttributedString?
 
     private let outerStackView = UIStackView()
     private let topInnerStackView = UIStackView()
@@ -151,7 +151,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        updateGuideView()
+        rebuildGuideViewIfNeeded()
     }
 
     private func configureView() {
@@ -239,6 +239,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
         self.statSection = statSection
         self.lastPostInsight = dataRow.lastPostInsight
         self.statsSummaryType = dataRow.statsSummaryType
+        self.guideText = dataRow.guideText
         self.siteStatsInsightsDelegate = siteStatsInsightsDelegate
         self.siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
 
@@ -247,14 +248,13 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         countLabel.text = dataRow.count.abbreviatedString()
 
-        updateGuideView()
+        updateGuideView(withGuideText: dataRow.guideText)
         updateComparisonLabel(withCount: dataRow.count, difference: dataRow.difference, percentage: dataRow.percentage)
     }
 
-    private func updateGuideView() {
-        if let statsSummaryType = statsSummaryType,
-           let guideText = StatsTotalInsightsData.makeTotalInsightsGuideText(lastPostInsight: lastPostInsight, statsSummaryType: statsSummaryType),
-           guideText.string.isEmpty == false {
+    private func updateGuideView(withGuideText guideText: NSAttributedString?) {
+        if let guideText = guideText,
+            guideText.string.isEmpty == false {
             outerStackView.addArrangedSubview(guideView)
 
             guideViewLabel.attributedText = addTipEmojiToGuide(guideText)
@@ -264,6 +264,16 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
         } else if guideView.superview != nil {
             guideView.removeFromSuperview()
+        }
+    }
+
+    // Rebuilds and sest guide view from scratch only if it already exists on the cell
+    private func rebuildGuideViewIfNeeded() {
+        if guideText != nil,
+            let statsSummaryType = statsSummaryType,
+           let guideText = StatsTotalInsightsData.makeTotalInsightsGuideText(lastPostInsight: lastPostInsight, statsSummaryType: statsSummaryType) {
+            self.guideText = guideText
+            updateGuideView(withGuideText: guideText)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -267,7 +267,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
         }
     }
 
-    // Rebuilds and sest guide view from scratch only if it already exists on the cell
+    // Rebuilds guide view for accessibility only if guide view already exists
     private func rebuildGuideViewIfNeeded() {
         if guideText != nil,
             let statsSummaryType = statsSummaryType,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -270,7 +270,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
     // Rebuilds guide view for accessibility only if guide view already exists
     private func rebuildGuideViewIfNeeded() {
         if guideText != nil,
-            let statsSummaryType = statsSummaryType,
+           let statsSummaryType = statsSummaryType,
            let guideText = StatsTotalInsightsData.makeTotalInsightsGuideText(lastPostInsight: lastPostInsight, statsSummaryType: statsSummaryType) {
             self.guideText = guideText
             updateGuideView(withGuideText: guideText)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -106,7 +106,7 @@ struct StatsTotalInsightsData {
     private enum TextContent {
         static let likesTotalGuideTextSingular = NSLocalizedString("Your latest post <a href=\"\">%@</a> has received <strong>one</strong> like.", comment: "A hint shown to the user in stats informing the user that one of their posts has received a like. The %@ placeholder will be replaced with the title of a post, and the HTML tags should remain intact.")
         static let likesTotalGuideTextPlural = NSLocalizedString("Your latest post <a href=\"\">%@</a> has received <strong>%d</strong> likes.", comment: "A hint shown to the user in stats informing the user how many likes one of their posts has received. The %@ placeholder will be replaced with the title of a post, the %d with the number of likes, and the HTML tags should remain intact.")
-        static let commentsTotalGuideText = NSLocalizedString("Tap \"Week\" to see your top commenters.", comment: "A hint shown to the user in stats telling them how to navigate to the Comments detail view.")
+        static let commentsTotalGuideText = NSLocalizedString("Tap \"View more\" to see your top commenters.", comment: "A hint shown to the user in stats telling them how to navigate to the Comments detail view.")
     }
 }
 


### PR DESCRIPTION
Fixes #19726

## Description

"Week" is show for "Total Comments" card CTA which is misleading since we do not open the week switching view. Show "View more" instead same as on Android.

I also noticed that guide text is shown in the details view even though it shouldn't. Fixing that as well.
 
## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags


### Case 1 Total Comments card:

1. Open Stats
2. Click Settings icon on the top right
3. Add "Total Comments" card
4. Confirm that "View more" CTA exists
5. Confirm that guide text exists at the bottom, with the message that explains "View more" CTA
6. Click "View more"
7. Confirm that guide text does not exist in the details view

### Case 2 Dynamic type continues to be working:
1. Open Stats
2. Click Settings icon on the top right
3. Add "Total Comments" and "Total Likes" cards
4. Increase text size
5. Confirm that guide text size increases

## Regression Notes

1. Potential unintended areas of impact

Guide text breaking in "Total Comments" and "Total Likes" cards

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

## Updated button and guide text title

<img width="425" alt="image" src="https://user-images.githubusercontent.com/4062343/209337806-9f7031db-6e29-459f-8f98-3e3e36856cf3.png">

## Guide text not shown in details

<img width="425" alt="image" src="https://user-images.githubusercontent.com/4062343/209337758-ce3f4917-0e23-47e5-90e0-4ce585767c56.png">

