### PR TITLE
Blogging Prompts: Add new prompts social feature flag and move prompt social changes to it

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -4,6 +4,7 @@
 enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case bloggingPrompts
     case bloggingPromptsEnhancements
+    case bloggingPromptsSocial
     case jetpackDisconnect
     case debugMenu
     case readerCSS
@@ -54,6 +55,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .bloggingPrompts:
             return AppConfiguration.isJetpack
         case .bloggingPromptsEnhancements:
+            return false
+        case .bloggingPromptsSocial:
             return false
         case .jetpackDisconnect:
             return BuildConfiguration.current == .localDeveloper
@@ -185,6 +188,8 @@ extension FeatureFlag {
             return "Blogging Prompts"
         case .bloggingPromptsEnhancements:
             return "Blogging Prompts Enhancements"
+        case .bloggingPromptsSocial:
+            return "Blogging Prompts Social"
         case .jetpackDisconnect:
             return "Jetpack disconnect"
         case .debugMenu:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -169,7 +169,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         button.setTitle(answerInfoText, for: .normal)
         button.titleLabel?.font = WPStyleGuide.BloggingPrompts.answerInfoButtonFont
         button.setTitleColor(
-            FeatureFlag.bloggingPromptsEnhancements.enabled
+            FeatureFlag.bloggingPromptsSocial.enabled
             ? WPStyleGuide.BloggingPrompts.buttonTitleColor
             : WPStyleGuide.BloggingPrompts.answerInfoButtonColor,
             for: .normal
@@ -182,7 +182,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
 
     @objc
     private func didTapAnswerInfoButton() {
-        guard FeatureFlag.bloggingPromptsEnhancements.enabled,
+        guard FeatureFlag.bloggingPromptsSocial.enabled,
         let promptID = prompt?.promptID else {
             return
         }


### PR DESCRIPTION
Closes #20041 

## Description

Moves the "MVP Social Prompts" feature to its own feature flag.

## Testing

To test:
- Enable the feature flag `bloggingPromptsEnhancements`
- Install Jetpack and login
- Navigate to the Home dashboard
- On the blogging prompts card, verify:
  - `%d answers` text is gray
  - `%d answers` is not tappable
- Navigate to Me -> App Settings -> Debug
- Enable "Blogging Prompts Social"
- Navigate back to the home dashboard and reload it (can be reloaded by switching to the reader tab and then back)
- On the blogging prompts card, verify:
  - `%d answers` text is highlighted
  - `%d answers` is tappable

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
