### PR TITLE
Blogging Prompts: Hide blogging prompt options for self-hosted sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowSettingsViewController.swift
@@ -187,7 +187,7 @@ class BloggingRemindersFlowSettingsViewController: UIViewController {
         let view = UIView()
         view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubviews([bloggingPromptsTitleStackView, bloggingPromptsDescription, bloggingPromptsSwitch])
-        view.isHidden = !FeatureFlag.bloggingPrompts.enabled
+        view.isHidden = !isBloggingPromptsEnabled
         return view
     }()
 
@@ -558,7 +558,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     }
 
     func configureBloggingPromptsConstraints() {
-        guard FeatureFlag.bloggingPrompts.enabled else {
+        guard isBloggingPromptsEnabled else {
             NSLayoutConstraint.activate([
                 bloggingPromptsView.widthAnchor.constraint(equalToConstant: .zero),
                 bloggingPromptsView.heightAnchor.constraint(equalToConstant: .zero),
@@ -664,8 +664,12 @@ extension BloggingRemindersFlowSettingsViewController: ChildDrawerPositionable {
 
 private extension BloggingRemindersFlowSettingsViewController {
 
+    var isBloggingPromptsEnabled: Bool {
+        return FeatureFlag.bloggingPrompts.enabled && blog.isAccessibleThroughWPCom()
+    }
+
     var promptRemindersEnabled: Bool {
-        guard FeatureFlag.bloggingPrompts.enabled,
+        guard isBloggingPromptsEnabled,
               let settings = bloggingPromptsService?.localSettings else {
             return false
         }
@@ -680,7 +684,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     ///
     /// - Returns: A closure used to reset changes made to the prompt settings. Returns nil if the update condition is not fulfilled.
     func temporarilyUpdatePromptSettings() -> (() -> Void)? {
-        guard FeatureFlag.bloggingPrompts.enabled,
+        guard isBloggingPromptsEnabled,
               bloggingPromptsSwitch.isOn || (promptRemindersEnabled && !bloggingPromptsSwitch.isOn),
               let settings = bloggingPromptsService?.localSettings,
               let context = settings.managedObjectContext else {
@@ -725,7 +729,7 @@ private extension BloggingRemindersFlowSettingsViewController {
     ///
     /// - Parameter completion: Closure called when the process completes.
     func syncPromptsScheduleIfNeeded(_ completion: @escaping () -> Void) {
-        guard FeatureFlag.bloggingPrompts.enabled,
+        guard isBloggingPromptsEnabled,
               let service = bloggingPromptsService,
               let settings = service.localSettings else {
             completion()

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -38,7 +38,7 @@ private extension SiteSettingsViewController {
         if blog.areBloggingRemindersAllowed() {
             rows.append(.reminders)
         }
-        if FeatureFlag.bloggingPromptsEnhancements.enabled {
+        if blog.isAccessibleThroughWPCom() && FeatureFlag.bloggingPromptsEnhancements.enabled {
             rows.append(.prompts)
         }
         return rows


### PR DESCRIPTION
Fixes #20083

## Description

Hides the Site Setting "Show prompts" and the "Include a Blogging Prompt" on the reminder screen for self-hosted sites.

## Testing

<details><summary><strong>SiteSettingsViewController+Blogging.swift</strong></summary>

```swift
    var bloggingSettingsRows: [BloggingSettingsRows] {
        var rows = [BloggingSettingsRows]()
//        if blog.areBloggingRemindersAllowed() {
            rows.append(.reminders)
//        }
        if blog.isAccessibleThroughWPCom() && FeatureFlag.bloggingPromptsEnhancements.enabled {
            rows.append(.prompts)
        }
        return rows
    }
```

</details>

To test:

- Create a self-hosted site
- Install Jetpack
- Login and add the self-hosted site or use the self-hosted site instead of logging in
- With the self-hosted site selected, tap on `Site Settings`
- Verify the blogging prompts option "Show prompts" does not appear
- Tap on `Reminders` (I had to make the code change at the top of the testing section to force it to appear)
- Verify the prompts section, "Include a Blogging Prompt", does not appear


## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
