### PR TITLE
Jetpack Login: Fix image view display logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -40,6 +40,13 @@ class JetpackLoginViewController: UIViewController {
     @objc init(blog: Blog) {
         self.blog = blog
         super.init(nibName: nil, bundle: nil)
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(deviceOrientationDidChange),
+            name: UIDevice.orientationDidChangeNotification,
+            object: nil
+        )
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -54,9 +61,8 @@ class JetpackLoginViewController: UIViewController {
         setupControls()
     }
 
-    override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
-        super.willTransition(to: newCollection, with: coordinator)
-        toggleHidingImageView(for: newCollection)
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Configuration
@@ -65,7 +71,7 @@ class JetpackLoginViewController: UIViewController {
     ///
     fileprivate func setupControls() {
         jetpackImage.image = promptType.image
-        toggleHidingImageView(for: traitCollection)
+        toggleHidingImageView()
 
         descriptionLabel.font = WPStyleGuide.fontForTextStyle(.body)
         descriptionLabel.textColor = .text
@@ -78,8 +84,12 @@ class JetpackLoginViewController: UIViewController {
         updateMessageAndButton()
     }
 
-    private func toggleHidingImageView(for collection: UITraitCollection) {
-        jetpackImage.isHidden = collection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact))
+    @objc private func deviceOrientationDidChange() {
+        toggleHidingImageView()
+    }
+
+    private func toggleHidingImageView() {
+        jetpackImage.isHidden = WPDeviceIdentification.isiPhone() && UIDevice.current.orientation.isLandscape
     }
 
     fileprivate func observeLoginNotifications(_ observe: Bool) {


### PR DESCRIPTION
Fixes #19396 

This PR fixes an issue where the image view in the JetpackLoginViewController dissappeared after rotating the device to landscape orientation.

## How to test

1. On an iPhone, log into a self-hosted site which doesn't have Jetpack installed (i.e. spin up a JN site and uncheck the "include Jetpack" box)
2. Go to Notifications
3. Rotate the device so that it's in landscape orientation
4. ✅ Verify: the image view should be hidden
5. Rotate the device so that it's in portrait orientation
6. ✅ Verify: the image view should be visible
7. Repeat the same steps for the Stats screen


https://user-images.githubusercontent.com/6711616/216314877-0e2081e0-01c9-4926-80a1-b1a14f093f0d.mp4


https://user-images.githubusercontent.com/6711616/216314906-9ca0e202-2b44-4132-95aa-ff3cefc098cb.mp4



## Notes
willTransition isn’t being propagated down to JetpackLoginViewController, which is why toggleHidingImageView wasn’t being called. willTransition isn't triggered to NotificationsViewController either, which is the parent vc of JetpackLoginViewController. 

I think the issue lies in the way we override willTransition in WPSplitViewController:

https://github.com/wordpress-mobile/WordPress-iOS/blob/7fb946b515ce183a71155532dccca525b0f7b695/WordPress/Classes/ViewRelated/System/WPSplitViewController.swift#L160-L173

Rather than refactoring this, I opted to rely on notifications instead to handle toggline the image view. If you have a better solution lmk!

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
