### PR TITLE
Jetpack App: Fix a build error due to a change in `WindowManager`

### DIFF
--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -14,7 +14,7 @@ class JetpackWindowManager: WindowManager {
         && !UserPersistentStoreFactory.instance().isJPContentImportComplete
     }
 
-    override func showUI(for blog: Blog?) {
+    override func showUI(for blog: Blog?, animated: Bool = true) {
         if AccountHelper.isLoggedIn {
             showAppUI(for: blog)
             return


### PR DESCRIPTION
## Description
This PR fixes a build error in the Jetpack target introduced by #19828
The issue was caused by updating the signature of a public function that was being overridden by `JetpackWindowManager` 

## Testing Instructions

No detailed testing is needed.
Make sure the Jetpack app builds and runs normally.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.