### PR TITLE
Rename `GHHELPER_REPO` to `GITHUB_REPO`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -51,7 +51,7 @@ ALL_JETPACK_BUNDLE_IDENTIFIERS = [JETPACK_BUNDLE_IDENTIFIER, *JETPACK_EXTENSIONS
 # Environment Variables — used by lanes but also potentially actions
 Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)
-GHHELPER_REPO = 'wordpress-mobile/wordpress-iOS'
+GITHUB_REPO = 'wordpress-mobile/wordpress-iOS'
 ENV['PROJECT_NAME'] = 'WordPress'
 ENV['PUBLIC_CONFIG_FILE'] = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.Public.xcconfig')
 ENV['INTERNAL_CONFIG_FILE'] = File.join(PROJECT_ROOT_FOLDER, 'config', 'Version.internal.xcconfig')

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -150,7 +150,7 @@ platform :ios do
 
     version = options[:beta_release] ? ios_get_build_version : ios_get_app_version
     create_release(
-      repository: GHHELPER_REPO,
+      repository: GITHUB_REPO,
       version: version,
       release_notes_file_path: File.join(PROJECT_ROOT_FOLDER, 'WordPress', 'Resources', 'release_notes.txt'),
       release_assets: archive_zip_path.to_s,

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -44,8 +44,8 @@ platform :ios do
     )
     ios_update_release_notes(new_version: new_version)
 
-    setbranchprotection(repository: GHHELPER_REPO, branch: "release/#{new_version}")
-    setfrozentag(repository: GHHELPER_REPO, milestone: new_version)
+    setbranchprotection(repository: GITHUB_REPO, branch: "release/#{new_version}")
+    setfrozentag(repository: GITHUB_REPO, milestone: new_version)
     ios_check_beta_deps(podfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile'))
 
     print_release_notes_reminder
@@ -142,10 +142,10 @@ platform :ios do
 
     # Wrap up
     version = ios_get_app_version
-    removebranchprotection(repository: GHHELPER_REPO, branch: release_branch_name)
-    setfrozentag(repository: GHHELPER_REPO, milestone: version, freeze: false)
-    create_new_milestone(repository: GHHELPER_REPO)
-    close_milestone(repository: GHHELPER_REPO, milestone: version)
+    removebranchprotection(repository: GITHUB_REPO, branch: release_branch_name)
+    setfrozentag(repository: GITHUB_REPO, milestone: version, freeze: false)
+    create_new_milestone(repository: GITHUB_REPO)
+    close_milestone(repository: GITHUB_REPO, milestone: version)
 
     trigger_release_build
   end


### PR DESCRIPTION
`GHHELPER_REPO` used to be a meaningful name in release-toolkit, but as of version 6.0.0, that [is no longer the case](https://github.com/wordpress-mobile/release-toolkit/pull/420).

`GITHUB_REPO` is a much clearer and appropriate name for what the constant represents.

## Testing 

This is a mechanical find and replace (`find . -name '*.rb' -o -name 'Fastfile' -print0 | xargs -0 sed -i "" "s/GHHELPER_REPO/GITHUB_REPO/g"`). Checking the diff is all we need.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
