### PR TITLE
Remove context from a few service types

### DIFF
--- a/WordPress/Classes/Models/Role.swift
+++ b/WordPress/Classes/Models/Role.swift
@@ -12,6 +12,15 @@ extension Role {
     func toUnmanaged() -> RemoteRole {
         return RemoteRole(slug: slug, name: name)
     }
+
+    /// Returns a role from Core Data with the given slug.
+    static func lookup(withBlogID blogID: NSManagedObjectID, slug: String, in context: NSManagedObjectContext) throws -> Role? {
+        guard let blog = try context.existingObject(with: blogID) as? Blog else {
+            return nil
+        }
+        let predicate = NSPredicate(format: "slug = %@ AND blog = %@", slug, blog)
+        return context.firstObject(ofType: Role.self, matching: predicate)
+    }
 }
 
 extension Role {

--- a/WordPress/Classes/Models/Role.swift
+++ b/WordPress/Classes/Models/Role.swift
@@ -13,7 +13,6 @@ extension Role {
         return RemoteRole(slug: slug, name: name)
     }
 
-    /// Returns a role from Core Data with the given slug.
     static func lookup(withBlogID blogID: NSManagedObjectID, slug: String, in context: NSManagedObjectContext) throws -> Role? {
         guard let blog = try context.existingObject(with: blogID) as? Blog else {
             return nil

--- a/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
+++ b/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
@@ -60,14 +60,11 @@ import CocoaLumberjack
     @objc func deleteAllSuggestions() {
         self.coreDataStack.performAndSave { context in
             let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
-            var suggestions = [ReaderSearchSuggestion]()
             do {
-                suggestions = try context.fetch(fetchRequest) as! [ReaderSearchSuggestion]
+                let suggestions = try context.fetch(fetchRequest) as! [ReaderSearchSuggestion]
+                suggestions.forEach(context.delete(_:))
             } catch let error as NSError {
                 DDLogError("Error fetching search suggestion : \(error.localizedDescription)")
-            }
-            for suggestion in suggestions {
-                context.delete(suggestion)
             }
         }
     }

--- a/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
+++ b/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
@@ -18,9 +18,10 @@ import CocoaLumberjack
     /// - Parameters:
     ///     - phrase: The search phrase in question.
     ///
-    @objc func createOrUpdateSuggestionForPhrase(_ phrase: String) {
+    @objc(createOrUpdateSuggestionForPhrase:)
+    func createOrUpdateSuggestion(forPhrase phrase: String) {
         self.coreDataStack.performAndSave { context in
-            var suggestion = self.findSuggestionForPhrase(phrase, in: context)
+            var suggestion = self.findSuggestion(forPhrase: phrase, in: context)
             if suggestion == nil {
                 suggestion = NSEntityDescription.insertNewObject(
                     forEntityName: ReaderSearchSuggestion.classNameWithoutNamespaces(),
@@ -40,7 +41,7 @@ import CocoaLumberjack
     ///
     /// - Returns: A matching search phrase or nil.
     ///
-    private func findSuggestionForPhrase(_ phrase: String, in context: NSManagedObjectContext) -> ReaderSearchSuggestion? {
+    private func findSuggestion(forPhrase phrase: String, in context: NSManagedObjectContext) -> ReaderSearchSuggestion? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
         fetchRequest.predicate = NSPredicate(format: "searchPhrase MATCHES[cd] %@", phrase)
 

--- a/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
+++ b/WordPress/Classes/Services/ReaderSearchSuggestionService.swift
@@ -4,7 +4,14 @@ import CocoaLumberjack
 /// Provides functionality for fetching, saving, and deleting search phrases
 /// used to search for content in the reader.
 ///
-@objc class ReaderSearchSuggestionService: LocalCoreDataService {
+@objc class ReaderSearchSuggestionService: NSObject {
+
+    private let coreDataStack: CoreDataStack
+
+    @objc init(coreDataStack: CoreDataStack) {
+        self.coreDataStack = coreDataStack
+        super.init()
+    }
 
     /// Creates or updates an existing record for the specified search phrase.
     ///
@@ -12,14 +19,17 @@ import CocoaLumberjack
     ///     - phrase: The search phrase in question.
     ///
     @objc func createOrUpdateSuggestionForPhrase(_ phrase: String) {
-        var suggestion = findSuggestionForPhrase(phrase)
-        if suggestion == nil {
-            suggestion = NSEntityDescription.insertNewObject(forEntityName: ReaderSearchSuggestion.classNameWithoutNamespaces(),
-                                                                             into: managedObjectContext) as? ReaderSearchSuggestion
-            suggestion?.searchPhrase = phrase
+        self.coreDataStack.performAndSave { context in
+            var suggestion = self.findSuggestionForPhrase(phrase, in: context)
+            if suggestion == nil {
+                suggestion = NSEntityDescription.insertNewObject(
+                    forEntityName: ReaderSearchSuggestion.classNameWithoutNamespaces(),
+                    into: context
+                ) as? ReaderSearchSuggestion
+                suggestion?.searchPhrase = phrase
+            }
+            suggestion?.date = Date()
         }
-        suggestion?.date = Date()
-        ContextManager.sharedInstance().save(managedObjectContext)
     }
 
 
@@ -30,13 +40,13 @@ import CocoaLumberjack
     ///
     /// - Returns: A matching search phrase or nil.
     ///
-    @objc func findSuggestionForPhrase(_ phrase: String) -> ReaderSearchSuggestion? {
+    private func findSuggestionForPhrase(_ phrase: String, in context: NSManagedObjectContext) -> ReaderSearchSuggestion? {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
         fetchRequest.predicate = NSPredicate(format: "searchPhrase MATCHES[cd] %@", phrase)
 
         var suggestions = [ReaderSearchSuggestion]()
         do {
-            suggestions = try managedObjectContext.fetch(fetchRequest) as! [ReaderSearchSuggestion]
+            suggestions = try context.fetch(fetchRequest) as! [ReaderSearchSuggestion]
         } catch let error as NSError {
             DDLogError("Error fetching search suggestion for phrase \(phrase) : \(error.localizedDescription)")
         }
@@ -44,57 +54,21 @@ import CocoaLumberjack
         return suggestions.first
     }
 
-
-    /// Finds and returns all ReaderSearchSuggestion starting with the specified search phrase.
-    ///
-    /// - Parameters:
-    ///     - phrase: The search phrase in question.
-    ///
-    /// - Returns: An array of matching `ReaderSearchSuggestion`s.
-    ///
-    @objc func fetchSuggestionsLikePhrase(_ phrase: String) -> [ReaderSearchSuggestion] {
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
-        fetchRequest.predicate = NSPredicate(format: "searchPhrase BEGINSWITH[cd] %@", phrase)
-
-        let sort = NSSortDescriptor(key: "date", ascending: false)
-        fetchRequest.sortDescriptors = [sort]
-
-        var suggestions = [ReaderSearchSuggestion]()
-        do {
-            suggestions = try managedObjectContext.fetch(fetchRequest) as! [ReaderSearchSuggestion]
-        } catch let error as NSError {
-            DDLogError("Error fetching search suggestions for phrase \(phrase) : \(error.localizedDescription)")
-        }
-
-        return suggestions
-    }
-
-
-    /// Deletes the specified search suggestion.
-    ///
-    /// - Parameters:
-    ///     - suggestion: The `ReaderSearchSuggestion` to delete.
-    ///
-    @objc func deleteSuggestion(_ suggestion: ReaderSearchSuggestion) {
-        managedObjectContext.delete(suggestion)
-        ContextManager.sharedInstance().saveContextAndWait(managedObjectContext)
-    }
-
-
     /// Deletes all saved search suggestions.
     ///
     @objc func deleteAllSuggestions() {
-        let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
-        var suggestions = [ReaderSearchSuggestion]()
-        do {
-            suggestions = try managedObjectContext.fetch(fetchRequest) as! [ReaderSearchSuggestion]
-        } catch let error as NSError {
-            DDLogError("Error fetching search suggestion : \(error.localizedDescription)")
+        self.coreDataStack.performAndSave { context in
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ReaderSearchSuggestion")
+            var suggestions = [ReaderSearchSuggestion]()
+            do {
+                suggestions = try context.fetch(fetchRequest) as! [ReaderSearchSuggestion]
+            } catch let error as NSError {
+                DDLogError("Error fetching search suggestion : \(error.localizedDescription)")
+            }
+            for suggestion in suggestions {
+                context.delete(suggestion)
+            }
         }
-        for suggestion in suggestions {
-            managedObjectContext.delete(suggestion)
-        }
-        ContextManager.sharedInstance().save(managedObjectContext)
     }
 
 }

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -267,7 +267,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     topic.following = NO;
 
     // Save / update the search phrase to use it as a suggestion later.
-    ReaderSearchSuggestionService *suggestionService = [[ReaderSearchSuggestionService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    ReaderSearchSuggestionService *suggestionService = [[ReaderSearchSuggestionService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     [suggestionService createOrUpdateSuggestionForPhrase:phrase];
 
     [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];

--- a/WordPress/Classes/Services/SiteSegmentsService.swift
+++ b/WordPress/Classes/Services/SiteSegmentsService.swift
@@ -11,28 +11,27 @@ protocol SiteSegmentsService {
 }
 
 // MARK: - SiteSegmentsService
-final class SiteCreationSegmentsService: LocalCoreDataService, SiteSegmentsService {
+final class SiteCreationSegmentsService: SiteSegmentsService {
 
     // MARK: Properties
 
     /// A facade for WPCOM services.
     private let remoteService: WordPressComServiceRemote
 
-    // MARK: LocalCoreDataService
-
-    override init(managedObjectContext context: NSManagedObjectContext) {
+    init(coreDataStack: CoreDataStack) {
+        let account = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
 
         let api: WordPressComRestApi
 
-        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context) {
+        if let account {
             api = account.wordPressComRestV2Api
         } else {
             api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         }
 
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
-
-        super.init(managedObjectContext: context)
     }
 
     // MARK: SiteSegmentsService

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -47,26 +47,25 @@ final class MockSiteVerticalsService: SiteVerticalsService {
 
 /// Retrieves candidate Site Verticals used to create a new site.
 ///
-final class SiteCreationVerticalsService: LocalCoreDataService, SiteVerticalsService {
+final class SiteCreationVerticalsService: SiteVerticalsService {
 
     // MARK: Properties
 
     /// A facade for WPCOM services.
     private let remoteService: WordPressComServiceRemote
 
-    // MARK: LocalCoreDataService
-
-    override init(managedObjectContext context: NSManagedObjectContext) {
+    init(coreDataStack: CoreDataStack) {
+        let account = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
 
         let api: WordPressComRestApi
-        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context) {
+        if let account {
             api = account.wordPressComRestV2Api
         } else {
             api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         }
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
-
-        super.init(managedObjectContext: context)
     }
 
     // MARK: SiteVerticalsService

--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -510,7 +510,7 @@ private extension QuickStartTourGuide {
     }
 
     private func grantCongratulationsAward(for blog: Blog) {
-        let service = SiteManagementService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = SiteManagementService(coreDataStack: ContextManager.sharedInstance())
         service.markQuickStartChecklistAsComplete(for: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -221,7 +221,7 @@ open class DeleteSiteViewController: UITableViewController {
 
         let trackedBlog = blog
         WPAppAnalytics.track(.siteSettingsDeleteSiteRequested, with: trackedBlog)
-        let service = SiteManagementService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = SiteManagementService(coreDataStack: ContextManager.sharedInstance())
         service.deleteSiteForBlog(blog,
                                   success: { [weak self] in
                                     WPAppAnalytics.track(.siteSettingsDeleteSiteResponseOK, with: trackedBlog)

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
@@ -48,7 +48,7 @@ public extension SiteSettingsViewController {
 
         let trackedBlog = blog
         WPAppAnalytics.track(.siteSettingsExportSiteRequested, with: trackedBlog)
-        let service = SiteManagementService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = SiteManagementService(coreDataStack: ContextManager.sharedInstance())
         service.exportContentForBlog(blog,
             success: {
                 WPAppAnalytics.track(.siteSettingsExportSiteResponseOK, with: trackedBlog)
@@ -79,7 +79,7 @@ public extension SiteSettingsViewController {
         SVProgressHUD.show(withStatus: status)
 
         WPAppAnalytics.track(.siteSettingsDeleteSitePurchasesRequested, with: blog)
-        let service = SiteManagementService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = SiteManagementService(coreDataStack: ContextManager.sharedInstance())
         service.getActivePurchasesForBlog(blog,
             success: { [weak self] purchases in
                 SVProgressHUD.dismiss()

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -173,7 +173,7 @@ class PeopleViewController: UITableViewController, UIViewControllerRestoration {
         tableView.deselectSelectedRowWithAnimation(true)
         refreshNoResultsView()
 
-        guard let blog = blog else {
+        guard let blog else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PeopleViewController.swift
@@ -420,7 +420,7 @@ private extension PeopleViewController {
     func loadUsersPage(_ offset: Int = 0, success: @escaping ((_ retrieved: Int, _ shouldLoadMore: Bool) -> Void)) {
         guard let blog = blogInContext,
             let peopleService = PeopleService(blog: blog, coreDataStack: ContextManager.shared),
-            let roleService = RoleService(blog: blog, context: viewContext) else {
+            let roleService = RoleService(blog: blog, coreDataStack: ContextManager.shared) else {
                 return
         }
 
@@ -438,7 +438,7 @@ private extension PeopleViewController {
         })
 
         group.enter()
-        roleService.fetchRoles(success: {_ in
+        roleService.fetchRoles(success: {
             group.leave()
         }, failure: { error in
             loadError = error
@@ -521,11 +521,10 @@ private extension PeopleViewController {
     }
 
     func role(person: Person) -> Role? {
-        guard let blog = blog,
-            let service = RoleService(blog: blog, context: viewContext) else {
-                return nil
+        guard let blog = blog else {
+            return nil
         }
-        return service.getRole(slug: person.role)
+        return try? Role.lookup(withBlogID: blog.objectID, slug: person.role, in: viewContext)
     }
 
     func setupFilterBar() {

--- a/WordPress/Classes/ViewRelated/People/PersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/PersonViewController.swift
@@ -598,10 +598,7 @@ private extension PersonViewController {
         case .Viewer:
             return .viewer
         case .User:
-            guard let service = RoleService(blog: blog, context: context) else {
-                return nil
-            }
-            return service.getRole(slug: person.role)?.toUnmanaged()
+            return try? Role.lookup(withBlogID: blog.objectID, slug: person.role, in: context)?.toUnmanaged()
         case .Email:
             return .follower
         }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchSuggestionsViewController.swift
@@ -143,7 +143,7 @@ class ReaderSearchSuggestionsViewController: UIViewController {
 
 
     @objc func clearSearchHistory() {
-        let service = ReaderSearchSuggestionService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = ReaderSearchSuggestionService(coreDataStack: ContextManager.sharedInstance())
         service.deleteAllSuggestions()
         tableView.reloadData()
         updateHeightConstraint()

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -252,7 +252,6 @@ extension ReaderTabViewModel {
     }
 
     private func clearSearchSuggestions() {
-        let context = ContextManager.sharedInstance().mainContext
-        ReaderSearchSuggestionService(managedObjectContext: context).deleteAllSuggestions()
+        ReaderSearchSuggestionService(coreDataStack: ContextManager.sharedInstance()).deleteAllSuggestions()
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -82,7 +82,7 @@ final class SiteCreationWizardLauncher {
         case .name:
             return SiteNameStep(creator: self.creator)
         case .segments:
-            let segmentsService = SiteCreationSegmentsService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            let segmentsService = SiteCreationSegmentsService(coreDataStack: ContextManager.sharedInstance())
             return SiteSegmentsStep(creator: self.creator, service: segmentsService)
         case .siteAssembly:
             let siteAssemblyService = EnhancedSiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)

--- a/WordPress/WordPressTest/SiteManagementServiceTests.swift
+++ b/WordPress/WordPressTest/SiteManagementServiceTests.swift
@@ -56,7 +56,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
-        siteManagementService = SiteManagementServiceTester(managedObjectContext: contextManager.mainContext)
+        siteManagementService = SiteManagementServiceTester(coreDataStack: contextManager)
         mockRemoteService = siteManagementService.mockRemoteService
     }
 
@@ -95,18 +95,14 @@ class SiteManagementServiceTests: CoreDataTestCase {
         waitForExpectations(timeout: 2, handler: nil)
     }
 
-    func testDeleteSiteRemovesExistingBlogOnSuccess() {
+    func testDeleteSiteRemovesExistingBlogOnSuccess() throws {
         let context = contextManager.mainContext
-        let blog =
+        let blog = insertBlog(context)
 
-
-            insertBlog(context)
         let blogObjectID = blog.objectID
-
         XCTAssertFalse(blogObjectID.isTemporaryID, "Should be a permanent object")
 
-        let expect = expectation(
-            description: "Remove Blog success expectation")
+        let expect = expectation(description: "Remove Blog success expectation")
         mockRemoteService.reset()
         siteManagementService.deleteSiteForBlog(blog,
             success: {
@@ -115,8 +111,7 @@ class SiteManagementServiceTests: CoreDataTestCase {
         mockRemoteService.successBlockPassedIn?()
         waitForExpectations(timeout: 2, handler: nil)
 
-        let shouldBeRemoved = try? context.existingObject(with: blogObjectID)
-        XCTAssertFalse(shouldBeRemoved != nil, "Blog was not removed")
+        try XCTAssertEqual(context.count(for: Blog.fetchRequest()), 0)
     }
 
     func testDeleteSiteCallsFailureBlock() {


### PR DESCRIPTION
Use `CoreDataStack` instead of `NSManagedObjectContext` in a few service types. See the "Issue" and "Proposal" sections of https://github.com/wordpress-mobile/WordPress-iOS/pull/19893 for rational behind this change.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
