### PR TITLE
Update "Skip for today" string

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -569,7 +569,7 @@ private extension DashboardPromptsCardCell {
             case .viewMore:
                 return NSLocalizedString("View more prompts", comment: "Menu title to show more prompts.")
             case .skip:
-                return NSLocalizedString("Skip this prompt", comment: "Menu title to skip today's prompt.")
+                return NSLocalizedString("Skip for today", comment: "Menu title to skip today's prompt.")
             case .remove:
                 return NSLocalizedString("Remove from dashboard", comment: "Destructive menu title to remove the prompt card from the dashboard.")
             case .learnMore:


### PR DESCRIPTION
Fixes #19889

To test:
- Launch and login JP.
- Tap 3 dot menu from Blogging Prompts
- Verify the skip text is now "Skip for today"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
