### PR TITLE
[JP Plugin] Feature Flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -42,6 +42,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackFeaturesRemovalPhaseFour
     case jetpackFeaturesRemovalPhaseNewUsers
     case jetpackFeaturesRemovalPhaseSelfHosted
+    case jetpackIndividualPluginSupport
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -133,6 +134,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackFeaturesRemovalPhaseNewUsers:
             return false
         case .jetpackFeaturesRemovalPhaseSelfHosted:
+            return false
+        case .jetpackIndividualPluginSupport:
             return false
         }
     }
@@ -258,6 +261,8 @@ extension FeatureFlag {
             return "Jetpack Features Removal Phase For New Users"
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return "Jetpack Features Removal Phase For Self-Hosted Sites"
+        case .jetpackIndividualPluginSupport:
+            return "Jetpack Individual Plugin Support"
         }
     }
 


### PR DESCRIPTION
Fixes #20014 

To test:
1. Launch JP Mobile
2. Open Feature Flag List
3. Verify if "Jetpack Individual Plugin" feature flag is available at the bottom of the list.

## Regression Notes
1. Potential unintended areas of impact
N/A

4. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
