### PR TITLE
Add prompts viewed analytics to the card and bottom sheet

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -384,6 +384,7 @@ import Foundation
     // Blogging Prompts
     case promptsBottomSheetAnswerPrompt
     case promptsBottomSheetHelp
+    case promptsBottomSheetViewed
     case promptsIntroductionModalViewed
     case promptsIntroductionModalDismissed
     case promptsIntroductionModalTryItNow
@@ -395,6 +396,7 @@ import Foundation
     case promptsDashboardCardMenuSkip
     case promptsDashboardCardMenuRemove
     case promptsDashboardCardMenuLearnMore
+    case promptsDashboardCardViewed
     case promptsListViewed
     case promptsReminderSettingsIncludeSwitch
     case promptsReminderSettingsHelp
@@ -1072,6 +1074,8 @@ import Foundation
             return "my_site_create_sheet_answer_prompt_tapped"
         case .promptsBottomSheetHelp:
             return "my_site_create_sheet_prompt_help_tapped"
+        case .promptsBottomSheetViewed:
+            return "blogging_prompts_create_sheet_card_viewed"
         case .promptsIntroductionModalViewed:
             return "blogging_prompts_introduction_modal_viewed"
         case .promptsIntroductionModalDismissed:
@@ -1094,6 +1098,8 @@ import Foundation
             return "blogging_prompts_my_site_card_menu_remove_from_dashboard_tapped"
         case .promptsDashboardCardMenuLearnMore:
             return "blogging_prompts_my_site_card_menu_learn_more_tapped"
+        case .promptsDashboardCardViewed:
+            return "blogging_prompts_my_site_card_viewed"
         case .promptsListViewed:
             return "blogging_prompts_prompts_list_viewed"
         case .promptsReminderSettingsIncludeSwitch:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -332,3 +332,11 @@ extension BlogDashboardViewController: UIPopoverPresentationControllerDelegate {
         return .none
     }
 }
+
+// MARK: - Helper functions
+
+private extension Collection where Element == DashboardCardModel {
+    var hasPrompts: Bool {
+        contains(where: { $0.cardType == .prompts })
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -73,7 +73,12 @@ final class BlogDashboardViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        viewModel.loadCards()
+        viewModel.loadCards { cards in
+            guard cards.hasPrompts else {
+                return
+            }
+            WPAnalytics.track(.promptsDashboardCardViewed)
+        }
         QuickStartTourGuide.shared.currentEntryPoint = .blogDashboard
         startAlertTimer()
 
@@ -122,7 +127,7 @@ final class BlogDashboardViewController: UIViewController {
     }
 
     func pulledToRefresh(completion: (() -> Void)? = nil) {
-        viewModel.loadCards {
+        viewModel.loadCards { _ in
             completion?()
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -86,19 +86,19 @@ class BlogDashboardViewModel {
     }
 
     /// Call the API to return cards for the current blog
-    func loadCards(completion: (() -> Void)? = nil) {
+    func loadCards(completion: (([DashboardCardModel]) -> Void)? = nil) {
         viewController?.showLoading()
 
         service.fetch(blog: blog, completion: { [weak self] cards in
             self?.viewController?.stopLoading()
             self?.updateCurrentCards(cards: cards)
-            completion?()
+            completion?(cards)
         }, failure: { [weak self] cards in
             self?.viewController?.stopLoading()
             self?.loadingFailure()
             self?.updateCurrentCards(cards: cards)
 
-            completion?()
+            completion?(cards)
         })
     }
 
@@ -223,5 +223,11 @@ private extension Collection where Element == DashboardCardModel {
 
     var hasScheduled: Bool {
         return contains(where: { $0.cardType == .scheduledPosts })
+    }
+}
+
+extension Collection where Element == DashboardCardModel {
+    var hasPrompts: Bool {
+        contains(where: { $0.cardType == .prompts })
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -225,9 +225,3 @@ private extension Collection where Element == DashboardCardModel {
         return contains(where: { $0.cardType == .scheduledPosts })
     }
 }
-
-extension Collection where Element == DashboardCardModel {
-    var hasPrompts: Bool {
-        contains(where: { $0.cardType == .prompts })
-    }
-}

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -31,6 +31,7 @@ class BloggingPromptsHeaderView: UIView, NibLoadable {
     static func view(for prompt: BloggingPrompt?) -> BloggingPromptsHeaderView {
         let promptsHeaderView = BloggingPromptsHeaderView.loadFromNib()
         promptsHeaderView.configure(prompt)
+        WPAnalytics.track(.promptsBottomSheetViewed)
         return promptsHeaderView
     }
 }


### PR DESCRIPTION
## Description

Adds analytics to track when the dashboard card and prompts bottom sheet header is shown.

## Testing

To test:
- Launch Jetpack and login
- Select a blog with blogging prompts
- Verify the analytic `blogging_prompts_my_site_card_viewed` is sent when the home view is shown
- Tap on the FAB "+" in the bottom right
- Verify `blogging_prompts_create_sheet_card_viewed` is sent when the action sheet is shown

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
