### PR TITLE
Jetpack Plugin: Card display logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -7,8 +7,16 @@ class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
     private var blog: Blog?
     private weak var presenterViewController: BlogDashboardViewController?
 
+    private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
+        let onHideThisTap: UIActionHandler = { [weak self] _ in
+            JetpackInstallPluginHelper.hideCard(for: self?.blog)
+            self?.presenterViewController?.reloadCardsLocally()
+        }
+        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap)
+    }()
+
     private lazy var cardView: JetpackRemoteInstallCardView = {
-        let cardView = JetpackRemoteInstallCardView()
+        let cardView = JetpackRemoteInstallCardView(cardViewModel)
         cardView.translatesAutoresizingMaskIntoConstraints = false
         return cardView
     }()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -51,7 +51,7 @@ enum DashboardCard: String, CaseIterable {
     func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil, mySiteSettings: DefaultSectionProvider = MySiteSettings()) -> Bool {
         switch self {
         case .jetpackInstall:
-            return JetpackRemoteInstallCardView.shouldShowJetpackInstallCard
+            return JetpackInstallPluginHelper.shouldShowCard(for: blog)
         case .quickStart:
             return QuickStartTourGuide.quickStartEnabled(for: blog) && mySiteSettings.defaultSection == .dashboard
         case .draftPosts, .scheduledPosts, .todaysStats:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -745,7 +745,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }
 
-    if ([JetpackInstallPluginHelper shouldShowCardFor:self.blog]) {
+    if (![WPDeviceIdentification isiPad] && [JetpackInstallPluginHelper shouldShowCardFor:self.blog]) {
         [marr addObject:[self jetpackInstallSectionViewModel]];
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -745,7 +745,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }
 
-    if (JetpackRemoteInstallCardView.shouldShowJetpackInstallCard) {
+    if ([JetpackInstallPluginHelper shouldShowCardFor:self.blog]) {
         [marr addObject:[self jetpackInstallSectionViewModel]];
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -1,0 +1,46 @@
+@objcMembers
+class JetpackInstallPluginHelper: NSObject {
+
+    private static var cardHiddenSites: [String] {
+        get {
+            guard let sites = UserPersistentStoreFactory.instance().array(forKey: Constants.cardHiddenSitesKey) as? [String] else {
+                return [String]()
+            }
+            return sites
+        }
+        set {
+            UserPersistentStoreFactory.instance().set(newValue, forKey: Constants.cardHiddenSitesKey)
+        }
+    }
+
+    static func shouldShow(for blog: Blog?) -> Bool {
+        guard let blog, blog.account != nil else {
+            return false
+        }
+        let isFeatureEnabled = FeatureFlag.jetpackIndividualPluginSupport.enabled
+        return isFeatureEnabled && blog.jetpackIsConnectedWithoutFullPlugin
+    }
+
+    static func shouldShowCard(for blog: Blog?) -> Bool {
+        guard let siteID = blog?.dotComID?.stringValue else {
+            return false
+        }
+        let isCardHidden = cardHiddenSites.contains { $0 == siteID }
+        return shouldShow(for: blog) && !isCardHidden
+    }
+
+    static func hideCard(for blog: Blog?) {
+        guard let blog, let siteID = blog.dotComID?.stringValue else {
+            return
+        }
+
+        var sites = cardHiddenSites
+        sites.append(siteID)
+        cardHiddenSites = sites
+    }
+
+    private struct Constants {
+        static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
+    }
+
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
@@ -64,9 +64,8 @@ class JetpackRemoteInstallCardView: UIView {
     private lazy var contextMenu: UIMenu = {
         let hideThisAction = UIAction(title: Strings.hideThis,
                                       image: Constants.hideThisImage,
-                                      attributes: [UIMenuElement.Attributes.destructive]) { _ in
-            // TODO: Showing/hiding the card
-        }
+                                      attributes: [UIMenuElement.Attributes.destructive],
+                                      handler: viewModel.onHideThisTap)
         return UIMenu(title: String(), options: .displayInline, children: [hideThisAction])
     }()
 
@@ -134,6 +133,7 @@ class JetpackRemoteInstallCardView: UIView {
 struct JetpackRemoteInstallCardViewModel {
 
     let layoutDirection: UITraitEnvironmentLayoutDirection
+    let onHideThisTap: UIActionHandler
     let onLearnMoreTap: () -> Void
     var noticeLabel: NSAttributedString {
         switch installedPlugin {
@@ -153,9 +153,11 @@ struct JetpackRemoteInstallCardViewModel {
     private let installedPlugin: JetpackPlugin
 
     init(layoutDirection: UITraitEnvironmentLayoutDirection = .leftToRight,
+         onHideThisTap: @escaping UIActionHandler = { _ in },
          onLearnMoreTap: @escaping () -> Void = {},
          installedPlugin: JetpackPlugin = .multiple) {
         self.layoutDirection = layoutDirection
+        self.onHideThisTap = onHideThisTap
         self.onLearnMoreTap = onLearnMoreTap
         self.installedPlugin = installedPlugin
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
@@ -5,12 +5,6 @@ class JetpackRemoteInstallCardView: UIView {
 
     // MARK: Properties
 
-    @objc static var shouldShowJetpackInstallCard: Bool {
-        // TODO: Display logic for showing/hiding the card
-        // TODO: iPad display logic. Currently displays in both menu and dashboard
-        return false
-    }
-
     private let viewModel: JetpackRemoteInstallCardViewModel
 
     private lazy var animation: Animation? = {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
@@ -8,7 +8,7 @@ class JetpackRemoteInstallCardView: UIView {
     private let viewModel: JetpackRemoteInstallCardViewModel
 
     private lazy var animation: Animation? = {
-        viewModel.layoutDirection == .leftToRight ?
+        effectiveUserInterfaceLayoutDirection == .leftToRight ?
         Animation.named(Constants.lottieLTRFileName) :
         Animation.named(Constants.lottieRTLFileName)
     }()
@@ -132,7 +132,6 @@ class JetpackRemoteInstallCardView: UIView {
 
 struct JetpackRemoteInstallCardViewModel {
 
-    let layoutDirection: UITraitEnvironmentLayoutDirection
     let onHideThisTap: UIActionHandler
     let onLearnMoreTap: () -> Void
     var noticeLabel: NSAttributedString {
@@ -152,11 +151,9 @@ struct JetpackRemoteInstallCardViewModel {
 
     private let installedPlugin: JetpackPlugin
 
-    init(layoutDirection: UITraitEnvironmentLayoutDirection = .leftToRight,
-         onHideThisTap: @escaping UIActionHandler = { _ in },
+    init(onHideThisTap: @escaping UIActionHandler = { _ in },
          onLearnMoreTap: @escaping () -> Void = {},
          installedPlugin: JetpackPlugin = .multiple) {
-        self.layoutDirection = layoutDirection
         self.onHideThisTap = onHideThisTap
         self.onLearnMoreTap = onLearnMoreTap
         self.installedPlugin = installedPlugin

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -8,8 +8,16 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
     private var blog: Blog?
     private weak var presenterViewController: BlogDetailsViewController?
 
+    private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
+        let onHideThisTap: UIActionHandler = { [weak self] _ in
+            JetpackInstallPluginHelper.hideCard(for: self?.blog)
+            self?.presenterViewController?.reloadTableView()
+        }
+        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap)
+    }()
+
     private lazy var cardView: JetpackRemoteInstallCardView = {
-        let cardView = JetpackRemoteInstallCardView()
+        let cardView = JetpackRemoteInstallCardView(cardViewModel)
         cardView.translatesAutoresizingMaskIntoConstraints = false
         return cardView
     }()

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1927,6 +1927,8 @@
 		8379669D299C0C44004A92B9 /* JetpackRemoteInstallTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8379669B299C0C44004A92B9 /* JetpackRemoteInstallTableViewCell.swift */; };
 		8379669F299D51EC004A92B9 /* JetpackPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8379669E299D51EC004A92B9 /* JetpackPlugin.swift */; };
 		837966A0299D51EC004A92B9 /* JetpackPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8379669E299D51EC004A92B9 /* JetpackPlugin.swift */; };
+		837966A2299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */; };
+		837966A3299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */; };
 		837B49D7283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */; };
 		837B49D8283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */; };
 		837B49D9283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 837B49D4283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift */; };
@@ -7130,6 +7132,7 @@
 		83796698299C048E004A92B9 /* DashboardJetpackInstallCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardJetpackInstallCardCell.swift; sourceTree = "<group>"; };
 		8379669B299C0C44004A92B9 /* JetpackRemoteInstallTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackRemoteInstallTableViewCell.swift; sourceTree = "<group>"; };
 		8379669E299D51EC004A92B9 /* JetpackPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackPlugin.swift; sourceTree = "<group>"; };
+		837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackInstallPluginHelper.swift; sourceTree = "<group>"; };
 		837B49C6283C28730061A657 /* WordPress 141.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 141.xcdatamodel"; sourceTree = "<group>"; };
 		837B49D3283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BloggingPromptSettings+CoreDataClass.swift"; sourceTree = "<group>"; };
 		837B49D4283C2AE80061A657 /* BloggingPromptSettings+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BloggingPromptSettings+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -14135,6 +14138,7 @@
 		9A8ECE032254A3260043C8DA /* Install */ = {
 			isa = PBXGroup;
 			children = (
+				837966A1299E9C85004A92B9 /* JetpackInstallPluginHelper.swift */,
 				8379669E299D51EC004A92B9 /* JetpackPlugin.swift */,
 				9A8ECE062254A3260043C8DA /* JetpackRemoteInstallViewController.swift */,
 				9A8ECE1F22550A210043C8DA /* Error */,
@@ -21332,6 +21336,7 @@
 				D8212CC520AA83F9008E8AE8 /* ReaderCommentAction.swift in Sources */,
 				FAD954B825B7A99900F011B5 /* JetpackBackupStatusFailedViewController.swift in Sources */,
 				37EAAF4D1A11799A006D6306 /* CircularImageView.swift in Sources */,
+				837966A2299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */,
 				3FD0316F24201E08005C0993 /* GravatarButtonView.swift in Sources */,
 				7EBB4126206C388100012D98 /* StockPhotosService.swift in Sources */,
 				E17FEADA221494B2006E1D2D /* Blog+Analytics.swift in Sources */,
@@ -24321,6 +24326,7 @@
 				FABB24F52602FC2C00C8785C /* ReaderTagTopic.swift in Sources */,
 				FABB24F62602FC2C00C8785C /* Media.swift in Sources */,
 				9839CEBC26FAA0530097406E /* CommentModerationBar.swift in Sources */,
+				837966A3299E9C85004A92B9 /* JetpackInstallPluginHelper.swift in Sources */,
 				17039227282E6DF500F602E9 /* ViewsVisitorsChartMarker.swift in Sources */,
 				FABB24F72602FC2C00C8785C /* WordPressOrgRestApi+WordPress.swift in Sources */,
 				FABB24F82602FC2C00C8785C /* GravatarPickerViewController.swift in Sources */,


### PR DESCRIPTION
See #20153 

## Description

- Adds the `JetpackInstallPluginHelper` class with helper display functions
- Hides the Jetpack install card in the `Menu` for iPad
- Adds an action for `Hide this` on the Jetpack install cards
- Updates the Jetpack install card's layout direction logic

## Testing

> **Note**
> These instructions assume the tests are done in order. Some of the steps will be assumed completed such as enabling the feature flag in a previous test.

### Prerequisites

- Setup a self-hosted site with an individual Jetpack plugin installed and connected to your WP account
- Setup a self-hosted site with the full plugin installed and connected to your WP account

Test code for making the `Hide this` testing easier:

**`MySiteViewController.swift#450-#455`**
```swift
    private func pulledToRefresh() {
        UserPersistentStoreFactory.instance().set([String](), forKey: "jetpack-install-card-hidden-sites")
        guard let blog = blog,
              let section = currentSection else {
                  return
        }

```

### Feature flag logic

- Set `jetpackIndividualPluginSupport` set to `false` if needed
- Install Jetpack, login, and select the self-hosted site with the **individual plugin**
- Navigate to the `Home` dashboard if necessary
- **Verify** the Jetpack install card does not display
- Tap on `Menu`
- **Verify** the Jetpack install card does not display
- Set `jetpackIndividualPluginSupport` set to `true`
- Navigate to the `Home` dashboard
- **Verify** the Jetpack install card does display
- Tap on `Menu`
- **Verify** the Jetpack install card does display

### Jetpack full plugin display logic

- Select the self-hosted site with the **full Jetpack plugin**
- Navigate to the `Home` dashboard if necessary
- **Verify** the Jetpack install card does not display
- Tap on `Menu`
- **Verify** the Jetpack install card does not display

### Hide this menu action

- Use the test code from the Prerequisites section
- Select the self-hosted site with the **individual plugin**
- Navigate to the `Home` dashboard if necessary
- Tap on the context menu `...` on the install card
- Tap on `Hide this`
- **Verify** the install card is hidden
- Tap on `Menu`
- **Verify** the install card is hidden
- While on the `Menu` screen, pull to refresh to make it appear again
- Tap on the context menu `...` on the install card
- Tap on `Hide this`
- **Verify** the install card is hidden
- Tap on `Home`
- **Verify** the install card is hidden

### Layout direction

- Edit the Jetpack scheme, under `Run` > `Options`, change the `App Language` to `Right-to-Left Pseudolanguage`
- Launch the app and select the self-hosted site with the **individual plugin**
- Pull to refresh if necessary
- **Verify** the RtL layout for card is correct

### iPad

- Select an iPad simulator
- Install Jetpack, login, and select the self-hosted site with the **individual plugin**
- Set `jetpackIndividualPluginSupport` set to `true` if necessary
- **Verify**:
  - The install card does not show up in the `Menu` view
  - The install card does show up on the `Home` dashboard

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
