### PR TITLE
Jetpack Focus: Remove Jetpack-powered site settings in phase 4

### DIFF
--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -556,7 +556,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureJetpackImageSettings:
             return [self supportsJetpackImageSettings];
         case BlogFeatureJetpackSettings:
-            return [self supportsRestApi] && ![self isHostedAtWPcom] && [self isAdmin];
+            return [self supportsJetpackSettings];
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
@@ -716,6 +716,14 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 - (BOOL)supportsEmbedVariation:(NSString *)requiredJetpackVersion
 {
     return [self hasRequiredJetpackVersion:requiredJetpackVersion] || self.isHostedAtWPcom;
+}
+
+- (BOOL)supportsJetpackSettings
+{
+    return [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled]
+    && [self supportsRestApi]
+    && ![self isHostedAtWPcom]
+    && [self isAdmin];
 }
 
 - (BOOL)accountIsDefaultAccount


### PR DESCRIPTION
Closes #19895

## Description
This PR removes the following site settings during phase 4:
- Jetpack -> Security
- Jetpack -> Manage Connection
- Related Posts
- Speed up your site

## Testing Instructions

### Normal Phase

1. Run the app
2. Open the debug menu and disable all "Jetpack Features Removal" flags
3. Switch to a normal site
4. Open Site settings
5. Make sure the "Related Posts" setting is displayed
6. Go back
7. Switch to a Self-hosted site
8. Make sure the following settings are displayed:
    - Jetpack -> Security
    - Jetpack -> Manage Connection
    - Related Posts
    - Speed up your site

### Phase Four

1. Run the app
2. Open the debug menu and enable "Jetpack Features Removal Phase Four"
3. Switch to a normal site
4. Open Site settings
5. Make sure the "Related Posts" setting is not displayed
6. Go back
7. Switch to a Self-hosted site
8. Make sure the following settings are not displayed:
    - Jetpack -> Security
    - Jetpack -> Manage Connection
    - Related Posts
    - Speed up your site

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.