### PR TITLE
Use async version of performAndSave in PlanStorage

### DIFF
--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -223,15 +223,18 @@ extension PlanService {
                         success()
                         return
                 }
-                PlanStorage.updateHasDomainCredit(planIdInt,
-                                                  forSite: siteID,
-                                                  hasDomainCredit: plans.activePlan.hasDomainCredit ?? false)
+                PlanStorage.updateHasDomainCredit(
+                    planIdInt,
+                    forSite: siteID,
+                    hasDomainCredit: plans.activePlan.hasDomainCredit ?? false
+                )
                 success()
-        },
+            },
             failure: { error in
                 DDLogError("Failed checking prices for blog for site \(siteID): \(error.localizedDescription)")
                 failure(error)
-        })
+            }
+        )
     }
 }
 

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -236,20 +236,6 @@ extension PlanService {
 }
 
 struct PlanStorage {
-    static func activatePlan(_ planID: Int, forSite siteID: Int) {
-        ContextManager.shared.performAndSave { context in
-            guard let blog = try? Blog.lookup(withID: siteID, in: context) else {
-                let error = "Tried to activate a plan for a non-existing site (ID: \(siteID))"
-                assertionFailure(error)
-                DDLogError(error)
-                return
-            }
-            if blog.planID?.intValue != planID {
-                blog.planID = NSNumber(value: planID)
-            }
-        }
-    }
-
     static func updateHasDomainCredit(_ planID: Int, forSite siteID: Int, hasDomainCredit: Bool) {
         ContextManager.shared.performAndSave { context in
             guard let blog = try? Blog.lookup(withID: siteID, in: context) else {


### PR DESCRIPTION
Replace `performAndSave(_:)` in `PlanStorage` with `performAndSave(_:completion:)`. See pbArwn-5Qy-p2 for more details.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.