### PR TITLE
Add support for Google SignIn without SDK

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -232,8 +232,8 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  # pod 'WordPressAuthenticator', '~> 5.6-beta'
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'mokagio/social-service-without-google'
+  pod 'WordPressAuthenticator', '~> 6.0-beta'
+  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile
+++ b/Podfile
@@ -232,8 +232,8 @@ abstract_target 'Apps' do
 
   pod 'Gridicons', '~> 1.1.0'
 
-  pod 'WordPressAuthenticator', '~> 5.6-beta'
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'trunk'
+  # pod 'WordPressAuthenticator', '~> 5.6-beta'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: 'mokagio/social-service-without-google'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -503,7 +503,7 @@ PODS:
   - WordPress-Aztec-iOS (1.19.8)
   - WordPress-Editor-iOS (1.19.8):
     - WordPress-Aztec-iOS (= 1.19.8)
-  - WordPressAuthenticator (5.7.0):
+  - WordPressAuthenticator (6.0.0):
     - GoogleSignIn (~> 6.0.1)
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
@@ -611,7 +611,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `mokagio/social-service-without-google`)
+  - WordPressAuthenticator (~> 6.0-beta)
   - WordPressKit (~> 7.0.0-beta)
   - WordPressShared (~> 2.0-beta)
   - WordPressUI (~> 1.12.5)
@@ -660,6 +660,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressAuthenticator
     - WordPressKit
     - WordPressUI
     - WPMediaPicker
@@ -777,9 +778,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.92.0
-  WordPressAuthenticator:
-    :branch: mokagio/social-service-without-google
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.92.0/third-party-podspecs/Yoga.podspec.json
 
@@ -795,9 +793,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.92.0
-  WordPressAuthenticator:
-    :commit: a78ed0deb485f60606fdc3cb93716af34975e0a7
-    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -885,7 +880,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: 51627ce18a62d29f71c9d01dc1e54b3c077fcc7a
+  WordPressAuthenticator: b93b797eae278f7cda42693a652329173f1d5423
   WordPressKit: a161c49306369cfa22c648866cee5aba16d7cbac
   WordPressShared: 8e59bc8cec256f54a7c4cc6c94911adc2a9a65d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
@@ -901,6 +896,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: abeb64ef7e2c2dbe3f48ce51f80e9371f2dfc2cd
+PODFILE CHECKSUM: e8074cd059cc2018e1e491754ebaa6d098c5432e
 
 COCOAPODS: 1.11.3

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -611,7 +611,7 @@ DEPENDENCIES:
   - SVProgressHUD (= 2.2.5)
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
-  - WordPressAuthenticator (~> 5.6-beta)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, branch `mokagio/social-service-without-google`)
   - WordPressKit (~> 7.0.0-beta)
   - WordPressShared (~> 2.0-beta)
   - WordPressUI (~> 1.12.5)
@@ -622,7 +622,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
+    - WordPressShared
   trunk:
     - Alamofire
     - AlamofireImage
@@ -661,7 +661,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressKit
-    - WordPressShared
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc
@@ -778,6 +777,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.92.0
+  WordPressAuthenticator:
+    :branch: mokagio/social-service-without-google
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.92.0/third-party-podspecs/Yoga.podspec.json
 
@@ -793,6 +795,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.92.0
+  WordPressAuthenticator:
+    :commit: a78ed0deb485f60606fdc3cb93716af34975e0a7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -880,9 +885,9 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: e6a801d25f4f178de5bdf475ffe29050d0148176
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
-  WordPressAuthenticator: fc22569ef113e728823418120014725a7fdee8df
+  WordPressAuthenticator: 51627ce18a62d29f71c9d01dc1e54b3c077fcc7a
   WordPressKit: a161c49306369cfa22c648866cee5aba16d7cbac
-  WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
+  WordPressShared: 8e59bc8cec256f54a7c4cc6c94911adc2a9a65d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -896,6 +901,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: 63504603fd92b4077b1a9556356336a69e571422
+PODFILE CHECKSUM: abeb64ef7e2c2dbe3f48ce51f80e9371f2dfc2cd
 
 COCOAPODS: 1.11.3

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
 * [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
+* [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]
+* [**] [internal] Refactored Google SignIn implementation to not use the Google SDK [#20128]
 
 22.0
 -----

--- a/WordPress/Classes/Utility/App Configuration/AppDependency.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppDependency.swift
@@ -5,7 +5,10 @@ import Foundation
 /// Make sure to keep them in sync to avoid build errors when builing the Jetpack target.
 @objc class AppDependency: NSObject {
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
-        return WordPressAuthenticationManager(windowManager: windowManager)
+        return WordPressAuthenticationManager(
+            windowManager: windowManager,
+            remoteFeaturesStore: RemoteFeatureFlagStore()
+        )
     }
 
     static func windowManager(window: UIWindow) -> WindowManager {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,7 +40,6 @@ enum FeatureFlag: Int, CaseIterable {
     case siteCreationDomainPurchasing
     case readerUserBlocking
     case personalizeHomeTab
-    case sdkLessGoogleSignIn
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -129,8 +128,6 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .personalizeHomeTab:
             return false
-        case .sdkLessGoogleSignIn:
-            return true
         }
     }
 
@@ -229,8 +226,6 @@ extension FeatureFlag {
             return "Reader User Blocking"
         case .personalizeHomeTab:
             return "Personalize Home Tab"
-        case .sdkLessGoogleSignIn:
-            return "Sign-In with Google without the Google SDK"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -40,6 +40,7 @@ enum FeatureFlag: Int, CaseIterable {
     case siteCreationDomainPurchasing
     case readerUserBlocking
     case personalizeHomeTab
+    case sdkLessGoogleSignIn
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -128,6 +129,8 @@ enum FeatureFlag: Int, CaseIterable {
             return true
         case .personalizeHomeTab:
             return false
+        case .sdkLessGoogleSignIn:
+            return true
         }
     }
 
@@ -226,6 +229,8 @@ extension FeatureFlag {
             return "Reader User Blocking"
         case .personalizeHomeTab:
             return "Personalize Home Tab"
+        case .sdkLessGoogleSignIn:
+            return "Sign-In with Google without the Google SDK"
         }
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -16,6 +16,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case directDomainsPurchaseDashboardCard
     case pagesDashboardCard
     case activityLogDashboardCard
+    case sdkLessGoogleSignIn
 
     var defaultValue: Bool {
         switch self {
@@ -46,6 +47,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .pagesDashboardCard:
             return false
         case .activityLogDashboardCard:
+            return false
+        case .sdkLessGoogleSignIn:
             return false
         }
     }
@@ -81,6 +84,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "dashboard_card_pages"
         case .activityLogDashboardCard:
             return "dashboard_card_activity_log"
+        case .sdkLessGoogleSignIn:
+            return "google_signin_without_sdk"
         }
     }
 
@@ -114,6 +119,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Pages Dashboard Card"
         case .activityLogDashboardCard:
             return "Activity Log Dashboard Card"
+        case .sdkLessGoogleSignIn:
+            return "Sign-In with Google without the Google SDK"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
+++ b/WordPress/Classes/ViewRelated/NUX/LoginEpilogueUserInfo.swift
@@ -49,13 +49,7 @@ extension LoginEpilogueUserInfo {
     /// Updates the Epilogue properties, given a SocialService instance.
     ///
     mutating func update(with service: SocialService) {
-        switch service {
-        case .google(let user):
-            fullName = user.profile?.name ?? String()
-            email = user.profile?.email ?? String()
-        case .apple(let user):
-            fullName = user.fullName
-            email = user.email
-        }
+        fullName = service.user.fullName
+        email = service.user.email
     }
 }

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -75,7 +75,8 @@ extension WordPressAuthenticationManager {
                                                    enableSignupWithGoogle: AppConfiguration.allowSignUp,
                                                    enableUnifiedAuth: true,
                                                    enableUnifiedCarousel: FeatureFlag.unifiedPrologueCarousel.enabled,
-                                                   enableSocialLogin: true)
+                                                   enableSocialLogin: true,
+                                                   googleLoginWithoutSDK: FeatureFlag.sdkLessGoogleSignIn.enabled)
     }
 
     private func authenticatorStyle() -> WordPressAuthenticatorStyle {

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -68,7 +68,7 @@ extension WordPressAuthenticationManager {
             case .appStore:
                 // Rely on the remote flag in production
                 return RemoteFeatureFlag.sdkLessGoogleSignIn.enabled(using: remoteFeaturesStore)
-            case _:
+            default:
                 return true
             }
         }()

--- a/WordPress/Jetpack/AppDependency.swift
+++ b/WordPress/Jetpack/AppDependency.swift
@@ -5,7 +5,11 @@ import Foundation
 /// Make sure to keep them in sync to avoid build errors when builing the WordPress target.
 @objc class AppDependency: NSObject {
     static func authenticationManager(windowManager: WindowManager) -> WordPressAuthenticationManager {
-        return WordPressAuthenticationManager(windowManager: windowManager, authenticationHandler: JetpackAuthenticationManager())
+        return WordPressAuthenticationManager(
+            windowManager: windowManager,
+            authenticationHandler: JetpackAuthenticationManager(),
+            remoteFeaturesStore: RemoteFeatureFlagStore()
+        )
     }
 
     static func windowManager(window: UIWindow) -> WindowManager {

--- a/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
+++ b/WordPress/WordPressTest/PrepublishingNudgesViewControllerTests.swift
@@ -12,7 +12,10 @@ class PrepublishingNudgesViewControllerTests: XCTestCase {
 
         /// We need that in order to initialize the Authenticator, otherwise this test crashes
         /// This is because we're using the NUXButton. Ideally, that component should be extracted
-        WordPressAuthenticationManager(windowManager: windowManager).initializeWordPressAuthenticator()
+        WordPressAuthenticationManager(
+            windowManager: windowManager,
+            remoteFeaturesStore: RemoteFeatureFlagStore()
+        ).initializeWordPressAuthenticator()
     }
 
     /// Call the completion block when the "Publish" button is pressed


### PR DESCRIPTION
Relies on the changes in [WordPress Authenticator 5.6.0](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/releases/tag/5.6.0) to run Google SignIn without the Google SDK, plus the fixes for issues found after integrating, see https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/764 and https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/762. See also https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/741

The behavior is off by default for App Store build, on otherwise. That is, App Store builds will still use the SDK, but all other builds won't. This should give us time to test the new implementation internally and see if we run against hard edges.

## Testing

Given the "on internally" configuration, one can verify that Google SignIn doesn't use the SDK by adding a breakpoint in `GoogleAuthenticator.swift` (a file from the WordPressAuthenticator pod) line 190 (or wherever you prefer in that method or other methods in the Google authentication chain) and attempting to login with Google:

https://user-images.githubusercontent.com/1218433/226505067-52a99c05-9142-42fd-8010-8858d4a041d4.mp4

Repeat by either changing the hardcoded value or by enabling the flag from the in-app debug view _and restarting the app (from Xcode, given we're interested in breakpoints)_ and observe the breakpoint being hit.

## Regression Notes

1. Potential unintended areas of impact – App authentication
2. What I did to test those areas of impact (or what existing automated tests I relied on) – The logic is thoroughly tested at the WordPress Authenticator level
3. What automated tests I added (or what prevented me from doing so) – I started working on some at the library level but run into [issues](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/714#issuecomment-1469424162) because of MFA.

## Next steps

- [x] I need to create a new account via Google to see if it works. I don't see why because the only thing we do on our side is getting a token and email pair to pass to the WordPress API. 
- [x] It would be good to add some logging to monitor the behavior in production

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

