### PR TITLE
Blaze: Add feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -45,6 +45,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackFeaturesRemovalPhaseSelfHosted
     case wordPressSupportForum
     case jetpackIndividualPluginSupport
+    case blaze
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -143,6 +144,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .jetpackIndividualPluginSupport:
             return false
+        case .blaze:
+            return false
         }
     }
 
@@ -169,6 +172,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "prevent_duplicate_notifs_remote_field"
         case .wordPressSupportForum:
             return "enable_wordpress_support_forum"
+        case .blaze:
+            return "blaze"
             default:
                 return nil
         }
@@ -275,6 +280,8 @@ extension FeatureFlag {
             return "Provide support through a forum"
         case .jetpackIndividualPluginSupport:
             return "Jetpack Individual Plugin Support"
+        case .blaze:
+            return "Blaze"
         }
     }
 


### PR DESCRIPTION
Closes #20081

## Description
This PR adds a feature flag for the Blaze feature.
 
## How to test
1. Go to My Site > Me > App Settings > Debug
2. ✅ Verify: the feature flag for Blaze is set to false

## Regression Notes
1. Potential unintended areas of impact
N/A

3. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

4. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
