### PR TITLE
Add higher CI priority to release builds

### DIFF
--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -17,7 +17,7 @@ steps:
 
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
-    priority: 1
+    priority: 2
     env: *common_env
     plugins: *common_plugins
     notify:
@@ -33,7 +33,7 @@ steps:
 
   - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
-    priority: 1
+    priority: 2
     env: *common_env
     plugins: *common_plugins
     notify:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -17,6 +17,7 @@ steps:
 
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
+    # The TestFlight build has a priority of 2 so that it is higher than the AppCenter build
     priority: 2
     env: *common_env
     plugins: *common_plugins
@@ -33,6 +34,7 @@ steps:
 
   - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
+    # The TestFlight build has a priority of 2 so that it is higher than the AppCenter build
     priority: 2
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -17,6 +17,7 @@ steps:
 
   - label: ":wordpress: :testflight: WordPress Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-wordpress.sh $BETA_RELEASE"
+    priority: 1
     env: *common_env
     plugins: *common_plugins
     notify:
@@ -24,6 +25,7 @@ steps:
 
   - label: ":wordpress: :appcenter: WordPress Release Build (App Center)"
     command: ".buildkite/commands/release-build-wordpress-internal.sh"
+    priority: 1
     env: *common_env
     plugins: *common_plugins
     notify:
@@ -31,6 +33,7 @@ steps:
 
   - label: ":jetpack: :testflight: Jetpack Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build-jetpack.sh"
+    priority: 1
     env: *common_env
     plugins: *common_plugins
     notify:


### PR DESCRIPTION
### Summary of changes:

This PR increases the priority of release builds on Buildkite. This will be useful so that release builds won't get delayed if the CI queue gets backed up. The default priority of a build is 0, so increasing the release builds to 1 will put them before other builds: https://buildkite.com/docs/pipelines/managing-priorities