### PR TITLE
Blogging Prompts: Update prompts dashboard card and FAB display logic to match

### DIFF
--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -10,6 +10,7 @@ public class BloggingPromptSettings: NSManagedObject {
         self.reminderTime = remoteSettings.reminderTime
         self.promptRemindersEnabled = remoteSettings.promptRemindersEnabled
         self.isPotentialBloggingSite = remoteSettings.isPotentialBloggingSite
+        updatePromptSettingsIfNecessary(siteID: String(siteID), enabled: isPotentialBloggingSite)
         self.reminderDays = reminderDays ?? BloggingPromptSettingsReminderDays(context: context)
         reminderDays?.configure(with: remoteSettings.reminderDays)
     }
@@ -21,6 +22,15 @@ public class BloggingPromptSettings: NSManagedObject {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "HH.mm"
         return dateFormatter.date(from: reminderTime)
+    }
+
+    private func updatePromptSettingsIfNecessary(siteID: String, enabled: Bool) {
+        let repository = UserPersistentStoreFactory.instance()
+        var promptsEnabledSettings = repository.promptsEnabledSettings
+        if promptsEnabledSettings[siteID] == nil {
+            promptsEnabledSettings[siteID] = enabled
+            repository.promptsEnabledSettings = promptsEnabledSettings
+        }
     }
 
 }

--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -17,7 +17,7 @@ private enum UPRUConstants {
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
     static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
     static let jetpackContentMigrationStateKey = "jetpackContentMigrationState"
-    static let promptsRemovedKey = "prompts-removed-sites"
+    static let promptsEnabledSettingsKey = "prompts-enabled-site-settings"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -187,15 +187,15 @@ extension UserPersistentRepositoryUtility {
         }
     }
 
-    var promptsRemovedSites: Set<String> {
+    var promptsEnabledSettings: [String: Bool] {
         get {
-            guard let sites = UserPersistentStoreFactory.instance().array(forKey: UPRUConstants.promptsRemovedKey) as? [String] else {
-                return Set()
+            guard let sites = UserPersistentStoreFactory.instance().dictionary(forKey: UPRUConstants.promptsEnabledSettingsKey) as? [String: Bool] else {
+                return [String: Bool]()
             }
-            return Set(sites)
+            return sites
         }
         set {
-            UserPersistentStoreFactory.instance().set(newValue.array, forKey: UPRUConstants.promptsRemovedKey)
+            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.promptsEnabledSettingsKey)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -96,7 +96,7 @@ private extension SiteSettingsViewController {
             return false
         }
 
-        return !UserPersistentStoreFactory.instance().promptsRemovedSites.contains(siteID)
+        return UserPersistentStoreFactory.instance().promptsEnabledSettings[siteID] ?? false
     }
 
     var promptsSwitchOnChange: (Bool) -> () {
@@ -106,14 +106,9 @@ private extension SiteSettingsViewController {
                 return
             }
             let repository = UserPersistentStoreFactory.instance()
-            var removedSites = repository.promptsRemovedSites
-
-            if isPromptsEnabled {
-                removedSites.remove(siteID)
-            } else {
-                removedSites.insert(siteID)
-            }
-            repository.promptsRemovedSites = removedSites
+            var promptsEnabledSettings = repository.promptsEnabledSettings
+            promptsEnabledSettings[siteID] = isPromptsEnabled
+            repository.promptsEnabledSettings = promptsEnabledSettings
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -302,7 +302,8 @@ private extension CreateButtonCoordinator {
               blog.isAccessibleThroughWPCom(),
               let prompt = prompt,
               let siteID = blog.dotComID?.stringValue,
-              !UserPersistentStoreFactory.instance().promptsRemovedSites.contains(siteID),
+              let isPromptsEnabled = UserPersistentStoreFactory.instance().promptsEnabledSettings[siteID],
+              isPromptsEnabled,
               !userSkippedPrompt(prompt, for: blog) else {
             return nil
         }


### PR DESCRIPTION
Fixes #20084

## Description

The Blogging Prompts dashboard card and FAB header had slightly different display logic. This aligns the two to be the same.

## Testing

**Blogging prompts enabled site**
- Install Jetpack and login
- Select a blogging prompts **enabled** site
- Verify the prompts dashboard card is displayed
- Tap on the FAB (+)
- Verify the prompts header is displayed
- Navigate to the Site Settings (Menu > Site Settings)
- Disable the "Show prompts" switch
- Navigate back to the Home dashboard
- Verify the prompts dashboard card is not displayed
- Tap on the FAB (+)
- Verify the prompts header is not displayed

**Blogging prompts disabled site**
- Install Jetpack and login
- Select a blogging prompts **disabled** site
- Verify the prompts dashboard card is not displayed
- Tap on the FAB (+)
- Verify the prompts header is not displayed
- Navigate to the Site Settings (Menu > Site Settings)
- Enable the "Show prompts" switch
- Navigate back to the Home dashboard
- Verify the prompts dashboard card is displayed
- Tap on the FAB (+)
- Verify the prompts header is displayed

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
