### PR TITLE
Jetpack Focus: Correctly configure learn more buttons

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -206,10 +206,6 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
             return RemoteConfig().phaseThreeBlogPostUrl.value
         case .four:
             return RemoteConfig().phaseFourBlogPostUrl.value
-        case .newUsers:
-            return RemoteConfig().phaseNewUsersBlogPostUrl.value
-        case .selfHosted:
-            return RemoteConfig().phaseSelfHostedBlogPostUrl.value
         default:
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -187,7 +187,6 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         containerStackView.addArrangedSubviews(stackViewSubviews)
         logosAnimationView.currentProgress = 1.0
         label.text = config?.description
-        learnMoreSuperview.isHidden = config?.learnMoreButtonURL == nil
     }
 
     private func applyStyles() {
@@ -202,15 +201,13 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     // MARK: Actions
 
     @objc private func learnMoreButtonTapped() {
-        guard let config = config,
-              let urlString = config.learnMoreButtonURL,
-              let url = URL(string: urlString) else {
+        guard let viewController else {
             return
         }
 
-        let webViewController = WebViewControllerFactory.controller(url: url, source: Constants.analyticsSource)
-        let navController = UINavigationController(rootViewController: webViewController)
-        viewController?.present(navController, animated: true)
+        JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: viewController,
+                                                                 source: .card,
+                                                                 blog: viewController.blog)
         presenter?.trackLinkTapped()
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -9,7 +9,6 @@ class JetpackBrandingMenuCardPresenter {
         }
 
         let description: String
-        let learnMoreButtonURL: String?
         let type: CardType
     }
 
@@ -44,19 +43,16 @@ class JetpackBrandingMenuCardPresenter {
         switch phase {
         case .three:
             let description = Strings.phaseThreeDescription
-            let url = RemoteConfig(store: remoteConfigStore).phaseThreeBlogPostUrl.value
-            return .init(description: description, learnMoreButtonURL: url, type: .expanded)
+            return .init(description: description, type: .expanded)
         case .four:
             let description = Strings.phaseFourTitle
-            return .init(description: description, learnMoreButtonURL: nil, type: .compact)
+            return .init(description: description, type: .compact)
         case .newUsers:
             let description = Strings.newUsersPhaseDescription
-            let url = RemoteConfig(store: remoteConfigStore).phaseNewUsersBlogPostUrl.value
-            return .init(description: description, learnMoreButtonURL: url, type: .expanded)
+            return .init(description: description, type: .expanded)
         case .selfHosted:
             let description = Strings.selfHostedPhaseDescription
-            let url = RemoteConfig(store: remoteConfigStore).phaseSelfHostedBlogPostUrl.value
-            return .init(description: description, learnMoreButtonURL: url, type: .expanded)
+            return .init(description: description, type: .expanded)
         default:
             return nil
         }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -109,7 +109,6 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
         // Then
         XCTAssertEqual(config.description, "Stats, Reader, Notifications and other features will move to the Jetpack mobile app soon.")
-        XCTAssertEqual(config.learnMoreButtonURL, "example.com")
         XCTAssertEqual(config.type, .expanded)
     }
 
@@ -127,7 +126,6 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
         // Then
         XCTAssertEqual(config.description, "Switch to Jetpack")
-        XCTAssertNil(config.learnMoreButtonURL)
         XCTAssertEqual(config.type, .compact)
     }
 
@@ -146,7 +144,6 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
         // Then
         XCTAssertEqual(config.description, "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.")
-        XCTAssertEqual(config.learnMoreButtonURL, "example.com")
         XCTAssertEqual(config.type, .expanded)
     }
 
@@ -167,7 +164,6 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
         // Then
         XCTAssertEqual(config.description, "Unlock your site’s full potential. Get stats, notifications and more with Jetpack.")
-        XCTAssertEqual(config.learnMoreButtonURL, "example.com")
         XCTAssertEqual(config.type, .expanded)
     }
 


### PR DESCRIPTION
Ref: p1673545326946679-slack-C04564QS0V7

## Description
This PR does two things:
* Removes the learn more button from the self-hosted and new-users overlays.
* Makes tapping the learn more button of the menu card open up the overlay instead of opening up a link.

## Testing Instructions

### Phase 3

1. Run the app
2. Open the debug menu and enable "Jetpack Features Removal Phase Three"
3. Navigate to My Site
4. Tap on the learn more button in the card
5. Make sure the overlay is displayed
6. Make sure the overlay contains a learn more button

### New Users

1. Run the app
2. Open the debug menu and enable "Jetpack Features Removal For New Users"
3. Navigate to My Site
4. Tap on the learn more button in the card
5. Make sure the overlay is displayed
6. Make sure the overlay does not contain a learn more button

### Self-Hosted

1. Run the app
2. Open the debug menu and enable "Jetpack Features Removal For Self-Hosted Sites"
3. Navigate to My Site
4. Tap on the learn more button in the card
5. Make sure the overlay is displayed
6. Make sure the overlay does not contain a learn more button

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.