### PR TITLE
Extract `ReaderPostService.fetchPostsV2` to a new service type

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -9,9 +9,6 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
 
 @interface ReaderPostService : LocalCoreDataService
 
-@property (copy, nonatomic) NSString *nextPageHandle;
-@property (nonatomic) NSInteger pageNumber;
-
 /**
  Fetches the posts for the specified topic
 

--- a/WordPress/Classes/Services/ReaderPostStreamService.swift
+++ b/WordPress/Classes/Services/ReaderPostStreamService.swift
@@ -1,23 +1,25 @@
 import Foundation
 
-extension ReaderPostService {
-    func fetchPostsV2(for topic: ReaderTagTopic, isFirstPage: Bool = true, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {
+class ReaderPostStreamService {
+
+    private let coreDataStack: CoreDataStack
+
+    private var nextPageHandle: String?
+    private var pageNumber: Int = 0
+
+    init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+    }
+
+    func fetchPosts(for topic: ReaderTagTopic, isFirstPage: Bool = true, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {
         if isFirstPage {
             nextPageHandle = nil
         }
 
         let remoteService = ReaderPostServiceRemote.withDefaultApi()
         remoteService.fetchPosts(for: [topic.slug], page: nextPageHandle, success: { posts, pageHandle in
-            self.managedObjectContext.perform {
-
-                if self.managedObjectContext.parent == ContextManager.shared.mainContext {
-                    // Its possible the ReaderAbstractTopic was deleted the parent main context.
-                    // If so, and we merge and save, it will cause a crash.
-                    // Reset the context so it will be current with its parent context.
-                    self.managedObjectContext.reset()
-                }
-
-                guard let readerTopic = try? self.managedObjectContext.existingObject(with: topic.objectID) as? ReaderAbstractTopic else {
+            self.coreDataStack.performAndSave { context in
+                guard let readerTopic = try? context.existingObject(with: topic.objectID) as? ReaderAbstractTopic else {
                     // if there was an error or the topic was deleted just bail.
                     success(0, false)
                     return
@@ -27,44 +29,41 @@ extension ReaderPostService {
 
                 if isFirstPage {
                     self.pageNumber = 1
-                    self.removePosts(forTopic: readerTopic)
+                    self.removePosts(forTopic: readerTopic, in: context)
                 } else {
                     self.pageNumber += 1
                 }
 
                 posts.enumerated().forEach { index, remotePost in
-                    let post = ReaderPost.createOrReplace(fromRemotePost: remotePost, for: readerTopic, context: self.managedObjectContext)
+                    let post = ReaderPost.createOrReplace(fromRemotePost: remotePost, for: readerTopic, context: context)
                     // To keep the API order
                     post?.sortRank = NSNumber(value: Date().timeIntervalSinceReferenceDate - Double(((self.pageNumber * Constants.paginationMultiplier) + index)))
                 }
 
                 // Clean up
-                self.deletePostsInExcessOfMaxAllowed(for: readerTopic)
-                self.deletePostsFromBlockedSites()
-
-                ContextManager.shared.save(self.managedObjectContext) {
-                    let hasMore = pageHandle != nil
-                    success(posts.count, hasMore)
-                }
-
+                let serivce = ReaderPostService(managedObjectContext: context)
+                serivce.deletePostsInExcessOfMaxAllowed(for: readerTopic)
+                serivce.deletePostsFromBlockedSites()
+            } completion: {
+                let hasMore = pageHandle != nil
+                success(posts.count, hasMore)
             }
-
         }, failure: { error in
             failure(error)
         })
     }
 
-    private func removePosts(forTopic topic: ReaderAbstractTopic) {
+    private func removePosts(forTopic topic: ReaderAbstractTopic, in context: NSManagedObjectContext) {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: ReaderPost.classNameWithoutNamespaces())
         fetchRequest.predicate = NSPredicate(format: "topic == %@", argumentArray: [topic])
         fetchRequest.sortDescriptors = [NSSortDescriptor(key: "sortRank", ascending: false)]
         fetchRequest.returnsObjectsAsFaults = false
 
         do {
-            let results = try managedObjectContext.fetch(fetchRequest)
+            let results = try context.fetch(fetchRequest)
             for object in results {
                 guard let objectData = object as? NSManagedObject else { continue }
-                managedObjectContext.delete(objectData)
+                context.delete(objectData)
 
                 // Checar se ta em uso ou foi salvo
             }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -48,6 +48,8 @@ import Combine
     private var noResultsStatusViewController = NoResultsViewController.controller()
     private var noFollowedSitesViewController: NoResultsViewController?
 
+    private lazy var readerPostStreamService = ReaderPostStreamService(coreDataStack: coreDataStack)
+
     var resultsStatusView: NoResultsViewController {
         get {
             guard let noFollowedSitesVC = noFollowedSitesViewController else {
@@ -1048,12 +1050,13 @@ import Combine
                 return
             }
 
-            let service = ReaderPostService(managedObjectContext: context)
             if ReaderHelpers.isTopicSearchTopic(topic) {
+                let service = ReaderPostService(managedObjectContext: context)
                 service.fetchPosts(for: topic, atOffset: 0, deletingEarlier: false, success: success, failure: failure)
             } else if let topic = topic as? ReaderTagTopic {
-                service.fetchPostsV2(for: topic, success: success, failure: failure)
+                self.readerPostStreamService.fetchPosts(for: topic, success: success, failure: failure)
             } else {
+                let service = ReaderPostService(managedObjectContext: context)
                 service.fetchPosts(for: topic, earlierThan: Date(), success: success, failure: failure)
             }
         }
@@ -1168,13 +1171,14 @@ import Combine
                 return
             }
 
-            let service = ReaderPostService(managedObjectContext: context)
             if ReaderHelpers.isTopicSearchTopic(topic) {
+                let service = ReaderPostService(managedObjectContext: context)
                 let offset = UInt(self.content.contentCount)
                 service.fetchPosts(for: topic, atOffset: UInt(offset), deletingEarlier: false, success: success, failure: failure)
             } else if let topic = topic as? ReaderTagTopic {
-                service.fetchPostsV2(for: topic, isFirstPage: false, success: success, failure: failure)
+                self.readerPostStreamService.fetchPosts(for: topic, isFirstPage: false, success: success, failure: failure)
             } else {
+                let service = ReaderPostService(managedObjectContext: context)
                 let earlierThan = sortDate
                 service.fetchPosts(for: topic, earlierThan: earlierThan, success: success, failure: failure)
             }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1929,7 +1929,7 @@
 		8B15CDAC27EB89AD00A75749 /* BlogDashboardPostsParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B15CDAA27EB89AC00A75749 /* BlogDashboardPostsParser.swift */; };
 		8B15D27428009EBF0076628A /* BlogDashboardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B15D27328009EBF0076628A /* BlogDashboardAnalytics.swift */; };
 		8B15D27528009EBF0076628A /* BlogDashboardAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B15D27328009EBF0076628A /* BlogDashboardAnalytics.swift */; };
-		8B16CE9A25251C89007BE5A9 /* ReaderPostService+PostsV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE9925251C89007BE5A9 /* ReaderPostService+PostsV2.swift */; };
+		8B16CE9A25251C89007BE5A9 /* ReaderPostStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE9925251C89007BE5A9 /* ReaderPostStreamService.swift */; };
 		8B1CF00F2433902700578582 /* PasswordAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF00E2433902700578582 /* PasswordAlertController.swift */; };
 		8B1CF0112433E61C00578582 /* AbstractPost+TitleForVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */; };
 		8B1E62D625758AAF009A0F80 /* ActivityTypeSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1E62D525758AAF009A0F80 /* ActivityTypeSelectorViewController.swift */; };
@@ -5144,7 +5144,7 @@
 		FABB26182602FC2C00C8785C /* RegisterDomainDetailsViewModel+SectionDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436D56102117312700CEAA33 /* RegisterDomainDetailsViewModel+SectionDefinitions.swift */; };
 		FABB26192602FC2C00C8785C /* ActionRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F53FF3A723EA723D001AD596 /* ActionRow.swift */; };
 		FABB261A2602FC2C00C8785C /* AppSettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA162301CB7031A00E2E110 /* AppSettingsViewController.swift */; };
-		FABB261B2602FC2C00C8785C /* ReaderPostService+PostsV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE9925251C89007BE5A9 /* ReaderPostService+PostsV2.swift */; };
+		FABB261B2602FC2C00C8785C /* ReaderPostStreamService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B16CE9925251C89007BE5A9 /* ReaderPostStreamService.swift */; };
 		FABB261C2602FC2C00C8785C /* ReferrerStatsRecordValue+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 400A2C7D2217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift */; };
 		FABB261E2602FC2C00C8785C /* PostCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57AA848E228715DA00D3C2A2 /* PostCardCell.swift */; };
 		FABB26202602FC2C00C8785C /* iAd.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7E21C760202BBC8D00837CF5 /* iAd.framework */; };
@@ -7074,7 +7074,7 @@
 		8B0CE7D22481CFF8004C4799 /* ReaderDetailHeaderView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReaderDetailHeaderView.xib; sourceTree = "<group>"; };
 		8B15CDAA27EB89AC00A75749 /* BlogDashboardPostsParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPostsParser.swift; sourceTree = "<group>"; };
 		8B15D27328009EBF0076628A /* BlogDashboardAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardAnalytics.swift; sourceTree = "<group>"; };
-		8B16CE9925251C89007BE5A9 /* ReaderPostService+PostsV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPostService+PostsV2.swift"; sourceTree = "<group>"; };
+		8B16CE9925251C89007BE5A9 /* ReaderPostStreamService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostStreamService.swift; sourceTree = "<group>"; };
 		8B1CF00E2433902700578582 /* PasswordAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasswordAlertController.swift; sourceTree = "<group>"; };
 		8B1CF0102433E61C00578582 /* AbstractPost+TitleForVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+TitleForVisibility.swift"; sourceTree = "<group>"; };
 		8B1E62D525758AAF009A0F80 /* ActivityTypeSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTypeSelectorViewController.swift; sourceTree = "<group>"; };
@@ -13413,7 +13413,7 @@
 				8BB185C524B5FB8500A4CCE8 /* ReaderCardService.swift */,
 				5D3D559518F88C3500782892 /* ReaderPostService.h */,
 				5D3D559618F88C3500782892 /* ReaderPostService.m */,
-				8B16CE9925251C89007BE5A9 /* ReaderPostService+PostsV2.swift */,
+				8B16CE9925251C89007BE5A9 /* ReaderPostStreamService.swift */,
 				FA8E1F7625EEFA7300063673 /* ReaderPostService+RelatedPosts.swift */,
 				E62079E01CF7A61200F5CD46 /* ReaderSearchSuggestionService.swift */,
 				17CE77EC20C6C2F3001DEA5A /* ReaderSiteSearchService.swift */,
@@ -21730,7 +21730,7 @@
 				F53FF3A823EA723D001AD596 /* ActionRow.swift in Sources */,
 				FFA162311CB7031A00E2E110 /* AppSettingsViewController.swift in Sources */,
 				F111B87826580FCE00057942 /* BloggingRemindersStore.swift in Sources */,
-				8B16CE9A25251C89007BE5A9 /* ReaderPostService+PostsV2.swift in Sources */,
+				8B16CE9A25251C89007BE5A9 /* ReaderPostStreamService.swift in Sources */,
 				400A2C872217A985000A8A59 /* ReferrerStatsRecordValue+CoreDataProperties.swift in Sources */,
 				57AA848F228715DA00D3C2A2 /* PostCardCell.swift in Sources */,
 				FE43DAAF26DFAD1C00CFF595 /* CommentContentTableViewCell.swift in Sources */,
@@ -24457,7 +24457,7 @@
 				9815D0B426B49A0600DF7226 /* Comment+CoreDataProperties.swift in Sources */,
 				FABB261A2602FC2C00C8785C /* AppSettingsViewController.swift in Sources */,
 				4A82C43228D321A300486CFF /* Blog+Post.swift in Sources */,
-				FABB261B2602FC2C00C8785C /* ReaderPostService+PostsV2.swift in Sources */,
+				FABB261B2602FC2C00C8785C /* ReaderPostStreamService.swift in Sources */,
 				FABB261C2602FC2C00C8785C /* ReferrerStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB261E2602FC2C00C8785C /* PostCardCell.swift in Sources */,
 				8F228B22E190FF92D05E53DB /* TimeZoneSearchHeaderView.swift in Sources */,


### PR DESCRIPTION
## Issue

In the Reader tab, when filter by a topic, only first page of posts are loaded. When scroll to the bottom of the posts list, the new posts are not displayed.

## Root cause

`ReaderStreamViewController` was refactored in [my previous PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/19539). Before this refactor, the view controller hold [a `ReaderPostSerivce` instance as a stored property](https://github.com/wordpress-mobile/WordPress-iOS/blob/0405eb4353b42a19871ed739f898cd4951b44ac2/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift#L65-L67). The PR [removed this store property](https://github.com/wordpress-mobile/WordPress-iOS/commit/46632d268e551e0ebb95e2a196ff1d42fdf263c1#diff-7cc79c8a9ebb1582022da45d82c189f9e8512a97bd9b4ee38b8ad9196c055cadL65-L67), used temporary instances when needed instead (see [this example](https://github.com/wordpress-mobile/WordPress-iOS/commit/46632d268e551e0ebb95e2a196ff1d42fdf263c1#diff-7cc79c8a9ebb1582022da45d82c189f9e8512a97bd9b4ee38b8ad9196c055cadR1048)).

Creating a service instance and discarding it when done is a common pattern throughout the app, I thought it should be okay to do the same here. But I didn't realize the posts [pagination info](https://github.com/wordpress-mobile/WordPress-iOS/blob/5d0d98664009e7c0472e7a2627629eb24d236062/WordPress/Classes/Services/ReaderPostService.h#L12-L13) is accessed in [`ReaderPostSerivce.fetchPostsV2`](https://github.com/wordpress-mobile/WordPress-iOS/blob/5d0d98664009e7c0472e7a2627629eb24d236062/WordPress/Classes/Services/ReaderPostService%2BPostsV2.swift#L4). Since `ReaderPostSerivce` instances are created and discarded, the pagination info is also discarded, which is why the posts in second page are not loaded.

## Fix

I've moved the `fetchPostsV2` into its own `ReaderPostStreamService` type, so that we can keep the pagination info around in the view controller.

Reason we can't simply store `ReaderPostSerivce` instances as a property of the view controller is we don't want to create a new background context (which is a deprecated pattern) to initialize a `ReaderPostSerivce` instance. 

## Test Instructions

Go to Reader tab, in the "Discover" section, select a topic/tag, scroll to bottom the posts list, verify new posts can be loaded.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
