### PR TITLE
Jetpack: Fix Login flow restarting every time the app enters the foreground

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
 * [**] [internal] Disable StockPhoto and Tenor media sources when Jetpack features are removed [#19826]
 * [*] [Jetpack-only] Fixed a bug where analytics calls weren't synced to the user account. [#19926]
+* [*] [Jetpack-only] Fixed a bug where the Login flow was restarting every time the app enters the foreground. [#19952]
 
 21.4
 -----

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -17,9 +17,17 @@ class WindowManager: NSObject {
     ///
     private var overlayingWindow: UIWindow?
 
-    /// A boolean to track whether we're showing the sign in flow in fullscreen mode..
+    /// A boolean to track whether we're showing the sign in flow in fullscreen mode.
     ///
     private(set) var isShowingFullscreenSignIn = false
+
+    /// The root view controller for the window.
+    /// 
+    var rootViewController: UIViewController? {
+        return window.rootViewController
+    }
+
+    // MARK: - Init
 
     init(window: UIWindow) {
         self.window = window

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -123,8 +123,7 @@ private extension JetpackWindowManager {
         // 1. The first login screen is visible
         // 2. Or, The root view controller is not set
         if let loginNavigationController = self.rootViewController as? LoginNavigationController,
-           loginNavigationController.viewControllers.count == 1
-        {
+           loginNavigationController.viewControllers.count == 1 {
             loginNavigationController.present(UINavigationController(rootViewController: loadWordPressViewController), animated: true)
         } else if rootViewController == nil {
             self.show(loadWordPressViewController)

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/Views/MigrationStepView.swift
@@ -101,7 +101,7 @@ class MigrationStepView: UIView {
         mainScrollView.verticalScrollIndicatorInsets.bottom = bottomInset
     }
 
-    private enum Constants {
+    enum Constants {
         /// Adds space between the content bottom edge and actions sheet top edge.
         ///
         /// Bottom inset is added to the `scrollView` so the content is not covered by the Actions Sheet view.

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Load WordPress/MigrationLoadWordPressViewController.swift
@@ -7,6 +7,14 @@ class MigrationLoadWordPressViewController: UIViewController {
     private let viewModel: MigrationLoadWordPressViewModel
     private let tracker: MigrationAnalyticsTracker
 
+    // MARK: - Views
+
+    private lazy var migrationView = MigrationStepView(
+        headerView: MigrationHeaderView(configuration: viewModel.header),
+        actionsView: MigrationActionsView(configuration: viewModel.actions),
+        centerView: UIView()
+    )
+
     // MARK: - Init
 
     init(viewModel: MigrationLoadWordPressViewModel, tracker: MigrationAnalyticsTracker = .init()) {
@@ -22,21 +30,39 @@ class MigrationLoadWordPressViewController: UIViewController {
     // MARK: - View Lifecycle
 
     override func loadView() {
-        let migrationView = MigrationStepView(
-            headerView: MigrationHeaderView(configuration: viewModel.header),
-            actionsView: MigrationActionsView(configuration: viewModel.actions),
-            centerView: UIView()
-        )
-        self.view = migrationView
+        self.view = self.migrationView
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = MigrationAppearance.backgroundColor
+        self.setupNavigationBar()
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.tracker.track(.loadWordPressScreenShown)
+    }
+
+    override func viewDidLayoutSubviews() {
+        let isNavBarHidden = navigationController?.isNavigationBarHidden ?? true
+        self.migrationView.additionalContentInset.top = isNavBarHidden ? MigrationStepView.Constants.topContentInset : 0
+        super.viewDidLayoutSubviews()
+    }
+
+    // MARK: - Setup UI
+
+    private func setupNavigationBar() {
+        let closeButton = UIButton.makeCloseButton()
+        closeButton.addTarget(self, action: #selector(closeButtonTapped), for: .touchUpInside)
+        let item = UIBarButtonItem(customView: closeButton)
+        self.navigationItem.rightBarButtonItem = item
+    }
+
+    // MARK: - User Interaction
+
+    @objc private func closeButtonTapped() {
+        self.tracker.track(.loadWordPressScreenNoThanksTapped)
+        self.dismiss(animated: true)
     }
 }


### PR DESCRIPTION
Fixes #19950

## Description

This PR resolves an issue where the Login Flow restarts every time the app enters the foreground. 

| Before | After |
| ------ | ------ |
| <video src="https://user-images.githubusercontent.com/2092798/213519899-d7e88864-0ca7-4dab-80d7-6ecb0ae1e611.mp4"/> | <video src="https://user-images.githubusercontent.com/9609223/213575619-209dc960-517e-47b7-b8a8-79d0227710c3.mp4"/> |

## Test Instructions

#### Case 1: WordPress app installed

1. Clean install WordPress and log in.
2. Clean install the Jetpack app and run it.
3. **Expect** the "Load WordPress" screen to appear in full-screen mode.
4. Tap "No Thanks".
5. Move the Jetpack app to background and open it again.
6. **Expect** the "Load WordPress" to be presented modally.
7. Tap "No Thanks".
8. Tap "Continue with WordPress.com".
9. Move the Jetpack app to background and open it again.
10. **Expect** to see the same screen you saw before the app was moved to background.

#### Case 2: WordPress app not installed

1. Delete the WordPress app.
2. Kill the Jetpack app and run it again.
3. **Expect** the Login Prologue screen to appear.
4. Tap "Continue with WordPress.com".
5. Move the Jetpack app to background and open it again.
6. **Expect** to see the same screen you saw before the app was moved to background.

#### Bonus 
Although this PR shouldn't impact the content migration logic, but it would be great to make sure the migration flow is still working as expected. 🙇 

## Regression Notes
1. Potential unintended areas of impact
When the Jetpack app fails to import the content,  the "Load WordPress" screen appears ( or not ) depending on some conditions. The scenario of what happens after the content import failure should be tested.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
