### PR TITLE
Blogging Prompts: Add option to disable blogging prompts feature

### DIFF
--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -17,6 +17,7 @@ private enum UPRUConstants {
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
     static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
     static let jetpackContentMigrationStateKey = "jetpackContentMigrationState"
+    static let promptsRemovedKey = "prompts-removed-sites"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -183,6 +184,18 @@ extension UserPersistentRepositoryUtility {
             }
         } set {
             UserPersistentStoreFactory.instance().set(newValue.rawValue, forKey: UPRUConstants.jetpackContentMigrationStateKey)
+        }
+    }
+
+    var promptsRemovedSites: Set<String> {
+        get {
+            guard let sites = UserPersistentStoreFactory.instance().array(forKey: UPRUConstants.promptsRemovedKey) as? [String] else {
+                return Set()
+            }
+            return Set(sites)
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue.array, forKey: UPRUConstants.promptsRemovedKey)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -568,11 +568,11 @@ private extension DashboardPromptsCardCell {
         static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
         static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")
         static let promptRemovedTitle = NSLocalizedString("prompts.notification.removed.title",
-                                                          value: "Prompts hidden from Dashboard",
-                                                          comment: "Title of the notification when prompts are removed from the dashboard")
+                                                          value: "Blogging Prompts hidden",
+                                                          comment: "Title of the notification when prompts are hidden from the dashboard card")
         static let promptRemovedSubtitle = NSLocalizedString("prompts.notification.removed.subtitle",
                                                              value: "Visit Site Settings to turn back on",
-                                                             comment: "Subtitle of the notification when prompts are removed from the dashboard")
+                                                             comment: "Subtitle of the notification when prompts are hidden from the dashboard card")
     }
 
     struct Style {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -77,7 +77,6 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     // This provides a quick way to toggle in flux features.
     // Since they probably will not be included in Blogging Prompts V1,
     // they are disabled by default.
-    private let removeFromDashboardEnabled = false
     private let sharePromptEnabled = false
 
     // Used to present:
@@ -301,8 +300,8 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
             .skip(skipMenuTapped)
         ]
 
-        if removeFromDashboardEnabled {
-            return [defaultItems, [.learnMore(learnMoreTapped), .remove(removeMenuTapped)]]
+        if FeatureFlag.bloggingPromptsEnhancements.enabled {
+            return [defaultItems, [.learnMore(learnMoreTapped)], [.remove(removeMenuTapped)]]
         }
 
         return [defaultItems, [.learnMore(learnMoreTapped)]]
@@ -353,11 +352,12 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     static func shouldShowCard(for blog: Blog) -> Bool {
         guard FeatureFlag.bloggingPrompts.enabled,
               let promptsService = BloggingPromptsService(blog: blog),
-              let settings = promptsService.localSettings else {
+              let settings = promptsService.localSettings,
+              let siteID = blog.dotComID?.stringValue else {
             return false
         }
-
-        let shouldDisplayCard = settings.promptRemindersEnabled || settings.isPotentialBloggingSite
+        let promptsRemovedSites = UserPersistentStoreFactory.instance().promptsRemovedSites
+        let shouldDisplayCard = !promptsRemovedSites.contains(siteID) && (settings.promptRemindersEnabled || settings.isPotentialBloggingSite)
         guard let todaysPrompt = promptsService.localTodaysPrompt else {
             // If there is no cached prompt, it can't have been skipped. So show the card.
             return shouldDisplayCard
@@ -499,8 +499,28 @@ private extension DashboardPromptsCardCell {
     }
 
     func removeMenuTapped() {
+        guard let siteID = blog?.dotComID?.stringValue else {
+            return
+        }
         WPAnalytics.track(.promptsDashboardCardMenuRemove)
-        // TODO.
+        updatePromptSettings(for: siteID, removed: true)
+        let notice = Notice(title: Strings.promptRemovedTitle, message: Strings.promptRemovedSubtitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { [weak self] _ in
+            self?.updatePromptSettings(for: siteID, removed: false)
+        }
+        ActionDispatcher.dispatch(NoticeAction.post(notice))
+    }
+
+    func updatePromptSettings(for siteID: String, removed: Bool) {
+        let repository = UserPersistentStoreFactory.instance()
+        var promptsRemovedSites = repository.promptsRemovedSites
+
+        if removed {
+            promptsRemovedSites.insert(siteID)
+        } else {
+            promptsRemovedSites.remove(siteID)
+        }
+        repository.promptsRemovedSites = promptsRemovedSites
+        presenterViewController?.reloadCardsLocally()
     }
 
     func learnMoreTapped() {
@@ -547,6 +567,12 @@ private extension DashboardPromptsCardCell {
         static let errorTitle = NSLocalizedString("Error loading prompt", comment: "Text displayed when there is a failure loading a blogging prompt.")
         static let promptSkippedTitle = NSLocalizedString("Prompt skipped", comment: "Title of the notification presented when a prompt is skipped")
         static let undoSkipTitle = NSLocalizedString("Undo", comment: "Button in the notification presented when a prompt is skipped")
+        static let promptRemovedTitle = NSLocalizedString("prompts.notification.removed.title",
+                                                          value: "Prompts hidden from Dashboard",
+                                                          comment: "Title of the notification when prompts are removed from the dashboard")
+        static let promptRemovedSubtitle = NSLocalizedString("prompts.notification.removed.subtitle",
+                                                             value: "Visit Site Settings to turn back on",
+                                                             comment: "Subtitle of the notification when prompts are removed from the dashboard")
     }
 
     struct Style {
@@ -585,7 +611,7 @@ private extension DashboardPromptsCardCell {
             case .skip:
                 return NSLocalizedString("Skip for today", comment: "Menu title to skip today's prompt.")
             case .remove:
-                return NSLocalizedString("Remove from dashboard", comment: "Destructive menu title to remove the prompt card from the dashboard.")
+                return NSLocalizedString("Turn off prompts", comment: "Destructive menu title to remove the prompt card from the dashboard.")
             case .learnMore:
                 return NSLocalizedString("Learn more", comment: "Menu title to show the prompts feature introduction modal.")
             }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -1,0 +1,128 @@
+
+extension SiteSettingsViewController {
+
+    @objc var bloggingSettingsRowCount: Int {
+        bloggingSettingsRows.count
+    }
+
+    @objc func tableView(_ tableView: UITableView, cellForBloggingSettingsInRow row: Int) -> UITableViewCell {
+        switch bloggingSettingsRows[row] {
+        case .reminders:
+            return remindersTableViewCell
+        case .prompts:
+            return promptsTableViewCell
+        }
+    }
+
+    @objc func tableView(_ tableView: UITableView, didSelectInBloggingSettingsAt indexPath: IndexPath) {
+        switch bloggingSettingsRows[indexPath.row] {
+        case .reminders:
+            presentBloggingRemindersFlow(indexPath: indexPath)
+        default:
+            break
+        }
+    }
+
+}
+
+// MARK: - Private methods
+
+private extension SiteSettingsViewController {
+    enum BloggingSettingsRows {
+        case reminders
+        case prompts
+    }
+
+    var bloggingSettingsRows: [BloggingSettingsRows] {
+        var rows = [BloggingSettingsRows]()
+        if blog.areBloggingRemindersAllowed() {
+            rows.append(.reminders)
+        }
+        if FeatureFlag.bloggingPromptsEnhancements.enabled {
+            rows.append(.prompts)
+        }
+        return rows
+    }
+
+    // MARK: - Reminders
+
+    var remindersTableViewCell: SettingTableViewCell {
+        let cell = SettingTableViewCell(label: Strings.remindersTitle,
+                                        editable: true,
+                                        reuseIdentifier: nil)
+        cell?.detailTextLabel?.adjustsFontSizeToFitWidth = true
+        cell?.detailTextLabel?.minimumScaleFactor = 0.75
+        cell?.accessoryType = .none
+        cell?.textValue = schedule(for: blog)
+        return cell ?? SettingTableViewCell()
+    }
+
+
+    func schedule(for blog: Blog) -> String {
+        guard let scheduler = try? ReminderScheduleCoordinator() else {
+            return ""
+        }
+
+        let formatter = BloggingRemindersScheduleFormatter()
+        return formatter.shortScheduleDescription(for: scheduler.schedule(for: blog),
+                                                  time: scheduler.scheduledTime(for: blog).toLocalTime()).string
+    }
+
+    func presentBloggingRemindersFlow(indexPath: IndexPath) {
+        BloggingRemindersFlow.present(from: self, for: blog, source: .blogSettings) { [weak self] in
+            guard let self = self,
+                  let cell = self.tableView.cellForRow(at: indexPath) as? SettingTableViewCell else {
+                return
+            }
+
+            cell.textValue = self.schedule(for: self.blog)
+        }
+
+        tableView.deselectRow(at: indexPath, animated: true)
+    }
+
+    // MARK: - Prompts
+
+    var promptsTableViewCell: SwitchTableViewCell {
+        let cell = SwitchTableViewCell()
+        cell.name = Strings.promptsTitle
+        cell.on = isPromptsSwitchEnabled
+        cell.onChange = promptsSwitchOnChange
+        return cell
+    }
+
+    var isPromptsSwitchEnabled: Bool {
+        guard let siteID = blog.dotComID?.stringValue else {
+            return false
+        }
+
+        return !UserPersistentStoreFactory.instance().promptsRemovedSites.contains(siteID)
+    }
+
+    var promptsSwitchOnChange: (Bool) -> () {
+        return { [weak self] isPromptsEnabled in
+            guard let siteID = self?.blog.dotComID?.stringValue else {
+                return
+            }
+            let repository = UserPersistentStoreFactory.instance()
+            var removedSites = repository.promptsRemovedSites
+
+            if isPromptsEnabled {
+                removedSites.remove(siteID)
+            } else {
+                removedSites.insert(siteID)
+            }
+            repository.promptsRemovedSites = removedSites
+        }
+    }
+
+    // MARK: - Constants
+
+    struct Strings {
+        static let remindersTitle = NSLocalizedString("Blogging Reminders",
+                                                      comment: "Label for the blogging reminders setting")
+        static let promptsTitle = NSLocalizedString("sitesettings.prompts.title",
+                                                    value: "Blogging Prompts",
+                                                    comment: "Label for the blogging prompts setting")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -119,10 +119,11 @@ private extension SiteSettingsViewController {
     // MARK: - Constants
 
     struct Strings {
-        static let remindersTitle = NSLocalizedString("Blogging Reminders",
+        static let remindersTitle = NSLocalizedString("sitesettings.reminders.title",
+                                                      value: "Reminders",
                                                       comment: "Label for the blogging reminders setting")
         static let promptsTitle = NSLocalizedString("sitesettings.prompts.title",
-                                                    value: "Blogging Prompts",
+                                                    value: "Show prompts",
                                                     comment: "Label for the blogging prompts setting")
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
@@ -6,6 +6,7 @@
 
 typedef NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionGeneral = 0,
+    SiteSettingsSectionBlogging,
     SiteSettingsSectionHomepage,
     SiteSettingsSectionAccount,
     SiteSettingsSectionEditor,

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -163,6 +163,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     }
 
     NSMutableArray *sections = [NSMutableArray arrayWithObjects:@(SiteSettingsSectionGeneral), nil];
+    
+    if (self.bloggingSettingsRowCount > 0) {
+        [sections addObject:@(SiteSettingsSectionBlogging)];
+    }
 
     if ([Feature enabled:FeatureFlagHomepageSettings] && [self.blog supports:BlogFeatureHomepageSettings]) {
         [sections addObject:@(SiteSettingsSectionHomepage)];
@@ -242,6 +246,8 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         {
             return self.generalSettingsRowCount;
         }
+        case SiteSettingsSectionBlogging:
+            return self.bloggingSettingsRowCount;
         case SiteSettingsSectionHomepage:
         {
             return SiteSettingsHomepageCount;
@@ -641,6 +647,9 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
         case SiteSettingsSectionGeneral:
             return [self tableView:tableView cellForGeneralSettingsInRow:indexPath.row];
 
+        case SiteSettingsSectionBlogging:
+            return [self tableView:tableView cellForBloggingSettingsInRow:indexPath.row];
+            
         case SiteSettingsSectionHomepage:
             return self.homepageSettingsCell;
 
@@ -697,6 +706,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     switch (section) {
         case SiteSettingsSectionGeneral:
             headingTitle = NSLocalizedString(@"General", @"Title for the general section in site settings screen");
+            break;
+        
+        case SiteSettingsSectionBlogging:
+            headingTitle = NSLocalizedString(@"Blogging", @"Title for the blogging section in site settings screen");
             break;
 
         case SiteSettingsSectionHomepage:
@@ -978,6 +991,10 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     switch (settingsSection) {
         case SiteSettingsSectionGeneral:
             [self tableView:tableView didSelectInGeneralSettingsAt:indexPath];
+            break;
+            
+        case SiteSettingsSectionBlogging:
+            [self tableView:tableView didSelectInBloggingSettingsAt:indexPath];
             break;
 
         case SiteSettingsSectionHomepage:

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -299,7 +299,9 @@ private extension CreateButtonCoordinator {
         guard FeatureFlag.bloggingPrompts.enabled,
               let blog = blog,
               blog.isAccessibleThroughWPCom(),
-              let prompt = prompt else {
+              let prompt = prompt,
+              let siteID = blog.dotComID?.stringValue,
+              !UserPersistentStoreFactory.instance().promptsRemovedSites.contains(siteID) else {
             return nil
         }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1866,6 +1866,8 @@
 		83043E55126FA31400EC9953 /* MessageUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 83043E54126FA31400EC9953 /* MessageUI.framework */; };
 		830A58D82793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
 		830A58D92793AB4500CDE94F /* LoginEpilogueAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */; };
+		8313B9EE298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8313B9ED298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift */; };
+		8313B9EF298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8313B9ED298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift */; };
 		8320BDE5283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8320BDE6283D9359009DF2DE /* BlogService+BloggingPrompts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */; };
 		8323789828526E6D003F4443 /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
@@ -7014,6 +7016,7 @@
 		82FFBF4E1F45E03D00F4573F /* WordPress 66.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 66.xcdatamodel"; sourceTree = "<group>"; };
 		83043E54126FA31400EC9953 /* MessageUI.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = MessageUI.framework; path = System/Library/Frameworks/MessageUI.framework; sourceTree = SDKROOT; };
 		830A58D72793AB4400CDE94F /* LoginEpilogueAnimator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginEpilogueAnimator.swift; sourceTree = "<group>"; };
+		8313B9ED298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SiteSettingsViewController+Blogging.swift"; sourceTree = "<group>"; };
 		8320BDE4283D9359009DF2DE /* BlogService+BloggingPrompts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogService+BloggingPrompts.swift"; sourceTree = "<group>"; };
 		8332DD2329259AE300802F7D /* DataMigrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigrator.swift; sourceTree = "<group>"; };
 		8332DD2729259BEB00802F7D /* DataMigratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataMigratorTests.swift; sourceTree = "<group>"; };
@@ -10711,6 +10714,7 @@
 				82B85DF81EDDB807004FD510 /* SiteIconPickerPresenter.swift */,
 				83FEFC7311FF6C5A0078B462 /* SiteSettingsViewController.h */,
 				83FEFC7411FF6C5A0078B462 /* SiteSettingsViewController.m */,
+				8313B9ED298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift */,
 				82C420751FE44BD900CFB15B /* SiteSettingsViewController+Swift.swift */,
 				3F43603723F369A9001DEE70 /* Related Posts */,
 			);
@@ -20214,6 +20218,7 @@
 				F52CACCC24512EA700661380 /* EmptyActionView.swift in Sources */,
 				D8212CBF20AA7B7F008E8AE8 /* ReaderShowAttributionAction.swift in Sources */,
 				FFABD800213423F1003C65B6 /* LinkSettingsViewController.swift in Sources */,
+				8313B9EE298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */,
 				E15644F11CE0E56600D96E64 /* FeatureItemCell.swift in Sources */,
 				8BAC9D9E27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift in Sources */,
 				E62AFB6B1DC8E593007484FC /* WPRichContentView.swift in Sources */,
@@ -24052,6 +24057,7 @@
 				FABB24DF2602FC2C00C8785C /* TimeZoneStore.swift in Sources */,
 				FABB24E02602FC2C00C8785C /* UserSuggestion+CoreDataClass.swift in Sources */,
 				069A4AA72664448F00413FA9 /* GutenbergFeaturedImageHelper.swift in Sources */,
+				8313B9EF298B1ACD000AF26E /* SiteSettingsViewController+Blogging.swift in Sources */,
 				982DA9A8263B1E2F00E5743B /* CommentService+Likes.swift in Sources */,
 				FABB24E12602FC2C00C8785C /* MediaLibraryPicker.swift in Sources */,
 				3F435222289B2B5A00CE19ED /* JetpackOverlayView.swift in Sources */,


### PR DESCRIPTION
Closes #19971 

## Description

- Adds a new menu item to turn off blogging prompts for selected site
- Adds a new site setting option to disable blogging prompts for selected site
- Hides the prompts header view in the FAB (+) menu when a prompt is skipped

## Screenshots

| Menu | Settings |
|-------|----------|
| <img width="360" src="https://user-images.githubusercontent.com/2454408/215537198-d975a738-221f-444b-9b52-de1bc9ce8d37.png"> | <img width="369" src="https://user-images.githubusercontent.com/2454408/216197079-8b575847-d2b4-42eb-9bd9-6eb8db2e016d.png"> |

## Testing

**Dashboard card menu item**
- Enable the feature flag `bloggingPromptsEnhancements`
- Install Jetpack and login
- Tap on the three dot menu on the blogging prompts dashboard card
- Tap on `Turn off prompts`
- Verify:
  - Blogging prompts card is hidden
  - Prompts is hidden in the FAB (+) menu
  - Notification pop up with an `Undo` action and the following text appears:
    - `Prompts hidden from Dashboard`
    - `Visit Site Settings to turn back on`

**Site settings switch**
- Follow the steps from `Dashboard card menu item` to disable prompts
- Navigate to `Menu` > `Site Settings`
- Verify a `Blogging Prompts` setting appears in the list with the switch off
- Tap on the `Blogging Prompts` switch to enable the feature
- Navigate back to the `Home` dashboard screen
- Verify:
  - Blogging prompts dashboard card appears
  - Prompts header view appears in the FAB (+) menu

**Undo notification button**
- Follow the steps from `Dashboard card menu item`
- When the notification appears, tap `Undo`
- Verify:
  - Blogging prompts dashboard card appears
  - Prompts header view appears in the FAB (+) menu

**Prompt skipped**
- Tap on the three dot menu on the blogging prompts dashboard card
- Tap on `Skip for today`
- Tap on the FAB (+)
- Verify the blogging prompts header view is hidden

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
