### PR TITLE
Draft Extension: Revert the display string for Jetpack's draft action

### DIFF
--- a/WordPress/JetpackDraftActionExtension/Info.plist
+++ b/WordPress/JetpackDraftActionExtension/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-	<string>Save to Jetpack</string>
+	<string>Save as Draft</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIcons</key>

--- a/WordPress/JetpackDraftActionExtension/en.lproj/InfoPlist.strings
+++ b/WordPress/JetpackDraftActionExtension/en.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
-/* Name of the "Save to Jetpack" action as it should appear in the iOS Share Sheet when sharing content from other apps to WordPress */
-CFBundleDisplayName = "Save to Jetpack";
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to Jetpack */
+CFBundleDisplayName = "Save as Draft";
 
-/* Name of the "Save to Jetpack" action as it should appear in the iOS Share Sheet when sharing content from other apps to WordPress. Must be less than 16 characters long. Typically the same text as CFBundleDisplayName, but could be shorter if needed. */
-CFBundleName = "Save to Jetpack";
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to Jetpack. Must be less than 16 characters long. Typically the same text as CFBundleDisplayName, but could be shorter if needed. */
+CFBundleName = "Save as Draft";


### PR DESCRIPTION
Ref: p1674141012608899/1673416835.578209-slack-C0180B5PRJ4

## Description
Reverts the display string for Jetpack's draft action from "Save to Jetpack" back to "Save as Draft"

## Testing Instructions

1. Install Jetpack.
2. Go to the system's Photos app.
3. Select a photo.
4. Tap on the share button.
5. Scroll down.
6. Make sure the action reads "Save as Draft"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.