### PR TITLE
[Stats Revamp] Fix crash after backgrounding app from Stats screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -65,13 +65,6 @@ struct StatsTotalInsightsData {
     }
 
     public static func makeTotalInsightsGuideText(lastPostInsight: StatsLastPostInsight?, statsSummaryType: StatsSummaryType) -> NSAttributedString? {
-
-        /// NSAttributedString initialized with HTML on the background  crashes the app
-        /// This method can be called when traitCollectionDidChange which can be triggered when app goes to background
-        guard UIApplication.shared.applicationState != .background else {
-            return nil
-        }
-
         switch statsSummaryType {
         case .likes:
             guard let summary = lastPostInsight else {
@@ -276,6 +269,12 @@ class StatsTotalInsightsCell: StatsBaseCell {
 
     // Rebuilds guide view for accessibility only if guide view already exists
     private func rebuildGuideViewIfNeeded() {
+        /// NSAttributedString initialized with HTML on the background  crashes the app
+        /// This method can be called when traitCollectionDidChange which can be triggered when app goes to background
+        guard UIApplication.shared.applicationState != .background else {
+            return
+        }
+
         if guideText != nil,
            let statsSummaryType = statsSummaryType,
            let guideText = StatsTotalInsightsData.makeTotalInsightsGuideText(lastPostInsight: lastPostInsight, statsSummaryType: statsSummaryType) {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -65,6 +65,13 @@ struct StatsTotalInsightsData {
     }
 
     public static func makeTotalInsightsGuideText(lastPostInsight: StatsLastPostInsight?, statsSummaryType: StatsSummaryType) -> NSAttributedString? {
+
+        /// NSAttributedString initialized with HTML on the background  crashes the app
+        /// This method can be called when traitCollectionDidChange which can be triggered when app goes to background
+        guard UIApplication.shared.applicationState != .background else {
+            return nil
+        }
+
         switch statsSummaryType {
         case .likes:
             guard let summary = lastPostInsight else {


### PR DESCRIPTION
Fixes #20006

## Description

![image](https://user-images.githubusercontent.com/4062343/214893043-41596d57-ab6a-4f23-a007-e916061dd593.png)
We call this method when the app is in the background, [which causes the crash](https://stackoverflow.com/questions/46881393/ios-crash-report-unexpected-start-state-exception). This method is called in the background since `traidCollectionDidChange` method is triggered when apps go into background. This issue is only reproducible when there's Total Likes and Total Comments cards with guide text when going into background. That's why it wasn't found before. 

It's concerning since we used a failable `try?` initializer.

Fixing the issue by checking if app is not in the background before rebuilding `NSAttributedString` with html.

## Testing instructions

### Case 1:
1. Install app version 21.6 or above (e.g. from trunk or TestFlight)
2. Log in to an open Stats, Total Likes / Total Comments card should be visible that has guide informational text
3. Background the app
4. The app shouldn't crash

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos





