### PR TITLE
Jetpack Content Migration: Refactor "Open WordPress" screen to appear only when the app launches

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] [internal] Editor: Only register core blocks when `onlyCoreBlocks` capability is enabled [https://github.com/wordpress-mobile/gutenberg-mobile/pull/5293]
 * [**] [internal] Disable StockPhoto and Tenor media sources when Jetpack features are removed [#19826]
 * [*] [Jetpack-only] Fixed a bug where analytics calls weren't synced to the user account. [#19926]
+* [*] [Jetpack-only] Fixed a bug where the Login flow was restarting every time the app enters the foreground. [#19961]
 
 21.4
 -----

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -21,6 +21,12 @@ class WindowManager: NSObject {
     ///
     private(set) var isShowingFullscreenSignIn = false
 
+    /// The root view controller for the window.
+    ///
+    var rootViewController: UIViewController? {
+        return window.rootViewController
+    }
+
     init(window: UIWindow) {
         self.window = window
     }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -139,11 +139,15 @@ private extension JetpackWindowManager {
             !hasFailedExportAttempts,
             let schemeUrl = URL(string: "\(AppScheme.wordpressMigrationV1.rawValue)\(WordPressExportRoute().path.removingPrefix("/"))")
         else {
-            showSignInUI()
+            if rootViewController == nil {
+                showSignInUI()
+            }
             return
         }
 
         /// WordPress is a compatible version for migrations, but needs to be loaded to prepare the data
-        showLoadWordPressUI(schemeUrl: schemeUrl)
+        if rootViewController == nil {
+            showLoadWordPressUI(schemeUrl: schemeUrl)
+        }
     }
 }

--- a/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
+++ b/WordPress/Jetpack/Classes/System/JetpackWindowManager.swift
@@ -139,15 +139,41 @@ private extension JetpackWindowManager {
             !hasFailedExportAttempts,
             let schemeUrl = URL(string: "\(AppScheme.wordpressMigrationV1.rawValue)\(WordPressExportRoute().path.removingPrefix("/"))")
         else {
-            if rootViewController == nil {
-                showSignInUI()
+            performSafeRootNavigation { [weak self] in
+                self?.showSignInUI()
             }
             return
         }
 
         /// WordPress is a compatible version for migrations, but needs to be loaded to prepare the data
-        if rootViewController == nil {
-            showLoadWordPressUI(schemeUrl: schemeUrl)
+        performSafeRootNavigation { [weak self] in
+            self?.showLoadWordPressUI(schemeUrl: schemeUrl)
+        }
+    }
+
+    /// This method takes care of preventing screens being abruptly replaced.
+    ///
+    /// Since the import method is called whenever the app is foregrounded, we want to make sure that
+    /// any root view controller replacements only happen where it is "allowed":
+    ///
+    ///   1. When there's no root view controller yet, or
+    ///   2. When the Load WordPress screen is shown.
+    ///
+    /// Note: We should remove this method when the migration phase is concluded and we no longer need
+    /// to perfom the migration.
+    ///
+    /// - Parameter navigationClosure: The closure containing logic that eventually calls the `show` method.
+    func performSafeRootNavigation(with navigationClosure: @escaping () -> Void) {
+        switch rootViewController {
+        case .none:
+            // we can perform the navigation directly when there's no root view controller yet.
+            navigationClosure()
+        case .some(let viewController) where viewController is MigrationLoadWordPressViewController:
+            // allow the Load WordPress view to be replaced in case the migration process fails.
+            viewController.dismiss(animated: true, completion: navigationClosure)
+        default:
+            // do nothing when another root view controller is already displayed.
+            break
         }
     }
 }


### PR DESCRIPTION
Fixes #19950

## Description

This PR fixes an issue where the Login Flow was restarting every time the app enters the foreground. The solution that resolves this issue is showing the "Load WordPress" screen only if the `rootViewController` is `nil`.

| Before | After |
| ------ | ------ |
| <video src="https://user-images.githubusercontent.com/2092798/213519899-d7e88864-0ca7-4dab-80d7-6ecb0ae1e611.mp4" /> | <video src="https://user-images.githubusercontent.com/9609223/213693550-6b4d99a2-8e48-4c25-b609-085ddb1e3432.mp4" /> |

## Test Instructions

#### Case 1: WordPress app installed

1. Clean install WordPress and log in.
2. Clean install the Jetpack app and run it.
3. **Expect** the "Load WordPress" screen to appear.
4. Tap "No Thanks".
5. Tap "Continue with WordPress.com".
6. Move the Jetpack app to background and open it again.
7. **Expect** to see the same screen you saw before moving the app to background.

#### Case 2: WordPress app not installed

1. Delete the WordPress app.
2. Kill the Jetpack app and run it again.
3. **Expect** the Login Prologue screen to appear.
8. Tap "Continue with WordPress.com".
9. Move the Jetpack app to background and open it again.
10. **Expect** to see the same screen you saw before moving the app to background.

#### Bonus 
Although this PR shouldn't impact the content migration logic, but it would be great to make sure the migration flow is still working as expected. 🙇 

## Regression Notes
1. Potential unintended areas of impact
This PR only impacts when the "Load WordPress" is shown. Previously it was shown every time the app enters foreground, now it only appears at launch.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
