### PR TITLE
WPAuthenticator - Remove custom step value from `GetStartedViewController`

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -233,9 +233,9 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  # pod 'WordPressAuthenticator', '~> 5.0'
+  pod 'WordPressAuthenticator', '~> 5.1.0-beta.1'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
-  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'bf6681f979ea3edbc07021130cfc0f4644138575'
+  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
   # 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile
+++ b/Podfile
@@ -233,9 +233,9 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 5.0'
+  # pod 'WordPressAuthenticator', '~> 5.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
-  # pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => ''
+  pod 'WordPressAuthenticator', :git => 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', :commit => 'bf6681f979ea3edbc07021130cfc0f4644138575'
   # 'WordPressAuthenticator', :path => '../WordPressAuthenticator-iOS'
 
   pod 'MediaEditor', '~> 1.2.1'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -609,7 +609,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `bf6681f979ea3edbc07021130cfc0f4644138575`)
+  - WordPressAuthenticator (~> 5.1.0-beta.1)
   - WordPressKit (~> 5.0)
   - WordPressShared (~> 2.0.1-beta.1)
   - WordPressUI (~> 1.12.5)
@@ -619,6 +619,8 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
+  https://github.com/wordpress-mobile/cocoapods-specs.git:
+    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AlamofireImage
@@ -773,9 +775,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.87.1
-  WordPressAuthenticator:
-    :commit: bf6681f979ea3edbc07021130cfc0f4644138575
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.87.1/third-party-podspecs/Yoga.podspec.json
 
@@ -791,9 +790,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.87.1
-  WordPressAuthenticator:
-    :commit: bf6681f979ea3edbc07021130cfc0f4644138575
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -880,7 +876,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 95f698805ebbbe86c5721ce244e1302ea810326b
+  WordPressAuthenticator: b4df3148e7a7c1ad739bcbe6cc7b5ce728a1b15d
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 5ba89467f7ba468c023c441045bb70b4933ff6d4
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -896,6 +892,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: b85278c4ad365f23abe43e51514ad4d1c334a2dc
+PODFILE CHECKSUM: e08eecc6737d45cb8b10dc6626062ec4edadf6c9
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -502,7 +502,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
     - WordPress-Aztec-iOS (= 1.19.8)
-  - WordPressAuthenticator (5.0.0):
+  - WordPressAuthenticator (5.1.0-beta.1):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -609,7 +609,7 @@ DEPENDENCIES:
   - Starscream (= 3.0.6)
   - SVProgressHUD (= 2.2.5)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 5.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `bf6681f979ea3edbc07021130cfc0f4644138575`)
   - WordPressKit (~> 5.0)
   - WordPressShared (~> 2.0.1-beta.1)
   - WordPressUI (~> 1.12.5)
@@ -619,8 +619,6 @@ DEPENDENCIES:
   - ZIPFoundation (~> 0.9.8)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
   trunk:
     - Alamofire
     - AlamofireImage
@@ -775,6 +773,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.87.1
+  WordPressAuthenticator:
+    :commit: bf6681f979ea3edbc07021130cfc0f4644138575
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.87.1/third-party-podspecs/Yoga.podspec.json
 
@@ -790,6 +791,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.87.1
+  WordPressAuthenticator:
+    :commit: bf6681f979ea3edbc07021130cfc0f4644138575
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -876,7 +880,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 0cdf1bff75bd3f58fe733d6457221f27bbbdc9f4
+  WordPressAuthenticator: 95f698805ebbbe86c5721ce244e1302ea810326b
   WordPressKit: 202f529323b079a344f7bc1493b7ebebfd9ed4b5
   WordPressShared: 5ba89467f7ba468c023c441045bb70b4933ff6d4
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -892,6 +896,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 42b08cc7024f28711cc5eecbb6ec28f3219c4020
+PODFILE CHECKSUM: b85278c4ad365f23abe43e51514ad4d1c334a2dc
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
- [x] ⚠️  @selanthiraiyan Release WPAuthenticator pod and update podfile.

Fixes https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/723
Related to: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/724

## Description

A previous update made to WordPress Authenticator changed the `step` value of an analytics event from `GetStartedViewController`. This started impacting the looker dashboard of WordPress Mobile.

To fix it, we have created a configuration flag and moved the `step` value change behind it. 

More details [here](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/723)

This PR updates the WordPress Authenticator pod to the latest release to revert the `step` value change.

## Testing Instructions

- Install and launch the app.
- Tap on "Log in or sign up with WordPress.com" button
- You will land in the `GetStartedViewController` (Ref screenshot below)
- <img src="https://user-images.githubusercontent.com/524475/213078882-e9a47bf2-801c-4a6d-ad9a-f6e3664ca4c1.png" width="320"/>
- Check the Xcode console and ensure that the following event is tracked
```
Tracked: unified_login_step <flow: wordpress_com, source: default, step: start>
```
- Note that the step value is `start` and not `enter_email_address` anymore

## Regression Notes
1. Potential unintended areas of impact
NA

2. What I did to test those areas of impact (or what existing automated tests I relied on)
NA

3. What automated tests I added (or what prevented me from doing so)
NA

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
