### PR TITLE
Jetpack Migration: Disable export on launch

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -21,3 +21,5 @@ protocol UserPersistentRepositoryWriter: KeyValueDatabase {
 }
 
 typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter & UserPersistentRepositoryUtility
+
+extension UserDefaults: UserPersistentRepository {}

--- a/WordPress/Classes/Stores/UserPersistentRepository.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepository.swift
@@ -21,19 +21,3 @@ protocol UserPersistentRepositoryWriter: KeyValueDatabase {
 }
 
 typealias UserPersistentRepository = UserPersistentRepositoryReader & UserPersistentRepositoryWriter & UserPersistentRepositoryUtility
-
-extension UserDefaults: UserPersistentRepository {}
-
-extension UserPersistentStore {
-    private static var isOneOffMigrationCompleteKey: String {
-        "defaults_one_off_migration"
-    }
-
-    var isOneOffMigrationComplete: Bool {
-        get {
-            bool(forKey: Self.isOneOffMigrationCompleteKey)
-        } set {
-            set(newValue, forKey: Self.isOneOffMigrationCompleteKey)
-        }
-    }
-}

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -329,22 +329,6 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         setupWordPressExtensions()
 
-        if AppConfiguration.isWordPress,
-           FeatureFlag.contentMigration.enabled {
-            // To prevent race condition, initialize the shared instance synchronously so it can listen to account change notifications.
-            let _ = ContentMigrationCoordinator.shared
-
-            let launchUrl = launchOptions[.url] as? URL
-            let exportUrl = URL(string: "\(AppScheme.wordpressMigrationV1.rawValue)\(WordPressExportRoute().path.removingPrefix("/"))")
-            if launchUrl != exportUrl {
-                // Start proactively exporting WP data in the background if the conditions are fulfilled.
-                // This needs to be called after `setupWordPressExtensions` because it updates the stored data.
-                DispatchQueue.global().async {
-                    ContentMigrationCoordinator.shared.startOnceIfNeeded()
-                }
-            }
-        }
-
         shortcutCreator.createShortcutsIf3DTouchAvailable(AccountHelper.isLoggedIn)
 
         AccountService.loadDefaultAccountCookies()

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -193,6 +193,5 @@ extension AppConfiguration: ContentMigrationEligibilityProvider {
 // MARK: - Constants
 
 private extension String {
-    static let oneOffMigrationKey = "wordpress_one_off_export"
     static let exportErrorSharedKey = "wordpress_shared_export_error"
 }

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -97,28 +97,6 @@
         }
     }
 
-    /// Starts the content migration process from WordPress to Jetpack.
-    /// This method ensures that the migration will only be executed once per installation,
-    /// and only performed when all the conditions are fulfilled.
-    ///
-    /// Note: If the conditions are not fulfilled, this method will attempt to migrate
-    /// again on the next call.
-    ///
-    func startOnceIfNeeded(completion: (() -> Void)? = nil) {
-        if userPersistentRepository.bool(forKey: .oneOffMigrationKey) {
-            completion?()
-            return
-        }
-
-        startAndDo { [weak self] result in
-            if case .success = result {
-                self?.userPersistentRepository.set(true, forKey: .oneOffMigrationKey)
-            }
-
-            completion?()
-        }
-    }
-
     /// Attempts to clean up the exported data by re-exporting user content if they're still eligible, or deleting them otherwise.
     /// Re-exporting user content ensures that the exported data will match the latest state of Account and Blogs.
     ///

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -180,41 +180,6 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
         wait(for: [expect], timeout: timeout)
     }
 
-    // MARK: `startOnce` tests
-
-    func test_startOnce_whenUserDefaultsDoesNotExist_shouldMigrate() {
-        let expect = expectation(description: "Content migration should succeed")
-        coordinator.startOnceIfNeeded { [unowned self] in
-            XCTAssertTrue(mockDataMigrator.exportCalled)
-            XCTAssertTrue(mockPersistentRepository.bool(forKey: userDefaultsKey))
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: timeout)
-    }
-
-    func test_startOnce_givenErrorResult_shouldNotSaveUserDefaults() {
-        mockDataMigrator.exportErrorToReturn = .databaseCopyError
-
-        let expect = expectation(description: "Content migration should succeed")
-        coordinator.startOnceIfNeeded { [unowned self] in
-            XCTAssertTrue(mockDataMigrator.exportCalled)
-            XCTAssertFalse(mockPersistentRepository.bool(forKey: userDefaultsKey))
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: timeout)
-    }
-
-    func test_startOnce_whenUserDefaultsExists_shouldNotMigrate() {
-        mockPersistentRepository.set(true, forKey: userDefaultsKey)
-
-        let expect = expectation(description: "Content migration should not be called")
-        coordinator.startOnceIfNeeded { [unowned self] in
-            XCTAssertFalse(mockDataMigrator.exportCalled)
-            expect.fulfill()
-        }
-        wait(for: [expect], timeout: timeout)
-    }
-
     // MARK: Export data cleanup tests
 
     func test_cleanupExportedData_givenUserIsIneligible_shouldDeleteData() {


### PR DESCRIPTION
Refs pcdRpT-1sp-p2#comment-2619

When user content is migrated on launch, there's a window where the user might make some changes to their local settings, which can cause the migrated data to be outdated. This can be reproduced by 1) making changes (app settings, saved posts, etc.) after export-on-launch is performed, and 2) opening the Jetpack app voluntarily (i.e., without tapping the Jetpack button.

A low-effort and low-risk solution to fix this is to remove the export-on-launch mechanism. We can somewhat afford this solution because we have the "Open WordPress" flow, allowing users to migrate their most recent data from the WordPress app.

## To test

Reusing the table from #19787, observe the added `New flow` column:

No. | WordPress app | Account state | Scenario | Previous flow | New flow
-|-|-|-|-|-
1 | Not installed | n/a | n/a | 🔐 Sign-in flow | _unchanged_
2 | Incompatible | Any | Any | 🔐 Sign-in flow | _unchanged_
3 | Compatible | Logged out | Never opened | 🔁 Open WordPress | _unchanged_
4 | Compatible | Logged out | Opened at least once | 🔐 Sign-in flow | 🔁 Open WordPress
5 | Compatible | Logged out | Log in > then tap the Jetpack banner | 🟢 Normal migration | _unchanged_
6 | Compatible | Logged in | Never opened | 🔁 Open WordPress | _unchanged_
7 | Compatible | Logged in | Opened at least once | 🟢 Normal migration | 🔁 Open WordPress
8 | Compatible | Logged in | Tap the Jetpack banner | 🟢 Normal migration | _unchanged_
9 | Compatible | Logged in | Airplane mode > create local draft > tap the Jetpack banner | 🔐 Sign-in flow | _unchanged_
10 | Compatible | Logged in | Log out | 🔐 Sign-in flow | _unchanged_

Here's how to test flow no. 7:

- Install the WP app that includes this PR.
- Log in to any WP.com account.
- Kill the WP app.
- Open the WP app again. 
- Make some changes to local settings (e.g., Me > App Settings > Media).
- Switch to the Jetpack app.
- 🔍 Verify that 🔁 Open WordPress flow is shown, instead of 🟢 Normal migration.

> **Note**: For a quick recap on how each flow looks, refer to the description in #19787.

## Regression Notes
1. Potential unintended areas of impact
Changes may impact the other migration paths.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes (not fully covered yet)

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.