### PR TITLE
Jetpack Focus: Remove Jetpack features during phase 4

### DIFF
--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+/// `MySitesCoordinator` is used as the root presenter when Jetpack features are disabled
+/// and the app's UI is simplified.
+extension MySitesCoordinator: RootViewPresenter {
+
+}

--- a/WordPress/Classes/System/RootViewControllerCoordinator.swift
+++ b/WordPress/Classes/System/RootViewControllerCoordinator.swift
@@ -2,13 +2,6 @@ import Foundation
 
 class RootViewControllerCoordinator {
 
-    // MARK: Class Enum
-
-    enum AppUIType {
-        case normal
-        case simplified
-    }
-
     // MARK: Static shared variables
 
     static let shared = RootViewControllerCoordinator()
@@ -25,12 +18,10 @@ class RootViewControllerCoordinator {
 
     init() {
         if JetpackFeaturesRemovalCoordinator.shouldRemoveJetpackFeatures() {
-            self.currentAppUIType = .simplified
             let meScenePresenter = MeScenePresenter()
             self.rootViewPresenter = MySitesCoordinator(meScenePresenter: meScenePresenter, onBecomeActiveTab: {})
         }
         else {
-            self.currentAppUIType = .normal
             self.rootViewPresenter = WPTabBarController.sharedInstance() // TODO: Remove shared instance and create an instance here
         }
     }

--- a/WordPress/Classes/System/RootViewControllerCoordinator.swift
+++ b/WordPress/Classes/System/RootViewControllerCoordinator.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+class RootViewControllerCoordinator {
+
+    // MARK: Class Enum
+
+    enum AppUIType {
+        case normal
+        case simplified
+    }
+
+    // MARK: Static shared variables
+
+    static let shared = RootViewControllerCoordinator()
+    static var sharedPresenter: RootViewPresenter {
+        shared.rootViewPresenter
+    }
+
+    // MARK: Private instance variables
+
+    private var currentAppUIType: AppUIType
+    private var rootViewPresenter: RootViewPresenter
+
+    // MARK: Initializer
+
+    init() {
+        if JetpackFeaturesRemovalCoordinator.shouldRemoveJetpackFeatures() {
+            self.currentAppUIType = .simplified
+            let meScenePresenter = MeScenePresenter()
+            self.rootViewPresenter = MySitesCoordinator(meScenePresenter: meScenePresenter, onBecomeActiveTab: {})
+        }
+        else {
+            self.currentAppUIType = .normal
+            self.rootViewPresenter = WPTabBarController.sharedInstance() // TODO: Remove shared instance and create an instance here
+        }
+    }
+}

--- a/WordPress/Classes/System/RootViewControllerCoordinator.swift
+++ b/WordPress/Classes/System/RootViewControllerCoordinator.swift
@@ -11,7 +11,6 @@ class RootViewControllerCoordinator {
 
     // MARK: Private instance variables
 
-    private var currentAppUIType: AppUIType
     private var rootViewPresenter: RootViewPresenter
 
     // MARK: Initializer

--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+protocol RootViewPresenter {
+    var rootViewController: UIViewController { get }
+    func showBlogDetails(for blog: Blog)
+}

--- a/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// `WPTabBarController` is used as the root presenter when Jetpack features are enabled
+/// and the app's UI is normal.
+extension WPTabBarController: RootViewPresenter {
+    var rootViewController: UIViewController {
+        return self
+    }
+}

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -57,13 +57,13 @@ class WindowManager: NSObject {
     ///
     @objc func showAppUI(for blog: Blog? = nil, completion: Completion? = nil) {
         isShowingFullscreenSignIn = false
-        show(WPTabBarController.sharedInstance(), completion: completion)
+        show(RootViewControllerCoordinator.sharedPresenter.rootViewController, completion: completion)
 
         guard let blog = blog else {
             return
         }
 
-        WPTabBarController.sharedInstance()?.showBlogDetails(for: blog)
+        RootViewControllerCoordinator.sharedPresenter.showBlogDetails(for: blog)
     }
 
     /// Shows the initial UI for unauthenticated users.

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -17,7 +17,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case weeklyRoundupBGProcessingTask
     case domains
     case timeZoneSuggester
-    case mySiteDashboard
     case mediaPickerPermissionsNotice
     case notificationCommentDetails
     case siteIntentQuestion
@@ -82,8 +81,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             // See BlogDetailsViewController.shouldShowDomainRegistration for an example.
             return true
         case .timeZoneSuggester:
-            return true
-        case .mySiteDashboard:
             return true
         case .mediaPickerPermissionsNotice:
             return true
@@ -203,8 +200,6 @@ extension FeatureFlag {
             return "Domain Purchases"
         case .timeZoneSuggester:
             return "TimeZone Suggester"
-        case .mySiteDashboard:
-            return "My Site Dashboard"
         case .mediaPickerPermissionsNotice:
             return "Media Picker Permissions Notice"
         case .notificationCommentDetails:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
@@ -3,6 +3,6 @@ import Foundation
 extension BlogDetailsViewController {
 
     @objc func isDashboardEnabled() -> Bool {
-        return FeatureFlag.mySiteDashboard.enabled && blog.isAccessibleThroughWPCom()
+        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() && blog.isAccessibleThroughWPCom()
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+QuickActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+QuickActions.swift
@@ -1,5 +1,6 @@
 import UIKit
 
+// TODO: Consider completely removing all Quick Action logic
 extension BlogDetailsViewController {
 
     @objc func quickActionsSectionViewModel() -> BlogDetailsSection {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -39,4 +39,25 @@ extension BlogDetailsViewController {
     @objc func sectionCategory(subsection: BlogDetailsSubsection, blog: Blog) -> BlogDetailsSectionCategory {
         return subsection.sectionCategory(for: blog)
     }
+
+    @objc func shouldAddJetpackSection() -> Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return false
+        }
+        return blog.shouldShowJetpackSection
+    }
+
+    @objc func shouldAddGeneralSection() -> Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return false
+        }
+        return blog.shouldShowJetpackSection == false
+    }
+
+    @objc func shouldAddPersonalizeSection() -> Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return false
+        }
+        return blog.supports(.themeBrowsing) || blog.supports(.menus)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -60,4 +60,28 @@ extension BlogDetailsViewController {
         }
         return blog.supports(.themeBrowsing) || blog.supports(.menus)
     }
+
+    @objc func shouldAddSharingRow() -> Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return false
+        }
+        return blog.supports(.sharing)
+    }
+
+    @objc func shouldAddPeopleRow() -> Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return false
+        }
+        return blog.supports(.people)
+    }
+
+    @objc func shouldAddPluginsRow() -> Bool {
+        return blog.supports(.pluginManagement)
+    }
+
+    @objc func shouldAddDomainRegistrationRow() -> Bool {
+        return FeatureFlag.domains.enabled
+        && AppConfiguration.allowsDomainRegistration
+        && blog.supports(.domains)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -40,6 +40,20 @@ extension BlogDetailsViewController {
         return subsection.sectionCategory(for: blog)
     }
 
+    @objc func defaultSubsection() -> BlogDetailsSubsection {
+        if JetpackFeaturesRemovalCoordinator.shouldRemoveJetpackFeatures() {
+            return .posts
+        }
+        if shouldShowDashboard() {
+            return .home
+        }
+        return .stats
+    }
+
+    @objc func shouldShowStats() -> Bool {
+        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+    }
+
     @objc func shouldAddJetpackSection() -> Bool {
         guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
             return false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -970,7 +970,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     __weak __typeof(self) weakSelf = self;
     NSMutableArray *rows = [NSMutableArray array];
 
-    if ([self.blog supports:BlogFeatureSharing]) {
+    if ([self shouldAddSharingRow]) {
         BlogDetailsRow *row = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Sharing", @"Noun. Title. Links to a blog's sharing options.")
                                         image:[UIImage gridiconOfType:GridiconTypeShare]
                                      callback:^{
@@ -980,7 +980,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [rows addObject:row];
     }
 
-    if ([self.blog supports:BlogFeaturePeople]) {
+    if ([self shouldAddPeopleRow]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
                                                         image:[UIImage gridiconOfType:GridiconTypeUser]
                                                      callback:^{
@@ -988,7 +988,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                      }]];
     }
 
-    if ([self.blog supports:BlogFeaturePluginManagement]) {
+    if ([self shouldAddPluginsRow]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Plugins", @"Noun. Title. Links to the plugin management feature.")
                                                         image:[UIImage gridiconOfType:GridiconTypePlugins]
                                                      callback:^{
@@ -1006,7 +1006,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     [rows addObject:row];
 
-    if ([self shouldShowDomainRegistration]) {
+    if ([self shouldAddDomainRegistrationRow]) {
         BlogDetailsRow *domainsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Domains", @"Noun. Title. Links to the Domains screen.")
                                                                 identifier:BlogDetailsSettingsCellIdentifier
                                                    accessibilityIdentifier:@"Domains Row"
@@ -1400,20 +1400,13 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)preloadDomains
 {
-    if (![self shouldShowDomainRegistration]) {
+    if (![self shouldAddDomainRegistrationRow]) {
         return;
     }
 
     [self.blogService refreshDomainsFor:self.blog
                                 success:nil
                                 failure:nil];
-}
-
-- (BOOL)shouldShowDomainRegistration
-{
-    return [Feature enabled:FeatureFlagDomains]
-            && [AppConfiguration allowsDomainRegistration]
-            && [self.blog supports:BlogFeatureDomains];
 }
 
 - (void)scrollToElement:(QuickStartTourElement) element

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -758,16 +758,20 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     if ([self isDashboardEnabled] && ![self splitViewControllerIsHorizontallyCompact]) {
         [marr addObject:[self homeSectionViewModel]];
     }
-    if (self.blog.shouldShowJetpackSection) {
+    if ([self shouldAddJetpackSection]) {
         [marr addObject:[self jetpackSectionViewModel]];
-    } else {
+    }
+    
+    if ([self shouldAddGeneralSection]) {
         [marr addObject:[self generalSectionViewModel]];
     }
 
     [marr addObject:[self publishTypeSectionViewModel]];
-    if ([self.blog supports:BlogFeatureThemeBrowsing] || [self.blog supports:BlogFeatureMenus]) {
+    
+    if ([self shouldAddPersonalizeSection]) {
         [marr addObject:[self personalizeSectionViewModel]];
     }
+    
     [marr addObject:[self configurationSectionViewModel]];
     [marr addObject:[self externalSectionViewModel]];
     if ([self.blog supports:BlogFeatureRemovable]) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -738,9 +738,6 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     NSMutableArray *marr = [NSMutableArray array];
     
-    if (AppConfiguration.showsQuickActions && ![self isDashboardEnabled]) {
-        [marr addObject:[self quickActionsSectionViewModel]];
-    }
     if (MigrationSuccessCardView.shouldShowMigrationSuccessCard == YES) {
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -599,7 +599,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 {
     if (!_restorableSelectedIndexPath) {
         // If nil, default to stats subsection.
-        BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
+        BlogDetailsSubsection subsection = [self defaultSubsection];
         self.selectedSectionCategory = [self sectionCategoryWithSubsection:subsection blog: self.blog];
         NSUInteger section = [self findSectionIndexWithSections:self.tableSections category:self.selectedSectionCategory];
         _restorableSelectedIndexPath = [NSIndexPath indexPathForRow:0 inSection:section];
@@ -703,7 +703,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
             case BlogDetailsSectionCategoryQuickStart:
             case BlogDetailsSectionCategoryJetpackBrandingCard:
             case BlogDetailsSectionCategoryDomainCredit: {
-                BlogDetailsSubsection subsection = [self shouldShowDashboard] ? BlogDetailsSubsectionHome : BlogDetailsSubsectionStats;
+                BlogDetailsSubsection subsection = [self defaultSubsection];
                 BlogDetailsSectionCategory category = [self sectionCategoryWithSubsection:subsection blog: self.blog];
                 sectionIndex = [self findSectionIndexWithSections:self.tableSections category:category];
             }
@@ -1113,11 +1113,19 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     
     WPSplitViewController *splitViewController = (WPSplitViewController *)self.splitViewController;
     splitViewController.isShowingInitialDetail = YES;
-    
-    if ([self shouldShowDashboard]) {
-        [self showDetailViewForSubsection:BlogDetailsSubsectionHome];
-    } else {
-        [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
+    BlogDetailsSubsection subsection = [self defaultSubsection];
+    switch (subsection) {
+        case BlogDetailsSubsectionHome:
+            [self showDetailViewForSubsection:BlogDetailsSubsectionHome];
+            break;
+        case BlogDetailsSubsectionStats:
+            [self showDetailViewForSubsection:BlogDetailsSubsectionStats];
+            break;
+        case BlogDetailsSubsectionPosts:
+            [self showDetailViewForSubsection: BlogDetailsSubsectionPosts];
+            break;
+        default:
+            break;
     }
 }
 
@@ -1744,10 +1752,15 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (UIViewController *)initialDetailViewControllerForSplitView:(WPSplitViewController *)splitView
 {
-    StatsViewController *statsView = [StatsViewController new];
-    statsView.blog = self.blog;
-
-    return statsView;
+    if ([self shouldShowStats]) {
+        StatsViewController *statsView = [StatsViewController new];
+        statsView.blog = self.blog;
+        return statsView;
+    } else {
+        PostListViewController *postsView = [PostListViewController controllerWithBlog:self.blog];
+        postsView.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+        return postsView;
+    }
 }
 
 #pragma mark - UIViewControllerTransitioningDelegate

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -283,7 +283,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     private func updateSegmentedControl(for blog: Blog, switchTabsIfNeeded: Bool = false) {
         // The segmented control should be hidden if the blog is not a WP.com/Atomic/Jetpack site, or if the device doesn't have a horizontally compact view
         let hideSegmentedControl =
-            !FeatureFlag.mySiteDashboard.enabled ||
+            JetpackFeaturesRemovalCoordinator.shouldRemoveJetpackFeatures() ||
             !blog.isAccessibleThroughWPCom() ||
             !splitViewControllerIsHorizontallyCompact
 
@@ -357,7 +357,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func setupNavigationItem() {
-        navigationItem.largeTitleDisplayMode = FeatureFlag.mySiteDashboard.enabled ? .never : .always
+        navigationItem.largeTitleDisplayMode = .never
         navigationItem.title = Strings.mySite
         navigationItem.backButtonTitle = Strings.mySite
 
@@ -382,11 +382,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func setupNavBarAppearance() {
-        navigationController?.navigationBar.scrollEdgeAppearance?.configureWithTransparentBackground()
-        if FeatureFlag.mySiteDashboard.enabled {
-            let transparentTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.clear]
-            navigationController?.navigationBar.scrollEdgeAppearance?.titleTextAttributes = transparentTitleAttributes
-        }
+        let scrollEdgeAppearance = navigationController?.navigationBar.scrollEdgeAppearance
+        let transparentTitleAttributes = [NSAttributedString.Key.foregroundColor: UIColor.clear]
+        scrollEdgeAppearance?.titleTextAttributes = transparentTitleAttributes
+        scrollEdgeAppearance?.configureWithTransparentBackground()
     }
 
     private func resetNavBarAppearance() {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -652,7 +652,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                                     trailingAnchor: view.safeAreaLayoutGuide.trailingAnchor,
                                     bottomAnchor: view.safeAreaLayoutGuide.bottomAnchor)
 
-        if let blog = blog, tabBarController is WPTabBarController,
+        if let blog = blog,
            noResultsViewController.view.superview == nil {
             createButtonCoordinator?.showCreateButton(for: blog)
         }

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -47,6 +47,10 @@ open class QuickStartTourGuide: NSObject {
     private override init() {}
 
     func setup(for blog: Blog, type: QuickStartType, withCompletedSteps steps: [QuickStartTour] = []) {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return
+        }
+
         if type == .newSite {
             let createTour = QuickStartCreateTour()
             completed(tour: createTour, for: blog)
@@ -80,7 +84,15 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func quickStartEnabled(for blog: Blog) -> Bool {
-        QuickStartFactory.collections(for: blog).isEmpty == false
+        let enabled = QuickStartFactory.collections(for: blog).isEmpty == false
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            if enabled { // If quick start exists, remove it to clean up.
+                QuickStartTourGuide.shared.remove(from: blog)
+            }
+            return false
+        }
+
+        return enabled
     }
 
     /// Provides a tour to suggest to the user

--- a/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditEligibilityChecker.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain credit/DomainCreditEligibilityChecker.swift
@@ -1,5 +1,5 @@
 class DomainCreditEligibilityChecker: NSObject {
     @objc static func canRedeemDomainCredit(blog: Blog) -> Bool {
-        return (blog.isHostedAtWPcom || blog.isAtomic()) && blog.hasDomainCredit
+        return (blog.isHostedAtWPcom || blog.isAtomic()) && blog.hasDomainCredit && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -117,6 +117,12 @@ class JetpackFeaturesRemovalCoordinator {
         }
     }
 
+    /// Inverse of `shouldRemoveJetpackFeatures`.
+    /// Added to enhance verbosity in some areas of the code.
+    static func jetpackFeaturesEnabled() -> Bool {
+        !shouldRemoveJetpackFeatures()
+    }
+
     /// Used to display feature-specific or feature-collection overlays.
     /// - Parameters:
     ///   - source: The source that triggers the display of the overlay.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -107,6 +107,16 @@ class JetpackFeaturesRemovalCoordinator {
         return formatter.date(from: dateString)
     }
 
+    /// Used to determine if the Jetpack features should be removed based on the removal phase.
+    static func shouldRemoveJetpackFeatures() -> Bool {
+        switch generalPhase() {
+        case .four, .newUsers:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Used to display feature-specific or feature-collection overlays.
     /// - Parameters:
     ///   - source: The source that triggers the display of the overlay.

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -501,7 +501,7 @@ private extension AppSettingsViewController {
             rows.insert(iconRow, at: 0)
         }
 
-        if FeatureFlag.mySiteDashboard.enabled {
+        if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
             let initialScreen = NavigationItemRow(title: NSLocalizedString("Initial Screen", comment: "Title of the option to change the default initial screen"), detail: MySiteSettings().defaultSection.title, action: pushInitialScreenSettings())
 
             rows.append(initialScreen)

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -370,7 +370,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
             ABTest.start()
 
             self.recentSiteService.touch(blog: blog)
-            self.presentOnboardingQuestionsPrompt(in: navigationController, onDismiss: onDismiss)
+            self.presentOnboardingQuestionsPrompt(in: navigationController, blog: blog, onDismiss: onDismiss)
         }
 
         // If the user has only 1 blog, skip the site selector and go right to the next step
@@ -543,8 +543,17 @@ private extension WordPressAuthenticationManager {
 
 // MARK: - Onboarding Questions Prompt
 private extension WordPressAuthenticationManager {
-    private func presentOnboardingQuestionsPrompt(in navigationController: UINavigationController, onDismiss: (() -> Void)? = nil) {
+    private func presentOnboardingQuestionsPrompt(in navigationController: UINavigationController, blog: Blog, onDismiss: (() -> Void)? = nil) {
         let windowManager = self.windowManager
+
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            if self.windowManager.isShowingFullscreenSignIn {
+                self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
+            } else {
+                self.windowManager.showAppUI(for: blog)
+            }
+            return
+        }
 
         let coordinator = OnboardingQuestionsCoordinator()
         coordinator.navigationController = navigationController

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressAuthenticator
 
 @objc
 class MySitesCoordinator: NSObject {
@@ -18,8 +19,9 @@ class MySitesCoordinator: NSObject {
     init(meScenePresenter: ScenePresenter, onBecomeActiveTab becomeActiveTab: @escaping () -> Void) {
         self.meScenePresenter = meScenePresenter
         self.becomeActiveTab = becomeActiveTab
-
         super.init()
+
+        addSignInObserver()
     }
 
     // MARK: - Root View Controller
@@ -73,8 +75,12 @@ class MySitesCoordinator: NSObject {
     }()
 
     private lazy var mySiteViewController: MySiteViewController = {
-        MySiteViewController(meScenePresenter: self.meScenePresenter)
+        makeMySiteViewController()
     }()
+
+    private func makeMySiteViewController() -> MySiteViewController {
+        MySiteViewController(meScenePresenter: self.meScenePresenter)
+    }
 
     // MARK: - Navigation
 
@@ -218,5 +224,20 @@ class MySitesCoordinator: NSObject {
         let listViewController = PluginListViewController(site: site, query: query)
 
         navigationController.pushViewController(listViewController, animated: false)
+    }
+
+    // MARK: Notifications Handling
+
+    private func addSignInObserver() {
+        let notificationName = NSNotification.Name(WordPressAuthenticator.WPSigninDidFinishNotification)
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(signinDidFinish),
+                                               name: notificationName,
+                                               object: nil)
+    }
+
+    @objc func signinDidFinish() {
+        mySiteViewController = makeMySiteViewController()
+        navigationController.viewControllers = [rootContentViewController]
     }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -252,7 +252,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     _readerNavigationController = nil;
     _notificationsNavigationController = nil;
     _notificationsSplitViewController = nil;
-    _mySitesCoordinator = nil;
     
     [self setViewControllers:[self tabViewControllers]];
     

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1559,6 +1559,14 @@
 		8031F34B292FF46E00E8F95E /* ExtensionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800035C0292307E8007D2D26 /* ExtensionConfiguration.swift */; };
 		8031F34C29302A2500E8F95E /* ExtensionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800035C229230A0B007D2D26 /* ExtensionConfiguration.swift */; };
 		8031F34D29302C8100E8F95E /* ExtensionConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 800035C0292307E8007D2D26 /* ExtensionConfiguration.swift */; };
+		803BB9792959543D00B3F6D6 /* RootViewControllerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB9782959543D00B3F6D6 /* RootViewControllerCoordinator.swift */; };
+		803BB97A2959543D00B3F6D6 /* RootViewControllerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB9782959543D00B3F6D6 /* RootViewControllerCoordinator.swift */; };
+		803BB97C2959559500B3F6D6 /* RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB97B2959559500B3F6D6 /* RootViewPresenter.swift */; };
+		803BB97D2959559500B3F6D6 /* RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB97B2959559500B3F6D6 /* RootViewPresenter.swift */; };
+		803BB980295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB97F295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift */; };
+		803BB981295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB97F295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift */; };
+		803BB983295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB982295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift */; };
+		803BB984295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB982295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift */; };
 		803C493B283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */; };
 		803C493C283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */; };
 		803C493E283A7C2200003E9B /* QuickStartChecklistHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 803C493D283A7C2200003E9B /* QuickStartChecklistHeader.xib */; };
@@ -6878,6 +6886,10 @@
 		801D9519291AC0B00051993E /* JetpackOverlayFrequencyTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackOverlayFrequencyTracker.swift; sourceTree = "<group>"; };
 		801D951C291ADB7E0051993E /* JetpackOverlayFrequencyTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackOverlayFrequencyTrackerTests.swift; sourceTree = "<group>"; };
 		80293CF6284450AD0083F946 /* WordPress-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPress-Swift.h"; sourceTree = "<group>"; };
+		803BB9782959543D00B3F6D6 /* RootViewControllerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewControllerCoordinator.swift; sourceTree = "<group>"; };
+		803BB97B2959559500B3F6D6 /* RootViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewPresenter.swift; sourceTree = "<group>"; };
+		803BB97F295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPTabBarController+RootViewPresenter.swift"; sourceTree = "<group>"; };
+		803BB982295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MySitesCoordinator+RootViewPresenter.swift"; sourceTree = "<group>"; };
 		803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistHeader.swift; sourceTree = "<group>"; };
 		803C493D283A7C2200003E9B /* QuickStartChecklistHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartChecklistHeader.xib; sourceTree = "<group>"; };
 		803D90F6292F0188007CC0D0 /* JetpackRedirector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRedirector.swift; sourceTree = "<group>"; };
@@ -12506,6 +12518,17 @@
 			name = "Lottie Animations";
 			sourceTree = "<group>";
 		};
+		803BB97E295957A200B3F6D6 /* Root View */ = {
+			isa = PBXGroup;
+			children = (
+				803BB9782959543D00B3F6D6 /* RootViewControllerCoordinator.swift */,
+				803BB97B2959559500B3F6D6 /* RootViewPresenter.swift */,
+				803BB97F295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift */,
+				803BB982295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift */,
+			);
+			name = "Root View";
+			sourceTree = "<group>";
+		};
 		803DE81D29063689007D4E9C /* Jetpack */ = {
 			isa = PBXGroup;
 			children = (
@@ -12901,6 +12924,7 @@
 			isa = PBXGroup;
 			children = (
 				0107E0F128FD6A3100DE87DB /* Constants */,
+				803BB97E295957A200B3F6D6 /* Root View */,
 				BE87E19E1BD4052F0075D45B /* 3DTouch */,
 				B5FD4520199D0C9A00286FBB /* WordPress-Bridging-Header.h */,
 				1749965E2271BF08007021BD /* WordPressAppDelegate.swift */,
@@ -20416,6 +20440,7 @@
 				98458CB821A39D350025D232 /* StatsNoDataRow.swift in Sources */,
 				3234BB172530DFCA0068DA40 /* ReaderTableCardCell.swift in Sources */,
 				7462BFD42028CD4400B552D8 /* ShareNoticeNavigationCoordinator.swift in Sources */,
+				803BB97C2959559500B3F6D6 /* RootViewPresenter.swift in Sources */,
 				D80BC7A02074722000614A59 /* CameraCaptureCoordinator.swift in Sources */,
 				178810B52611D25600A98BD8 /* Text+BoldSubString.swift in Sources */,
 				3FA53E9C256571D800F4D9A2 /* HomeWidgetCache.swift in Sources */,
@@ -21039,6 +21064,7 @@
 				73C8F06021BEED9100DDDF7E /* SiteAssemblyStep.swift in Sources */,
 				17870A702816F2A000D1C627 /* StatsLatestPostSummaryInsightsCell.swift in Sources */,
 				82C420761FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift in Sources */,
+				803BB983295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift in Sources */,
 				8BBC778B27B5531700DBA087 /* BlogDashboardPersistence.swift in Sources */,
 				F5E29038243FAB0300C19CA5 /* FilterTableData.swift in Sources */,
 				E6A3384C1BB08E3F00371587 /* ReaderGapMarker.m in Sources */,
@@ -21157,6 +21183,7 @@
 				F10465142554260600655194 /* BindableTapGestureRecognizer.swift in Sources */,
 				E62079DF1CF79FC200F5CD46 /* ReaderSearchSuggestion.swift in Sources */,
 				E64ECA4D1CE62041000188A0 /* ReaderSearchViewController.swift in Sources */,
+				803BB9792959543D00B3F6D6 /* RootViewControllerCoordinator.swift in Sources */,
 				98F537A722496CF300B334F9 /* SiteStatsTableHeaderView.swift in Sources */,
 				E14977181C0DC0770057CD60 /* MediaSizeSliderCell.swift in Sources */,
 				C7BB60162863609C00748FD9 /* QRLoginInternetConnectionChecker.swift in Sources */,
@@ -21238,6 +21265,7 @@
 				9808655C203D079B00D58786 /* EpilogueUserInfoCell.swift in Sources */,
 				08216FD41CDBF96000304BA7 /* MenuItemTypeSelectionView.m in Sources */,
 				43B0BA962229927F00328C69 /* WordPressAppDelegate+openURL.swift in Sources */,
+				803BB980295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift in Sources */,
 				176DEEE91D4615FE00331F30 /* WPSplitViewController.swift in Sources */,
 				400F4625201E74EE000CFD9E /* CollectionViewContainerRow.swift in Sources */,
 				9A8ECE0E2254A3260043C8DA /* JetpackConnectionWebViewController.swift in Sources */,
@@ -22727,6 +22755,7 @@
 				24351255264DCA08009BB2B6 /* Secrets.swift in Sources */,
 				98A047732821CEBF001B4E2D /* BloggingPromptsViewController.swift in Sources */,
 				FABB21102602FC2C00C8785C /* MySiteViewController+FAB.swift in Sources */,
+				803BB981295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift in Sources */,
 				FABB21112602FC2C00C8785C /* BaseRestoreOptionsViewController.swift in Sources */,
 				8B4DDF25278F44CC0022494D /* BlogDashboardViewController.swift in Sources */,
 				FABB21122602FC2C00C8785C /* AddSiteAlertFactory.swift in Sources */,
@@ -22739,6 +22768,7 @@
 				FABB21172602FC2C00C8785C /* JetpackBackupOptionsViewController.swift in Sources */,
 				F4D829682931059000038726 /* MigrationSuccessActionHandler.swift in Sources */,
 				FABB21182602FC2C00C8785C /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
+				803BB97D2959559500B3F6D6 /* RootViewPresenter.swift in Sources */,
 				FABB21192602FC2C00C8785C /* NotificationContentRangeFactory.swift in Sources */,
 				FABB211A2602FC2C00C8785C /* SiteInfo.swift in Sources */,
 				FABB211B2602FC2C00C8785C /* CredentialsService.swift in Sources */,
@@ -22758,6 +22788,7 @@
 				FABB21272602FC2C00C8785C /* Media+Blog.swift in Sources */,
 				FABB21282602FC2C00C8785C /* MenuItemEditingHeaderView.m in Sources */,
 				3F8B45AB292C42CC00730FA4 /* MigrationSuccessCell.swift in Sources */,
+				803BB984295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift in Sources */,
 				FABB21292602FC2C00C8785C /* Routes+Banners.swift in Sources */,
 				8B5E1DD927EA5929002EBEE3 /* PostCoordinator+Dashboard.swift in Sources */,
 				93F72150271831820021A09F /* SiteStatsPinnedItemStore.swift in Sources */,
@@ -22862,6 +22893,7 @@
 				FABB21762602FC2C00C8785C /* CameraHandler.swift in Sources */,
 				FA73D7EA27987BA500DF24B3 /* SitePickerViewController+SiteIcon.swift in Sources */,
 				FABB21772602FC2C00C8785C /* JetpackConnectionViewController.swift in Sources */,
+				803BB97A2959543D00B3F6D6 /* RootViewControllerCoordinator.swift in Sources */,
 				FABB21782602FC2C00C8785C /* NotificationActionsService.swift in Sources */,
 				FABB21792602FC2C00C8785C /* JetpackScanService.swift in Sources */,
 				FABB217A2602FC2C00C8785C /* FilterSheetView.swift in Sources */,


### PR DESCRIPTION
Part of #19810 

## Description
This PR partially removes the jetpack features for users in P4. It removes the tab bar and removes the visible entry points for Jetpack features.

This PR also disables Quick Start and the onboarding prompt for the simplified UI. It also removed the outdated My Site Dashboard feature flag.

## ⚠️ Disclaimer ⚠️ 
In the simplified UI, we no longer display a WPTabBarController. However, many areas of the app depend on `WPTabBarController.sharedInstance` to perform some actions. And for that, the simplified UI at this point has some known issues. One issue, for example, is that the Floating Button actions are not working.

These issues will be addressed in a following PR that removes all the dependencies on `WPTabBarController.sharedInstance`.

## Screenshots
| iPhone | iPad |
| - | - |
|![iPhone](https://user-images.githubusercontent.com/25306722/209741992-06e5878a-a28e-4221-8860-868f87cc2970.png)|![iPad](https://user-images.githubusercontent.com/25306722/209741984-356fc687-37ec-42c9-a5fc-0c3bfd2d5a07.png)|

## Testing Instructions

1. Run the app
2. Open the debug menu and disable all the Jetpack Features Removal flags
3. Kill the app
4. Relaunch the app
5. Make sure the app is behaving normally
6. Open the debug menu and enable "Jetpack Features Removal Phase Four"
7. Kill the app
8. Relaunch the app
9. Make sure the tap bar is gone and all Jetpack features are removed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.