### PR TITLE
Jetpack Focus: Fix Site creation after sign up during phase three

### DIFF
--- a/WordPress/Classes/System/RootViewPresenter.swift
+++ b/WordPress/Classes/System/RootViewPresenter.swift
@@ -10,6 +10,7 @@ protocol RootViewPresenter: AnyObject {
     func getMeScenePresenter() -> ScenePresenter
     func currentlySelectedScreen() -> String
     func currentlyVisibleBlog() -> Blog?
+    func willDisplayPostSignupFlow()
 
     // MARK: Reader
 

--- a/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/WPTabBarController+RootViewPresenter.swift
@@ -29,6 +29,10 @@ extension WPTabBarController: RootViewPresenter {
         return mySitesCoordinator.currentBlog
     }
 
+    func willDisplayPostSignupFlow() {
+        mySitesCoordinator.willDisplayPostSignupFlow()
+    }
+
     // MARK: My Site
 
     func showPages(for blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -87,6 +87,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
+    /// A boolean indicating whether a site creation or adding self-hosted site flow has been initiated but not yet displayed.
     var willDisplayPostSignupFlow: Bool = false
 
     private var createButtonCoordinator: CreateButtonCoordinator?

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -87,6 +87,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
+    var willDisplayPostSignupFlow: Bool = false
+
     private var createButtonCoordinator: CreateButtonCoordinator?
 
     private let meScenePresenter: ScenePresenter

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1042,7 +1042,7 @@ extension MySiteViewController: BlogDetailsPresentationDelegate {
 
 private extension MySiteViewController {
     @objc func displayOverlayIfNeeded() {
-        if isViewOnScreen() {
+        if isViewOnScreen(), !willDisplayPostSignupFlow {
             let didReloadUI = RootViewCoordinator.shared.reloadUIIfNeeded(blog: self.blog)
             if !didReloadUI {
                 JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .appOpen, blog: self.blog)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -705,6 +705,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     @objc
     func launchSiteCreationFromNotification() {
         self.launchSiteCreation(source: "signup_epilogue")
+        willDisplayPostSignupFlow = false
     }
 
     func launchSiteCreation(source: String) {
@@ -726,6 +727,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     @objc
     private func showAddSelfHostedSite() {
         WordPressAuthenticator.showLoginForSelfHostedSite(self)
+        willDisplayPostSignupFlow = false
     }
 
     @objc

--- a/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Post Signup Interstitial/PostSignUpInterstitialViewController.swift
@@ -87,6 +87,7 @@ class PostSignUpInterstitialViewController: UIViewController {
             WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "create_new_site"])
         })
 
+        RootViewCoordinator.sharedPresenter.willDisplayPostSignupFlow()
         dismiss?(.createSite)
 
     }
@@ -96,6 +97,7 @@ class PostSignUpInterstitialViewController: UIViewController {
             WPAnalytics.track(.welcomeNoSitesInterstitialButtonTapped, withProperties: ["button": "add_self_hosted_site"])
         })
 
+        RootViewCoordinator.sharedPresenter.willDisplayPostSignupFlow()
         dismiss?(.addSelfHosted)
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -159,6 +159,10 @@ class MySitesCoordinator: NSObject {
 
     // MARK: - Adding a new site
 
+    func willDisplayPostSignupFlow() {
+        mySiteViewController.willDisplayPostSignupFlow = true
+    }
+
     func showSiteCreation() {
         showRootViewController()
         mySiteViewController.launchSiteCreation(source: "my_site")


### PR DESCRIPTION
Fixes #19937  

## Description
This PR fixes an issue during phase 3, where if a user chooses to create a new site after signing up, the site creation flow never starts.

## Testing Instructions

1. Fresh install the app
2. Login with any account
3. Open the debug menu and enable "Jetpack Features Removal Phase Three"
4. Logout immediately
5. Sign up or sign in with an account with no sites
6. Tap on "Create a new site"
7. Make sure the site creation overlay is displayed
8. Dismiss the overlay
9. Close and reopen the app
10. Make sure the phase three overlay is displayed on app-open

P.S: At the moment dismissing the site creation overlay by tapping "Continue without Jetpack" doesn't display the normal site creation flow. This issue is fixed by #19938, which is merged to `release/21.5` but not yet merged to `trunk`. 

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.