### PR TITLE
Fix typo – "muti-author" to "multi-author"

### DIFF
--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -180,7 +180,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
         [self updateMultiAuthor:users forBlog:blogObjectID];
         dispatch_group_leave(syncGroup);
     } failure:^(NSError *error) {
-        DDLogError(@"Failed checking muti-author status for blog %@: %@", blog.url, error);
+        DDLogError(@"Failed checking multi-author status for blog %@: %@", blog.url, error);
         dispatch_group_leave(syncGroup);
     }];
 
@@ -273,7 +273,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
         [self updateMultiAuthor:users forBlog:blogObjectID];
         success();
     } failure:^(NSError *error) {
-        DDLogError(@"Failed checking muti-author status for blog %@: %@", blog.url, error);
+        DDLogError(@"Failed checking multi-author status for blog %@: %@", blog.url, error);
         failure(error);
     }];
 }


### PR DESCRIPTION
I noticed this while reading the encrypted logs in one of the tickets I worked on during my yearly support rotation.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
