### PR TITLE
Show Zendesk to paying users

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  # pod 'WordPressKit', '~> 6.1.0-beta'
+  pod 'WordPressKit', '~> 6.1.0-beta'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'fix/plan-flag'
-  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '48d969d1fd9164e51b33bd4dc390ad1807f45f89'
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end
 

--- a/Podfile
+++ b/Podfile
@@ -47,10 +47,10 @@ def wordpress_ui
 end
 
 def wordpress_kit
-  pod 'WordPressKit', '~> 6.1.0-beta'
+  # pod 'WordPressKit', '~> 6.1.0-beta'
   # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', tag: ''
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: ''
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
+  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', branch: 'fix/plan-flag'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: '48d969d1fd9164e51b33bd4dc390ad1807f45f89'
   # pod 'WordPressKit', path: '../WordPressKit-iOS'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -511,7 +511,7 @@ PODS:
     - WordPressKit (~> 6.0-beta)
     - WordPressShared (~> 2.0-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (6.1.0-beta.1):
+  - WordPressKit (6.1.0-beta.2):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -612,7 +612,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 5.1-beta)
-  - WordPressKit (~> 6.1.0-beta)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `48d969d1fd9164e51b33bd4dc390ad1807f45f89`)
   - WordPressShared (~> 2.0-beta)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.7)
@@ -623,7 +623,6 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
-    - WordPressKit
     - WordPressShared
   trunk:
     - Alamofire
@@ -778,6 +777,9 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.89.0
+  WordPressKit:
+    :commit: 48d969d1fd9164e51b33bd4dc390ad1807f45f89
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.89.0/third-party-podspecs/Yoga.podspec.json
 
@@ -793,6 +795,9 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.89.0
+  WordPressKit:
+    :commit: 48d969d1fd9164e51b33bd4dc390ad1807f45f89
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -881,7 +886,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 0b13d0fc6488a9d6b2a48f4f841e41ce41f08f3b
-  WordPressKit: c44a1186285cf9bbd61c8e2c8ab323912d7de989
+  WordPressKit: 7e422fc4b5f274c0925fb9f5408265364abe2609
   WordPressShared: 8e59bc8cec256f54a7c4cc6c94911adc2a9a65d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
@@ -896,6 +901,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: d851d81f272d28ad08e164edaec3601d41c0198f
+PODFILE CHECKSUM: cbcc05904a09faed468f779758f1a480086841ff
 
 COCOAPODS: 1.11.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -511,7 +511,7 @@ PODS:
     - WordPressKit (~> 6.0-beta)
     - WordPressShared (~> 2.0-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (6.1.0-beta.2):
+  - WordPressKit (6.1.0-beta.3):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -612,7 +612,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.50)
   - WordPress-Editor-iOS (~> 1.19.8)
   - WordPressAuthenticator (~> 5.1-beta)
-  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `48d969d1fd9164e51b33bd4dc390ad1807f45f89`)
+  - WordPressKit (~> 6.1.0-beta)
   - WordPressShared (~> 2.0-beta)
   - WordPressUI (~> 1.12.5)
   - WPMediaPicker (~> 1.8.7)
@@ -623,6 +623,7 @@ DEPENDENCIES:
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
     - WordPressAuthenticator
+    - WordPressKit
     - WordPressShared
   trunk:
     - Alamofire
@@ -777,9 +778,6 @@ EXTERNAL SOURCES:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.89.0
-  WordPressKit:
-    :commit: 48d969d1fd9164e51b33bd4dc390ad1807f45f89
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   Yoga:
     :podspec: https://raw.githubusercontent.com/wordpress-mobile/gutenberg-mobile/v1.89.0/third-party-podspecs/Yoga.podspec.json
 
@@ -795,9 +793,6 @@ CHECKOUT OPTIONS:
     :git: https://github.com/wordpress-mobile/gutenberg-mobile.git
     :submodules: true
     :tag: v1.89.0
-  WordPressKit:
-    :commit: 48d969d1fd9164e51b33bd4dc390ad1807f45f89
-    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -886,7 +881,7 @@ SPEC CHECKSUMS:
   WordPress-Aztec-iOS: 7d11d598f14c82c727c08b56bd35fbeb7dafb504
   WordPress-Editor-iOS: 9eb9f12f21a5209cb837908d81ffe1e31cb27345
   WordPressAuthenticator: 0b13d0fc6488a9d6b2a48f4f841e41ce41f08f3b
-  WordPressKit: 7e422fc4b5f274c0925fb9f5408265364abe2609
+  WordPressKit: 1addcb4df350194b3e3fd2239afaac040f29293c
   WordPressShared: 8e59bc8cec256f54a7c4cc6c94911adc2a9a65d2
   WordPressUI: c5be816f6c7b3392224ac21de9e521e89fa108ac
   WPMediaPicker: 0d45dfd7b3c5651c5236ffd48c1b0b2f60a2d5d2
@@ -901,6 +896,6 @@ SPEC CHECKSUMS:
   ZendeskSupportSDK: 3a8e508ab1d9dd22dc038df6c694466414e037ba
   ZIPFoundation: ae5b4b813d216d3bf0a148773267fff14bd51d37
 
-PODFILE CHECKSUM: cbcc05904a09faed468f779758f1a480086841ff
+PODFILE CHECKSUM: 4ffd4693c4a029b5d79ba5f171448834181b3d2a
 
 COCOAPODS: 1.11.2

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -4,16 +4,22 @@ enum SupportConfiguration {
     case zendesk
     case forum
 
+    private static func hasSiteWithPaidPlan() -> Bool {
+        let allBlogs = (try? BlogQuery().blogs(in: ContextManager.sharedInstance().mainContext)) ?? []
+        return allBlogs.contains { $0.hasPaidPlan }
+    }
+
     static func current(
         featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
         isWordPress: Bool = AppConfiguration.isWordPress,
-        zendeskEnabled: Bool = ZendeskUtils.zendeskEnabled
+        zendeskEnabled: Bool = ZendeskUtils.zendeskEnabled,
+        hasPaidPlan: Bool = hasSiteWithPaidPlan()
     ) -> SupportConfiguration {
         guard zendeskEnabled else {
             return .forum
         }
 
-        if isWordPress && featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) {
+        if isWordPress && !hasPaidPlan && featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) {
             return .forum
         } else {
             return .zendesk

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -136,11 +136,11 @@ private extension SupportTableViewController {
 
     // MARK: - Table Model
 
-    func tableViewModel() -> ImmuTable {
+    func tableViewModel(supportConfiguration: SupportConfiguration) -> ImmuTable {
 
         // Support section
         let helpSection: ImmuTableSection?
-        switch SupportConfiguration.current() {
+        switch supportConfiguration {
         case .zendesk:
             var rows = [ImmuTableRow]()
             rows.append(HelpRow(title: LocalizedText.wpHelpCenter, action: helpCenterSelected(), accessibilityIdentifier: "help-center-link-button"))
@@ -161,7 +161,6 @@ private extension SupportTableViewController {
                                               accessibilityHint: LocalizedText.visitWpForumsButtonAccessibilityHint,
                                               action: visitForumsSelected(),
                                               accessibilityIdentifier: "visit-wordpress-forums-button"))
-
             helpSection = ImmuTableSection(headerText: LocalizedText.wpForumsSectionHeader, rows: rows, footerText: nil)
         }
 
@@ -201,7 +200,7 @@ private extension SupportTableViewController {
     }
 
     func reloadViewModel() {
-        tableHandler?.viewModel = tableViewModel()
+        tableHandler?.viewModel = tableViewModel(supportConfiguration: SupportConfiguration.current())
     }
 
     // MARK: - Row Handlers

--- a/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
+++ b/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
@@ -8,41 +8,56 @@ final class SupportConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration, .forum)
     }
 
-    func testSupportConfigurationWhenWordPressAndFeatureFlagEnabled() {
+    func testSupportConfigurationWhenWordPressWithFreePlanAndFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: true,
-            zendeskEnabled: true
+            zendeskEnabled: true,
+            hasPaidPlan: false
         )
 
         XCTAssertTrue(configuration == .forum)
     }
 
-    func testSupportConfigurationWhenWordPressAndFeatureFlagDisabled() {
+    func testSupportConfigurationWhenWordPressWithFreePlanAndFeatureFlagDisabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
             isWordPress: true,
-            zendeskEnabled: true
+            zendeskEnabled: true,
+            hasPaidPlan: false
         )
 
         XCTAssertTrue(configuration == .zendesk)
     }
 
-    func testSupportConfigurationWhenJetpackAndFeatureFlagEnabled() {
+    func testSupportConfigurationWhenWordPressWithPaidPlanAndFeatureFlagEnabled() {
+        let configuration = SupportConfiguration.current(
+            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
+            isWordPress: true,
+            zendeskEnabled: true,
+            hasPaidPlan: true
+        )
+
+        XCTAssertTrue(configuration == .zendesk)
+    }
+
+    func testSupportConfigurationWhenJetpackWithFreePlanAndFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: false,
-            zendeskEnabled: true
+            zendeskEnabled: true,
+            hasPaidPlan: false
         )
 
         XCTAssertTrue(configuration == .zendesk)
     }
 
-    func testSupportConfigurationWhenJetpackAndFeatureFlagDisabled() {
+    func testSupportConfigurationWhenJetpackWithPaidPlanAndFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
+            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: false,
-            zendeskEnabled: true
+            zendeskEnabled: true,
+            hasPaidPlan: true
         )
 
         XCTAssertTrue(configuration == .zendesk)


### PR DESCRIPTION
Fixes #20154

This PR updates the WP app to show Zendesk support to paying users (i.e. those with at least one site that has a paid plan) and show forum support to free users. No changes were made to the JP app.

⚠️ This PR relies on the following bug fix: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/578

## To test



Verify the following behavior:

| | Feature Flag | Plan | Support |
| - | - | - | - |
| WP App | On | Free | Forum |
| WP App | On | Paid | Zendesk |
| WP App | Off | Any | Zendesk |
| JP App | Any | Any | Zendesk |

Note:
- The feature flag is under Me | App Settings | Debug | "Provide support through a forum"
- If Zendesk is not available (if the Zendesk SDK isn't ready for whatever reason) we show the forum, no matter which app it is or what plan the user is on.

## Regression Notes
1. Potential unintended areas of impact

If this change isn't properly implemented, it could prevent users of the WP and JP apps from getting support.

5. What I did to test those areas of impact (or what existing automated tests I relied on)

I tested using the above table on an iPhone.

6. What automated tests I added (or what prevented me from doing so)

I updated existing tests to provide test coverage for this change.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
