### PR TITLE
Fix #19190: Do not delete the previous topic when the same topic is searched

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -314,7 +314,7 @@ import Gridicons
 
         endSearch()
 
-        if let previousTopic = previousTopic {
+        if let previousTopic, topic != previousTopic {
             service.delete(previousTopic)
         }
     }


### PR DESCRIPTION
Fix #19190. The `ReaderSearchTopic` objects `topic` (which is the current search topic) and `previousTopic` can be the same one.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
