### PR TITLE
[Stats Revamp] Changing "First day of week" results in incorrect numbers in Views & Visitors and Total Likes details

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -178,7 +178,7 @@ private extension Date {
         let components = DateComponents(day: 7 * offset, hour: -12)
 
         guard let weekAdjusted = calendar.date(byAdding: components, to: normalizedDate()),
-        let endOfAdjustedWeek = calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end else {
+              let endOfAdjustedWeek = StatsPeriodHelper().weekIncludingDate(weekAdjusted)?.weekEnd else {
             DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -95,8 +95,7 @@ class StatsPeriodHelper {
     func calculateEndDate(from currentDate: Date,
                           offsetBy count: Int = 1,
                           unit: StatsPeriodUnit,
-                          calendar: Calendar = Calendar.autoupdatingCurrent,
-                          statsRevampEnabled: Bool = AppConfiguration.showsStatsRevampV2) -> Date? {
+                          calendar: Calendar = Calendar.autoupdatingCurrent) -> Date? {
         guard let adjustedDate = calendar.date(byAdding: unit.calendarComponent, value: count, to: currentDate) else {
             DDLogError("[Stats] Couldn't do basic math on Calendars in Stats. Returning original value.")
             return currentDate
@@ -107,7 +106,7 @@ class StatsPeriodHelper {
             return adjustedDate.normalizedDate()
 
         case .week:
-            if statsRevampEnabled {
+            if FeatureFlag.statsNewInsights.enabled {
                 guard let endDate = currentDate.lastDayOfTheWeek(in: calendar, with: count) else {
                     DDLogError("[Stats] Couldn't determine the last day of the week for a given date in Stats. Returning original value.")
                     return currentDate

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -103,7 +103,12 @@ class StatsPeriodHelper {
             return adjustedDate.normalizedDate()
 
         case .week:
-            return currentDate.lastDayOfTheWeek(in: calendar, with: count)?.normalizedDate()
+            guard let endDate = currentDate.lastDayOfTheWeek(in: calendar, with: count) else {
+                DDLogError("[Stats] Couldn't determine the last day of the week for a given date in Stats. Returning original value.")
+                return currentDate
+            }
+
+            return endDate.normalizedDate()
         case .month:
             guard let endDate = adjustedDate.lastDayOfTheMonth(in: calendar) else {
                 DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -105,21 +105,7 @@ class StatsPeriodHelper {
             return adjustedDate.normalizedDate()
 
         case .week:
-
-            // The hours component here is because the `dateInterval` returned by Calendar is a closed range
-            // — so the "end" of a specific week is also simultenously a 'start' of the next one.
-            // This causes problem when calling this math on dates that _already are_ an end/start of a week.
-            // This doesn't work for our calculations, so we force it to rollover using this hack.
-            // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
-            // I spend like 10h on this ~50 LoC method. Beware.)
-            let components = DateComponents(day: 7 * count, hour: -12)
-
-            guard let weekAdjusted = calendar.date(byAdding: components, to: currentDate.normalizedDate()) else {
-                DDLogError("[Stats] Couldn't add a multiple of 7 days and -12 hours to a date in Stats. Returning original value.")
-                return currentDate
-            }
-            return calendar.dateInterval(of: .weekOfYear, for: weekAdjusted)?.end.normalizedDate()
-
+            return currentDate.lastDayOfTheWeek(in: calendar, with: count)?.normalizedDate()
         case .month:
             guard let endDate = adjustedDate.lastDayOfTheMonth(in: calendar) else {
                 DDLogError("[Stats] Couldn't determine number of days in a given month in Stats. Returning original value.")

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsPeriodHelper.swift
@@ -92,9 +92,7 @@ class StatsPeriodHelper {
         }
     }
 
-    func calculateEndDate(from currentDate: Date, offsetBy count: Int = 1, unit: StatsPeriodUnit) -> Date? {
-        let calendar = Calendar.autoupdatingCurrent
-
+    func calculateEndDate(from currentDate: Date, offsetBy count: Int = 1, unit: StatsPeriodUnit, calendar: Calendar = Calendar.autoupdatingCurrent) -> Date? {
         guard let adjustedDate = calendar.date(byAdding: unit.calendarComponent, value: count, to: currentDate) else {
             DDLogError("[Stats] Couldn't do basic math on Calendars in Stats. Returning original value.")
             return currentDate
@@ -155,13 +153,7 @@ private extension Date {
     }
 
     func lastDayOfTheWeek(in calendar: Calendar, with offset: Int) -> Date? {
-        // The hours component here is because the `dateInterval` returnd by Calendar is a closed range
-        // — so the "end" of a specific week is also simultenously a 'start' of the next one.
-        // This causes problem when calling this math on dates that _already are_ an end/start of a week.
-        // This doesn't work for our calculations, so we force it to rollover using this hack.
-        // (I *think* that's what's happening here. Doing Calendar math on this method has broken my brain.
-        // I spend like 10h on this ~50 LoC method. Beware.)
-        let components = DateComponents(day: 7 * offset, hour: -12)
+        let components = DateComponents(day: 7 * offset)
 
         guard let weekAdjusted = calendar.date(byAdding: components, to: normalizedDate()),
               let endOfAdjustedWeek = StatsPeriodHelper().weekIncludingDate(weekAdjusted)?.weekEnd else {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -498,8 +498,8 @@ class SiteStatsInsightsDetailsViewModel: Observable {
         return StatsTotalInsightsData.followersCount(insightsStore: insightsStore)
     }
 
-        func createLikesTotalInsightsRow(periodSummary: StatsSummaryTimeIntervalData?) -> StatsTotalInsightsData {
-        let weekEnd = futureEndOfWeekDate(for: periodStore.getSummary())
+    func createLikesTotalInsightsRow(periodSummary: StatsSummaryTimeIntervalData?) -> StatsTotalInsightsData {
+        let weekEnd = futureEndOfWeekDate(for: periodSummary)
         var data = StatsTotalInsightsData.createTotalInsightsData(periodSummary: periodSummary,
                                                                   insightsStore: insightsStore,
                                                                   statsSummaryType: .likes,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		01CE5013290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		01CE5014290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
+		01E78D1D296EA54F00FB6863 /* StatsPeriodHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */; };
 		02761EC02270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */; };
 		02761EC222700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */; };
 		02761EC4227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */; };
@@ -5508,6 +5509,7 @@
 		0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceMock.swift; sourceTree = "<group>"; };
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
+		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
 		02761EBF2270072F009BAF0F /* BlogDetailsViewController+SectionHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+SectionHelpers.swift"; sourceTree = "<group>"; };
 		02761EC122700A9C009BAF0F /* BlogDetailsSubsectionToSectionCategoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSubsectionToSectionCategoryTests.swift; sourceTree = "<group>"; };
 		02761EC3227010BC009BAF0F /* BlogDetailsSectionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDetailsSectionIndexTests.swift; sourceTree = "<group>"; };
@@ -11198,6 +11200,7 @@
 				40C403F72215D88100E8C894 /* TopViewedStatsTests.swift */,
 				400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */,
 				400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */,
+				01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -22525,6 +22528,7 @@
 				010459ED2915519C000C7778 /* JetpackNotificationMigrationServiceTests.swift in Sources */,
 				8B6214E627B1B446001DF7B6 /* BlogDashboardServiceTests.swift in Sources */,
 				C856749A243F4292001A995E /* TenorMockDataHelper.swift in Sources */,
+				01E78D1D296EA54F00FB6863 /* StatsPeriodHelperTests.swift in Sources */,
 				3FFE3C0828FE00D10021BB96 /* StatsSegmentedControlDataTests.swift in Sources */,
 				D81C2F5820F86CEA002AE1F1 /* NetworkStatus.swift in Sources */,
 				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,

--- a/WordPress/WordPressTest/StatsPeriodHelperTests.swift
+++ b/WordPress/WordPressTest/StatsPeriodHelperTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import WordPress
+
+final class StatsPeriodHelperTests: XCTestCase {
+    private var sut: StatsPeriodHelper!
+
+    override func setUpWithError() throws {
+        sut = StatsPeriodHelper()
+    }
+
+    override func tearDownWithError() throws {
+        sut = nil
+    }
+
+    func testEndOfWeekWhenMondayIsSetAsFirstWeekday() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        // Thursday
+        let dateComponents = DateComponents(year: 2023, month: 02, day: 02, hour: 8, minute: 34)
+
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: 0,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2023-02-05 Sunday should be end of the week
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 5)
+    }
+
+    func testEndOfWeekWhenSundayIsSetAsFirstWeekday() {
+        // A calendar with Sunday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 1
+
+        // Thursday
+        let dateComponents = DateComponents(year: 2023, month: 02, day: 02, hour: 8, minute: 34)
+
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: 0,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2023-02-05 Sunday should still be end of the week
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 5)
+    }
+
+    func testEndOfWeekWhenCurrentDateIsStartOfWeek() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        // Start of Monday
+        let dateComponents = DateComponents(year: 2021, month: 11, day: 15, hour: 00, minute: 00)
+
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: 0,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2021-11-21 Sunday should be end of the week
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 21)
+    }
+
+    func testEndOfWeekWhenCurrentDateIsEndOfWeek() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        // End of Sunday
+        let dateComponents = DateComponents(year: 2021, month: 11, day: 21, hour: 23, minute: 59)
+
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: 0,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2021-11-21 Sunday should be end of the week
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 21)
+    }
+
+    func testEndOfNextWeek() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        // Thursday
+        let dateComponents = DateComponents(year: 2023, month: 02, day: 02, hour: 8, minute: 34)
+
+        // Get end date of next week
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: 1,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2023-02-12
+        XCTAssertEqual(endDate?.dateAndTimeComponents().month, 2)
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 12)
+    }
+
+    func testEndOfLastWeek() {
+        // A calendar with Monday as first weekday
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.firstWeekday = 2
+
+        // Thursday
+        let dateComponents = DateComponents(year: 2023, month: 02, day: 02, hour: 8, minute: 34)
+
+        // Get end date of last week
+        let endDate = sut.calculateEndDate(
+            from: calendar.date(from: dateComponents)!,
+            offsetBy: -1,
+            unit: .week,
+            calendar: calendar
+        )
+
+        // 2023-01-29
+        XCTAssertEqual(endDate?.dateAndTimeComponents().month, 1)
+        XCTAssertEqual(endDate?.dateAndTimeComponents().day, 29)
+    }
+}

--- a/WordPress/WordPressTest/StatsPeriodHelperTests.swift
+++ b/WordPress/WordPressTest/StatsPeriodHelperTests.swift
@@ -6,10 +6,12 @@ final class StatsPeriodHelperTests: XCTestCase {
 
     override func setUpWithError() throws {
         sut = StatsPeriodHelper()
+        try? FeatureFlagOverrideStore().override(FeatureFlag.statsNewInsights, withValue: true)
     }
 
     override func tearDownWithError() throws {
         sut = nil
+        try? FeatureFlagOverrideStore().override(FeatureFlag.statsNewInsights, withValue: false)
     }
 
     func testEndOfWeekWhenMondayIsSetAsFirstWeekday() {
@@ -24,8 +26,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2023-02-05 Sunday should be end of the week
@@ -44,8 +45,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2023-02-05 Sunday should still be end of the week
@@ -64,8 +64,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2021-11-21 Sunday should be end of the week
@@ -84,8 +83,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2021-11-21 Sunday should be end of the week
@@ -105,8 +103,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 1,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2023-02-12
@@ -127,8 +124,7 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: -1,
             unit: .week,
-            calendar: calendar,
-            statsRevampEnabled: true
+            calendar: calendar
         )
 
         // 2023-01-29

--- a/WordPress/WordPressTest/StatsPeriodHelperTests.swift
+++ b/WordPress/WordPressTest/StatsPeriodHelperTests.swift
@@ -24,7 +24,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2023-02-05 Sunday should be end of the week
@@ -43,7 +44,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2023-02-05 Sunday should still be end of the week
@@ -62,7 +64,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2021-11-21 Sunday should be end of the week
@@ -81,7 +84,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 0,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2021-11-21 Sunday should be end of the week
@@ -101,7 +105,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: 1,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2023-02-12
@@ -122,7 +127,8 @@ final class StatsPeriodHelperTests: XCTestCase {
             from: calendar.date(from: dateComponents)!,
             offsetBy: -1,
             unit: .week,
-            calendar: calendar
+            calendar: calendar,
+            statsRevampEnabled: true
         )
 
         // 2023-01-29


### PR DESCRIPTION
## Description

Changing "First day of week" from Sunday to any other day in Language & Region, causes wrong numbers in Views & Visitors and Total Likes details pages after changing the date.

Stats views expect the week to be from Monday - Sunday but the method that calculates the date for this view uses the first day of week from settings.

## Solution

The error happens after calling `StatsPeriodHelper.calculateEndDate` for a `.week` period.

After calculating the previous week, use the already created `StatsPeriodHelper().weekIncludingDate` to calculate the end of the week. After this fix, the date calculation works as expected.

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags

### Case 1 Views & Visitors:
1. Open Settings -> General -> Language & Region -> First Day of Week
2. Change day of week to "Sunday"
3. Open Stats
4. Click gear icon on top right
5. Add Views & Visitors card
6. Click "Week"
7. Go back in weeks and remember the numbers
8. Go back to settings and change day of week to "Monday"
9. Come back to Stats
10. Go back in weeks and make sure they are the same as in step 6

### Case 2 Total Likes:
1. Repeat Case 1, but with "Total Likes" card

### Case 3 Date and time close to the beginning or end of the week
1. Change the phone time to the beginning of the week or the end of the week (Monday 00:00 + site time zone difference, Sunday 23:59 + site time zone difference)
2. Make sure Case 1 and Case 2 report the same numbers

## Regression Notes

1. Potential unintended areas of impact

Other parts of Stats that uses this calculation breaks

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually testing old stats: Days / Weeks / Months and changing dates to make sure they continue working as expected.

4. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before the fix

https://user-images.githubusercontent.com/4062343/210349292-0c85ab26-dec0-4691-baac-16c1fa470f49.mp4

### After the fix

https://user-images.githubusercontent.com/4062343/210349370-2c60301a-dbc3-4530-9136-4d71fcd9258b.mov
