### PR TITLE
UGC: Add "Report this user" button to Reader Post menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,12 +6,8 @@
 * [*] [internal] Refactored comment related operations (i.e. like a comment, reply to a post or comment).
 * [*] [internal] Refactored how reader topics are fetched from the database. [#20129]
 * [*] [internal] Refactored blog related operations (i.e. loading blogs of the logged in account, updating blog settings). [#20047]
-* [*] Add ability to block a followed site. [#20053]
 * [*] Reader: Add ability to block a followed site. [#20053]
-* [*] Add ability to block a followed site. [#20053]
-* [*] Reader: Add ability to block a followed site. [#20053]
-* [*] Add ability to block a followed site. [#20053]
-* [*] Add ability to report a post's author. [#20064]
+* [*] Reader: Add ability to report a post's author. [#20064]
 
 21.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Add ability to block a followed site. [#20053]
 * [*] Reader: Add ability to block a followed site. [#20053]
 * [*] Add ability to block a followed site. [#20053]
+* [*] Reader: Add ability to block a followed site. [#20053]
 
 21.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] [internal] Refactored blog related operations (i.e. loading blogs of the logged in account, updating blog settings). [#20047]
 * [*] Add ability to block a followed site. [#20053]
 * [*] Reader: Add ability to block a followed site. [#20053]
+* [*] Add ability to block a followed site. [#20053]
 
 21.7
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,8 @@
 * [*] Reader: Add ability to block a followed site. [#20053]
 * [*] Add ability to block a followed site. [#20053]
 * [*] Reader: Add ability to block a followed site. [#20053]
+* [*] Add ability to block a followed site. [#20053]
+* [*] Add ability to report a post's author. [#20064]
 
 21.7
 -----

--- a/WordPress/Classes/Models/Blocking/BlockedSite.swift
+++ b/WordPress/Classes/Models/Blocking/BlockedSite.swift
@@ -27,7 +27,7 @@ extension BlockedSite {
             return []
         }
     }
-    
+
     // MARK: Inserting Elements
 
     static func insert(into context: NSManagedObjectContext) -> BlockedSite {

--- a/WordPress/Classes/Models/Blocking/BlockedSite.swift
+++ b/WordPress/Classes/Models/Blocking/BlockedSite.swift
@@ -27,7 +27,7 @@ extension BlockedSite {
             return []
         }
     }
-
+    
     // MARK: Inserting Elements
 
     static func insert(into context: NSManagedObjectContext) -> BlockedSite {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -46,6 +46,11 @@ struct ReaderPostMenuButtonTitles {
     static let cancel = NSLocalizedString("Cancel", comment: "The title of a cancel button.")
     static let blockSite = NSLocalizedString("Block this site", comment: "The title of a button that triggers blocking a site from the user's reader.")
     static let reportPost = NSLocalizedString("Report this post", comment: "The title of a button that triggers reporting of a post from the user's reader.")
+    static let reportPostAuthor = NSLocalizedString(
+        "reader.post.menu.report.user",
+        value: "Report this user",
+        comment: "The title of a button that triggers the reporting of a post's author."
+    )
     static let share = NSLocalizedString("Share", comment: "Verb. Title of a button. Pressing lets the user share a post to others.")
     static let visit = NSLocalizedString("Visit", comment: "An option to visit the site to which a specific post belongs")
     static let unfollow = NSLocalizedString("Unfollow site", comment: "Verb. An option to unfollow a site.")

--- a/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderReportPostAction.swift
@@ -1,10 +1,7 @@
 /// Encapsulates a command to report a post
 final class ReaderReportPostAction {
-    func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: UIViewController) {
-        guard
-            let permalink = post.permaLink,
-            let url = reportURL(with: permalink)
-        else {
+    func execute(with post: ReaderPost, target: Target = .post, context: NSManagedObjectContext, origin: UIViewController) {
+        guard let url = Self.reportURL(with: post, target: target) else {
             return
         }
 
@@ -25,18 +22,40 @@ final class ReaderReportPostAction {
     }
 
     /// Safely generate the report URL
-    private func reportURL(with postURLString: String) -> URL? {
-        guard var components = URLComponents(string: Constants.reportURLString) else {
+    private static func reportURL(with post: ReaderPost, target: Target) -> URL? {
+        guard let postURLString = post.permaLink,
+              var components = URLComponents(string: Constants.reportURLString)
+        else {
             return nil
         }
 
-        let queryItem = URLQueryItem(name: Constants.reportKey, value: postURLString)
-        components.queryItems = [queryItem]
+        var queryItems = [URLQueryItem(name: Constants.reportKey, value: postURLString)]
+
+        if target == .author {
+            guard let authorID = post.authorID?.stringValue else {
+                DDLogWarn("Author ID is required to report a post's author")
+                return nil
+            }
+            queryItems.append(.init(name: Constants.userKey, value: authorID))
+        }
+
+        components.queryItems = queryItems
         return components.url
+    }
+
+    // MARK: - Types
+
+    enum Target {
+        /// Report the post itself.
+        case post
+
+        /// Report the post's author.
+        case author
     }
 
     private struct Constants {
         static let reportURLString = "https://wordpress.com/abuse/"
         static let reportKey = "report_url"
+        static let userKey = "report_user_id"
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderShowMenuAction.swift
@@ -43,15 +43,26 @@ final class ReaderShowMenuAction {
                                                handler: handler)
         }
 
-        // Report button
+        // Report post button
         if shouldShowReportPostMenuItem(readerTopic: readerTopic, post: post) {
             alertController.addActionWithTitle(ReaderPostMenuButtonTitles.reportPost,
-                                               style: .default,
+                                               style: .destructive,
                                                handler: { (action: UIAlertAction) in
                                                 if let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) {
                                                     ReaderReportPostAction().execute(with: post, context: context, origin: vc)
                                                 }
             })
+        }
+
+        // Report user button
+        if shouldShowReportUserMenuItem(readerTopic: readerTopic, post: post) {
+            let handler: (UIAlertAction) -> Void = { _ in
+                guard let post: ReaderPost = ReaderActionHelpers.existingObject(for: post.objectID, in: context) else {
+                    return
+                }
+                ReaderReportPostAction().execute(with: post, target: .author, context: context, origin: vc)
+            }
+            alertController.addActionWithTitle(ReaderPostMenuButtonTitles.reportPostAuthor, style: .destructive, handler: handler)
         }
 
         // Notification
@@ -180,6 +191,10 @@ final class ReaderShowMenuAction {
 
     private func shouldShowReportPostMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
         return shouldShowBlockSiteMenuItem(readerTopic: readerTopic, post: post)
+    }
+
+    private func shouldShowReportUserMenuItem(readerTopic: ReaderAbstractTopic?, post: ReaderPost) -> Bool {
+        return shouldShowReportPostMenuItem(readerTopic: readerTopic, post: post)
     }
 
     private static func trackToggleCommentSubscription(isSubscribed: Bool, post: ReaderPost, sourceViewController: UIViewController) {


### PR DESCRIPTION
Fixes #19983 

## Related PR
This PR depends on:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20053

## Description

Similar to Post Reporting feature, this PR adds ability to report a user and changed the "Report this Site" button color from blue to red to align with [Android](https://github.com/wordpress-mobile/WordPress-Android/issues/17602).

| Before | Actions Sheet | Web View | 
| ------ | ------ | ------------------- |
|  ![before](https://user-images.githubusercontent.com/9609223/218464466-996b40e7-6fa8-41bb-95cb-f2340831263a.png) | ![after](https://user-images.githubusercontent.com/9609223/218464776-152c6f6a-06e1-4aed-800e-97899c6eedeb.png) | ![webv](https://user-images.githubusercontent.com/9609223/218465781-075d55c3-2b24-4b1b-9346-1291e87bf572.png) |

## Test Instructions

1. Clean install the WordPress app and log into your account.
2. Head to either **Reader > Following** or **Reader > Discover** screens.
3. Tap a post's ⠇button.
4. **Expect** to see a "Report this user" red button. 
5. **Expect** the "Report this post" button to be red as well.
6. Tap "Report this user" button.
7. **Expect** the report author web view to be presented.

## Regression Notes
1. Potential unintended areas of impact
The existing "Report this post" code was tweaked so it would be great to smoke test that feature as well.

8. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests.

9. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
