### PR TITLE
Jetpack Focus: Update phase property names to use snake_case style

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -10,8 +10,8 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         case two
         case three
         case four
-        case newUsers
-        case selfHosted
+        case newUsers = "new_users"
+        case selfHosted = "self_hosted"
 
         var frequencyConfig: JetpackOverlayFrequencyTracker.FrequencyConfig {
             switch self {


### PR DESCRIPTION
Ref: pbArwn-5Le-p2#comment-7218
## Description
This PR changes the following property values for the removal phase property:
* `newUsers` -> `new_users`
* `selfHosted` -> `self_hosted` 

## Testing Instructions
Given the simplicity of the changes introduced, no testing is required. However, you can optionally test the following:

1. Run the app
2. Login
3. Open the debug menu and enable "Jetpack Features Removal For New Users"
4. Navigate to My Site
5. Close and re-open the app
6. Tap on the menu card
7. Check the logs for the `remove_feature_card_tapped` event and make sure the value for phase is `new_users`
8. Do the same for the self-hosted phase

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.