### PR TITLE
Refactor `ReaderTopicService.currentTopic`

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,8 +1,6 @@
 #import <Foundation/Foundation.h>
 #import "LocalCoreDataService.h"
 
-extern NSString * const ReaderTopicDidChangeViaUserInteractionNotification;
-extern NSString * const ReaderTopicDidChangeNotification;
 extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
 @class ReaderAbstractTopic;

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -10,11 +10,9 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
 @interface ReaderTopicService : LocalCoreDataService
 
-/**
- Sets the currentTopic and dispatches the `ReaderTopicDidChangeNotification` notification.
- Passing `nil` for the topic will not dispatch the notification.
- */
-@property (nonatomic) ReaderAbstractTopic *currentTopic;
+- (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
+
+- (void)setCurrentTopic:(ReaderAbstractTopic *)topic;
 
 /**
  Fetches the topics for the reader's menu.

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -120,10 +120,8 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     if (!topic) {
         [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:ReaderTopicCurrentTopicPathKey];
-        [NSUserDefaults resetStandardUserDefaults];
     } else {
         [[UserPersistentStoreFactory userDefaultsInstance] setObject:topic.path forKey:ReaderTopicCurrentTopicPathKey];
-        [NSUserDefaults resetStandardUserDefaults];
     }
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -10,8 +10,6 @@
 @import WordPressKit;
 
 
-NSString * const ReaderTopicDidChangeViaUserInteractionNotification = @"ReaderTopicDidChangeViaUserInteractionNotification";
-NSString * const ReaderTopicDidChangeNotification = @"ReaderTopicDidChangeNotification";
 NSString * const ReaderTopicFreshlyPressedPathCommponent = @"freshly-pressed";
 static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTopicPathKey";
 
@@ -126,10 +124,6 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     } else {
         [[UserPersistentStoreFactory userDefaultsInstance] setObject:topic.path forKey:ReaderTopicCurrentTopicPathKey];
         [NSUserDefaults resetStandardUserDefaults];
-        
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [[NSNotificationCenter defaultCenter] postNotificationName:ReaderTopicDidChangeNotification object:nil]; 
-        });
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -165,9 +165,11 @@ extension ReaderTagsTableViewModel {
         service.followTagNamed(tagName, withSuccess: { [weak self] in
             generator.notificationOccurred(.success)
 
+            guard let self else { return }
+
             // A successful follow makes the new tag the currentTopic.
-            if let tag = service.currentTopic as? ReaderTagTopic {
-                self?.scrollToTag(tag)
+            if let tag = service.currentTopic(in: self.context) as? ReaderTagTopic {
+                self.scrollToTag(tag)
             }
         }, failure: { (error) in
             DDLogError("Could not follow topic named \(tagName) : \(String(describing: error))")

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -278,7 +278,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
         // Setup
         let expect = expectation(description: "topics saved expectation")
         let service = ReaderTopicService(managedObjectContext: mainContext)
-        service.currentTopic = nil
+        service.setCurrentTopic(nil)
 
         // Current topic is not nil after a sync
         service.mergeMenuTopics(remoteTopics, withSuccess: { () -> Void in
@@ -295,12 +295,12 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
         let results = try! mainContext.fetch(request)
 
         var topic = results.last as! ReaderAbstractTopic
-        XCTAssertEqual(service.currentTopic.type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
+        XCTAssertEqual(service.currentTopic(in: mainContext).type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
 
         topic = results.first as! ReaderAbstractTopic
-        service.currentTopic = topic
+        service.setCurrentTopic(topic)
 
-        XCTAssertEqual(service.currentTopic.path, topic.path, "The current topic did not match the topic we assiged to it")
+        XCTAssertEqual(service.currentTopic(in: mainContext).path, topic.path, "The current topic did not match the topic we assiged to it")
     }
 
     /**


### PR DESCRIPTION
This PR replaces the `currentTopic` property in the interface file with a safer getter (which requires a context to perform the query) and a setter (whose implementation isn't changed).

During making this change, I noticed the `ReaderTopicDidChangeNotification` isn't observed by any code, so I deleted it for good—why bother sending this notification if no one observes it.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
