### PR TITLE
Stats: Make Views & Visitors, Total Likes, and Total Comments cards data consistent with the Web

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Charts/InsightsLineChart.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/InsightsLineChart.swift
@@ -83,9 +83,9 @@ class InsightsLineChart {
         var chartData = [LineChartData]()
 
         let thisWeekDataSet = LineChartDataSet(entries: thisWeekEntries,
-                label: NSLocalizedString("This Week", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart."))
+                label: NSLocalizedString("stats.insights.accessibility.label.viewsVisitorsLastDays", value: "Last 7-days", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart."))
         let prevWeekDataSet = LineChartDataSet(entries: prevWeekEntries,
-                label: NSLocalizedString("Previous Week", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart."))
+                label: NSLocalizedString("stats.insights.accessibility.label.viewsVisitorsPreviousDays", value: "Previous 7-days", comment: "Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart."))
         let viewsDataSets = [ thisWeekDataSet, prevWeekDataSet ]
         let viewsChartData = LineChartData(dataSets: viewsDataSets)
         chartData.append(viewsChartData)

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/SiteStatsImmuTableRows.swift
@@ -97,11 +97,23 @@ class SiteStatsImmuTableRows {
     }
 
     enum Constants {
-        static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
-        static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
-        static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
-        static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
-        static let viewsNoDifference = NSLocalizedString("Your views this week are the same as the previous week.\n", comment: "Stats insights label shown when the user's view count is the same as the previous week.")
-        static let visitorsNoDifference = NSLocalizedString("Your visitors this week are the same as the previous week.\n", comment: "Stats insights label shown when the user's visitor count is the same as the previous week.")
+        static let viewsHigher = NSLocalizedString("stats.insights.label.views.sevenDays.higher",
+                                                   value: "Your views in the last 7-days are %@ higher than the previous 7-days.\n",
+                                                   comment: "Stats insights views higher than previous 7 days")
+        static let viewsLower = NSLocalizedString("stats.insights.label.views.sevenDays.lower",
+                                                  value: "Your views in the last 7-days are %@ lower than the previous 7-days.\n",
+                                                  comment: "Stats insights views lower than previous 7 days")
+        static let visitorsHigher = NSLocalizedString("stats.insights.label.visitors.sevenDays.higher",
+                                                      value: "Your visitors in the last 7-days are %@ higher than the previous 7-days.\n",
+                                                      comment: "Stats insights visitors higher than previous 7 days")
+        static let visitorsLower = NSLocalizedString("stats.insights.label.visitors.sevenDays.lower",
+                                                     value: "Your visitors in the last 7-days are %@ lower than the previous 7-days.\n",
+                                                     comment: "Stats insights visitors lower than previous 7 days")
+        static let viewsNoDifference = NSLocalizedString("stats.insights.label.views.sevenDays.same",
+                                                         value: "Your views in the last 7-days are the same as the previous 7-days.\n",
+                                                         comment: "Stats insights label shown when the user's view count is the same as the previous 7 days.")
+        static let visitorsNoDifference = NSLocalizedString("stats.insights.label.visitors.sevenDays.same",
+                                                            value: "Your visitors in the last 7-days are the same as the previous 7-days.\n",
+                                                            comment: "Stats insights label shown when the user's visitor count is the same as the previous 7 days.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -47,6 +47,7 @@
                     .insightsTodaysStats,
                     .insightsPostingActivity,
                     .insightsTagsAndCategories,
+                    .insightsFollowersWordPress,
                     .insightsFollowersEmail,
                     .insightsPublicize]
         } else {

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -135,6 +135,11 @@ import Foundation
         let siteTimeZone = SiteStatsInformation.sharedInstance.siteTimeZone ?? .autoupdatingCurrent
         return Date().convert(from: siteTimeZone)
     }
+
+    class func yesterdayDateForSite() -> Date {
+        let components = DateComponents(day: -1)
+        return StatsDataHelper.calendar.date(byAdding: components, to: currentDateForSite()) ?? currentDateForSite()
+    }
 }
 
 fileprivate extension Date {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -22,7 +22,8 @@ class InsightsManagementViewController: UITableViewController {
     }
 
     private var insightsInactive: [StatSection] {
-        StatSection.allInsights.filter({ !self.insightsShown.contains($0) })
+        StatSection.allInsights
+            .filter({ !self.insightsShown.contains($0) && !InsightsManagementViewController.insightsNotSupportedForManagement.contains($0) })
     }
 
     private var hasChanges: Bool {
@@ -55,8 +56,9 @@ class InsightsManagementViewController: UITableViewController {
         self.init(style: FeatureFlag.statsNewAppearance.enabled ? .insetGrouped : .grouped)
         self.insightsDelegate = insightsDelegate
         self.insightsManagementDelegate = insightsManagementDelegate
-        self.insightsShown = insightsShown
-        self.originalInsightsShown = insightsShown
+        let insightsShownSupportedForManagement = insightsShown.filter { !InsightsManagementViewController.insightsNotSupportedForManagement.contains($0) }
+        self.insightsShown = insightsShownSupportedForManagement
+        self.originalInsightsShown = insightsShownSupportedForManagement
     }
 
     // MARK: - View
@@ -387,6 +389,15 @@ private extension InsightsManagementViewController {
                                  enabled: false,
                                  action: nil)
     }
+
+    /// Insight StatSections who share the same insightType are represented by a single card
+    /// Only display a single one of them for Insight Management
+    /// insightsCommentsPosts and insightsCommentsAuthors have the same insightType
+    /// insightsFollowersEmail and insightsFollowersWordpress have the same insightType
+    private static let insightsNotSupportedForManagement: [StatSection] = [
+        .insightsFollowersWordPress,
+        .insightsCommentsAuthors
+    ]
 
     // MARK: - Insights Categories
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -61,7 +61,9 @@ class SiteStatsInsightsViewModel: Observable {
         self.periodStore = periodStore
         let viewsCount = insightsStore.getAllTimeStats()?.viewsCount ?? 0
         self.itemToDisplay = pinnedItemStore?.itemToDisplay(for: viewsCount)
-        self.lastRequestedDate = StatsDataHelper.currentDateForSite()
+
+        // Exclude today's data for weekly insights
+        self.lastRequestedDate = StatsDataHelper.yesterdayDateForSite()
         self.lastRequestedPeriod = StatsPeriodUnit.day
 
         insightsChangeReceipt = self.insightsStore.onChange { [weak self] in

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -117,9 +117,9 @@ class StatsBaseCell: UITableViewCell {
             showDetailsButton.isHidden = false
 
             switch statSection {
-            case .insightsViewsVisitors, .insightsLikesTotals:
+            case .insightsViewsVisitors:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleThisWeek, for: .normal)
-            case .insightsFollowerTotals, .insightsCommentsTotals:
+            case .insightsFollowerTotals, .insightsCommentsTotals, .insightsLikesTotals:
                 showDetailsButton.setTitle(LocalizedText.buttonTitleViewMore, for: .normal)
             default:
                 showDetailsButton.setTitle("", for: .normal)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -376,8 +376,14 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
     private enum TextContent {
         static let differenceDelimiter = Character("*")
-        static let differenceHigher = NSLocalizedString("*%@%@ (%@%%)* higher than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
-        static let differenceLower = NSLocalizedString("*%@%@ (%@%%)* lower than the previous week", comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous week'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
-        static let differenceSame = NSLocalizedString("The same as the previous week", comment: "Label shown in Stats Insights when a metric is showing the same level as the previous week")
+        static let differenceHigher = NSLocalizedString("stats.insights.label.totalLikes.higher",
+                                                        value: "*%@%@ (%@%%)* higher than the previous 7-days",
+                                                        comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
+        static let differenceLower = NSLocalizedString("stats.insights.label.totalLikes.higher",
+                                                       value: "*%@%@ (%@%%)* lower than the previous 7-days",
+                                                       comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
+        static let differenceSame = NSLocalizedString("stats.insights.label.totalLikes.same",
+                                                      value: "The same as the previous 7-days",
+                                                      comment: "Label shown in Stats Insights when a metric is showing the same level as the previous 7 days")
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -112,13 +112,6 @@ struct StatsSegmentedControlData {
     var accessibilityValue: String? {
         return segmentDataStub != nil ? "" : "\(segmentData)"
     }
-
-    enum Constants {
-        static let viewsHigher = NSLocalizedString("Your views this week are %@ higher than the previous week.\n", comment: "Stats insights views higher than previous week")
-        static let viewsLower = NSLocalizedString("Your views this week are %@ lower than the previous week.\n", comment: "Stats insights views lower than previous week")
-        static let visitorsHigher = NSLocalizedString("Your visitors this week are %@ higher than the previous week.\n", comment: "Stats insights visitors higher than previous week")
-        static let visitorsLower = NSLocalizedString("Your visitors this week are %@ lower than the previous week.\n", comment: "Stats insights visitors lower than previous week")
-    }
 }
 
 
@@ -230,9 +223,9 @@ private extension ViewsVisitorsLineChartCell {
         previousData.adjustsFontSizeToFitWidth = true
         previousLabel.adjustsFontSizeToFitWidth = true
 
-        legendLatestLabel.text = NSLocalizedString("This week", comment: "This week legend label")
+        legendLatestLabel.text = NSLocalizedString("stats.insights.label.viewsVisitorsLastDays", value: "Last 7-days", comment: "Last 7-days legend label")
         legendLatestLabel.adjustsFontSizeToFitWidth = true
-        legendPreviousLabel.text = NSLocalizedString("Previous week", comment: "Previous week legend label")
+        legendPreviousLabel.text = NSLocalizedString("stats.insights.label.viewsVisitorsPreviousDays", value: "Previous 7-days", comment: "Previous 7-days legend label")
         legendPreviousLabel.adjustsFontSizeToFitWidth = true
     }
 


### PR DESCRIPTION
Fixes #19882

## Description

Calculate Views & Visitors, Total Likes, and Total Comments card data on Insights tab in a similar way as on the web, by excluding today. Also, remove ambiguity by renaming This week and Last week to Last 7-days and Previous 7-days which explains the numbers more accurately.

⚠️ Additionally fixing the issue, where `Followers` card would not open details. A regression from https://github.com/wordpress-mobile/WordPress-iOS/pull/19830. Explaining in the [commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/19900/commits/5d5fce760f0ad1503475a7c757b3761f0110abcd) and comment.

## Testing instructions

### Before all: 

Enable "New Appearance for Stats" and "New Cards for Stats Insights" feature flag

### Case 1: 
1. Navigate to Stats
2. Verify the titles on the Views and Visitors card read as Last 7-days and Previous 7-days
3. Verify that the graph for the Views and Visitors is displayed for the days excluding today
4. Verify Information below the graph uses the same like 7-days
5. Verify information on the Total Likes also reads like 7-days
6. Verify information on the Total Comments also reads 7-days and not Week
7. Also verify the Total count of Views, Visitors, Likes and Comments matches on the Web

## Regression Notes

1. Potential unintended areas of impact

Other cards start being represented in the wrong way when we switch to yesterday's date

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Code analysis. `lastRequestedDate` is only used for passing it to `periodStore` which is only used for those 3 cards.

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

<img width="375" alt="image" src="https://user-images.githubusercontent.com/4062343/212123207-dba8bd72-50c1-44c0-9c8b-cc203fdd0872.png">
<img width="371" alt="image" src="https://user-images.githubusercontent.com/4062343/212123048-2e3168c0-b9a4-47f8-9b01-65854bb858c2.png">
<img width="378" alt="image" src="https://user-images.githubusercontent.com/4062343/212123169-d3a98ace-caed-49e5-94bb-c00c6170b673.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/4062343/212123125-4e2ec5be-7208-417a-963d-3e9f5c41f04d.png">



