### PR TITLE
Blaze: Add entry point for post list

### DIFF
--- a/WordPress/Classes/Models/AbstractPost+Blaze.swift
+++ b/WordPress/Classes/Models/AbstractPost+Blaze.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+extension AbstractPost {
+
+    var canBlaze: Bool {
+        return blog.isBlazeApproved && status == .publish && password == nil
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Post/InteractivePostViewDelegate.swift
@@ -13,4 +13,5 @@ protocol InteractivePostViewDelegate: AnyObject {
     func cancelAutoUpload(_ post: AbstractPost)
     func share(_ post: AbstractPost, fromView view: UIView)
     func copyLink(_ post: AbstractPost)
+    func blaze(_ post: AbstractPost)
 }

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -111,7 +111,7 @@ class PostActionSheet {
         static let retry = NSLocalizedString("Retry", comment: "Retry uploading the post.")
         static let edit = NSLocalizedString("Edit", comment: "Edit the post.")
         static let share = NSLocalizedString("Share", comment: "Share the post.")
-        static let blaze = NSLocalizedString("Promote with Blaze", comment: "Promote the post with Blaze.")
+        static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")
         static let copyLink = NSLocalizedString("Copy Link", comment: "Copy the post url and paste anywhere in phone")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -76,6 +76,10 @@ class PostActionSheet {
                     actionSheetController.addDefaultActionWithTitle(Titles.share) { [weak self] _ in
                         self?.interactivePostViewDelegate?.share(post, fromView: view)
                     }
+                case .blaze:
+                    actionSheetController.addDefaultActionWithTitle(Titles.blaze) { [weak self] _ in
+                        self?.interactivePostViewDelegate?.blaze(post)
+                    }
                 case .more:
                     WordPressAppDelegate.crashLogging?.logMessage("Cannot handle unexpected button for post action sheet: \(button). This is a configuration error.", level: .error)
                 case .copyLink:
@@ -107,6 +111,7 @@ class PostActionSheet {
         static let retry = NSLocalizedString("Retry", comment: "Retry uploading the post.")
         static let edit = NSLocalizedString("Edit", comment: "Edit the post.")
         static let share = NSLocalizedString("Share", comment: "Share the post.")
+        static let blaze = NSLocalizedString("Promote with Blaze", comment: "Promote the post with Blaze.")
         static let copyLink = NSLocalizedString("Copy Link", comment: "Copy the post url and paste anywhere in phone")
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -19,6 +19,7 @@ class PostCardStatusViewModel: NSObject {
         case cancelAutoUpload
         case share
         case copyLink
+        case blaze
     }
 
     struct ButtonGroups: Equatable {
@@ -183,6 +184,13 @@ class PostCardStatusViewModel: NSObject {
                     buttons.append(.stats)
                 }
                 buttons.append(.share)
+            }
+
+            let canBlaze = post.blog.isBlazeApproved &&
+                post.status == .publish &&
+                post.password == nil
+            if FeatureFlag.blaze.enabled && canBlaze {
+                buttons.append(.blaze)
             }
 
             if post.status == .publish || post.status == .draft {

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -186,10 +186,7 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.share)
             }
 
-            let canBlaze = post.blog.isBlazeApproved &&
-                post.status == .publish &&
-                post.password == nil
-            if FeatureFlag.blaze.enabled && canBlaze {
+            if FeatureFlag.blaze.enabled && post.canBlaze {
                 buttons.append(.blaze)
             }
 

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -783,6 +783,10 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
         shareController.sharePost(post, fromView: view, inViewController: self)
     }
 
+    func blaze(_ post: AbstractPost) {
+        // TODO: Show Blaze webview with post details filled out
+    }
+
     // MARK: - Searching
 
     override func updateForLocalPostsMatchingSearchText() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3648,6 +3648,8 @@
 		FA3536F525B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA3536F425B01A2C0005A3A0 /* JetpackRestoreCompleteViewController.swift */; };
 		FA4ADAD81C50687400F858D7 /* SiteManagementService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */; };
 		FA4ADADA1C509FE400F858D7 /* SiteManagementServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */; };
+		FA4B203829A8C48F0089FE68 /* AbstractPost+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B203729A8C48F0089FE68 /* AbstractPost+Blaze.swift */; };
+		FA4B203929A8C48F0089FE68 /* AbstractPost+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4B203729A8C48F0089FE68 /* AbstractPost+Blaze.swift */; };
 		FA4BC0D02996A589005EB077 /* BlazeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4BC0CF2996A589005EB077 /* BlazeService.swift */; };
 		FA4BC0D12996A589005EB077 /* BlazeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4BC0CF2996A589005EB077 /* BlazeService.swift */; };
 		FA4F383627D766020068AAF5 /* MySiteSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA4F383527D766020068AAF5 /* MySiteSettings.swift */; };
@@ -8890,6 +8892,7 @@
 		FA41070D263957C000E90EBF /* JetpackBackupOptionsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBackupOptionsScreen.swift; sourceTree = "<group>"; };
 		FA4ADAD71C50687400F858D7 /* SiteManagementService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementService.swift; sourceTree = "<group>"; };
 		FA4ADAD91C509FE400F858D7 /* SiteManagementServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiteManagementServiceTests.swift; sourceTree = "<group>"; };
+		FA4B203729A8C48F0089FE68 /* AbstractPost+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AbstractPost+Blaze.swift"; sourceTree = "<group>"; };
 		FA4BC0CF2996A589005EB077 /* BlazeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeService.swift; sourceTree = "<group>"; };
 		FA4F383527D766020068AAF5 /* MySiteSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySiteSettings.swift; sourceTree = "<group>"; };
 		FA4F65A62594337300EAA9F5 /* JetpackRestoreOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRestoreOptionsViewController.swift; sourceTree = "<group>"; };
@@ -10271,6 +10274,7 @@
 				5D42A3D6175E7452005CFF05 /* AbstractPost.h */,
 				5D42A3D7175E7452005CFF05 /* AbstractPost.m */,
 				F1527300243B290D00C8DC7A /* AbstractPost+Autosave.swift */,
+				FA4B203729A8C48F0089FE68 /* AbstractPost+Blaze.swift */,
 				40232A9C230A6A740036B0B6 /* AbstractPost+HashHelpers.h */,
 				40232A9D230A6A740036B0B6 /* AbstractPost+HashHelpers.m */,
 				F15272FC243B27BC00C8DC7A /* AbstractPost+Local.swift */,
@@ -20973,6 +20977,7 @@
 				43DC0EF12040B23200896C9C /* SignupUsernameViewController.swift in Sources */,
 				1782BE841E70063100A91E7D /* MediaItemViewController.swift in Sources */,
 				F41E32FE287B47A500F89082 /* SuggestionsListViewModel.swift in Sources */,
+				FA4B203829A8C48F0089FE68 /* AbstractPost+Blaze.swift in Sources */,
 				E10A2E9B134E8AD3007643F9 /* PostAnnotation.m in Sources */,
 				2481B17F260D4D4E00AE59DB /* WPAccount+Lookup.swift in Sources */,
 				7E3E9B702177C9DC00FD5797 /* GutenbergViewController.swift in Sources */,
@@ -24359,6 +24364,7 @@
 				FABB24FA2602FC2C00C8785C /* AnnouncementsStore.swift in Sources */,
 				FABB24FB2602FC2C00C8785C /* ReaderListStreamHeader.swift in Sources */,
 				FABB24FC2602FC2C00C8785C /* NoResultsViewController+MediaLibrary.swift in Sources */,
+				FA4B203929A8C48F0089FE68 /* AbstractPost+Blaze.swift in Sources */,
 				FABB24FD2602FC2C00C8785C /* StockPhotosDataLoader.swift in Sources */,
 				010459E729153FFF000C7778 /* JetpackNotificationMigrationService.swift in Sources */,
 				FABB24FE2602FC2C00C8785C /* ReaderTopicToReaderTagTopic37to38.swift in Sources */,

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -98,6 +98,12 @@ final class BlogBuilder {
         return self
     }
 
+    func isBlazeApproved() -> Self {
+        blog.isBlazeApproved = true
+
+        return self
+    }
+
     func with(modules: [String]) -> Self {
         set(blogOption: "active_modules", value: modules)
     }

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -5,12 +5,14 @@ import XCTest
 
 private typealias Titles = PostActionSheet.Titles
 
-class PostActionSheetTests: XCTestCase {
+class PostActionSheetTests: CoreDataTestCase {
 
     private var postActionSheet: PostActionSheet!
     private var viewControllerMock: UIViewControllerMock!
     private var interactivePostViewDelegateMock: InteractivePostViewDelegateMock!
     private var view: UIView!
+
+    private let featureFlags = FeatureFlagOverrideStore()
 
     override func setUp() {
         viewControllerMock = UIViewControllerMock()
@@ -145,6 +147,25 @@ class PostActionSheetTests: XCTestCase {
         XCTAssertTrue(interactivePostViewDelegateMock.didCallView)
     }
 
+    func testCallDelegateWhenBlazeTapped() throws {
+        try featureFlags.override(FeatureFlag.blaze, withValue: true)
+
+        let blog = BlogBuilder(mainContext)
+            .isBlazeApproved()
+            .build()
+
+        let post = PostBuilder(mainContext, blog: blog)
+            .published()
+            .build()
+
+        let viewModel = PostCardStatusViewModel(post: post)
+
+        postActionSheet.show(for: viewModel, from: view)
+        tap("Promote with Blaze", in: viewControllerMock.viewControllerPresented)
+
+        XCTAssertTrue(interactivePostViewDelegateMock.didCallBlaze)
+    }
+
     func testCallsDelegateWhenCancelAutoUploadIsTapped() {
         let viewModel = PostCardStatusViewModel(post: PostBuilder().published().with(remoteStatus: .failed).confirmedAutoUpload().build())
 
@@ -198,6 +219,7 @@ class InteractivePostViewDelegateMock: InteractivePostViewDelegate {
     private(set) var didCallCancelAutoUpload = false
     private(set) var didCallShare = false
     private(set) var didCallCopyLink = false
+    private(set) var didCallBlaze = false
 
     func stats(for post: AbstractPost) {
         didCallHandleStats = true
@@ -245,5 +267,9 @@ class InteractivePostViewDelegateMock: InteractivePostViewDelegate {
 
     func copyLink(_ post: AbstractPost) {
         didCallCopyLink = true
+    }
+
+    func blaze(_ post: AbstractPost) {
+        didCallBlaze = true
     }
 }


### PR DESCRIPTION
Part of #20092

- Adds an entry point for the dashboard menu item
- Button actions will be addressed in a different PR
- Analytics will be addressed in a different PR
- Figma: cEGtlsm6xijEswaKkrQrIj-fi-477%3A5675

## Notes
- FWICT you can't use attributed strings for UIAlertAction titles, which means we can't add the blaze icon to "Promote with Blaze" :(

## How to test

1. Switch to a site that's eligible for Blaze (See peeHDf-zm-p2 for more info on Blaze requirements)
2. Create three types of posts: public, private, and password protected
3. Go to the posts lists page and select the published tab
4. On the public post, tap the ellipsis button
5. ✅ A "Promote with Blaze" alert action is displayed
6. On the private post, tap the ellipsis button
7. ✅ A "Promote with Blaze" alert action is NOT displayed
8. On the password protected post, tap the ellipsis button
9. ✅ A "Promote with Blaze" alert action is NOT displayed
10. On the posts list screen, switch to the drafts tab
11. On any post, tap the ellipsis button
12. ✅ A "Promote with Blaze" alert action is NOT displayed
13. Switch to a site that's not eligible for Blaze
14. On any post, tap the ellipsis button
15. ✅ A "Promote with Blaze" alert action is NOT displayed

Public | Password Protected | Private
-- | -- | --
![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 16 50 40](https://user-images.githubusercontent.com/6711616/218800937-d68f8c0c-9fd3-4fe1-b3f6-3a0350aa1316.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 16 50 51](https://user-images.githubusercontent.com/6711616/218800958-4f4e3faa-3d1b-4a31-aeb5-555b55769252.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-02-14 at 16 51 00](https://user-images.githubusercontent.com/6711616/218800960-410f6ccc-41fb-4ae3-b747-779b34ea99bb.png)


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
