### PR TITLE
[Stats Revamp] Remove "Comments" card from revamped Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -36,24 +36,21 @@
 
     static var allInsights: [StatSection] {
         if FeatureFlag.statsNewInsights.enabled {
-            return [StatSection.insightsViewsVisitors,
-                    .insightsLatestPostSummary,
-                    .insightsAllTime,
+            return [.insightsViewsVisitors,
                     .insightsLikesTotals,
                     .insightsCommentsTotals,
                     .insightsFollowerTotals,
                     .insightsMostPopularTime,
-                    .insightsTagsAndCategories,
+                    .insightsLatestPostSummary,
+                    .insightsAllTime,
                     .insightsAnnualSiteStats,
-                    .insightsCommentsAuthors,
-                    .insightsCommentsPosts,
-                    .insightsFollowersWordPress,
-                    .insightsFollowersEmail,
                     .insightsTodaysStats,
                     .insightsPostingActivity,
+                    .insightsTagsAndCategories,
+                    .insightsFollowersEmail,
                     .insightsPublicize]
         } else {
-            return [StatSection.insightsLatestPostSummary,
+            return [.insightsLatestPostSummary,
                     .insightsAllTime,
                     .insightsFollowerTotals,
                     .insightsMostPopularTime,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -22,7 +22,7 @@ class InsightsManagementViewController: UITableViewController {
     }
 
     private var insightsInactive: [StatSection] {
-        InsightsManagementViewController.allInsights.filter({ !self.insightsShown.contains($0) })
+        StatSection.allInsights.filter({ !self.insightsShown.contains($0) })
     }
 
     private var hasChanges: Bool {
@@ -387,22 +387,6 @@ private extension InsightsManagementViewController {
                                  enabled: false,
                                  action: nil)
     }
-
-    private static let allInsights: [StatSection] = [
-        .insightsViewsVisitors,
-        .insightsLikesTotals,
-        .insightsCommentsTotals,
-        .insightsFollowerTotals,
-        .insightsMostPopularTime,
-        .insightsLatestPostSummary,
-        .insightsAllTime,
-        .insightsAnnualSiteStats,
-        .insightsTodaysStats,
-        .insightsPostingActivity,
-        .insightsTagsAndCategories,
-        .insightsFollowersEmail,
-        .insightsPublicize
-    ]
 
     // MARK: - Insights Categories
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -16,6 +16,7 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController, St
     private var insightsToShow: [InsightType] {
         get {
             SiteStatsInformation.sharedInstance.getCurrentSiteInsights()
+                .filter(StatSection.allInsights.compactMap(\.insightType).contains)
         }
 
         set {


### PR DESCRIPTION
## Description

"Comments" card should not appear after Stats Revamp is enabled. Filter it out from visible insights.

## Testing instructions

### Case 1:
1. Disable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags
2. Open Stats
3. Add "Comments" card
4. Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags
5. Come back to Stats
6. "Comments" card should not be visible
7. Click gear icon on top right
8. "Comments" row should not be visible as well

## Regression Notes

1. Potential unintended areas of impact

Make sure "Comments" continues to be visible when feature flag is disabled, make sure other cards appear when Stats Revamp is enabled

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before the fix

https://user-images.githubusercontent.com/4062343/210353538-5afe3c08-ae8b-4a94-bd7b-f2b3f75b3627.mov

### After the fix

https://user-images.githubusercontent.com/4062343/210353563-c3f80bd6-dacb-41a0-be20-c76139e0e68d.mp4

