### PR TITLE
Blogging Prompts: Add a new prompt tag with the prompt ID

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -13,6 +13,10 @@ extension Post {
         } else {
             tags = Strings.promptTag
         }
+
+        if FeatureFlag.bloggingPromptsEnhancements.enabled {
+            tags?.append(", \(Strings.promptTag)-\(prompt.promptID)")
+        }
     }
 
     private struct Strings {


### PR DESCRIPTION
Closes #19901 

## Description

Adds a new tag to prompt posts with a format of `dailyprompt-{prompt_id}`.

## Testing

To test:
- Set the feature flag `bloggingPromptsEnhancements` to `true`
- Install Jetpack and login
- Select a blog which has blogging prompts
- On the prompts dashboard card, tap on `Answer Prompt`
- In the editor, tap on the three dots in the top right corner
- Tap on `Post Settings`
- Tap on `Tags`
- Verify both `dailyprompt` and `dailyprompt-{prompt_id}` are in the tags

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
