### PR TITLE
Jetpack Focus: Prevent FAB from obscuring the last row

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -39,6 +39,7 @@ CGFloat const BlogDetailGridiconAccessorySize = 17.0;
 CGFloat const BlogDetailQuickStartSectionHeaderHeight = 48.0;
 CGFloat const BlogDetailSectionTitleHeaderHeight = 40.0;
 CGFloat const BlogDetailSectionsSpacing = 20.0;
+CGFloat const BlogDetailSectionFooterHeight = 40.0;
 NSTimeInterval const PreloadingCacheTimeout = 60.0 * 5; // 5 minutes
 NSString * const HideWPAdminDate = @"2015-09-07T00:00:00Z";
 
@@ -650,7 +651,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         return UITableViewAutomaticDimension;
     }
     if (isLastSection) {
-        return BlogDetailSectionsSpacing;
+        return BlogDetailSectionFooterHeight;
     }
     return 0;
 }


### PR DESCRIPTION
Fixes #19873

Added more spacing to the bottom of the tableview so the FAB doesn't obscure the last item.

Before | After
:--: | :--:
<img src="https://user-images.githubusercontent.com/6711616/215845772-8b85536f-1bb5-491a-84a3-0d9746648d79.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/215845787-a208dcf5-1d18-48c2-a05c-eae634650b72.png" width=200>
![Simulator Screen Shot - iPhone 14 Pro - 2023-01-31 at 18 04 37](https://user-images.githubusercontent.com/6711616/215846114-ab024973-5ad2-45af-842e-af8cc5dabb35.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-01-31 at 18 03 00](https://user-images.githubusercontent.com/6711616/215846119-e7b17c1c-574e-4a34-ae24-c4190917230f.png)


## How to test
0. Test on an iPhone (e.g. a device with a compact height in landscape orientation)
1. Enable "Jetpack Features Removal Phase Four" from the debug menu
2. Change the device orientation to landscape
3. ✅ The FAB shouldn't obscure the last row, and the ellipsis button should be tappable

## Regression Notes
1. Potential unintended areas of impact
n/a

4. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

5. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
