### PR TITLE
Jetpack Focus: Fix overlay's subtitle not highlighting the date

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -104,11 +104,11 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         switch (phase, source) {
         // Phase One
         case (.one, .stats):
-            return .init(string: Strings.PhaseOne.Stats.subtitle)
+            return attributedSubtitle(with: Strings.PhaseOne.Stats.subtitle)
         case (.one, .notifications):
-            return .init(string: Strings.PhaseOne.Notifications.subtitle)
+            return attributedSubtitle(with: Strings.PhaseOne.Notifications.subtitle)
         case (.one, .reader):
-            return .init(string: Strings.PhaseOne.Reader.subtitle)
+            return attributedSubtitle(with: Strings.PhaseOne.Reader.subtitle)
 
         // Phase Two
         case (.two, _):
@@ -120,18 +120,18 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
 
         // Phase Four
         case (.four, _):
-            return .init(string: Strings.PhaseFour.subtitle)
+            return attributedSubtitle(with: Strings.PhaseFour.subtitle)
 
         // New Users
         case (.newUsers, _):
-            return .init(string: Strings.NewUsers.subtitle)
+            return attributedSubtitle(with: Strings.NewUsers.subtitle)
 
         // Self-Hosted
         case (.selfHosted, _):
-            return .init(string: Strings.SelfHosted.subtitle)
+            return attributedSubtitle(with: Strings.SelfHosted.subtitle)
 
         default:
-            return .init(string: "")
+            return attributedSubtitle(with: "")
         }
     }
 
@@ -287,9 +287,14 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
         return formatter
     }()
 
+    func attributedSubtitle(with string: String) -> NSAttributedString {
+        let font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        return NSAttributedString(string: string, attributes: [.font: font])
+    }
+
     func phaseTwoAndThreeSubtitle() -> NSAttributedString {
         guard let deadline = JetpackFeaturesRemovalCoordinator.removalDeadline() else {
-            return NSAttributedString(string: Strings.PhaseTwoAndThree.fallbackSubtitle)
+            return attributedSubtitle(with: Strings.PhaseTwoAndThree.fallbackSubtitle)
         }
 
         let formattedDate = Self.dateFormatter.string(from: deadline)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -170,7 +170,6 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     private func setupFonts() {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
         titleLabel.adjustsFontForContentSizeCategory = true
-        subtitleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         subtitleLabel.adjustsFontForContentSizeCategory = true
         footnoteLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         footnoteLabel.adjustsFontForContentSizeCategory = true


### PR DESCRIPTION
Related to #19914  

## Description
This PR fixes a regression caused by #19924 where the date in phases 2 and 3 was not highlighted (bold).

## Testing Instructions

1. Fresh Install the app
2. Open the debug menu and enable "Jetpack Features Removal Phase Two"
3. Navigate to Stats
4. The overlay should be displayed
5. Make sure the date in the subtitle is bold
6. Change the font size from Xcode's Environment Overrides
7. Make sure that the subtitle adjusts to the new font size

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.