### PR TITLE
Jetpack app: Update tint color in editor's navigation bar

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -30,6 +30,7 @@ class PostEditorNavigationBarManager {
         cancelButton.rightSpacing = Constants.cancelButtonPadding.right
         cancelButton.setContentHuggingPriority(.required, for: .horizontal)
         cancelButton.accessibilityIdentifier = "editor-close-button"
+        cancelButton.tintColor = .editorPrimary
         return cancelButton
     }()
 
@@ -71,6 +72,7 @@ class PostEditorNavigationBarManager {
         button.sizeToFit()
         button.isEnabled = delegate?.isPublishButtonEnabled ?? false
         button.setContentHuggingPriority(.required, for: .horizontal)
+        button.tintColor = .editorPrimary
         return button
     }()
 


### PR DESCRIPTION
## Description

The `tintColor` used in the editor's navigation bar differs across the WordPress and Jetpack apps.

In the WordPress app, the publish button changes from grey to blue, which gives a user a clear indication that the post is ready to be published. There is a less clear indication in the Jetpack app, as the publish button always remains a shade of grey:

| WordPress  | Jetpack |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/2998162/211799419-b0a15b3f-fb78-4f1a-abee-d8f6c064601f.png" width="100%"> | <img src="https://user-images.githubusercontent.com/2998162/211802478-67cd23a5-9b00-453d-9386-a5043925bf76.png" width="100%"> |

The reason for the difference is that `appBarTint` is set to `.primary` (blue) [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/fc64c0b5f963890952da7c200f9f9c10900637a4/WordPress/Classes/Extensions/Colors%20and%20Styles/UIColor%2BWordPressColors.swift#L11-L13) for WordPress and `.text` (a shade of grey) for Jetpack [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/fc64c0b5f963890952da7c200f9f9c10900637a4/WordPress/Jetpack/UIColor%2BJetpackColors.swift#L11-L13).

This PR addresses that issue by explicitly updating the `tintColor` of the cancel and publish buttons within the editor to `.editorPrimary`, which was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/19113. The buttons will now be blue in **both** the WordPress and Jetpack apps.

## Testing

To test:

* Locally check out these changes and run the Jetpack app.
* Navigate to the post or page editor and type in some text, so that the post/page is publishable.
* Verify that the publish button changes from grey to blue. 

## Regression Notes
1. Potential unintended areas of impact

This PR should _only_ change the colour in the editor's navigation bar, no other colours. The colours should also be the same across both apps and in dark/light modes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manually tested both apps and different modes. 

3. What automated tests I added (or what prevented me from doing so)

No automated tests added as this is a really small change that I didn't feel warranted tests.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
