### PR TITLE
[Stats Revamp] Recalculate the height of Insights Update prompt header when dynamic text size changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -304,6 +304,9 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
             // This helps reset the header changes after a rotation.
             scrollViewDidScroll(scrollableView)
             scrollViewDidEndDecelerating(scrollableView)
+        } else {
+            layoutHeader()
+            snapToHeight(scrollableView)
         }
     }
 


### PR DESCRIPTION
Fixes #19720

## Description

Fixing Insights Update prompt header not adapting to dynamic text size changes. This is a minor issue since the view **does** adapt to dynamic type and the bug only happens when dynamic type **changes** when the view is open.

The issue happens because Insights Update uses a more advanced `CollapsableHeaderViewController` which has more complex header height calculations that are not recalculated when the dynamic text changes. 

The solution is to manually ask to layout header when `traitCollectionDidChange` event is triggered by the system

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags

### Case 1:
1. Fresh install Jetpack (or kill the app after enabling feature flags)
2. Log in
3. Insights Update pop up should appear
4. Increase font size
5. The header height should be adapting depending on the font size


## Regression Notes

1. Potential unintended areas of impact

None, the changes are isolated

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before

https://user-images.githubusercontent.com/4062343/209816605-769abfb4-2d19-4b30-81ae-f138e9f7c7da.mp4

### After

https://user-images.githubusercontent.com/4062343/209816647-9d21d7cd-94f7-44ac-9687-ddf53ff3a1ce.mp4




