### PR TITLE
[Stats Revamp] Fix Total cards show "higher" word instead of "lower" label

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -379,7 +379,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
         static let differenceHigher = NSLocalizedString("stats.insights.label.totalLikes.higher",
                                                         value: "*%@%@ (%@%%)* higher than the previous 7-days",
                                                         comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
-        static let differenceLower = NSLocalizedString("stats.insights.label.totalLikes.higher",
+        static let differenceLower = NSLocalizedString("stats.insights.label.totalLikes.lower",
                                                        value: "*%@%@ (%@%%)* lower than the previous 7-days",
                                                        comment: "Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text.")
         static let differenceSame = NSLocalizedString("stats.insights.label.totalLikes.same",


### PR DESCRIPTION
Fixes #19995

## Description

Total cards show "higher" word instead of "lower" label. The problem happened because 2 labels had the same identifiers.

## Testing instructions

1. Launch the JP and login.
2. Navigate to "My Site → Stats".
3. Ensure the Total cards are on your screen. If not, add them via the ⚙️ button at the top of the screen.
4. Verify that positive changes should say ... higher than, negative changes should say ... lower than.

## Regression Notes

1. Potential unintended areas of impact

none

2. What I did to test those areas of impact (or what existing automated tests I relied on)

none

3. What automated tests I added (or what prevented me from doing so)

none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### Before

<img width="442" alt="before_bug_higher_lower" src="https://user-images.githubusercontent.com/4062343/214783077-32767feb-2643-41f8-850c-c18b088ed3c0.png">

### After
<img width="442" alt="after_bug_higher_lower" src="https://user-images.githubusercontent.com/4062343/214783089-beebecd0-1178-4cbf-b5d7-8b1be69b1801.png">






