### PR TITLE
Update WordPressShared to the latest version

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -516,7 +516,7 @@ PODS:
     - UIDeviceIdentifier (~> 2.0)
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
-  - WordPressShared (2.0.0)
+  - WordPressShared (2.0.1)
   - WordPressUI (1.12.5)
   - WPMediaPicker (1.8.7)
   - wpxmlrpc (0.10.0)
@@ -622,6 +622,7 @@ SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
     - WordPressKit
+    - WordPressShared
   trunk:
     - Alamofire
     - AlamofireImage
@@ -658,7 +659,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -878,7 +878,7 @@ SPEC CHECKSUMS:
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 0e60da9761bf9d1055949991bb1f873c8702b2ea
   WordPressKit: 21d48d3279d4da2e146727d302e4f506cb4befa0
-  WordPressShared: 35d41bdf0927e714af1fc85fa9cb692f934473be
+  WordPressShared: 6afe7e21e26cf9fdbe2403f43c62245fb8654ba2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd


### PR DESCRIPTION
It was accidentally reverted in https://github.com/wordpress-mobile/WordPress-iOS/pull/19908

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
