### PR TITLE
Take user support to Help screen instead of Zendesk

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -180,13 +180,9 @@ open class DeleteSiteViewController: UITableViewController {
 
         WPAppAnalytics.track(.siteSettingsStartOverContactSupportClicked, with: blog)
 
-        if ZendeskUtils.zendeskEnabled {
-            ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: self, with: .deleteSite)
-        } else {
-            if let contact = URL(string: "https://support.wordpress.com/contact/") {
-                UIApplication.shared.open(contact)
-            }
-        }
+        let supportViewController = SupportTableViewController()
+        supportViewController.sourceTag = .deleteSite
+        supportViewController.showFromTabBar()
     }
 
     // MARK: - Delete Site Helpers

--- a/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/WordPressAuthenticationManager.swift
@@ -293,33 +293,14 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag,
                         lastStep: AuthenticatorAnalyticsTracker.Step,
                         lastFlow: AuthenticatorAnalyticsTracker.Flow) {
-        // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
-        WPStyleGuide.configureNavigationAppearance()
-
-        // Since we're presenting the support VC as a form sheet, the parent VC's viewDidAppear isn't called
-        // when this VC is dismissed.  This means the tracking step isn't reset properly, so we'll need to do
-        // it here manually before tracking the new step.
-        let step = tracker.state.lastStep
-
-        tracker.track(step: .help)
-
-        let controller = SupportTableViewController { [weak self] in
-            self?.tracker.track(click: .dismiss)
-            self?.tracker.set(step: step)
-        }
-        controller.sourceTag = sourceTag
-
-        let navController = UINavigationController(rootViewController: controller)
-        navController.modalPresentationStyle = .formSheet
-
-        sourceViewController.present(navController, animated: true)
+        presentSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
     /// Presents Support new request, with the specified ViewController as a source.
     /// Additional metadata is supplied, such as the sourceTag and Login details.
     ///
     func presentSupportRequest(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
-        ZendeskUtils.sharedInstance.showNewRequestIfPossible(from: sourceViewController, with: sourceTag)
+        presentSupport(from: sourceViewController, sourceTag: sourceTag)
     }
 
     /// A self-hosted site URL is available and needs validated
@@ -734,5 +715,33 @@ private extension WordPressAuthenticationManager {
             RecentSitesService().touch(blog: blog)
             onCompletion()
         }
+    }
+}
+
+// MARK: - Support Helper
+//
+private extension WordPressAuthenticationManager {
+    /// Presents the support screen which displays different support options depending on whether this is the WordPress app or the Jetpack app.
+    private func presentSupport(from sourceViewController: UIViewController, sourceTag: WordPressSupportSourceTag) {
+        // Reset the nav style so the Support nav bar has the WP style, not the Auth style.
+        WPStyleGuide.configureNavigationAppearance()
+
+        // Since we're presenting the support VC as a form sheet, the parent VC's viewDidAppear isn't called
+        // when this VC is dismissed.  This means the tracking step isn't reset properly, so we'll need to do
+        // it here manually before tracking the new step.
+        let step = tracker.state.lastStep
+
+        tracker.track(step: .help)
+
+        let controller = SupportTableViewController { [weak self] in
+            self?.tracker.track(click: .dismiss)
+            self?.tracker.set(step: step)
+        }
+        controller.sourceTag = sourceTag
+
+        let navController = UINavigationController(rootViewController: controller)
+        navController.modalPresentationStyle = .formSheet
+
+        sourceViewController.present(navController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
@@ -7,6 +7,7 @@ struct SupportTableViewControllerConfiguration {
     var meHeaderConfiguration: MeHeaderView.Configuration?
     var showsLogOutButton: Bool = false
     var showsLogsSection: Bool = true
+    
 
     // MARK: Default Configurations
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewControllerConfiguration.swift
@@ -7,7 +7,6 @@ struct SupportTableViewControllerConfiguration {
     var meHeaderConfiguration: MeHeaderView.Configuration?
     var showsLogOutButton: Bool = false
     var showsLogsSection: Bool = true
-    
 
     // MARK: Default Configurations
 


### PR DESCRIPTION
Addresses #20117

There are many flows throughout the app where we offer user support. This PR aims to update some of them – both in the JP and the WP app – to open the Help screen. Previously the app would skip the "Help" screen and go straight to Zendesk's "Contact us" screen. We're changing this to later tailor user support by customizing the Help screen based on what app is running (JP vs. WP) and which user is logged in.

This change adds another step between a user wanting support and getting it. However, the app now offers two types of support (forum and Zendesk) so taking the user always to the "Help" screen allows us to customize their support experience. It also allows us to provide users with guides/docs on the "Help" screen so they can get solutions to their problems faster.

⚠️ Not covered by this PR are support options: the app review flow and the "start over" flow. They will be covered in separate PRs.

## To test

When testing, I tried both on an iPad and an iPhone since the presentation logic for the "Help" screen differs in each case.

### Flow: User has trouble finding their site address
1. Tap "Enter your existing site address"
2. Tap "Find your site address"
3. Tap "Need more help?"
4. Notice the app now opens the Help screen instead of the "Contact us" screen as seen below


<details>
  <summary>See diagram ⬇️</summary>
   <img width="2000" alt="A diagram showing how the new support flow in login takes the user to the Help screen" src="https://user-images.githubusercontent.com/1898325/219492492-1ac8fe4d-f329-46be-b191-bb02f7d929d7.png">
</details>

### Flow: Device has no internet during login
1. Tap "Log in or sign up with WordPress.com"
2. Enter an email address
3. Turn off the device's internet connection
4. Tap "Continue"
5. Tap "Need more help?"
6. Notice the app now opens the Help screen instead of the "Contact us" screen (very similar to the previous scenario)

### Flow: User has trouble deleting site
1. Log in to WP.com account
2. Tap "Menu" 
3. Tap "Site Settings"
4. Tap "Delete Site"
5. Tap "Contact Support"
6. Notice the app now opens the Help screen instead of the "Contact us" screen as seen below


<details>
  <summary>See diagram ⬇️</summary>
  <img width="2000" alt="A diagram showing how the new support flow in the site deletion flow takes the user to the Help screen" src="https://user-images.githubusercontent.com/1898325/219496693-d373805e-7f4b-432c-adba-4828af761de2.png">
</details>


## Regression Notes
1. Potential unintended areas of impact

This change could impact users' ability to get support if not implemented correctly.

10. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested the above scenarios on iPhone and ~~some~~ on iPad.

11. What automated tests I added (or what prevented me from doing so)

I didn't try adding automated tests because I felt that the flows and presentation logic wouldn't be suited to unit tests. As for UI tests, I don't think we have them for the contact support flow and I don't think we add new ones to avoid increasing CI test time.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
