### PR TITLE
Core Spotlight: mark blog as recently used when opening from a spotlight suggestion

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -107,6 +107,8 @@ class MySitesCoordinator: NSObject {
         showRootViewController()
 
         mySiteViewController.blog = blog
+        RecentSitesService().touch(blog: blog)
+
         if mySiteViewController.presentedViewController != nil {
             mySiteViewController.dismiss(animated: true, completion: nil)
         }


### PR DESCRIPTION
Fixes #20050 

This PR fixes an issue where a blog wasn't being marked as recently used when opening from a spotlight suggestion.

## How to test
1. Install the app
2. Log in into an account with multiple sites
3. Select a site (Let's call this site A)
5. Close the app
6. Swipe down on the main screen on your phone
7. Check the Spotlight suggestion for a site other than site A (Let's call this site B)
8. Tap on it
9. Site B should be the current site in the app
10. Close then reopen the app
11. ✅ Verify: Site B is shown


https://user-images.githubusercontent.com/6711616/216023492-b940368e-abfe-4186-9f41-d8da7cd6197e.mp4



## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
