### PR TITLE
Log missing cookies event instead of reporting it as error

### DIFF
--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -298,6 +298,12 @@ class RequestAuthenticator: NSObject {
     }
 
     private func logErrorIfNeeded(_ error: Swift.Error) {
+
+        if let cookieError = error as? AuthenticationService.RequestAuthCookieError {
+            WordPressAppDelegate.crashLogging?.logMessage(cookieError.localizedDescription)
+            return
+        }
+
         let nsError = error as NSError
 
         switch nsError.code {


### PR DESCRIPTION
Addresses #18556

The goal of this PR is to stop treating missing web view authentication cookies as errors and instead treat them as logs (info-level) messages.

### To test

Recreate a scenario where the `wordpress_logged_in` cookie is retrieved with an empty value. Then, verify the log appears in Sentry.

Charles proxy can remove the cookie's value from the server response. Here's how I tested:

1. Setup Charles proxy to intercept traffic from an iOS simulator
2. Do a clean install of the WP app on the simulator (you could use the JP app, either is fine)
3. Log in to a WP.com site that uses a custom domain (because the reports of the missing cookie are on sites with custom domains, e.g. xyz.blog)
4. Enable logs: Tap profile photo → App Settings → Debug → Always Send Crash Logs
5. Create a post in the block editor
6. Unzip [CookieResponseBreakpoints.xml.zip](https://github.com/wordpress-mobile/WordPress-iOS/files/10876490/CookieResponseBreakpoints.xml.zip) and import it into Charles (or manually add a breakpoint to Charles for the **response** of the `https://wordpress.com:443/wp-login.php` URL)
7. Ensure breakpoints are enabled in Charles (Proxy → Breakpoint Settings)
8. In the editor, tap the ellipsis menu (three dots) and select Preview
9. When Charles opens the Breakpoints window, click the Edit Response button, find the `wordpress_logged_in` cookie, and remove its value (in my testing this gets hit twice, so remove it both times)
10. Click Execute in the Breakpoints window
11. Expect the app to show a "Page not found" error
12. Search for `Response to request for auth cookie for WP.com site failed to return cookie.` in Sentry (it should appear in under a minute)
11. Verify it's logged in Sentry at an info level (not as an error as it used to be):

| Before | After |
| - | - |
| <img src="https://user-images.githubusercontent.com/1898325/222580986-57e99576-048c-4419-9867-ac255f1f33c3.png" alt="" width="350"> | <img src="https://user-images.githubusercontent.com/1898325/222580974-96b2a19d-589c-4f07-80de-cb74ee2f0d03.png" alt="" width="350"> |

## Regression Notes
1. Potential unintended areas of impact

There's little risk but this could effect error handling in web views across the app.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

The tests I describe above.

3. What automated tests I added (or what prevented me from doing so)

Since this requires a convoluted testing setup, I don't think automated tests are worth it.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
