### PR TITLE
Fix potential concurrency issues in some Core Data queries

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+FollowedInterests.swift
@@ -83,10 +83,9 @@ extension ReaderTopicService: ReaderFollowedInterestsService {
     }
 
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = self.coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        let token = self.coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.authToken
         }
-        let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,
                                               userAgent: WPUserAgent.wordPress())

--- a/WordPress/Classes/Services/ReaderTopicService+Interests.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Interests.swift
@@ -25,10 +25,9 @@ extension ReaderTopicService: ReaderInterestsService {
 
     /// Creates a new WP.com API instances that allows us to specify the LocaleKeyV2
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        let token = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.authToken
         }
-        let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,
                                               userAgent: WPUserAgent.wordPress(),

--- a/WordPress/Classes/Services/ReaderTopicService+SiteInfo.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+SiteInfo.swift
@@ -17,10 +17,9 @@ extension ReaderTopicService: ReaderSiteInfoService {
     }
 
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = self.coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        let token = self.coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.authToken
         }
-        let token: String? = defaultAccount?.authToken
 
         return WordPressComRestApi.defaultApi(oAuthToken: token,
                                               userAgent: WPUserAgent.wordPress())

--- a/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
@@ -13,11 +13,10 @@ extension ReaderTopicService {
     // MARK: Private methods
 
     private func apiRequest() -> WordPressComRestApi {
-
-        let defaultAccount = coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+        let api = coreDataStack.performQuery { context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.wordPressComRestApi
         }
-        if let api = defaultAccount?.wordPressComRestApi, api.hasCredentials() {
+        if let api, api.hasCredentials() {
             return api
         }
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -550,11 +550,11 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 {
     ReaderSiteTopic * __block siteTopic = nil;
 
-    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+    [self.coreDataStack.mainContext performBlockAndWait:^{
         if (isFeed) {
-            siteTopic = [ReaderSiteTopic lookupWithFeedID:siteID inContext:context];
+            siteTopic = [ReaderSiteTopic lookupWithFeedID:siteID inContext:self.coreDataStack.mainContext];
         } else {
-            siteTopic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:context];
+            siteTopic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:self.coreDataStack.mainContext];
         }
     }];
 

--- a/WordPress/Classes/Services/SiteSegmentsService.swift
+++ b/WordPress/Classes/Services/SiteSegmentsService.swift
@@ -19,17 +19,9 @@ final class SiteCreationSegmentsService: SiteSegmentsService {
     private let remoteService: WordPressComServiceRemote
 
     init(coreDataStack: CoreDataStack) {
-        let account = coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
-        }
-
-        let api: WordPressComRestApi
-
-        if let account {
-            api = account.wordPressComRestV2Api
-        } else {
-            api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
-        }
+        let api = coreDataStack.performQuery({ context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.wordPressComRestV2Api
+        }) ?? WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
 
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
     }

--- a/WordPress/Classes/Services/SiteVerticalsService.swift
+++ b/WordPress/Classes/Services/SiteVerticalsService.swift
@@ -55,16 +55,9 @@ final class SiteCreationVerticalsService: SiteVerticalsService {
     private let remoteService: WordPressComServiceRemote
 
     init(coreDataStack: CoreDataStack) {
-        let account = coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)
-        }
-
-        let api: WordPressComRestApi
-        if let account {
-            api = account.wordPressComRestV2Api
-        } else {
-            api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
-        }
+        let api = coreDataStack.performQuery({ context in
+            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.wordPressComRestV2Api
+        }) ?? WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.wordPress(), localeKey: WordPressComRestApi.LocaleKeyV2)
         self.remoteService = WordPressComServiceRemote(wordPressComRestApi: api)
     }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -68,13 +68,13 @@ class GutenbergSettings {
     func performGutenbergPhase2MigrationIfNeeded() {
         guard
             ReachabilityUtils.isInternetReachable(),
-            let account = coreDataStack.performQuery({ try? WPAccount.lookupDefaultWordPressComAccount(in: $0) })
+            let userID = coreDataStack.performQuery({ try? WPAccount.lookupDefaultWordPressComAccount(in: $0)?.userID })
         else {
             return
         }
 
         var rollout = GutenbergRollout(database: database)
-        if rollout.shouldPerformPhase2Migration(userId: account.userID.intValue) {
+        if rollout.shouldPerformPhase2Migration(userId: userID.intValue) {
             setGutenbergEnabledForAllSites()
             rollout.isUserInRolloutGroup = true
             trackSettingChange(to: true, from: .onProgressiveRolloutPhase2)


### PR DESCRIPTION
I realized I made a mistake to return a `NSManagedObject` in some `performQuery` calls. The potential issue with that pattern is, it's unsafe to access the main context bound `NSManagedObject` from a non-main thread.

This PR also corrected one place where I used `performAndSave` to perform a query 🤦‍♂️ 

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
