### PR TITLE
Jetpack Focus: Update the overlay's close button background in dark mode

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -327,4 +327,12 @@ extension UIColor {
         }
         return self
     }
+
+    func lightVariant() -> UIColor {
+        return color(for: UITraitCollection(userInterfaceStyle: .light))
+    }
+
+    func darkVariant() -> UIColor {
+        return color(for: UITraitCollection(userInterfaceStyle: .dark))
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -305,9 +305,3 @@ private extension JetpackFullscreenOverlayViewController {
                                                   dark: .muriel(color: .jetpackGreen, .shade90))
     }
 }
-
-fileprivate extension UIColor {
-    func lightVariant() -> UIColor {
-        return self.resolvedColor(with: UITraitCollection(userInterfaceStyle: .light))
-    }
-}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -292,6 +292,7 @@ private extension JetpackFullscreenOverlayViewController {
     enum Colors {
         private static let jetpackGreen50 = UIColor.muriel(color: .jetpackGreen, .shade50).lightVariant()
         private static let jetpackGreen30 = UIColor.muriel(color: .jetpackGreen, .shade30).lightVariant()
+        private static let jetpackGreen90 = UIColor.muriel(color: .jetpackGreen, .shade90).lightVariant()
 
         static let backgroundColor = UIColor(light: .systemBackground,
                                              dark: .muriel(color: .jetpackGreen, .shade100))
@@ -302,6 +303,6 @@ private extension JetpackFullscreenOverlayViewController {
         static let continueButtonTextColor = UIColor(light: jetpackGreen50, dark: .white)
         static let switchButtonTextColor = UIColor.white
         static let closeButtonTintColor = UIColor(light: .muriel(color: .gray, .shade5),
-                                                  dark: .muriel(color: .jetpackGreen, .shade90))
+                                                  dark: jetpackGreen90)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Overlay/JetpackOverlayView.swift
@@ -7,7 +7,7 @@ class JetpackOverlayView: UIView {
 
     private var dismissButtonTintColor: UIColor {
         UIColor(light: .muriel(color: .gray, .shade5),
-                dark: .muriel(color: .jetpackGreen, .shade90))
+                       dark: .muriel(color: .jetpackGreen, .shade90).lightVariant())
     }
 
     private var dismissButtonImage: UIImage {


### PR DESCRIPTION
Fixes #19599

## Description
This PR updates the background color of the close button in the fullscreen, and the bottom sheet overlays in Dark mode.

### Screenshots

| / | Before | After |
| - | - | - |
| Fullscreen Overlay |![stats-dark](https://user-images.githubusercontent.com/25306722/200698392-28fa8d72-adf8-4ec4-9d8c-84a4d7ff06df.png)|![image](https://user-images.githubusercontent.com/25306722/214170108-67663951-ace5-495b-a338-19d41d762e4b.png)|
| Bottom Sheet Overlay |![image](https://user-images.githubusercontent.com/25306722/214171051-34ebca30-d97c-417c-9df4-d520725db989.png)|![Bottom-After](https://user-images.githubusercontent.com/25306722/214170431-a97da85e-78bd-4e1b-a8c3-2e1ba0ab4dbf.png)|

## Testing Instructions

1. Enable Dark mode
2. Fresh install the app
3. Login
4. Open the debug menu and enable the "Jetpack Features Removal Phase one" flag only.
5. Navigate to Stats
6. The overlay should be displayed
7. Make sure the close button matched the design
8. Dismiss the overlay
9. Tap on the "Jetpack Powered" banner
10. The bottom sheet overlay should be displayed
11. Make sure the close button matched the design

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.