### PR TITLE
[Jetpack Plugin] Coordinator refactor for VM's

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -425,6 +425,9 @@ import Foundation
     case jetpackBrandingMenuCardRemindLater
     case jetpackBrandingMenuCardContextualMenuAccessed
     case jetpackFeatureIncorrectlyAccessed
+    case jetpackInstallPluginModalViewed
+    case jetpackInstallPluginModalDismissed
+    case jetpackInstallPluginModalInstallTapped
 
     // Help & Support
     case supportOpenMobileForumTapped
@@ -1159,6 +1162,12 @@ import Foundation
             return "remove_feature_card_menu_accessed"
         case .jetpackFeatureIncorrectlyAccessed:
             return "jetpack_feature_incorrectly_accessed"
+        case .jetpackInstallPluginModalViewed:
+            return "jp_install_full_plugin_onboarding_modal_viewed"
+        case .jetpackInstallPluginModalDismissed:
+            return "jp_install_full_plugin_onboarding_modal_dismissed"
+        case .jetpackInstallPluginModalInstallTapped:
+            return "jp_install_full_plugin_onboarding_modal_install_tapped"
 
         // Help & Support
         case .supportOpenMobileForumTapped:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackDefaultOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackDefaultOverlayCoordinator.swift
@@ -1,0 +1,24 @@
+import UIKit
+
+final class JetpackDefaultOverlayCoordinator: JetpackOverlayCoordinator {
+    weak var viewModel: JetpackFullscreenOverlayViewModel?
+    weak var navigationController: UINavigationController?
+
+    func navigateToPrimaryRoute() {
+        ContentMigrationCoordinator.shared.startAndDo { _ in
+            JetpackRedirector.redirectToJetpack()
+        }
+    }
+
+    func navigateToSecondaryRoute() {
+        navigationController?.dismiss(animated: true) { [weak self] in
+            self?.viewModel?.onDidDismiss?()
+        }
+    }
+
+    func navigateToLinkRoute(url: URL, source: String) {
+        let webViewController = WebViewControllerFactory.controller(url: url, source: source)
+        let navController = UINavigationController(rootViewController: webViewController)
+        navigationController?.present(navController, animated: true)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -149,7 +149,13 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         let phase = generalPhase()
         let frequencyConfig = phase.frequencyConfig
         let frequencyTrackerPhaseString = source.frequencyTrackerPhaseString(phase: phase)
-        var viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source, blog: blog)
+
+        let coordinator = JetpackDefaultOverlayCoordinator()
+        let viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source, blog: blog, coordinator: coordinator)
+        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
+        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        coordinator.navigationController = navigationViewController
+        coordinator.viewModel = viewModel
         viewModel.onWillDismiss = onWillDismiss
         viewModel.onDidDismiss = onDidDismiss
         let frequencyTracker = JetpackOverlayFrequencyTracker(frequencyConfig: frequencyConfig,
@@ -160,7 +166,12 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             onDidDismiss?()
             return
         }
-        createAndPresentOverlay(with: viewModel, in: viewController, fullScreen: fullScreen)
+        presentOverlay(
+            navigationViewController: navigationViewController,
+            viewModel: viewModel,
+            in: viewController,
+            fullScreen: fullScreen
+        )
         frequencyTracker.track()
     }
 
@@ -175,7 +186,16 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
                                                    onWillDismiss: JetpackOverlayDismissCallback? = nil,
                                                    onDidDismiss: JetpackOverlayDismissCallback? = nil) {
         let phase = siteCreationPhase()
-        var viewModel = JetpackFullscreenOverlaySiteCreationViewModel(phase: phase, source: source)
+        let coordinator = JetpackDefaultOverlayCoordinator()
+        //
+        let viewModel = JetpackFullscreenOverlaySiteCreationViewModel(
+            phase: phase,
+            source: source,
+            coordinator: coordinator
+        )
+        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
+        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        coordinator.viewModel = viewModel
         viewModel.onWillDismiss = onWillDismiss
         viewModel.onDidDismiss = onDidDismiss
         guard viewModel.shouldShowOverlay else {
@@ -183,14 +203,17 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             onDidDismiss?()
             return
         }
-        createAndPresentOverlay(with: viewModel, in: viewController)
+        presentOverlay(
+            navigationViewController: navigationViewController,
+            viewModel: viewModel,
+            in: viewController
+        )
     }
 
-    private static func createAndPresentOverlay(with viewModel: JetpackFullscreenOverlayViewModel,
-                                                in viewController: UIViewController,
-                                                fullScreen: Bool = false) {
-        let overlay = JetpackFullscreenOverlayViewController(with: viewModel)
-        let navigationViewController = UINavigationController(rootViewController: overlay)
+    private static func presentOverlay(navigationViewController: UINavigationController,
+                                       viewModel: JetpackFullscreenOverlayViewModel,
+                                       in viewController: UIViewController,
+                                       fullScreen: Bool = false) {
         let shouldUseFormSheet = WPDeviceIdentification.isiPad() || !fullScreen
         navigationViewController.modalPresentationStyle = shouldUseFormSheet ? .formSheet : .fullScreen
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -166,12 +166,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             onDidDismiss?()
             return
         }
-        presentOverlay(
-            navigationViewController: navigationViewController,
-            viewModel: viewModel,
-            in: viewController,
-            fullScreen: fullScreen
-        )
+        presentOverlay(navigationViewController: navigationViewController, in: viewController, fullScreen: fullScreen)
         frequencyTracker.track()
     }
 
@@ -203,15 +198,10 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
             onDidDismiss?()
             return
         }
-        presentOverlay(
-            navigationViewController: navigationViewController,
-            viewModel: viewModel,
-            in: viewController
-        )
+        presentOverlay(navigationViewController: navigationViewController, in: viewController)
     }
 
     private static func presentOverlay(navigationViewController: UINavigationController,
-                                       viewModel: JetpackFullscreenOverlayViewModel,
                                        in viewController: UIViewController,
                                        fullScreen: Bool = false) {
         let shouldUseFormSheet = WPDeviceIdentification.isiPad() || !fullScreen

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackOverlayCoordinator.swift
@@ -1,0 +1,5 @@
+protocol JetpackOverlayCoordinator {
+    func navigateToPrimaryRoute()
+    func navigateToSecondaryRoute()
+    func navigateToLinkRoute(url: URL, source: String)
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -1,5 +1,3 @@
-import UIKit
-
 final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     private unowned let viewController: UIViewController
 
@@ -8,14 +6,14 @@ final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     }
 
     func navigateToPrimaryRoute() {
-        // TODO
+        // TODO: Navigate to the installation flow.
     }
 
     func navigateToSecondaryRoute() {
-        // TODO
+        // TODO: Contact support with support origin.
     }
 
     func navigateToLinkRoute(url: URL, source: String) {
-        // TODO
+        // TODO: Open wordpress.com/tos via in-app browser.
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
+    private unowned let viewController: UIViewController
+
+    init(viewController: UIViewController) {
+        self.viewController = viewController
+    }
+
+    func navigateToPrimaryRoute() {
+        // TODO
+    }
+
+    func navigateToSecondaryRoute() {
+        // TODO
+    }
+
+    func navigateToLinkRoute(url: URL, source: String) {
+        // TODO
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -2,12 +2,25 @@ import Foundation
 
 /// Dynamic implementation of `JetpackFullscreenOverlayViewModel` based on the general phase
 /// Should be used for feature-specific and feature-collection overlays.
-struct JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewModel {
-
+final class JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayViewModel {
     let phase: JetpackFeaturesRemovalCoordinator.GeneralPhase
     let source: JetpackFeaturesRemovalCoordinator.OverlaySource
     let blog: Blog?
-    let actionInfoText: NSAttributedString? = nil
+    let actionInfoText: NSAttributedString?
+
+    let coordinator: JetpackDefaultOverlayCoordinator?
+
+    init(phase: JetpackFeaturesRemovalCoordinator.GeneralPhase,
+         source: JetpackFeaturesRemovalCoordinator.OverlaySource,
+         blog: Blog?,
+         actionInfoText: NSAttributedString? = nil,
+         coordinator: JetpackDefaultOverlayCoordinator) {
+        self.phase = phase
+        self.source = source
+        self.blog = blog
+        self.actionInfoText = actionInfoText
+        self.coordinator = coordinator
+    }
 
     var shouldShowOverlay: Bool {
         switch (phase, source) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
@@ -26,24 +26,32 @@ extension JetpackFullscreenOverlaySiteCreationViewModel {
 
     // MARK: Analytics Implementation
 
-    func trackOverlayDisplayed() {
+    func didDisplayOverlay() {
         WPAnalytics.track(.jetpackSiteCreationOverlayDisplayed, properties: defaultProperties)
     }
 
-    func trackLearnMoreTapped() {
+    func didTapLink() {
         assert(false, "Not implemnted because it should never be called.")
     }
 
-    func trackSwitchButtonTapped() {
-        WPAnalytics.track(.jetpackSiteCreationOverlayButtonTapped, properties: defaultProperties)
+    func didTapPrimary() {
+        // Try to export WordPress data to a shared location before redirecting the user.
+        ContentMigrationCoordinator.shared.startAndDo { [weak self] _ in
+            guard let self = self else {
+                return
+            }
+            JetpackRedirector.redirectToJetpack()
+            WPAnalytics.track(.jetpackFullscreenOverlayButtonTapped, properties: self.defaultProperties)
+        }
     }
 
-    func trackCloseButtonTapped() {
+    func didTapClose() {
         trackOverlayDismissed(dismissalType: .close)
     }
 
-    func trackContinueButtonTapped() {
+    func didTapSecondary() {
         trackOverlayDismissed(dismissalType: .continue)
+        onWillDismiss?()
     }
 
     // MARK: Helpers

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -2,13 +2,28 @@ import Foundation
 
 /// Dynamic implementation of `JetpackFullscreenOverlayViewModel` based on the site creation phase
 /// Should be used for Site Creation overlays.
-struct JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayViewModel {
-
+final class JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOverlayViewModel {
     let phase: JetpackFeaturesRemovalCoordinator.SiteCreationPhase
     let source: String
-    let actionInfoText: NSAttributedString? = nil
-    let footnote: String? = nil
-    let learnMoreButtonURL: String? = nil
+    let actionInfoText: NSAttributedString?
+    let footnote: String?
+    let learnMoreButtonURL: String?
+
+    let coordinator: JetpackDefaultOverlayCoordinator?
+
+    init(phase: JetpackFeaturesRemovalCoordinator.SiteCreationPhase,
+         source: String,
+         actionInfoText: NSAttributedString? = nil,
+         learnMoreButtonURL: String? = nil,
+         footnote: String? = nil,
+         coordinator: JetpackDefaultOverlayCoordinator) {
+        self.phase = phase
+        self.source = source
+        self.footnote = footnote
+        self.actionInfoText = actionInfoText
+        self.learnMoreButtonURL = learnMoreButtonURL
+        self.coordinator = coordinator
+    }
 
     var shouldShowOverlay: Bool {
         switch phase {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -82,7 +82,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         setupFonts()
         setupButtons()
         animationView.play()
-        viewModel.trackOverlayDisplayed()
+        viewModel.didDisplayOverlay()
     }
 
     // MARK: Helpers
@@ -232,7 +232,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     // MARK: Actions
 
     @objc private func closeButtonPressed(sender: UIButton) {
-        viewModel.trackCloseButtonTapped()
+        viewModel.didTapClose()
         viewModel.onWillDismiss?()
         dismiss(animated: true) { [weak self] in
             self?.viewModel.onDidDismiss?()
@@ -241,15 +241,11 @@ class JetpackFullscreenOverlayViewController: UIViewController {
 
 
     @IBAction func switchButtonPressed(_ sender: Any) {
-        // Try to export WordPress data to a shared location before redirecting the user.
-        ContentMigrationCoordinator.shared.startAndDo { [weak self] _ in
-            JetpackRedirector.redirectToJetpack()
-            self?.viewModel.trackSwitchButtonTapped()
-        }
+        viewModel.didTapPrimary()
     }
 
     @IBAction func continueButtonPressed(_ sender: Any) {
-        viewModel.trackContinueButtonTapped()
+        viewModel.didTapSecondary()
         viewModel.onWillDismiss?()
         dismiss(animated: true) { [weak self] in
             self?.viewModel.onDidDismiss?()
@@ -257,16 +253,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     }
 
     @IBAction func learnMoreButtonPressed(_ sender: Any) {
-        guard let urlString = viewModel.learnMoreButtonURL,
-              let url = URL(string: urlString) else {
-            return
-        }
-
-        let source = "jetpack_overlay_\(viewModel.analyticsSource)"
-        let webViewController = WebViewControllerFactory.controller(url: url, source: source)
-        let navController = UINavigationController(rootViewController: webViewController)
-        present(navController, animated: true)
-        viewModel.trackLearnMoreTapped()
+        viewModel.didTapLink()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -98,8 +98,8 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEp-ih-kuy">
-                                    <rect key="frame" x="29" y="448" width="317" height="0.0"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEp-ih-kuy">
+                                    <rect key="frame" x="29" y="427.5" width="317" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -3,7 +3,7 @@ import Foundation
 typealias JetpackOverlayDismissCallback = () -> Void
 
 /// Protocol used to configure `JetpackFullscreenOverlayViewController`
-protocol JetpackFullscreenOverlayViewModel {
+protocol JetpackFullscreenOverlayViewModel: AnyObject {
     var title: String { get }
     var subtitle: NSAttributedString { get }
     var animationLtr: String { get }
@@ -26,11 +26,11 @@ protocol JetpackFullscreenOverlayViewModel {
     /// Useful for packed overlays.
     var isCompact: Bool { get }
 
-    func trackOverlayDisplayed()
-    func trackLearnMoreTapped()
-    func trackSwitchButtonTapped()
-    func trackCloseButtonTapped()
-    func trackContinueButtonTapped()
+    func didDisplayOverlay()
+    func didTapLink()
+    func didTapPrimary()
+    func didTapClose()
+    func didTapSecondary()
 }
 
 extension JetpackFullscreenOverlayViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -159,7 +159,7 @@ private extension JetpackPluginOverlayViewModel {
             """,
             comment: """
             Jetpack Plugin Modal (single plugin) subtitle with formatted texts.
-            One is for the site name, the other for the specıfıc plugin
+            One is for the site name, the other for the specific plugin
             and the last one for 'full Jetpack Plugin'
             """
         )

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -11,6 +11,8 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         case multiple
     }
 
+    // MARK: View Model Properties
+
     let title: String = Strings.title
     let subtitle: NSAttributedString
     let animationLtr: String = Constants.lottieLTRFileName
@@ -25,9 +27,13 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     var onWillDismiss: JetpackOverlayDismissCallback?
     var onDidDismiss: JetpackOverlayDismissCallback?
     var secondaryView: UIView? = nil
-    let isCompact = false
+    let isCompact = false // compact layout is not supported for this overlay.
+
+    // MARK: Dependencies
 
     var coordinator: JetpackOverlayCoordinator?
+
+    // MARK: Methods
 
     init(siteName: String, plugin: Plugin) {
         self.subtitle = Self.subtitle(withSiteName: siteName, plugin: plugin)
@@ -47,12 +53,13 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     }
 
     func didTapClose() {
+        // TODO: Dismiss the overlay.
         WPAnalytics.track(.jetpackInstallPluginModalDismissed)
     }
 
     func didTapSecondary() {
+        // TODO: Make the auto-dismiss logic optional in the view controller's `continueButtonPressed`.
         coordinator?.navigateToSecondaryRoute()
-        // TODO: Do we use the same `jetpackInstallPluginModalDismissed` event here?
     }
 
     private static func subtitle(withSiteName siteName: String, plugin: Plugin) -> NSAttributedString {
@@ -76,20 +83,14 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         )
 
         return NSAttributedString(
-            format: attributedSubtitle(
-                with: Strings.subtitlePlural,
-                fontWeight: .regular),
+            format: attributedSubtitle(with: Strings.subtitlePlural, fontWeight: .regular),
             args: ("%1$@", siteNameAttributedText), ("%2$@", jetpackPluginAttributedText)
         )
     }
 
     private static func subtitleSinglePlugin(withSiteName siteName: String, pluginName: String) -> NSAttributedString {
-        let siteNameAttributedText = attributedSubtitle(
-            with: siteName,
-            fontWeight: .bold
-        )
-        let jetpackBackupAttributedText = attributedSubtitle(
-            with: pluginName,
+        let siteNameAttributedText = attributedSubtitle(with: siteName, fontWeight: .bold)
+        let jetpackBackupAttributedText = attributedSubtitle(with: pluginName,
             fontWeight: .bold
         )
         let jetpackPluginAttributedText = attributedSubtitle(
@@ -153,39 +154,39 @@ private extension JetpackPluginOverlayViewModel {
         static let subtitleSingular = NSLocalizedString(
             "jetpack.plugin.modal.subtitle.singular",
             value: """
-            %1$@ is using the %2$@, which doesn't support all features of the app yet.
+            %1$@ is using the %2$@ plugin, which doesn't support all features of the app yet.
 
             Please install the %3$@ to use the app with this site.
             """,
             comment: """
             Jetpack Plugin Modal (single plugin) subtitle with formatted texts.
-            One is for the site name, the other for the specific plugin
-            and the last one for 'full Jetpack Plugin'
+            %1$@ is for the site name, %2$@ for the specific plugin name,
+            and %3$@ is for 'full Jetpack plugin' in bold style.
             """
         )
 
         static let subtitlePlural = NSLocalizedString(
             "jetpack.plugin.modal.subtitle.plural",
             value: """
-            %1$@ is using individual plugins, which don't support all features of the app yet.
+            %1$@ is using individual Jetpack plugins, which don't support all features of the app yet.
 
             Please install the %2$@ to use the app with this site.
             """,
             comment: """
-            Jetpack Plugin Modal (multiple plugin) subtitle with formatted texts.
-            One is for the site name and the other one for 'full Jetpack Plugin'
+            Jetpack Plugin Modal (multiple plugins) subtitle with formatted texts.
+            %1$@ is for the site name, and %2$@ for 'full Jetpack plugin' in bold style.
             """
         )
 
         static let jetpackPluginText = NSLocalizedString(
             "jetpack.plugin.modal.subtitle.jetpack.plugin",
-            value: "full Jetpack Plugin",
-            comment: "The 'full Jetpack Plugin' string in the subtitle"
+            value: "full Jetpack plugin",
+            comment: "The 'full Jetpack plugin' string in the subtitle"
         )
 
         static let footnote = NSLocalizedString(
             "jetpack.plugin.modal.footnote",
-            value: "By setting up jetpack you agree to our %@",
+            value: "By setting up Jetpack you agree to our %@",
             comment: "Jetpack Plugin Modal footnote"
         )
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -27,23 +27,28 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     var secondaryView: UIView? = nil
     let isCompact = false
 
+    var coordinator: JetpackOverlayCoordinator?
+
     init(siteName: String, plugin: Plugin) {
         self.subtitle = Self.subtitle(withSiteName: siteName, plugin: plugin)
     }
 
-    func trackOverlayDisplayed() {
+    func didDisplayOverlay() {
     }
 
-    func trackLearnMoreTapped() {
+    func didTapLink() {
+        // TODO: coordinator?.navigateToLinkRoute
     }
 
-    func trackSwitchButtonTapped() {
+    func didTapPrimary() {
+        coordinator?.navigateToPrimaryRoute()
     }
 
-    func trackCloseButtonTapped() {
+    func didTapClose() {
     }
 
-    func trackContinueButtonTapped() {
+    func didTapSecondary() {
+        coordinator?.navigateToSecondaryRoute()
     }
 
     private static func subtitle(withSiteName siteName: String, plugin: Plugin) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -34,6 +34,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     }
 
     func didDisplayOverlay() {
+        WPAnalytics.track(.jetpackInstallPluginModalViewed)
     }
 
     func didTapLink() {
@@ -42,13 +43,16 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
 
     func didTapPrimary() {
         coordinator?.navigateToPrimaryRoute()
+        WPAnalytics.track(.jetpackInstallPluginModalInstallTapped)
     }
 
     func didTapClose() {
+        WPAnalytics.track(.jetpackInstallPluginModalDismissed)
     }
 
     func didTapSecondary() {
         coordinator?.navigateToSecondaryRoute()
+        // TODO: Do we use the same `jetpackInstallPluginModalDismissed` event here?
     }
 
     private static func subtitle(withSiteName siteName: String, plugin: Plugin) -> NSAttributedString {
@@ -145,7 +149,7 @@ private extension JetpackPluginOverlayViewModel {
             value: "Please install the full Jetpack plugin",
             comment: "Jetpack Plugin Modal title"
         )
-        
+
         static let subtitleSingular = NSLocalizedString(
             "jetpack.plugin.modal.subtitle.singular",
             value: """

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -195,11 +195,17 @@
 		082A645C291C2DD700668D2C /* Routes+Jetpack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 082A645A291C2DD700668D2C /* Routes+Jetpack.swift */; };
 		082AB9D91C4EEEF4000CA523 /* PostTagService.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9D81C4EEEF4000CA523 /* PostTagService.m */; };
 		082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */ = {isa = PBXBuildFile; fileRef = 082AB9DC1C4F035E000CA523 /* PostTag.m */; };
+		0839F88B2993C0C000415038 /* JetpackDefaultOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857BB3F299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift */; };
+		0839F88C2993C1B500415038 /* JetpackPluginOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FC3BA29914C7F00A17BCF /* JetpackPluginOverlayCoordinator.swift */; };
+		0839F88D2993C1B600415038 /* JetpackPluginOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FC3BA29914C7F00A17BCF /* JetpackPluginOverlayCoordinator.swift */; };
 		0845B8C61E833C56001BA771 /* URL+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0845B8C51E833C56001BA771 /* URL+Helpers.swift */; };
 		08472A201C727E020040769D /* PostServiceOptions.m in Sources */ = {isa = PBXBuildFile; fileRef = 08472A1F1C727E020040769D /* PostServiceOptions.m */; };
 		084A07062848E1820054508A /* FeatureHighlightStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084A07052848E1820054508A /* FeatureHighlightStore.swift */; };
 		084D94AF1EDF842F00C385A6 /* test-video-device-gps.m4v in Resources */ = {isa = PBXBuildFile; fileRef = 084D94AE1EDF842600C385A6 /* test-video-device-gps.m4v */; };
 		084FC3B729913B1B00A17BCF /* JetpackPluginOverlayViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FC3B629913B1B00A17BCF /* JetpackPluginOverlayViewModelTests.swift */; };
+		084FC3BC299155C900A17BCF /* JetpackOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FC3B829914BD700A17BCF /* JetpackOverlayCoordinator.swift */; };
+		084FC3BD299155CA00A17BCF /* JetpackOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 084FC3B829914BD700A17BCF /* JetpackOverlayCoordinator.swift */; };
+		0857BB40299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0857BB3F299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift */; };
 		0857C2771CE5375F0014AE99 /* MenuItemAbstractView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2701CE5375F0014AE99 /* MenuItemAbstractView.m */; };
 		0857C2781CE5375F0014AE99 /* MenuItemInsertionView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2721CE5375F0014AE99 /* MenuItemInsertionView.m */; };
 		0857C2791CE5375F0014AE99 /* MenuItemsVisualOrderingView.m in Sources */ = {isa = PBXBuildFile; fileRef = 0857C2741CE5375F0014AE99 /* MenuItemsVisualOrderingView.m */; };
@@ -5636,7 +5642,10 @@
 		084A07052848E1820054508A /* FeatureHighlightStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureHighlightStore.swift; sourceTree = "<group>"; };
 		084D94AE1EDF842600C385A6 /* test-video-device-gps.m4v */ = {isa = PBXFileReference; lastKnownFileType = file; path = "test-video-device-gps.m4v"; sourceTree = "<group>"; };
 		084FC3B629913B1B00A17BCF /* JetpackPluginOverlayViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackPluginOverlayViewModelTests.swift; sourceTree = "<group>"; };
+		084FC3B829914BD700A17BCF /* JetpackOverlayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackOverlayCoordinator.swift; sourceTree = "<group>"; };
+		084FC3BA29914C7F00A17BCF /* JetpackPluginOverlayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackPluginOverlayCoordinator.swift; sourceTree = "<group>"; };
 		084FF460C7742309671B3A86 /* Pods-WordPressTest.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.debug.xcconfig"; sourceTree = "<group>"; };
+		0857BB3F299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackDefaultOverlayCoordinator.swift; sourceTree = "<group>"; };
 		0857C26F1CE5375F0014AE99 /* MenuItemAbstractView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemAbstractView.h; sourceTree = "<group>"; };
 		0857C2701CE5375F0014AE99 /* MenuItemAbstractView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MenuItemAbstractView.m; sourceTree = "<group>"; };
 		0857C2711CE5375F0014AE99 /* MenuItemInsertionView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MenuItemInsertionView.h; sourceTree = "<group>"; };
@@ -10804,6 +10813,9 @@
 				803DE820290642B4007D4E9C /* JetpackFeaturesRemovalCoordinator.swift */,
 				803D90F6292F0188007CC0D0 /* JetpackRedirector.swift */,
 				801D9519291AC0B00051993E /* JetpackOverlayFrequencyTracker.swift */,
+				084FC3B829914BD700A17BCF /* JetpackOverlayCoordinator.swift */,
+				084FC3BA29914C7F00A17BCF /* JetpackPluginOverlayCoordinator.swift */,
+				0857BB3F299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift */,
 			);
 			path = Coordinator;
 			sourceTree = "<group>";
@@ -20127,6 +20139,7 @@
 				C395FB262821FE7B00AE7C11 /* RemoteSiteDesign+Thumbnail.swift in Sources */,
 				9A73B7152362FBAE004624A8 /* SiteStatsViewModel+AsyncBlock.swift in Sources */,
 				74AF4D7C1FE417D200E3EBFE /* PostUploadOperation.swift in Sources */,
+				0857BB40299275760011CBD1 /* JetpackDefaultOverlayCoordinator.swift in Sources */,
 				37022D931981C19000F322B7 /* VerticallyStackedButton.m in Sources */,
 				59DCA5211CC68AF3000F245F /* PageListViewController.swift in Sources */,
 				B5ECA6CA1DBAA0020062D7E0 /* CoreDataHelper.swift in Sources */,
@@ -20663,6 +20676,7 @@
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
 				E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */,
 				1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */,
+				084FC3BC299155C900A17BCF /* JetpackOverlayCoordinator.swift in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
 				E1B912891BB01288003C25B9 /* PeopleViewController.swift in Sources */,
 				3FEC241525D73E8B007AFE63 /* ConfettiView.swift in Sources */,
@@ -21069,6 +21083,7 @@
 				46B1A16B26A774E500F058AE /* CollapsableHeaderView.swift in Sources */,
 				590E873B1CB8205700D1B734 /* PostListViewController.swift in Sources */,
 				E15644EB1CE0E4C500D96E64 /* FeatureItemRow.swift in Sources */,
+				0839F88C2993C1B500415038 /* JetpackPluginOverlayCoordinator.swift in Sources */,
 				F5A738BF244DF7E400EDE065 /* ReaderTagsTableViewController+Cells.swift in Sources */,
 				FAA9084C27BD60710093FFA8 /* MySiteViewController+QuickStart.swift in Sources */,
 				8B0732E9242BA1F000E7FBD3 /* PrepublishingHeaderView.swift in Sources */,
@@ -23276,6 +23291,7 @@
 				FABB22282602FC2C00C8785C /* GutenbergAudioUploadProcessor.swift in Sources */,
 				FABB22292602FC2C00C8785C /* AsyncOperation.swift in Sources */,
 				FABB222A2602FC2C00C8785C /* JetpackScanThreatSectionGrouping.swift in Sources */,
+				0839F88D2993C1B600415038 /* JetpackPluginOverlayCoordinator.swift in Sources */,
 				FABB222B2602FC2C00C8785C /* MediaService+Swift.swift in Sources */,
 				FABB222C2602FC2C00C8785C /* ReaderActionHelpers.swift in Sources */,
 				FABB222D2602FC2C00C8785C /* NoteBlockUserTableViewCell.swift in Sources */,
@@ -23291,6 +23307,7 @@
 				FABB22352602FC2C00C8785C /* CameraCaptureCoordinator.swift in Sources */,
 				C77FC90A28009C7000726F00 /* OnboardingQuestionsPromptViewController.swift in Sources */,
 				FABB22362602FC2C00C8785C /* HomeWidgetCache.swift in Sources */,
+				0839F88B2993C0C000415038 /* JetpackDefaultOverlayCoordinator.swift in Sources */,
 				FABB22372602FC2C00C8785C /* JetpackRestoreStatusCoordinator.swift in Sources */,
 				FABB22382602FC2C00C8785C /* EventLoggingDelegate.swift in Sources */,
 				FABB22392602FC2C00C8785C /* TodayStatsRecordValue+CoreDataClass.swift in Sources */,
@@ -23890,6 +23907,7 @@
 				FABB24102602FC2C00C8785C /* ThemeService.m in Sources */,
 				FABB24112602FC2C00C8785C /* NSAttributedString+RichTextView.swift in Sources */,
 				FABB24122602FC2C00C8785C /* NoteBlockButtonTableViewCell.swift in Sources */,
+				084FC3BD299155CA00A17BCF /* JetpackOverlayCoordinator.swift in Sources */,
 				C7F7ABD6261CED7A00CE547F /* JetpackAuthenticationManager.swift in Sources */,
 				FABB24142602FC2C00C8785C /* ThemeBrowserSectionHeaderView.swift in Sources */,
 				8B065CC727BD5452005BA7AB /* DashboardEmptyPostsCardCell.swift in Sources */,


### PR DESCRIPTION
This PR refactors `JetpackFullscreenOverlayViewModel` & `JetpackFullscreenOverlayViewController` to extract navigation logic into Coordinators. This way we can keep using the same layout and business logic protocol whereas have different routes for our view.

* `JetpackPluginOverlayCoordinator` is in a TODO state as we need the next screens to connect.
* I've renamed the VM Protocol's functions as they were specific to that view and they were only for tracking. Now it includes the navigation logic through Coordinator.
* I've kept the former `+Analytics` extension files to reduce the invasiveness of the PR. Yet they are better off renamed (imo simply moved back to the VM's)
* VM's are now of class type and not struct. Reason being is they were keeping reference type objects (closures) and now will retain Coordinator. We need to access the same state throughout the life View Controller
* Tracks are added but if we need to pass source, we need to add parameters there.

**Life Cycle**
VC ----retains----> VM ----retains----> Coordinator
Coordinator ----weak----> VM

**TODO:** 
* Terms & Conditions needs to be tappable and call the `navigateToLink` function.
* Unit tests for the  VM's 

**To test:**

**For the existing modal**
* Tapping the “Switch to the Jetpack app” button should open up the Jetpack app if you have it or the app store if you don’t
* Tapping the “Continue without Jetpack” button should dismiss the overlay
* Tapping the “learn more at [jetpack.com](http://jetpack.com/)” button should open up a web view. (P.S: the web view doesn’t correctly load, this is a [known issue](https://github.com/wordpress-mobile/WordPress-iOS/issues/20043#issuecomment-1411291012))

To see the different states of that modal [this line](https://github.com/wordpress-mobile/WordPress-iOS/blob/0b008008e857029f4bb32ee9eca5090a516c5445/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift#L149) can be modified. (also you can comment out the guard statement below to bypass the checks that determines whether or not to show the modal)

We needn't test every combination of `source` and `phase` as the changes are the same for all of them. If the buttons function as expected, they should function in every case. But in practice, all are affected by this change.

## Regression Notes
1. Potential unintended areas of impact
See notes above

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the existing screen.

3. What automated tests I added (or what prevented me from doing so)
It is now much more testable, but I haven't put in any. It would be nice to add some quick tests for the navigation.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
