### PR TITLE
Quick Start: Prevent tour notice from obscuring FAB

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsSectionHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19162" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19144"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21207"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -26,7 +26,7 @@
                     </connections>
                 </button>
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eUE-Sb-m3L">
-                    <rect key="frame" x="36" y="11" width="30.5" height="14.5"/>
+                    <rect key="frame" x="16" y="10" width="32.5" height="16"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                     <color key="textColor" name="Gray50"/>
@@ -36,7 +36,7 @@
             <color key="backgroundColor" red="0.9137254901960784" green="0.93725490196078431" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="eUE-Sb-m3L" firstAttribute="centerY" secondItem="OEo-2z-Cmk" secondAttribute="centerY" id="5cB-Im-fBT"/>
-                <constraint firstAttribute="leadingMargin" secondItem="eUE-Sb-m3L" secondAttribute="leading" constant="-20" id="Bi6-N7-44O"/>
+                <constraint firstAttribute="leadingMargin" secondItem="eUE-Sb-m3L" secondAttribute="leading" id="Bi6-N7-44O"/>
                 <constraint firstAttribute="trailingMargin" secondItem="OEo-2z-Cmk" secondAttribute="trailing" id="EWN-SE-Ilb"/>
                 <constraint firstAttribute="bottom" secondItem="OEo-2z-Cmk" secondAttribute="bottom" id="a35-Lf-TpM"/>
             </constraints>

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController+QuickStart.swift
@@ -18,7 +18,7 @@ extension MySiteViewController {
                     self?.scrollView.scrollToTop(animated: true)
                     fallthrough
 
-                case .siteMenu, .pages, .sharing, .stats, .readerTab, .notifications:
+                case .siteMenu, .pages, .sharing, .stats, .readerTab, .notifications, .mediaScreen:
                     self?.additionalSafeAreaInsets = Constants.quickStartNoticeInsets
 
                 default:


### PR DESCRIPTION
Fixes #20048 

- Fixed media tour notice obscuring the FAB by adjusting additionalSafeAreaInsets
- Removed extra padding from Quick Start section header view so that "Next Steps" has the same leading alignment as the other section titles

Before | After
-- | --
<img src="https://user-images.githubusercontent.com/6711616/216015309-c7a5e40a-c5b1-4463-ac41-6878d495428a.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/216015314-a5ccc2a2-d84b-4c2d-a352-b01af01a9500.png" width=200>
<img src="https://user-images.githubusercontent.com/6711616/216015496-010f05b6-8970-47a2-9f7d-d86d7200080c.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/216015504-0ba5e5af-99ef-472b-9448-c1008055a5c8.png" width=200>

## How to test

1. Enable Quick Start for Existing Users via the debug menu
2. ✅ Verify: "Next Steps" header is aligned with the other section titles
3. Tap on the "Get to know the WordPress app" card
4. Select "Upload photos or videos"
5. ✅ Verify: tour notice doesn't obscure FAB


## Regression Notes
1. Potential unintended areas of impact
n/a

3. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
