### PR TITLE
Fix a concurrency issue in the Core Data writing APIs

### DIFF
--- a/WordPress/Classes/Extensions/Media+Sync.swift
+++ b/WordPress/Classes/Extensions/Media+Sync.swift
@@ -34,7 +34,7 @@ extension Media {
     ///   - onError: block to invoke if any error occurs while the update is being made.
     ///
     static func refreshMediaStatus(using coreDataStack: CoreDataStackSwift, onCompletion: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
-        coreDataStack.performAndSave { context in
+        coreDataStack.performAndSave({ context in
             let fetch = NSFetchRequest<Media>(entityName: Media.classNameWithoutNamespaces())
             let pushingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: MediaRemoteStatus.pushing.rawValue))
             let processingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: MediaRemoteStatus.processing.rawValue))
@@ -54,17 +54,15 @@ extension Media {
                     context.delete(media)
                 }
             }
-        } completion: { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success:
-                    onCompletion?()
-                case let .failure(error):
-                    DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
-                    onError?(error)
-                }
+        }, completion: { result in
+            switch result {
+            case .success:
+                onCompletion?()
+            case let .failure(error):
+                DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
+                onError?(error)
             }
-        }
+        }, on: .main)
     }
 
 }

--- a/WordPress/Classes/Extensions/Media+Sync.swift
+++ b/WordPress/Classes/Extensions/Media+Sync.swift
@@ -33,7 +33,7 @@ extension Media {
     ///   - onCompletion: block to invoke when status update is finished.
     ///   - onError: block to invoke if any error occurs while the update is being made.
     ///
-    static func refreshMediaStatus(using coreDataStack: CoreDataStack, onCompletion: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
+    static func refreshMediaStatus(using coreDataStack: CoreDataStackSwift, onCompletion: (() -> Void)? = nil, onError: ((Error) -> Void)? = nil) {
         coreDataStack.performAndSave { context in
             let fetch = NSFetchRequest<Media>(entityName: Media.classNameWithoutNamespaces())
             let pushingPredicate = NSPredicate(format: "remoteStatusNumber = %@", NSNumber(value: MediaRemoteStatus.pushing.rawValue))

--- a/WordPress/Classes/Services/BlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/BlockEditorSettingsService.swift
@@ -111,7 +111,7 @@ private extension BlockEditorSettingsService {
             }
 
             blog.blockEditorSettings = BlockEditorSettings(editorTheme: editorTheme, context: context)
-        }, completion: completion)
+        }, completion: completion, on: .main)
     }
 }
 
@@ -175,7 +175,7 @@ private extension BlockEditorSettingsService {
             }
 
             blog.blockEditorSettings = BlockEditorSettings(remoteSettings: remoteSettings, context: context)
-        }, completion: completion)
+        }, completion: completion, on: .main)
     }
 }
 

--- a/WordPress/Classes/Services/BlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/BlockEditorSettingsService.swift
@@ -15,13 +15,13 @@ class BlockEditorSettingsService {
 
     let blog: Blog
     let remote: BlockEditorSettingsServiceRemote
-    let coreDataStack: CoreDataStack
+    let coreDataStack: CoreDataStackSwift
 
     var cachedSettings: BlockEditorSettings? {
         return blog.blockEditorSettings
     }
 
-    convenience init?(blog: Blog, coreDataStack: CoreDataStack) {
+    convenience init?(blog: Blog, coreDataStack: CoreDataStackSwift) {
         let remoteAPI: WordPressRestApi
         if blog.isAccessibleThroughWPCom(),
            blog.dotComID?.intValue != nil,
@@ -37,7 +37,7 @@ class BlockEditorSettingsService {
         self.init(blog: blog, remoteAPI: remoteAPI, coreDataStack: coreDataStack)
     }
 
-    init(blog: Blog, remoteAPI: WordPressRestApi, coreDataStack: CoreDataStack) {
+    init(blog: Blog, remoteAPI: WordPressRestApi, coreDataStack: CoreDataStackSwift) {
         assert(blog.objectID.persistentStore != nil, "The blog instance should be saved first")
         self.blog = blog
         self.coreDataStack = coreDataStack

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -2,7 +2,7 @@ import CoreData
 import WordPressKit
 
 class BloggingPromptsService {
-    private let contextManager: CoreDataStack
+    private let contextManager: CoreDataStackSwift
     private let siteID: NSNumber
     private let remote: BloggingPromptsServiceRemote
     private let calendar: Calendar = .autoupdatingCurrent
@@ -179,7 +179,7 @@ class BloggingPromptsService {
 
     // MARK: - Init
 
-    required init?(contextManager: CoreDataStack = ContextManager.shared,
+    required init?(contextManager: CoreDataStackSwift = ContextManager.shared,
                    remote: BloggingPromptsServiceRemote? = nil,
                    blog: Blog? = nil) {
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext),
@@ -198,10 +198,10 @@ class BloggingPromptsService {
 /// Convenience factory to generate `BloggingPromptsService` for different blogs.
 ///
 class BloggingPromptsServiceFactory {
-    let contextManager: CoreDataStack
+    let contextManager: CoreDataStackSwift
     let remote: BloggingPromptsServiceRemote?
 
-    init(contextManager: CoreDataStack = ContextManager.shared, remote: BloggingPromptsServiceRemote? = nil) {
+    init(contextManager: CoreDataStackSwift = ContextManager.shared, remote: BloggingPromptsServiceRemote? = nil) {
         self.contextManager = contextManager
         self.remote = remote
     }

--- a/WordPress/Classes/Services/BloggingPromptsService.swift
+++ b/WordPress/Classes/Services/BloggingPromptsService.swift
@@ -286,7 +286,7 @@ private extension BloggingPromptsService {
         let fetchRequest = BloggingPrompt.fetchRequest()
         fetchRequest.predicate = predicate
 
-        contextManager.performAndSave { derivedContext in
+        contextManager.performAndSave({ derivedContext in
             var foundExistingIDs = [Int32]()
             let results = try derivedContext.fetch(fetchRequest)
             results.forEach { prompt in
@@ -307,11 +307,7 @@ private extension BloggingPromptsService {
                 }
                 newPrompt.configure(with: remotePrompt, for: self.siteID.int32Value)
             }
-        } completion: { result in
-            DispatchQueue.main.async {
-                completion(result)
-            }
-        }
+        }, completion: completion, on: .main)
     }
 
     /// Updates existing settings or creates new settings from the remote prompt settings.

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -11,7 +11,7 @@ import enum Alamofire.AFError
 class MediaCoordinator: NSObject {
     @objc static let shared = MediaCoordinator()
 
-    private let coreDataStack: CoreDataStack
+    private let coreDataStack: CoreDataStackSwift
 
     private var mainContext: NSManagedObjectContext {
         coreDataStack.mainContext
@@ -42,7 +42,7 @@ class MediaCoordinator: NSObject {
 
     private let mediaServiceFactory: MediaService.Factory
 
-    init(_ mediaServiceFactory: MediaService.Factory = MediaService.Factory(), coreDataStack: CoreDataStack = ContextManager.shared) {
+    init(_ mediaServiceFactory: MediaService.Factory = MediaService.Factory(), coreDataStack: CoreDataStackSwift = ContextManager.shared) {
         self.mediaServiceFactory = mediaServiceFactory
         self.coreDataStack = coreDataStack
 

--- a/WordPress/Classes/Services/PageLayoutService.swift
+++ b/WordPress/Classes/Services/PageLayoutService.swift
@@ -106,7 +106,7 @@ extension PageLayoutService {
             cleanUpStoredLayouts(forBlog: blog, context: context)
             try persistCategoriesToCoreData(blog, layouts.categories, context: context)
             try persistLayoutsToCoreData(blog, layouts.layouts, context: context)
-        }, completion: completion)
+        }, completion: completion, on: .main)
     }
 
     private static func cleanUpStoredLayouts(forBlog blog: Blog, context: NSManagedObjectContext) {

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -11,7 +11,7 @@ struct PeopleService {
 
     // MARK: - Private Properties
     ///
-    private let coreDataStack: CoreDataStack
+    private let coreDataStack: CoreDataStackSwift
     fileprivate let remote: PeopleServiceRemote
 
 
@@ -21,7 +21,7 @@ struct PeopleService {
     ///     - blog: Target Blog Instance
     ///     - context: CoreData context to be used.
     ///
-    init?(blog: Blog, coreDataStack: CoreDataStack) {
+    init?(blog: Blog, coreDataStack: CoreDataStackSwift) {
         guard let api = blog.wordPressComRestApi(), let dotComID = blog.dotComID as? Int else {
             return nil
         }

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -407,7 +407,7 @@ extension PeopleService {
     ///   - onComplete: A completion block that is called after changes are saved to core data.
     ///
     func merge(remoteInvites: [RemoteInviteLink], for siteID: Int, onComplete: @escaping (() -> Void)) {
-        coreDataStack.performAndSave { context in
+        coreDataStack.performAndSave({ context in
             guard let blog = try Blog.lookup(withID: siteID, in: context) else {
                 return
             }
@@ -422,11 +422,7 @@ extension PeopleService {
             for remoteInvite in remoteInvites {
                 createOrUpdateInviteLink(remoteInvite: remoteInvite, blog: blog, context: context)
             }
-        } completion: { _ in
-            DispatchQueue.main.async {
-                onComplete()
-            }
-        }
+        }, completion: { _ in onComplete() }, on: .main)
     }
 
     /// Deletes InviteLinks whose inviteKeys belong to the supplied array of keys.

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -27,8 +27,8 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
     /// A serial queue used to ensure there is only one writing operation at a time.
     ///
     /// - Note: This queue currently is not used in `performAndSave(_:)` the "save synchronously" function, since it's
-    ///   not safe to block current thread. Considering this function is going to be removed soon, I think it's okay to
-    ///   make this compromise.
+    ///   not safe to block current thread. Considering the aforementioned `performAndSave(_:)` function is going to be
+    ///   removed soon, I think it's okay to make this compromise.
     private let writerQueue: OperationQueue
 
     @objc

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -182,27 +182,6 @@ extension ContextManager {
 }
 
 extension CoreDataStack {
-    func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T, completion: ((Result<T, Error>) -> Void)?) {
-        let context = newDerivedContext()
-        context.perform {
-            let result = Result(catching: { try block(context) })
-            if case .success = result {
-                self.saveContextAndWait(context)
-            }
-            DispatchQueue.main.async {
-                completion?(result)
-            }
-        }
-    }
-
-    func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {
-        try await withCheckedThrowingContinuation { continuation in
-            performAndSave(block) {
-                continuation.resume(with: $0)
-            }
-        }
-    }
-
     /// Perform a query using the `mainContext` and return the result.
     func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T {
         var value: T! = nil

--- a/WordPress/Classes/Utility/CoreDataStack.h
+++ b/WordPress/Classes/Utility/CoreDataStack.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^ _Nullable)(void))completionBlock onQueue:(dispatch_queue_t)queue NS_SWIFT_NAME(save(_:completion:on:));
 - (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
-- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^)(void))completion onQueue:(dispatch_queue_t)queue;
+- (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^ _Nullable)(void))completion onQueue:(dispatch_queue_t)queue;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -221,7 +221,7 @@ class MediaFileManager: NSObject {
     /// Removes any local Media files, except any Media matching the predicate.
     ///
     fileprivate func purgeMediaFiles(exceptMedia predicate: NSPredicate, onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
-        ContextManager.shared.performAndSave { context in
+        ContextManager.shared.performAndSave({ context in
             let fetch = NSFetchRequest<NSDictionary>(entityName: Media.classNameWithoutNamespaces())
             fetch.predicate = predicate
             fetch.resultType = .dictionaryResultType
@@ -243,17 +243,15 @@ class MediaFileManager: NSObject {
                 }
             }
             try self.purgeDirectory(exceptFiles: filesToKeep)
-        } completion: { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success:
-                    onCompletion?()
-                case let .failure(error):
-                    DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
-                    onError?(error)
-                }
+        }, completion: { result in
+            switch result {
+            case .success:
+                onCompletion?()
+            case let .failure(error):
+                DDLogError("Error while attempting to clean local media: \(error.localizedDescription)")
+                onError?(error)
             }
-        }
+        }, on: .main)
     }
 
     /// Removes files in the Media directory, except any files found in the set.

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -135,7 +135,7 @@ private final class CoreDataStackMock: CoreDataStack {
     func save(_ context: NSManagedObjectContext, completion completionBlock: (() -> Void)?, on queue: DispatchQueue) {}
 
     func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void) {}
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: @escaping () -> Void, on queue: DispatchQueue) {}
+    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: (() -> Void)?, on queue: DispatchQueue) {}
 }
 
 // MARK: - KeychainUtilsMock

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -142,7 +142,7 @@ private final class CoreDataStackMock: CoreDataStack {
     func save(_ context: NSManagedObjectContext, completion completionBlock: (() -> Void)?, on queue: DispatchQueue) {}
 
     func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void) {}
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: @escaping () -> Void, on queue: DispatchQueue) {}
+    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: (() -> Void)?, on queue: DispatchQueue) {}
 }
 
 // MARK: - KeychainUtilsMock


### PR DESCRIPTION
I've cleaned up the commits in this PR to be individually reviewable, it might be easier to review commit by commit.

## Issue

Current version of `performAndSave` functions aren't thread-safe. When called concurrently, there is chance that duplicated date are stored in the database.

This issue was caught by `testBasicPostPublishWithCategoryAndTag` UI tests (first in https://github.com/wordpress-mobile/WordPress-iOS/pull/19956), where duplicated post categories were saved and displayed on screen.

This issue was actually documented in the "5. Make conflicts impossible by avoiding multiple background contexts" section of paaHJt-1I7-p2 (kudos to @jkmassel ), but I forgot to implement it.

## Solution

My understanding of `NSManagedObjectContext` is, it's supposed to be temporary, as in create as needed and discard when done with it. I have my concerns (see paaHJt-1I7-p2#comment-6336) on using a long running writer context, which is why have chosen a different approach in this PR, using a serial `OperationQueue` to make sure there is only one writing operation at a time.

## Compromise

Please note there is a small compromise in this PR, explained in the comment of `ContextManager.writerQueue`. `-[CoreDataStack performAndSaveUsingBlock:]` isn't changed in this PR, which means it's still no thread-safe (also indicated in one of the new unit tests).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.