### PR TITLE
[UI Tests] Make current WordPress UI Tests to run against Jetpack app

### DIFF
--- a/WordPress/JetpackUITests/Flows/EditorFlow.swift
+++ b/WordPress/JetpackUITests/Flows/EditorFlow.swift
@@ -1,0 +1,23 @@
+import UITestsFoundation
+import XCTest
+
+class EditorFlow {
+    static func returnToMainEditorScreen() {
+        while EditorPostSettings.isLoaded() || CategoriesComponent.isLoaded() || TagsComponent.isLoaded() || MediaPickerAlbumListScreen.isLoaded() || MediaPickerAlbumScreen.isLoaded() {
+            navigateBack()
+        }
+    }
+
+    static func goToMySiteScreen() throws -> MySiteScreen {
+        return try TabNavComponent().goToMySiteScreen()
+    }
+
+    static func toggleBlockEditor(to state: SiteSettingsScreen.Toggle) throws -> SiteSettingsScreen {
+        if !SiteSettingsScreen.isLoaded() {
+            _ = try TabNavComponent()
+                .goToMySiteScreen()
+                .goToSettingsScreen()
+        }
+        return try SiteSettingsScreen().toggleBlockEditor(to: state)
+    }
+}

--- a/WordPress/JetpackUITests/Flows/LoginFlow.swift
+++ b/WordPress/JetpackUITests/Flows/LoginFlow.swift
@@ -1,0 +1,43 @@
+import UITestsFoundation
+import XCTest
+
+class LoginFlow {
+
+    @discardableResult
+    static func login(email: String, password: String, selectedSiteTitle: String? = nil) throws -> MySiteScreen {
+        return try PrologueScreen().selectContinue()
+            .proceedWith(email: email)
+            .proceedWith(password: password)
+            .continueWithSelectedSite(title: selectedSiteTitle)
+            .dismissNotificationAlertIfNeeded()
+    }
+
+    // Login with self-hosted site via Site Address.
+    @discardableResult
+    static func login(siteUrl: String, username: String, password: String) throws -> MySiteScreen {
+        return try PrologueScreen().selectSiteAddress()
+            .proceedWith(siteUrl: siteUrl)
+            .proceedWith(username: username, password: password)
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+    }
+
+    // Login with WP site via Site Address.
+    @discardableResult
+    static func login(siteUrl: String, email: String, password: String) throws -> MySiteScreen {
+        return try PrologueScreen().selectSiteAddress()
+            .proceedWithWP(siteUrl: siteUrl)
+            .proceedWith(email: email)
+            .proceedWith(password: password)
+        .continueWithSelectedSite()
+        .dismissNotificationAlertIfNeeded()
+    }
+
+    // Login with self-hosted site via Site Address.
+    static func loginIfNeeded(siteUrl: String, username: String, password: String) throws -> TabNavComponent {
+        guard TabNavComponent.isLoaded() else {
+            return try login(siteUrl: siteUrl, username: username, password: password).tabBar
+        }
+        return try TabNavComponent()
+    }
+}

--- a/WordPress/JetpackUITests/JetpackUITests.swift
+++ b/WordPress/JetpackUITests/JetpackUITests.swift
@@ -1,0 +1,42 @@
+//
+//  JetpackUITests.swift
+//  JetpackUITests
+//
+//  Created by Tiago Marques on 03/01/23.
+//  Copyright © 2023 WordPress. All rights reserved.
+//
+
+import XCTest
+
+final class JetpackUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/WordPress/JetpackUITests/JetpackUITests.xctestplan
+++ b/WordPress/JetpackUITests/JetpackUITests.xctestplan
@@ -1,0 +1,38 @@
+{
+  "configurations" : [
+    {
+      "id" : "0BAD9BB4-5B91-4378-828D-69177CF0A0CB",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en",
+    "region" : "US",
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:WordPress.xcodeproj",
+      "identifier" : "FABB1F8F2602FC2C00C8785C",
+      "name" : "Jetpack"
+    }
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "EditorAztecTests",
+        "LoginTests\/testEmailMagicLinkLogin()",
+        "MainNavigationTests",
+        "SignupTests",
+        "SignupTests\/testEmailSignup()",
+        "StatsTests"
+      ],
+      "target" : {
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "EA0C6DA22964BCF700000518",
+        "name" : "JetpackUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/WordPress/JetpackUITests/JetpackUITestsLaunchTests.swift
+++ b/WordPress/JetpackUITests/JetpackUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  JetpackUITestsLaunchTests.swift
+//  JetpackUITests
+//
+//  Created by Tiago Marques on 03/01/23.
+//  Copyright © 2023 WordPress. All rights reserved.
+//
+
+import XCTest
+
+final class JetpackUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/WordPress/JetpackUITests/LoginTests.swift
+++ b/WordPress/JetpackUITests/LoginTests.swift
@@ -1,0 +1,90 @@
+import UITestsFoundation
+import XCTest
+
+class LoginTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        setUpTestSuite()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp()
+    }
+
+    // Unified email login/out
+    func testWPcomLoginLogout() throws {
+        let prologueScreen = try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+            .tabBar.goToMeScreen()
+            .logoutToPrologue()
+
+        XCTAssert(prologueScreen.isLoaded)
+    }
+
+    /**
+     This test opens safari to trigger the mocked magic link redirect
+     */
+    func testEmailMagicLinkLogin() throws {
+        let welcomeScreen = try WelcomeScreen().selectLogin()
+            .selectEmailLogin()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWithLink()
+            .openMagicLoginLink()
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+            .tabBar.goToMeScreen()
+            .logout()
+
+        XCTAssert(welcomeScreen.isLoaded)
+    }
+
+    // Unified self hosted login/out
+    func testSelfHostedLoginLogout() throws {
+        let prologueScreen = try PrologueScreen()
+
+        try prologueScreen
+            .selectSiteAddress()
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .removeSelfHostedSite()
+
+        XCTAssert(prologueScreen.isLoaded)
+    }
+
+    // Unified WordPress.com email login failure due to incorrect password
+    func testWPcomInvalidPassword() throws {
+        _ = try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .tryProceed(password: "invalidPswd")
+            .verifyLoginError()
+    }
+
+    // Self-Hosted after WordPress.com login.
+    // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
+    func testAddSelfHostedSiteAfterWPcomLogin() throws {
+        try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite() //returns MySite screen
+
+            // From here, bring up the sites list and choose to add a new self-hosted site.
+            .showSiteSwitcher()
+            .addSelfHostedSite()
+
+            // Then, go through the self-hosted login flow:
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+
+            // Login flow returns MySites modal, which needs to be closed.
+            .closeModal()
+
+        XCTAssert(MySiteScreen.isLoaded())
+    }
+}

--- a/WordPress/JetpackUITests/Screens/BaseScreen.swift
+++ b/WordPress/JetpackUITests/Screens/BaseScreen.swift
@@ -1,0 +1,63 @@
+import UITestsFoundation
+import XCTest
+
+private extension XCUIElementAttributes {
+    var isNetworkLoadingIndicator: Bool {
+        if hasAllowListedIdentifier { return false }
+
+        let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+        let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+        return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+    }
+
+    var hasAllowListedIdentifier: Bool {
+        let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+        return allowListedIdentifiers.contains(identifier)
+    }
+
+    func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+        if elementType == .statusBar { return true }
+        guard frame.origin == .zero else { return false }
+
+        let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+        let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+        return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+    }
+}
+
+private extension XCUIElementQuery {
+    var networkLoadingIndicators: XCUIElementQuery {
+        let isNetworkLoadingIndicator = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isNetworkLoadingIndicator
+        }
+
+        return self.containing(isNetworkLoadingIndicator)
+    }
+
+    var deviceStatusBars: XCUIElementQuery {
+        let deviceWidth = XCUIApplication().frame.width
+
+        let isStatusBar = NSPredicate { (evaluatedObject, _) in
+            guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+            return element.isStatusBar(deviceWidth)
+        }
+
+        return self.containing(isStatusBar)
+    }
+
+    func first(where predicate: (XCUIElement) throws -> Bool) rethrows -> XCUIElement? {
+        return try self.allElementsBoundByIndex.first(where: predicate)
+    }
+}
+
+private extension CGFloat {
+    func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+        return numberA...numberB ~= self
+    }
+}

--- a/WordPress/JetpackUITests/Tests/EditorAztecTests.swift
+++ b/WordPress/JetpackUITests/Tests/EditorAztecTests.swift
@@ -1,0 +1,78 @@
+import UITestsFoundation
+import XCTest
+
+class EditorAztecTests: XCTestCase {
+    private var editorScreen: AztecEditorScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite()
+
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        editorScreen = try EditorFlow
+            .toggleBlockEditor(to: .off)
+            .goBackToMySite()
+            .tabBar.goToAztecEditorScreen()
+            .dismissNotificationAlertIfNeeded(.accept)
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp()
+    }
+
+    // TODO: Re-enable Aztec tests but for editing an existing Aztec post.
+    // For more information, see Issue: https://github.com/wordpress-mobile/WordPress-iOS/issues/16218
+//    func testTextPostPublish() {
+//        let title = getRandomPhrase()
+//        let content = getRandomContent()
+//        editorScreen
+//            .enterTextInTitle(text: title)
+//            .enterText(text: content)
+//            .publish()
+//            .viewPublishedPost(withTitle: title)
+//            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+//            .done()
+//    }
+//
+//    func testBasicPostPublish() {
+//        let title = getRandomPhrase()
+//        let content = getRandomContent()
+//        let category = getCategory()
+//        let tag = getTag()
+//        editorScreen
+//            .enterTextInTitle(text: title)
+//            .enterText(text: content)
+//            .addImageByOrder(id: 0)
+//            .openPostSettings()
+//            .selectCategory(name: category)
+//            .addTag(name: tag)
+//            .setFeaturedImage()
+//            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: true)
+//            .removeFeatureImage()
+//            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: false)
+//            .setFeaturedImage()
+//            .verifyPostSettings(withCategory: category, withTag: tag, hasImage: true)
+//            .closePostSettings()
+//        AztecEditorScreen(mode: .rich).publish()
+//            .viewPublishedPost(withTitle: title)
+//            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+//            .done()
+//    }
+//
+//    // Github issue https://github.com/wordpress-mobile/AztecEditor-iOS/issues/385
+//    func testLongTitle() {
+//        let longTitle = "long title in a galaxy not so far away"
+//        // Title heigh contains of actual textfield height + bottom line.
+//        // 16.5px - is the height of that bottom line. Its not changing with different font sizes
+//        let titleTextView = editorScreen.titleView
+//        let titleLineHeight = titleTextView.frame.height - 16.5
+//        let oneLineTitleHeight = titleTextView.frame.height
+//
+//        let repeatTimes = isIPhone ? 6 : 20
+//        _ = editorScreen.enterTextInTitle(text: String(repeating: "very ", count: repeatTimes) + longTitle)
+//
+//        let twoLineTitleHeight = titleTextView.frame.height
+//
+//        XCTAssert(twoLineTitleHeight - oneLineTitleHeight >= titleLineHeight )
+//    }
+}

--- a/WordPress/JetpackUITests/Tests/EditorGutenbergTests.swift
+++ b/WordPress/JetpackUITests/Tests/EditorGutenbergTests.swift
@@ -1,0 +1,79 @@
+import UITestsFoundation
+import XCTest
+
+class EditorGutenbergTests: XCTestCase {
+    private var editorScreen: BlockEditorScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite(for: "Jetpack")
+
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        editorScreen = try EditorFlow
+            .goToMySiteScreen()
+            .tabBar.gotoBlockEditorScreen()
+            .dismissNotificationAlertIfNeeded(.accept)
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    let title = "Rich post title"
+    let content = "Some text, and more text"
+
+    func testTextPostPublish() throws {
+
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
+            .publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testBasicPostPublishWithCategoryAndTag() throws {
+
+        let category = getCategory()
+        let tag = getTag()
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .addImage()
+            .verifyContentStructure(blocks: 2, words: content.components(separatedBy: " ").count, characters: content.count)
+            .openPostSettings()
+            .selectCategory(name: category)
+            .addTag(name: tag)
+            .closePostSettings()
+        try BlockEditorScreen().publish()
+            .viewPublishedPost(withTitle: title)
+            .verifyEpilogueDisplays(postTitle: title, siteAddress: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .done()
+    }
+
+    func testAddRemoveFeaturedImage() throws {
+
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .verifyContentStructure(blocks: 1, words: content.components(separatedBy: " ").count, characters: content.count)
+            .openPostSettings()
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .removeFeatureImage()
+            .verifyPostSettings(hasImage: false)
+            .setFeaturedImage()
+            .verifyPostSettings(hasImage: true)
+            .closePostSettings()
+    }
+
+    func testAddGalleryBlock() throws {
+        try editorScreen
+            .enterTextInTitle(text: title)
+            .addParagraphBlock(withText: content)
+            .addImageGallery()
+            .verifyContentStructure(blocks: 2, words: content.components(separatedBy: " ").count, characters: content.count)
+    }
+}

--- a/WordPress/JetpackUITests/Tests/LoginTests.swift
+++ b/WordPress/JetpackUITests/Tests/LoginTests.swift
@@ -1,0 +1,90 @@
+import UITestsFoundation
+import XCTest
+
+class LoginTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        setUpTestSuite(for: "Jetpack")
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    // Unified email login/out
+    func testWPcomLoginLogout() throws {
+        let prologueScreen = try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+            .tabBar.goToMeScreen()
+            .logoutToPrologue()
+
+        XCTAssert(prologueScreen.isLoaded)
+    }
+
+    /**
+     This test opens safari to trigger the mocked magic link redirect
+     */
+    func testEmailMagicLinkLogin() throws {
+        let welcomeScreen = try WelcomeScreen().selectLogin()
+            .selectEmailLogin()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWithLink()
+            .openMagicLoginLink()
+            .continueWithSelectedSite()
+            .dismissNotificationAlertIfNeeded()
+            .tabBar.goToMeScreen()
+            .logout()
+
+        XCTAssert(welcomeScreen.isLoaded)
+    }
+
+    // Unified self hosted login/out
+    func testSelfHostedLoginLogout() throws {
+        let prologueScreen = try PrologueScreen()
+
+        try prologueScreen
+            .selectSiteAddress()
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWithSelfHosted(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+            .removeSelfHostedSite()
+
+        XCTAssert(prologueScreen.isLoaded)
+    }
+
+    // Unified WordPress.com email login failure due to incorrect password
+    func testWPcomInvalidPassword() throws {
+        _ = try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .tryProceed(password: "invalidPswd")
+            .verifyLoginError()
+    }
+
+    // Self-Hosted after WordPress.com login.
+    // Login to a WordPress.com account, open site switcher, then add a self-hosted site.
+    func testAddSelfHostedSiteAfterWPcomLogin() throws {
+        try PrologueScreen().selectContinue()
+            .proceedWith(email: WPUITestCredentials.testWPcomUserEmail)
+            .proceedWith(password: WPUITestCredentials.testWPcomPassword)
+            .verifyEpilogueDisplays(username: WPUITestCredentials.testWPcomUsername, siteUrl: WPUITestCredentials.testWPcomSitePrimaryAddress)
+            .continueWithSelectedSite() //returns MySite screen
+
+            // From here, bring up the sites list and choose to add a new self-hosted site.
+            .showSiteSwitcher()
+            .addSelfHostedSite()
+
+            // Then, go through the self-hosted login flow:
+            .proceedWith(siteUrl: WPUITestCredentials.selfHostedSiteAddress)
+            .proceedWithSelfHostedSiteAddedFromSitesList(username: WPUITestCredentials.selfHostedUsername, password: WPUITestCredentials.selfHostedPassword)
+
+            // Login flow returns MySites modal, which needs to be closed.
+            .closeModal()
+
+        XCTAssert(MySiteScreen.isLoaded())
+    }
+}

--- a/WordPress/JetpackUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/JetpackUITests/Tests/MainNavigationTests.swift
@@ -1,0 +1,43 @@
+import UITestsFoundation
+import XCTest
+
+class MainNavigationTests: XCTestCase {
+    private var mySiteScreen: MySiteScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite(for: "Jetpack")
+
+        try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        mySiteScreen = try TabNavComponent()
+            .goToMySiteScreen()
+//            .goToMenu()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    func testTabBarNavigation() throws {
+        XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
+
+        _ = try mySiteScreen
+            .tabBar.goToReaderScreen()
+
+        XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
+
+        // We may get a notifications fancy alert when loading the reader for the first time
+        if let alert = try? FancyAlertComponent() {
+            alert.cancelAlert()
+        }
+
+        _ = try mySiteScreen
+            .tabBar.goToNotificationsScreen()
+            .dismissNotificationAlertIfNeeded()
+
+        XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in
+            XCTAssert(NotificationsScreen.isLoaded(), "Notifications screen isn't loaded.")
+            XCTAssert(TabNavComponent.isVisible(), "Main navigation bar isn't visible.")
+        }
+    }
+}

--- a/WordPress/JetpackUITests/Tests/ReaderTests.swift
+++ b/WordPress/JetpackUITests/Tests/ReaderTests.swift
@@ -1,0 +1,32 @@
+import UITestsFoundation
+import XCTest
+
+class ReaderTests: XCTestCase {
+    private var readerScreen: ReaderScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite(for: "Jetpack")
+
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        readerScreen = try EditorFlow
+            .goToMySiteScreen()
+            .tabBar.goToReaderScreen()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    let expectedPostContent = "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis. Proin dictum non ligula aliquam varius. Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec. Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."
+
+    func testViewPost() {
+        readerScreen.openLastPost()
+        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
+    }
+
+    func testViewPostInSafari() {
+        readerScreen.openLastPostInSafari()
+        XCTAssert(readerScreen.postContentEquals(expectedPostContent))
+    }
+}

--- a/WordPress/JetpackUITests/Tests/StatsTests.swift
+++ b/WordPress/JetpackUITests/Tests/StatsTests.swift
@@ -1,0 +1,65 @@
+import UITestsFoundation
+import XCTest
+
+class StatsTests: XCTestCase {
+    private var statsScreen: StatsScreen!
+
+    override func setUpWithError() throws {
+        setUpTestSuite(for: "Jetpack")
+        _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
+        statsScreen = try MySiteScreen()
+            .goToStatsScreen()
+            .switchTo(mode: .insights)
+            .refreshStatsIfNeeded()
+            .dismissCustomizeInsightsNotice()
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    let insightsStats: [String] = [
+        "Views",
+        "2,243",
+        "Posts",
+        "2",
+        "Visitors",
+        "1,201",
+        "Best views ever",
+        "48"
+    ]
+
+    let yearsStats: [String] = [
+        "9,148",
+        "+7,933 (653%)",
+        "United States, 60",
+        "Canada, 44",
+        "Germany, 15",
+        "France, 14",
+        "United Kingdom, 12",
+        "India, 121"
+    ]
+
+    let yearsChartBars: [String] = [
+        "Views,  2019: 9148",
+        "Visitors,  2019: 4216",
+        "Views,  2018: 1215",
+        "Visitors,  2018: 632",
+        "Views,  2017: 788",
+        "Visitors,  2017: 465"
+    ]
+
+    func testInsightsStatsLoadProperly() {
+        statsScreen
+            .switchTo(mode: .insights)
+            .assertStatsAreLoaded(insightsStats)
+    }
+
+    func testYearsStatsLoadProperly() {
+        statsScreen
+            .switchTo(mode: .years)
+            .assertStatsAreLoaded(yearsStats)
+            .assertChartIsLoaded(yearsChartBars)
+    }
+}

--- a/WordPress/JetpackUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/JetpackUITests/Tests/SupportScreenTests.swift
@@ -1,0 +1,23 @@
+import UITestsFoundation
+import XCTest
+
+class SupportScreenTests: XCTestCase {
+    override func setUpWithError() throws {
+        setUpTestSuite(for: "Jetpack")
+    }
+
+    override func tearDownWithError() throws {
+        takeScreenshotOfFailedTest()
+        removeApp("Jetpack")
+    }
+
+    func testContactUsCanBeLoadedDuringLogin() throws {
+        try PrologueScreen()
+            .selectContinue()
+            .selectHelp()
+            .contactSupport()
+            .assertCanNotSendEmptyMessage()
+            .enterText("A")
+            .assertCanSendMessage()
+    }
+}

--- a/WordPress/JetpackUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/JetpackUITests/Utils/XCTest+Extensions.swift
@@ -1,0 +1,94 @@
+import UITestsFoundation
+import XCTest
+
+extension XCTestCase {
+
+    public func setUpTestSuite(for appName: String? = nil, app: XCUIApplication = XCUIApplication()) {
+        super.setUp()
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        app.launchArguments = ["-wpcom-api-base-url", WireMock.URL().absoluteString, "-no-animations", "-ui-testing"]
+
+        if let appName = appName {
+            removeApp(appName)
+        }
+
+        app.activate()
+
+        // Media permissions alert handler
+        let alertButtonTitle = "Allow Access to All Photos"
+        systemAlertHandler(alertTitle: "“WordPress” Would Like to Access Your Photos", alertButton: alertButtonTitle)
+    }
+
+    public func takeScreenshotOfFailedTest() {
+        guard let failuresCount = testRun?.failureCount, failuresCount > 0 else { return }
+
+        XCTContext.runActivity(named: "Take a screenshot at the end of a failed test") { activity in
+            add(XCTAttachment(screenshot: XCUIApplication().windows.firstMatch.screenshot()))
+        }
+    }
+
+    public func systemAlertHandler(alertTitle: String, alertButton: String) {
+        addUIInterruptionMonitor(withDescription: alertTitle) { (alert) -> Bool in
+            let alertButtonElement = alert.buttons[alertButton]
+            XCTAssert(alertButtonElement.waitForExistence(timeout: 5))
+            alertButtonElement.tap()
+            return true
+        }
+    }
+
+    public func getRandomPhrase() -> String {
+        var wordArray: [String] = []
+        let phraseLength = Int.random(in: 3...6)
+        for _ in 1...phraseLength {
+            wordArray.append(DataHelper.words.randomElement()!)
+        }
+        let phrase = wordArray.joined(separator: " ")
+
+        return phrase
+    }
+
+    public func getRandomContent() -> String {
+        var sentenceArray: [String] = []
+        let paraLength = Int.random(in: 1...DataHelper.sentences.count)
+        for _ in 1...paraLength {
+            sentenceArray.append(DataHelper.sentences.randomElement()!)
+        }
+        let paragraph = sentenceArray.joined(separator: " ")
+
+        return paragraph
+    }
+
+    public func getCategory() -> String {
+        return "Wedding"
+    }
+
+    public func getTag() -> String {
+        return "tag \(Date().toString())"
+    }
+
+    public struct DataHelper {
+        static let words = ["Lorem", "Ipsum", "Dolor", "Sit", "Amet", "Consectetur", "Adipiscing", "Elit"]
+        static let sentences = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit.", "Nam ornare accumsan ante, sollicitudin bibendum erat bibendum nec.", "Nam congue efficitur leo eget porta.", "Proin dictum non ligula aliquam varius.", "Aenean vehicula nunc in sapien rutrum, nec vehicula enim iaculis."]
+        static let category = "iOS Test"
+        static let tag = "tag \(Date().toString())"
+    }
+
+    public func removeApp(_ appName: String = "WordPress", app: XCUIApplication = XCUIApplication()) {
+        app.terminate()
+
+        let appToRemove = Constants.homeApp.icons[appName]
+        if appToRemove.exists {
+            appToRemove.firstMatch.press(forDuration: 1)
+            waitAndTap(Constants.homeApp.buttons["Remove App"])
+            waitAndTap(Constants.homeApp.alerts.buttons["Delete App"])
+            waitAndTap(Constants.homeApp.alerts.buttons["Delete"])
+        }
+    }
+
+    private enum Constants {
+        static let homeApp = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+    }
+}

--- a/WordPress/JetpackUITests/WPUITestCredentials.swift
+++ b/WordPress/JetpackUITests/WPUITestCredentials.swift
@@ -1,0 +1,17 @@
+import UITestsFoundation
+
+// These are fake credentials used for the mocked UI tests
+struct WPUITestCredentials {
+    static let testWPcomUserEmail: String = "t@wp.com"
+    static let testWPcomUsername: String = "e2eflowtestingmobile"
+    static let testWPcomPassword: String = "pw"
+    static let testWPcomSiteAddress: String = "tricountyrealestate.wordpress.com"
+    static let testWPcomSitePrimaryAddress: String = "tricountyrealestate.wordpress.com"
+    static let selfHostedUsername: String = "e2eflowtestingmobile"
+    static let selfHostedPassword: String = "mocked_password"
+    static let selfHostedSiteAddress: String = "\(WireMock.URL().absoluteString)"
+    static let signupEmail: String = "e2eflowsignuptestingmobile@example.com"
+    static let signupUsername: String = "e2eflowsignuptestingmobile"
+    static let signupDisplayName: String = "Eeflowsignuptestingmobile"
+    static let signupPassword: String = "mocked_password"
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3227,6 +3227,20 @@
 		E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		EA0C6DB22965D2CA00000518 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716911CAAC87B0006E2D4 /* LoginTests.swift */; };
+		EA0C6DBF2965D2E300000518 /* EditorGutenbergTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DB82965D2E100000518 /* EditorGutenbergTests.swift */; };
+		EA0C6DC02965D2E400000518 /* SupportScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DB62965D2DF00000518 /* SupportScreenTests.swift */; };
+		EA0C6DC12965D2E400000518 /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DBD2965D2E300000518 /* StatsTests.swift */; };
+		EA0C6DC22965D2E400000518 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DB92965D2E100000518 /* ReaderTests.swift */; };
+		EA0C6DC32965D2E400000518 /* MainNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DB72965D2E000000518 /* MainNavigationTests.swift */; };
+		EA0C6DC42965D2E400000518 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DBA2965D2E100000518 /* LoginTests.swift */; };
+		EA0C6DC92965D2ED00000518 /* LoginFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DC72965D2EC00000518 /* LoginFlow.swift */; };
+		EA0C6DCA2965D2ED00000518 /* EditorFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DC82965D2ED00000518 /* EditorFlow.swift */; };
+		EA0C6DCD2965D30000000518 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DCC2965D2FF00000518 /* XCTest+Extensions.swift */; };
+		EA0C6DD02965D30400000518 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DCF2965D30400000518 /* BaseScreen.swift */; };
+		EA0C6DD22965D31300000518 /* WPUITestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA0C6DD12965D31300000518 /* WPUITestCredentials.swift */; };
+		EA0C6DD32965EE0D00000518 /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA640572670CCD40064401E /* UITestsFoundation.framework */; };
+		EA0C6DD72965EE3C00000518 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = EA0C6DD62965EE3C00000518 /* BuildkiteTestCollector */; };
 		EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA78189327596B2F00554DFA /* ContactUsScreen.swift */; };
 		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
 		EAD2BF4227594DAB00A847BB /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BF4127594DAB00A847BB /* StatsTests.swift */; };
@@ -5333,7 +5347,6 @@
 		FF1B11E7238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1B11E6238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift */; };
 		FF1FD0242091268900186384 /* URL+LinkNormalization.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1FD0232091268900186384 /* URL+LinkNormalization.swift */; };
 		FF1FD02620912AA900186384 /* URL+LinkNormalizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1FD02520912AA900186384 /* URL+LinkNormalizationTests.swift */; };
-		FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716911CAAC87B0006E2D4 /* LoginTests.swift */; };
 		FF2716A11CABC7D40006E2D4 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */; };
 		FF286C761DE70A4500383A62 /* NSURL+Exporters.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF286C751DE70A4500383A62 /* NSURL+Exporters.swift */; };
 		FF2EC3C02209A144006176E1 /* GutenbergImgUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2EC3BF2209A144006176E1 /* GutenbergImgUploadProcessor.swift */; };
@@ -5457,6 +5470,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1D6058900D05DD3D006BFB54;
 			remoteInfo = WordPress;
+		};
+		EA0C6DA92964BCF900000518 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FABB1F8F2602FC2C00C8785C;
+			remoteInfo = Jetpack;
 		};
 		F1F163D425658B4D003DC13B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -8432,6 +8452,19 @@
 		E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanFeature.swift; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
+		EA0C6DA32964BCF700000518 /* JetpackUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JetpackUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA0C6DB02964C28D00000518 /* JetpackUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = JetpackUITests.xctestplan; sourceTree = "<group>"; };
+		EA0C6DB62965D2DF00000518 /* SupportScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportScreenTests.swift; sourceTree = "<group>"; };
+		EA0C6DB72965D2E000000518 /* MainNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainNavigationTests.swift; sourceTree = "<group>"; };
+		EA0C6DB82965D2E100000518 /* EditorGutenbergTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorGutenbergTests.swift; sourceTree = "<group>"; };
+		EA0C6DB92965D2E100000518 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
+		EA0C6DBA2965D2E100000518 /* LoginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginTests.swift; sourceTree = "<group>"; };
+		EA0C6DBD2965D2E300000518 /* StatsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
+		EA0C6DC72965D2EC00000518 /* LoginFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFlow.swift; sourceTree = "<group>"; };
+		EA0C6DC82965D2ED00000518 /* EditorFlow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorFlow.swift; sourceTree = "<group>"; };
+		EA0C6DCC2965D2FF00000518 /* XCTest+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Extensions.swift"; sourceTree = "<group>"; };
+		EA0C6DCF2965D30400000518 /* BaseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseScreen.swift; sourceTree = "<group>"; };
+		EA0C6DD12965D31300000518 /* WPUITestCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPUITestCredentials.swift; sourceTree = "<group>"; };
 		EA78189327596B2F00554DFA /* ContactUsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
 		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EAD2BF4127594DAB00A847BB /* StatsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
@@ -9162,6 +9195,15 @@
 				3F338B71289BD3040014ADC5 /* Nimble in Frameworks */,
 				3F3B23C22858A1B300CACE60 /* BuildkiteTestCollector in Frameworks */,
 				E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA0C6DA02964BCF700000518 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA0C6DD72965EE3C00000518 /* BuildkiteTestCollector in Frameworks */,
+				EA0C6DD32965EE0D00000518 /* UITestsFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9902,6 +9944,7 @@
 				80F6D05428EE866A00953C1A /* JetpackNotificationServiceExtension.appex */,
 				0107E0EA28F97D5000DE87DB /* JetpackStatsWidgets.appex */,
 				0107E15428FE9DB200DE87DB /* JetpackIntents.appex */,
+				EA0C6DA32964BCF700000518 /* JetpackUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -9971,6 +10014,7 @@
 				8511CFB71C607A7000B7CEED /* WordPressScreenshotGeneration */,
 				FAF64BC82637DF0600E8A1DF /* JetpackScreenshotGeneration */,
 				3FA640582670CCD40064401E /* UITestsFoundation */,
+				EA0C6DA42964BCF900000518 /* JetpackUITests */,
 				29B97323FDCFA39411CA2CEA /* Frameworks */,
 				19C28FACFE9D520D11CA2CBB /* Products */,
 				93FA0F0118E451A80007903B /* LICENSE */,
@@ -14979,8 +15023,8 @@
 			children = (
 				EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */,
 				6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */,
-				FF2716911CAAC87B0006E2D4 /* LoginTests.swift */,
 				CC7CB97222B1510900642EE9 /* SignupTests.swift */,
+				FF2716911CAAC87B0006E2D4 /* LoginTests.swift */,
 				FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */,
 				BED4D82F1FF11DEF00A11345 /* EditorAztecTests.swift */,
 				CC2BB0CF228ACF710034F9AB /* EditorGutenbergTests.swift */,
@@ -16205,6 +16249,57 @@
 				E6D2E1601B8AA4410000ED14 /* ReaderTagStreamHeader.xib */,
 			);
 			name = Headers;
+			sourceTree = "<group>";
+		};
+		EA0C6DA42964BCF900000518 /* JetpackUITests */ = {
+			isa = PBXGroup;
+			children = (
+				EA0C6DB52965D2DE00000518 /* Tests */,
+				EA0C6DC62965D2EB00000518 /* Flows */,
+				EA0C6DCB2965D2FF00000518 /* Utils */,
+				EA0C6DCE2965D30300000518 /* Screens */,
+				EA0C6DD12965D31300000518 /* WPUITestCredentials.swift */,
+				EA0C6DB02964C28D00000518 /* JetpackUITests.xctestplan */,
+			);
+			path = JetpackUITests;
+			sourceTree = "<group>";
+		};
+		EA0C6DB52965D2DE00000518 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				EA0C6DB92965D2E100000518 /* ReaderTests.swift */,
+				EA0C6DB62965D2DF00000518 /* SupportScreenTests.swift */,
+				EA0C6DBA2965D2E100000518 /* LoginTests.swift */,
+				EA0C6DB72965D2E000000518 /* MainNavigationTests.swift */,
+				EA0C6DB82965D2E100000518 /* EditorGutenbergTests.swift */,
+				EA0C6DBD2965D2E300000518 /* StatsTests.swift */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		EA0C6DC62965D2EB00000518 /* Flows */ = {
+			isa = PBXGroup;
+			children = (
+				EA0C6DC72965D2EC00000518 /* LoginFlow.swift */,
+				EA0C6DC82965D2ED00000518 /* EditorFlow.swift */,
+			);
+			path = Flows;
+			sourceTree = "<group>";
+		};
+		EA0C6DCB2965D2FF00000518 /* Utils */ = {
+			isa = PBXGroup;
+			children = (
+				EA0C6DCC2965D2FF00000518 /* XCTest+Extensions.swift */,
+			);
+			path = Utils;
+			sourceTree = "<group>";
+		};
+		EA0C6DCE2965D30300000518 /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				EA0C6DCF2965D30400000518 /* BaseScreen.swift */,
+			);
+			path = Screens;
 			sourceTree = "<group>";
 		};
 		EC4696A80EA74DAC0040EE8E /* Pages */ = {
@@ -17711,6 +17806,27 @@
 			productReference = E16AB92A14D978240047A2E5 /* WordPressTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		EA0C6DA22964BCF700000518 /* JetpackUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA0C6DAF2964BCFA00000518 /* Build configuration list for PBXNativeTarget "JetpackUITests" */;
+			buildPhases = (
+				EA0C6D9F2964BCF700000518 /* Sources */,
+				EA0C6DA02964BCF700000518 /* Frameworks */,
+				EA0C6DA12964BCF700000518 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EA0C6DAA2964BCF900000518 /* PBXTargetDependency */,
+			);
+			name = JetpackUITests;
+			packageProductDependencies = (
+				EA0C6DD62965EE3C00000518 /* BuildkiteTestCollector */,
+			);
+			productName = JetpackUITests;
+			productReference = EA0C6DA32964BCF700000518 /* JetpackUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		F1F163BD25658B4D003DC13B /* WordPressIntents */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F1F163DC25658B4D003DC13B /* Build configuration list for PBXNativeTarget "WordPressIntents" */;
@@ -17915,6 +18031,10 @@
 						LastSwiftMigration = 1000;
 						TestTargetID = 1D6058900D05DD3D006BFB54;
 					};
+					EA0C6DA22964BCF700000518 = {
+						CreatedOnToolsVersion = 14.2;
+						TestTargetID = FABB1F8F2602FC2C00C8785C;
+					};
 					F1F163BD25658B4D003DC13B = {
 						CreatedOnToolsVersion = 12.2;
 						ProvisioningStyle = Manual;
@@ -18002,6 +18122,7 @@
 				A2795807198819DE0031C6A3 /* OCLint */,
 				FFA8E22A1F94E3DE0002170F /* SwiftLint */,
 				FABB1F8F2602FC2C00C8785C /* Jetpack */,
+				EA0C6DA22964BCF700000518 /* JetpackUITests */,
 				FAF64B662637DEEC00E8A1DF /* JetpackScreenshotGeneration */,
 				3FA640562670CCD40064401E /* UITestsFoundation */,
 				809620CF28E540D700940A5D /* JetpackShareExtension */,
@@ -18551,6 +18672,13 @@
 				7E53AB0620FE6905005796FE /* activity-log-comment.json in Resources */,
 				93C882A41EEB18D700227A59 /* rsd.xml in Resources */,
 				F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA0C6DA12964BCF700000518 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -22679,6 +22807,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EA0C6D9F2964BCF700000518 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA0C6DC12965D2E400000518 /* StatsTests.swift in Sources */,
+				EA0C6DC22965D2E400000518 /* ReaderTests.swift in Sources */,
+				EA0C6DC42965D2E400000518 /* LoginTests.swift in Sources */,
+				EA0C6DCA2965D2ED00000518 /* EditorFlow.swift in Sources */,
+				EA0C6DC02965D2E400000518 /* SupportScreenTests.swift in Sources */,
+				EA0C6DBF2965D2E300000518 /* EditorGutenbergTests.swift in Sources */,
+				EA0C6DD22965D31300000518 /* WPUITestCredentials.swift in Sources */,
+				EA0C6DC32965D2E400000518 /* MainNavigationTests.swift in Sources */,
+				EA0C6DCD2965D30000000518 /* XCTest+Extensions.swift in Sources */,
+				EA0C6DC92965D2ED00000518 /* LoginFlow.swift in Sources */,
+				EA0C6DD02965D30400000518 /* BaseScreen.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F1F163BA25658B4D003DC13B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -24503,8 +24649,8 @@
 				EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */,
 				BED4D8301FF11DEF00A11345 /* EditorAztecTests.swift in Sources */,
 				3F2F856326FAF612000FCDA5 /* EditorGutenbergTests.swift in Sources */,
-				FF2716921CAAC87B0006E2D4 /* LoginTests.swift in Sources */,
 				BE2B4E9F1FD664F5007AE3E4 /* BaseScreen.swift in Sources */,
+				EA0C6DB22965D2CA00000518 /* LoginTests.swift in Sources */,
 				6E5BA46926A59D620043A6F2 /* SupportScreenTests.swift in Sources */,
 				EAD2BF4227594DAB00A847BB /* StatsTests.swift in Sources */,
 				CC8A5EAB22159FA6001B7874 /* WPUITestCredentials.swift in Sources */,
@@ -24578,6 +24724,11 @@
 			isa = PBXTargetDependency;
 			target = 1D6058900D05DD3D006BFB54 /* WordPress */;
 			targetProxy = E16AB93E14D978520047A2E5 /* PBXContainerItemProxy */;
+		};
+		EA0C6DAA2964BCF900000518 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FABB1F8F2602FC2C00C8785C /* Jetpack */;
+			targetProxy = EA0C6DA92964BCF900000518 /* PBXContainerItemProxy */;
 		};
 		F1F163D525658B4D003DC13B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -28064,6 +28215,156 @@
 			};
 			name = Release;
 		};
+		EA0C6DAB2964BCFA00000518 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = Debug;
+		};
+		EA0C6DAC2964BCFA00000518 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = Release;
+		};
+		EA0C6DAD2964BCFA00000518 /* Release-Internal */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = "Release-Internal";
+		};
+		EA0C6DAE2964BCFA00000518 /* Release-Alpha */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				MARKETING_VERSION = 1.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = "Release-Alpha";
+		};
 		F1F163DD25658B4D003DC13B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */;
@@ -29144,6 +29445,17 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		EA0C6DAF2964BCFA00000518 /* Build configuration list for PBXNativeTarget "JetpackUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA0C6DAB2964BCFA00000518 /* Debug */,
+				EA0C6DAC2964BCFA00000518 /* Release */,
+				EA0C6DAD2964BCFA00000518 /* Release-Internal */,
+				EA0C6DAE2964BCFA00000518 /* Release-Alpha */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F1F163DC25658B4D003DC13B /* Build configuration list for PBXNativeTarget "WordPressIntents" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -29324,6 +29636,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
+		};
+		EA0C6DD62965EE3C00000518 /* BuildkiteTestCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3F3B23C02858A1B300CACE60 /* XCRemoteSwiftPackageReference "test-collector-swift" */;
+			productName = BuildkiteTestCollector;
 		};
 		FABB1FA62602FC2C00C8785C /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,7 +27,24 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:JetpackUITests/JetpackUITests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EA0C6DA22964BCF700000518"
+               BuildableName = "JetpackUITests.xctest"
+               BlueprintName = "JetpackUITests"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction


### PR DESCRIPTION
### What
The objective of this PR is to make the current Wordpress UI Tests to run against the Jetpack app locally. 

### How
* `WordPress > WordPress UI Tests` folder was copied into `WordPress > Jetpack UI Tests`
* Creating `JetpackUITests` Test Plan

### Notes
* `MainNavigationTests` and `StatsTests` are disabled and will be enabled in an upcoming PR.
* Work to minimize duplications will be tackled in another PR after all the tests are enabled.

### Testing
<details>
  <summary>Run the <b>JetpackUITests</b> Test Plan and confirm all the enabled tests pass.</summary>
  <img alt="image" src="https://user-images.githubusercontent.com/42008628/215933598-1cfeaad5-7df7-4579-b757-3535570010c3.png">
</details>

### Regression Notes
No impacts are expected on the WordPress UI Tests as none of their files were changed.
