### PR TITLE
[Blogging prompts] Add empty block below blogging prompts block

### DIFF
--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -5,7 +5,7 @@ extension Post {
             return
         }
 
-        content = promptContentWithEmptyParagraph(promptText: prompt.text)
+        content = promptContent(withPromptText: prompt.text)
         bloggingPromptID = String(prompt.promptID)
 
         if let currentTags = tags {
@@ -19,8 +19,12 @@ extension Post {
         }
     }
 
-    private func promptContentWithEmptyParagraph(promptText: String) -> String {
-        pullquoteBlock(promptText: promptText) + Strings.emptyParagraphBlock
+    private func promptContent(withPromptText promptText: String) -> String {
+        if FeatureFlag.bloggingPromptsEnhancements.enabled {
+            return pullquoteBlock(promptText: promptText) + Strings.emptyParagraphBlock
+        } else {
+            return pullquoteBlock(promptText: promptText)
+        }
     }
 
     private func pullquoteBlock(promptText: String) -> String {

--- a/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
+++ b/WordPress/Classes/Extensions/Post+BloggingPrompts.swift
@@ -5,7 +5,7 @@ extension Post {
             return
         }
 
-        content = prompt.content
+        content = promptContentWithEmptyParagraph(promptText: prompt.text)
         bloggingPromptID = String(prompt.promptID)
 
         if let currentTags = tags {
@@ -19,8 +19,24 @@ extension Post {
         }
     }
 
-    private struct Strings {
-        static let promptTag = "dailyprompt"
+    private func promptContentWithEmptyParagraph(promptText: String) -> String {
+        pullquoteBlock(promptText: promptText) + Strings.emptyParagraphBlock
     }
 
+    private func pullquoteBlock(promptText: String) -> String {
+        return """
+            <!-- wp:pullquote -->
+            <figure class="wp-block-pullquote"><blockquote><p>\(promptText)</p></blockquote></figure>
+            <!-- /wp:pullquote -->
+            """
+    }
+
+    private enum Strings {
+        static let promptTag = "dailyprompt"
+        static let emptyParagraphBlock = """
+        <!-- wp:paragraph -->
+        <p></p>
+        <!-- /wp:paragraph -->
+        """
+    }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1116,7 +1116,7 @@ import Foundation
         case .promptsNotificationDismissed:
             return "blogging_reminders_notification_prompt_dismissed"
         case .promptsOtherAnswersTapped:
-            return "blogging_prompts_other_answers_tapped"
+            return "blogging_prompts_my_site_card_view_answers_tapped"
 
         // Jetpack branding
         case .jetpackPoweredBadgeTapped:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -547,10 +547,6 @@ private extension DashboardPromptsCardCell {
         static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
         static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
         static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")
-        static let dailyPromptsSearchText = NSLocalizedString(
-            "dailyprompts",
-            comment: "Search text that we fill when users taps the answers button on Daily Prompts Card to see answers from other people"
-        )
     }
 
     struct Style {


### PR DESCRIPTION
Fixes #19921

To test:
1 - Install Jetpack and log in;
2- Open "Debug settings" and make sure Blogging Prompts Enhancements is disabled
3 - Open "My Site" -> "HOME" with a blog selected
4 - Tap on "Answer prompt" in the prompts card. You should seen the current behavior of blogging prompts in Editor screen.
5 - Open "Debug settings" and enable  Blogging Prompts Enhancements
6 - Open "My Site" -> "HOME" with a blog selected
7 - Tap on "Answer prompt" in the prompts card. You should see the new behavior of blogging prompts in Editor screen, which is the prompt block with an empty block below it

![Simulator Screen Shot - iPhone 14 Pro - 2023-01-23 at 20 48 04](https://user-images.githubusercontent.com/15968946/214135859-fc7af2f1-b74b-45fc-9241-30bb3b0bf6f0.png)


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
