### PR TITLE
[Stats Revamp]: Remove "Week >" button from Views & Visitors card in details

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -12,7 +12,8 @@ class SiteStatsImmuTableRows {
                                           periodDate: Date,
                                           periodEndDate: Date? = nil,
                                           statsLineChartViewDelegate: StatsLineChartViewDelegate?,
-                                          siteStatsInsightsDelegate: SiteStatsInsightsDelegate?) -> [ImmuTableRow] {
+                                          siteStatsInsightsDelegate: SiteStatsInsightsDelegate?,
+                                          viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?) -> [ImmuTableRow] {
         var tableRows = [ImmuTableRow]()
 
         let viewsData = SiteStatsInsightsViewModel.intervalData(statsSummaryTimeIntervalData, summaryType: .views, periodEndDate: periodEndDate)
@@ -69,7 +70,9 @@ class SiteStatsImmuTableRows {
                 chartStyling: lineChartStyling,
                 period: StatsPeriodUnit.day,
                 statsLineChartViewDelegate: statsLineChartViewDelegate,
-                siteStatsInsightsDelegate: siteStatsInsightsDelegate, xAxisDates: xAxisDates
+                siteStatsInsightsDelegate: siteStatsInsightsDelegate,
+                viewsAndVisitorsDelegate: viewsAndVisitorsDelegate,
+                xAxisDates: xAxisDates
             )
             tableRows.append(row)
         }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsDelegate.swift
@@ -19,5 +19,4 @@ import Foundation
     @objc optional func addInsightSelected(_ insight: StatSection)
     @objc optional func addInsightDismissed()
     @objc optional func manageInsightSelected(_ insight: StatSection, fromButton: UIButton)
-    @objc optional func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int)
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -119,6 +119,7 @@ private extension SiteStatsInsightsTableViewController {
     func initViewModel() {
         viewModel = SiteStatsInsightsViewModel(insightsToShow: insightsToShow,
                                                insightsDelegate: self,
+                                               viewsAndVisitorsDelegate: self,
                                                insightsStore: insightsStore,
                                                pinnedItemStore: pinnedItemStore)
         addViewModelListeners()
@@ -606,13 +607,6 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
         alert.popoverPresentationController?.sourceView = fromButton
         present(alert, animated: true)
     }
-
-    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
-        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
-            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
-            refreshTableView()
-        }
-    }
 }
 
 // MARK: - StatsInsightsManagementDelegate
@@ -628,6 +622,17 @@ extension SiteStatsInsightsTableViewController: StatsInsightsManagementDelegate 
         insightsToShow = insightTypes
         refreshInsights(forceRefresh: true)
         updateView()
+    }
+}
+
+// MARK: - ViewsVisitorsDelegate
+
+extension SiteStatsInsightsTableViewController: StatsInsightsViewsAndVisitorsDelegate {
+    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
+        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
+            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
+            refreshTableView()
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -15,6 +15,7 @@ class SiteStatsInsightsViewModel: Observable {
     let changeDispatcher = Dispatcher<Void>()
 
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?
 
     private let insightsStore: StatsInsightsStore
     private let periodStore: StatsPeriodStore
@@ -48,10 +49,12 @@ class SiteStatsInsightsViewModel: Observable {
 
     init(insightsToShow: [InsightType],
          insightsDelegate: SiteStatsInsightsDelegate,
+         viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?,
          insightsStore: StatsInsightsStore,
          pinnedItemStore: SiteStatsPinnedItemStore?,
          periodStore: StatsPeriodStore = StoreContainer.shared.statsPeriod) {
         self.siteStatsInsightsDelegate = insightsDelegate
+        self.viewsAndVisitorsDelegate = viewsAndVisitorsDelegate
         self.insightsToShow = insightsToShow
         self.insightsStore = insightsStore
         self.pinnedItemStore = pinnedItemStore
@@ -520,7 +523,8 @@ private extension SiteStatsInsightsViewModel {
                                                                 selectedSegment: selectedViewsVisitorsSegment,
                                                                 periodDate: periodDate,
                                                                 statsLineChartViewDelegate: statsLineChartViewDelegate,
-                                                                siteStatsInsightsDelegate: siteStatsInsightsDelegate)
+                                                                siteStatsInsightsDelegate: siteStatsInsightsDelegate,
+                                                                viewsAndVisitorsDelegate: viewsAndVisitorsDelegate)
     }
 
     func createAllTimeStatsRows() -> [StatsTwoColumnRowData] {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -121,6 +121,11 @@ struct StatsSegmentedControlData {
     }
 }
 
+
+protocol StatsInsightsViewsAndVisitorsDelegate: AnyObject {
+    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int)
+}
+
 class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
 
     @IBOutlet weak var labelsStackView: UIStackView!
@@ -138,6 +143,8 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
     @IBOutlet weak var bottomStackView: UIStackView!
 
     private weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    private weak var viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?
+
     private typealias Style = WPStyleGuide.Stats
     private var segmentsData = [StatsSegmentedControlData]()
 
@@ -166,27 +173,20 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
         applyStyles()
     }
 
-    func configure(segmentsData: [StatsSegmentedControlData],
-                   selectedSegment: StatsSegmentedControlData.Segment,
-                   lineChartData: [LineChartDataConvertible] = [],
-                   lineChartStyling: [LineChartStyling] = [],
-                   period: StatsPeriodUnit? = nil,
-                   statsLineChartViewDelegate: StatsLineChartViewDelegate? = nil,
-                   xAxisDates: [Date],
-                   delegate: SiteStatsInsightsDelegate? = nil
-    ) {
-        siteStatsInsightsDelegate = delegate
-        siteStatsInsightDetailsDelegate = siteStatsInsightsDelegate
+    func configure(row: ViewsVisitorsRow) {
+        siteStatsInsightsDelegate = row.siteStatsInsightsDelegate
+        siteStatsInsightDetailsDelegate = row.siteStatsInsightsDelegate
         statSection = .insightsViewsVisitors
 
-        self.segmentsData = segmentsData
-        self.chartData = lineChartData
-        self.chartStyling = lineChartStyling
-        self.statsLineChartViewDelegate = statsLineChartViewDelegate
-        self.period = period
-        self.xAxisDates = xAxisDates
+        self.segmentsData = row.segmentsData
+        self.chartData = row.chartData
+        self.chartStyling = row.chartStyling
+        self.statsLineChartViewDelegate = row.statsLineChartViewDelegate
+        self.viewsAndVisitorsDelegate = row.viewsAndVisitorsDelegate
+        self.period = row.period
+        self.xAxisDates = row.xAxisDates
 
-        setupSegmentedControl(selectedSegment: selectedSegment)
+        setupSegmentedControl(selectedSegment: row.selectedSegment)
         configureChartView()
         updateLabels()
     }
@@ -198,7 +198,7 @@ class ViewsVisitorsLineChartCell: StatsBaseCell, NibLoadable {
         configureChartView()
         updateLabels()
 
-        siteStatsInsightsDelegate?.viewsAndVisitorsSegmendChanged?(to: selectedSegmentIndex)
+        viewsAndVisitorsDelegate?.viewsAndVisitorsSegmendChanged(to: selectedSegmentIndex)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -140,7 +140,8 @@ private extension SiteStatsInsightsDetailsTableViewController {
     func initViewModel() {
         viewModel = SiteStatsInsightsDetailsViewModel(insightsDetailsDelegate: self,
                                                       detailsDelegate: self,
-                                                      referrerDelegate: self)
+                                                      referrerDelegate: self,
+                                                      viewsAndVisitorsDelegate: self)
 
         guard let statSection = statSection else {
             return
@@ -334,13 +335,6 @@ extension SiteStatsInsightsDetailsTableViewController: SiteStatsInsightsDelegate
                                             selectedPeriod: .week)
         navigationController?.pushViewController(detailTableViewController, animated: true)
     }
-
-    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
-        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
-            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
-            refreshTableView()
-        }
-    }
 }
 
 // MARK: - SiteStatsReferrerDelegate
@@ -401,5 +395,16 @@ extension SiteStatsInsightsDetailsTableViewController: SiteStatsTableHeaderDeleg
         selectedDate = newDate
         viewModel?.updateSelectedDate(newDate)
         refreshTableView()
+    }
+}
+
+// MARK: - ViewsVisitorsDelegate
+
+extension SiteStatsInsightsDetailsTableViewController: StatsInsightsViewsAndVisitorsDelegate {
+    func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {
+        if let selectedSegment = StatsSegmentedControlData.Segment(rawValue: selectedSegmentIndex) {
+            viewModel?.updateViewsAndVisitorsSegment(selectedSegment)
+            refreshTableView()
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -17,6 +17,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
     private weak var insightsDetailsDelegate: SiteStatsInsightsDelegate?
     private weak var detailsDelegate: SiteStatsDetailsDelegate?
     private weak var referrerDelegate: SiteStatsReferrerDelegate?
+    private weak var viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?
 
     private let insightsStore = StoreContainer.shared.statsInsights
     private var insightsReceipt: Receipt?
@@ -41,10 +42,12 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
     init(insightsDetailsDelegate: SiteStatsInsightsDelegate,
          detailsDelegate: SiteStatsDetailsDelegate,
-         referrerDelegate: SiteStatsReferrerDelegate) {
+         referrerDelegate: SiteStatsReferrerDelegate,
+         viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate) {
         self.insightsDetailsDelegate = insightsDetailsDelegate
         self.detailsDelegate = detailsDelegate
         self.referrerDelegate = referrerDelegate
+        self.viewsAndVisitorsDelegate = viewsAndVisitorsDelegate
     }
 
     // MARK: - Data Fetching
@@ -262,7 +265,8 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                                                                                              periodDate: selectedDate!,
                                                                                              periodEndDate: weekEnd,
                                                                                              statsLineChartViewDelegate: nil,
-                                                                                             siteStatsInsightsDelegate: insightsDetailsDelegate))
+                                                                                             siteStatsInsightsDelegate: nil,
+                                                                                             viewsAndVisitorsDelegate: viewsAndVisitorsDelegate))
 
                     // Referrers
                     if let referrers = viewsAndVisitorsData.topReferrers {

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -45,6 +45,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
     let period: StatsPeriodUnit?
     weak var statsLineChartViewDelegate: StatsLineChartViewDelegate?
     weak var siteStatsInsightsDelegate: SiteStatsInsightsDelegate?
+    weak var viewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate?
     let xAxisDates: [Date]
 
     func configureCell(_ cell: UITableViewCell) {
@@ -53,7 +54,7 @@ struct ViewsVisitorsRow: ImmuTableRow {
             return
         }
 
-        cell.configure(segmentsData: segmentsData, selectedSegment: selectedSegment, lineChartData: chartData, lineChartStyling: chartStyling, period: period, statsLineChartViewDelegate: statsLineChartViewDelegate, xAxisDates: xAxisDates, delegate: siteStatsInsightsDelegate)
+        cell.configure(row: self)
     }
 }
 

--- a/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Helpers/SiteStatsImmuTableRowsTests.swift
@@ -15,7 +15,7 @@ class SiteStatsImmuTableRowsTests: XCTestCase {
         let date = Calendar.autoupdatingCurrent.date(from: feb21)!
 
         // When creating rows from statsSummaryTimeIntervalData
-        let rows = SiteStatsImmuTableRows.viewVisitorsImmuTableRows(statsSummaryTimeIntervalData, selectedSegment: .views, periodDate: date, statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil)
+        let rows = SiteStatsImmuTableRows.viewVisitorsImmuTableRows(statsSummaryTimeIntervalData, selectedSegment: .views, periodDate: date, statsLineChartViewDelegate: nil, siteStatsInsightsDelegate: nil, viewsAndVisitorsDelegate: nil)
 
         // Then
         XCTAssertTrue(rows.count == 1)

--- a/WordPress/WordPressTest/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModelTests.swift
@@ -9,7 +9,8 @@ class SiteStatsInsightsDetailsViewModelTests: XCTestCase {
     override func setUpWithError() throws {
         viewModel = SiteStatsInsightsDetailsViewModel(insightsDetailsDelegate: MockInsightsDelegate(),
                                                       detailsDelegate: MockDetailsDelegate(),
-                                                      referrerDelegate: MockReferrerDeletage())
+                                                      referrerDelegate: MockReferrerDeletage(),
+                                                      viewsAndVisitorsDelegate: MockViewsAndVisitorsDelegate())
 
         viewModel.fetchDataFor(statSection: StatSection.insightsAddInsight)
     }
@@ -66,6 +67,10 @@ private extension SiteStatsInsightsDetailsViewModelTests {
     class MockInsightsDelegate: SiteStatsInsightsDelegate { }
 
     class MockDetailsDelegate: SiteStatsDetailsDelegate { }
+
+    class MockViewsAndVisitorsDelegate: StatsInsightsViewsAndVisitorsDelegate {
+        func viewsAndVisitorsSegmendChanged(to selectedSegmentIndex: Int) {}
+    }
 
     class MockReferrerDeletage: SiteStatsReferrerDelegate {
         func showReferrerDetails(_ data: StatsTotalRowData) { }


### PR DESCRIPTION
## Description

"Views and Visitors" card in details view has "Week >" button which leads nowhere. 

It's a regression from [Rebuild Views & Visitors card when selected segment changes](https://github.com/wordpress-mobile/WordPress-iOS/pull/19818) since I expanded `siteStatsInsightDetailsDelegate` with `viewsAndVisitorsSegmentChanged` and started using in both details and insights tab. However, `StatsBaseCell` uses `siteStatsInsightDetailsDelegate != nil` to determine whether to show the "Week >" button.

## 

Move `viewsAndVisitorsSegmentChanged` to a separate delegate to avoid breaking `siteStatsInsightDetailsDelegate != nil` `shouldShowDetailsButton()` mechanism in `StatsBaseCell`

## Testing instructions

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flag

### Case 1:
1. Open Stats
2. Add Views & Visitors card
3. Click "Week"
4. Confirm that Views & Visitors in details view does not have "Week button"

## Regression Notes

1. Potential unintended areas of impact

Breaking changes in https://github.com/wordpress-mobile/WordPress-iOS/pull/19818

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Retesting

5. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

## Before the fix

https://user-images.githubusercontent.com/4062343/210357851-34dc0954-57dc-4c1c-b77f-dbc4d7dbc22a.MP4

## After the fix

https://user-images.githubusercontent.com/4062343/210358982-5b861b1c-364a-4799-a45c-37626d5774e3.mp4



