### PR TITLE
Autocorrect SwiftLint violations

### DIFF
--- a/WordPress/Classes/Extensions/String+CondenseWhitespace.swift
+++ b/WordPress/Classes/Extensions/String+CondenseWhitespace.swift
@@ -22,7 +22,7 @@ extension String {
     ///
     /// This is the last line
     /// ```
-    /// 
+    ///
     func condenseWhitespace() -> String {
         return self.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
             .replacingOccurrences(of: "\\s\n", with: "\n", options: .regularExpression, range: nil)

--- a/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
+++ b/WordPress/Classes/Extensions/UINavigationController+SplitViewFullscreen.swift
@@ -54,9 +54,9 @@ extension UIView {
 
     /// Hides this view by inserting a snapshot into the view hierarchy.
     ///
-    /// - Parameter afterScreenUpdates: A Boolean value that specifies whether 
-    ///             the snapshot should be taken after recent changes have been 
-    ///             incorporated. Pass the value false to capture the screen in 
+    /// - Parameter afterScreenUpdates: A Boolean value that specifies whether
+    ///             the snapshot should be taken after recent changes have been
+    ///             incorporated. Pass the value false to capture the screen in
     ///             its current state, which might not include recent changes.
     @objc func hideWithBlankingSnapshot(afterScreenUpdates: Bool = false) {
         if subviews.first is BlankingView {

--- a/WordPress/Classes/Models/BlockEditorSettings+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/BlockEditorSettings+CoreDataProperties.swift
@@ -16,11 +16,11 @@ extension BlockEditorSettings {
     ///
     @NSManaged public var isFSETheme: Bool
 
-    /// Stores a date indicating the last time stamp that the settings were modified. 
+    /// Stores a date indicating the last time stamp that the settings were modified.
     ///
     @NSManaged public var lastUpdated: Date
 
-    /// Stores the raw JSON string that comes from the Global Styles Setting Request. 
+    /// Stores the raw JSON string that comes from the Global Styles Setting Request.
     ///
     @NSManaged public var rawStyles: String?
 
@@ -33,7 +33,7 @@ extension BlockEditorSettings {
     ///
     @NSManaged public var elements: Set<BlockEditorSettingElement>?
 
-    /// Stores a reference back to the parent blog. 
+    /// Stores a reference back to the parent blog.
     ///
     @NSManaged public var blog: Blog
 }

--- a/WordPress/Classes/Models/Blog+BlockEditorSettings.swift
+++ b/WordPress/Classes/Models/Blog+BlockEditorSettings.swift
@@ -4,7 +4,7 @@ import CoreData
 extension Blog {
 
     /// Stores the relationship to the `BlockEditorSettings` which is an optional entity that holds settings realated to the BlockEditor. These are features
-    /// such as Global Styles and Full Site Editing settings and capabilities. 
+    /// such as Global Styles and Full Site Editing settings and capabilities.
     ///
     @NSManaged public var blockEditorSettings: BlockEditorSettings?
 

--- a/WordPress/Classes/Services/AuthenticationService.swift
+++ b/WordPress/Classes/Services/AuthenticationService.swift
@@ -89,7 +89,7 @@ class AuthenticationService {
             atomicSite: false) { hasCookie in
 
                 guard !hasCookie else {
-                    // The stored cookie can be stale but we'll try to use it and refresh it if the request fails. 
+                    // The stored cookie can be stale but we'll try to use it and refresh it if the request fails.
                     success()
                     return
                 }

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -2,7 +2,7 @@ extension CommentService {
 
     /**
      Fetches a list of users from remote that liked the comment with the given IDs.
-     
+
      @param commentID       The ID of the comment to fetch likes for
      @param siteID          The ID of the site that contains the post
      @param count           Number of records to retrieve. Optional. Defaults to the endpoint max of 90.
@@ -52,7 +52,7 @@ extension CommentService {
 
     /**
      Fetches a list of users from Core Data that liked the comment with the given IDs.
-     
+
      @param commentID   The ID of the comment to fetch likes for.
      @param siteID      The ID of the site that contains the post.
      @param after       Filter results to likes after this Date. Optional.

--- a/WordPress/Classes/Services/DomainsService.swift
+++ b/WordPress/Classes/Services/DomainsService.swift
@@ -106,7 +106,7 @@ struct DomainsService {
                               success: @escaping ([DomainSuggestion]) -> Void,
                               failure: @escaping (Error) -> Void) {
         let request = DomainSuggestionRequest(query: query, quantity: quantity)
-        
+
         remote.getDomainSuggestions(base: base,
                                     quantity: quantity,
                                     domainSuggestionType: domainSuggestionType,

--- a/WordPress/Classes/Services/PostAutoUploadInteractor.swift
+++ b/WordPress/Classes/Services/PostAutoUploadInteractor.swift
@@ -78,7 +78,7 @@ final class PostAutoUploadInteractor {
 
     /// Temporary method to support old _Retry_ upload functionality.
     ///
-    /// This is going to be removed later. 
+    /// This is going to be removed later.
     func canRetryUpload(of post: AbstractPost) -> Bool {
         guard post.isFailed,
             let status = post.status else {

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -2,7 +2,7 @@ extension PostService {
 
     /**
      Fetches a list of users from remote that liked the post with the given IDs.
-     
+
      @param postID          The ID of the post to fetch likes for
      @param siteID          The ID of the site that contains the post
      @param count           Number of records to retrieve. Optional. Defaults to the endpoint max of 90.
@@ -52,7 +52,7 @@ extension PostService {
 
     /**
      Fetches a list of users from Core Data that liked the post with the given IDs.
-     
+
      @param postID  The ID of the post to fetch likes for.
      @param siteID  The ID of the site that contains the post.
      @param after   Filter results to likes after this Date.

--- a/WordPress/Classes/Services/ReaderPostService+RelatedPosts.swift
+++ b/WordPress/Classes/Services/ReaderPostService+RelatedPosts.swift
@@ -4,7 +4,7 @@ extension ReaderPostService {
 
     /**
      Fetches related posts for a specific post.
-     
+
      @param post The reader post to fetch related posts for.
      @param success block called on a successful fetch.
      @param failure block called if there is any error. `error` can be any underlying network error.

--- a/WordPress/Classes/Stores/NoticeStore.swift
+++ b/WordPress/Classes/Stores/NoticeStore.swift
@@ -132,7 +132,7 @@ enum NoticeAction: Action {
     /// 4. MediaBrowser dispatches `dismiss` which dismisses **NoticeB**!
     ///
     /// If MediaBrowser used `clear` or `clearWithTag`, the NoticeB should not have been dismissed
-    /// prematurely. 
+    /// prematurely.
     case dismiss
     /// Removes the given `Notice` from the Store.
     case clear(Notice)

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -130,7 +130,7 @@ class WindowManager: NSObject {
 
 
     /// Removes the temporary overlaying window if it exists. And makes the main window the key window again.
-    /// 
+    ///
     func clearOverlayingWindow() {
         guard let overlayingWindow = overlayingWindow else {
             return

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -456,7 +456,7 @@ import Foundation
             return "media_library_photo_added"
         case .editorAddedPhotoViaTenor:
             return "editor_photo_added"
-        // Editor    
+        // Editor
         case .editorPostPublishTap:
             return "editor_post_publish_tapped"
         case .editorPostPublishDismissed:

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -169,7 +169,7 @@ import AutomatticTracks
         case .privateSelfHostedSite:
             finalURL = url
         case .publicWPComSite: fallthrough
-        case .privateAtomicWPComSite(siteID: _):
+        case .privateAtomicWPComSite:
             finalURL = photonUrl(with: url, preferredSize: size)
         case .privateWPComSite:
             finalURL = privateImageURL(with: url, from: host, preferredSize: size)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -35,7 +35,7 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
 
         configureCardFrameView(for: blog)
 
-        let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .dashboardCardItemTapped, properties:["type": DashboardCard.quickStart.rawValue])
+        let checklistTappedTracker: QuickStartChecklistTappedTracker = (event: .dashboardCardItemTapped, properties: ["type": DashboardCard.quickStart.rawValue])
 
         tourStateView.configure(blog: blog, sourceController: viewController, checklistTappedTracker: checklistTappedTracker)
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -310,7 +310,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     ///     - Segmented control container view
     ///       - Segmented control
     ///     - Blog dashboard view controller OR blog details view controller
-    /// 
+    ///
     private func setupConstraints() {
         view.addSubview(scrollView)
         view.pinSubviewToAllEdges(scrollView)

--- a/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Blog/WPStyleGuide+Sharing.swift
@@ -36,15 +36,15 @@ extension WPStyleGuide {
 
         // Handle special cases
         switch name {
-        case "print" :
+        case "print":
             return .gridicon(.print)
-        case "email" :
+        case "email":
             return .gridicon(.mail)
-        case "google-plus-1" :
+        case "google-plus-1":
             iconName = "social-google-plus"
-        case "press-this" :
+        case "press-this":
             iconName = "social-wordpress"
-        default :
+        default:
             iconName = "social-\(name)"
         }
 

--- a/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/PickerTableViewCell.swift
@@ -10,7 +10,7 @@ open class PickerTableViewCell: WPTableViewCell, UIPickerViewDelegate, UIPickerV
 
     /// Closure, to be executed on selection change
     ///
-    @objc open var onChange : ((_ newValue: Int) -> ())?
+    @objc open var onChange: ((_ newValue: Int) -> ())?
 
 
     /// String Format, to be applied to the Row Titles

--- a/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/SwitchTableViewCell.swift
@@ -5,7 +5,7 @@ import WordPressShared
 ///
 open class SwitchTableViewCell: WPTableViewCell {
     // MARK: - Public Properties
-    @objc open var onChange : ((_ newValue: Bool) -> ())?
+    @objc open var onChange: ((_ newValue: Bool) -> ())?
 
     @objc open var name: String {
         get {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -97,7 +97,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         didSet {
             visualEffects.forEach { (visualEffect) in
                 visualEffect.effect = UIBlurEffect.init(style: .systemChromeMaterial)
-                // Allow touches to pass through to the scroll view behind the header. 
+                // Allow touches to pass through to the scroll view behind the header.
                 visualEffect.contentView.isUserInteractionEnabled = false
             }
         }
@@ -475,7 +475,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
      * at the bottome of the tableView when multiple cells are rendered.
      */
     private func updateFooterInsets() {
-        /// Update the footer height if it's being displayed. 
+        /// Update the footer height if it's being displayed.
         if footerHeightContraint.constant > 0 {
             footerHeightContraint.constant = footerHeight
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -140,7 +140,7 @@ private extension JetpackPluginOverlayViewModel {
             value: "Please install the full Jetpack plugin",
             comment: "Jetpack Plugin Modal title"
         )
-        
+
         static let subtitleSingular = NSLocalizedString(
             "jetpack.plugin.modal.subtitle.singular",
             value: """

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanViewController.swift
@@ -170,7 +170,7 @@ class JetpackScanViewController: UIViewController, JetpackScanView {
         navigationController?.pushViewController(viewController, animated: true)
     }
 
-    // MARK: - Private: 
+    // MARK: - Private:
     private func configureTableView() {
         tableView.delegate = self
         tableView.register(JetpackScanStatusCell.defaultNib, forCellReuseIdentifier: Constants.statusCellIdentifier)

--- a/WordPress/Classes/ViewRelated/Media/AnimatedImageCache.swift
+++ b/WordPress/Classes/ViewRelated/Media/AnimatedImageCache.swift
@@ -71,7 +71,7 @@ class AnimatedImageCache {
 
     func animatedImage(_ urlRequest: URLRequest,
                        placeholderImage: UIImage?,
-                       success: ((Data, UIImage?) -> Void)? ,
+                       success: ((Data, UIImage?) -> Void)?,
                        failure: ((NSError?) -> Void)? ) -> URLSessionTask? {
 
         if let cachedImageData = cachedData(url: urlRequest.url) {

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
@@ -49,7 +49,7 @@ final class StockPhotosDataLoader {
             return
         }
 
-        // Bail out if we do not expect more pages of data 
+        // Bail out if we do not expect more pages of data
         guard request.pageable?.next() != nil else {
             return
         }

--- a/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/NUX/EpilogueUserInfoCell.swift
@@ -58,7 +58,7 @@ class EpilogueUserInfoCell: UITableViewCell {
         configureAccessibility()
 
         switch gravatarStatus {
-        case .uploading(image: _):
+        case .uploading:
             gravatarActivityIndicator.startAnimating()
         case .finished:
             gravatarActivityIndicator.stopAnimating()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -35,7 +35,7 @@ class ReaderSelectInterestsCoordinator {
     // MARK: - Display Logic
 
     /// Determines whether or not the select interests view should be displayed
-    /// - Returns: true 
+    /// - Returns: true
     public func isFollowingInterests(completion: @escaping (Bool) -> Void) {
         interestsService.fetchFollowedInterestsLocally { followedInterests in
             guard let interests = followedInterests else {

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -92,7 +92,7 @@ class ReaderSuggestedTopicsStyleGuide {
         let colorCount = Self.colors.count
 
         // Safety feature if for some reason the count of returned topics ever increases past 4 we will
-        // loop through the list colors again. 
+        // loop through the list colors again.
         return Self.colors[index % colorCount]
     }
 

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeView.swift
@@ -120,7 +120,7 @@ class NoticeView: UIView {
         // Construct a mask path with the notice's roundrect cut out of a larger padding rect.
         // This, combined with the `kCAFillRuleEvenOdd` gives us an inverted mask, so
         // the shadow only appears _outside_ of the notice roundrect, and doesn't appear underneath
-        // and obscure the blur visual effect view. 
+        // and obscure the blur visual effect view.
         let maskPath = CGMutablePath()
         let leftInset = notice.style.layoutMargins.left * 2
         let topInset = notice.style.layoutMargins.top * 2

--- a/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsPickerViewController.swift
@@ -40,7 +40,7 @@ open class SettingsPickerViewController: UITableViewController {
     open var pickerMaximumValue: Int!
 
     /// Closure to be executed whenever the Switch / Picker is updated
-    @objc open var onChange : ((_ enabled: Bool, _ newValue: Int) -> ())?
+    @objc open var onChange: ((_ enabled: Bool, _ newValue: Int) -> ())?
 
 
 

--- a/WordPress/Classes/ViewRelated/Views/AlertView/AlertInternalView.swift
+++ b/WordPress/Classes/ViewRelated/Views/AlertView/AlertInternalView.swift
@@ -6,7 +6,7 @@ import WordPressShared
 ///
 open class AlertInternalView: UIView {
     // MARK: - Public Properties
-    @objc open var onClick : (() -> ())?
+    @objc open var onClick: (() -> ())?
 
 
 

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -1,7 +1,7 @@
 import ScreenObject
 import XCTest
 
-/// This screen object is for the Support section. In the app, it's a modal we can get to from Me 
+/// This screen object is for the Support section. In the app, it's a modal we can get to from Me
 /// > Help & Support, or, when logged out, from Prologue > tap either continue button > Help.
 public class SupportScreen: ScreenObject {
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RichNotificationContentFormatter.swift
@@ -93,7 +93,7 @@ private extension RichNotificationContentFormatter {
         self.attributedBody = formattedBody
 
         // Grab the first media attachment that is not an Emoji so it can be displayed as a
-        // push notification media attachment 
+        // push notification media attachment
         if let notificationTextContent = formattableContent as? NotificationTextContent {
             self.mediaURL = notificationTextContent.media.first(where: {
                 !($0.mediaURL?.isEmojiURL() ?? false)

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -140,7 +140,7 @@ class NotificationService: UNNotificationServiceExtension {
             if !NotificationKind.omitsRichNotificationBody(notificationKind) {
                 notificationContent.title = contentFormatter.attributedSubject?.string ?? apsAlert
 
-                // Improve the notification body by trimming whitespace and reducing any multiple blank lines 
+                // Improve the notification body by trimming whitespace and reducing any multiple blank lines
                 notificationContent.body = contentFormatter.body?.condenseWhitespace() ?? ""
             }
 
@@ -260,7 +260,7 @@ private extension NotificationService {
     /// This isn't meant to be extensive and has a few flaws, but since we don't know
     /// much information about the URL and if it's a blog without having to do another request
     /// this works for the current usecases.
-    /// 
+    ///
     /// - Parameter url: The URL to check
     /// - Returns: True if it's a WP.com site, False if not.
     private func isWPComSite(url: URL) -> Bool {

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -271,7 +271,7 @@ extension AppExtensionsService {
         })
     }
 
-    /// Saves a new post + media items to the shared container db and then uploads it in the background. 
+    /// Saves a new post + media items to the shared container db and then uploads it in the background.
     ///
     /// - Parameters:
     ///   - shareData: The shareData with which to create the post

--- a/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
+++ b/WordPress/WordPressShareExtension/NSExtensionContext+Extensions.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Encapsulates NSExtensionContext Helper Methods.
 ///
 extension NSExtensionContext {
-    /// Returns all the NSItemProvider attachments on the first NSItemProvider 
+    /// Returns all the NSItemProvider attachments on the first NSItemProvider
     /// that conform to a specific type identifier
     ///
     func itemProviders(ofType type: String) -> [NSItemProvider] {

--- a/WordPress/WordPressTest/Bundle+LoadFromNib.swift
+++ b/WordPress/WordPressTest/Bundle+LoadFromNib.swift
@@ -4,7 +4,7 @@ extension Bundle {
     /// Assumes that the xib and Swift file will have the same name
     ///
     /// - Parameter type: the actual type of the view we want to load
-    /// - Returns: an optional instance of the type passed as parameter    
+    /// - Returns: an optional instance of the type passed as parameter
     static func loadRootViewFromNib<T: AnyObject>(type: T.Type) -> T? {
         let bundle = Bundle(for: type as AnyClass)
         return bundle.loadNibNamed(String(describing: type), owner: nil, options: nil)?.first as? T

--- a/WordPress/WordPressTest/NullMockUserDefaults.swift
+++ b/WordPress/WordPressTest/NullMockUserDefaults.swift
@@ -1,7 +1,7 @@
 @testable import WordPress
 
 
-/// A null mock implementation of the KeyValueDatabase protocol 
+/// A null mock implementation of the KeyValueDatabase protocol
 class NullMockUserDefaults: KeyValueDatabase {
     func object(forKey defaultName: String) -> Any? {
         return nil


### PR DESCRIPTION
This is built on top of #20103 and simply tracks the changes made by `rake lint:autocorrect` (`./Pods/SwiftLint/swiftlint lint --autocorrect --quiet`).

I split this PR from #20103 to focus on the automated code changes and the SwiftLint setup changes, respectively.

You'll see that most changes are whitespace only.