### PR TITLE
[JP Plugin] Add cancellation and misc. fixes

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -112,6 +112,7 @@ private extension JetpackRemoteInstallViewController {
     /// Cancels the flow.
     @objc func cancel() {
         viewModel.track(.cancel)
+        viewModel.cancelTapped()
         delegate?.jetpackRemoteInstallCanceled()
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -158,6 +158,8 @@ extension JetpackRemoteInstallViewController: JetpackRemoteInstallStateViewDeleg
     }
 
     func customerSupportButtonDidTouch() {
-        navigationController?.pushViewController(SupportTableViewController(), animated: true)
+        let supportViewController = SupportTableViewController()
+        supportViewController.sourceTag = viewModel.supportSourceTag
+        navigationController?.pushViewController(supportViewController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
@@ -5,7 +5,7 @@ protocol JetpackRemoteInstallStateViewDelegate: AnyObject {
     func customerSupportButtonDidTouch()
 }
 
-struct JetpackRemoteInstallStateViewData {
+struct JetpackRemoteInstallStateViewModel {
     let image: UIImage?
     let titleText: String
     let descriptionText: String
@@ -35,18 +35,18 @@ class JetpackRemoteInstallStateView: UIViewController {
         imageView.isHidden = collection.containsTraits(in: UITraitCollection(verticalSizeClass: .compact))
     }
 
-    func configure(with viewData: JetpackRemoteInstallStateViewData) {
-        imageView.image = viewData.image
+    func configure(with viewModel: JetpackRemoteInstallStateViewModel) {
+        imageView.image = viewModel.image
 
-        titleLabel.text = viewData.titleText
-        descriptionLabel.text = viewData.descriptionText
+        titleLabel.text = viewModel.titleText
+        descriptionLabel.text = viewModel.descriptionText
 
-        mainButton.isHidden = viewData.hidesMainButton
-        mainButton.setTitle(viewData.buttonTitleText, for: .normal)
+        mainButton.isHidden = viewModel.hidesMainButton
+        mainButton.setTitle(viewModel.buttonTitleText, for: .normal)
 
-        activityIndicatorContainer.isHidden = viewData.hidesLoadingIndicator
+        activityIndicatorContainer.isHidden = viewModel.hidesLoadingIndicator
 
-        supportButton.isHidden = viewData.hidesSupportButton
+        supportButton.isHidden = viewModel.hidesSupportButton
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
@@ -35,6 +35,12 @@ protocol JetpackRemoteInstallViewModel: AnyObject {
     ///
     /// - Parameter event: The events to track. See `JetpackRemoteInstallEvent` for more info.
     func track(_ event: JetpackRemoteInstallEvent)
+
+    /// Called by the view controller when the user taps Cancel.
+    ///
+    /// This allows the view model to perform necessary operation cleanups, but note that
+    /// the actual navigation actions upon cancellation should be controlled by `JetpackRemoteInstallDelegate`.
+    func cancelTapped()
 }
 
 // MARK: - Default Init Jetpack State View Data

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
@@ -10,7 +10,7 @@ protocol JetpackRemoteInstallViewModel: AnyObject {
     // MARK: Properties
 
     /// The view controller can implement the closure to subscribe to every `state` changes.
-    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewData) -> Void)? { get set }
+    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewModel) -> Void)? { get set }
 
     /// An enum that represents the current installation state.
     var state: JetpackRemoteInstallState { get }
@@ -48,9 +48,9 @@ protocol JetpackRemoteInstallViewModel: AnyObject {
     func cancelTapped()
 }
 
-// MARK: - Default Init Jetpack State View Data
+// MARK: - Default Init Jetpack State View Model
 
-extension JetpackRemoteInstallStateViewData {
+extension JetpackRemoteInstallStateViewModel {
 
     init(state: JetpackRemoteInstallState,
          image: UIImage? = nil,

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/JetpackRemoteInstallViewModel.swift
@@ -1,3 +1,5 @@
+import WordPressAuthenticator
+
 /// Represents the core logic behind the Jetpack Remote Install.
 ///
 /// This protocol is mainly used by `JetpackRemoteInstallViewController`, and allows the installation process
@@ -15,6 +17,9 @@ protocol JetpackRemoteInstallViewModel: AnyObject {
 
     /// Whether the install flow should continue with establishing a Jetpack connection for the site.
     var shouldConnectToJetpack: Bool { get }
+
+    /// The source tag to be used when the user opens the Support screen in case of installation errors.
+    var supportSourceTag: WordPressSupportSourceTag? { get }
 
     // MARK: Methods
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
@@ -1,4 +1,5 @@
 import WordPressFlux
+import WordPressAuthenticator
 
 class SelfHostedJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
     var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewData) -> Void)?
@@ -7,6 +8,8 @@ class SelfHostedJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
 
     /// Always proceed to the Jetpack Connection flow after successfully installing Jetpack.
     let shouldConnectToJetpack = true
+
+    let supportSourceTag: WordPressSupportSourceTag? = nil
 
     private(set) var state: JetpackRemoteInstallState = .install {
         didSet {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
@@ -2,7 +2,7 @@ import WordPressFlux
 import WordPressAuthenticator
 
 class SelfHostedJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
-    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewData) -> Void)?
+    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewModel) -> Void)?
     private let store = StoreContainer.shared.jetpackInstall
     private var storeReceipt: Receipt?
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
@@ -60,4 +60,8 @@ class SelfHostedJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
             break
         }
     }
+
+    func cancelTapped() {
+         // No op
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
@@ -1,3 +1,5 @@
+import WordPressAuthenticator
+
 /// Controls the Jetpack Remote Install flow for Jetpack-connected self-hosted sites.
 ///
 /// A site can establish a Jetpack connection through individual Jetpack plugins, but the site may not have
@@ -18,6 +20,8 @@ class WPComJetpackRemoteInstallViewModel {
 
     // The flow should always complete after the plugin is installed.
     let shouldConnectToJetpack = false
+
+    let supportSourceTag: WordPressSupportSourceTag? = .jetpackFullPluginInstallErrorSourceTag
 
     var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewData) -> Void)? = nil
 
@@ -126,6 +130,12 @@ private extension WPComJetpackRemoteInstallViewModel {
             descriptionText: (state == .success ? Constants.successDescriptionText : state.message),
             buttonTitleText: (state == .success ? Constants.successButtonTitleText : state.buttonTitle)
         )
+    }
+}
+
+extension WordPressSupportSourceTag {
+    static var jetpackFullPluginInstallErrorSourceTag: WordPressSupportSourceTag {
+        .init(name: "jetpackInstallFullPluginError", origin: "origin:jp-install-full-plugin-error")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/WPComJetpackRemoteInstallViewModel.swift
@@ -23,11 +23,11 @@ class WPComJetpackRemoteInstallViewModel {
 
     let supportSourceTag: WordPressSupportSourceTag? = .jetpackFullPluginInstallErrorSourceTag
 
-    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewData) -> Void)? = nil
+    var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewModel) -> Void)? = nil
 
     private(set) var state: JetpackRemoteInstallState = .install {
         didSet {
-            onChangeState?(state, viewData)
+            onChangeState?(state, stateViewModel)
         }
     }
 
@@ -123,8 +123,8 @@ private extension WPComJetpackRemoteInstallViewModel {
         )
     }
 
-    // View data overrides.
-    var viewData: JetpackRemoteInstallStateViewData {
+    // State view model overrides.
+    var stateViewModel: JetpackRemoteInstallStateViewModel {
         return .init(
             state: state,
             descriptionText: (state == .success ? Constants.successDescriptionText : state.message),


### PR DESCRIPTION
Refs #20018

---

⚠️ **Note: Auto-merge is enabled!** ⚠️ 

---

Several minor changes in this PR:

- Request cancellation — The `Progress` object returned from the service is now retained in the view model, and `cancel()` is called whenever the user taps the Cancel button.
- Added a support origin tag when the user taps "Contact Support" from the error state.
- Renamed `ViewData` -> `ViewModel`, as per [this review comment](https://github.com/wordpress-mobile/WordPress-iOS/pull/20066#discussion_r1104889541).

## To test

For convenience, add this temporary code on the FAB again:

```swift
// MySiteViewController+FAB.swift: line 8
        let newPage = {
            // FIXME: Remove changes after testing.
            let presenter = RootViewCoordinator.sharedPresenter
            let blog = presenter.currentOrLastBlog()
//            presenter.showPageEditor(forBlog: blog)

            let viewModel = WPComJetpackRemoteInstallViewModel()
            let controller = JetpackRemoteInstallViewController(blog: blog!, delegate: nil, viewModel: viewModel)
            let navController = UINavigationController(rootViewController: controller)
            navController.modalPresentationStyle = .fullScreen
            presenter.rootViewController.dismiss(animated: true) { [weak presenter] in
                presenter?.rootViewController.present(navController, animated: true)
            }
        }
```

- Run the Jetpack app, and log in to your WordPress.com account.
- Switch to the self-hosted site.
- Turn on airplane mode / disable your connection to easily reach the error page.
- Tap on the FAB > Site Page.
- Tap Continue, and the error screen should be shown shortly.
- Tap Contact Support > Ticket List.
- Verify that this event fired: `🔵 Tracked: support_ticket_list_viewed <source: origin:jp-install-full-plugin-error>` (notice the origin part)

> **Note**: The cancellation part is not manually testable right now, because part of the cancellation flow involves dismissing the modal, which will be implemented by the `JetpackRemoteInstallDelegate` later on in the wiring part.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
