### PR TITLE
[Stats Revamp] Show cached data for new insights cards when there's no internet connection

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -128,6 +128,11 @@ class SiteStatsInsightsViewModel: Observable {
                             return [errorBlock(.insightsViewsVisitors)]
                         }))
             case .growAudience:
+                /// Grow Audience is an additional informational card that is not added by the user, no need to show it if fails to load
+                guard insightsStore.allTimeStatus != . error else {
+                    return
+                }
+
                 tableRows.append(blocks(for: .growAudience,
                                         type: .insights,
                                         status: insightsStore.allTimeStatus,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -67,6 +67,7 @@ class SiteStatsInsightsViewModel: Observable {
 
         if FeatureFlag.statsNewInsights.enabled {
             periodChangeReceipt = self.periodStore.onChange { [weak self] in
+                self?.updateMostRecentChartData(self?.periodStore.getSummary())
                 self?.emitChange()
             }
         }
@@ -511,9 +512,6 @@ private extension SiteStatsInsightsViewModel {
     // MARK: - Create Table Rows
 
     func overviewTableRows() -> [ImmuTableRow] {
-        let periodSummary = periodStore.getSummary()
-        updateMostRecentChartData(periodSummary)
-
         let periodDate = self.lastRequestedDate
 
         return SiteStatsImmuTableRows.viewVisitorsImmuTableRows(mostRecentChartData,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -107,11 +107,6 @@ class SiteStatsInsightsViewModel: Observable {
             return ImmuTable.Empty
         }
 
-        let summaryErrorBlock: AsyncBlock<[ImmuTableRow]> = {
-            return [PeriodEmptyCellHeaderRow(),
-                    StatsErrorRow(rowStatus: .error, statType: .period, statSection: nil)]
-        }
-
         insightsToShow.forEach { insightType in
             let errorBlock = { statSection in
                 return StatsErrorRow(rowStatus: .error, statType: .insights, statSection: statSection)
@@ -126,11 +121,12 @@ class SiteStatsInsightsViewModel: Observable {
                             return self?.mostRecentChartData != nil
                         },
                         block: { [weak self] in
-                            return self?.overviewTableRows() ?? summaryErrorBlock()
+                            return self?.overviewTableRows() ?? [errorBlock(.insightsViewsVisitors)]
                         }, loading: {
-                    return [PeriodEmptyCellHeaderRow(),
-                            StatsGhostChartImmutableRow()]
-                }, error: summaryErrorBlock))
+                            return [StatsGhostChartImmutableRow()]
+                        }, error: {
+                            return [errorBlock(.insightsViewsVisitors)]
+                        }))
             case .growAudience:
                 tableRows.append(blocks(for: .growAudience,
                                         type: .insights,

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -182,9 +182,12 @@ class SiteStatsInsightsViewModel: Observable {
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsLikesTotals,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .likesTotals,
-                                           type: .period,
-                                           status: periodStore.summaryLikesStatus,
-                                           block: {
+                                        type: .period,
+                                        status: periodStore.summaryStatus,
+                                        checkingCache: { [weak self] in
+                                            return self?.mostRecentChartData != nil
+                                        },
+                                        block: {
                     return TotalInsightStatsRow(dataRow: createLikesTotalInsightsRow(), statSection: .insightsLikesTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()
@@ -195,9 +198,12 @@ class SiteStatsInsightsViewModel: Observable {
                 tableRows.append(InsightCellHeaderRow(statSection: StatSection.insightsCommentsTotals,
                                                       siteStatsInsightsDelegate: siteStatsInsightsDelegate))
                 tableRows.append(blocks(for: .commentsTotals,
-                                           type: .period,
-                                           status: periodStore.summaryLikesStatus,
-                                           block: {
+                                        type: .period,
+                                        status: periodStore.summaryStatus,
+                                        checkingCache: { [weak self] in
+                                            return self?.mostRecentChartData != nil
+                                        },
+                                        block: {
                     return TotalInsightStatsRow(dataRow: createCommentsTotalInsightsRow(), statSection: .insightsCommentsTotals, siteStatsInsightsDelegate: siteStatsInsightsDelegate)
                 }, loading: {
                     return StatsGhostTwoColumnImmutableRow()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -316,7 +316,7 @@ private extension SiteStatsPeriodViewModel {
         let likesData = intervalData(summaryType: .likes)
         // If Summary Likes is still loading, show dashes (instead of 0)
         // to indicate it's still loading.
-        let likesLoadingStub = likesData.count > 0 ? nil : (store.isFetchingSummaryLikes ? "----" : nil)
+        let likesLoadingStub = likesData.count > 0 ? nil : (store.isFetchingSummary ? "----" : nil)
         let likesTabData = OverviewTabData(tabTitle: StatSection.periodOverviewLikes.tabTitle,
                                            tabData: likesData.count,
                                            tabDataStub: likesLoadingStub,

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -157,7 +157,7 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 guard let storeQuery = queryForInsightStatSection(statSection) else {
                     return true
                 }
-                return insightsStore.fetchingFailed(for: storeQuery)
+                return periodStore.getSummary() == nil && insightsStore.fetchingFailed(for: storeQuery)
             default:
                 guard let storeQuery = queryForInsightStatSection(statSection) else {
                     return true
@@ -367,7 +367,17 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 return rows
             }
         case .insightsCommentsAuthors, .insightsCommentsPosts, .insightsCommentsTotals:
-            return insightsImmuTable(for: (.allComments, insightsStore.allCommentsInsightStatus)) {
+            /// Comments depend both on PeriodStore and InsightsStore states
+            let status: StoreFetchingStatus = {
+                if insightsStore.allCommentsInsightStatus == .loading {
+                    return .loading
+                } else if periodStore.getSummary() != nil {
+                    return .success
+                } else {
+                    return insightsStore.allCommentsInsightStatus
+                }
+            }()
+            return insightsImmuTable(for: (.allComments, status)) {
                 var rows = [ImmuTableRow]()
                 rows.append(TotalInsightStatsRow(dataRow: createCommentsTotalInsightsRow(), statSection: .insightsCommentsTotals, siteStatsInsightsDelegate: nil))
 


### PR DESCRIPTION
## Description

The cached data is not shown for "Views & Visitors", "Total Likes" and "Total Comments" cards if there's no internet connection.

### Fixes for "Views & Visitors"

-`mostRecentChartData` variable is used to determine whether there's cached data for "Views & Visitors". However, `mostRecentChartData` is not set when we have cached data with `.error` loading state. The solution is to update `mostRecentChartData` once `StatsPeriodStore` indicates data change.
- Updated `loading` state so unneeded header wouldn't be shown
- Updated `error` state so "`Views & Visitors" header would be shown

### Fixes for "Total Likes" and "Total Comments"

Total Likes are loaded in the same way as "Views & Visitors". The change [that fetched likes separately
](https://github.com/wordpress-mobile/WordPress-iOS/pull/11841) was [changed more than a year ago](https://github.com/wordpress-mobile/WordPressKit-iOS/pull/438). Right now, both likes and comments are fetched together with the summary.

- Using the same mechanism of checking `mostRecentChartData` to determine if the cache exists
- Removed the unneeded code for likesSummary

## Testing instructions

0. Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flags
1. Open Stats
2. Add "Views & Visitors", "Total Likes", "Total Comments" (and optionally other Stats cards)
3. Wait for data to load
4. Come back to main menu
5. Disable internet connection
6. Come back to stats
7. Cached versions of "Views & Visitors", "Total Likes", "Total Comments" should appear
8. Switch to a site for which Stats hasn't been loaded yet
9. Open Stats
10. Error states should appear for cards that do not have cached data

## Regression Notes

1. Potential unintended areas of impact

Older Stats (Days, Weeks, Months) not loading `likes` properly

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

11. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before the fix

https://user-images.githubusercontent.com/4062343/210616159-4f67e930-1176-4851-a326-45d97f73e754.mp4

### After the fix

https://user-images.githubusercontent.com/4062343/210614935-a71b8454-92e1-4e3d-8f8b-5f89245897d1.mp4

