### PR TITLE
Jetpack Plugin: Jetpack Install Card Tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -434,6 +434,9 @@ import Foundation
     case jetpackInstallFullPluginRetryTapped
     case jetpackInstallFullPluginCompleted
     case jetpackInstallFullPluginDoneTapped
+    case jetpackInstallFullPluginCardViewed
+    case jetpackInstallFullPluginCardTapped
+    case jetpackInstallFullPluginCardDismissed
 
     // Help & Support
     case supportOpenMobileForumTapped
@@ -1184,6 +1187,12 @@ import Foundation
             return "jp_install_full_plugin_flow_success"
         case .jetpackInstallFullPluginDoneTapped:
             return "jp_install_full_plugin_flow_done_tapped"
+        case .jetpackInstallFullPluginCardViewed:
+            return "jp_install_full_plugin_card_viewed"
+        case .jetpackInstallFullPluginCardTapped:
+            return "jp_install_full_plugin_card_tapped"
+        case .jetpackInstallFullPluginCardDismissed:
+            return "jp_install_full_plugin_card_dismissed"
 
         // Help & Support
         case .supportOpenMobileForumTapped:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -73,11 +73,11 @@ final class BlogDashboardViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
-        viewModel.loadCards { cards in
-            guard cards.hasPrompts else {
+        viewModel.loadCards { [weak self] cards in
+            guard let trackCardViewed = self?.trackCardViewed else {
                 return
             }
-            WPAnalytics.track(.promptsDashboardCardViewed)
+            cards.forEach(trackCardViewed)
         }
         QuickStartTourGuide.shared.currentEntryPoint = .blogDashboard
         startAlertTimer()
@@ -207,6 +207,13 @@ final class BlogDashboardViewController: UIViewController {
     @objc private func willEnterForeground() {
         BlogDashboardAnalytics.shared.reset()
         loadCards()
+    }
+
+    private func trackCardViewed(_ card: DashboardCardModel) {
+        guard let event = card.cardType.viewedAnalytic else {
+            return
+        }
+        WPAnalytics.track(event, properties: [WPAppAnalyticsKeyTabSource: "dashboard"])
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -9,10 +9,16 @@ class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
 
     private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
         let onHideThisTap: UIActionHandler = { [weak self] _ in
+            WPAnalytics.track(.jetpackInstallFullPluginCardDismissed, properties: [WPAppAnalyticsKeyTabSource: "dashboard"])
             JetpackInstallPluginHelper.hideCard(for: self?.blog)
             self?.presenterViewController?.reloadCardsLocally()
         }
-        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap)
+
+        let onLearnMoreTap: () -> Void = {
+            WPAnalytics.track(.jetpackInstallFullPluginCardTapped, properties: [WPAppAnalyticsKeyTabSource: "dashboard"])
+        }
+        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap,
+                                                 onLearnMoreTap: onLearnMoreTap)
     }()
 
     private lazy var cardView: JetpackRemoteInstallCardView = {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/DashboardCard.swift
@@ -48,6 +48,17 @@ enum DashboardCard: String, CaseIterable {
         }
     }
 
+    var viewedAnalytic: WPAnalyticsEvent? {
+        switch self {
+        case .jetpackInstall:
+            return .jetpackInstallFullPluginCardViewed
+        case .prompts:
+            return .promptsDashboardCardViewed
+        default:
+            return nil
+        }
+    }
+
     func shouldShow(for blog: Blog, apiResponse: BlogDashboardRemoteEntity? = nil, mySiteSettings: DefaultSectionProvider = MySiteSettings()) -> Bool {
         switch self {
         case .jetpackInstall:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -416,6 +416,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     
     tourGuide.currentEntryPoint = QuickStartTourEntryPointBlogDetails;
     [WPAnalytics trackEvent: WPAnalyticsEventMySiteSiteMenuShown];
+
+    if ([self shouldShowJetpackInstall]) {
+        [WPAnalytics trackEvent:WPAnalyticsEventJetpackInstallFullPluginCardViewed
+                     properties:@{WPAppAnalyticsKeyTabSource: @"site_menu"}];
+    }
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -745,7 +750,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }
 
-    if (![WPDeviceIdentification isiPad] && [JetpackInstallPluginHelper shouldShowCardFor:self.blog]) {
+    if ([self shouldShowJetpackInstall]) {
         [marr addObject:[self jetpackInstallSectionViewModel]];
     }
 
@@ -1700,6 +1705,11 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[UIApplication sharedApplication] openURL:[NSURL URLWithString:dashboardUrl] options:nil completionHandler:nil];
 
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
+}
+
+- (BOOL)shouldShowJetpackInstall
+{
+    return ![WPDeviceIdentification isiPad] && [JetpackInstallPluginHelper shouldShowCardFor:self.blog];
 }
 
 #pragma mark - Remove Site

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -10,10 +10,15 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
 
     private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
         let onHideThisTap: UIActionHandler = { [weak self] _ in
+            WPAnalytics.track(.jetpackInstallFullPluginCardDismissed, properties: [WPAppAnalyticsKeyTabSource: "site_menu"])
             JetpackInstallPluginHelper.hideCard(for: self?.blog)
             self?.presenterViewController?.reloadTableView()
         }
-        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap)
+        let onLearnMoreTap: () -> Void = {
+            WPAnalytics.track(.jetpackInstallFullPluginCardTapped, properties: [WPAppAnalyticsKeyTabSource: "site_menu"])
+        }
+        return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap,
+                                                 onLearnMoreTap: onLearnMoreTap)
     }()
 
     private lazy var cardView: JetpackRemoteInstallCardView = {


### PR DESCRIPTION
See: #20019 
Requires changes from the previous PR #20155

## Description

Adds tracks when the card is viewed, dismissed, or when `Learn more` is tapped.

## Testing


### Prerequisites

- Setup a self-hosted site with an individual Jetpack plugin installed and connected to your WP account

Test code for making the `Hide this` testing easier:

**`MySiteViewController.swift#450-#455`**
```swift
    private func pulledToRefresh() {
        UserPersistentStoreFactory.instance().set([String](), forKey: "jetpack-install-card-hidden-sites")
        guard let blog = blog,
              let section = currentSection else {
                  return
        }

```

### Tracks

- Set `jetpackIndividualPluginSupport` set to `true`
- Install Jetpack, login, and select the self-hosted site with the **individual plugin**
- Navigate to the `Home` dashboard if necessary
- **Verify** `🔵 Tracked: jp_install_full_plugin_card_viewed <tab_source: dashboard>` is sent
- Tap on `Learn more`
- **Verify** `🔵 Tracked: jp_install_full_plugin_card_tapped <tab_source: dashboard>` is sent
- Tap on the context menu `...`
- Tap on `Hide this`
- **Verify** `🔵 Tracked: jp_install_full_plugin_card_dismissed <tab_source: dashboard>` is sent
- Pull to refresh so the card appears again with the test code
- Tap on `Menu`
- Repeat the above steps verifying each track except **tab_source** should be `site_menu`

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
