### PR TITLE
Document an issue with sync version of `performAndSave` API

### DIFF
--- a/WordPress/WordPressTest/ContextManagerTests.swift
+++ b/WordPress/WordPressTest/ContextManagerTests.swift
@@ -373,6 +373,9 @@ class ContextManagerTests: XCTestCase {
         try XCTAssertEqual(contextManager.mainContext.count(for: request), 1)
     }
 
+    /// This test case documents a pitfall in `ContextManager.performAndSave(_:)`, where the
+    /// saved changes aren't immediately accessible on the objects in the main context. This
+    /// issue doesn't present in `performAndSave(_:completion:on:)`.
     func testUpdateUsingSyncAPI() throws {
         // First, insert an account into the database.
         let contextManager = ContextManager.forTesting()


### PR DESCRIPTION
See pbArwn-5Qy-p2 for details about the potential issue.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
All changes in this PR

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.