### PR TITLE
Stats Revamp: Enable feature flags on Jetpack

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 21.6
 -----
 * [*] Fix a layout issue impacting the "No media matching your search" empty state message of the Media Picker screen.  [#19820]
+* [***] [Jetpack-only] Stats Insights Update. Helps you understand how your content is performing and what’s resonating with your audience. [#19909]
 
 21.5
 -----

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -22,6 +22,6 @@ import Foundation
     @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
-    @objc static let showsStatsRevampV2: Bool = false
+    @objc static let showsStatsRevampV2: Bool = true
     @objc static let qrLoginEnabled: Bool = true
 }


### PR DESCRIPTION
## Description

- Enabled feature flags for [Stats Revamp project](https://github.com/orgs/wordpress-mobile/projects/126) on Jetpack app 
- Updated release notes, [used Android as an example](https://github.com/wordpress-mobile/WordPress-Android/blob/07adff02655c972e92259bccb1e2f9449b691d89/RELEASE-NOTES.txt#L102)

## Testing instructions

### Case 1 - No changes on WordPress:
1. Launch WordPress
2. Open Stats
3. Open Insights tab
4. Older Stats should appear

### Case 2 - Changes on Jetpack:
1. Launch Jetpack
2. Open Stats
3. Open Insights tab
5. Newer Stats should appear

### Case 3 - New Cards:
1. Launch Jetpack
2. Open Stats
3. Open Insights tab
5. Click gear icon on top right
6. "Add new insight card view" is opened
7. Add "Views & Visitors", "Total Likes", and "Total Comments" cards
9. Confirm they appear in the same place as added in the "Add new insight card view"
10. Click "View More / Week" button on the card
11. Confirm details view is opened

### Case 4 - All cards - visual representation:
1. Launch Jetpack
2. Open Stats
3. Open Insights tab
4. Click gear icon on top right
5. Add all available cards
6. Observe how the cards look and if there aren't any visual glitches
7. Change accessibility font sizes
8. Observe how the cards look and if there aren't any visual glitches
9. Switch between dark/light mode
10. Observe how the cards look and if there aren't any visual glitches

### Case 5 - No internet connection"
1. Launch Jetpack
2. Open Stats
3. Open Insights tab
4. Click gear icon on top right
5. Add all available cards
6. Allow data to load
7. Come back to the main screen
8. Turn off internet connection on the phone
9. Reopen Stats
10. Previously loaded data should be shown

### Case 6 - Comparing data with the web
1. Launch Jetpack
2. Open Stats
3. Open Insights tab
4. Click gear icon on top right
5. Add "Views & Visitors", "Total Likes", and "Total Comments"
6. Compare the numbers with the web stats for the given dates
7. Open details view by tapping "View More/ Week"
8. Compare the numbers with the web stats for the given dates

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.




