### PR TITLE
[Jetpack] Content Migration App Appearance Fix

### DIFF
--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -179,6 +179,7 @@ private extension DataMigrator {
         for (key, value) in temporaryDictionary {
             localDefaults.set(value, forKey: key)
         }
+        AppAppearance.overrideAppearance()
         sharedDefaults.removeObject(forKey: DefaultsWrapper.dictKey)
         return true
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/19783

To test:

1. Set App Theme on WP to a specific value (not system default)
2. Fresh install on JP
3. Start Migration
4. Verify JP app has the App Theme set from WP when the Migration is complete.

To test:

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
