### PR TITLE
Jetpack Focus: Fix misalignment of overlay buttons when system font increases

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -79,7 +79,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         setupContent()
         setupColors()
         setupFonts()
-        setupButtonInsets()
+        setupButtons()
         animationView.play()
         viewModel.trackOverlayDisplayed()
     }
@@ -141,7 +141,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         footnoteLabel.isHidden = viewModel.footnoteIsHidden
         learnMoreButton.isHidden = viewModel.learnMoreButtonIsHidden
         continueButton.isHidden = viewModel.continueButtonIsHidden
-        setupLearnMoreButton()
+        setupLearnMoreButtonTitle()
     }
 
     private func setTitle() {
@@ -178,6 +178,12 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         continueButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
     }
 
+    private func setupButtons() {
+        setupButtonInsets()
+        switchButton.titleLabel?.textAlignment = .center
+        continueButton.titleLabel?.textAlignment = .center
+    }
+
     private func setupButtonInsets() {
         if #available(iOS 15.0, *) {
             // Continue & Switch Buttons
@@ -208,7 +214,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         }
     }
 
-    private func setupLearnMoreButton() {
+    private func setupLearnMoreButtonTitle() {
         let externalAttachment = NSTextAttachment(image: UIImage.gridicon(.external, size: Metrics.externalIconSize).withTintColor(Colors.learnMoreButtonTextColor))
         externalAttachment.bounds = Metrics.externalIconBounds
         let attachmentString = NSAttributedString(attachment: externalAttachment)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -278,8 +278,8 @@ private extension JetpackFullscreenOverlayViewController {
         static let normalStackViewSpacing: CGFloat = 20
         static let compactStackViewSpacing: CGFloat = 10
         static let closeButtonRadius: CGFloat = 30
-        static let mainButtonsContentInsets = NSDirectionalEdgeInsets(top: 0, leading: 24, bottom: 0, trailing: 24)
-        static let mainButtonsContentEdgeInsets = UIEdgeInsets(top: 0, left: 24, bottom: 0, right: 24)
+        static let mainButtonsContentInsets = NSDirectionalEdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 12)
+        static let mainButtonsContentEdgeInsets = UIEdgeInsets(top: 4, left: 12, bottom: 4, right: 12)
         static let learnMoreButtonContentInsets = NSDirectionalEdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 24)
         static let learnMoreButtonContentEdgeInsets = UIEdgeInsets(top: 4, left: 0, bottom: 4, right: 24)
         static let externalIconSize = CGSize(width: 16, height: 16)


### PR DESCRIPTION
Ref: p1675366747887719-slack-C0180B5PRJ4 

## Description
This PR fixes an issue where the overlay's buttons' text is misaligned when the system text size is increased. 

## Testing Instructions

Test on both iPhone and iPad:

1. Fresh install and launch WordPress app ([The pop up can also be triggered manually](https://github.com/wordpress-mobile/WordPress-iOS/pull/19537))
2. Log in
3. Open the Notifications tab
4. Migration "Get your notifications with the Jetpack app" pop-up view should appear
5. "Switch to the new Jetpack app" button should be visible, the text centered and not truncated
6. Increase a text size ("Settings -> Accessibility -> Display & Text Size -> Larger Text")
7. "Switch to the new Jetpack app" button should be visible, the text centered and not truncated
8. Change the phone orientation from vertical to horizontal 
9. "Switch to the new Jetpack app" button should be visible, the text centered and not truncated

## Regression Notes
1. Potential unintended areas of impact

None, the styling only applies to this one button

8. What I did to test those areas of impact (or what existing automated tests I relied on)

N/A

9. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.