### PR TITLE
Jetpack Focus: Allow deactivating Jetpack when JP features are removed from WordPress 

### DIFF
--- a/WordPress/Classes/Models/Plugin.swift
+++ b/WordPress/Classes/Models/Plugin.swift
@@ -12,6 +12,13 @@ struct Plugin: Equatable {
         return state.name
     }
 
+    var deactivateAllowed: Bool {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return true
+        }
+        return state.deactivateAllowed
+    }
+
     static func ==(lhs: Plugin, rhs: Plugin) -> Bool {
         return lhs.state == rhs.state
             && lhs.directoryEntry == rhs.directoryEntry

--- a/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/PluginViewModel.swift
@@ -296,7 +296,7 @@ class PluginViewModel: Observable {
 
     private func activeRow(plugin: Plugin?) -> ImmuTableRow? {
         guard let activationPlugin = plugin,
-            activationPlugin.state.deactivateAllowed else { return nil }
+              activationPlugin.deactivateAllowed else { return nil }
 
         return SwitchRow(
             title: NSLocalizedString("Active", comment: "Whether a plugin is active on a site"),
@@ -327,8 +327,9 @@ class PluginViewModel: Observable {
 
     private func removeRow(plugin: Plugin?, capabilities: SitePluginCapabilities?) -> ImmuTableRow? {
         guard let pluginToRemove = plugin,
-            let siteCapabilities = capabilities,
-            siteCapabilities.modify && pluginToRemove.state.deactivateAllowed else { return nil }
+              let siteCapabilities = capabilities,
+              siteCapabilities.modify,
+              pluginToRemove.deactivateAllowed else { return nil }
 
         return  DestructiveButtonRow(
             title: NSLocalizedString("Remove Plugin", comment: "Button to remove a plugin from a site"),
@@ -339,10 +340,10 @@ class PluginViewModel: Observable {
             accessibilityIdentifier: "remove-plugin")
     }
 
-    private func settingsLinkRow(state: PluginState?) -> ImmuTableRow? {
-        guard let pluginState = state,
-            let settingsURL = pluginState.settingsURL,
-            pluginState.deactivateAllowed == true  else {
+    private func settingsLinkRow(plugin: Plugin?) -> ImmuTableRow? {
+        guard let plugin,
+              let settingsURL = plugin.state.settingsURL,
+              plugin.deactivateAllowed == true  else {
                 return nil
         }
 
@@ -445,7 +446,7 @@ class PluginViewModel: Observable {
         let active = activeRow(plugin: plugin)
         let autoupdates = autoUpdatesRow(plugin: plugin, capabilities: capabilities)
 
-        let settingsLink = settingsLinkRow(state: plugin?.state)
+        let settingsLink = settingsLinkRow(plugin: plugin)
         let wpOrgPluginLink = wpOrgLinkRow(directoryEntry: directoryEntry, state: plugin?.state)
         let homeLink = homeLinkRow(state: plugin?.state)
 


### PR DESCRIPTION
Closes #19847 

## Description
This PR allows removing or deactivating the Jetpack plugin on a self-hosted site from the WordPress app during the self-hosted phase. The old behavior is maintained in earlier phases and in the Jetpack app. 

## Testing Instructions

### Jetpack app

1. Run the JP app
2. Sign into a self-hosted site that has the Jetpack plugin.
3. Navigate to Plugins > Jetpack
4. Make sure there isn't an option to deactivate the plugin
5. Make sure there isn't an option to remove the plugin

### WordPress app normal phase

1. Run the WP app
2. Open the debug menu and disable all "Jetpack Features Removal" flags
3. Sign into a self-hosted site that has the Jetpack plugin.
4. Navigate to Plugins > Jetpack
5. Make sure there isn't an option to deactivate the plugin
6. Make sure there isn't an option to remove the plugin

### WordPress app self-hosted phase

1. Run the WP app
2. Open the debug menu and enable "Jetpack Features Removal For Self-Hosted Sites"
3. Sign into a self-hosted site that has the Jetpack plugin.
4. Navigate to Plugins > Jetpack
5. Make sure there is an option to deactivate the plugin
6. Make sure there is an option to remove the plugin

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.