### PR TITLE
Replace `DomainsService.context` with `CoreDataStack`

### DIFF
--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -22,7 +22,7 @@ extension BlogService {
             return
         }
 
-        let service = DomainsService(managedObjectContext: managedObjectContext, account: account)
+        let service = DomainsService(coreDataStack: ContextManager.shared, account: account)
 
         service.refreshDomains(siteID: siteID) { result in
             switch result {

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -81,7 +81,7 @@ private extension DomainSuggestion {
     // Used to help with testing
     init(managedObjectContext context: NSManagedObjectContext, api: WordPressComRestApi) {
         let remoteService = DomainsServiceRemote(wordPressComRestApi: api)
-        self.domainsService = DomainsService(managedObjectContext: context, remote: remoteService)
+        self.domainsService = DomainsService(coreDataStack: ContextManager.shared, remote: remoteService)
         super.init(managedObjectContext: context)
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsServiceProxy.swift
@@ -70,7 +70,7 @@ class RegisterDomainDetailsServiceProxy: RegisterDomainDetailsServiceProxyProtoc
     }()
 
     private lazy var domainService = {
-        DomainsService(managedObjectContext: context, remote: domainsServiceRemote)
+        DomainsService(coreDataStack: ContextManager.shared, remote: domainsServiceRemote)
     }()
 
     private lazy var domainsServiceRemote = {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/DomainSuggestionsTableViewController.swift
@@ -138,7 +138,7 @@ class DomainSuggestionsTableViewController: UITableViewController {
         let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)
         let api = account?.wordPressComRestApi ?? WordPressComRestApi.defaultApi(oAuthToken: "")
 
-        let service = DomainsService(managedObjectContext: ContextManager.sharedInstance().mainContext, remote: DomainsServiceRemote(wordPressComRestApi: api))
+        let service = DomainsService(coreDataStack: ContextManager.sharedInstance(), remote: DomainsServiceRemote(wordPressComRestApi: api))
 
         SVProgressHUD.setContainerView(tableView)
         SVProgressHUD.show(withStatus: NSLocalizedString("Loading domains", comment: "Shown while the app waits for the domain suggestions web service to return during the site creation process."))

--- a/WordPress/WordPressTest/DomainsServiceTests.swift
+++ b/WordPress/WordPressTest/DomainsServiceTests.swift
@@ -19,6 +19,7 @@ class DomainsServiceTests: CoreDataTestCase {
         let api = WordPressComRestApi(oAuthToken: "")
         remote = DomainsServiceRemote(wordPressComRestApi: api)
         testBlog = makeTestBlog()
+        contextManager.saveContextAndWait(mainContext)
     }
 
     override func tearDown() {
@@ -64,7 +65,7 @@ class DomainsServiceTests: CoreDataTestCase {
 
     fileprivate func fetchDomains() {
         let expect = expectation(description: "Domains fetch complete expectation")
-        let service = DomainsService(managedObjectContext: mainContext, remote: remote)
+        let service = DomainsService(coreDataStack: contextManager, remote: remote)
         service.refreshDomains(siteID: testBlog.dotComID!.intValue) { result in
             expect.fulfill()
         }


### PR DESCRIPTION
Use `CoreDataStack` instead of `NSManagedObjectContext` in `DomainsService`. See the "Issue" and "Proposal" sections of https://github.com/wordpress-mobile/WordPress-iOS/pull/19893 for rational behind this change.

## Test Instructions

On Jetpack app, go to "Domains" screen from the "My sites" tab, verify domains can be loaded and displayed on screen.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
