### PR TITLE
[Support Forum] Hide Gutenberg support section

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1231,7 +1231,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
             .instagramEmbed: post.blog.supports(.instagramEmbed),
             .loomEmbed: post.blog.supports(.loomEmbed),
             .smartframeEmbed: post.blog.supports(.smartframeEmbed),
-            .supportSection: true
+            .supportSection: SupportConfiguration.current() == .zendesk
         ]
     }
 


### PR DESCRIPTION
## Description

Use the functionality developed in https://github.com/wordpress-mobile/WordPress-iOS/pull/19691 to disable the support section on Gutenberg editor together with support forum

## Testing instructions

Open block editor, tap three-dot menu and, tap Help & Support

**WordPress app & Feature flag enabled:** Support section not visible
**WordPress app & Feature flag disabled:** Support section not visible
**Jetpack app & Feature flag enabled:** Support section not visible
**Jetpack app & Feature flag disabled:** Support section not visible

## Regression Notes

1. Potential unintended areas of impact

None

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

| WP - feature flag disabled | WP - feature flag enabled |
| --- | ----------- |
| ![Simulator Screen Shot - iPhone 14 - 2023-02-08 at 17 27 40](https://user-images.githubusercontent.com/4062343/217574459-2925f38e-0b4a-4acb-9b88-e933062d3900.png) | ![Simulator Screen Shot - iPhone 14 - 2023-02-08 at 17 28 01](https://user-images.githubusercontent.com/4062343/217574448-00fe6c8c-fdbf-470c-8446-fe02039b8f10.png)

