### PR TITLE
[Jetpack Focus] Do not continue migration flow if notification alert was dismissed with iOS home action

### DIFF
--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationEvent.swift
@@ -28,6 +28,7 @@ enum MigrationEvent: String {
     case notificationsScreenDecideLaterButtonTapped = "migration_notifications_screen_decide_later_button_tapped"
     case notificationsScreenPermissionGranted = "migration_notifications_screen_permission_granted"
     case notificationsScreenPermissionDenied = "migration_notifications_screen_permission_denied"
+    case notificationsScreenPermissionNotDetermined = "migration_notifications_screen_permission_notDetermined"
 
     // Thanks Screen
     case thanksScreenShown = "migration_thanks_screen_shown"


### PR DESCRIPTION
## Description

iOS Notification Alert can be dismissed with the home button or swipe-up action. It still triggers `requestAuthorization` completion block which continues the migration flow. 

Do not continue the flow if after `requestAuthorization` completion the notification permission is still `.notDetermined`. 

## Testing instructions

### Case 1:
1. Install WordPress and log in
2. Install and open Jetpack
3. Continue the flow until "Notification migration" view
4. When iOS Notification Alert appears click "home" button or "swipe-up"
5. Confirm iOS Notification Alert disappears and the app stays at the same Notification migration" view
6. Click "Continue again"
7. "Allow" / "Deny" iOS Notification Alert
8. Confirm the flow continues

## Regression Notes

1. Potential unintended areas of impact

None

9. What I did to test those areas of impact (or what existing automated tests I relied on)

10. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

## Before the fix

00:05 home button is tapped and the migration flow continues

https://user-images.githubusercontent.com/4062343/210749062-1b1ccafa-dd32-4d38-bce6-7ad07c719476.mp4

## After the fix

Clicking the home button does not continue the migration flow, until "Deny" / "Allow" is tapped.

https://user-images.githubusercontent.com/4062343/210749245-3a1f78d9-0826-4b07-b4dd-9a045c7d53e9.mp4


