### PR TITLE
Jetpack Focus: Fix overlay's subtitle font not adjusting to the current size category

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -170,6 +170,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     private func setupFonts() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
         titleLabel.adjustsFontForContentSizeCategory = true
+        subtitleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         subtitleLabel.adjustsFontForContentSizeCategory = true
         footnoteLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         footnoteLabel.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
Fixes #19914  

## Description
This PR fixes an issue where the overlay's subtitle wasn't adjusting to size category changes.

## Screenshots
|Before|After|
|-|-|
|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 02 44 15](https://user-images.githubusercontent.com/25306722/212785903-246b9fd0-2c0b-4d2a-983d-41a8b00a89ef.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-01-17 at 02 39 15](https://user-images.githubusercontent.com/25306722/212785551-7f2d988e-ccc2-4c30-b2d2-7ac2c8a40b0f.png)|

## Testing Instructions

1. Fresh Install the app
2. Open the debug menu and enable "Jetpack Features Removal Phase One"
3. Navigate to Stats
4. The overlay should be displayed
5. Change the font size from Xcode's Environment Overrides
6. Make sure that the subtitle adjusts to the new font size
7. [Optional] Repeat the above steps for the rest of the phases. 

## Regression Notes
1. Potential unintended areas of impact
The subtitle for phases 2 and 3 since they were already adjusting to size category changes.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.