### PR TITLE
Jetpack Focus: New users phase menu card and overlay display logic

### DIFF
--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -32,6 +32,7 @@ class RemoteFeatureFlagStore {
                     callback?()
                 case .failure(let error):
                     DDLogError("🚩 Unable to update Feature Flag Store: \(error.localizedDescription)")
+                callback?()
             }
         }
     }

--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -32,7 +32,7 @@ class RemoteFeatureFlagStore {
                     callback?()
                 case .failure(let error):
                     DDLogError("🚩 Unable to update Feature Flag Store: \(error.localizedDescription)")
-                callback?()
+                    callback?()
             }
         }
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -672,16 +672,17 @@ extension WordPressAppDelegate {
         }
     }
 
-    /// Updates the remote feature flags using an authenticated remote if an account exists, or using an anonymous remote if no account exists.
-    func updateFeatureFlags() {
-        do {
-            let defaultAccount = try WPAccount.lookupDefaultWordPressComAccount(in: mainContext)
-            let api = defaultAccount?.wordPressComRestV2Api ?? WordPressComRestApi.defaultApi()
-            let remote = FeatureFlagRemote(wordPressComRestApi: api)
-            remoteFeatureFlagStore.update(using: remote)
-        } catch {
-            DDLogError("Error fetching default user account: \(error)")
+    /// Updates the remote feature flags using an authenticated remote if a token is provided or an account exists
+    /// Otherwise an anonymous remote will be used
+    func updateFeatureFlags(authToken: String? = nil, completion: (() -> Void)? = nil) {
+        var api: WordPressComRestApi
+        if let authToken {
+            api = WordPressComRestApi.defaultV2Api(authToken: authToken)
+        } else {
+            api = WordPressComRestApi.defaultV2Api(in: mainContext)
         }
+        let remote = FeatureFlagRemote(wordPressComRestApi: api)
+        remoteFeatureFlagStore.update(using: remote, then: completion)
     }
 
     func updateRemoteConfig() {

--- a/WordPress/Classes/Utility/Networking/WordPressComRestApi+Defaults.swift
+++ b/WordPress/Classes/Utility/Networking/WordPressComRestApi+Defaults.swift
@@ -21,6 +21,21 @@ extension WordPressComRestApi {
         let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,
-                                              userAgent: WPUserAgent.wordPress())
+                                              userAgent: userAgent,
+                                              localeKey: localeKey)
+    }
+
+    @objc public static func defaultV2Api(authToken: String? = nil) -> WordPressComRestApi {
+        let userAgent = WPUserAgent.wordPress()
+        let localeKey = WordPressComRestApi.LocaleKeyV2
+        return WordPressComRestApi.defaultApi(oAuthToken: authToken,
+                                              userAgent: userAgent,
+                                              localeKey: localeKey)
+    }
+
+    @objc public static func defaultV2Api(in context: NSManagedObjectContext) -> WordPressComRestApi {
+        return WordPressComRestApi.defaultApi(in: context,
+                                              userAgent: WPUserAgent.wordPress(),
+                                              localeKey: WordPressComRestApi.LocaleKeyV2)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -30,13 +30,19 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.three, _):
             return true
 
-        // Phase Four: Show feature-collection overlays. Features are removed by this point so they are irrelevant.
-        case (.four, .card):
+        // Do not show feature overlays in phases where they are removed.
+        case (_, .stats):
             fallthrough
-        case (.four, .appOpen):
+        case (_, .reader):
+            fallthrough
+        case (_, .notifications):
+            return false
+
+        // Phase Four: Show feature-collection overlays.
+        case (.four, _):
             return true
 
-        // New Users Phase: Show feature-collection overlays. Features are removed by this point so they are irrelevant.
+        // New Users Phase: Show feature-collection overlays.
         case (.newUsers, _):
             return true
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -47,6 +47,10 @@ class JetpackBrandingMenuCardPresenter {
             let description = Strings.phaseFourTitle
             let url = RemoteConfig(store: remoteConfigStore).phaseFourBlogPostUrl.value
             return .init(description: description, learnMoreButtonURL: url, type: .compact)
+        case .newUsers:
+            let description = Strings.newUsersPhaseTitle
+            let url = RemoteConfig(store: remoteConfigStore).phaseNewUsersBlogPostUrl.value
+            return .init(description: description, learnMoreButtonURL: url, type: .expanded)
         default:
             return nil
         }
@@ -70,6 +74,8 @@ class JetpackBrandingMenuCardPresenter {
         }
         switch phase {
         case .four:
+            fallthrough
+        case .newUsers:
             return true
         default:
             return false
@@ -184,5 +190,8 @@ private extension JetpackBrandingMenuCardPresenter {
         static let phaseFourTitle = NSLocalizedString("jetpack.menuCard.phaseFour.title",
                                                            value: "Switch to Jetpack",
                                                            comment: "Title of a button prompting users to switch to the Jetpack app.")
+        static let newUsersPhaseTitle = NSLocalizedString("jetpack.menuCard.newUsers.title",
+                                                           value: "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.",
+                                                           comment: "Description inside a menu card prompting users to switch to the Jetpack app.")
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -719,7 +719,6 @@ private extension WordPressAuthenticationManager {
         syncGroup.notify(queue: .main) {
             onCompletion()
         }
-
     }
 
     /// Synchronizes a WordPress.org account with the specified credentials.

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -691,6 +691,11 @@ private extension WordPressAuthenticationManager {
     private func syncWPCom(authToken: String, isJetpackLogin: Bool, onCompletion: @escaping () -> ()) {
         let service = WordPressComSyncService()
 
+        // Create a dispatch group to wait for both API calls.
+        let syncGroup = DispatchGroup()
+
+        // Sync account and blog
+        syncGroup.enter()
         service.syncWPCom(authToken: authToken, isJetpackLogin: isJetpackLogin, onSuccess: { account in
 
             /// HACK: An alternative notification to LoginFinished. Observe this instead of `WPSigninDidFinishNotification` for Jetpack logins.
@@ -699,14 +704,22 @@ private extension WordPressAuthenticationManager {
             let notification = isJetpackLogin == true ? .wordpressLoginFinishedJetpackLogin : Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification)
             NotificationCenter.default.post(name: notification, object: account)
 
-            // Refresh Remote Feature Flags
-            WordPressAppDelegate.shared?.updateFeatureFlags()
-
-            onCompletion()
-
+            syncGroup.leave()
         }, onFailure: { _ in
-            onCompletion()
+            syncGroup.leave()
         })
+
+        // Refresh Remote Feature Flags
+        syncGroup.enter()
+        WordPressAppDelegate.shared?.updateFeatureFlags(authToken: authToken, completion: {
+            syncGroup.leave()
+        })
+
+        // Sync done
+        syncGroup.notify(queue: .main) {
+            onCompletion()
+        }
+
     }
 
     /// Synchronizes a WordPress.org account with the specified credentials.

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -70,7 +70,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
 
         // Phase New Users
         remoteFeatureFlagsStore.removalPhaseNewUsers = true
-        XCTAssertFalse(presenter.shouldShowBottomCard())
+        XCTAssertTrue(presenter.shouldShowBottomCard())
     }
 
     func testPhaseThreeCardConfig() throws {


### PR DESCRIPTION
Closes #19453

## Description
This PR adds the menu card for new users. It also tweaks when the remote feature flags are updated. Instead of updating them after login is complete, we update it them during login, so they are always ready post-login. 

### Screenshots

| Light Mode | Dark Mode |
| - | - |
|![light](https://user-images.githubusercontent.com/25306722/211939006-feee84eb-e5fd-4822-b3db-211f8c60a150.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-12 at 01 26 27](https://user-images.githubusercontent.com/25306722/211939771-f05cb1df-9209-445c-aee1-1f4f5bec0071.png)|


## Pre-testing Instructions
- To disable the learn more button:
    - Go to `JetpackFullscreenOverlayGeneralViewModel.swift` line 183
    - Replace this line with `return nil`
    - This won't be needed in production since the learn more button will be disabled remotely by then
- To enable the new users phase on login (Not needed if using the [test account](https://github.com/wordpress-mobile/WordPress-iOS/pull/19894#issuecomment-1379622320))
    - Go to `FeatureFlag.swift` line 130
    - Replace this line with `return true`
    - Go to `FeatureFlag.swift` line 150
    - Replace this line with `return "dummy_key"`

## Testing Instructions

1. Fresh install the app
2. Log in
3. Choose any blog
4. You should eventually land on My Site
5. Make sure the overlay is displayed
6. Dismiss the overlay
7. Make sure the card is displayed and matches the design

## Regression Notes
1. Potential unintended areas of impact
Sign-in and sign-up flows

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.