### PR TITLE
Blogging Prompts: Allow selecting a prompt from the prompts list view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -11,7 +11,7 @@ class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var answersToStateSeparatorDot: UILabel!
     @IBOutlet private weak var answeredStateLabel: UILabel!
 
-    private var prompt: BloggingPrompt?
+    private(set) var prompt: BloggingPrompt?
 
     private let dateFormatter: DateFormatter = {
         let formatter = DateFormatter()

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.xib
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,50 +17,49 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9EJ-O9-rUs" userLabel="Title Label">
-                        <rect key="frame" x="16" y="10" width="336" height="17"/>
+                        <rect key="frame" x="16" y="10" width="336" height="20.5"/>
                         <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillProportionally" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="NgJ-e1-8mj" userLabel="Prompt Information Stack View">
-                        <rect key="frame" x="16" y="29" width="336" height="28"/>
+                        <rect key="frame" x="16" y="32.5" width="336" height="24.5"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ing-nT-4vc" userLabel="Date Label">
-                                <rect key="frame" x="0.0" y="0.0" width="26.5" height="28"/>
+                                <rect key="frame" x="0.0" y="0.0" width="28.5" height="24.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hFE-3l-xA6" userLabel="Separator Dot">
-                                <rect key="frame" x="32.5" y="0.0" width="4" height="28"/>
+                                <rect key="frame" x="34.5" y="0.0" width="4" height="24.5"/>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="99 answers" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZmC-VB-tZs" userLabel="Answer Count Label">
-                                <rect key="frame" x="42.5" y="0.0" width="65.5" height="28"/>
+                                <rect key="frame" x="44.5" y="0.0" width="69.5" height="24.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                 <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hLQ-2r-lrL" userLabel="Answered State View">
-                                <rect key="frame" x="114" y="0.0" width="222" height="28"/>
+                                <rect key="frame" x="120" y="0.0" width="216" height="24.5"/>
                                 <subviews>
                                     <label userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jxn-g5-OtR" userLabel="Separator Dot">
-                                        <rect key="frame" x="0.0" y="7" width="4" height="14.5"/>
+                                        <rect key="frame" x="0.0" y="4.5" width="4" height="16"/>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="TopLeft" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Answered" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MGq-ZW-fgb" userLabel="Answered State Label">
-                                        <rect key="frame" x="10" y="0.0" width="212" height="28"/>
+                                        <rect key="frame" x="10" y="0.0" width="206" height="24.5"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                         <color key="textColor" white="0.33333333329999998" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="MGq-ZW-fgb" secondAttribute="trailing" id="68Y-Hc-DBg"/>
                                     <constraint firstItem="Jxn-g5-OtR" firstAttribute="leading" secondItem="hLQ-2r-lrL" secondAttribute="leading" id="Lmu-jA-SLi"/>
@@ -96,9 +94,4 @@
             <point key="canvasLocation" x="198.55072463768118" y="133.59375"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -66,6 +66,7 @@ private extension BloggingPromptsViewController {
                            forCellReuseIdentifier: BloggingPromptTableViewCell.defaultReuseID)
 
         tableView.accessibilityIdentifier = "Blogging Prompts List"
+        tableView.allowsSelection = FeatureFlag.bloggingPromptsEnhancements.enabled
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
     }
@@ -155,6 +156,25 @@ extension BloggingPromptsViewController: UITableViewDataSource, UITableViewDeleg
 
         cell.configure(prompt)
         return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard FeatureFlag.bloggingPromptsEnhancements.enabled,
+              let blog,
+              let cell = tableView.cellForRow(at: indexPath) as? BloggingPromptTableViewCell,
+              let prompt = cell.prompt else {
+            return
+        }
+
+        if prompt.answered {
+            // TODO: We are still figuring out what should be done when the prompt is already answered
+        } else {
+            let editor = EditPostViewController(blog: blog, prompt: prompt)
+            editor.modalPresentationStyle = .fullScreen
+            editor.entryPoint = .bloggingPromptsListView
+            present(editor, animated: true)
+        }
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptsViewController.swift
@@ -167,14 +167,10 @@ extension BloggingPromptsViewController: UITableViewDataSource, UITableViewDeleg
             return
         }
 
-        if prompt.answered {
-            // TODO: We are still figuring out what should be done when the prompt is already answered
-        } else {
-            let editor = EditPostViewController(blog: blog, prompt: prompt)
-            editor.modalPresentationStyle = .fullScreen
-            editor.entryPoint = .bloggingPromptsListView
-            present(editor, animated: true)
-        }
+        let editor = EditPostViewController(blog: blog, prompt: prompt)
+        editor.modalPresentationStyle = .fullScreen
+        editor.entryPoint = .bloggingPromptsListView
+        present(editor, animated: true)
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -157,4 +157,5 @@ enum PostEditorEntryPoint: String {
     case bloggingPromptsActionSheetHeader = "add_new_sheet_answer_prompt"
     case bloggingPromptsNotification = "blogging_reminders_notification_answer_prompt"
     case bloggingPromptsDashboardCard = "my_site_card_answer_prompt"
+    case bloggingPromptsListView = "blogging_prompts_list_view"
 }


### PR DESCRIPTION
Closes #19890 

## Description

On the blogging prompts list view, enables tapping on the cells to answer prompts. Allowing for users to answer older prompts than the current day's prompt.

## Testing 

**With the feature flag disabled**

- Set the `bloggingPromptsEnhancements` feature flag to `false`
- Install Jetpack and login
- Tap on the three dots on the blogging prompts dashboard card
- Tap on "View more prompts"
- Verify no cell is selectable

**With the feature flag enabled**

- Set the `bloggingPromptsEnhancements` feature flag to `true`
- Install Jetpack and login
- Choose a public site that has blogging prompts
- Tap on the three dots on the blogging prompts dashboard card
- Tap on "View more prompts"
- Tap on an unanswered prompt
- Verify the editor appears with the prompt
- Publish the post
- Refresh the status of the prompt (I just closed and reopened the app)
- Verify the prompt you published is answered

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
