### PR TITLE
Remove Buildkite commands that are included in the VM

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -16,10 +16,6 @@ echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products.tar
 tar -xf build-products.tar
 
-echo "--- :wrench: Fixing VM"
-brew install openjdk@11
-sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk
-
 echo "--- :rubygems: Setting up Gems"
 install_gems
 


### PR DESCRIPTION
### Summary of Changes

This PR removes: 
- The JDK install and fix commands from `run-ui-tests.sh`

Those commands are already included in the CI image manifest ([latest for the Xcode 14.2 image](https://github.com/Automattic/buildkite-ci/blob/trunk/src/macos-vms/manifests/xcode-14.2.yml)), so they don't need to be included in these scripts. 

### How to Test
- For the UI test script change, you can see in [a build before this change](https://buildkite.com/automattic/wordpress-ios/builds/12518#01865fdc-0bce-4344-a927-70c63b48710f) that CI reports that the JDK is already installed. After this change, the UI test step should still complete successfully. 

<img width="571" alt="Screenshot 2023-02-17 at 11 43 17 AM" src="https://user-images.githubusercontent.com/17955542/219757507-cf873a9d-5a24-4ec7-8ded-2979937a2f77.png">

