### PR TITLE
Hide .org forum on Jetpack

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -17,6 +17,7 @@ class SupportTableViewController: UITableViewController {
     private var tableHandler: ImmuTableViewHandler?
     private let userDefaults = UserPersistentStoreFactory.instance()
     private let featureFlagStore: RemoteFeatureFlagStore
+    private let isForumShown = SupportConfiguration.current() == .forum
 
     /// This closure is called when this VC is about to be dismissed due to the user
     /// tapping the dismiss button.
@@ -101,7 +102,7 @@ private extension SupportTableViewController {
     }
 
     func setupNavBar() {
-        title = featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) ? LocalizedText.viewTitle : LocalizedText.viewTitleSupport
+        title = isForumShown ? LocalizedText.viewTitle : LocalizedText.viewTitleSupport
 
         if isModal() {
             navigationItem.leftBarButtonItem = UIBarButtonItem(title: LocalizedText.closeButton,
@@ -142,14 +143,14 @@ private extension SupportTableViewController {
         var helpSection: ImmuTableSection?
         if SupportConfiguration.current(featureFlagStore: featureFlagStore) == .zendesk {
             var helpSectionRows = [ImmuTableRow]()
-            helpSectionRows.append(HelpRow(title: LocalizedText.contactUs, action: contactUsSelected(), accessibilityIdentifier: "contact-support-button", featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
-            helpSectionRows.append(HelpRow(title: LocalizedText.tickets, action: myTicketsSelected(), showIndicator: ZendeskUtils.showSupportNotificationIndicator, accessibilityIdentifier: "my-tickets-button", featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+            helpSectionRows.append(HelpRow(title: LocalizedText.contactUs, action: contactUsSelected(), accessibilityIdentifier: "contact-support-button", featureFlagSupportForum: isForumShown))
+            helpSectionRows.append(HelpRow(title: LocalizedText.tickets, action: myTicketsSelected(), showIndicator: ZendeskUtils.showSupportNotificationIndicator, accessibilityIdentifier: "my-tickets-button", featureFlagSupportForum: isForumShown))
             helpSectionRows.append(SupportEmailRow(title: LocalizedText.email,
                                                    value: ZendeskUtils.userSupportEmail() ?? LocalizedText.emailNotSet,
                                                    accessibilityHint: LocalizedText.contactEmailAccessibilityHint,
                                                    action: supportEmailSelected(),
                                                    accessibilityIdentifier: "set-contact-email-button",
-                                                   featureFlagSupportForumEnabled: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+                                                   featureFlagSupportForumEnabled: isForumShown))
             helpSection = ImmuTableSection(
                     headerText: LocalizedText.prioritySupportSectionHeader,
                     rows: helpSectionRows,
@@ -206,19 +207,19 @@ private extension SupportTableViewController {
 
         // Help Section
         var helpSectionRows = [ImmuTableRow]()
-        helpSectionRows.append(HelpRow(title: LocalizedText.wpHelpCenter, action: helpCenterSelected(), accessibilityIdentifier: "help-center-link-button", featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+        helpSectionRows.append(HelpRow(title: LocalizedText.wpHelpCenter, action: helpCenterSelected(), accessibilityIdentifier: "help-center-link-button", featureFlagSupportForum: isForumShown))
 
         if ZendeskUtils.zendeskEnabled {
-            helpSectionRows.append(HelpRow(title: LocalizedText.contactUs, action: contactUsSelected(), accessibilityIdentifier: "contact-support-button", featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
-            helpSectionRows.append(HelpRow(title: LocalizedText.myTickets, action: myTicketsSelected(), showIndicator: ZendeskUtils.showSupportNotificationIndicator, accessibilityIdentifier: "my-tickets-button", featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+            helpSectionRows.append(HelpRow(title: LocalizedText.contactUs, action: contactUsSelected(), accessibilityIdentifier: "contact-support-button", featureFlagSupportForum: isForumShown))
+            helpSectionRows.append(HelpRow(title: LocalizedText.myTickets, action: myTicketsSelected(), showIndicator: ZendeskUtils.showSupportNotificationIndicator, accessibilityIdentifier: "my-tickets-button", featureFlagSupportForum: isForumShown))
             helpSectionRows.append(SupportEmailRow(title: LocalizedText.contactEmail,
                                                    value: ZendeskUtils.userSupportEmail() ?? LocalizedText.emailNotSet,
                                                    accessibilityHint: LocalizedText.contactEmailAccessibilityHint,
                                                    action: supportEmailSelected(),
                                                    accessibilityIdentifier: "set-contact-email-button",
-                                                   featureFlagSupportForumEnabled: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+                                                   featureFlagSupportForumEnabled: isForumShown))
         } else {
-            helpSectionRows.append(HelpRow(title: LocalizedText.wpForums, action: contactUsSelected(), featureFlagSupportForum: featureFlagStore.value(for: FeatureFlag.wordPressSupportForum)))
+            helpSectionRows.append(HelpRow(title: LocalizedText.wpForums, action: contactUsSelected(), featureFlagSupportForum: isForumShown))
         }
 
         let helpSection = ImmuTableSection(
@@ -262,7 +263,7 @@ private extension SupportTableViewController {
     }
 
     func reloadViewModel() {
-        tableHandler?.viewModel = featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) ? tableViewModel() : oldTableViewModel()
+        tableHandler?.viewModel = isForumShown ? tableViewModel() : oldTableViewModel()
     }
 
     // MARK: - Row Handlers


### PR DESCRIPTION
Update the JP app to not show the .org forum. The designs used in https://github.com/wordpress-mobile/WordPress-iOS/pull/19993 called for adding the forum to the Jetpack app but we determined that wasn't what we wanted so this PR hides the forum on Jetpack.

This is how the JP app looks now with the forum removed (it's now looks the same as the current App Store version).

| <img src="https://user-images.githubusercontent.com/1898325/217881797-96d81f4a-6a8d-460b-ad94-1fc08582dedf.jpeg" alt="" width="350"> |
| - |

### To test

#### Ensure the JP app does not show the .org forum
1. Install the Jetpack app
2. Verify that the forum **not** shown (it should look the same as the current App Store version)

#### Regression test the WP app
1. Install the WordPress app
2. Verify that the forum is shown 

## Regression Notes
1. Potential unintended areas of impact

To test this change I checked to make sure the JP app stopped showing the forum and the WP kept showing it

3. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing of support in both the JP and WP apps

4. What automated tests I added (or what prevented me from doing so)

TO-DO

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

This change was discussed in p1675954769540669/1675951976.134069-slack-C441E3YTS.