### PR TITLE
Jetpack Focus: Add Jetpack branding for Post Stats screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -178,9 +178,10 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.publish)
             }
 
-            let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
-            if jetpackFeaturesEnabled && post.status == .publish && post.hasRemote() {
-                buttons.append(.stats)
+            if post.status == .publish && post.hasRemote() {
+                if JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
+                    buttons.append(.stats)
+                }
                 buttons.append(.share)
             }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -178,7 +178,8 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.publish)
             }
 
-            if post.status == .publish && post.hasRemote() {
+            let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+            if jetpackFeaturesEnabled && post.status == .publish && post.hasRemote() {
                 buttons.append(.stats)
                 buttons.append(.share)
             }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -679,8 +679,9 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         SiteStatsInformation.sharedInstance.siteID = blog.dotComID
 
         let postURL = URL(string: apost.permaLink! as String)
-        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postID: postID, postTitle: apost.titleForDisplay(), postURL: postURL)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: apost.titleForDisplay(),
+                                                                                            postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -449,8 +449,9 @@ extension SiteStatsInsightsTableViewController: SiteStatsInsightsDelegate {
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
         removeViewModelListeners()
 
-        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: postTitle,
+                                                                                            postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -296,8 +296,9 @@ extension SiteStatsPeriodTableViewController: SiteStatsPeriodDelegate {
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
         removeViewModelListeners()
 
-        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: postTitle,
+                                                                                            postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController+JetpackBannerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController+JetpackBannerViewController.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension PostStatsTableViewController {
+
+    static func withJPBannerForBlog(postID: Int, postTitle: String?, postURL: URL?) -> UIViewController {
+        let statsVC = PostStatsTableViewController.loadFromStoryboard()
+        statsVC.configure(postID: postID, postTitle: postTitle, postURL: postURL)
+        return JetpackBannerWrapperViewController(childVC: statsVC, screen: .stats)
+    }
+
+    override func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if let jetpackBannerWrapper = parent as? JetpackBannerWrapperViewController {
+            jetpackBannerWrapper.processJetpackBannerVisibility(scrollView)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -43,6 +43,11 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
         addWillEnterForegroundObserver()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .stats)
+    }
+
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         removeWillEnterForegroundObserver()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -26,7 +26,7 @@ class PostStatsTableViewController: UITableViewController, StoryboardLoadable {
     private var changeReceipt: Receipt?
 
     private lazy var tableHandler: ImmuTableViewHandler = {
-        return ImmuTableViewHandler(takeOver: self)
+        return ImmuTableViewHandler(takeOver: self, with: self)
     }()
 
     // MARK: - View

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -290,8 +290,9 @@ extension SiteStatsDetailTableViewController: SiteStatsDetailsDelegate {
     }
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
-        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: postTitle,
+                                                                                            postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -300,8 +300,9 @@ extension SiteStatsInsightsDetailsTableViewController: SiteStatsDetailsDelegate 
 
     func showPostStats(postID: Int, postTitle: String?, postURL: URL?) {
         removeViewModelListeners()
-        let postStatsTableViewController = PostStatsTableViewController.loadFromStoryboard()
-        postStatsTableViewController.configure(postID: postID, postTitle: postTitle, postURL: postURL)
+        let postStatsTableViewController = PostStatsTableViewController.withJPBannerForBlog(postID: postID,
+                                                                                            postTitle: postTitle,
+                                                                                            postURL: postURL)
         navigationController?.pushViewController(postStatsTableViewController, animated: true)
     }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1780,6 +1780,8 @@
 		80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */; };
 		80B016D12803AB9F00D15566 /* DashboardPostsListCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */; };
 		80B016D22803AB9F00D15566 /* DashboardPostsListCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */; };
+		80C740FB2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C740FA2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift */; };
+		80C740FC2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80C740FA2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift */; };
 		80EF671F27F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672027F135EB0063B138 /* WhatIsNewViewAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */; };
 		80EF672227F160720063B138 /* DashboardCustomAnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */; };
@@ -6964,6 +6966,7 @@
 		8096218A28E55D2400940A5D /* Info-Alpha.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Alpha.plist"; sourceTree = "<group>"; };
 		80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPostsListCardCell.swift; sourceTree = "<group>"; };
+		80C740FA2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostStatsTableViewController+JetpackBannerViewController.swift"; sourceTree = "<group>"; };
 		80EF671E27F135EB0063B138 /* WhatIsNewViewAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WhatIsNewViewAppearance.swift; sourceTree = "<group>"; };
 		80EF672127F160720063B138 /* DashboardCustomAnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCustomAnnouncementCell.swift; sourceTree = "<group>"; };
 		80EF672427F3D63B0063B138 /* DashboardStatsStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardStatsStackView.swift; sourceTree = "<group>"; };
@@ -13568,6 +13571,7 @@
 			children = (
 				986C908522319F2600FC31E1 /* PostStatsTableViewController.storyboard */,
 				986C908322319EFF00FC31E1 /* PostStatsTableViewController.swift */,
+				80C740FA2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift */,
 				986C90872231AD6200FC31E1 /* PostStatsViewModel.swift */,
 				98FCFC212231DF43006ECDD4 /* PostStatsTitleCell.swift */,
 				98FCFC222231DF43006ECDD4 /* PostStatsTitleCell.xib */,
@@ -21467,6 +21471,7 @@
 				CE46018B21139E8300F242B6 /* FooterTextContent.swift in Sources */,
 				E6D6A1302683ABE6004C24A7 /* ReaderSubscribeCommentsAction.swift in Sources */,
 				F1BC842E27035A1800C39993 /* BlogService+Domains.swift in Sources */,
+				80C740FB2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */,
 				B5EEDB971C91F10400676B2B /* Blog+Interface.swift in Sources */,
 				982DDF96263238A6002B3904 /* LikeUserPreferredBlog+CoreDataProperties.swift in Sources */,
 				5D839AA8187F0D6B00811F4A /* PostFeaturedImageCell.m in Sources */,
@@ -23622,6 +23627,7 @@
 				FABB23832602FC2C00C8785C /* BasePageListCell.m in Sources */,
 				F163541726DE2ECE008B625B /* NotificationEventTracker.swift in Sources */,
 				0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */,
+				80C740FC2989FC4600199027 /* PostStatsTableViewController+JetpackBannerViewController.swift in Sources */,
 				FABB23852602FC2C00C8785C /* WPError.m in Sources */,
 				FABB23862602FC2C00C8785C /* ContentRouter.swift in Sources */,
 				FABB23872602FC2C00C8785C /* BlogToBlog32to33.swift in Sources */,


### PR DESCRIPTION
Closes #20039

## Description
This PR adds Jetpack branding to the post stats page. An overlay is displayed while respecting the frequency logic. And a banner is added.
This PR also removes the Stats action from the Post action menu.

### Screenshots

| / |P1|P2|P3|P4|
| :-: | :-: | :-: | :-: | :-: |
|Menu|![P1-Menu](https://user-images.githubusercontent.com/25306722/215933862-51686dc6-b74a-4a90-80f7-7a9e97eb1f77.png)|![P1-Menu](https://user-images.githubusercontent.com/25306722/215933862-51686dc6-b74a-4a90-80f7-7a9e97eb1f77.png)|![P1-Menu](https://user-images.githubusercontent.com/25306722/215933862-51686dc6-b74a-4a90-80f7-7a9e97eb1f77.png)|![P4-Menu png](https://user-images.githubusercontent.com/25306722/215933878-b9467fdc-7b5f-4663-b0c9-f0ef2c798cbb.png)|
|Banner|![P1-banner](https://user-images.githubusercontent.com/25306722/215933876-f1886dc0-9fe0-4957-bc4c-394649eaeeb0.png)|![P2-banner](https://user-images.githubusercontent.com/25306722/215933873-beaad8be-7350-4c5b-9181-7236b1b08199.png)|![P3-banner](https://user-images.githubusercontent.com/25306722/215933852-731cfe8d-ee38-4c5a-8dbb-0f17464bba38.png)|N/A|

## Testing Instructions

### Actions Menu

1. Open the app
2. Navigate to the posts list > published posts
3. Tap on the More menu on a post item
4. Make sure the Stats action is visible
5. Navigate to the debug menu and enable the "Jetpack Features Removal Phase Four" flag
6. Close and re-open the app
7. The UI should be reloaded
8. Navigate to the posts list > published posts
9. Tap on the More menu on a post item
10. Make sure the Stats action is no longer visible

### Jetpack Branding

1. Fresh install the app
2. Launch and log in
3. Navigate to the posts list > published posts
4. Tap on the More menu on a post item
5. Tap on Stats
6. Make sure an overlay is presented
7. Dismiss the overlay
8. Make sure a banner is added
9. Scroll down
10. Make sure the banner disappears when scrolling down
11. Repeat the above steps for phases 2 and 3, making sure that the banner text adapts to the phase

## Regression Notes
1. Potential unintended areas of impact
Accessing post stats from other entry points like insights and period stats views.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

5. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.