### PR TITLE
[Tooling] Improve Prototype (aka Installable) Build comment and metadata

### DIFF
--- a/.buildkite/commands/installable-build-wordpress.sh
+++ b/.buildkite/commands/installable-build-wordpress.sh
@@ -14,4 +14,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_installable_build
+bundle exec fastlane build_and_upload_wordpress_installable_build

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
+# FIXIT-13.1: Prototype Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli
 
@@ -14,4 +14,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_jetpack_installable_build
+bundle exec fastlane build_and_upload_jetpack_prototype_build

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Installable Builds want the latest version of Sentry CLI
+# FIXIT-13.1: Prototype Builds want the latest version of Sentry CLI
 brew update
 brew upgrade sentry-cli
 
@@ -14,4 +14,4 @@ echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_and_upload_wordpress_installable_build
+bundle exec fastlane build_and_upload_wordpress_prototype_build

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,27 +15,27 @@ common_params:
 steps:
 
   #################
-  # Create Installable Builds for WP and JP
+  # Create Prototype Builds for WP and JP
   #################
-  - group: "🛠 Installable Builds"
+  - group: "🛠 Prototype Builds"
     steps:
-      - label: "🛠 WordPress Installable Build"
-        command: ".buildkite/commands/installable-build-wordpress.sh"
+      - label: "🛠 WordPress Prototype Build"
+        command: ".buildkite/commands/prototype-build-wordpress.sh"
         env: *common_env
         plugins: *common_plugins
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
           - github_commit_status:
-              context: "WordPress Installable Build"
+              context: "WordPress Prototype Build"
 
-      - label: "🛠 Jetpack Installable Build"
-        command: ".buildkite/commands/installable-build-jetpack.sh"
+      - label: "🛠 Jetpack Prototype Build"
+        command: ".buildkite/commands/prototype-build-jetpack.sh"
         env: *common_env
         plugins: *common_plugins
         if: "build.pull_request.id != null || build.pull_request.draft"
         notify:
           - github_commit_status:
-              context: "Jetpack Installable Build"
+              context: "Jetpack Prototype Build"
 
   #################
   # Build the app

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -330,6 +330,14 @@ platform :ios do
     )
 
     # Upload to App Center
+    commit = ENV.fetch('BUILDKITE_COMMIT', 'Unknown')
+    pr = ENV.fetch('BUILDKITE_PULL_REQUEST', nil)
+    release_notes = <<~NOTES
+      - Branch: \`#{ENV.fetch('BUILDKITE_BRANCH', 'Unknown')}\`\n
+      - Commit: [#{commit[0...7]}](https://github.com/#{GITHUB_REPO}/commit/#{commit})\n
+      - Pull Request: [\##{pr}](https://github.com/#{GITHUB_REPO}/pull/#{pr})\n
+    NOTES
+
     appcenter_upload(
       api_token: get_required_env('APPCENTER_API_TOKEN'),
       owner_name: APPCENTER_OWNER_NAME,
@@ -337,6 +345,7 @@ platform :ios do
       app_name: appcenter_app_name,
       file: lane_context[SharedValues::IPA_OUTPUT_PATH],
       dsym: lane_context[SharedValues::DSYM_OUTPUT_PATH],
+      release_notes: release_notes,
       destinations: 'Collaborators',
       notify_testers: false
     )

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -240,17 +240,17 @@ platform :ios do
     )
   end
 
-  # Builds the WordPress app for an Installable Build ("WordPress Alpha" scheme), and uploads it to App Center
+  # Builds the WordPress app for a Prototype Build ("WordPress Alpha" scheme), and uploads it to App Center
   #
   # @called_by CI
   #
-  desc 'Builds and uploads an installable build'
-  lane :build_and_upload_wordpress_installable_build do
+  desc 'Builds and uploads a Prototype Build'
+  lane :build_and_upload_wordpress_prototype_build do
     sentry_check_cli_installed
 
     alpha_code_signing
 
-    build_and_upload_installable_build(
+    build_and_upload_prototype_build(
       scheme: 'WordPress Alpha',
       output_app_name: 'WordPress Alpha',
       appcenter_app_name: 'WPiOS-One-Offs',
@@ -258,17 +258,17 @@ platform :ios do
     )
   end
 
-  # Builds the Jetpack app for an Installable Build ("Jetpack" scheme), and uploads it to App Center
+  # Builds the Jetpack app for a Prototype Build ("Jetpack" scheme), and uploads it to App Center
   #
   # @called_by CI
   #
-  desc 'Builds and uploads a Jetpack installable build'
-  lane :build_and_upload_jetpack_installable_build do
+  desc 'Builds and uploads a Jetpack prototype build'
+  lane :build_and_upload_jetpack_prototype_build do
     sentry_check_cli_installed
 
     jetpack_alpha_code_signing
 
-    build_and_upload_installable_build(
+    build_and_upload_prototype_build(
       scheme: 'Jetpack',
       output_app_name: 'Jetpack Alpha',
       appcenter_app_name: 'jetpack-installable-builds',
@@ -281,11 +281,11 @@ platform :ios do
   #################################################
 
 
-  # Generates a build number for Installable Builds, based on the PR number and short commit SHA1
+  # Generates a build number for Prototype Builds, based on the PR number and short commit SHA1
   #
   # @note This function uses Buildkite-specific ENV vars
   #
-  def generate_installable_build_number
+  def generate_prototype_build_number
     if ENV['BUILDKITE']
       commit = ENV.fetch('BUILDKITE_COMMIT', nil)[0, 7]
       branch = ENV.fetch('BUILDKITE_BRANCH', nil)
@@ -303,13 +303,13 @@ platform :ios do
 
   # Builds a Prototype Build for WordPress or Jetpack, then uploads it to App Center and comment with a link to it on the PR.
   #
-  def build_and_upload_installable_build(scheme:, output_app_name:, appcenter_app_name:, sentry_project_slug:)
+  def build_and_upload_prototype_build(scheme:, output_app_name:, appcenter_app_name:, sentry_project_slug:)
     configuration = 'Release-Alpha'
 
     # Get the current build version, and update it if needed
     version_config_path = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.internal.xcconfig')
     versions = Xcodeproj::Config.new(File.new(version_config_path)).to_hash
-    build_number = generate_installable_build_number
+    build_number = generate_prototype_build_number
     UI.message("Updating build version to #{build_number}")
     versions['VERSION_LONG'] = build_number
     new_config = Xcodeproj::Config.new(versions)

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -363,6 +363,14 @@ platform :ios do
       reuse_identifier: "prototype-build-link-#{appcenter_app_name}",
       body: comment_body
     )
+
+    # Attach version information as Buildkite metadata and annotation
+    appcenter_id = lane_context.dig(SharedValues::APPCENTER_BUILD_INFORMATION, 'id')
+    metadata = versions.merge(build_type: 'Prototype', 'appcenter:id': appcenter_id)
+    buildkite_metadata(set: metadata)
+    appcenter_install_url = "https://install.appcenter.ms/orgs/#{APPCENTER_OWNER_NAME}/apps/#{appcenter_app_name}/releases/#{appcenter_id}"
+    list = metadata.map { |k, v| " - **#{k}**: #{v}" }.join("\n")
+    buildkite_annotate(context: "appcenter-info-#{output_app_name}", style: 'info', message: "#{output_app_name} [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}")
   end
 
   def inject_buildkite_analytics_environment(xctestrun_path:)

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -303,6 +303,7 @@ platform :ios do
 
   # Builds a Prototype Build for WordPress or Jetpack, then uploads it to App Center and comment with a link to it on the PR.
   #
+  # rubocop:disable Metrics/AbcSize
   def build_and_upload_prototype_build(scheme:, output_app_name:, appcenter_app_name:, sentry_project_slug:)
     configuration = 'Release-Alpha'
 
@@ -381,6 +382,7 @@ platform :ios do
     list = metadata.map { |k, v| " - **#{k}**: #{v}" }.join("\n")
     buildkite_annotate(context: "appcenter-info-#{output_app_name}", style: 'info', message: "#{output_app_name} [App Center Build](#{appcenter_install_url}) Info:\n\n#{list}")
   end
+  # rubocop:enable Metrics/AbcSize
 
   def inject_buildkite_analytics_environment(xctestrun_path:)
     require 'plist'


### PR DESCRIPTION
### What?

Improve Prototype (aka Installable) Builds in a couple of ways:
 - Make the PR comment announcing the Prototype build QR code and information nicer
    - In particular, the QR code and URLs now directly links to the appropriate build on App Center, instead of defaulting to show the latest build in App Center as before
 - Change the wording used throughout Fastfile/Buildkite from "Installable Build" to "Prototype Build".
   - Every build is "installable" in some way, so that wording didn't make much sense. We're already using the term "Prototype Builds" for those in other apps, which feels like a better fit already, so we've decided to slowly adopt this new wording for those from now on to us make the term less ambiguous and more descriptive.
 - Attach Buildkite metadata to the CI build with relevant infos
 - Add a Buildkite annotation to the CI build with relevant infos
 - Add more info to the App Center "Release Notes" field of each Prototype Builds being created

### To test:

 - Check that the PR got two PR comments, providing the information for the WordPress and Jetpack Prototype builds respectively, unfold the triangle/spoiler blocks, and verify that the information displayed for those builds is accurate
 - Scan the QR code (and/or follow the URL) and validate that it directly redirects you to the page in App Center that corresponds to the right build, even if new builds have been uploaded to App Center since and this is not the latest one anymore
 - Verify that the "Release Notes" field in App Center for that build contains the appropriate information about the Commit and PR it corresponds to
 - Open [the Buildkite build for this PR](https://buildkite.com/automattic/wordpress-ios/builds/12939), and check that the annotation shows some metadata about the App Center build (short/long version, app center id, …)
 - [Add `/meta-data` to the URL of the Buildkite build](https://buildkite.com/automattic/wordpress-ios/builds/12939/meta-data) and validate that it includes the correct metadata
 - Use the `?meta_data` query parameter on the Buildkite URL, e.g. [`?meta_data[build_type]=Prototype`](https://buildkite.com/automattic/wordpress-ios/builds?meta_data%5Bbuild_type%5D=Prototype) to search for all CI builds that correspond to / include Prototype builds