### PR TITLE
Redirect all support interactions to the support screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -180,13 +180,9 @@ open class DeleteSiteViewController: UITableViewController {
 
         WPAppAnalytics.track(.siteSettingsStartOverContactSupportClicked, with: blog)
 
-        if ZendeskUtils.zendeskEnabled {
-            ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: self, with: .deleteSite)
-        } else {
-            if let contact = URL(string: "https://support.wordpress.com/contact/") {
-                UIApplication.shared.open(contact)
-            }
-        }
+        let supportViewController = SupportTableViewController()
+        supportViewController.sourceTag = .deleteSite
+        supportViewController.showFromTabBar()
     }
 
     // MARK: - Delete Site Helpers

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -293,33 +293,14 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag,
                         lastStep: AuthenticatorAnalyticsTracker.Step,
                         lastFlow: AuthenticatorAnalyticsTracker.Flow) {
-        // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
-        WPStyleGuide.configureNavigationAppearance()
-
-        // Since we're presenting the support VC as a form sheet, the parent VC's viewDidAppear isn't called
-        // when this VC is dismissed.  This means the tracking step isn't reset properly, so we'll need to do
-        // it here manually before tracking the new step.
-        let step = tracker.state.lastStep
-
-        tracker.track(step: .help)
-
-        let controller = SupportTableViewController { [weak self] in
-            self?.tracker.track(click: .dismiss)
-            self?.tracker.set(step: step)
-        }
-        controller.sourceTag = sourceTag
-
-        let navController = UINavigationController(rootViewController: controller)
-        navController.modalPresentationStyle = .formSheet
-
-        sourceViewController.present(navController, animated: true)
+        presentSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
     /// Presents Support new request, with the specified ViewController as a source.
     /// Additional metadata is supplied, such as the sourceTag and Login details.
     ///
     func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
-        ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: sourceViewController, with: sourceTag)
+        presentSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
     /// A self-hosted site URL is available and needs validated
@@ -734,5 +715,33 @@ private extension WordPressAuthenticationManager {
             RecentSitesService().touch(blog: blog)
             onCompletion()
         }
+    }
+}
+
+// MARK: - Support Helper
+//
+private extension WordPressAuthenticationManager {
+    /// Presents the support screen which displays different support options depending on whether this is the WordPress app or the Jetpack app.
+    private func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
+        // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+
+        // Since we're presenting the support VC as a form sheet, the parent VC's viewDidAppear isn't called
+        // when this VC is dismissed.  This means the tracking step isn't reset properly, so we'll need to do
+        // it here manually before tracking the new step.
+        let step = tracker.state.lastStep
+
+        tracker.track(step: .help)
+
+        let controller = SupportTableViewController { [weak self] in
+            self?.tracker.track(click: .dismiss)
+            self?.tracker.set(step: step)
+        }
+        controller.sourceTag = sourceTag
+
+        let navController = UINavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .formSheet
+
+        sourceViewController.present(navController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
@@ -7,6 +7,7 @@ struct SupportTableViewControllerConfiguration {
     var meHeaderConfiguration: MeHeaderView.Configuration?
     var showsLogOutButton: Bool = false
     var showsLogsSection: Bool = true
+    
 
     // MARK: Default Configurations
 


### PR DESCRIPTION
Fixes #20117

To test:

### Site deletion flow
1. Tap My Site → Menu → Site Settings → Delete Site → Contact Support
2. Notice that it now opens the support screen



## Regression Notes
1. Potential unintended areas of impact

TO-DO

4. What I did to test those areas of impact (or what existing automated tests I relied on)

TO-DO

5. What automated tests I added (or what prevented me from doing so)

TO-DO

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
