### PR TITLE
Increase the migration welcome screen top inset in iOS 14 only

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Welcome/MigrationWelcomeViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Welcome/MigrationWelcomeViewController.swift
@@ -99,7 +99,7 @@ final class MigrationWelcomeViewController: UIViewController {
         ])
     }
 
-    /// Increases the tableView's bottom inset so it doesn't cover the bottom actions sheet.
+    /// Increases the tableView's bottom inset so it doesn't get covered by  the bottom actions sheet.
     private func updateTableViewContentInset() {
         let bottomInset = -view.safeAreaInsets.bottom + bottomSheet.bounds.height
         self.tableView.contentInset.bottom = bottomInset + Constants.tableViewBottomInsetMargin
@@ -116,7 +116,13 @@ final class MigrationWelcomeViewController: UIViewController {
         static let tableViewLeadingMargin = CGFloat(30)
 
         /// Used for the `tableHeaderView` layout guide margins.
-        static let tableHeaderViewMargins = NSDirectionalEdgeInsets(top: 0, leading: 30, bottom: 30, trailing: 30)
+        static let tableHeaderViewMargins: NSDirectionalEdgeInsets = {
+            var insets = NSDirectionalEdgeInsets(top: 20, leading: 30, bottom: 30, trailing: 30)
+            if #available(iOS 15, *) {
+                insets.top = 0
+            }
+            return insets
+        }()
     }
 }
 


### PR DESCRIPTION
Fixes #19821

### Description

in iOS 15+, the scroll edge appearance of the navigation bar is transparent and becomes translucent when the user starts scrolling. But this behavior is not working in iOS 14, the navigation bar is always translucent. See "Before" screenshot.

Ideally, the navigation bar appearance in iOS 14 should behave like iOS 15+, but it's a little bit challenging to implement that behavior and probably not worth the hassle. This PR simply adds a spacing between the navigation bar and the table view content.

| Before | After |
| ------ | ------ |
| ![](https://user-images.githubusercontent.com/9609223/210076740-f08bd685-0ad2-46f4-847e-1466f7346676.png) | ![fix](https://user-images.githubusercontent.com/9609223/210078407-af6674e5-8d70-4d52-9037-69792b36a0f3.png) |

### Test Instructions

**N.B.: Use a device running iOS 14**

1. Clean install both WordPress and Jetpack apps
2. In WordPress, log into your account
3. Find any Jetpack Powered feature and tap "Jetpack Powered" badge
4. Tap "Try the new Jetpack app" to trigger the Migration flow
5. The Welcome Migration screen should appear on Jetpack
6. **Expect** the navigation bar to be translucent and there is a margin between the navigation bar and the table view content.


### Regression Notes
1. Potential unintended areas of impact
None.

7. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

8. What automated tests I added (or what prevented me from doing so)
None.

### PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
