### PR TITLE
Jetpack: Refresh the analytics metadata after successful import from WordPress

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [**] [internal] Disable Story posts when Jetpack features are removed [#19823]
 * [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
 * [**] [internal] Disable StockPhoto and Tenor media sources when Jetpack features are removed [#19826]
+* [*] [Jetpack-only] Fixed a bug where analytics calls weren't synced to the user account. [#19926]
 
 21.4
 -----

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Analytics/MigrationAnalyticsTracker.swift
@@ -33,6 +33,8 @@ struct MigrationAnalyticsTracker {
     }
 
     func trackContentImportSucceeded() {
+        /// Refresh the account metadata so subsequent analytics calls are linked to the user.
+        WPAnalytics.refreshMetadata()
         self.track(.contentImportSucceeded)
     }
 


### PR DESCRIPTION
Fixes #19929

## Description
This PR refreshes the analytics metadata after a successful import from the WordPress app. 

When the Jetpack (and WordPress) app is initially started in an unauthenticated state, it sends events anonymously. Once the app is authenticated the event trackers are "refreshed" to pick up the account details. We need to do the same after importing the user's account and data from WordPress, otherwise events will continue to be sent anonymously.

## Testing

1. Clean install the WordPress app and authenticate.
2. Clean install the Jetpack app.
3. From WordPress, initiate a migration by tapping on a Jetpack badge or banner.
4. **Expect** to see the full migration event flow for the user in the Tracks tool.

Events for the user should be similar to:

**Note:** This isn't an exhaustive list as we're not testing which events are fired and in what order - we're just confirming that the entire migration flow is logged for the user.

1. `wpios_signed_in`
2. `wpios_application_closed`
3. `jpios_migration_content_import_succeeded`
4. `jpios_migration_welcome_screen_shown`
5. `jpios_migration_thanks_screen_shown`
6. `jpios_migration_thanks_screen_finish_button_tapped`
7. `jpios_migration_please_delete_wordpress_card_shown`

<details><summary>Programmatic testing steps</summary>

1. Add a breakpoint to `TracksService:139` in the `Automattic-Tracks-iOS` pod
8. Observe the values for `self.username` and `self.isAnonymous`

After the import has successfully taken place at `JetpackWindowManager.swift:41`, these values should be updated to the username and `NO` respectively.
</details>

## Regression Notes
1. Potential unintended areas of impact
    - This should be isolated to the Jetpack app only

9. What I did to test those areas of impact (or what existing automated tests I relied on)
    - Checked 

10. What automated tests I added (or what prevented me from doing so)
    - None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
