### PR TITLE
[Stats Revamp] Fix Crash when dismissing "Manage Stats Cards" on iPad 

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -192,7 +192,8 @@ class InsightsManagementViewController: UITableViewController {
     }
 
     private func promptToSave(from viewController: UIViewController?) {
-        let alert = UIAlertController(title: nil, message: TextContent.savePromptMessage, preferredStyle: .actionSheet)
+        let alertStyle: UIAlertController.Style = UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet
+        let alert = UIAlertController(title: nil, message: TextContent.savePromptMessage, preferredStyle: alertStyle)
         alert.addAction(UIAlertAction(title: TextContent.savePromptSaveButton, style: .default, handler: { _ in
             self.saveTapped()
         }))


### PR DESCRIPTION
Fixes #20003

## Description

A crash happens when dismissing "Manage Stats Cards" on iPad after making changes.

This is a classic iOS crash that happens when `UIAlertViewController` is presented as `actionSheet` on `iPad` without specifying `sourceView`.

### Solution

Instead of setting `sourceView`, I decided to show `alert` on iPad when there're unsaved changes.

## Testing instructions

### Case 1:
1. Launch the JP app on the iPad and log in.
2. Open "My Site → Stats".
3. Tap ⚙️ button at the top of the screen.
4. Make some changes by adding or removing active cards.
5. Tap Ⅹ button to close the Manage Stats Cards.
6. Alert should appear, no crash should be happening

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

None

3. What automated tests I added (or what prevented me from doing so)

None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

### iPad

https://user-images.githubusercontent.com/4062343/215035210-f36c4d11-b73b-4428-a545-81f175470bc0.mp4

### iPhone

https://user-images.githubusercontent.com/4062343/215035246-fbfaae6d-e14f-4f65-9102-4c01bf28c1eb.mp4



