### PR TITLE
Jetpack Focus: Self-hosted removal phase implementation

### DIFF
--- a/WordPress/Classes/Models/Blog+Jetpack.swift
+++ b/WordPress/Classes/Models/Blog+Jetpack.swift
@@ -31,4 +31,24 @@ extension Blog {
         state.automatedTransfer = getOption(name: "is_automated_transfer") ?? false
         return state
     }
+
+    /// Returns true if the blog has the proper version of Jetpack installed,
+    /// otherwise false
+    ///
+    var hasJetpack: Bool {
+        guard let jetpack else {
+            return false
+        }
+        return (jetpack.isConnected && jetpack.isUpdatedToRequiredVersion)
+    }
+
+    /// Returns true if the blog has a version of the Jetpack plugin installed,
+    /// otherwise false
+    ///
+    var jetpackIsConnected: Bool {
+        guard let jetpack else {
+            return false
+        }
+        return jetpack.isConnected
+    }
 }

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -52,20 +52,20 @@ class RootViewCoordinator {
 
     /// Reload the UI if needed after the app has already been launched.
     /// - Returns: Boolean value describing whether the UI was reloaded or not.
-    func reloadUIIfNeeded() -> Bool {
+    func reloadUIIfNeeded(blog: Blog?) -> Bool {
         let newUIType: AppUIType = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() ? .normal : .simplified
         let oldUIType = currentAppUIType
         guard newUIType != oldUIType, let windowManager = WordPressAppDelegate.shared?.windowManager else {
             return false
         }
         currentAppUIType = newUIType
-        displayOverlay(using: windowManager)
+        displayOverlay(using: windowManager, blog: blog)
         reloadUI(using: windowManager)
         postUIReloadedNotification()
         return true
     }
 
-    private func displayOverlay(using windowManager: WindowManager) {
+    private func displayOverlay(using windowManager: WindowManager, blog: Blog?) {
         guard currentAppUIType == .simplified else {
             return
         }
@@ -78,6 +78,7 @@ class RootViewCoordinator {
                                                                  source: .appOpen,
                                                                  forced: true,
                                                                  fullScreen: true,
+                                                                 blog: blog,
                                                                  onWillDismiss: {
             viewController.removeBlurView()
         }, onDidDismiss: {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,6 +40,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackFeaturesRemovalPhaseThree
     case jetpackFeaturesRemovalPhaseFour
     case jetpackFeaturesRemovalPhaseNewUsers
+    case jetpackFeaturesRemovalPhaseSelfHosted
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -128,6 +129,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .jetpackFeaturesRemovalPhaseNewUsers:
             return false
+        case .jetpackFeaturesRemovalPhaseSelfHosted:
+            return false
         }
     }
 
@@ -148,6 +151,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "jp_removal_four"
         case .jetpackFeaturesRemovalPhaseNewUsers:
             return "jp_removal_new_users"
+        case .jetpackFeaturesRemovalPhaseSelfHosted:
+            return "jp_removal_self_hosted"
         case .jetpackMigrationPreventDuplicateNotifications:
             return "prevent_duplicate_notifs_remote_field"
             default:
@@ -246,6 +251,8 @@ extension FeatureFlag {
             return "Jetpack Features Removal Phase Four"
         case .jetpackFeaturesRemovalPhaseNewUsers:
             return "Jetpack Features Removal Phase For New Users"
+        case .jetpackFeaturesRemovalPhaseSelfHosted:
+            return "Jetpack Features Removal Phase For Self-Hosted Sites"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1039,9 +1039,9 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
 private extension MySiteViewController {
     @objc func displayOverlayIfNeeded() {
         if isViewOnScreen() {
-            let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded()
+            let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded(blog: self.blog)
             if !didReloadUI {
-                JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .appOpen)
+                JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .appOpen, blog: self.blog)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -11,6 +11,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         case three
         case four
         case newUsers
+        case selfHosted
 
         var frequencyConfig: JetpackOverlayFrequencyTracker.FrequencyConfig {
             switch self {
@@ -61,6 +62,10 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             return .normal // Always return normal for Jetpack
         }
 
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted),
+           AccountHelper.noWordPressDotComAccount {
+            return .selfHosted
+        }
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers) {
             return .newUsers
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -62,9 +62,10 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             return .normal // Always return normal for Jetpack
         }
 
-        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted),
-           AccountHelper.noWordPressDotComAccount {
-            return .selfHosted
+
+        if AccountHelper.noWordPressDotComAccount {
+            let selfHostedRemoval = featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted)
+            return selfHostedRemoval ? .selfHosted : .normal
         }
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers) {
             return .newUsers

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -131,18 +131,20 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     ///   - forced: Pass `true` to override the overlay frequency logic. Default is `false`.
     ///   - fullScreen: If `true` and not on iPad, the fullscreen modal presentation type is used.
     ///   Else the form sheet type is used. Default is `false`.
+    ///   - blog: `Blog` object used to determine if Jetpack is installed in case of the self-hosted phase.
     ///   - onWillDismiss: Callback block to be called when the overlay is about to be dismissed.
     ///   - onDidDismiss: Callback block to be called when the overlay has finished dismissing.
     static func presentOverlayIfNeeded(in viewController: UIViewController,
                                        source: OverlaySource,
                                        forced: Bool = false,
                                        fullScreen: Bool = false,
+                                       blog: Blog? = nil,
                                        onWillDismiss: JetpackOverlayDismissCallback? = nil,
                                        onDidDismiss: JetpackOverlayDismissCallback? = nil) {
         let phase = generalPhase()
         let frequencyConfig = phase.frequencyConfig
         let frequencyTrackerPhaseString = source.frequencyTrackerPhaseString(phase: phase)
-        var viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source)
+        var viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source, blog: blog)
         viewModel.onWillDismiss = onWillDismiss
         viewModel.onDidDismiss = onDidDismiss
         let frequencyTracker = JetpackOverlayFrequencyTracker(frequencyConfig: frequencyConfig,

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -116,7 +116,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
         switch generalPhase() {
-        case .four, .newUsers:
+        case .four, .newUsers, .selfHosted:
             return false
         default:
             return true

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -47,6 +47,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.newUsers, _):
             return true
 
+        // Self-Hosted Users Phase: Show feature-collection overlays.
         case (.selfHosted, _):
             return blog?.jetpackIsConnected ?? false
 
@@ -91,6 +92,9 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.newUsers, _):
             return Strings.NewUsers.generalTitle
 
+        // Self-Hosted
+        case (.selfHosted, _):
+            return Strings.SelfHosted.generalTitle
         default:
             return ""
         }
@@ -121,6 +125,11 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         // New Users
         case (.newUsers, _):
             return .init(string: Strings.NewUsers.subtitle)
+
+        // Self-Hosted
+        case (.selfHosted, _):
+            return .init(string: Strings.SelfHosted.subtitle)
+
         default:
             return .init(string: "")
         }
@@ -135,6 +144,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.reader, _):
             return Constants.readerLogoAnimationLtr
         case (_, .newUsers):
+            fallthrough
+        case (_, .selfHosted):
             return Constants.wpJetpackLogoAnimationLtr
         case (.card, _):
             fallthrough
@@ -154,6 +165,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.reader, _):
             return Constants.readerLogoAnimationRtl
         case (_, .newUsers):
+            fallthrough
+        case (_, .selfHosted):
             return Constants.wpJetpackLogoAnimationRtl
         case (.card, _):
             fallthrough
@@ -173,7 +186,11 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case .three:
             fallthrough
         case .four:
-            return Strings.PhaseTwoAndThree.footnote
+            fallthrough
+        case .newUsers:
+            fallthrough
+        case .selfHosted:
+            return Strings.General.footnote
         default:
             return nil
         }
@@ -191,6 +208,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
             return RemoteConfig().phaseFourBlogPostUrl.value
         case .newUsers:
             return RemoteConfig().phaseNewUsersBlogPostUrl.value
+        case .selfHosted:
+            return RemoteConfig().phaseSelfHostedBlogPostUrl.value
         default:
             return nil
         }
@@ -207,6 +226,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case .four:
             fallthrough
         case .newUsers:
+            fallthrough
+        case .selfHosted:
             return Strings.General.latePhasesSwitchButtonTitle
         default:
             return ""
@@ -325,6 +346,9 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let continueButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.general.continue.title",
                                                                value: "Continue without Jetpack",
                                                                comment: "Title of a button that dismisses an overlay that showcases the Jetpack app.")
+            static let footnote = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.footnote",
+                                                    value: "Switching is free and only takes a minute.",
+                                                    comment: "A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app.")
         }
 
         enum PhaseOne {
@@ -373,9 +397,6 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let fallbackSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseTwoAndThree.fallbackSubtitle",
                                                     value: "Stats, Reader, Notifications and other Jetpack powered features will be removed from the WordPress app soon.",
                                                     comment: "Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app.")
-            static let footnote = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.footnote",
-                                                    value: "Switching is free and only takes a minute.",
-                                                    comment: "A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app.")
         }
 
         enum PhaseThree {
@@ -406,6 +427,16 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.subtitle",
                                                                   value: "Jetpack lets you do more with your WordPress site. Switching is free and only takes a minute.",
                                                                   comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+        }
+
+        enum SelfHosted {
+            static let generalTitle = NSLocalizedString("jetpack.fullscreen.overlay.selfHosted.title",
+                                                        value: "Your site has the Jetpack plugin",
+                                                        comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+
+            static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.selfHosted.subtitle",
+                                                    value: "The Jetpack mobile app is designed to work in companion with the Jetpack plugin. Switch now to get access to stats, notifications, reader, and more.",
+                                                    comment: "Title of a screen that prompts the user to switch the Jetpack app.")
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -401,32 +401,32 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
 
         enum PhaseThree {
             static let generalTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseThree.general.title",
-                                                                  value: "Jetpack features are moving soon.",
-                                                                  comment: "Title of a screen that showcases the Jetpack app.")
+                                                        value: "Jetpack features are moving soon.",
+                                                        comment: "Title of a screen that showcases the Jetpack app.")
         }
 
         enum PhaseFour {
             static let generalTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseFour.title",
-                                                                  value: "Jetpack features have moved.",
-                                                                  comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+                                                        value: "Jetpack features have moved.",
+                                                        comment: "Title of a screen that prompts the user to switch the Jetpack app.")
 
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseFour.subtitle",
-                                                                  value: "Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app.",
-                                                                  comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+                                                    value: "Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app.",
+                                                    comment: "Title of a screen that prompts the user to switch the Jetpack app.")
 
             static let generalContinueButtonTitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseFour.general.continue.title",
-                                                                            value: "Do this later",
-                                                                            comment: "Title of a button that dismisses an overlay that prompts the user to switch the Jetpack app.")
+                                                                      value: "Do this later",
+                                                                      comment: "Title of a button that dismisses an overlay that prompts the user to switch the Jetpack app.")
         }
 
         enum NewUsers {
             static let generalTitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.title",
-                                                                  value: "Give WordPress a boost with Jetpack",
-                                                                  comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+                                                        value: "Give WordPress a boost with Jetpack",
+                                                        comment: "Title of a screen that prompts the user to switch the Jetpack app.")
 
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.subtitle",
-                                                                  value: "Jetpack lets you do more with your WordPress site. Switching is free and only takes a minute.",
-                                                                  comment: "Title of a screen that prompts the user to switch the Jetpack app.")
+                                                    value: "Jetpack lets you do more with your WordPress site. Switching is free and only takes a minute.",
+                                                    comment: "Title of a screen that prompts the user to switch the Jetpack app.")
         }
 
         enum SelfHosted {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -6,6 +6,7 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
 
     let phase: JetpackFeaturesRemovalCoordinator.GeneralPhase
     let source: JetpackFeaturesRemovalCoordinator.OverlaySource
+    let blog: Blog?
 
     var shouldShowOverlay: Bool {
         switch (phase, source) {
@@ -45,6 +46,9 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         // New Users Phase: Show feature-collection overlays.
         case (.newUsers, _):
             return true
+
+        case (.selfHosted, _):
+            return blog?.jetpackIsConnected ?? false
 
         default:
             return false

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -435,7 +435,7 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
                                                         comment: "Title of a screen that prompts the user to switch the Jetpack app.")
 
             static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.selfHosted.subtitle",
-                                                    value: "The Jetpack mobile app is designed to work in companion with the Jetpack plugin. Switch now to get access to stats, notifications, reader, and more.",
+                                                    value: "The Jetpack mobile app is designed to work in companion with the Jetpack plugin. Switch now to get access to Stats, Reader, Notifications and more.",
                                                     comment: "Title of a screen that prompts the user to switch the Jetpack app.")
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -16,7 +16,7 @@ extension BlogDetailsViewController {
         let row = BlogDetailsRow()
         row.callback = {
             let presenter = JetpackBrandingMenuCardPresenter(blog: self.blog)
-            JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .card)
+            JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .card, blog: self.blog)
             presenter.trackCardTapped()
         }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/BlogDetailsViewController+JetpackBrandingMenuCard.swift
@@ -3,19 +3,19 @@ import Foundation
 extension BlogDetailsViewController {
 
     @objc var shouldShowTopJetpackBrandingMenuCard: Bool {
-        let presenter = JetpackBrandingMenuCardPresenter()
+        let presenter = JetpackBrandingMenuCardPresenter(blog: self.blog)
         return presenter.shouldShowTopCard()
     }
 
     @objc var shouldShowBottomJetpackBrandingMenuCard: Bool {
-        let presenter = JetpackBrandingMenuCardPresenter()
+        let presenter = JetpackBrandingMenuCardPresenter(blog: self.blog)
         return presenter.shouldShowBottomCard()
     }
 
     @objc func jetpackCardSectionViewModel() -> BlogDetailsSection {
         let row = BlogDetailsRow()
         row.callback = {
-            let presenter = JetpackBrandingMenuCardPresenter()
+            let presenter = JetpackBrandingMenuCardPresenter(blog: self.blog)
             JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .card)
             presenter.trackCardTapped()
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -40,13 +40,9 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
 
     private lazy var containerStackView: UIStackView = {
         let stackView = UIStackView()
-        stackView.axis = stackViewAxis
         stackView.alignment = .fill
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = stackViewSpacing
-        stackView.directionalLayoutMargins = stackViewLayoutMargins
         stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.addArrangedSubviews(stackViewSubviews)
         return stackView
     }()
 
@@ -84,9 +80,6 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     private lazy var label: UILabel = {
         let label = UILabel()
         label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = labelFont
-        label.textColor = labelTextColor
-        label.numberOfLines = labelNumberOfLines
         label.adjustsFontForContentSizeCategory = true
         return label
     }()
@@ -153,25 +146,57 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         return button
     }()
 
+    // MARK: Initializers
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        commonInit()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    private func commonInit() {
+        addSubviews()
+    }
+
+    // MARK: Cell Lifecycle
+
+    override func prepareForReuse() {
+        containerStackView.removeAllSubviews()
+    }
+
     // MARK: Helpers
 
     private func configure() {
-        setupViews()
         setupContent()
+        applyStyles()
 
         presenter?.trackCardShown()
     }
 
-    private func setupViews() {
+    private func addSubviews() {
         contentView.addSubview(cardFrameView)
         contentView.pinSubviewToAllEdges(cardFrameView, priority: Metrics.cardFrameConstraintPriority)
         cardFrameView.add(subview: containerStackView)
     }
 
     private func setupContent() {
+        containerStackView.addArrangedSubviews(stackViewSubviews)
         logosAnimationView.currentProgress = 1.0
         label.text = config?.description
         learnMoreSuperview.isHidden = config?.learnMoreButtonURL == nil
+    }
+
+    private func applyStyles() {
+        containerStackView.axis = stackViewAxis
+        containerStackView.spacing = stackViewSpacing
+        containerStackView.directionalLayoutMargins = stackViewLayoutMargins
+        label.font = labelFont
+        label.textColor = labelTextColor
+        label.numberOfLines = labelNumberOfLines
     }
 
     // MARK: Actions

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -6,7 +6,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Private Variables
 
     private weak var viewController: BlogDetailsViewController?
-    private var presenter: JetpackBrandingMenuCardPresenter
+    private var presenter: JetpackBrandingMenuCardPresenter?
     private var config: JetpackBrandingMenuCardPresenter.Config?
 
     /// Sets the animation based on the language orientation
@@ -30,7 +30,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         if cardType == .expanded {
             frameView.configureButtonContainerStackView()
             frameView.onEllipsisButtonTap = { [weak self] in
-                self?.presenter.trackContexualMenuAccessed()
+                self?.presenter?.trackContexualMenuAccessed()
             }
             frameView.ellipsisButton.showsMenuAsPrimaryAction = true
             frameView.ellipsisButton.menu = contextMenu
@@ -148,35 +148,19 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         button.showsMenuAsPrimaryAction = true
         button.menu = contextMenu
         button.on([.touchUpInside, .menuActionTriggered]) { [weak self] _ in
-            self?.presenter.trackContexualMenuAccessed()
+            self?.presenter?.trackContexualMenuAccessed()
         }
         return button
     }()
 
-    // MARK: Initializers
+    // MARK: Helpers
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        presenter = JetpackBrandingMenuCardPresenter()
-        config = presenter.cardConfig()
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
-        commonInit()
-    }
-
-    required init?(coder: NSCoder) {
-        presenter = JetpackBrandingMenuCardPresenter()
-        config = presenter.cardConfig()
-        super.init(coder: coder)
-        commonInit()
-    }
-
-    private func commonInit() {
+    private func configure() {
         setupViews()
         setupContent()
 
-        presenter.trackCardShown()
+        presenter?.trackCardShown()
     }
-
-    // MARK: Helpers
 
     private func setupViews() {
         contentView.addSubview(cardFrameView)
@@ -202,7 +186,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         let webViewController = WebViewControllerFactory.controller(url: url, source: Constants.analyticsSource)
         let navController = UINavigationController(rootViewController: webViewController)
         viewController?.present(navController, animated: true)
-        presenter.trackLinkTapped()
+        presenter?.trackLinkTapped()
     }
 }
 
@@ -227,12 +211,12 @@ private extension JetpackBrandingMenuCardCell {
     // MARK: Actions
 
     private func remindMeLaterTapped() {
-        presenter.remindLaterTapped()
+        presenter?.remindLaterTapped()
         viewController?.reloadTableView()
     }
 
     private func hideThisTapped() {
-        presenter.hideThisTapped()
+        presenter?.hideThisTapped()
         viewController?.reloadTableView()
     }
 }
@@ -406,5 +390,8 @@ extension JetpackBrandingMenuCardCell {
     @objc(configureWithViewController:)
     func configure(with viewController: BlogDetailsViewController) {
         self.viewController = viewController
+        presenter = JetpackBrandingMenuCardPresenter(blog: viewController.blog)
+        config = presenter?.cardConfig()
+        configure()
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -30,7 +30,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         if cardType == .expanded {
             frameView.configureButtonContainerStackView()
             frameView.onEllipsisButtonTap = { [weak self] in
-                self?.presenter?.trackContexualMenuAccessed()
+                self?.presenter?.trackContextualMenuAccessed()
             }
             frameView.ellipsisButton.showsMenuAsPrimaryAction = true
             frameView.ellipsisButton.menu = contextMenu
@@ -141,7 +141,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         button.showsMenuAsPrimaryAction = true
         button.menu = contextMenu
         button.on([.touchUpInside, .menuActionTriggered]) { [weak self] _ in
-            self?.presenter?.trackContexualMenuAccessed()
+            self?.presenter?.trackContextualMenuAccessed()
         }
         return button
     }()
@@ -215,7 +215,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     }
 }
 
-// MARK: Contexual Menu
+// MARK: Contextual Menu
 
 private extension JetpackBrandingMenuCardCell {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -199,7 +199,7 @@ private extension JetpackBrandingMenuCardPresenter {
                                                            value: "Switch to Jetpack",
                                                            comment: "Title of a button prompting users to switch to the Jetpack app.")
         static let newUsersPhaseDescription = NSLocalizedString("jetpack.menuCard.newUsers.title",
-                                                                value: "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.",
+                                                                value: "Unlock your site’s full potential. Get Stats, Reader, Notifications and more with Jetpack.",
                                                                 comment: "Description inside a menu card prompting users to switch to the Jetpack app.")
         static let selfHostedPhaseDescription = newUsersPhaseDescription
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -54,6 +54,10 @@ class JetpackBrandingMenuCardPresenter {
             let description = Strings.newUsersPhaseDescription
             let url = RemoteConfig(store: remoteConfigStore).phaseNewUsersBlogPostUrl.value
             return .init(description: description, learnMoreButtonURL: url, type: .expanded)
+        case .selfHosted:
+            let description = Strings.selfHostedPhaseDescription
+            let url = RemoteConfig(store: remoteConfigStore).phaseSelfHostedBlogPostUrl.value
+            return .init(description: description, learnMoreButtonURL: url, type: .expanded)
         default:
             return nil
         }
@@ -66,6 +70,8 @@ class JetpackBrandingMenuCardPresenter {
         switch phase {
         case .three:
             return true
+        case .selfHosted:
+            return blog?.jetpackIsConnected ?? false
         default:
             return false
         }
@@ -196,5 +202,6 @@ private extension JetpackBrandingMenuCardPresenter {
         static let newUsersPhaseDescription = NSLocalizedString("jetpack.menuCard.newUsers.title",
                                                                 value: "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.",
                                                                 comment: "Description inside a menu card prompting users to switch to the Jetpack app.")
+        static let selfHostedPhaseDescription = newUsersPhaseDescription
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -15,6 +15,7 @@ class JetpackBrandingMenuCardPresenter {
 
     // MARK: Private Variables
 
+    private let blog: Blog?
     private let remoteConfigStore: RemoteConfigStore
     private let persistenceStore: UserPersistentRepository
     private let currentDateProvider: CurrentDateProvider
@@ -25,10 +26,12 @@ class JetpackBrandingMenuCardPresenter {
 
     // MARK: Initializers
 
-    init(remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
+    init(blog: Blog?,
+         remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
          featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
          persistenceStore: UserPersistentRepository = UserDefaults.standard,
          currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
+        self.blog = blog
         self.remoteConfigStore = remoteConfigStore
         self.persistenceStore = persistenceStore
         self.currentDateProvider = currentDateProvider

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -48,8 +48,7 @@ class JetpackBrandingMenuCardPresenter {
             return .init(description: description, learnMoreButtonURL: url, type: .expanded)
         case .four:
             let description = Strings.phaseFourTitle
-            let url = RemoteConfig(store: remoteConfigStore).phaseFourBlogPostUrl.value
-            return .init(description: description, learnMoreButtonURL: url, type: .compact)
+            return .init(description: description, learnMoreButtonURL: nil, type: .compact)
         case .newUsers:
             let description = Strings.newUsersPhaseDescription
             let url = RemoteConfig(store: remoteConfigStore).phaseNewUsersBlogPostUrl.value

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -124,7 +124,7 @@ extension JetpackBrandingMenuCardPresenter {
         WPAnalytics.track(.jetpackBrandingMenuCardTapped, properties: analyticsProperties)
     }
 
-    func trackContexualMenuAccessed() {
+    func trackContextualMenuAccessed() {
         WPAnalytics.track(.jetpackBrandingMenuCardContextualMenuAccessed, properties: analyticsProperties)
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -51,7 +51,7 @@ class JetpackBrandingMenuCardPresenter {
             let url = RemoteConfig(store: remoteConfigStore).phaseFourBlogPostUrl.value
             return .init(description: description, learnMoreButtonURL: url, type: .compact)
         case .newUsers:
-            let description = Strings.newUsersPhaseTitle
+            let description = Strings.newUsersPhaseDescription
             let url = RemoteConfig(store: remoteConfigStore).phaseNewUsersBlogPostUrl.value
             return .init(description: description, learnMoreButtonURL: url, type: .expanded)
         default:
@@ -193,8 +193,8 @@ private extension JetpackBrandingMenuCardPresenter {
         static let phaseFourTitle = NSLocalizedString("jetpack.menuCard.phaseFour.title",
                                                            value: "Switch to Jetpack",
                                                            comment: "Title of a button prompting users to switch to the Jetpack app.")
-        static let newUsersPhaseTitle = NSLocalizedString("jetpack.menuCard.newUsers.title",
-                                                           value: "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.",
-                                                           comment: "Description inside a menu card prompting users to switch to the Jetpack app.")
+        static let newUsersPhaseDescription = NSLocalizedString("jetpack.menuCard.newUsers.title",
+                                                                value: "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.",
+                                                                comment: "Description inside a menu card prompting users to switch to the Jetpack app.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -31,16 +31,6 @@ class JetpackLoginViewController: UIViewController {
     @IBOutlet private var tacButton: UIButton!
     @IBOutlet private var faqButton: UIButton!
 
-    /// Returns true if the blog has the proper version of Jetpack installed,
-    /// otherwise false
-    ///
-    fileprivate var hasJetpack: Bool {
-        guard let jetpack = blog.jetpack else {
-            return false
-        }
-        return (jetpack.isConnected && jetpack.isUpdatedToRequiredVersion)
-    }
-
     // MARK: - Initializers
 
     /// Required initializer for JetpackLoginViewController
@@ -136,11 +126,11 @@ class JetpackLoginViewController: UIViewController {
         descriptionLabel.sizeToFit()
 
         installJetpackButton.setTitle(Constants.Buttons.jetpackInstallTitle, for: .normal)
-        installJetpackButton.isHidden = hasJetpack
+        installJetpackButton.isHidden = blog.hasJetpack
         installJetpackButton.contentEdgeInsets = UIEdgeInsets(top: 12, left: 20, bottom: 12, right: 20)
 
         signinButton.setTitle(Constants.Buttons.loginTitle, for: .normal)
-        signinButton.isHidden = !hasJetpack
+        signinButton.isHidden = !blog.hasJetpack
 
         let paragraph = NSMutableParagraphStyle(minLineHeight: WPStyleGuide.fontSizeForTextStyle(.footnote),
                                                 lineBreakMode: .byWordWrapping,

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -145,7 +145,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let config = try XCTUnwrap(presenter.cardConfig())
 
         // Then
-        XCTAssertEqual(config.description, "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.")
+        XCTAssertEqual(config.description, "Unlock your site’s full potential. Get Stats, Reader, Notifications and more with Jetpack.")
         XCTAssertEqual(config.learnMoreButtonURL, "example.com")
         XCTAssertEqual(config.type, .expanded)
     }
@@ -166,7 +166,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let config = try XCTUnwrap(presenter.cardConfig())
 
         // Then
-        XCTAssertEqual(config.description, "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.")
+        XCTAssertEqual(config.description, "Unlock your site’s full potential. Get Stats, Reader, Notifications and more with Jetpack.")
         XCTAssertEqual(config.learnMoreButtonURL, "example.com")
         XCTAssertEqual(config.type, .expanded)
     }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WordPress
 
-final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
+final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
     private var mockUserDefaults: InMemoryUserDefaults!
     private var remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
@@ -9,13 +9,21 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
     private var currentDateProvider: MockCurrentDateProvider!
 
     override func setUp() {
+        contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
         currentDateProvider = MockCurrentDateProvider()
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+    }
+
+    override func tearDown() {
+        UserSettings.defaultDotComUUID = nil
     }
 
     func testShouldShowTopCardBasedOnPhase() {
         // Given
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults)
 
@@ -46,6 +54,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
     func testShouldShowBottomCardBasedOnPhase() {
         // Given
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults)
 
@@ -76,6 +85,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
     func testPhaseThreeCardConfig() throws {
         // Given
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults)
@@ -93,6 +103,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
     func testHidingTheMenuCard() {
         // Given
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults)
         remoteFeatureFlagsStore.removalPhaseThree = true
@@ -109,6 +120,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
         let secondsInDay = TimeInterval(86_400)
         let currentDate = Date()
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults,
             currentDateProvider: currentDateProvider)
@@ -128,6 +140,7 @@ final class JetpackBrandingMenuCardPresenterTests: XCTestCase {
         let secondsInSevenDays = TimeInterval(86_400 * 4)
         let currentDate = Date()
         let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults,
             currentDateProvider: currentDateProvider)

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -98,6 +98,44 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         // Then
         XCTAssertEqual(config.description, "Stats, Reader, Notifications and other features will move to the Jetpack mobile app soon.")
         XCTAssertEqual(config.learnMoreButtonURL, "example.com")
+        XCTAssertEqual(config.type, .expanded)
+    }
+
+    func testPhaseFourCardConfig() throws {
+        // Given
+        let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
+            remoteConfigStore: remoteConfigStore,
+            featureFlagStore: remoteFeatureFlagsStore,
+            persistenceStore: mockUserDefaults)
+        remoteFeatureFlagsStore.removalPhaseFour = true
+
+        // When
+        let config = try XCTUnwrap(presenter.cardConfig())
+
+        // Then
+        XCTAssertEqual(config.description, "Switch to Jetpack")
+        XCTAssertNil(config.learnMoreButtonURL)
+        XCTAssertEqual(config.type, .compact)
+    }
+
+    func testPhaseNewUsersCardConfig() throws {
+        // Given
+        let presenter = JetpackBrandingMenuCardPresenter(
+            blog: nil,
+            remoteConfigStore: remoteConfigStore,
+            featureFlagStore: remoteFeatureFlagsStore,
+            persistenceStore: mockUserDefaults)
+        remoteFeatureFlagsStore.removalPhaseNewUsers = true
+        remoteConfigStore.phaseNewUsersBlogPostUrl = "example.com"
+
+        // When
+        let config = try XCTUnwrap(presenter.cardConfig())
+
+        // Then
+        XCTAssertEqual(config.description, "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.")
+        XCTAssertEqual(config.learnMoreButtonURL, "example.com")
+        XCTAssertEqual(config.type, .expanded)
     }
 
     func testHidingTheMenuCard() {

--- a/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingTextProviderTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WordPress
 
-final class JetpackBrandingTextProviderTests: XCTestCase {
+final class JetpackBrandingTextProviderTests: CoreDataTestCase {
 
     // MARK: Private Variables
 
@@ -17,9 +17,16 @@ final class JetpackBrandingTextProviderTests: XCTestCase {
     // MARK: Setup
 
     override func setUp() {
+        contextManager.useAsSharedInstance(untilTestFinished: self)
         remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
         currentDateProvider = MockCurrentDateProvider()
         remoteConfigStore.removalDeadline = "2022-10-10"
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+    }
+
+    override func tearDown() {
+        UserSettings.defaultDotComUUID = nil
     }
 
     // MARK: Tests

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -1,12 +1,19 @@
 import XCTest
 @testable import WordPress
 
-final class JetpackFeaturesRemovalCoordinatorTests: XCTestCase {
+final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
 
     private var mockUserDefaults: InMemoryUserDefaults!
 
     override func setUp() {
+        contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
+        let account = AccountBuilder(contextManager).build()
+        UserSettings.defaultDotComUUID = account.uuid
+    }
+
+    override func tearDown() {
+        UserSettings.defaultDotComUUID = nil
     }
 
     // MARK: General Phase Tests

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -75,6 +75,35 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .newUsers)
     }
 
+    func testSelfHostedGeneralPhase() {
+        // Given
+        UserSettings.defaultDotComUUID = nil
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: true)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.update(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .selfHosted)
+    }
+
+    func testGeneralPhaseIfSelfHostedIsEnabledWhileLoggedIn() {
+        // Given
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: true)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.update(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .one)
+    }
+
     func testGeneralPhaseOne() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -32,6 +32,21 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .normal)
     }
 
+    func testReturnNormalPhaseForLoggedOutUsers() {
+        // Given
+        UserSettings.defaultDotComUUID = nil
+        let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
+        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let remote = MockFeatureFlagRemote(flags: flags)
+        store.update(using: remote)
+
+        // When
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store)
+
+        // Then
+        XCTAssertEqual(phase, .normal)
+    }
+
     func testNewUsersGeneralPhase() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)

--- a/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/WordPress/WordPressTest/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -21,7 +21,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testNormalGeneralPhase() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -36,7 +36,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         // Given
         UserSettings.defaultDotComUUID = nil
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -50,7 +50,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testNewUsersGeneralPhase() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -64,7 +64,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testNewUsersGeneralPhasePrecedence() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: true)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: true, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -78,7 +78,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseOne() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -92,7 +92,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseTwo() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -106,7 +106,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseTwoPrecedence() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -120,7 +120,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseThree() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -134,7 +134,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseThreePrecedence() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -148,7 +148,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseFour() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -162,7 +162,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testGeneralPhaseFourPrecedence() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -178,7 +178,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
     func testNormalSiteCreationPhase() {
         // Given
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
-        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        let flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
 
@@ -194,7 +194,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
 
         // When
-        var flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        var flags = generateFlags(phaseOne: true, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -203,7 +203,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .one)
 
         // When
-        flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false)
+        flags = generateFlags(phaseOne: false, phaseTwo: true, phaseThree: false, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         remote.flags = flags
         store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -212,7 +212,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .one)
 
         // When
-        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false)
+        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: true, phaseFour: false, phaseNewUsers: false, phaseSelfHosted: false)
         remote.flags = flags
         store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -226,7 +226,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
 
         // When
-        var flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false)
+        var flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: true, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -235,7 +235,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .two)
 
         // When
-        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true)
+        flags = generateFlags(phaseOne: false, phaseTwo: false, phaseThree: false, phaseFour: false, phaseNewUsers: true, phaseSelfHosted: false)
         remote.flags = flags
         store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -249,7 +249,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         let store = RemoteFeatureFlagStore(persistenceStore: mockUserDefaults)
 
         // When
-        var flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false)
+        var flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: true, phaseNewUsers: false, phaseSelfHosted: false)
         let remote = MockFeatureFlagRemote(flags: flags)
         store.update(using: remote)
         var phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -258,7 +258,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
         XCTAssertEqual(phase, .two)
 
         // When
-        flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: true)
+        flags = generateFlags(phaseOne: true, phaseTwo: true, phaseThree: true, phaseFour: false, phaseNewUsers: true, phaseSelfHosted: false)
         remote.flags = flags
         store.update(using: remote)
         phase = JetpackFeaturesRemovalCoordinator.siteCreationPhase(featureFlagStore: store)
@@ -298,13 +298,15 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
                                phaseTwo: Bool,
                                phaseThree: Bool,
                                phaseFour: Bool,
-                               phaseNewUsers: Bool) -> [WordPressKit.FeatureFlag] {
+                               phaseNewUsers: Bool,
+                               phaseSelfHosted: Bool) -> [WordPressKit.FeatureFlag] {
         return [
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseOne.remoteKey ?? "", value: phaseOne),
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseTwo.remoteKey ?? "", value: phaseTwo),
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseThree.remoteKey ?? "", value: phaseThree),
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseFour.remoteKey ?? "", value: phaseFour),
             .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.remoteKey ?? "", value: phaseNewUsers),
+            .init(title: FeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted.remoteKey ?? "", value: phaseSelfHosted),
         ]
     }
 }

--- a/WordPress/WordPressTest/RemoteConfigStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteConfigStoreMock.swift
@@ -5,6 +5,7 @@ class RemoteConfigStoreMock: RemoteConfigStore {
 
     var phaseThreeBlogPostUrl: String?
     var removalDeadline: String?
+    var phaseNewUsersBlogPostUrl: String?
 
     override func value(for key: String) -> Any? {
         if key == "phase_three_blog_post" {
@@ -12,6 +13,9 @@ class RemoteConfigStoreMock: RemoteConfigStore {
         }
         if key == "jp_deadline" {
             return removalDeadline
+        }
+        if key == "phase_new_users_blog_post" {
+            return phaseNewUsersBlogPostUrl
         }
         return super.value(for: key)
     }

--- a/WordPress/WordPressTest/RemoteConfigStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteConfigStoreMock.swift
@@ -6,6 +6,7 @@ class RemoteConfigStoreMock: RemoteConfigStore {
     var phaseThreeBlogPostUrl: String?
     var removalDeadline: String?
     var phaseNewUsersBlogPostUrl: String?
+    var phaseSelfHostedBlogPostUrl: String?
 
     override func value(for key: String) -> Any? {
         if key == "phase_three_blog_post" {
@@ -16,6 +17,9 @@ class RemoteConfigStoreMock: RemoteConfigStore {
         }
         if key == "phase_new_users_blog_post" {
             return phaseNewUsersBlogPostUrl
+        }
+        if key == "phase_self_hosted_blog_post" {
+            return phaseSelfHostedBlogPostUrl
         }
         return super.value(for: key)
     }

--- a/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
@@ -8,6 +8,7 @@ class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
     var removalPhaseThree = false
     var removalPhaseFour = false
     var removalPhaseNewUsers = false
+    var removalPhaseSelfHosted = false
 
     override func value(for flag: OverrideableFlag) -> Bool {
         guard let flag = flag as? WordPress.FeatureFlag else {
@@ -24,6 +25,8 @@ class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
             return removalPhaseFour
         case .jetpackFeaturesRemovalPhaseNewUsers:
             return removalPhaseNewUsers
+        case .jetpackFeaturesRemovalPhaseSelfHosted:
+            return removalPhaseSelfHosted
         default:
             return super.value(for: flag)
         }


### PR DESCRIPTION
Closes #19592
Ref: pe7hp4-4k-p2

## Description
This PR configures the app experience for self-hosted users if the self-hosted removal flag is enabled. It adds the menu card and displays the relevant overlay. Also removes the Jetpack features. 

### Screenshots

| Menu Card | Overlay |
| - | - |
|![card](https://user-images.githubusercontent.com/25306722/212101987-c0802e9b-b927-4f61-9c25-1e366665111a.png)|![overlay](https://user-images.githubusercontent.com/25306722/212101999-f84347b9-a083-4e6b-92be-6ecf72895f38.png)|

## Testing prerequisites
- A self-hosted test site with the Jetpack plugin (Site A)
- A WPCOM account connected to Site A
- A self-hosted test site without Jetpack (Site B)

## Testing Instructions

### Jetpack Site with flag disabled

1. Fresh install the app
2. Sign into Site A
3. Make sure an overlay is not displayed 
4. Make sure the tab bar and stats are displayed normally
5. Make sure a menu card is not displayed

### Basic Site with flag enabled

1. Fresh install the app
2. Log in with any account
3. Open the debug menu and enable "Jetpack Features Removal For Self-Hosted Sites"
4. Logout
5. Sign into Site B
6. Make sure an overlay is not displayed 
7. Make sure a menu card is not displayed
8. Make sure the tab bar and stats are removed

### Jetpack Site with flag enabled

1. Fresh install the app
2. Log in with any account
3. Open the debug menu and enable "Jetpack Features Removal For Self-Hosted Sites"
4. Logout
5. Sign into Site A
6. Make sure an overlay is displayed 
7. Make sure a menu card is displayed
8. Make sure the tab bar and stats are removed

### Logged in to user account with flag enabled

1. Fresh install the app
2. Log in with any account
3. Open the debug menu and enable "Jetpack Features Removal For Self-Hosted Sites"
4. Logout
5. Sign in to the WPCOM account connected to Site A
6. Choose Site A
7. Make sure an overlay is not displayed 
8. Make sure the tab bar and stats are displayed normally
9. Make sure a menu card is not displayed

## Regression Notes
1. Potential unintended areas of impact
Phase 3 and 4 menu card

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.