### PR TITLE
Use `CoreDataStack` in `ReaderTopicService`

### DIFF
--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -20,8 +20,8 @@ class ReaderCardService {
          siteInfoService: ReaderSiteInfoService? = nil) {
         self.service = service
         self.coreDataStack = coreDataStack
-        self.followedInterestsService = followedInterestsService ?? ReaderTopicService(managedObjectContext: coreDataStack.mainContext)
-        self.siteInfoService = siteInfoService ?? ReaderTopicService(managedObjectContext: coreDataStack.mainContext)
+        self.followedInterestsService = followedInterestsService ?? ReaderTopicService(coreDataStack: coreDataStack)
+        self.siteInfoService = siteInfoService ?? ReaderTopicService(coreDataStack: coreDataStack)
     }
 
     func fetch(isFirstPage: Bool, refreshCount: Int = 0, success: @escaping (Int, Bool) -> Void, failure: @escaping (Error?) -> Void) {

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -308,7 +308,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 
     // If this post belongs to a site topic, let the topic service do the work.
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
 
     if ([readerPost.topic isKindOfClass:[ReaderSiteTopic class]]) {
         ReaderSiteTopic *siteTopic = (ReaderSiteTopic *)readerPost.topic;

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -78,7 +78,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
     ReaderSiteServiceRemote *service = [[ReaderSiteServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [service unfollowSiteWithID:siteID success:^(){
-        [self unfollowSiteTopicWithSiteID:@(siteID)];
+        [self markUnfollowedSiteTopicWithSiteID:@(siteID)];
         if (success) {
             success();
         }
@@ -139,24 +139,12 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
     ReaderSiteServiceRemote *service = [[ReaderSiteServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [service unfollowSiteAtURL:siteURL success:^(){
-        [self unfollowSiteTopicWithURL:siteURL];
+        [self markUnfollowedSiteTopicWithFeedURL:siteURL];
         if (success) {
             success();
         }
         [WPAnalytics trackReaderStat:WPAnalyticsStatReaderSiteUnfollowed properties:@{@"url":siteURL}];
     } failure:failure];
-}
-
-- (void)unfollowSiteTopicWithSiteID:(NSNumber *)siteID
-{
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [topicService markUnfollowedSiteTopicWithSiteID:siteID];
-}
-
-- (void)unfollowSiteTopicWithURL:(NSString *)siteURL
-{
-    ReaderTopicService *topicService = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [topicService markUnfollowedSiteTopicWithFeedURL:siteURL];
 }
 
 - (void)syncPostsForFollowedSites
@@ -274,6 +262,27 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     [service flagPostsFromSite:siteID asBlocked:blocked];
 }
 
+// Updates the site topic's following status in core data only.
+- (void)markUnfollowedSiteTopicWithFeedURL:(NSString *)feedURL
+{
+    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithFeedURL:feedURL inContext:self.managedObjectContext];
+    if (!topic) {
+        return;
+    }
+    topic.following = NO;
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+}
+
+// Updates the site topic's following status in core data only.
+- (void)markUnfollowedSiteTopicWithSiteID:(NSNumber *)siteID
+{
+    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:self.managedObjectContext];
+    if (!topic) {
+        return;
+    }
+    topic.following = NO;
+    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+}
 
 #pragma mark - Error messages
 

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -214,7 +214,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 - (void)fetchTopicServiceWithID:(NSUInteger)siteID success:(void(^)(void))success failure:(void(^)(NSError *error))failure
 {
     DDLogInfo(@"Fetch and store followed topic");
-    ReaderTopicService *service  = [[ReaderTopicService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    ReaderTopicService *service  = [[ReaderTopicService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     [service siteTopicForSiteWithID:@(siteID)
                              isFeed:false
                             success:^(NSManagedObjectID *objectID, BOOL isFollowing) {

--- a/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
@@ -27,7 +27,9 @@ protocol ReaderFollowedInterestsService: AnyObject {
 // MARK: - CoreData Fetching
 extension ReaderTopicService: ReaderFollowedInterestsService {
     public func fetchFollowedInterestsLocally(completion: @escaping ([ReaderTagTopic]?) -> Void) {
-        completion(followedInterests())
+        DispatchQueue.main.async {
+            completion(self.followedInterests())
+        }
     }
 
     public func fetchFollowedInterestsRemotely(completion: @escaping ([ReaderTagTopic]?) -> Void) {
@@ -70,19 +72,20 @@ extension ReaderTopicService: ReaderFollowedInterestsService {
                                         success: @escaping ([ReaderTagTopic]?) -> Void,
                                         failure: @escaping (Error) -> Void) {
 
-
-        interests.forEach { interest in
-            let topic = ReaderTagTopic(remoteInterest: interest, context: managedObjectContext, isFollowing: true)
-            topic.path = path(slug: interest.slug)
-        }
-
-        ContextManager.sharedInstance().save(managedObjectContext, completion: { [weak self] in
+        self.coreDataStack.performAndSave({ context in
+            interests.forEach { interest in
+                let topic = ReaderTagTopic(remoteInterest: interest, context: context, isFollowing: true)
+                topic.path = self.path(slug: interest.slug)
+            }
+        }, completion: { [weak self] in
             self?.fetchFollowedInterestsLocally(completion: success)
         }, on: .main)
     }
 
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext)
+        let defaultAccount = self.coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
         let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,
@@ -100,9 +103,11 @@ extension ReaderTopicService: ReaderFollowedInterestsService {
     }
 
     private func followedInterests() -> [ReaderTagTopic]? {
+        assert(Thread.isMainThread, "\(#function) must be called from the main thread")
+
         let fetchRequest = followedInterestsFetchRequest()
         do {
-            return try managedObjectContext.fetch(fetchRequest)
+            return try coreDataStack.mainContext.fetch(fetchRequest)
         } catch {
             DDLogError("Could not fetch followed interests: \(String(describing: error))")
 

--- a/WordPress/Classes/Services/ReaderTopicService+Interests.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Interests.swift
@@ -25,7 +25,9 @@ extension ReaderTopicService: ReaderInterestsService {
 
     /// Creates a new WP.com API instances that allows us to specify the LocaleKeyV2
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext)
+        let defaultAccount = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
         let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,

--- a/WordPress/Classes/Services/ReaderTopicService+SiteInfo.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+SiteInfo.swift
@@ -17,7 +17,9 @@ extension ReaderTopicService: ReaderSiteInfoService {
     }
 
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext)
+        let defaultAccount = self.coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
         let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,

--- a/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
@@ -14,7 +14,9 @@ extension ReaderTopicService {
 
     private func apiRequest() -> WordPressComRestApi {
 
-        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext)
+        let defaultAccount = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        }
         if let api = defaultAccount?.wordPressComRestApi, api.hasCredentials() {
             return api
         }

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -62,10 +62,9 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  Creates a ReaderSearchTopic from the specified search phrase.
  
  @param phrase: The search phrase.
- 
- @return A ReaderSearchTopic instance.
+ @param completion: A completion callback to receive the created ReaderSearchTopic instance.
  */
-- (ReaderSearchTopic *)searchTopicForSearchPhrase:(NSString *)phrase;
+- (void)createSearchTopicForSearchPhrase:(NSString *)phrase completion:(void (^)(NSManagedObjectID *))completion;
 
 /**
  Unfollows the specified topic

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -109,22 +109,6 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
                        failure:(void (^)(BOOL follow, NSError *error))failure;
 
 /**
- Mark a site topic as unfollowed in core data only. Should be called after unfollowing
- a post to ensure that any existing site topics reflect the correct following status.
-
- @param feedURL The feedURL of the site topic.
- */
-- (void)markUnfollowedSiteTopicWithFeedURL:(NSString *)feedURL;
-
-/**
- Mark a site topic as unfollowed in core data only. Should be called after unfollowing
- a post to ensure that any existing site topics reflect the correct following status.
-
- @param siteID the siteID of the site topic.
- */
-- (void)markUnfollowedSiteTopicWithSiteID:(NSNumber *)siteID;
-
-/**
  Fetch a tag topic for a tag with the specified slug.
 
  @param slug The slug for the tag.

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "LocalCoreDataService.h"
+#import "CoreDataService.h"
 
 extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
@@ -8,7 +8,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 @class ReaderSiteTopic;
 @class ReaderSearchTopic;
 
-@interface ReaderTopicService : LocalCoreDataService
+@interface ReaderTopicService : CoreDataService
 
 - (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -539,7 +539,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)refreshPostsForFollowedTopic
 {
-    ReaderPostService *postService = [[ReaderPostService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    ReaderPostService *postService = [[ReaderPostService alloc] initWithManagedObjectContext:self.coreDataStack.mainContext];
     [postService refreshPostsForFollowedTopic];
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -45,7 +45,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)fetchFollowedSitesWithSuccess:(void(^)(void))success failure:(void(^)(NSError *error))failure
 {
-    ReaderTopicServiceRemote *service = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequestInContext:self.managedObjectContext]];
+    ReaderTopicServiceRemote *service = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [service fetchFollowedSitesWithSuccess:^(NSArray *sites) {
         [WPAnalytics setSubscriptionCount: sites.count];
         [self mergeFollowedSites:sites withSuccess:success];
@@ -580,6 +580,15 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     if (![api hasCredentials]) {
         api = [WordPressComRestApi defaultApiWithOAuthToken:nil userAgent:[WPUserAgent wordPressUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
     }
+    return api;
+}
+
+- (WordPressComRestApi *)apiForRequest
+{
+    WordPressComRestApi * __block api = nil;
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        api = [self apiForRequestInContext:context];
+    }];
     return api;
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -190,15 +190,14 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)deleteAllTopics
 {
-    [self setCurrentTopic:nil];
-    NSArray *currentTopics = [ReaderAbstractTopic lookupAllInContext:self.managedObjectContext error:nil];
-    for (ReaderAbstractTopic *topic in currentTopics) {
-        DDLogInfo(@"Deleting topic: %@", topic.title);
-        [self preserveSavedPostsFromTopic:topic];
-        [self.managedObjectContext deleteObject:topic];
-    }
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        [self setCurrentTopic:nil];
+        NSArray *currentTopics = [ReaderAbstractTopic lookupAllInContext:context error:nil];
+        for (ReaderAbstractTopic *topic in currentTopics) {
+            DDLogInfo(@"Deleting topic: %@", topic.title);
+            [self preserveSavedPostsFromTopic:topic];
+            [context deleteObject:topic];
+        }
     }];
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -172,20 +172,20 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)clearInUseFlags
 {
-    NSError *error;
-    NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];
-    request.predicate = [NSPredicate predicateWithFormat:@"inUse = true"];
-    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
-    if (error) {
-        DDLogError(@"%@, marking topic not in use.: %@", NSStringFromSelector(_cmd), error);
-        return;
-    }
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        NSError *error;
+        NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:[ReaderAbstractTopic classNameWithoutNamespaces]];
+        request.predicate = [NSPredicate predicateWithFormat:@"inUse = true"];
+        NSArray *results = [context executeFetchRequest:request error:&error];
+        if (error) {
+            DDLogError(@"%@, marking topic not in use.: %@", NSStringFromSelector(_cmd), error);
+            return;
+        }
 
-    for (ReaderAbstractTopic *topic in results) {
-        topic.inUse = NO;
-    }
-
-    [[ContextManager sharedInstance] saveContextAndWait:self.managedObjectContext];
+        for (ReaderAbstractTopic *topic in results) {
+            topic.inUse = NO;
+        }
+    }];
 }
 
 - (void)deleteAllTopics

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -127,22 +127,21 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
 - (void)deleteAllSearchTopics
 {
-    NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderSearchTopic classNameWithoutNamespaces]];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        NSFetchRequest *request = [NSFetchRequest fetchRequestWithEntityName:[ReaderSearchTopic classNameWithoutNamespaces]];
 
-    NSError *error;
-    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
-    if (error) {
-        DDLogError(@"%@ error executing fetch request: %@", NSStringFromSelector(_cmd), error);
-        return;
-    }
+        NSError *error;
+        NSArray *results = [context executeFetchRequest:request error:&error];
+        if (error) {
+            DDLogError(@"%@ error executing fetch request: %@", NSStringFromSelector(_cmd), error);
+            return;
+        }
 
-    for (ReaderAbstractTopic *topic in results) {
-        DDLogInfo(@"Deleting topic: %@", topic.title);
-        [self preserveSavedPostsFromTopic:topic];
-        [self.managedObjectContext deleteObject:topic];
-    }
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        for (ReaderAbstractTopic *topic in results) {
+            DDLogInfo(@"Deleting topic: %@", topic.title);
+            [self preserveSavedPostsFromTopic:topic];
+            [context deleteObject:topic];
+        }
     }];
 }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -337,7 +337,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         return;
     }
 
-    ReaderTopicServiceRemote *remoteService = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequestInContext:self.managedObjectContext]];
+    ReaderTopicServiceRemote *remoteService = [[ReaderTopicServiceRemote alloc] initWithWordPressComRestApi:[self apiForRequest]];
     [remoteService followTopicWithSlug:slug withSuccess:^(NSNumber *topicID) {
         successBlock();
     } failure:^(NSError *error) {

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -523,28 +523,6 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     [postService refreshPostsForFollowedTopic];
 }
 
-// Updates the site topic's following status in core data only.
-- (void)markUnfollowedSiteTopicWithFeedURL:(NSString *)feedURL
-{
-    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithFeedURL:feedURL inContext:self.managedObjectContext];
-    if (!topic) {
-        return;
-    }
-    topic.following = NO;
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-}
-
-// Updates the site topic's following status in core data only.
-- (void)markUnfollowedSiteTopicWithSiteID:(NSNumber *)siteID
-{
-    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:self.managedObjectContext];
-    if (!topic) {
-        return;
-    }
-    topic.following = NO;
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-}
-
 - (void)siteTopicForSiteWithID:(NSNumber *)siteID
                         isFeed:(BOOL)isFeed
                        success:(void (^)(NSManagedObjectID *objectID, BOOL isFollowing))success

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -206,10 +206,13 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
     if (!topic) {
         return;
     }
-    [self preserveSavedPostsFromTopic:topic];
-    [self.managedObjectContext deleteObject:topic];
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderAbstractTopic *topicInContext = [context existingObjectWithID:topic.objectID error:nil];
+        if (topicInContext == nil) {
+            return;
+        }
+        [self preserveSavedPostsFromTopic:topicInContext];
+        [context deleteObject:topicInContext];
     }];
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -123,7 +123,7 @@ class NotificationSettingsViewController: UIViewController {
         let service = NotificationSettingsService(coreDataStack: ContextManager.sharedInstance())
 
         let dispatchGroup = DispatchGroup()
-        let siteService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let siteService = ReaderTopicService(coreDataStack: ContextManager.shared)
 
         activityIndicatorView.startAnimating()
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -64,7 +64,7 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
     }
 
     private var sections: [Section] = []
-    private let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+    private let service = ReaderTopicService(coreDataStack: ContextManager.shared)
     private let siteId: Int
     private var siteTopic: ReaderSiteTopic?
     private let siteSubscription = SiteSubscription()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -108,7 +108,7 @@ class ReaderDetailCoordinator {
     /// - Parameter service: a Reader Post Service
     init(coreDataStack: CoreDataStack = ContextManager.shared,
          readerPostService: ReaderPostService = ReaderPostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
-         topicService: ReaderTopicService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext),
+         topicService: ReaderTopicService = ReaderTopicService(coreDataStack: ContextManager.shared),
          postService: PostService = PostService(managedObjectContext: ContextManager.sharedInstance().mainContext),
          commentService: CommentService = CommentService(coreDataStack: ContextManager.shared),
          sharingController: PostSharingController = PostSharingController(),

--- a/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Filter/FilterProvider.swift
@@ -161,7 +161,7 @@ extension ReaderSiteTopic {
     /// Fetch sites from remote service
     ///
     private static func fetchFollowedSites(completion: @escaping (Result<[ReaderSiteTopic], Error>) -> Void) {
-        let siteService = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let siteService = ReaderTopicService(coreDataStack: ContextManager.shared)
 
         siteService.fetchFollowedSites(success: {
             let sites = (try? ReaderAbstractTopic.lookupAllSites(in: ContextManager.shared.mainContext)) ?? []

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -157,7 +157,7 @@ extension ReaderTagsTableViewModel {
             return
         }
 
-        let service = ReaderTopicService(managedObjectContext: context)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
 
         let generator = UINotificationFeedbackGenerator()
         generator.prepare()
@@ -189,7 +189,7 @@ extension ReaderTagsTableViewModel {
     /// - Parameters:
     ///     - topic: The tag topic that is to be unfollowed.
     private func unfollow(_ topic: ReaderTagTopic) {
-        let service = ReaderTopicService(managedObjectContext: context)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.unfollowTag(topic, withSuccess: nil) { (error) in
             DDLogError("Could not unfollow topic \(topic), \(String(describing: error))")
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -177,7 +177,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             return
         }
         isSyncing = true
-        let service = ReaderTopicService(managedObjectContext: managedObjectContext())
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.fetchFollowedSites(success: {[weak self] in
             self?.isSyncing = false
             self?.configureNoResultsView()
@@ -212,7 +212,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
                                         object: nil,
                                         userInfo: [ReaderNotificationKeys.topic: site])
 
-        let service = ReaderTopicService(managedObjectContext: managedObjectContext())
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleFollowing(forSite: site, success: { [weak self] follow in
             let siteURL = URL(string: site.siteURL)
             let notice = Notice(title: NSLocalizedString("Unfollowed site", comment: "User unfollowed a site."),

--- a/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderHelpers.swift
@@ -446,7 +446,7 @@ struct ReaderPostMenuButtonTitles {
         let notice = Notice(title: String(format: NoticeMessages.followSuccess, siteTitle),
                             message: NoticeMessages.enableNotifications,
                             actionTitle: NoticeMessages.enableButtonLabel) { _ in
-            let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            let service = ReaderTopicService(coreDataStack: ContextManager.shared)
             service.toggleSubscribingNotifications(for: siteID.intValue, subscribe: true, {
                 WPAnalytics.track(.readerListNotificationEnabled)
             })

--- a/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderInterestsCoordinator.swift
@@ -13,7 +13,7 @@ class ReaderSelectInterestsCoordinator {
          userId: NSNumber? = nil,
          context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
 
-        self.interestsService = service ?? ReaderTopicService(managedObjectContext: context)
+        self.interestsService = service ?? ReaderTopicService(coreDataStack: ContextManager.shared)
         self.userId = userId ?? {
             return try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.userID
         }()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -151,8 +151,7 @@ import Gridicons
         }
         // When the parent is nil then we've been removed from the nav stack.
         // Clean up any search topics at this point.
-        let context = ContextManager.sharedInstance().mainContext
-        ReaderTopicService(managedObjectContext: context).deleteAllSearchTopics()
+        ReaderTopicService(coreDataStack: ContextManager.shared).deleteAllSearchTopics()
     }
 
 
@@ -304,8 +303,7 @@ import Gridicons
 
         let previousTopic = streamController.readerTopic
 
-        let context = ContextManager.sharedInstance().mainContext
-        let service = ReaderTopicService(managedObjectContext: context)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.createSearchTopic(forSearchPhrase: phrase) { topicID in
             assert(Thread.isMainThread)
             self.endSearch()

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSearchViewController.swift
@@ -306,14 +306,19 @@ import Gridicons
 
         let context = ContextManager.sharedInstance().mainContext
         let service = ReaderTopicService(managedObjectContext: context)
+        service.createSearchTopic(forSearchPhrase: phrase) { topicID in
+            assert(Thread.isMainThread)
+            self.endSearch()
 
-        let topic = service.searchTopic(forSearchPhrase: phrase)
-        streamController.readerTopic = topic
+            guard let topicID, let topic = try? ContextManager.shared.mainContext.existingObject(with: topicID) as? ReaderAbstractTopic else {
+                DDLogError("Failed to create a search topic")
+                return
+            }
+            streamController.readerTopic = topic
 
-        endSearch()
-
-        if let previousTopic, topic != previousTopic {
-            service.delete(previousTopic)
+            if let previousTopic, topic != previousTopic {
+                service.delete(previousTopic)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -425,7 +425,7 @@ import Combine
             displayLoadingStream()
         }
 
-        let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.siteTopicForSite(withID: siteID,
             isFeed: isFeed,
             success: { [weak self] (objectID: NSManagedObjectID?, isFollowing: Bool) in
@@ -462,7 +462,7 @@ import Combine
             displayLoadingStream()
         }
         assert(tagSlug != nil, "A tag slug is requred before fetching a tag topic")
-        let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.tagTopicForTag(withSlug: tagSlug,
             success: { [weak self] (objectID: NSManagedObjectID?) in
 
@@ -1303,7 +1303,7 @@ import Combine
             generator.notificationOccurred(.success)
         }
 
-        let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleFollowing(forTag: topic, success: {
             completion?(true)
         }, failure: { (error: Error?) in
@@ -1317,7 +1317,7 @@ import Combine
             ReaderSubscribingNotificationAction().execute(for: siteID, context: viewContext, subscribe: false)
         }
 
-        let service = ReaderTopicService(managedObjectContext: topic.managedObjectContext!)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleFollowing(forSite: topic, success: { follow in
             ReaderHelpers.dispatchToggleFollowSiteMessage(site: topic, follow: follow, success: true)
             completion?(true)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSubscribingNotificationAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSubscribingNotificationAction.swift
@@ -5,7 +5,7 @@ final class ReaderSubscribingNotificationAction {
             return
         }
 
-        let service = ReaderTopicService(managedObjectContext: context)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.toggleSubscribingNotifications(for: siteID.intValue, subscribe: subscribe, completion, failure)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsDataSource.swift
@@ -55,8 +55,7 @@ class ReaderInterestsDataSource {
         self.topics = topics
 
         guard let service = service else {
-            let context = ContextManager.sharedInstance().mainContext
-            self.interestsService = ReaderTopicService(managedObjectContext: context)
+            self.interestsService = ReaderTopicService(coreDataStack: ContextManager.shared)
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabItemsStore.swift
@@ -15,7 +15,7 @@ class ReaderTabItemsStore: ItemsStore {
     init(context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext,
          service: ReaderTopicService? = nil) {
         self.context = context
-        self.service = service ?? ReaderTopicService(managedObjectContext: context)
+        self.service = service ?? ReaderTopicService(coreDataStack: ContextManager.shared)
     }
 
     enum State {

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewModel.swift
@@ -232,7 +232,7 @@ extension ReaderTabViewModel {
     private func clearFlags() {
         let context = ContextManager.sharedInstance().mainContext
         ReaderPostService(managedObjectContext: context).clearInUseFlags()
-        ReaderTopicService(managedObjectContext: context).clearInUseFlags()
+        ReaderTopicService(coreDataStack: ContextManager.shared).clearInUseFlags()
     }
 
     private func clearTopics(removeAllTopics removeAll: Bool) {
@@ -240,9 +240,9 @@ extension ReaderTabViewModel {
         ReaderPostService(managedObjectContext: context).deletePostsWithNoTopic()
 
         if removeAll {
-            ReaderTopicService(managedObjectContext: context).deleteAllTopics()
+            ReaderTopicService(coreDataStack: ContextManager.shared).deleteAllTopics()
         } else {
-            ReaderTopicService(managedObjectContext: context).deleteNonMenuTopics()
+            ReaderTopicService(coreDataStack: ContextManager.shared).deleteNonMenuTopics()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/ReaderCoordinator.swift
@@ -65,7 +65,7 @@ class ReaderCoordinator: NSObject {
     }
 
     private func getTagTopic(tagSlug: String, completion: @escaping (Result<ReaderTagTopic, Error>) -> Void) {
-        let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.tagTopicForTag(withSlug: tagSlug,
             success: { objectID in
 
@@ -94,7 +94,7 @@ class ReaderCoordinator: NSObject {
     }
 
     private func getSiteTopic(siteID: NSNumber, isFeed: Bool, completion: @escaping (Result<ReaderSiteTopic, Error>) -> Void) {
-        let service = ReaderTopicService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+        let service = ReaderTopicService(coreDataStack: ContextManager.shared)
         service.siteTopicForSite(withID: siteID,
         isFeed: isFeed,
         success: { objectID, isFollowing in

--- a/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
+++ b/WordPress/WordPressTest/ReaderTabItemsStoreTests.swift
@@ -35,7 +35,7 @@ class ReaderTabItemsStoreTests: CoreDataTestCase {
     private let mockError = NSError(domain: "mockContextDomain", code: -1, userInfo: nil)
 
     override func setUp() {
-        service = MockTopicService(managedObjectContext: mainContext)
+        service = MockTopicService(coreDataStack: contextManager)
         store = ReaderTabItemsStore(context: mainContext, service: service)
     }
 

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -150,7 +150,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
     func testUnfollowedSiteIsUnfollowedDuringSync() {
         // Arrange: Setup
         let remoteSites = remoteSiteInfoForTests()
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
         let foo = remoteSites.first as RemoteReaderSiteInfo?
 
         // Act: Save sites
@@ -194,7 +194,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
 
         // Setup
         var expect = expectation(description: "topics saved expectation")
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
         service.mergeMenuTopics(remoteTopics, isLoggedIn: true, withSuccess: { () -> Void in
             expect.fulfill()
         })
@@ -237,7 +237,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
 
         // Setup
         var expect = expectation(description: "topics saved expectation")
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
         service.mergeMenuTopics(startingTopics, isLoggedIn: true, withSuccess: { () -> Void in
             expect.fulfill()
         })
@@ -278,7 +278,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
 
         // Setup
         let expect = expectation(description: "topics saved expectation")
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
         service.setCurrentTopic(nil)
 
         // Current topic is not nil after a sync
@@ -310,7 +310,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
     func testDeleteAllTopics() {
         seedTopics()
         XCTAssertFalse(countTopics() == 0, "The number of seeded topics should not be zero")
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
         service.deleteAllTopics()
         XCTAssertTrue(countTopics() == 0, "The number of seeded topics should be zero")
     }
@@ -355,7 +355,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
     }
 
     func testTopicTitleFormatting() {
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
 
         var unformatted = "WordPress"
         var formatted = service.formatTitle(unformatted)
@@ -382,7 +382,7 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
     }
 
     func testReaderSearchTopicCreated() {
-        let service = ReaderTopicService(managedObjectContext: mainContext)
+        let service = ReaderTopicService(coreDataStack: contextManager)
 
         let phrase = "coffee talk"
         waitUntil { done in

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Foundation
 import CoreData
+import Nimble
 
 @testable import WordPress
 
@@ -384,8 +385,18 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
         let service = ReaderTopicService(managedObjectContext: mainContext)
 
         let phrase = "coffee talk"
-        let topic = service.searchTopic(forSearchPhrase: phrase)
+        waitUntil { done in
+            service.createSearchTopic(forSearchPhrase: phrase) { objectID in
+                guard let objectID else {
+                    XCTFail("A nil object id is returned")
+                    return
+                }
 
-        XCTAssert(topic?.type == "search")
+                let topic = try? self.mainContext.existingObject(with: objectID) as? ReaderSearchTopic
+                XCTAssertEqual(topic?.type, "search")
+
+                done()
+            }
+        }
     }
 }


### PR DESCRIPTION
This is yet another large PR about replacing using context object directly with `CoreDataStack`. Like some of the other PRs, the commits are organized in small and reviewable size.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
