### PR TITLE
Jetpack Focus: Update banners and badges text based on the current phase

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityDetailViewController.swift
@@ -163,7 +163,8 @@ class ActivityDetailViewController: UIViewController, StoryboardLoadable {
             return
         }
         jetpackBadgeView.isHidden = false
-        let jetpackBadgeButton = JetpackButton(style: .badge)
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.activityDetail)
+        let jetpackBadgeButton = JetpackButton(style: .badge, title: textProvider.brandingText())
         jetpackBadgeButton.translatesAutoresizingMaskIntoConstraints = false
         jetpackBadgeButton.addTarget(self, action: #selector(jetpackButtonTapped), for: .touchUpInside)
         jetpackBadgeView.addSubview(jetpackBadgeButton)

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController+JetpackBannerViewController.swift
@@ -6,7 +6,7 @@ extension BackupListViewController {
         guard let backupListVC = BackupListViewController(blog: blog) else {
             return nil
         }
-        return JetpackBannerWrapperViewController(childVC: backupListVC, analyticsId: .backup)
+        return JetpackBannerWrapperViewController(childVC: backupListVC, screen: .backup)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/JetpackActivityLogViewController.swift
@@ -44,7 +44,8 @@ class JetpackActivityLogViewController: BaseActivityListViewController {
     private func configureBanner() {
         containerStackView.addArrangedSubview(jetpackBannerView)
         addTranslationObserver(jetpackBannerView)
-        jetpackBannerView.buttonAction = { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.activityLog)
+        jetpackBannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .activityLog)
         }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -14,7 +14,6 @@ typedef NS_ENUM(NSInteger, SharingSectionIdentifier){
 };
 
 static NSString *const CellIdentifier = @"CellIdentifier";
-static CGFloat const jetpackBadgePadding = 30;
 
 @interface SharingViewController ()
 
@@ -253,10 +252,7 @@ static CGFloat const jetpackBadgePadding = 30;
 - (UIView *)tableView:(UITableView *)tableView viewForFooterInSection:(NSInteger)section
 {
     if (section == SharingButtons && [SharingViewController jetpackBrandingVisibile]) {
-        return [JetpackButton makeBadgeViewWithTopPadding:jetpackBadgePadding
-                                            bottomPadding:jetpackBadgePadding
-                                                   target:self
-                                                 selector:@selector(jetpackButtonTapped)];
+        return [self makeJetpackBadge];
     }
 
     return nil;
@@ -370,13 +366,6 @@ static CGFloat const jetpackBadgePadding = 30;
     [sharingService syncSharingButtonsForBlog:self.blog success:nil failure:^(NSError *error) {
         DDLogError([error description]);
     }];
-}
-
-#pragma mark - Jetpack badge button
-
-- (void) jetpackButtonTapped
-{
-    [self presentJetpackOverlay];
 }
 
 @end

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.swift
@@ -1,9 +1,23 @@
 import Foundation
 
 extension SharingViewController {
+
+    static let jetpackBadgePadding: CGFloat = 30
+
     @objc
     static func jetpackBrandingVisibile() -> Bool {
         return JetpackBrandingVisibility.all.enabled
+    }
+
+    @objc
+    func makeJetpackBadge() -> UIView {
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.sharing)
+        let badge = JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                                topPadding: Self.jetpackBadgePadding,
+                                                bottomPadding: Self.jetpackBadgePadding,
+                                                target: self,
+                                                selector: #selector(presentJetpackOverlay))
+        return badge
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Badge/DashboardBadgeCell.swift
@@ -4,7 +4,8 @@ import UIKit
 class DashboardBadgeCell: UICollectionViewCell, Reusable {
 
     private lazy var jetpackButton: JetpackButton = {
-        let button = JetpackButton(style: .badge)
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.home)
+        let button = JetpackButton(style: .badge, title: textProvider.brandingText())
         button.translatesAutoresizingMaskIntoConstraints = false
         button.addTarget(self, action: #selector(jetpackButtonTapped), for: .touchUpInside)
         return button

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerView.swift
@@ -3,11 +3,15 @@ import UIKit
 
 class JetpackBannerView: UIView {
 
-    var buttonAction: (() -> Void)?
+    // MARK: Private Variables
 
-    init(buttonAction: (() -> Void)? = nil) {
+    private var button: JetpackButton?
+    private var buttonAction: (() -> Void)?
+
+    // MARK: Initializers
+
+    init() {
         super.init(frame: .zero)
-        self.buttonAction = buttonAction
         setup()
     }
 
@@ -21,6 +25,15 @@ class JetpackBannerView: UIView {
         setup()
     }
 
+    // MARK: Public Functions
+
+    func configure(title: String, buttonAction: (() -> Void)?) {
+        self.button?.title = title
+        self.buttonAction = buttonAction
+    }
+
+    // MARK: Private Helpers
+
     @objc private func jetpackButtonTapped() {
         buttonAction?()
     }
@@ -29,14 +42,17 @@ class JetpackBannerView: UIView {
         translatesAutoresizingMaskIntoConstraints = false
         heightAnchor.constraint(equalToConstant: JetpackBannerView.minimumHeight).isActive = true
         backgroundColor = Self.jetpackBannerBackgroundColor
-
-        let jetpackButton = JetpackButton(style: .banner)
+        let textProvider = JetpackBrandingTextProvider(screen: nil) // Use default text in case `configure()` is never called.
+        let jetpackButton = JetpackButton(style: .banner, title: textProvider.brandingText())
         jetpackButton.translatesAutoresizingMaskIntoConstraints = false
         jetpackButton.addTarget(self, action: #selector(jetpackButtonTapped), for: .touchUpInside)
         addSubview(jetpackButton)
+        self.button = jetpackButton
 
         pinSubviewToSafeArea(jetpackButton)
     }
+
+    // MARK: Constants
 
     /// Preferred minimum height to be used for constraints
     static let minimumHeight: CGFloat = 44

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Banner/JetpackBannerWrapperViewController.swift
@@ -5,15 +5,15 @@ import WordPressShared
 class JetpackBannerWrapperViewController: UIViewController {
     /// The wrapped child view controller.
     private(set) var childVC: UIViewController?
-    private var analyticsId: JetpackBrandingAnalyticsHelper.JetpackBannerScreen?
+    private var screen: JetpackBannerScreen?
 
     convenience init(
         childVC: UIViewController,
-        analyticsId: JetpackBrandingAnalyticsHelper.JetpackBannerScreen? = nil
+        screen: JetpackBannerScreen? = nil
     ) {
         self.init()
         self.childVC = childVC
-        self.analyticsId = analyticsId
+        self.screen = screen
     }
 
     override func viewDidLoad() {
@@ -48,10 +48,11 @@ class JetpackBannerWrapperViewController: UIViewController {
         guard JetpackBrandingVisibility.all.enabled, !isModal() else {
             return
         }
-
-        let jetpackBannerView = JetpackBannerView() { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: screen)
+        let jetpackBannerView = JetpackBannerView()
+        jetpackBannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
-            if let screen = analyticsId {
+            if let screen = screen {
                 JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: screen)
             }
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -9,6 +9,12 @@ class JetpackButton: CircularImageButton {
         case banner
     }
 
+    var title: String? {
+        didSet {
+            setTitle(title, for: .normal)
+        }
+    }
+
     private let style: ButtonStyle
 
     init(style: ButtonStyle, title: String) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Button/JetpackButton.swift
@@ -11,10 +11,10 @@ class JetpackButton: CircularImageButton {
 
     private let style: ButtonStyle
 
-    init(style: ButtonStyle) {
+    init(style: ButtonStyle, title: String) {
         self.style = style
         super.init(frame: .zero)
-        configureButton()
+        configureButton(with: title)
     }
 
     required init?(coder: NSCoder) {
@@ -60,9 +60,9 @@ class JetpackButton: CircularImageButton {
         }
     }
 
-    private func configureButton() {
+    private func configureButton(with title: String) {
         isUserInteractionEnabled = FeatureFlag.jetpackPoweredBottomSheet.enabled
-        setTitle(Appearance.title, for: .normal)
+        setTitle(title, for: .normal)
         tintColor = buttonTintColor
         backgroundColor = buttonBackgroundColor
         setTitleColor(buttonTitleColor, for: .normal)
@@ -81,8 +81,6 @@ class JetpackButton: CircularImageButton {
     }
 
     private enum Appearance {
-        static let title = NSLocalizedString("jetpack.branding.badge_banner.title", value: "Jetpack powered",
-                                             comment: "Title of the Jetpack powered badge.")
         static let minimumScaleFactor: CGFloat = 0.6
         static let iconInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
         static let contentInsets = UIEdgeInsets(top: 6, left: 6, bottom: 6, right: 10)
@@ -108,18 +106,20 @@ class JetpackButton: CircularImageButton {
 extension JetpackButton {
 
     /// Instantiates a view containing a Jetpack powered badge
+    /// - Parameter title: Title of the button
     /// - Parameter topPadding: top padding, defaults to 30 pt
     /// - Parameter bottomPadding: bottom padding, defaults to 30 pt
     /// - Parameter target: optional target for the button action
     /// - Parameter selector: optional selector for the button action
     /// - Returns: the view containing the badge
     @objc
-    static func makeBadgeView(topPadding: CGFloat = 30,
+    static func makeBadgeView(title: String,
+                              topPadding: CGFloat = 30,
                               bottomPadding: CGFloat = 30,
                               target: Any? = nil,
                               selector: Selector? = nil) -> UIView {
         let view = UIView()
-        let badge = JetpackButton(style: .badge)
+        let badge = JetpackButton(style: .badge, title: title)
         badge.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(badge)
         NSLayoutConstraint.activate([

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -9,7 +9,6 @@ protocol JetpackBrandedScreen {
     /// Whether the feature is in plural form.
     /// Used to decide on using "is" or "are" when constructing the branding text.
     var isPlural: Bool { get }
-    var analyticsId: String { get }
 }
 
 enum JetpackBannerScreen: String, JetpackBrandedScreen {
@@ -57,10 +56,6 @@ enum JetpackBannerScreen: String, JetpackBrandedScreen {
         case .stats:
             return true
         }
-    }
-
-    var analyticsId: String {
-        rawValue
     }
 }
 
@@ -115,9 +110,5 @@ enum JetpackBadgeScreen: String, JetpackBrandedScreen {
         case .notificationsSettings:
             return true
         }
-    }
-
-    var analyticsId: String {
-        rawValue
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+protocol JetpackBrandedScreen {
+    var featureName: String? { get }
+    var isPlural: Bool { get }
+    var analyticsId: String { get }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -24,7 +24,7 @@ enum JetpackBannerScreen: String, JetpackBrandedScreen {
         case .notifications:
             return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
         case .people:
-            return NSLocalizedString("People Management", comment: "Noun. Name of the People feature")
+            return nil
         case .reader:
             return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
         case .readerSearch:
@@ -74,14 +74,14 @@ enum JetpackBadgeScreen: String, JetpackBrandedScreen {
             fallthrough
         case .home:
             fallthrough
+        case .person:
+            fallthrough
         case .me:
             return nil
         case .activityDetail:
             return NSLocalizedString("Activity", comment: "Noun. Name of the Activity Log feature")
         case .notificationsSettings:
             return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
-        case .person:
-            return NSLocalizedString("People Management", comment: "Noun. Name of the People feature")
         case .readerDetail:
             return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
         case .sharing:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -5,3 +5,104 @@ protocol JetpackBrandedScreen {
     var isPlural: Bool { get }
     var analyticsId: String { get }
 }
+
+enum JetpackBannerScreen: String, JetpackBrandedScreen {
+    case activityLog = "activity_log"
+    case backup
+    case notifications
+    case reader
+    case readerSearch = "reader_search"
+    case stats
+
+    var featureName: String? {
+        switch self {
+
+        case .activityLog:
+            return NSLocalizedString("Activity", comment: "Noun. Name of the Activity Log feature")
+        case .backup:
+            return NSLocalizedString("Backup", comment: "Noun. Name of the Backup feature")
+        case .notifications:
+            return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
+        case .reader:
+            return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
+        case .readerSearch:
+            return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
+        case .stats:
+            return NSLocalizedString("Stats", comment: "Noun. Abbreviation of Statistics. Name of the Stats feature")
+        }
+    }
+
+    var isPlural: Bool {
+        switch self {
+        case .activityLog:
+            fallthrough
+        case .backup:
+            fallthrough
+        case .reader:
+            fallthrough
+        case .readerSearch:
+            return false
+        case .notifications:
+            fallthrough
+        case .stats:
+            return true
+        }
+    }
+
+    var analyticsId: String {
+        rawValue
+    }
+}
+
+enum JetpackBadgeScreen: String, JetpackBrandedScreen {
+    case activityDetail = "activity_detail"
+    case appSettings = "app_settings"
+    case home
+    case me
+    case notificationsSettings = "notifications_settings"
+    case readerDetail = "reader_detail"
+    case sharing
+
+    var featureName: String? {
+        switch self {
+        case .appSettings:
+            fallthrough
+        case .home:
+            fallthrough
+        case .me:
+            return nil
+        case .activityDetail:
+            return NSLocalizedString("Activity", comment: "Noun. Name of the Activity Log feature")
+        case .notificationsSettings:
+            return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
+        case .readerDetail:
+            return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
+        case .sharing:
+            return NSLocalizedString("Sharing", comment: "Noun. Name of the Social Sharing feature")
+        }
+
+    }
+
+    var isPlural: Bool {
+        switch self {
+        case .appSettings:
+            fallthrough
+        case .home:
+            fallthrough
+        case .me:
+            fallthrough
+        case .activityDetail:
+            fallthrough
+        case .readerDetail:
+            fallthrough
+        case .sharing:
+            return false
+        case .notificationsSettings:
+            return true
+        }
+    }
+
+    var analyticsId: String {
+        rawValue
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -1,7 +1,13 @@
 import Foundation
 
 protocol JetpackBrandedScreen {
+
+    /// Name to use when constructing phase three branding text.
+    /// Set to `nil` to fallback to the default branding text.
     var featureName: String? { get }
+
+    /// Whether the feature is in plural form.
+    /// Used to decide on using "is" or "are" when constructing the branding text.
     var isPlural: Bool { get }
     var analyticsId: String { get }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandedScreen.swift
@@ -10,19 +10,21 @@ enum JetpackBannerScreen: String, JetpackBrandedScreen {
     case activityLog = "activity_log"
     case backup
     case notifications
+    case people
     case reader
     case readerSearch = "reader_search"
     case stats
 
     var featureName: String? {
         switch self {
-
         case .activityLog:
             return NSLocalizedString("Activity", comment: "Noun. Name of the Activity Log feature")
         case .backup:
             return NSLocalizedString("Backup", comment: "Noun. Name of the Backup feature")
         case .notifications:
             return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
+        case .people:
+            return NSLocalizedString("People Management", comment: "Noun. Name of the People feature")
         case .reader:
             return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
         case .readerSearch:
@@ -39,6 +41,8 @@ enum JetpackBannerScreen: String, JetpackBrandedScreen {
         case .backup:
             fallthrough
         case .reader:
+            fallthrough
+        case .people:
             fallthrough
         case .readerSearch:
             return false
@@ -60,6 +64,7 @@ enum JetpackBadgeScreen: String, JetpackBrandedScreen {
     case home
     case me
     case notificationsSettings = "notifications_settings"
+    case person
     case readerDetail = "reader_detail"
     case sharing
 
@@ -75,6 +80,8 @@ enum JetpackBadgeScreen: String, JetpackBrandedScreen {
             return NSLocalizedString("Activity", comment: "Noun. Name of the Activity Log feature")
         case .notificationsSettings:
             return NSLocalizedString("Notifications", comment: "Noun. Name of the Notifications feature")
+        case .person:
+            return NSLocalizedString("People Management", comment: "Noun. Name of the People feature")
         case .readerDetail:
             return NSLocalizedString("Reader", comment: "Noun. Name of the Reader feature")
         case .sharing:
@@ -94,6 +101,8 @@ enum JetpackBadgeScreen: String, JetpackBrandedScreen {
         case .activityDetail:
             fallthrough
         case .readerDetail:
+            fallthrough
+        case .person:
             fallthrough
         case .sharing:
             return false

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -5,13 +5,13 @@ struct JetpackBrandingAnalyticsHelper {
     private static let screenPropertyKey = "screen"
 
     // MARK: - Jetpack powered badge tapped
-    static func trackJetpackPoweredBadgeTapped(screen: Self.JetpackBadgeScreen) {
+    static func trackJetpackPoweredBadgeTapped(screen: JetpackBadgeScreen) {
         let properties = [screenPropertyKey: screen.rawValue]
         WPAnalytics.track(.jetpackPoweredBadgeTapped, properties: properties)
     }
 
     // MARK: - Jetpack powered banner tapped
-    static func trackJetpackPoweredBannerTapped(screen: Self.JetpackBannerScreen) {
+    static func trackJetpackPoweredBannerTapped(screen: JetpackBannerScreen) {
         let properties = [screenPropertyKey: screen.rawValue]
         WPAnalytics.track(.jetpackPoweredBannerTapped, properties: properties)
     }
@@ -19,26 +19,5 @@ struct JetpackBrandingAnalyticsHelper {
     // MARK: - Jetpack powered bottom sheet button tapped
     static func trackJetpackPoweredBottomSheetButtonTapped() {
         WPAnalytics.track(.jetpackPoweredBottomSheetButtonTapped)
-    }
-
-    enum JetpackBannerScreen: String {
-        case activityLog = "activity_log"
-        case backup
-        case notifications
-        case people
-        case reader
-        case readerSearch = "reader_search"
-        case stats
-    }
-
-    enum JetpackBadgeScreen: String {
-        case activityDetail = "activity_detail"
-        case appSettings = "app_settings"
-        case home
-        case me
-        case notificationsSettings = "notifications_settings"
-        case person
-        case readerDetail = "reader_detail"
-        case sharing
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -4,7 +4,7 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Private Variables
 
-    private let screen: JetpackBrandedScreen
+    private let screen: JetpackBrandedScreen?
     private let featureFlagStore: RemoteFeatureFlagStore
     private let remoteConfigStore: RemoteConfigStore
     private let currentDateProvider: CurrentDateProvider
@@ -15,7 +15,7 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Initializer
 
-    init(screen: JetpackBrandedScreen,
+    init(screen: JetpackBrandedScreen?,
          featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
          remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
          currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
@@ -41,7 +41,7 @@ struct JetpackBrandingTextProvider {
     // MARK: Helpers
 
     private func phaseThreeText() -> String {
-        guard let featureName = screen.featureName else {
+        guard let screen = screen, let featureName = screen.featureName else {
             return Strings.defaultText
         }
 
@@ -110,11 +110,15 @@ private extension JetpackBrandingTextProvider {
                                                                       comment: "Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks")
     }
 
+    private var isPlural: Bool {
+        screen?.isPlural ?? false
+    }
+
     var movingSoonString: String {
-        return screen.isPlural ? Strings.phaseThreePluralMovingSoonText : Strings.phaseThreeSingularMovingSoonText
+        return isPlural ? Strings.phaseThreePluralMovingSoonText : Strings.phaseThreeSingularMovingSoonText
     }
 
     var movingInString: String {
-        return screen.isPlural ? Strings.phaseThreePluralMovingInText : Strings.phaseThreeSingularMovingInText
+        return isPlural ? Strings.phaseThreePluralMovingInText : Strings.phaseThreeSingularMovingInText
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -4,9 +4,13 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Private Variables
 
+    private let featureFlagStore: RemoteFeatureFlagStore
+
     // MARK: Initializer
 
-    init() {}
+    init(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) {
+        self.featureFlagStore = featureFlagStore
+    }
 
     // MARK: Public Functions
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -6,6 +6,10 @@ struct JetpackBrandingTextProvider {
 
     private let featureFlagStore: RemoteFeatureFlagStore
 
+    private var phase: JetpackFeaturesRemovalCoordinator.GeneralPhase {
+        return JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
+    }
+
     // MARK: Initializer
 
     init(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) {
@@ -15,7 +19,12 @@ struct JetpackBrandingTextProvider {
     // MARK: Public Functions
 
     func brandingText() -> String {
-        return Strings.defaultText
+        switch phase {
+        case .two:
+            return Strings.phaseTwoText
+        default:
+            return Strings.defaultText
+        }
     }
 }
 
@@ -24,5 +33,8 @@ private extension JetpackBrandingTextProvider {
         static let defaultText = NSLocalizedString("jetpack.branding.badge_banner.title",
                                                    value: "Jetpack powered",
                                                    comment: "Title of the Jetpack powered badge.")
+        static let phaseTwoText = NSLocalizedString("jetpack.branding.badge_banner.title.phase2",
+                                                    value: "Get the Jetpack app",
+                                                    comment: "Title of the Jetpack powered badge.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -5,6 +5,8 @@ struct JetpackBrandingTextProvider {
     // MARK: Private Variables
 
     private let featureFlagStore: RemoteFeatureFlagStore
+    private let remoteConfigStore: RemoteConfigStore
+    private let currentDateProvider: CurrentDateProvider
 
     private var phase: JetpackFeaturesRemovalCoordinator.GeneralPhase {
         return JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
@@ -12,8 +14,12 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Initializer
 
-    init(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) {
+    init(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
+         remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
+         currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
         self.featureFlagStore = featureFlagStore
+        self.remoteConfigStore = remoteConfigStore
+        self.currentDateProvider = currentDateProvider
     }
 
     // MARK: Public Functions

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -42,20 +42,20 @@ struct JetpackBrandingTextProvider {
 
     private func phaseThreeText() -> String {
         guard let screen = screen, let featureName = screen.featureName else {
-            return Strings.defaultText
+            return Strings.defaultText // Screen not provided, or was opted out by defining a nil featureName
         }
 
         guard let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline(remoteConfigStore: remoteConfigStore) else {
-            return String(format: movingSoonString, featureName)
+            return String(format: movingSoonString, featureName) // Couldn't retrieve the deadline
         }
 
         let now = currentDateProvider.date()
         guard now < deadline else {
-            return Strings.defaultText
+            return Strings.defaultText // Deadline has passed. Avoid displaying negative values.
         }
 
         guard let dateString = dateString(now: now, deadline: deadline) else {
-            return String(format: movingSoonString, featureName)
+            return String(format: movingSoonString, featureName) // Deadline is more than a month away
         }
 
         return String(format: movingInString, featureName, dateString)
@@ -66,7 +66,7 @@ struct JetpackBrandingTextProvider {
         var components = calendar.dateComponents([.month], from: now, to: deadline)
         let months = components.month ?? 0
         if months > 0 {
-            return nil
+            return nil // Fallback to moving soon text
         }
 
         let formatter = DateComponentsFormatter()
@@ -77,14 +77,14 @@ struct JetpackBrandingTextProvider {
         let weeks = components.weekOfMonth ?? 0
         if weeks > 0 {
             formatter.allowedUnits = [.weekOfMonth]
-            return formatter.string(from: components)
+            return formatter.string(from: components) // Deadline is x weeks away
         }
 
         components = calendar.dateComponents([.day], from: now, to: deadline)
-        let days = max(components.day ?? 0, 1)
+        let days = max(components.day ?? 0, 1) // Avoid displaying "0 days"
         components.day = days
         formatter.allowedUnits = [.day]
-        return formatter.string(from: components)
+        return formatter.string(from: components) // Deadline is x days away
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+struct JetpackBrandingTextProvider {
+
+    // MARK: Private Variables
+
+    // MARK: Initializer
+
+    init() {}
+
+    // MARK: Public Functions
+
+    func brandingText() -> String {
+        return Strings.defaultText
+    }
+}
+
+private extension JetpackBrandingTextProvider {
+    enum Strings {
+        static let defaultText = NSLocalizedString("jetpack.branding.badge_banner.title",
+                                                   value: "Jetpack powered",
+                                                   comment: "Title of the Jetpack powered badge.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -4,6 +4,7 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Private Variables
 
+    private let screen: JetpackBrandedScreen
     private let featureFlagStore: RemoteFeatureFlagStore
     private let remoteConfigStore: RemoteConfigStore
     private let currentDateProvider: CurrentDateProvider
@@ -14,9 +15,11 @@ struct JetpackBrandingTextProvider {
 
     // MARK: Initializer
 
-    init(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
+    init(screen: JetpackBrandedScreen,
+         featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
          remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
          currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
+        self.screen = screen
         self.featureFlagStore = featureFlagStore
         self.remoteConfigStore = remoteConfigStore
         self.currentDateProvider = currentDateProvider

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -31,9 +31,60 @@ struct JetpackBrandingTextProvider {
         switch phase {
         case .two:
             return Strings.phaseTwoText
+        case .three:
+            return phaseThreeText()
         default:
             return Strings.defaultText
         }
+    }
+
+    // MARK: Helpers
+
+    private func phaseThreeText() -> String {
+        guard let featureName = screen.featureName else {
+            return Strings.defaultText
+        }
+
+        guard let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline(remoteConfigStore: remoteConfigStore) else {
+            return String(format: movingSoonString, featureName)
+        }
+
+        let now = currentDateProvider.date()
+        guard now < deadline else {
+            return Strings.defaultText
+        }
+
+        guard let dateString = dateString(now: now, deadline: deadline) else {
+            return String(format: movingSoonString, featureName)
+        }
+
+        return String(format: movingInString, featureName, dateString)
+    }
+
+    private func dateString(now: Date, deadline: Date) -> String? {
+        let calendar = Calendar.current
+        var components = calendar.dateComponents([.month], from: now, to: deadline)
+        let months = components.month ?? 0
+        if months > 0 {
+            return nil
+        }
+
+        let formatter = DateComponentsFormatter()
+        formatter.maximumUnitCount = 1
+        formatter.unitsStyle = .full
+
+        components = calendar.dateComponents([.weekOfMonth], from: now, to: deadline)
+        let weeks = components.weekOfMonth ?? 0
+        if weeks > 0 {
+            formatter.allowedUnits = [.weekOfMonth]
+            return formatter.string(from: components)
+        }
+
+        components = calendar.dateComponents([.day], from: now, to: deadline)
+        let days = max(components.day ?? 0, 1)
+        components.day = days
+        formatter.allowedUnits = [.day]
+        return formatter.string(from: components)
     }
 }
 
@@ -45,5 +96,25 @@ private extension JetpackBrandingTextProvider {
         static let phaseTwoText = NSLocalizedString("jetpack.branding.badge_banner.title.phase2",
                                                     value: "Get the Jetpack app",
                                                     comment: "Title of the Jetpack powered badge.")
+        static let phaseThreePluralMovingSoonText = NSLocalizedString("jetpack.branding.badge_banner.moving_soon.plural",
+                                                                      value: "%@ are moving soon",
+                                                                      comment: "Title of a badge indicating that a feature in plural form will be removed soon. First argument is the feature name. Ex: Notifications are moving soon")
+        static let phaseThreeSingularMovingSoonText = NSLocalizedString("jetpack.branding.badge_banner.moving_soon.singular",
+                                                                      value: "%@ is moving soon",
+                                                                      comment: "Title of a badge indicating that a feature in singular form will be removed soon. First argument is the feature name. Ex: Reader is moving soon")
+        static let phaseThreePluralMovingInText = NSLocalizedString("jetpack.branding.badge_banner.moving_in.plural",
+                                                                      value: "%@ are moving in %@",
+                                                                      comment: "Title of a badge indicating when a feature in plural form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Notifications are moving in 2 weeks")
+        static let phaseThreeSingularMovingInText = NSLocalizedString("jetpack.branding.badge_banner.moving_in.singular",
+                                                                      value: "%@ is moving in %@",
+                                                                      comment: "Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks")
+    }
+
+    var movingSoonString: String {
+        return screen.isPlural ? Strings.phaseThreePluralMovingSoonText : Strings.phaseThreeSingularMovingSoonText
+    }
+
+    var movingInString: String {
+        return screen.isPlural ? Strings.phaseThreePluralMovingInText : Strings.phaseThreeSingularMovingInText
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -538,7 +538,10 @@ extension AppSettingsViewController {
               JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        let jetpackButton = JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.appSettings)
+        let jetpackButton = JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                                        target: self,
+                                                        selector: #selector(jetpackButtonTapped))
 
         return jetpackButton
     }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -552,7 +552,10 @@ extension MeViewController {
               JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.me)
+        return JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                           target: self,
+                                           selector: #selector(jetpackButtonTapped))
     }
 
     @objc private func jetpackButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -343,7 +343,9 @@ private extension NotificationSettingsViewController {
 
         labelView.translatesAutoresizingMaskIntoConstraints = false
 
-        let badgeView = JetpackButton.makeBadgeView(topPadding: FooterMetrics.jetpackBadgeTopPadding,
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.notificationsSettings)
+        let badgeView = JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                                    topPadding: FooterMetrics.jetpackBadgeTopPadding,
                                                     bottomPadding: FooterMetrics.jetpackBadgeBottomPatting,
                                                     target: self,
                                                     selector: #selector(jetpackButtonTapped))

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -635,7 +635,8 @@ extension NotificationsViewController {
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }
-        jetpackBannerView.buttonAction = { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.notifications)
+        jetpackBannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .notifications)
         }

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController+JetpackBannerViewController.swift
@@ -9,7 +9,7 @@ extension PeopleViewController {
         guard JetpackBrandingCoordinator.shouldShowBannerForJetpackDependentFeatures() else {
             return peopleViewVC
         }
-        return JetpackBannerWrapperViewController(childVC: peopleViewVC, analyticsId: .people)
+        return JetpackBannerWrapperViewController(childVC: peopleViewVC, screen: .people)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -627,8 +627,10 @@ extension PersonViewController {
         else {
             return nil
         }
-
-        return JetpackButton.makeBadgeView(target: self, selector: #selector(jetpackButtonTapped))
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.person)
+        return JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                           target: self,
+                                           selector: #selector(jetpackButtonTapped))
     }
 
     override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -119,7 +119,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         guard section == 0, JetpackBrandingVisibility.all.enabled else {
             return nil
         }
-        return JetpackButton.makeBadgeView(bottomPadding: Constants.jetpackBadgeBottomPadding,
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.readerDetail)
+        return JetpackButton.makeBadgeView(title: textProvider.brandingText(),
+                                           bottomPadding: Constants.jetpackBadgeBottomPadding,
                                            target: self,
                                            selector: #selector(jetpackButtonTapped))
     }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -54,7 +54,9 @@ import Gridicons
     fileprivate var didBumpStats = false
 
     private lazy var bannerView: JetpackBannerView = {
-        let bannerView = JetpackBannerView() { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.readerSearch)
+        let bannerView = JetpackBannerView()
+        bannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .readerSearch)
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -43,7 +43,7 @@ import Gridicons
     fileprivate var streamController: ReaderStreamViewController?
     fileprivate lazy var jpSiteSearchController = JetpackBannerWrapperViewController(
         childVC: ReaderSiteSearchViewController(),
-        analyticsId: .readerSearch
+        screen: .readerSearch
     )
     fileprivate var siteSearchController: ReaderSiteSearchViewController? {
         return jpSiteSearchController.childVC as? ReaderSiteSearchViewController

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -506,7 +506,9 @@ import Combine
         guard JetpackBrandingVisibility.all.enabled else {
             return
         }
-        let bannerView = JetpackBannerView() { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.reader)
+        let bannerView = JetpackBannerView()
+        bannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .reader)
         }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -117,7 +117,8 @@ class SiteStatsDashboardViewController: UIViewController {
             jetpackBannerView.removeFromSuperview()
             return
         }
-        jetpackBannerView.buttonAction = { [unowned self] in
+        let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.stats)
+        jetpackBannerView.configure(title: textProvider.brandingText()) { [unowned self] in
             JetpackBrandingCoordinator.presentOverlay(from: self)
             JetpackBrandingAnalyticsHelper.trackJetpackPoweredBannerTapped(screen: .stats)
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1605,6 +1605,7 @@
 		805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */; };
 		805CC0BC29668986002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
 		805CC0BD29668987002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
+		805CC0BF29668A97002941DC /* MockCurrentDateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BE29668A97002941DC /* MockCurrentDateProvider.swift */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
@@ -6926,6 +6927,7 @@
 		805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStoreMock.swift; sourceTree = "<group>"; };
 		805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStoreMock.swift; sourceTree = "<group>"; };
 		805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandedScreen.swift; sourceTree = "<group>"; };
+		805CC0BE29668A97002941DC /* MockCurrentDateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCurrentDateProvider.swift; sourceTree = "<group>"; };
 		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
 		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
 		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
@@ -15734,6 +15736,7 @@
 				8070EB3D28D807CB005C6513 /* InMemoryUserDefaults.swift */,
 				805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */,
 				805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */,
+				805CC0BE29668A97002941DC /* MockCurrentDateProvider.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -22555,6 +22558,7 @@
 				174C116F2624603400346EC6 /* MBarRouteTests.swift in Sources */,
 				46B30B782582C7DD00A25E66 /* SiteAddressServiceTests.swift in Sources */,
 				C81CCD6C243AEFBF00A83E27 /* TenorReponseData.swift in Sources */,
+				805CC0BF29668A97002941DC /* MockCurrentDateProvider.swift in Sources */,
 				570BFD902282418A007859A8 /* PostBuilder.swift in Sources */,
 				C738CB0F28626466001BE107 /* QRLoginScanningCoordinatorTests.swift in Sources */,
 				010459ED2915519C000C7778 /* JetpackNotificationMigrationServiceTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1601,6 +1601,8 @@
 		80535DC3294BDE2B00873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */; };
 		80535DC5294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */; };
 		8058730B28F7B70B00340C11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8058730D28F7B70B00340C11 /* InfoPlist.strings */; };
+		805CC0B7296680CF002941DC /* RemoteFeatureFlagStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */; };
+		805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
@@ -6919,6 +6921,8 @@
 		80535DBF294B7D3200873161 /* BlogDetailsViewController+JetpackBrandingMenuCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+JetpackBrandingMenuCard.swift"; sourceTree = "<group>"; };
 		80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingMenuCardPresenterTests.swift; sourceTree = "<group>"; };
 		8058730C28F7B70B00340C11 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStoreMock.swift; sourceTree = "<group>"; };
+		805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStoreMock.swift; sourceTree = "<group>"; };
 		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
 		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
 		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
@@ -15724,6 +15728,8 @@
 				F4426FD2287E08C300218003 /* SuggestionServiceMock.swift */,
 				F4426FD8287F02FD00218003 /* SiteSuggestionsServiceMock.swift */,
 				8070EB3D28D807CB005C6513 /* InMemoryUserDefaults.swift */,
+				805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */,
+				805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -22568,6 +22574,7 @@
 				931215E1267DE1C0008C3B69 /* StatsTotalRowDataTests.swift in Sources */,
 				F41E4E8C28F18B7B001880C6 /* AppIconListViewModelTests.swift in Sources */,
 				08F8CD2D1EBD24600049D0C0 /* MediaExporterTests.swift in Sources */,
+				805CC0B7296680CF002941DC /* RemoteFeatureFlagStoreMock.swift in Sources */,
 				73178C3321BEE94700E37C9A /* SiteAssemblyServiceTests.swift in Sources */,
 				D88A6492208D7A0A008AE9BC /* MockStockPhotosService.swift in Sources */,
 				F5D0A65223CCD3B600B20D27 /* PreviewWebKitViewControllerTests.swift in Sources */,
@@ -22593,6 +22600,7 @@
 				8B5FEC0225A750CB000CBFF7 /* UIApplication+mainWindow.swift in Sources */,
 				E6843840221F5A2200752258 /* PostListExcessiveLoadMoreTests.swift in Sources */,
 				325D3B3D23A8376400766DF6 /* FullScreenCommentReplyViewControllerTests.swift in Sources */,
+				805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */,
 				0147D651294B6EA600AA6410 /* StatsRevampStoreTests.swift in Sources */,
 				57D6C83E22945A10003DDC7E /* PostCompactCellTests.swift in Sources */,
 				B030FE0A27EBF0BC000F6F5E /* SiteCreationIntentTracksEventTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1603,6 +1603,7 @@
 		8058730B28F7B70B00340C11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8058730D28F7B70B00340C11 /* InfoPlist.strings */; };
 		805CC0B7296680CF002941DC /* RemoteFeatureFlagStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */; };
 		805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */; };
+		805CC0BB29668918002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
@@ -6923,6 +6924,7 @@
 		8058730C28F7B70B00340C11 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteFeatureFlagStoreMock.swift; sourceTree = "<group>"; };
 		805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteConfigStoreMock.swift; sourceTree = "<group>"; };
+		805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandedScreen.swift; sourceTree = "<group>"; };
 		8067340827E3A50900ABC95E /* UIViewController+RemoveQuickStart.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UIViewController+RemoveQuickStart.h"; sourceTree = "<group>"; };
 		8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "UIViewController+RemoveQuickStart.m"; sourceTree = "<group>"; };
 		806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsViewModel.swift; sourceTree = "<group>"; };
@@ -11040,6 +11042,7 @@
 				3F720C2028899DD900519938 /* JetpackBrandingVisibility.swift */,
 				C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */,
 				803BB98E29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift */,
+				805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */,
 				3FFA5ED0287612AD00830E28 /* Banner */,
 				3F5B9B44288B0521001D17E9 /* Badge */,
 				800035BF291DDF57007D2D26 /* Fullscreen Overlay */,
@@ -22379,6 +22382,7 @@
 				732A473F21878EB10015DA74 /* WPRichContentViewTests.swift in Sources */,
 				8BDA5A6D247C2F8400AB124C /* ReaderDetailViewControllerTests.swift in Sources */,
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
+				805CC0BB29668918002941DC /* JetpackBrandedScreen.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */,
 				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1603,7 +1603,8 @@
 		8058730B28F7B70B00340C11 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8058730D28F7B70B00340C11 /* InfoPlist.strings */; };
 		805CC0B7296680CF002941DC /* RemoteFeatureFlagStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B6296680CF002941DC /* RemoteFeatureFlagStoreMock.swift */; };
 		805CC0B9296680F7002941DC /* RemoteConfigStoreMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0B8296680F7002941DC /* RemoteConfigStoreMock.swift */; };
-		805CC0BB29668918002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
+		805CC0BC29668986002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
+		805CC0BD29668987002941DC /* JetpackBrandedScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805CC0BA29668918002941DC /* JetpackBrandedScreen.swift */; };
 		8067340A27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */ = {isa = PBXBuildFile; fileRef = 8067340927E3A50900ABC95E /* UIViewController+RemoveQuickStart.m */; };
 		806E53E127E01C7F0064315E /* DashboardStatsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806E53E027E01C7F0064315E /* DashboardStatsViewModel.swift */; };
@@ -21479,6 +21480,7 @@
 				98E58A2F2360D23400E5534B /* TodayWidgetStats.swift in Sources */,
 				F5E1577F25DE04E200EEEDFB /* GutenbergMediaFilesUploadProcessor.swift in Sources */,
 				80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */,
+				805CC0BC29668986002941DC /* JetpackBrandedScreen.swift in Sources */,
 				5DF7F7741B22337C003A05C8 /* WordPress-30-31.xcmappingmodel in Sources */,
 				436D562C2117312700CEAA33 /* RegisterDomainDetailsFooterView.swift in Sources */,
 				73F76E1E222851E300FDDAD2 /* Charts+AxisFormatters.swift in Sources */,
@@ -22382,7 +22384,6 @@
 				732A473F21878EB10015DA74 /* WPRichContentViewTests.swift in Sources */,
 				8BDA5A6D247C2F8400AB124C /* ReaderDetailViewControllerTests.swift in Sources */,
 				82301B8F1E787420009C9C4E /* AppRatingUtilityTests.swift in Sources */,
-				805CC0BB29668918002941DC /* JetpackBrandedScreen.swift in Sources */,
 				D81C2F5420F85DB1002AE1F1 /* ApproveCommentActionTests.swift in Sources */,
 				8B69F0E4255C2C3F006B1CEF /* ActivityListViewModelTests.swift in Sources */,
 				8BC12F7723201B86004DDA72 /* PostService+MarkAsFailedAndDraftIfNeededTests.swift in Sources */,
@@ -22937,6 +22938,7 @@
 				FABB217C2602FC2C00C8785C /* ReaderSearchTopic.swift in Sources */,
 				3F2ABE1B277118C4005D8916 /* Blog+VideoLimits.swift in Sources */,
 				FABB217D2602FC2C00C8785C /* WPMediaPicker+MediaPicker.swift in Sources */,
+				805CC0BD29668987002941DC /* JetpackBrandedScreen.swift in Sources */,
 				FABB217E2602FC2C00C8785C /* JetpackInstallError+Blocking.swift in Sources */,
 				FABB217F2602FC2C00C8785C /* QuickStartTourState.swift in Sources */,
 				FABB21802602FC2C00C8785C /* ReaderPostCardCell.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1572,6 +1572,9 @@
 		803BB98A295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB988295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift */; };
 		803BB98C29637AFC00B3F6D6 /* BlurredEmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB98B29637AFC00B3F6D6 /* BlurredEmptyViewController.swift */; };
 		803BB98D29637AFC00B3F6D6 /* BlurredEmptyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB98B29637AFC00B3F6D6 /* BlurredEmptyViewController.swift */; };
+		803BB98F29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB98E29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift */; };
+		803BB99029667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB98E29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift */; };
+		803BB99429667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803BB99329667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift */; };
 		803C493B283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */; };
 		803C493C283A7C0C00003E9B /* QuickStartChecklistHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */; };
 		803C493E283A7C2200003E9B /* QuickStartChecklistHeader.xib in Resources */ = {isa = PBXBuildFile; fileRef = 803C493D283A7C2200003E9B /* QuickStartChecklistHeader.xib */; };
@@ -6898,6 +6901,8 @@
 		803BB985295A873800B3F6D6 /* RootViewPresenter+MeNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootViewPresenter+MeNavigation.swift"; sourceTree = "<group>"; };
 		803BB988295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RootViewPresenter+EditorNavigation.swift"; sourceTree = "<group>"; };
 		803BB98B29637AFC00B3F6D6 /* BlurredEmptyViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlurredEmptyViewController.swift; sourceTree = "<group>"; };
+		803BB98E29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingTextProvider.swift; sourceTree = "<group>"; };
+		803BB99329667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingTextProviderTests.swift; sourceTree = "<group>"; };
 		803C493A283A7C0C00003E9B /* QuickStartChecklistHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuickStartChecklistHeader.swift; sourceTree = "<group>"; };
 		803C493D283A7C2200003E9B /* QuickStartChecklistHeader.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = QuickStartChecklistHeader.xib; sourceTree = "<group>"; };
 		803D90F6292F0188007CC0D0 /* JetpackRedirector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRedirector.swift; sourceTree = "<group>"; };
@@ -11030,6 +11035,7 @@
 			children = (
 				3F720C2028899DD900519938 /* JetpackBrandingVisibility.swift */,
 				C3FBF4E728AFEDF8003797DF /* JetpackBrandingAnalyticsHelper.swift */,
+				803BB98E29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift */,
 				3FFA5ED0287612AD00830E28 /* Banner */,
 				3F5B9B44288B0521001D17E9 /* Badge */,
 				800035BF291DDF57007D2D26 /* Fullscreen Overlay */,
@@ -12547,6 +12553,7 @@
 				803DE81E290636A4007D4E9C /* JetpackFeaturesRemovalCoordinatorTests.swift */,
 				801D951C291ADB7E0051993E /* JetpackOverlayFrequencyTrackerTests.swift */,
 				80535DC4294BF4BE00873161 /* JetpackBrandingMenuCardPresenterTests.swift */,
+				803BB99329667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift */,
 			);
 			name = Jetpack;
 			sourceTree = "<group>";
@@ -20117,6 +20124,7 @@
 				4070D75E20E6B4E4007CEBDA /* ActivityDateFormatting.swift in Sources */,
 				E2AA87A518523E5300886693 /* UIView+Subviews.m in Sources */,
 				FEFC0F892731182C001F7F1D /* CommentService+Replies.swift in Sources */,
+				803BB98F29667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */,
 				5D51ADAF19A832AF00539C0B /* WordPress-20-21.xcmappingmodel in Sources */,
 				C81CCD63243AECA100A83E27 /* TenorClient.swift in Sources */,
 				43FB3F471EC10F1E00FC8A62 /* LoginEpilogueTableViewController.swift in Sources */,
@@ -22330,6 +22338,7 @@
 				80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */,
 				7E53AB0420FE6681005796FE /* ActivityContentRouterTests.swift in Sources */,
 				F11023A323186BCA00C4E84A /* MediaBuilder.swift in Sources */,
+				803BB99429667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift in Sources */,
 				17AF92251C46634000A99CFB /* BlogSiteVisibilityHelperTest.m in Sources */,
 				73B6693A21CAD960008456C3 /* ErrorStateViewTests.swift in Sources */,
 				8BD34F0927D144FF005E931C /* BlogDashboardStateTests.swift in Sources */,
@@ -23786,6 +23795,7 @@
 				F1C197A72670DDB100DE1FF7 /* BloggingRemindersTracker.swift in Sources */,
 				FABB242E2602FC2C00C8785C /* OffsetTableViewHandler.swift in Sources */,
 				FABB242F2602FC2C00C8785C /* UINavigationController+SplitViewFullscreen.swift in Sources */,
+				803BB99029667BAF00B3F6D6 /* JetpackBrandingTextProvider.swift in Sources */,
 				FABB24302602FC2C00C8785C /* ReaderReblogPresenter.swift in Sources */,
 				FABB24312602FC2C00C8785C /* BodyContentGroup.swift in Sources */,
 				FABB24322602FC2C00C8785C /* WPStyleGuide+Search.swift in Sources */,

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -111,13 +111,4 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
         // Then
         XCTAssertTrue(presenter.shouldShowCard())
     }
-
-}
-
-private class MockCurrentDateProvider: CurrentDateProvider {
-    var dateToReturn: Date?
-
-    func date() -> Date {
-        return dateToReturn ?? Date()
-    }
 }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -114,18 +114,6 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
 
 }
 
-private class RemoteConfigStoreMock: RemoteConfigStore {
-
-    var phaseThreeBlogPostUrl: String?
-
-    override func value(for key: String) -> Any? {
-        if key == "phase_three_blog_post" {
-            return phaseThreeBlogPostUrl
-        }
-        return super.value(for: key)
-    }
-}
-
 private class MockCurrentDateProvider: CurrentDateProvider {
     var dateToReturn: Date?
 

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -114,35 +114,6 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
 
 }
 
-private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
-
-    var removalPhaseOne = false
-    var removalPhaseTwo = false
-    var removalPhaseThree = false
-    var removalPhaseFour = false
-    var removalPhaseNewUsers = false
-
-    override func value(for flag: OverrideableFlag) -> Bool {
-        guard let flag = flag as? WordPress.FeatureFlag else {
-            return false
-        }
-        switch flag {
-        case .jetpackFeaturesRemovalPhaseOne:
-            return removalPhaseOne
-        case .jetpackFeaturesRemovalPhaseTwo:
-            return removalPhaseTwo
-        case .jetpackFeaturesRemovalPhaseThree:
-            return removalPhaseThree
-        case .jetpackFeaturesRemovalPhaseFour:
-            return removalPhaseFour
-        case .jetpackFeaturesRemovalPhaseNewUsers:
-            return removalPhaseNewUsers
-        default:
-            return super.value(for: flag)
-        }
-    }
-}
-
 private class RemoteConfigStoreMock: RemoteConfigStore {
 
     var phaseThreeBlogPostUrl: String?

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -256,6 +256,108 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Feature is moving in 2 weeks")
     }
+
+    func testPhaseThreeWithDeadlineOneDayAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving in 1 day")
+    }
+
+    func testPhaseThreeWithDeadlineOneDayAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving in 1 day")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleDaysAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 2)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving in 2 days")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleDaysAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 2)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving in 2 days")
+    }
+
+    func testPhaseThreeWithDeadlineLessThanADayAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 0)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving in 1 day")
+    }
+
+    func testPhaseThreeWithDeadlineLessThanADayAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, days: 0)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving in 1 day")
+    }
 }
 
 // MARK: Helpers

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -70,6 +70,39 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Jetpack powered")
     }
+
+    func testPhaseThreeWithNoFeatureNameShouldReturnDefaultText() {
+        // Given
+        let screen = MockBrandedScreen(featureName: nil, isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
+
+    func testPhaseThreeWithNoDeadlineShouldReturnDefaultText() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        remoteConfigStore.removalDeadline = nil
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
 }
 
 // MARK: Helpers

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -15,9 +15,45 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
     // MARK: Tests
 
+    func testNormalPhaseText() {
+        // Given
+        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
+
+    func testPhaseOneText() {
+        // Given
+        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        remoteFeatureFlagsStore.removalPhaseOne = true
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
+
+    func testPhaseTwoText() {
+        // Given
+        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        remoteFeatureFlagsStore.removalPhaseTwo = true
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Get the Jetpack app")
+    }
+
     func testDefaultText() {
         // Given
         let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        remoteFeatureFlagsStore.removalPhaseFour = true
 
         // When
         let text = provider.brandingText()

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -188,6 +188,74 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Feature is moving soon")
     }
+
+    func testPhaseThreeWithDeadlineOneWeekAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, weeks: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving in 1 week")
+    }
+
+    func testPhaseThreeWithDeadlineOneWeekAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, weeks: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving in 1 week")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleWeeksAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, weeks: 2)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving in 2 weeks")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleWeeksAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, weeks: 2)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving in 2 weeks")
+    }
 }
 
 // MARK: Helpers

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -103,7 +103,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Feature are moving soon")
     }
-    
+
     func testPhaseThreeWithNoDeadlineAndFeatureIsSingular() {
         // Given
         let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
@@ -113,6 +113,74 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
                                                    currentDateProvider: currentDateProvider)
         remoteFeatureFlagsStore.removalPhaseThree = true
         remoteConfigStore.removalDeadline = nil
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving soon")
+    }
+
+    func testPhaseThreeWithDeadlineOneMonthAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, months: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving soon")
+    }
+
+    func testPhaseThreeWithDeadlineOneMonthAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, months: 1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature is moving soon")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleMonthsAwayAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, months: 2)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving soon")
+    }
+
+    func testPhaseThreeWithDeadlineMultipleMonthsAwayAndFeatureIsSingular() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, months: 2)
 
         // When
         let text = provider.brandingText()

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -86,6 +86,24 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Jetpack powered")
     }
+    
+    func testPhaseThreeWithDeadlinePassed() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        currentDateProvider.dateToReturn = dateBefore(removalDeadline, months: -1)
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
+
 
     func testPhaseThreeWithNoDeadlineAndFeatureIsPlural() {
         // Given

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -86,7 +86,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Jetpack powered")
     }
-    
+
     func testPhaseThreeWithDeadlinePassed() {
         // Given
         let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -6,11 +6,20 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
     // MARK: Private Variables
 
     private var remoteFeatureFlagsStore: RemoteFeatureFlagStoreMock!
+    private var remoteConfigStore = RemoteConfigStoreMock()
+    private var currentDateProvider: MockCurrentDateProvider!
+    private var removalDeadline: Date {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.date(from: "2022-10-10") ?? Date()
+    }
 
     // MARK: Setup
 
     override func setUp() {
         remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
+        currentDateProvider = MockCurrentDateProvider()
+        remoteConfigStore.removalDeadline = "2022-10-10"
     }
 
     // MARK: Tests
@@ -61,17 +70,32 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         // Then
         XCTAssertEqual(text, "Jetpack powered")
     }
+}
 
-    // MARK: Helpers
+// MARK: Helpers
 
-    private struct MockBrandedScreen: JetpackBrandedScreen {
+private extension JetpackBrandingTextProviderTests {
+    struct MockBrandedScreen: JetpackBrandedScreen {
         let featureName: String?
         let isPlural: Bool
         let analyticsId: String
 
         static var defaultScreen: MockBrandedScreen = .init(featureName: "Feature",
                                                             isPlural: false,
-                                                            analyticsId: "analyticsId")
+                                                            analyticsId: "")
     }
 
+    enum Constants {
+        static let secondsInDay = 86_400
+    }
+
+    private func dateBefore(_ date: Date,
+                            months: Int = 0,
+                            weeks: Int = 0,
+                            days: Int = 0) -> Date {
+        let calendar = Calendar.current
+        let components = DateComponents(month: -months, day: -days, second: -1, weekOfYear: -weeks)
+        let newDate = calendar.date(byAdding: components, to: date)
+        return newDate ?? date
+    }
 }

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -87,7 +87,24 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         XCTAssertEqual(text, "Jetpack powered")
     }
 
-    func testPhaseThreeWithNoDeadlineShouldReturnDefaultText() {
+    func testPhaseThreeWithNoDeadlineAndFeatureIsPlural() {
+        // Given
+        let screen = MockBrandedScreen(featureName: "Feature", isPlural: true, analyticsId: "")
+        let provider = JetpackBrandingTextProvider(screen: screen,
+                                                   featureFlagStore: remoteFeatureFlagsStore,
+                                                   remoteConfigStore: remoteConfigStore,
+                                                   currentDateProvider: currentDateProvider)
+        remoteFeatureFlagsStore.removalPhaseThree = true
+        remoteConfigStore.removalDeadline = nil
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Feature are moving soon")
+    }
+    
+    func testPhaseThreeWithNoDeadlineAndFeatureIsSingular() {
         // Given
         let screen = MockBrandedScreen(featureName: "Feature", isPlural: false, analyticsId: "")
         let provider = JetpackBrandingTextProvider(screen: screen,
@@ -101,7 +118,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
         let text = provider.brandingText()
 
         // Then
-        XCTAssertEqual(text, "Jetpack powered")
+        XCTAssertEqual(text, "Feature is moving soon")
     }
 }
 

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WordPress
+
+final class JetpackBrandingTextProviderTests: XCTestCase {
+
+    func testDefaultText() {
+        // Given
+        let provider = JetpackBrandingTextProvider()
+
+        // When
+        let text = provider.brandingText()
+
+        // Then
+        XCTAssertEqual(text, "Jetpack powered")
+    }
+
+}

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -17,7 +17,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
     func testNormalPhaseText() {
         // Given
-        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        let provider = JetpackBrandingTextProvider(screen: MockBrandedScreen.defaultScreen, featureFlagStore: remoteFeatureFlagsStore)
 
         // When
         let text = provider.brandingText()
@@ -28,7 +28,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
     func testPhaseOneText() {
         // Given
-        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        let provider = JetpackBrandingTextProvider(screen: MockBrandedScreen.defaultScreen, featureFlagStore: remoteFeatureFlagsStore)
         remoteFeatureFlagsStore.removalPhaseOne = true
 
         // When
@@ -40,7 +40,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
     func testPhaseTwoText() {
         // Given
-        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        let provider = JetpackBrandingTextProvider(screen: MockBrandedScreen.defaultScreen, featureFlagStore: remoteFeatureFlagsStore)
         remoteFeatureFlagsStore.removalPhaseTwo = true
 
         // When
@@ -52,7 +52,7 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
     func testDefaultText() {
         // Given
-        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
+        let provider = JetpackBrandingTextProvider(screen: MockBrandedScreen.defaultScreen, featureFlagStore: remoteFeatureFlagsStore)
         remoteFeatureFlagsStore.removalPhaseFour = true
 
         // When
@@ -60,6 +60,18 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
 
         // Then
         XCTAssertEqual(text, "Jetpack powered")
+    }
+
+    // MARK: Helpers
+
+    private struct MockBrandedScreen: JetpackBrandedScreen {
+        let featureName: String?
+        let isPlural: Bool
+        let analyticsId: String
+
+        static var defaultScreen: MockBrandedScreen = .init(featureName: "Feature",
+                                                            isPlural: false,
+                                                            analyticsId: "analyticsId")
     }
 
 }

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -3,9 +3,21 @@ import XCTest
 
 final class JetpackBrandingTextProviderTests: XCTestCase {
 
+    // MARK: Private Variables
+
+    private var remoteFeatureFlagsStore: RemoteFeatureFlagStoreMock!
+
+    // MARK: Setup
+
+    override func setUp() {
+        remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
+    }
+
+    // MARK: Tests
+
     func testDefaultText() {
         // Given
-        let provider = JetpackBrandingTextProvider()
+        let provider = JetpackBrandingTextProvider(featureFlagStore: remoteFeatureFlagsStore)
 
         // When
         let text = provider.brandingText()

--- a/WordPress/WordPressTest/JetpackNotificationMigrationServiceTests.swift
+++ b/WordPress/WordPressTest/JetpackNotificationMigrationServiceTests.swift
@@ -137,15 +137,17 @@ private class RemoteNotificationRegisterMock: RemoteNotificationRegister {
     }
 }
 
-private class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
-    var value = false {
-        didSet {
-            try? FeatureFlagOverrideStore().override(FeatureFlag.jetpackMigrationPreventDuplicateNotifications, withValue: value)
+private extension JetpackNotificationMigrationServiceTests {
+    class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
+        var value = false {
+            didSet {
+                try? FeatureFlagOverrideStore().override(FeatureFlag.jetpackMigrationPreventDuplicateNotifications, withValue: value)
+            }
         }
-    }
 
-    override func value(for flag: OverrideableFlag) -> Bool {
-        return value
+        override func value(for flag: OverrideableFlag) -> Bool {
+            return value
+        }
     }
 }
 

--- a/WordPress/WordPressTest/MockCurrentDateProvider.swift
+++ b/WordPress/WordPressTest/MockCurrentDateProvider.swift
@@ -1,0 +1,10 @@
+import Foundation
+@testable import WordPress
+
+class MockCurrentDateProvider: CurrentDateProvider {
+    var dateToReturn: Date?
+
+    func date() -> Date {
+        return dateToReturn ?? Date()
+    }
+}

--- a/WordPress/WordPressTest/RemoteConfigStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteConfigStoreMock.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import WordPress
+
+class RemoteConfigStoreMock: RemoteConfigStore {
+
+    var phaseThreeBlogPostUrl: String?
+
+    override func value(for key: String) -> Any? {
+        if key == "phase_three_blog_post" {
+            return phaseThreeBlogPostUrl
+        }
+        return super.value(for: key)
+    }
+}

--- a/WordPress/WordPressTest/RemoteConfigStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteConfigStoreMock.swift
@@ -4,10 +4,14 @@ import Foundation
 class RemoteConfigStoreMock: RemoteConfigStore {
 
     var phaseThreeBlogPostUrl: String?
+    var removalDeadline: String?
 
     override func value(for key: String) -> Any? {
         if key == "phase_three_blog_post" {
             return phaseThreeBlogPostUrl
+        }
+        if key == "jp_deadline" {
+            return removalDeadline
         }
         return super.value(for: key)
     }

--- a/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
@@ -1,0 +1,31 @@
+import Foundation
+@testable import WordPress
+
+class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
+
+    var removalPhaseOne = false
+    var removalPhaseTwo = false
+    var removalPhaseThree = false
+    var removalPhaseFour = false
+    var removalPhaseNewUsers = false
+
+    override func value(for flag: OverrideableFlag) -> Bool {
+        guard let flag = flag as? WordPress.FeatureFlag else {
+            return false
+        }
+        switch flag {
+        case .jetpackFeaturesRemovalPhaseOne:
+            return removalPhaseOne
+        case .jetpackFeaturesRemovalPhaseTwo:
+            return removalPhaseTwo
+        case .jetpackFeaturesRemovalPhaseThree:
+            return removalPhaseThree
+        case .jetpackFeaturesRemovalPhaseFour:
+            return removalPhaseFour
+        case .jetpackFeaturesRemovalPhaseNewUsers:
+            return removalPhaseNewUsers
+        default:
+            return super.value(for: flag)
+        }
+    }
+}


### PR DESCRIPTION
Closes #19449 
Preferably should be merged after #19844, #19845, and #19854 to avoid conflicts in other PRs.

## Description
This PR updates the text displayed in banners and badges based on the current phase.
Here's a breakdown of how each phase should behave:
* Phase 0
  * All banners and badges should read "Jetpack powered"
* Phase 1
  * All banners and badges should read "Jetpack powered"
* Phase 2
  * All banners and badges should read "Get the Jetpack app"
* Phase 3
  * People, Person, Me screen, App Settings, and Dashboard banner/badges should read "Jetpack powered"
  * All other banners and badges will have dynamic text based on the removal deadline
    * If we can't retrieve the deadline -> “Feature is/are moving soon”
    * If the deadline is more than one month away -> “Feature is/are moving soon”
    * If the deadline is more than one week away -> “Feature is/are moving in n weeks”
    * If the deadline is less than one week away -> “Feature is/are moving in n days”
    * If the deadline has passed -> “Jetpack powered”
* Phase 4
  * All banners and badges should be gone  

## Screenshots
|![Powered](https://user-images.githubusercontent.com/25306722/210879057-951d22e2-79af-44f2-829d-6969958496e8.png)|![Get](https://user-images.githubusercontent.com/25306722/210879083-3b2b118d-4f4e-4618-bf28-3c6fc69f722c.png)|![Soon](https://user-images.githubusercontent.com/25306722/210879105-32145da7-3422-45ac-b5b1-04ba7da51753.png)|
|-|-|-|
|![1Day](https://user-images.githubusercontent.com/25306722/210879124-6969d297-f823-48fe-9245-fe02de03cdbd.png)|![2Days](https://user-images.githubusercontent.com/25306722/210879139-ee187685-6079-4ff3-be23-7e3ed5b35045.png)|![3Weeks](https://user-images.githubusercontent.com/25306722/210879153-1224e2a4-5a6a-478e-b98c-67eb1353c19e.png)|


## Testing Instructions

Below is a list of the banners and badges in the app to ease the testing:
- Banners:
    - People (Displayed starting from phase 2)
    - Activity Log
    - Backup
    - Notifications
    - Reader
    - Reader Search
    - Stats
- Badges:
    - People -> Person View (Displayed starting from phase 2)
    - Dashboard
    - Me
    - App Setting
    - Activity Detail
    - Notifications Settings
    - Reader Detailed View
    - Sharing

### Phase 0

1. Launch the app
2. Open the debug menu and disable all Jetpack Features Removal flags
3. Validate that all banners and badges read "Jetpack Powered"

### Phase 1

1. Launch the app
2. Open the debug menu and enable "Jetpack Features Removal Phase One" 
3. Validate that all banners and badges read "Jetpack Powered"

### Phase 2

1. Launch the app
2. Open the debug menu and enable "Jetpack Features Removal Phase Two" 
3. Validate that all banners and badges read "Get the Jetpack app"

### Phase 3
1. Open the debug menu and enable "Jetpack Features Removal Phase Three" 
2. Go to `RemoteConfig.swift` line 20
3. Replace it with `RemoteConfigParameter<String>(key: "jp_deadline-temp", defaultValue: "YOUR_VALUE", store: store)`
4. Replace `YOUR_VALUE` with one of the following options (Format: yyyy-MM-dd) (Example: 2023-01-21):
    - nil
    - A date more than one month away 
    - A date more than one week away
    - A date more than one day away
    - A date less than a day away
    - A date in the past
5. Launch the app
6. Check that People, Person, Me screen, App Settings, and Dashboard banner/badges read "Jetpack Powered"
7. Check that all other banners and badges:
    - If the deadline you set is nil, they should read "Feature is/are moving soon"
    - If the deadline you set is more than one month away, they should read "Feature is/are moving soon"
    - If the deadline you set is more than one week away, they should read "Feature is/are moving in `n` week(s)"
    - If the deadline you set is more than one day away, they should read "Feature is/are moving in `n` day(s)"
    - If the deadline you set is less than one day away, they should read "Feature is/are moving in 1 day"
    - If the deadline you set has passed, they should read "Jetpack Powered"
8. Go back to step 4 and choose a different date and repeat

_P.S.: No need to check all banners and badges each time. `JetpackBrandingTextProviderTests` should give us confidence in many scenarios. So some mixing and matching should be fine._

## Regression Notes
1. Potential unintended areas of impact
Banners and badges throughout the app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
22 tests in `JetpackBrandingTextProviderTests` covering different scenarios for all phases.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.