### PR TITLE
Jetpack Focus: Display an overlay when the app is accessed from a disabled entry point

### DIFF
--- a/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/MySitesCoordinator+RootViewPresenter.swift
@@ -133,6 +133,10 @@ extension MySitesCoordinator: RootViewPresenter {
 
     /// Default implementation for functions that are not supported by the simplified UI.
     func unsupportedFeatureFallback(callingFunction: String = #function) {
+        // Display overlay
+        displayJetpackOverlayForDisabledEntryPoint()
+
+        // Track incorrect access
         let properties = ["calling_function": callingFunction]
         WPAnalytics.track(.jetpackFeatureIncorrectlyAccessed, properties: properties)
     }

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -102,6 +102,10 @@ import AutomatticTracks
         }
 
         guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            // Display overlay
+            RootViewCoordinator.sharedPresenter.mySitesCoordinator.displayJetpackOverlayForDisabledEntryPoint()
+
+            // Track incorrect access
             let properties = ["calling_function": "deep_link", "url": url.absoluteString]
             WPAnalytics.track(.jetpackFeatureIncorrectlyAccessed, properties: properties)
             return false

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -163,6 +163,10 @@ struct UniversalLinkRouter: LinkRouter {
 
         for matchedRoute in matches {
             if matchedRoute.jetpackPowered && !JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
+                // Display overlay
+                RootViewCoordinator.sharedPresenter.mySitesCoordinator.displayJetpackOverlayForDisabledEntryPoint()
+
+                // Track incorrect access
                 let properties = ["calling_function": "deep_link", TracksPropertyKeys.url: url.absoluteString]
                 WPAnalytics.track(.jetpackFeatureIncorrectlyAccessed, properties: properties)
                 continue

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -41,6 +41,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         case card
         case login
         case appOpen = "app_open"
+        case disabledEntryPoint = "disabled_entry_point"
 
         /// Used to differentiate between last saved dates for different phases.
         /// Should return a dynamic value if each phase should be treated differently.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayFrequencyTracker.swift
@@ -56,6 +56,8 @@ class JetpackOverlayFrequencyTracker {
         case .reader:
             return frequenciesPassed()
         case .card:
+            fallthrough
+        case .disabledEntryPoint:
             return true
         case .login:
             fallthrough

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -152,6 +152,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.login, _):
             fallthrough
         case (.appOpen, _):
+            fallthrough
+        case (.disabledEntryPoint, _):
             return Constants.allFeaturesLogosAnimationLtr
         }
     }
@@ -173,6 +175,8 @@ struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewMod
         case (.login, _):
             fallthrough
         case (.appOpen, _):
+            fallthrough
+        case (.disabledEntryPoint, _):
             return Constants.allFeaturesLogosAnimationRtl
         }
     }

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -254,4 +254,13 @@ class MySitesCoordinator: NSObject {
         mySiteViewController = makeMySiteViewController()
         navigationController.viewControllers = [rootContentViewController]
     }
+
+    func displayJetpackOverlayForDisabledEntryPoint() {
+        let viewController = mySiteViewController
+        if viewController.isViewOnScreen() {
+            JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: viewController,
+                                                                     source: .disabledEntryPoint,
+                                                                     blog: viewController.blog)
+        }
+    }
 }

--- a/WordPress/WordPressStatsWidgets/Model/StatsWidgetEntry.swift
+++ b/WordPress/WordPressStatsWidgets/Model/StatsWidgetEntry.swift
@@ -5,7 +5,7 @@ enum StatsWidgetEntry: TimelineEntry {
     case loggedOut(StatsWidgetKind)
     case noSite(StatsWidgetKind)
     case noData(StatsWidgetKind)
-    case disabled
+    case disabled(StatsWidgetKind)
 
     var date: Date {
         switch self {

--- a/WordPress/WordPressStatsWidgets/SiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/SiteListProvider.swift
@@ -44,7 +44,7 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
             return
         }
         guard !defaults.bool(forKey: AppConfiguration.Widget.Stats.userDefaultsJetpackFeaturesDisabledKey) else {
-            completion(Timeline(entries: [.disabled], policy: .never))
+            completion(Timeline(entries: [.disabled(widgetKind)], policy: .never))
             return
         }
         guard let defaultSiteID = defaultSiteID else {

--- a/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
+++ b/WordPress/WordPressStatsWidgets/Views/StatsWidgetsView.swift
@@ -11,7 +11,10 @@ struct StatsWidgetsView: View {
 
         switch timelineEntry {
 
-        case .loggedOut, .noSite, .noData, .disabled:
+        case .disabled(let kind):
+            UnconfiguredView(timelineEntry: timelineEntry)
+                .widgetURL(kind.statsURL)
+        case .loggedOut, .noSite, .noData:
             UnconfiguredView(timelineEntry: timelineEntry)
                 .widgetURL(nil)
                 // This seems to prevent a bug where the URL for subsequent widget
@@ -117,5 +120,18 @@ private extension HomeWidgetThisWeekData {
 
     var statsURL: URL? {
         URL(string: Self.statsUrl + "\(siteID)?source=widget")
+    }
+}
+
+private extension StatsWidgetKind {
+    var statsURL: URL? {
+        switch self {
+        case .today:
+            return URL(string: "https://wordpress.com/stats/day/?source=widget")
+        case .allTime:
+            return URL(string: "https://wordpress.com/stats/insights/?source=widget")
+        case .thisWeek:
+            return URL(string: "https://wordpress.com/stats/week/?source=widget")
+        }
     }
 }


### PR DESCRIPTION
Closes #20036

## Description
In this PR, we display an overlay when the app is accessed from a disabled entry point. Known entry points include deep links and widget taps. Other entry points, like notification taps, are irreproducible but are handled just in case.

## Screen Recording

https://user-images.githubusercontent.com/25306722/215612793-901981ee-c936-40e8-aff7-d640e97ed5f1.mov

## Testing Instructions
### Deep links

1. Make sure the Jetpack app is not installed on your testing device
2. Launch the WordPress app
3. Open the debug menu and enable "Jetpack Features Removal Phase Four"
4. Close and reopen the app
5. Copy the following links to a note on your device:
    - wordpress.com/stats
    - wordpress.com/read
    - wordpress.com/notifications
6. For each link:
    1. Tap on the link
    2. The app is opened
    3. Make sure an overlay is displayed
    4. Check the logs for a `jetpack_feature_incorrectly_accessed` tracked event with `{"calling_function": "deep_link"}` 
    5. Check the logs for a `remove_feature_overlay_displayed` tracked event with `{"source": "disabled_entry_point"}` 

### Widgets

1. Launch the app
2. Open the debug menu and disable all "Jetpack Features Removal" flags
3. Add a widget to the home screen
4. Open the debug menu and enable the "Jetpack Features Removal Phase Four" flag
5. Close and re-open the app
6. The app's UI should now be updated to not show JP features
7. Navigate to the home screen
8. The widget should now display a message stating stats have moved
9. Tap on the widget
10. The app should open
11. Make sure an overlay is displayed
12. Check the logs for a `jetpack_feature_incorrectly_accessed` tracked event with `{"calling_function": "deep_link", "url": "https://wordpress.com/stats/day/?source=widget"}` 
13. Check the logs for a `remove_feature_overlay_displayed` tracked event with `{"source": "disabled_entry_point"}` 
14. Repeat the above steps for different widgets


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.