### PR TITLE
Remove a couple of duplicated localization keys

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackNewUsersOverlaySecondaryView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackNewUsersOverlaySecondaryView.swift
@@ -165,10 +165,10 @@ private extension JetpackNewUsersOverlaySecondaryView {
         static let statsSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.stats.subtitle",
                                                   value: "Watch your traffic grow with helpful insights and comprehensive stats.",
                                                   comment: "Description of the Statistics feature.")
-        static let readerSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.stats.subtitle",
+        static let readerSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.reader.subtitle",
                                                       value: "Find and follow your favorite sites and communities, and share you content.",
                                                       comment: "Description of the Reader feature.")
-        static let notificationsSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.stats.subtitle",
+        static let notificationsSubtitle = NSLocalizedString("jetpack.fullscreen.overlay.newUsers.notifications.subtitle",
                                                              value: "Get notifications for new comments, likes, views, and more.",
                                                              comment: "Description of the Notifications feature.")
     }

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -65,9 +65,9 @@ enum LocalizableStrings {
                                                                          value: "Log in to Jetpack to see this week's stats.",
                                                                          comment: "Title of the unconfigured view in this week widget")
     // No data view
-    static let noDataViewTitle = AppLocalizedString("widget.today.nodata.view.title",
+    static let noDataViewTitle = AppLocalizedString("widget.today.nodata.view.fallbackTitle",
                                                     value: "Unable to load site stats.",
-                                                    comment: "Title of the no data view in today widget")
+                                                    comment: "Fallback title of the no data view in the stats widget")
 
     static let noDataViewTodayTitle = AppLocalizedString("widget.today.nodata.view.title",
                                                          value: "Unable to load today's stats.",

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -90,7 +90,7 @@ enum LocalizableStrings {
                                                            value: "Create or add a site to see all time stats.",
                                                            comment: "Title of the no site view in all time widget")
 
-    static let noSiteViewThisWeekTitle = AppLocalizedString("widget.thisweek.nosite.view.titlee",
+    static let noSiteViewThisWeekTitle = AppLocalizedString("widget.thisweek.nosite.view.title",
                                                             value: "Create or add a site to see this week's stats.",
                                                             comment: "Title of the no site view in this week widget")
 


### PR DESCRIPTION
I noticed these while testing the changes from #20009. Or rather, `bundle exec fastlane generate_strings_file_for_glotpress` noticed these:

```
[16:01:52]: -------------------------------------------------
[16:01:52]: --- Step: ios_generate_strings_file_from_code ---
[16:01:52]: -------------------------------------------------
[16:01:54]: ▸ Key "jetpack.fullscreen.overlay.newUsers.stats.subtitle" used with multiple values. Value "Watch your traffic grow with helpful insights and comprehensive stats." kept. Value "Find and follow your favorite sites and communities, and share you content." ignored.
[16:01:54]: ▸ Key "jetpack.fullscreen.overlay.newUsers.stats.subtitle" used with multiple values. Value "Watch your traffic grow with helpful insights and comprehensive stats." kept. Value "Get notifications for new comments, likes, views, and more." ignored.
[16:01:55]: ▸ Key "widget.today.nodata.view.title" used with multiple values. Value "Unable to load site stats." kept. Value "Unable to load today's stats." ignored.
```

## Testing

Checkout this branch, run `bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true` and verify it prints no warnings:

<img width="2558" alt="image" src="https://user-images.githubusercontent.com/1218433/215392934-62f1db80-9def-4fc9-98be-526a72d5bc62.png">

The diff will also show entries for the de-duplicated keys in `Localizable.strings`, but it will be tricky to spot them in between all the new strings. A way to verify this would be:

1. Checkout a new branch from `trunk`
2. Run `bundle exec fastlane generate_strings_file_for_glotpress`
3. Merge this PR in the new branch
4. Run `bundle exec fastlane generate_strings_file_for_glotpress skip_commit:true` again
5. This time, only the edited keys should show in the diff

However, our automation is tried and tested and I didn't feel the need to got to such length to verify it.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
