### PR TITLE
added .insightsFollowerTotals to case for followers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Fix a layout issue impacting the "No media matching your search" empty state message of the Media Picker screen.  [#19820]
 * [***] [Jetpack-only] Stats Insights Update. Helps you understand how your content is performing and what’s resonating with your audience. [#19909]
+* [*] [Jetpack-only] Fixed an issue where Stats Followers details did not update on Pull-to-refresh in the Stats Followers Details screen [#19935]
 
 21.5
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -212,7 +212,7 @@ private extension SiteStatsInsightsDetailsTableViewController {
         refreshControl.beginRefreshing()
 
         switch statSection {
-        case .insightsFollowersWordPress, .insightsFollowersEmail:
+        case .insightsFollowersWordPress, .insightsFollowersEmail, .insightsFollowerTotals:
             viewModel?.refreshFollowers()
         case .insightsCommentsAuthors, .insightsCommentsPosts:
             viewModel?.refreshComments()


### PR DESCRIPTION
This PR fixes an issue where pull to refresh was not updating the followers data on the Total Followers Details screen

Fixes #19912

To test:
1. Launch the JetPack iOS app.
2. On the web, follow your selected site with a different WP account.
3. Navigate to Stats.
4. Open the Total Followers detail screen by tapping the "View more" button on the Total Followers card.
5. On the Web, unfollow your selected site.
6. Pull to Refresh the Total Followers detail screen. The total followers data count should have updated

## Regression Notes 
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
