### PR TITLE
Login: Enable signing in with Google and Apple

### DIFF
--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -74,7 +74,8 @@ extension WordPressAuthenticationManager {
                                                    enableSignInWithApple: enableSignInWithApple,
                                                    enableSignupWithGoogle: AppConfiguration.allowSignUp,
                                                    enableUnifiedAuth: true,
-                                                   enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled)
+                                                   enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled,
+                                                   enableSocialLogin: true)
     }
 
     private func authenticatorStyle() -> WordPressAuthenticatorStyle {


### PR DESCRIPTION
## Description
Social login options are no longer showing on both apps. This regression was introduced by updating `WordPressAuthenticator` from `3.2.2` -> `5.0.0`. (#19643)
This newer version had a new config option for enabling social login and is disabled by default.
This PR enables this option to retain the old behavior.

### Screenshots

| Before | After |
| - | - |
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-11 at 19 16 32](https://user-images.githubusercontent.com/25306722/211872740-a8ac7f94-8559-4d6b-8cca-b9ee208b76be.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-11 at 19 15 07](https://user-images.githubusercontent.com/25306722/211872647-9174d659-fc73-48c8-8576-57f3210109aa.png)|

## Testing Instructions

1. Open the app
2. Logout if needed
3. Tap on "Continue with WordPress.com"
4. Make sure that Google and Apple login options are displayed.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.