### PR TITLE
[Stats Revamp]: Rebuild Views & Visitors card when selected segment changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -8,6 +8,7 @@ class SiteStatsImmuTableRows {
     /// Helper method to create the rows for the Views and Visitors section
     ///
     static func viewVisitorsImmuTableRows(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?,
+                                          selectedSegment: StatsSegmentedControlData.Segment,
                                           periodDate: Date,
                                           periodEndDate: Date? = nil,
                                           statsLineChartViewDelegate: StatsLineChartViewDelegate?,
@@ -62,12 +63,13 @@ class SiteStatsImmuTableRows {
             }
 
             let row = ViewsVisitorsRow(
-                    segmentsData: [viewsSegmentData, visitorsSegmentData],
-                    chartData: lineChartData,
-                    chartStyling: lineChartStyling,
-                    period: StatsPeriodUnit.day,
-                    statsLineChartViewDelegate: statsLineChartViewDelegate,
-                    siteStatsInsightsDelegate: siteStatsInsightsDelegate, xAxisDates: xAxisDates
+                segmentsData: [viewsSegmentData, visitorsSegmentData],
+                selectedSegment: selectedSegment,
+                chartData: lineChartData,
+                chartStyling: lineChartStyling,
+                period: StatsPeriodUnit.day,
+                statsLineChartViewDelegate: statsLineChartViewDelegate,
+                siteStatsInsightsDelegate: siteStatsInsightsDelegate, xAxisDates: xAxisDates
             )
             tableRows.append(row)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
@@ -19,4 +19,5 @@ import Foundation
     @objc optional func addInsightSelected(_ insight: StatSection)
     @objc optional func addInsightDismissed()
     @objc optional func manageInsightSelected(_ insight: StatSection, fromButton: UIButton)
+    @objc optional func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int)
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -607,6 +607,13 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         alert.popoverPresentationController?.sourceView = fromButton
         present(alert, animated: true)
     }
+
+    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
+        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
+            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
+            refreshTableView()
+        }
+    }
 }
 
 // MARK: - StatsInsightsManagementDelegate

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -42,6 +42,8 @@ class SiteStatsInsightsViewModel: Observable {
 
     private var mostRecentChartData: StatsSummaryTimeIntervalData?
 
+    private var selectedViewsVisitorsSegment: StatsSegmentedControlData.Segment = .views
+
     // MARK: - Constructor
 
     init(insightsToShow: [InsightType],
@@ -399,6 +401,10 @@ class SiteStatsInsightsViewModel: Observable {
         pinnedItemStore?.markPinnedItemAsHidden(item)
     }
 
+    func updateViewsAndVisitorsSegment(_ selectedSegment: StatsSegmentedControlData.Segment) {
+        selectedViewsVisitorsSegment = selectedSegment
+    }
+
     static func intervalData(_ statsSummaryTimeIntervalData: StatsSummaryTimeIntervalData?, summaryType: StatsSummaryType, periodEndDate: Date? = nil) -> (count: Int, prevCount: Int, difference: Int, percentage: Int) {
         guard let statsSummaryTimeIntervalData = statsSummaryTimeIntervalData else {
             return (0, 0, 0, 0)
@@ -510,8 +516,11 @@ private extension SiteStatsInsightsViewModel {
 
         let periodDate = self.lastRequestedDate
 
-        return SiteStatsImmuTableRows.viewVisitorsImmuTableRows(mostRecentChartData, periodDate: periodDate,
-                statsLineChartViewDelegate: statsLineChartViewDelegate, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+        return SiteStatsImmuTableRows.viewVisitorsImmuTableRows(mostRecentChartData,
+                                                                selectedSegment: selectedViewsVisitorsSegment,
+                                                                periodDate: periodDate,
+                                                                statsLineChartViewDelegate: statsLineChartViewDelegate,
+                                                                siteStatsInsightsDelegate: siteStatsInsightsDelegate)
     }
 
     func createAllTimeStatsRows() -> [StatsTwoColumnRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -12,6 +12,11 @@ struct StatsSegmentedControlData {
     var period: StatsPeriodUnit?
     var analyticsStat: WPAnalyticsStat?
 
+    enum Segment: Int {
+        case views
+        case visitors
+    }
+
     private(set) var accessibilityHint: String?
 
     init(segmentTitle: String, segmentData: Int, segmentPrevData: Int, difference: Int, differenceText: String, segmentDataStub: String? = nil, date: Date? = nil, period: StatsPeriodUnit? = nil, analyticsStat: WPAnalyticsStat? = nil, accessibilityHint: String? = nil, differencePercent: Int) {
@@ -162,6 +167,7 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
     }
 
     func configure(segmentsData: [StatsSegmentedControlData],
+                   selectedSegment: StatsSegmentedControlData.Segment,
                    lineChartData: [LineChartDataConvertible] = [],
                    lineChartStyling: [LineChartStyling] = [],
                    period: StatsPeriodUnit? = nil,
@@ -180,7 +186,7 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
         self.period = period
         self.xAxisDates = xAxisDates
 
-        setupSegmentedControl()
+        setupSegmentedControl(selectedSegment: selectedSegment)
         configureChartView()
         updateLabels()
     }
@@ -191,8 +197,9 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
 
         configureChartView()
         updateLabels()
-    }
 
+        siteStatsInsightsDelegate?.viewsAndVisitorsSegmendChanged?(to: selectedSegmentIndex)
+    }
 }
 
 
@@ -205,12 +212,13 @@ private extension ViewsVisitorsLineChartCell {
         styleLabels()
     }
 
-    func setupSegmentedControl() {
+    func setupSegmentedControl(selectedSegment: StatsSegmentedControlData.Segment) {
         segmentedControl.selectedSegmentTintColor = UIColor.white
         segmentedControl.setTitleTextAttributes([.font: UIFont.preferredFont(forTextStyle: .subheadline).bold()], for: .normal)
         segmentedControl.setTitleTextAttributes([.foregroundColor: UIColor.black], for: .selected)
         segmentedControl.setTitle(segmentsData[0].segmentTitle, forSegmentAt: 0)
         segmentedControl.setTitle(segmentsData[1].segmentTitle, forSegmentAt: 1)
+        segmentedControl.selectedSegmentIndex = selectedSegment.rawValue
     }
 
     func styleLabels() {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -334,6 +334,13 @@ extension SiteStatsInsightsDetailsTableViewController: SiteStatsInsightsDelegate
                                             selectedPeriod: .week)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
+
+    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
+        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
+            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
+            refreshTableView()
+        }
+    }
 }
 
 // MARK: - SiteStatsReferrerDelegate

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -35,6 +35,8 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
     private var allAnnualInsights = [StatsAnnualInsight]()
 
+    private var selectedViewsVisitorsSegment: StatsSegmentedControlData.Segment = .views
+
     // MARK: - Init
 
     init(insightsDetailsDelegate: SiteStatsInsightsDelegate,
@@ -256,10 +258,11 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     // Views Visitors
                     let weekEnd = futureEndOfWeekDate(for: periodSummary)
                     rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary,
+                                                                                             selectedSegment: selectedViewsVisitorsSegment,
                                                                                              periodDate: selectedDate!,
                                                                                              periodEndDate: weekEnd,
                                                                                              statsLineChartViewDelegate: nil,
-                                                                                             siteStatsInsightsDelegate: nil))
+                                                                                             siteStatsInsightsDelegate: insightsDetailsDelegate))
 
                     // Referrers
                     if let referrers = viewsAndVisitorsData.topReferrers {
@@ -622,6 +625,12 @@ class SiteStatsInsightsDetailsViewModel: Observable {
         }
 
         ActionDispatcher.dispatch(PeriodAction.refreshPostStats(postID: postID))
+    }
+
+    // MARK: - Views & Visitors
+
+    func updateViewsAndVisitorsSegment(_ selectedSegment: StatsSegmentedControlData.Segment) {
+        selectedViewsVisitorsSegment = selectedSegment
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -38,6 +38,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
     }()
 
     let segmentsData: [StatsSegmentedControlData]
+    let selectedSegment: StatsSegmentedControlData.Segment
     let action: ImmuTableAction? = nil
     let chartData: [LineChartDataConvertible]
     let chartStyling: [LineChartStyling]
@@ -52,7 +53,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(segmentsData: segmentsData, lineChartData: chartData, lineChartStyling: chartStyling, period: period, statsLineChartViewDelegate: statsLineChartViewDelegate, xAxisDates: xAxisDates, delegate: siteStatsInsightsDelegate)
+        cell.configure(segmentsData: segmentsData, selectedSegment: selectedSegment, lineChartData: chartData, lineChartStyling: chartStyling, period: period, statsLineChartViewDelegate: statsLineChartViewDelegate, xAxisDates: xAxisDates, delegate: siteStatsInsightsDelegate)
     }
 }
 

--- a/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
@@ -15,7 +15,7 @@ class SiteStatsImmuTableRowsTests: XCTestCase {
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         // When creating rows from statsSummaryTimeIntervalData
-        let rows = SiteStatsImmuTableRows.viewVisitorsImmuTableRows(statsSummaryTimeIntervalData, periodDate: date, statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil)
+        let rows = SiteStatsImmuTableRows.viewVisitorsImmuTableRows(statsSummaryTimeIntervalData, selectedSegment: .views, periodDate: date, statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil)
 
         // Then
         XCTAssertTrue(rows.count == 1)


### PR DESCRIPTION
Fixes #19722

## Description

When changing between Views and Visitors segments, the layout of the card can break if the content length between segments is not equal. The content expands or shrinks but the table view cell size remains the same.

To fix this properly we need to reload the cell when the selected segment changes to ensure that it's displayed properly. 

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags

### Case 1 Insights tab:
1. Open Stats
2. Add Views & Visitors card
3. Find a site that has description lengths for Views and Visitors segments different. You can also increase dynamic type to find a case when that happens.
4. Switch between Views and Visitors segments. If the content length is different for one of the segments, cell should expand or shrink.
5. Pull to refresh the view, make sure the same segment is selected

### Case 2 Views & Visitors details:
1. Open Stats
2. Add Views & Visitors card
3. Click on "Week" to open details
4. Find a site that has description lengths for Views and Visitors segments different. You can also increase dynamic type to find a case when that happens.
5. Switch between Views and Visitors segments. If the content length is different for one of the segments, cell should expand or shrink.
6. Pull to refresh the view, make sure the same segment is selected
7. Change the date at the top, make sure the same segment is selected

## Regression Notes

1. Potential unintended areas of impact

Switching between Views & Visitors segment breaking

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before the fix - see the gaps appear when switching

https://user-images.githubusercontent.com/4062343/209794097-44e86406-79e6-45df-8257-8e6ecd85ead6.mp4

### After the fix - the cell shrinks

https://user-images.githubusercontent.com/4062343/209794205-24545cd3-2b74-4771-bdb6-012a05ed0a53.mp4



