### PR TITLE
Blogging Reminders: Do not show introductory prompt after Content Migration Flow

### DIFF
--- a/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
+++ b/WordPress/Classes/Services/JetpackNotificationMigrationService.swift
@@ -184,7 +184,11 @@ final class JetpackNotificationMigrationService: JetpackNotificationMigrationSer
                    let time = self?.bloggingRemindersScheduler?.scheduledTime(for: blog) {
                     if schedule != .none {
                         group.enter()
-                        self?.bloggingRemindersScheduler?.schedule(schedule, for: blog, time: time) { _ in
+                        self?.bloggingRemindersScheduler?.schedule(schedule, for: blog, time: time) { result in
+                            if case .success = result {
+                                BloggingRemindersFlow.setHasShownWeeklyRemindersFlow(for: blog)
+                            }
+
                             group.leave()
                         }
                     }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlow.swift
@@ -68,7 +68,7 @@ class BloggingRemindersFlow {
         UserPersistentStoreFactory.instance().bool(forKey: weeklyRemindersKey(for: blog))
     }
 
-    private static func setHasShownWeeklyRemindersFlow(for blog: Blog) {
+    static func setHasShownWeeklyRemindersFlow(for blog: Blog) {
         UserPersistentStoreFactory.instance().set(true, forKey: weeklyRemindersKey(for: blog))
     }
 


### PR DESCRIPTION
Fixes #19860

## Description

After completing the Jetpack Content Migration flow and migrating blogging reminders, we continue to show "Set your blogging reminders" prompt

<img src="https://user-images.githubusercontent.com/4062343/211018402-fb663214-3aa2-4fe4-a3f5-88e698a134e5.jpeg" alt="" width="200"/>

### Solution

Set `blogging reminders` flow as shown after we successfully schedule blogging reminders in Jetpack

## Testing instructions

As described in #19860

## Regression Notes

1. Potential unintended areas of impact

Couldn't identify

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.



