### PR TITLE
Jetpack Switch prompt: fix typo

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -377,7 +377,7 @@ private extension JetpackFullscreenOverlayGeneralViewModel {
                                                      value: "Get your notifications with the Jetpack app",
                                                      comment: "Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
                 static let subtitle = NSLocalizedString("jetpack.fullscreen.overlay.phaseOne.notifications.subtitle",
-                                                     value: "Switch to the Jetpack app to keep recieving real-time notifications on your device.",
+                                                     value: "Switch to the Jetpack app to keep receiving real-time notifications on your device.",
                                                      comment: "Subtitle of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app.")
             }
         }


### PR DESCRIPTION
That's a small change, so I haven't really done any testing, sorry! This should fix this typo:

<img src="https://user-images.githubusercontent.com/426388/214929462-170d63a5-166f-48a9-b87a-e400b3cc677a.jpg" width="350" />

Props @codebykat for finding this!

To test:

See the following screen in the app.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
