### PR TITLE
Remove context from people service

### DIFF
--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -11,7 +11,7 @@ struct PeopleService {
 
     // MARK: - Private Properties
     ///
-    fileprivate let context: NSManagedObjectContext
+    private let coreDataStack: CoreDataStack
     fileprivate let remote: PeopleServiceRemote
 
 
@@ -21,14 +21,14 @@ struct PeopleService {
     ///     - blog: Target Blog Instance
     ///     - context: CoreData context to be used.
     ///
-    init?(blog: Blog, context: NSManagedObjectContext) {
+    init?(blog: Blog, coreDataStack: CoreDataStack) {
         guard let api = blog.wordPressComRestApi(), let dotComID = blog.dotComID as? Int else {
             return nil
         }
 
         self.remote = PeopleServiceRemote(wordPressComRestApi: api)
         self.siteID = dotComID
-        self.context = context
+        self.coreDataStack = coreDataStack
     }
 
     /// Loads a page of Users associated to the current blog, starting at the specified offset.
@@ -41,9 +41,11 @@ struct PeopleService {
     ///
     func loadUsersPage(_ offset: Int = 0, count: Int = 20, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void), failure: ((Error) -> Void)? = nil) {
         remote.getUsers(siteID, offset: offset, count: count, success: { users, hasMore in
-            self.mergePeople(users)
-            success(users.count, hasMore)
-
+            coreDataStack.performAndSave { context in
+                self.mergePeople(users, in: context)
+            } completion: {
+                success(users.count, hasMore)
+            }
         }, failure: { error in
             DDLogError(String(describing: error))
             failure?(error)
@@ -60,8 +62,11 @@ struct PeopleService {
     ///
     func loadFollowersPage(_ offset: Int = 0, count: Int = 20, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void), failure: ((Error) -> Void)? = nil) {
         remote.getFollowers(siteID, offset: offset, count: count, success: { followers, hasMore in
-            self.mergePeople(followers)
-            success(followers.count, hasMore)
+            coreDataStack.performAndSave { context in
+                self.mergePeople(followers, in: context)
+            } completion: {
+                success(followers.count, hasMore)
+            }
         }, failure: { error in
             DDLogError(String(describing: error))
             failure?(error)
@@ -82,8 +87,11 @@ struct PeopleService {
                                 failure: ((Error) -> Void)? = nil) {
         let page = (offset / count) + 1
         remote.getEmailFollowers(siteID, page: page, max: count, success: { followers, hasMore in
-            self.mergePeople(followers)
-            success(followers.count, hasMore)
+            self.coreDataStack.performAndSave { context in
+                self.mergePeople(followers, in: context)
+            } completion: {
+                success(followers.count, hasMore)
+            }
         }, failure: { error in
             DDLogError(String(describing: error))
             failure?(error)
@@ -100,9 +108,11 @@ struct PeopleService {
     ///
     func loadViewersPage(_ offset: Int = 0, count: Int = 20, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void), failure: ((Error) -> Void)? = nil) {
         remote.getViewers(siteID, offset: offset, count: count, success: { viewers, hasMore in
-            self.mergePeople(viewers)
-            success(viewers.count, hasMore)
-
+            self.coreDataStack.performAndSave { context in
+                self.mergePeople(viewers, in: context)
+            } completion: {
+                success(viewers.count, hasMore)
+            }
         }, failure: { error in
             DDLogError(String(describing: error))
             failure?(error)
@@ -119,33 +129,47 @@ struct PeopleService {
     /// - Returns: A new Person instance, with the new Role already assigned.
     ///
     func updateUser(_ user: User, role: String, failure: ((Error, User) -> Void)?) -> User {
-        guard let managedPerson = managedPersonFromPerson(user) else {
-            return user
+        var pristineRole: String?
+        var updated: User?
+        coreDataStack.performAndSave { context in
+            guard let managedPerson = managedPersonFromPerson(user, in: context) else {
+                return
+            }
+
+            // OP Reversal
+            pristineRole = managedPerson.role
+
+            // Pre-emptively update the role
+            managedPerson.role = role
+
+            updated = User(managedPerson: managedPerson)
         }
 
-        // OP Reversal
-        let pristineRole = managedPerson.role
+        // Early exit if failed to update the user
+        guard let updated else {
+            return user
+        }
 
         // Hit the Backend
         remote.updateUserRole(siteID, userID: user.ID, newRole: role, success: nil, failure: { error in
 
             DDLogError("### Error while updating person \(user.ID) in blog \(self.siteID): \(error)")
 
-            guard let managedPerson = self.managedPersonFromPerson(user) else {
-                DDLogError("### Person with ID \(user.ID) deleted before update")
-                return
+            var reloadedPerson: User!
+            self.coreDataStack.performAndSave { context in
+                guard let managedPerson = self.managedPersonFromPerson(user, in: context) else {
+                    DDLogError("### Person with ID \(user.ID) deleted before update")
+                    return
+                }
+
+                managedPerson.role = pristineRole!
+
+                reloadedPerson = User(managedPerson: managedPerson)
             }
-
-            managedPerson.role = pristineRole
-
-            let reloadedPerson = User(managedPerson: managedPerson)
             failure?(error, reloadedPerson)
         })
 
-        // Pre-emptively update the role
-        managedPerson.role = role
-
-        return User(managedPerson: managedPerson)
+        return updated
     }
 
     /// Deletes a given User.
@@ -156,24 +180,19 @@ struct PeopleService {
     ///     - failure: Closure to be executed on error
     ///
     func deleteUser(_ user: User, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
-        guard let managedPerson = managedPersonFromPerson(user) else {
-            return
-        }
-
-        // Hit the Backend
-        remote.deleteUser(siteID, userID: user.ID, success: {
-            success?()
-        }, failure: { error in
-            DDLogError("### Error while deleting person \(user.ID) from blog \(self.siteID): \(error)")
-
-            // Revert the deletion
-            self.createManagedPerson(user)
-
-            failure?(error)
-        })
-
-        // Pre-emptively nuke the entity
-        context.delete(managedPerson)
+        delete(
+            user,
+            using: { completion in
+                remote.deleteUser(
+                    siteID,
+                    userID: user.ID,
+                    success: { completion(.success(())) },
+                    failure: { completion(.failure($0)) }
+                )
+            },
+            success: success,
+            failure: failure
+        )
     }
 
     /// Deletes a given Follower.
@@ -184,24 +203,19 @@ struct PeopleService {
     ///     - failure: Closure to be executed on error
     ///
     func deleteFollower(_ person: Follower, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
-        guard let managedPerson = managedPersonFromPerson(person) else {
-            return
-        }
-
-        // Hit the Backend
-        remote.deleteFollower(siteID, userID: person.ID, success: {
-            success?()
-        }, failure: { error in
-            DDLogError("### Error while deleting follower \(person.ID) from blog \(self.siteID): \(error)")
-
-            // Revert the deletion
-            self.createManagedPerson(person)
-
-            failure?(error)
-        })
-
-        // Pre-emptively nuke the entity
-        context.delete(managedPerson)
+        delete(
+            person,
+            using: { completion in
+                remote.deleteFollower(
+                    siteID,
+                    userID: person.ID,
+                    success: { completion(.success(())) },
+                    failure: { completion(.failure($0)) }
+                )
+            },
+            success: success,
+            failure: failure
+        )
     }
 
     /// Deletes a given EmailFollower.
@@ -212,20 +226,19 @@ struct PeopleService {
     ///     - failure: Closure to be executed on error
     ///
     func deleteEmailFollower(_ person: EmailFollower, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
-        guard let managedPerson = managedPersonFromPerson(person) else {
-            return
-        }
-
-        remote.deleteEmailFollower(siteID, userID: person.ID, success: {
-            success?()
-        }, failure: { error in
-            DDLogError("Error while deleting follower \(person.ID) from blog \(self.siteID): \(error)")
-
-            self.createManagedPerson(person)
-            failure?(error)
-        })
-
-        context.delete(managedPerson)
+        delete(
+            person,
+            using: { completion in
+                remote.deleteEmailFollower(
+                    siteID,
+                    userID: person.ID,
+                    success: { completion(.success(())) },
+                    failure: { completion(.failure($0)) }
+                )
+            },
+            success: success,
+            failure: failure
+        )
     }
 
     /// Deletes a given Viewer.
@@ -236,33 +249,30 @@ struct PeopleService {
     ///     - failure: Closure to be executed on error
     ///
     func deleteViewer(_ person: Viewer, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
-        guard let managedPerson = managedPersonFromPerson(person) else {
-            return
-        }
-
-        // Hit the Backend
-        remote.deleteViewer(siteID, userID: person.ID, success: {
-            success?()
-        }, failure: { error in
-            DDLogError("### Error while deleting viewer \(person.ID) from blog \(self.siteID): \(error)")
-
-            // Revert the deletion
-            self.createManagedPerson(person)
-
-            failure?(error)
-        })
-
-        // Pre-emptively nuke the entity
-        context.delete(managedPerson)
+        delete(
+            person,
+            using: { completion in
+                remote.deleteViewer(
+                    siteID,
+                    userID: person.ID,
+                    success: { completion(.success(())) },
+                    failure: { completion(.failure($0)) }
+                )
+            },
+            success: success,
+            failure: failure
+        )
     }
 
     /// Nukes all users from Core Data.
     ///
     func removeManagedPeople() {
-        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
-        request.predicate = NSPredicate(format: "siteID = %@", NSNumber(value: siteID))
-        if let objects = (try? context.fetch(request)) as? [NSManagedObject] {
-            objects.forEach { context.delete($0) }
+        coreDataStack.performAndSave { context in
+            let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
+            request.predicate = NSPredicate(format: "siteID = %@", NSNumber(value: siteID))
+            if let objects = (try? context.fetch(request)) as? [NSManagedObject] {
+                objects.forEach { context.delete($0) }
+            }
         }
     }
 
@@ -320,7 +330,7 @@ extension PeopleService {
     ///   - success: A success block.
     ///   - failure: A failure block
     ///
-    func inviteLinks(_ siteID: Int) -> [InviteLinks] {
+    private func inviteLinks(_ siteID: Int, in context: NSManagedObjectContext) -> [InviteLinks] {
         let request = InviteLinks.fetchRequest() as NSFetchRequest<InviteLinks>
         request.predicate = NSPredicate(format: "blog.blogID = %@", NSNumber(value: siteID))
         if let invites = try? context.fetch(request) {
@@ -341,8 +351,10 @@ extension PeopleService {
                           failure: @escaping ((Error) -> Void)) {
         remote.fetchInvites(siteID) { remoteInvites in
             merge(remoteInvites: remoteInvites, for: siteID) {
-                let links = inviteLinks(siteID)
-                success(links)
+                self.coreDataStack.mainContext.perform {
+                    let links = inviteLinks(siteID, in: self.coreDataStack.mainContext)
+                    success(links)
+                }
             }
         } failure: { error in
             failure(error)
@@ -395,7 +407,7 @@ extension PeopleService {
     ///   - onComplete: A completion block that is called after changes are saved to core data.
     ///
     func merge(remoteInvites: [RemoteInviteLink], for siteID: Int, onComplete: @escaping (() -> Void)) {
-        ContextManager.shared.performAndSave { context in
+        coreDataStack.performAndSave { context in
             guard let blog = try Blog.lookup(withID: siteID, in: context) else {
                 return
             }
@@ -425,7 +437,7 @@ extension PeopleService {
     ///   - onComplete: A completion block that is called after changes are saved to core data.
     ///
     func deleteInviteLinks(keys: [String], for siteID: Int, onComplete: @escaping (() -> Void)) {
-        ContextManager.shared.performAndSave { context in
+        coreDataStack.performAndSave { context in
             let request = InviteLinks.fetchRequest() as NSFetchRequest<InviteLinks>
             request.predicate = NSPredicate(format: "inviteKey IN %@ AND blog.blogID = %@", keys, NSNumber(value: siteID))
 
@@ -496,22 +508,54 @@ extension PeopleService {
 // MARK: - Private Methods
 
 private extension PeopleService {
+
+    func delete(
+        _ person: RemotePerson,
+        using api: @escaping (@escaping (Result<Void, Error>) -> Void) -> Void,
+        success: (() -> Void)?,
+        failure: ((Error) -> Void)?
+    ) {
+        coreDataStack.performAndSave { context in
+            guard let managedPerson = managedPersonFromPerson(person, in: context) else {
+                return
+            }
+            // Pre-emptively nuke the entity
+            context.delete(managedPerson)
+        } completion: {
+            // Hit the Backend
+            api { result in
+                switch result {
+                case .success:
+                    success?()
+                case let .failure(error):
+                    // Revert the deletion
+                    self.coreDataStack.performAndSave { context in
+                        self.createManagedPerson(person, in: context)
+                    } completion: {
+                        failure?(error)
+                    }
+                }
+            }
+        }
+
+    }
+
     /// Updates the Core Data collection of users, to match with the array of People received.
     ///
-    func mergePeople<T: Person>(_ remotePeople: [T]) {
+    func mergePeople<T: Person>(_ remotePeople: [T], in context: NSManagedObjectContext) {
         for remotePerson in remotePeople {
-            if let existingPerson = managedPersonFromPerson(remotePerson) {
+            if let existingPerson = managedPersonFromPerson(remotePerson, in: context) {
                 existingPerson.updateWith(remotePerson)
                 DDLogDebug("Updated person \(existingPerson)")
             } else {
-                createManagedPerson(remotePerson)
+                createManagedPerson(remotePerson, in: context)
             }
         }
     }
 
     /// Retrieves the collection of users, persisted in Core Data, associated with the current blog.
     ///
-    func loadPeople<T: Person>(_ siteID: Int, type: T.Type) -> [T] {
+    func loadPeople<T: Person>(_ siteID: Int, type: T.Type, in context: NSManagedObjectContext) -> [T] {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
         request.predicate = NSPredicate(format: "siteID = %@ AND kind = %@",
                                         NSNumber(value: siteID as Int),
@@ -529,7 +573,7 @@ private extension PeopleService {
 
     /// Retrieves a Person from Core Data, with the specifiedID.
     ///
-    func managedPersonFromPerson(_ person: Person) -> ManagedPerson? {
+    func managedPersonFromPerson(_ person: Person, in context: NSManagedObjectContext) -> ManagedPerson? {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
         request.predicate = NSPredicate(format: "siteID = %@ AND userID = %@ AND kind = %@",
                                                 NSNumber(value: siteID as Int),
@@ -543,7 +587,7 @@ private extension PeopleService {
 
     /// Nukes the set of users, from Core Data, with the specified ID's.
     ///
-    func removeManagedPeopleWithIDs<T: Person>(_ ids: Set<Int>, type: T.Type) {
+    func removeManagedPeopleWithIDs<T: Person>(_ ids: Set<Int>, type: T.Type, in context: NSManagedObjectContext) {
         if ids.isEmpty {
             return
         }
@@ -564,7 +608,7 @@ private extension PeopleService {
 
     /// Inserts a new Person instance into Core Data, with the specified payload.
     ///
-    func createManagedPerson<T: Person>(_ person: T) {
+    func createManagedPerson<T: Person>(_ person: T, in context: NSManagedObjectContext) {
         let managedPerson = NSEntityDescription.insertNewObject(forEntityName: "Person", into: context) as! ManagedPerson
         managedPerson.updateWith(person)
         managedPerson.creationDate = Date()

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -179,7 +179,7 @@ struct PeopleService {
     ///     - success: Closure to be executed in case of success.
     ///     - failure: Closure to be executed on error
     ///
-    func deleteUser(_ user: User, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
+    func deleteUser(_ user: User, success: @escaping () -> Void, failure: ((Error) -> Void)? = nil) {
         delete(
             user,
             using: { completion in
@@ -248,7 +248,7 @@ struct PeopleService {
     ///     - success: Closure to be executed in case of success.
     ///     - failure: Closure to be executed on error
     ///
-    func deleteViewer(_ person: Viewer, success: (() -> Void)? = nil, failure: ((Error) -> Void)? = nil) {
+    func deleteViewer(_ person: Viewer, success: @escaping () -> Void, failure: ((Error) -> Void)? = nil) {
         delete(
             person,
             using: { completion in

--- a/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/InvitePersonViewController.swift
@@ -437,7 +437,7 @@ extension InvitePersonViewController {
     }
 
     @objc func sendInvitation(_ blog: Blog, recipient: String, role: String, message: String) {
-        guard let service = PeopleService(blog: blog, context: context) else {
+        guard let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared) else {
             return
         }
 
@@ -503,7 +503,7 @@ extension InvitePersonViewController {
 private extension InvitePersonViewController {
 
     func validateInvitation() {
-        guard let usernameOrEmail = usernameOrEmail, let service = PeopleService(blog: blog, context: context) else {
+        guard let usernameOrEmail = usernameOrEmail, let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared) else {
             sendActionEnabled = false
             return
         }
@@ -669,7 +669,7 @@ private extension InvitePersonViewController {
         guard let siteID = blog.dotComID?.intValue else {
             return
         }
-        let service = PeopleService(blog: blog, context: context)
+        let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared)
         service?.fetchInviteLinks(siteID, success: { [weak self] _ in
             self?.bumpStat(event: .inviteLinksGetStatus, error: nil)
             self?.updatingInviteLinks = false
@@ -690,7 +690,7 @@ private extension InvitePersonViewController {
             return
         }
         updatingInviteLinks = true
-        let service = PeopleService(blog: blog, context: context)
+        let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared)
         service?.generateInviteLinks(siteID, success: { [weak self] _ in
             self?.bumpStat(event: .inviteLinksGenerate, error: nil)
             self?.updatingInviteLinks = false
@@ -739,7 +739,7 @@ private extension InvitePersonViewController {
             return
         }
         updatingInviteLinks = true
-        let service = PeopleService(blog: blog, context: context)
+        let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared)
         service?.disableInviteLinks(siteID, success: { [weak self] in
             self?.bumpStat(event: .inviteLinksDisable, error: nil)
             self?.updatingInviteLinks = false

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -77,18 +77,9 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         }
     }
 
-    /// Core Data Context
-    ///
-    /// This particular section of the app is interesting because it's completely ephemeral – none of the data the user sees is persisted at any point. For this reason, we create a special context that
-    /// only lives as long as the `PeopleViewController` does. In the future, this could be adjusted to use its own entire Core Data Stack with NSInMemoryStoreType or some other
-    /// mechanism to deal with this (or could be adapted to persist its data but disable interactivity until on a User / Follower until we've validated that our local data is still correct).
-    /// Either way, for now this approach is preserved for this unique case while not requiring the Core Data Stack to be aware of it.
-    /// - @jkmassel, Feb 11 2021
-    private lazy var viewContext: NSManagedObjectContext = {
-        let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
-        context.parent = ContextManager.sharedInstance().mainContext
-        return context
-    }()
+    private var viewContext: NSManagedObjectContext {
+        ContextManager.sharedInstance().mainContext
+    }
 
     /// Core Data FRC
     ///

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -388,7 +388,7 @@ private extension PeopleViewController {
     func resetManagedPeople() {
         isInitialLoad = true
 
-        guard let blog = blog, let service = PeopleService(blog: blog, context: viewContext) else {
+        guard let blog = blog, let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared) else {
             return
         }
 
@@ -410,7 +410,7 @@ private extension PeopleViewController {
     }
 
     func loadPeoplePage(_ offset: Int = 0, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void)) {
-        guard let blog = blog, let service = PeopleService(blog: blog, context: viewContext) else {
+        guard let blog = blog, let service = PeopleService(blog: blog, coreDataStack: ContextManager.shared) else {
             return
         }
 
@@ -428,7 +428,7 @@ private extension PeopleViewController {
 
     func loadUsersPage(_ offset: Int = 0, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void)) {
         guard let blog = blogInContext,
-            let peopleService = PeopleService(blog: blog, context: viewContext),
+            let peopleService = PeopleService(blog: blog, coreDataStack: ContextManager.shared),
             let roleService = RoleService(blog: blog, context: viewContext) else {
                 return
         }

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -67,7 +67,7 @@ final class PersonViewController: UITableViewController {
         self.context = context
         self.person = person
         self.screenMode = screenMode
-        self.service = PeopleService(blog: blog, context: context)
+        self.service = PeopleService(blog: blog, coreDataStack: ContextManager.shared)
 
         super.init(coder: coder)
     }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1114,6 +1114,7 @@
 		4A878551290F2C7D0083AB78 /* Media+Sync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A87854F290F2C7D0083AB78 /* Media+Sync.swift */; };
 		4A9948E4297624EF006282A9 /* Blog+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9948E3297624EF006282A9 /* Blog+Creation.swift */; };
 		4A9948E5297624EF006282A9 /* Blog+Creation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9948E3297624EF006282A9 /* Blog+Creation.swift */; };
+		4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9314DB297790C300360232 /* PeopleServiceTests.swift */; };
 		4A9B81E32921AE03007A05D1 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9B81E22921AE02007A05D1 /* ContextManager.swift */; };
 		4A9B81E42921AE03007A05D1 /* ContextManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9B81E22921AE02007A05D1 /* ContextManager.swift */; };
 		4AD5656C28E3D0670054C676 /* ReaderPost+Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */; };
@@ -6468,6 +6469,7 @@
 		4A82C43028D321A300486CFF /* Blog+Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog+Post.swift"; sourceTree = "<group>"; };
 		4A87854F290F2C7D0083AB78 /* Media+Sync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Media+Sync.swift"; sourceTree = "<group>"; };
 		4A9948E3297624EF006282A9 /* Blog+Creation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Creation.swift"; sourceTree = "<group>"; };
+		4A9314DB297790C300360232 /* PeopleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleServiceTests.swift; sourceTree = "<group>"; };
 		4A9B81E22921AE02007A05D1 /* ContextManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextManager.swift; sourceTree = "<group>"; };
 		4AD5656B28E3D0670054C676 /* ReaderPost+Helper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ReaderPost+Helper.swift"; sourceTree = "<group>"; };
 		4AD5656E28E413160054C676 /* Blog+History.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+History.swift"; sourceTree = "<group>"; };
@@ -14707,6 +14709,7 @@
 				17FC0031264D728E00FCBD37 /* SharingServiceTests.swift */,
 				FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */,
 				010459EC2915519C000C7778 /* JetpackNotificationMigrationServiceTests.swift */,
+				4A9314DB297790C300360232 /* PeopleServiceTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -22622,6 +22625,7 @@
 				0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */,
 				400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */,
 				C8567498243F41CA001A995E /* MockTenorService.swift in Sources */,
+				4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */,
 				4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,
 				8BB185CE24B62CE100A4CCE8 /* ReaderCardServiceTests.swift in Sources */,

--- a/WordPress/WordPressTest/PeopleServiceTests.swift
+++ b/WordPress/WordPressTest/PeopleServiceTests.swift
@@ -1,0 +1,224 @@
+import XCTest
+import Nimble
+import OHHTTPStubs
+
+@testable import WordPress
+
+class PeopleServiceTests: CoreDataTestCase {
+
+    let siteID = 123
+    var service: PeopleService!
+
+    override func setUpWithError() throws {
+        super.setUp()
+
+        stub(condition: isHost("public-api.wordpress.com")) { request in
+            NSLog("Received an unexpected request: \(request)")
+            return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+        }
+
+        contextManager.performAndSave { context in
+            let account = WPAccount(context: context)
+            account.username = "username"
+            account.authToken = "token"
+
+            let blog = Blog(context: context)
+            blog.dotComID = NSNumber(value: self.siteID)
+            blog.url = "https://site123.wrodpress.com"
+            blog.xmlrpc = "https://site123.wrodpress.com/xmlrpc"
+            blog.account = account
+        }
+
+        let blog = try XCTUnwrap(Blog.lookup(withID: siteID, in: mainContext))
+        self.service = try XCTUnwrap(PeopleService(blog: blog, coreDataStack: self.contextManager))
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        HTTPStubs.removeAllStubs()
+    }
+
+    func testLoadUsersSuccess() {
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/users")) { _ in
+            HTTPStubsResponse(
+                jsonObject: [
+                    "users":[
+                        [
+                            "ID": 1,
+                            "nice_name": "Name",
+                            "name": "username"
+                        ]
+                    ]
+                ],
+                statusCode: 200,
+                headers: nil
+            )
+        }
+
+        waitUntil { done in
+            self.service.loadUsersPage(
+                success: { count, _ in
+                    XCTAssertEqual(count, 1)
+                    done()
+                },
+                failure: {
+                    XCTFail("Unexpected failure: \($0)")
+                    done()
+                }
+            )
+        }
+    }
+
+    func testLoadUsersFailure() {
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/users")) { _ in
+            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+        }
+
+        waitUntil { done in
+            self.service.loadUsersPage(
+                success: { count, _ in
+                    XCTFail("The failure block should be called instead")
+                    done()
+                },
+                failure: { error in
+                    XCTAssertTrue(error is WordPressComRestApiError)
+                    done()
+                }
+            )
+        }
+    }
+
+    func testDeleteFollowerSuccess() throws {
+        // Load and save followers
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/follows")) { _ in
+            HTTPStubsResponse(
+                jsonObject: [
+                    "users":[
+                        [
+                            "ID": 1,
+                            "nice_name": "Nice Name",
+                            "name": "name"
+                        ]
+                    ]
+                ],
+                statusCode: 200,
+                headers: nil
+            )
+        }
+
+        waitUntil { done in
+            self.service.loadFollowersPage(success: { _, _ in done() }, failure: { _ in done() })
+        }
+
+        // Verify if the loaded followers are stored in the database
+        let request = NSFetchRequest<ManagedPerson>(entityName: "Person")
+        request.predicate = NSPredicate(format: "siteID = %@ AND userID = %@", NSNumber(value: siteID), NSNumber(value: 1))
+        try XCTAssertEqual(mainContext.count(for: request), 1)
+        let follower = try XCTUnwrap(mainContext.fetch(request).first)
+        XCTAssertEqual(follower.userID, 1)
+
+        // Make API call to delete the loaded follower
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/followers/\(follower.userID)/delete")) { _ in
+            HTTPStubsResponse(
+                jsonObject: [
+                    "users":[
+                        [
+                            "ID": 1,
+                            "nice_name": "Name",
+                            "name": "username"
+                        ]
+                    ]
+                ],
+                statusCode: 200,
+                headers: nil
+            )
+        }
+
+        waitUntil { done in
+            self.service.deleteFollower(
+                Follower(managedPerson: follower),
+                success: {
+                    done()
+                },
+                failure: {
+                    XCTFail("Unexpected failure: \($0)")
+                    done()
+                }
+            )
+        }
+
+        // Verify the follower is deleted
+        try XCTAssertEqual(mainContext.count(for: request), 0)
+    }
+
+    func testDeleteFollowerFailure() throws {
+        // Load and save followers
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/follows")) { _ in
+            HTTPStubsResponse(
+                jsonObject: [
+                    "users":[
+                        [
+                            "ID": 1,
+                            "nice_name": "Nice Name",
+                            "name": "name"
+                        ]
+                    ]
+                ],
+                statusCode: 200,
+                headers: nil
+            )
+        }
+
+        waitUntil { done in
+            self.service.loadFollowersPage(success: { _, _ in done() }, failure: { _ in done() })
+        }
+
+        // Verify if the loaded followers are stored in the database
+        let request = NSFetchRequest<ManagedPerson>(entityName: "Person")
+        request.predicate = NSPredicate(format: "siteID = %@ AND userID = %@", NSNumber(value: siteID), NSNumber(value: 1))
+        try XCTAssertEqual(mainContext.count(for: request), 1)
+        let follower = try XCTUnwrap(mainContext.fetch(request).first)
+        XCTAssertEqual(follower.userID, 1)
+
+        // Make API call to delete the loaded follower
+        stub(condition: isPath("/rest/v1.1/sites/\(siteID)/followers/\(follower.userID)/delete")) { _ in
+            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+        }
+
+        waitUntil { done in
+            self.service.deleteFollower(
+                Follower(managedPerson: follower),
+                success: {
+                    XCTFail("The failure block should be called instead")
+                    done()
+                },
+                failure: { _ in
+                    done()
+                }
+            )
+        }
+
+        // Verify the follower is not deleted from the database
+        try XCTAssertEqual(mainContext.count(for: request), 1)
+    }
+
+    func testLoadFollowersFailure() {
+        stub(condition: isPath("/rest/v1.1/sites/123/follows")) { _ in
+            HTTPStubsResponse(jsonObject: [:], statusCode: 500, headers: nil)
+        }
+
+        waitUntil { done in
+            self.service.loadFollowersPage(
+                success: { count, _ in
+                    XCTFail("The failure block should be called instead")
+                    done()
+                },
+                failure: { error in
+                    XCTAssertTrue(error is WordPressComRestApiError)
+                    done()
+                }
+            )
+        }
+    }
+
+}

--- a/WordPress/WordPressTest/PeopleServiceTests.swift
+++ b/WordPress/WordPressTest/PeopleServiceTests.swift
@@ -42,7 +42,7 @@ class PeopleServiceTests: CoreDataTestCase {
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/users")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
-                    "users":[
+                    "users": [
                         [
                             "ID": 1,
                             "nice_name": "Name",
@@ -93,7 +93,7 @@ class PeopleServiceTests: CoreDataTestCase {
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/follows")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
-                    "users":[
+                    "users": [
                         [
                             "ID": 1,
                             "nice_name": "Nice Name",
@@ -121,7 +121,7 @@ class PeopleServiceTests: CoreDataTestCase {
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/followers/\(follower.userID)/delete")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
-                    "users":[
+                    "users": [
                         [
                             "ID": 1,
                             "nice_name": "Name",
@@ -156,7 +156,7 @@ class PeopleServiceTests: CoreDataTestCase {
         stub(condition: isPath("/rest/v1.1/sites/\(siteID)/follows")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
-                    "users":[
+                    "users": [
                         [
                             "ID": 1,
                             "nice_name": "Nice Name",

--- a/WordPress/WordPressTest/PeopleServiceTests.swift
+++ b/WordPress/WordPressTest/PeopleServiceTests.swift
@@ -13,7 +13,7 @@ class PeopleServiceTests: CoreDataTestCase {
         super.setUp()
 
         stub(condition: isHost("public-api.wordpress.com")) { request in
-            NSLog("Received an unexpected request: \(request)")
+            XCTFail("Received an unexpected request sent to \(String(describing: request.url))")
             return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
         }
 


### PR DESCRIPTION
Use `CoreDataStack` instead of `NSManagedObjectContext` in `PeopleService`. See the "Issue" and "Proposal" sections of https://github.com/wordpress-mobile/WordPress-iOS/pull/19893 for rational behind this change.

## Breaking change

Obviously I shouldn't be introducing breaking changes to the app while doing this refactor. But I don't see there is a way around that in this case.

Please note, this is _not_ an "app feature" breaking change.

As you can see in [@jkmassel 's comments here](https://github.com/wordpress-mobile/WordPress-iOS/commit/0edcfd1682e26020834ec20e063094427187333b), unlike other parts of the app, the loaded "people" (site's users, followers, viewers, etc.) are not stored in the database. Unfortunately, if we want to migrate away from using a custom `NSManagedObjectContext` object to using `CoreDataStack`, "not saving data into the database" is not something `CoreDataStack.performAndSave` can do...

I don't see how storing the people data would impact other parts of the app (only `PeopleViewController` and `PeopleService` reference to `ManagedPerson`). Also after entering this screen, [all stored people data are removed](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/WordPress/Classes/ViewRelated/People/PeopleViewController.swift#L177), so another question is, why remove it if it's not even stored in the first place?.

So, I propose removing this ephemeral context and store the loaded "people" data in the database file like rest of the app.

## Test instructions

Go to "My sites" -> "People", verify all kinds of users can be added and removed.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
