### PR TITLE
Add blogging prompts enhancements feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -3,6 +3,7 @@
 @objc
 enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case bloggingPrompts
+    case bloggingPromptsEnhancements
     case jetpackDisconnect
     case debugMenu
     case readerCSS
@@ -50,6 +51,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         switch self {
         case .bloggingPrompts:
             return AppConfiguration.isJetpack
+        case .bloggingPromptsEnhancements:
+            return false
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
         case .debugMenu:
@@ -172,6 +175,8 @@ extension FeatureFlag {
         switch self {
         case .bloggingPrompts:
             return "Blogging Prompts"
+        case .bloggingPromptsEnhancements:
+            return "Blogging Prompts Enhancements"
         case .jetpackDisconnect:
             return "Jetpack disconnect"
         case .debugMenu:


### PR DESCRIPTION
Closes #19903 

## Testing

To test:

- Install Jetpack and login
- Tap on Me
- Tap on App Settings
- Tap on Debug
- Verify the feature flag is in the list

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
