### PR TITLE
Jetpack Focus: Fix site creation flow not being triggered after JP overlay is dismissed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog List/BlogListViewController+SiteCreation.swift
@@ -2,7 +2,7 @@ extension BlogListViewController {
     @objc
     func launchSiteCreation() {
         let source = "my_sites"
-        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onWillDismiss: {
+        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onDidDismiss: {
             guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -706,7 +706,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     func launchSiteCreation(source: String) {
-        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onWillDismiss: {
+        JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: self, source: source, onDidDismiss: {
             guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -387,7 +387,7 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
 
         epilogueViewController.onCreateNewSite = {
             let source = "login_epilogue"
-            JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: navigationController, source: source, onWillDismiss: {
+            JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: navigationController, source: source, onDidDismiss: {
                 guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
                     return
                 }


### PR DESCRIPTION
Fixes #19936  

## Description
This PR fixes an issue where the site creation flow doesn't get triggered after the user dismisses the fullscreen overlay. This affects users in phases one, two, and three. 

## Testing Instructions

### Site List flow

1. Open the app
2. Open the debug menu and enable "Jetpack Features Removal Phase One"
3. Navigate to the Sites list
4. Tap plus button
5. Tap "Create WordPress.com site"
6. Make sure an overlay is displayed with a continue button visible
7. Dismiss the overlay
8. Make sure the site creation flow starts

### Login flow

1. Open the app
2. Open the debug menu and enable "Jetpack Features Removal Phase One"
3. Logout
4. Login using any method
5. Tap "Create a new site"
6. Make sure an overlay is displayed with a continue button visible
7. Dismiss the overlay
8. Make sure the site creation flow starts

### Signup flow

1. Open the app
2. Open the debug menu and enable "Jetpack Features Removal Phase One"
3. Logout
4. Sign up for a new account
5. Tap "Create a new site"
6. Make sure an overlay is displayed with a continue button visible
7. Dismiss the overlay
8. Make sure the site creation flow starts

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.