### PR TITLE
Jetpack Focus: Avoid premature removal of features

### DIFF
--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -34,7 +34,7 @@ class RootViewCoordinator {
     // MARK: Private instance variables
 
     private(set) var rootViewPresenter: RootViewPresenter
-    private(set) var currentAppUIType: AppUIType
+    private var currentAppUIType: AppUIType
     private var featureFlagStore: RemoteFeatureFlagStore
     private var windowManager: WindowManager?
 

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -38,7 +38,7 @@ class RootViewCoordinator {
     // MARK: Initializer
 
     init() {
-        if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
+        if Self.shouldEnableJetpackFeatures() {
             self.currentAppUIType = .normal
             self.rootViewPresenter = WPTabBarController()
         }
@@ -50,10 +50,31 @@ class RootViewCoordinator {
         updatePromptsIfNeeded()
     }
 
+    // MARK: JP Features State
+
+    /// Used to determine if the Jetpack features are enabled based on the current app UI type.
+    /// Using this ensures features are not removed before reloading the UI.
+    /// - Returns: `true` if UI type if normal, and `false` if UI type is simplified.
+    func jetpackFeaturesEnabled() -> Bool {
+        return currentAppUIType == .normal
+    }
+
+    private static func shouldEnableJetpackFeatures() -> Bool {
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
+        switch phase {
+        case .four, .newUsers, .selfHosted:
+            return false
+        default:
+            return true
+        }
+    }
+
+    // MARK: UI Reload
+
     /// Reload the UI if needed after the app has already been launched.
     /// - Returns: Boolean value describing whether the UI was reloaded or not.
     func reloadUIIfNeeded(blog: Blog?) -> Bool {
-        let newUIType: AppUIType = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() ? .normal : .simplified
+        let newUIType: AppUIType = Self.shouldEnableJetpackFeatures() ? .normal : .simplified
         let oldUIType = currentAppUIType
         guard newUIType != oldUIType, let windowManager = WordPressAppDelegate.shared?.windowManager else {
             return false

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -34,7 +34,7 @@ class RootViewCoordinator {
     // MARK: Private instance variables
 
     private(set) var rootViewPresenter: RootViewPresenter
-    private var currentAppUIType: AppUIType
+    private(set) var currentAppUIType: AppUIType
     private var featureFlagStore: RemoteFeatureFlagStore
     private var windowManager: WindowManager?
 
@@ -58,13 +58,7 @@ class RootViewCoordinator {
 
     // MARK: JP Features State
 
-    /// Used to determine if the Jetpack features are enabled based on the current app UI type.
-    /// Using this ensures features are not removed before reloading the UI.
-    /// - Returns: `true` if UI type if normal, and `false` if UI type is simplified.
-    func jetpackFeaturesEnabled() -> Bool {
-        return currentAppUIType == .normal
-    }
-
+    /// Used to determine if the Jetpack features are enabled based on the removal phase.
     private static func shouldEnableJetpackFeatures(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -114,7 +114,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     }
 
     /// Used to determine if the Jetpack features are enabled based on the removal phase.
-    /// Default coordinator and feature flag store is used.
+    /// Default root view coordinator is used.
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
         return jetpackFeaturesEnabled(rootViewCoordinator: .shared)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -114,9 +114,16 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     }
 
     /// Used to determine if the Jetpack features are enabled based on the removal phase.
+    /// Default coordinator and feature flag store is used.
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
-        return RootViewCoordinator.shared.jetpackFeaturesEnabled()
+        return jetpackFeaturesEnabled(rootViewCoordinator: .shared)
+    }
+
+    /// Used to determine if the Jetpack features are enabled based on the removal phase.
+    /// Using two separate methods (rather than one method with a default argument) because Obj-C
+    static func jetpackFeaturesEnabled(rootViewCoordinator: RootViewCoordinator) -> Bool {
+        return rootViewCoordinator.jetpackFeaturesEnabled()
     }
 
     /// Used to display feature-specific or feature-collection overlays.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -116,12 +116,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     /// Used to determine if the Jetpack features are enabled based on the removal phase.
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
-        switch generalPhase() {
-        case .four, .newUsers, .selfHosted:
-            return false
-        default:
-            return true
-        }
+        return RootViewCoordinator.shared.jetpackFeaturesEnabled()
     }
 
     /// Used to display feature-specific or feature-collection overlays.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -113,17 +113,19 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         return formatter.date(from: dateString)
     }
 
-    /// Used to determine if the Jetpack features are enabled based on the removal phase.
+    /// Used to determine if the Jetpack features are enabled based on the current app UI type.
     /// Default root view coordinator is used.
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
         return jetpackFeaturesEnabled(rootViewCoordinator: .shared)
     }
 
-    /// Used to determine if the Jetpack features are enabled based on the removal phase.
-    /// Using two separate methods (rather than one method with a default argument) because Obj-C
+    /// Used to determine if the Jetpack features are enabled based on the current app UI type.
+    /// This way we ensure features are not removed before reloading the UI.
+    /// Using two separate methods (rather than one method with a default argument) because Obj-C.
+    /// - Returns: `true` if UI type if normal, and `false` if UI type is simplified.
     static func jetpackFeaturesEnabled(rootViewCoordinator: RootViewCoordinator) -> Bool {
-        return rootViewCoordinator.jetpackFeaturesEnabled()
+        return rootViewCoordinator.currentAppUIType == .normal
     }
 
     /// Used to display feature-specific or feature-collection overlays.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -123,7 +123,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     /// Used to determine if the Jetpack features are enabled based on the current app UI type.
     /// This way we ensure features are not removed before reloading the UI.
     /// Using two separate methods (rather than one method with a default argument) because Obj-C.
-    /// - Returns: `true` if UI type if normal, and `false` if UI type is simplified.
+    /// - Returns: `true` if UI type is normal, and `false` if UI type is simplified.
     static func jetpackFeaturesEnabled(rootViewCoordinator: RootViewCoordinator) -> Bool {
         return rootViewCoordinator.currentAppUIType == .normal
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -19,6 +19,7 @@ class JetpackBrandingMenuCardPresenter {
     private let persistenceStore: UserPersistentRepository
     private let currentDateProvider: CurrentDateProvider
     private let featureFlagStore: RemoteFeatureFlagStore
+    private let rootViewCoordinator: RootViewCoordinator
     private var phase: JetpackFeaturesRemovalCoordinator.GeneralPhase {
         return JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
     }
@@ -29,12 +30,14 @@ class JetpackBrandingMenuCardPresenter {
          remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
          featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
          persistenceStore: UserPersistentRepository = UserDefaults.standard,
-         currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
+         currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider(),
+         rootViewCoordinator: RootViewCoordinator = .shared) {
         self.blog = blog
         self.remoteConfigStore = remoteConfigStore
         self.persistenceStore = persistenceStore
         self.currentDateProvider = currentDateProvider
         self.featureFlagStore = featureFlagStore
+        self.rootViewCoordinator = rootViewCoordinator
     }
 
     // MARK: Public Functions
@@ -62,7 +65,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(rootViewCoordinator: rootViewCoordinator)
         switch (phase, jetpackFeaturesEnabled) {
         case (.three, true):
             return true
@@ -77,7 +80,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(rootViewCoordinator: rootViewCoordinator)
         switch (phase, jetpackFeaturesEnabled) {
         case (.four, false):
             fallthrough

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -62,10 +62,11 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        switch phase {
-        case .three:
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        switch (phase, jetpackFeaturesEnabled) {
+        case (.three, true):
             return true
-        case .selfHosted:
+        case (.selfHosted, false):
             return blog?.jetpackIsConnected ?? false
         default:
             return false
@@ -76,10 +77,11 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        switch phase {
-        case .four:
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        switch (phase, jetpackFeaturesEnabled) {
+        case (.four, false):
             fallthrough
-        case .newUsers:
+        case (.newUsers, false):
             return true
         default:
             return false

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -7,11 +7,14 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
     private var remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
     private var remoteConfigStore = RemoteConfigStoreMock()
     private var currentDateProvider: MockCurrentDateProvider!
+    private var rootViewCoordinator: RootViewCoordinator!
 
     override func setUp() {
         contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
         currentDateProvider = MockCurrentDateProvider()
+        rootViewCoordinator = RootViewCoordinator(featureFlagStore: remoteFeatureFlagsStore,
+                                                  windowManager: WindowManager(window: UIWindow()))
         let account = AccountBuilder(contextManager).build()
         UserSettings.defaultDotComUUID = account.uuid
     }
@@ -26,34 +29,36 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: blog,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
 
         // Normal phase
+        setPhase(phase: .normal)
         XCTAssertFalse(presenter.shouldShowTopCard())
 
         // Phase One
-        remoteFeatureFlagsStore.removalPhaseOne = true
+        setPhase(phase: .one)
         XCTAssertFalse(presenter.shouldShowTopCard())
 
         // Phase Two
-        remoteFeatureFlagsStore.removalPhaseTwo = true
+        setPhase(phase: .two)
         XCTAssertFalse(presenter.shouldShowTopCard())
 
         // Phase Three
-        remoteFeatureFlagsStore.removalPhaseThree = true
+        setPhase(phase: .three)
         XCTAssertTrue(presenter.shouldShowTopCard())
 
         // Phase Four
-        remoteFeatureFlagsStore.removalPhaseFour = true
+        setPhase(phase: .four)
         XCTAssertFalse(presenter.shouldShowTopCard())
 
         // Phase New Users
-        remoteFeatureFlagsStore.removalPhaseNewUsers = true
+        setPhase(phase: .newUsers)
         XCTAssertFalse(presenter.shouldShowTopCard())
 
         // Phase Self Hosted
         UserSettings.defaultDotComUUID = nil
-        remoteFeatureFlagsStore.removalPhaseSelfHosted = true
+        setPhase(phase: .selfHosted)
         XCTAssertTrue(presenter.shouldShowTopCard())
     }
 
@@ -63,34 +68,36 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: blog,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
 
         // Normal phase
+        setPhase(phase: .normal)
         XCTAssertFalse(presenter.shouldShowBottomCard())
 
         // Phase One
-        remoteFeatureFlagsStore.removalPhaseOne = true
+        setPhase(phase: .one)
         XCTAssertFalse(presenter.shouldShowBottomCard())
 
         // Phase Two
-        remoteFeatureFlagsStore.removalPhaseTwo = true
+        setPhase(phase: .two)
         XCTAssertFalse(presenter.shouldShowBottomCard())
 
         // Phase Three
-        remoteFeatureFlagsStore.removalPhaseThree = true
+        setPhase(phase: .three)
         XCTAssertFalse(presenter.shouldShowBottomCard())
 
         // Phase Four
-        remoteFeatureFlagsStore.removalPhaseFour = true
+        setPhase(phase: .four)
         XCTAssertTrue(presenter.shouldShowBottomCard())
 
         // Phase New Users
-        remoteFeatureFlagsStore.removalPhaseNewUsers = true
+        setPhase(phase: .newUsers)
         XCTAssertTrue(presenter.shouldShowBottomCard())
 
         // Phase Self Hosted
         UserSettings.defaultDotComUUID = nil
-        remoteFeatureFlagsStore.removalPhaseSelfHosted = true
+        setPhase(phase: .selfHosted)
         XCTAssertFalse(presenter.shouldShowBottomCard())
     }
 
@@ -100,8 +107,9 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
-        remoteFeatureFlagsStore.removalPhaseThree = true
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
+        setPhase(phase: .three)
         remoteConfigStore.phaseThreeBlogPostUrl = "example.com"
 
         // When
@@ -118,8 +126,9 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
-        remoteFeatureFlagsStore.removalPhaseFour = true
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
+        setPhase(phase: .four)
 
         // When
         let config = try XCTUnwrap(presenter.cardConfig())
@@ -135,8 +144,9 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
-        remoteFeatureFlagsStore.removalPhaseNewUsers = true
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
+        setPhase(phase: .newUsers)
         remoteConfigStore.phaseNewUsersBlogPostUrl = "example.com"
 
         // When
@@ -155,8 +165,9 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: blog,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
-        remoteFeatureFlagsStore.removalPhaseSelfHosted = true
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
+        setPhase(phase: .selfHosted)
         remoteConfigStore.phaseSelfHostedBlogPostUrl = "example.com"
 
         // When
@@ -172,8 +183,9 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults)
-        remoteFeatureFlagsStore.removalPhaseThree = true
+            persistenceStore: mockUserDefaults,
+            rootViewCoordinator: rootViewCoordinator)
+        setPhase(phase: .three)
 
         // When
         presenter.hideThisTapped()
@@ -191,7 +203,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults,
             currentDateProvider: currentDateProvider)
-        remoteFeatureFlagsStore.removalPhaseThree = true
+        setPhase(phase: .three)
         currentDateProvider.dateToReturn = currentDate
 
         // When
@@ -211,7 +223,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             featureFlagStore: remoteFeatureFlagsStore,
             persistenceStore: mockUserDefaults,
             currentDateProvider: currentDateProvider)
-        remoteFeatureFlagsStore.removalPhaseThree = true
+        setPhase(phase: .three)
         currentDateProvider.dateToReturn = currentDate
 
         // When
@@ -220,5 +232,31 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
 
         // Then
         XCTAssertTrue(presenter.shouldShowTopCard())
+    }
+
+    private func setPhase(phase: JetpackFeaturesRemovalCoordinator.GeneralPhase) {
+        remoteFeatureFlagsStore.removalPhaseOne = false
+        remoteFeatureFlagsStore.removalPhaseTwo = false
+        remoteFeatureFlagsStore.removalPhaseThree = false
+        remoteFeatureFlagsStore.removalPhaseFour = false
+        remoteFeatureFlagsStore.removalPhaseNewUsers = false
+        remoteFeatureFlagsStore.removalPhaseSelfHosted = false
+        switch phase {
+        case .normal:
+            break
+        case .one:
+            remoteFeatureFlagsStore.removalPhaseOne = true
+        case .two:
+            remoteFeatureFlagsStore.removalPhaseTwo = true
+        case .three:
+            remoteFeatureFlagsStore.removalPhaseThree = true
+        case .four:
+            remoteFeatureFlagsStore.removalPhaseFour = true
+        case .newUsers:
+            remoteFeatureFlagsStore.removalPhaseNewUsers = true
+        case .selfHosted:
+            remoteFeatureFlagsStore.removalPhaseSelfHosted = true
+        }
+        rootViewCoordinator.reloadUIIfNeeded(blog: nil)
     }
 }

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -235,12 +235,15 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
     }
 
     private func setPhase(phase: JetpackFeaturesRemovalCoordinator.GeneralPhase) {
+        // Reset to normal
         remoteFeatureFlagsStore.removalPhaseOne = false
         remoteFeatureFlagsStore.removalPhaseTwo = false
         remoteFeatureFlagsStore.removalPhaseThree = false
         remoteFeatureFlagsStore.removalPhaseFour = false
         remoteFeatureFlagsStore.removalPhaseNewUsers = false
         remoteFeatureFlagsStore.removalPhaseSelfHosted = false
+
+        // Set phase
         switch phase {
         case .normal:
             break
@@ -257,6 +260,8 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         case .selfHosted:
             remoteFeatureFlagsStore.removalPhaseSelfHosted = true
         }
+
+        // Reload UI
         rootViewCoordinator.reloadUIIfNeeded(blog: nil)
     }
 }


### PR DESCRIPTION
Fixes #19837

## Description
This PR fixes an issue where enabling phase 4 would result in a state where some features are removed but not all. The user remains in this state until we get a chance to reload the UI. Now we hold off on removing features and remove them all simultaneously.

## Testing Instructions

1. Launch the app
2. Open the debug menu and enable "Jetpack Features Removal Phase Three"
3. Navigate to My Site
4. Pull to refresh
5. Observe that the Phase 3 card is now displayed.
6. Open the debug menu and enable "Jetpack Features Removal Phase Four"
7. Navigate to My Site
8. Pull to refresh
9. Make sure that JP features like stats are still displayed
10. Make sure that the phase 4 menu card (Switch to Jetpack) is not displayed
11. Close and reopen the app
12. An overlay should be displayed
13. Dismiss the overlay
14. Make sure that all JP features are now removed
15. Make sure that the phase 4 menu card (Switch to Jetpack) is now displayed

## Regression Notes
1. Potential unintended areas of impact
New users and self-hosted menu cards

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.