### PR TITLE
Jetpack Focus: Fix double ellipsis buttons in the phase 4 menu card

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -210,6 +210,10 @@ class BlogDashboardCardFrameView: UIView {
         ])
     }
 
+    func removeButtonContainerStackView() {
+        buttonContainerStackView.removeFromSuperview()
+    }
+
     private func updateColors() {
         ellipsisButton.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardCell.swift
@@ -26,15 +26,6 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.hideHeader()
-
-        if cardType == .expanded {
-            frameView.configureButtonContainerStackView()
-            frameView.onEllipsisButtonTap = { [weak self] in
-                self?.presenter?.trackContextualMenuAccessed()
-            }
-            frameView.ellipsisButton.showsMenuAsPrimaryAction = true
-            frameView.ellipsisButton.menu = contextMenu
-        }
         return frameView
     }()
 
@@ -173,6 +164,7 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
     private func configure() {
         setupContent()
         applyStyles()
+        configureCardFrame()
 
         presenter?.trackCardShown()
     }
@@ -196,6 +188,21 @@ class JetpackBrandingMenuCardCell: UITableViewCell {
         label.font = labelFont
         label.textColor = labelTextColor
         label.numberOfLines = labelNumberOfLines
+    }
+
+    private func configureCardFrame() {
+        if cardType == .expanded {
+            cardFrameView.configureButtonContainerStackView()
+            cardFrameView.onEllipsisButtonTap = { [weak self] in
+                self?.presenter?.trackContextualMenuAccessed()
+            }
+            cardFrameView.ellipsisButton.showsMenuAsPrimaryAction = true
+            cardFrameView.ellipsisButton.menu = contextMenu
+        }
+        else {
+            cardFrameView.removeButtonContainerStackView()
+            cardFrameView.onEllipsisButtonTap = nil
+        }
     }
 
     // MARK: Actions


### PR DESCRIPTION
Fixes #19934

## Description
This PR fixes an issue where the switch to Jetpack card during phase 4 displays two ellipsis buttons.

## Testing Instructions

Open the app
Open the debug menu and enable "Jetpack Features Removal Phase Four"
Navigate to My Site
Refresh the menu
A compact card should be displayed
Make sure there's only one ellipsis button displayed on the card

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.