### PR TITLE
Add simple test to load People screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -987,6 +987,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
     if ([self shouldAddPeopleRow]) {
         [rows addObject:[[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"People", @"Noun. Title. Links to the people management feature.")
+                                      accessibilityIdentifier:@"People Row"
                                                         image:[UIImage gridiconOfType:GridiconTypeUser]
                                                      callback:^{
                                                          [weakSelf showPeople];

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -11,6 +11,7 @@ private struct ElementStringIDs {
     static let postsButton = "Blog Post Row"
     static let mediaButton = "Media Row"
     static let statsButton = "Stats Row"
+    static let peopleButton = "People Row"
     static let settingsButton = "Settings Row"
     static let createButton = "floatingCreateButton"
     static let ReaderButton = "Reader"
@@ -151,6 +152,10 @@ public class MySiteScreen: ScreenObject {
 
     public func goToMenu() {
         segmentedControlMenuButton(app).tap()
+    }
+
+    public func goToPeople() {
+        app.cells[ElementStringIDs.peopleButton].tap()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -150,17 +150,21 @@ public class MySiteScreen: ScreenObject {
         homeButtonGetter(app).tap()
     }
 
-    public func goToMenu() {
+    @discardableResult
+    public func goToMenu() -> Self {
         // On iPad, the menu items are already listed on screen, so we don't need to tap the menu button
         guard XCUIDevice.isPhone else {
-            return
+            return self
         }
 
         segmentedControlMenuButton(app).tap()
+        return self
     }
 
-    public func goToPeople() {
+    @discardableResult
+    public func goToPeople() throws -> PeopleScreen {
         app.cells[ElementStringIDs.peopleButton].tap()
+        return try PeopleScreen()
     }
 
     public static func isLoaded() -> Bool {

--- a/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/MySiteScreen.swift
@@ -151,6 +151,11 @@ public class MySiteScreen: ScreenObject {
     }
 
     public func goToMenu() {
+        // On iPad, the menu items are already listed on screen, so we don't need to tap the menu button
+        guard XCUIDevice.isPhone else {
+            return
+        }
+
         segmentedControlMenuButton(app).tap()
     }
 

--- a/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
@@ -4,12 +4,18 @@ import XCTest
 public class PeopleScreen: ScreenObject {
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
+        let filterButtonGetter: (String) -> (XCUIApplication) -> XCUIElement = { identifier in
+            return { app in
+                app.buttons[identifier]
+            }
+        }
+
         try super.init(
             expectedElementGetters: [
                 // See the PeopleViewController.Filter rawValues
-                { $0.buttons["users"] },
-                { $0.buttons["followers"] },
-                { $0.buttons["email"] },
+                filterButtonGetter("users"),
+                filterButtonGetter("followers"),
+                filterButtonGetter("email")
             ],
             app: app,
             waitTimeout: 7

--- a/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/PeopleScreen.swift
@@ -1,0 +1,22 @@
+import ScreenObject
+import XCTest
+
+public class PeopleScreen: ScreenObject {
+
+    public init(app: XCUIApplication = XCUIApplication()) throws {
+        try super.init(
+            expectedElementGetters: [
+                // See the PeopleViewController.Filter rawValues
+                { $0.buttons["users"] },
+                { $0.buttons["followers"] },
+                { $0.buttons["email"] },
+            ],
+            app: app,
+            waitTimeout: 7
+        )
+    }
+
+    public static func isLoaded() -> Bool {
+        (try? PeopleScreen().isLoaded) ?? false
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -672,6 +672,7 @@
 		3F2F856126FAF235000FCDA5 /* ReaderScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE8707182006E48E004FB5A4 /* ReaderScreen.swift */; };
 		3F2F856326FAF612000FCDA5 /* EditorGutenbergTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2BB0CF228ACF710034F9AB /* EditorGutenbergTests.swift */; };
 		3F3087C424EDB7040087B548 /* AnnouncementCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3087C324EDB7040087B548 /* AnnouncementCell.swift */; };
+		3F30A6B0299B412E0004452F /* PeopleScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F30A6AF299B412E0004452F /* PeopleScreen.swift */; };
 		3F338B71289BD3040014ADC5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B70289BD3040014ADC5 /* Nimble */; };
 		3F338B73289BD5970014ADC5 /* Nimble in Frameworks */ = {isa = PBXBuildFile; productRef = 3F338B72289BD5970014ADC5 /* Nimble */; };
 		3F39C93527A09927001EC300 /* WordPressLibraryLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F39C93427A09927001EC300 /* WordPressLibraryLogger.swift */; };
@@ -6162,6 +6163,7 @@
 		3F2ABE192770EF3E005D8916 /* Blog+VideoLimits.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+VideoLimits.swift"; sourceTree = "<group>"; };
 		3F2F0C15256C6B2C003351C7 /* StatsWidgetsService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsService.swift; sourceTree = "<group>"; };
 		3F3087C324EDB7040087B548 /* AnnouncementCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementCell.swift; sourceTree = "<group>"; };
+		3F30A6AF299B412E0004452F /* PeopleScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleScreen.swift; sourceTree = "<group>"; };
 		3F39C93427A09927001EC300 /* WordPressLibraryLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressLibraryLogger.swift; sourceTree = "<group>"; };
 		3F3CA64F25D3003C00642A89 /* StatsWidgetsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsStore.swift; sourceTree = "<group>"; };
 		3F3D854A251E6418001CA4D2 /* AnnouncementsDataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnnouncementsDataStoreTests.swift; sourceTree = "<group>"; };
@@ -11110,13 +11112,14 @@
 				BE8707162006B774004FB5A4 /* MySiteScreen.swift */,
 				BE6DD32D1FD67EDA00E55192 /* MySitesScreen.swift */,
 				BE87071A2006E65C004FB5A4 /* NotificationsScreen.swift */,
+				3F30A6AF299B412E0004452F /* PeopleScreen.swift */,
 				F9C47A8B238C801600AAD9ED /* PostsScreen.swift */,
 				BE8707182006E48E004FB5A4 /* ReaderScreen.swift */,
 				CC7CB97422B159FE00642EE9 /* Signup */,
+				FA9276AE2888557500C323BB /* SiteIntentScreen.swift */,
 				7EF9F65622F03C9200F79BBF /* SiteSettingsScreen.swift */,
 				F9C47A8E238C9D6400AAD9ED /* StatsScreen.swift */,
 				BE6DD32F1FD67F3B00E55192 /* TabNavComponent.swift */,
-				FA9276AE2888557500C323BB /* SiteIntentScreen.swift */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -21919,6 +21922,7 @@
 				3FE39A3926F837E1006E2B3A /* ActivityLogScreen.swift in Sources */,
 				FA9276AD286C951200C323BB /* FeatureIntroductionScreen.swift in Sources */,
 				3F2F855B26FAF227000FCDA5 /* LoginPasswordScreen.swift in Sources */,
+				3F30A6B0299B412E0004452F /* PeopleScreen.swift in Sources */,
 				3F2F854A26FAF132000FCDA5 /* FeaturedImageScreen.swift in Sources */,
 				3F762E9B26784D2A0088CD45 /* XCUIElement+Utils.swift in Sources */,
 				3FE39A3E26F8383E006E2B3A /* MediaScreen.swift in Sources */,

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -17,26 +17,41 @@ class MainNavigationTests: XCTestCase {
         removeApp()
     }
 
-    func testTabBarNavigation() throws {
+    // We run into an issue where the People screen would crash short after loading.
+    // See https://github.com/wordpress-mobile/WordPress-iOS/issues/20112.
+    //
+    // It would be wise to add similar tests for each item in the menu (then remove this comment).
+    func testLoadsPeopleScreen() throws {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-        _ = try mySiteScreen
-            .tabBar.goToReaderScreen()
+        mySiteScreen.goToMenu()
+        mySiteScreen.goToPeople()
 
-        XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
-
-        // We may get a notifications fancy alert when loading the reader for the first time
-        if let alert = try? FancyAlertComponent() {
-            alert.cancelAlert()
-        }
-
-        _ = try mySiteScreen
-            .tabBar.goToNotificationsScreen()
-            .dismissNotificationAlertIfNeeded()
-
-        XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in
-            XCTAssert(NotificationsScreen.isLoaded(), "Notifications screen isn't loaded.")
-            XCTAssert(TabNavComponent.isVisible(), "Main navigation bar isn't visible.")
-        }
+        // We don't have a ScreenObject for the people screen,
+        // so we just check that the previous screen is not loaded
+        XCTAssertFalse(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
     }
+
+   func testTabBarNavigation() throws {
+       XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
+
+       _ = try mySiteScreen
+           .tabBar.goToReaderScreen()
+
+       XCTAssert(ReaderScreen.isLoaded(), "Reader screen isn't loaded.")
+
+       // We may get a notifications fancy alert when loading the reader for the first time
+       if let alert = try? FancyAlertComponent() {
+           alert.cancelAlert()
+       }
+
+       _ = try mySiteScreen
+           .tabBar.goToNotificationsScreen()
+           .dismissNotificationAlertIfNeeded()
+
+       XCTContext.runActivity(named: "Confirm Notifications screen and main navigation bar are loaded.") { (activity) in
+           XCTAssert(NotificationsScreen.isLoaded(), "Notifications screen isn't loaded.")
+           XCTAssert(TabNavComponent.isVisible(), "Main navigation bar isn't visible.")
+       }
+   }
 }

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -24,12 +24,11 @@ class MainNavigationTests: XCTestCase {
     func testLoadsPeopleScreen() throws {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
-        mySiteScreen.goToMenu()
-        mySiteScreen.goToPeople()
+        try mySiteScreen
+            .goToMenu()
+            .goToPeople()
 
-        // We don't have a ScreenObject for the people screen,
-        // so we just check that the previous screen is not loaded
-        XCTAssertFalse(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
+        XCTAssertTrue(PeopleScreen.isLoaded(), "PeopleScreen screen isn't loaded.")
     }
 
    func testTabBarNavigation() throws {


### PR DESCRIPTION
This relates to the issue reported in https://github.com/wordpress-mobile/WordPress-iOS/issues/20112.

I was hoping to use this to test #20114, but the test _doesn't actually catch the crash_. When the People screen loads from the UI tests, it does not crash but gets stuck in some kind of loading loop where the animation continually restarts.

I decided to not investigate this further because the issue with the loading loop is likely due to outdated or incomplete API request JSON stubs and I don't have the time at this point to chase that down

I decide to keep the test anyway because it's a valuable starting point to ensure that the people screen is available and interactive.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – This PR adds UI tests :)

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**