### PR TITLE
[JP Plugin] Fix UI issues for the T&C button

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -233,14 +233,12 @@ class JetpackFullscreenOverlayViewController: UIViewController {
 
         if let actionInfoText = viewModel.actionInfoText,
            !actionInfoText.string.isEmpty,
-           let titleLabel = actionInfoButton.titleLabel,
-           let stackView = actionInfoButton.superview as? UIStackView {
+           let titleLabel = actionInfoButton.titleLabel {
             titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
             titleLabel.adjustsFontForContentSizeCategory = true
             titleLabel.textAlignment = .center
             titleLabel.numberOfLines = 0
             actionInfoButton.pinSubviewToAllEdges(titleLabel)
-            stackView.setCustomSpacing(Metrics.actionInfoButtonBottomSpacing, after: actionInfoButton)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -54,7 +54,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     @IBOutlet weak var switchButton: UIButton!
     @IBOutlet weak var continueButton: UIButton!
     @IBOutlet weak var buttonsSuperViewBottomConstraint: NSLayoutConstraint!
-    @IBOutlet weak var actionInfoLabel: UILabel!
+    @IBOutlet weak var actionInfoButton: UIButton!
 
     // MARK: Initializers
 
@@ -137,13 +137,13 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         setTitle()
         subtitleLabel.attributedText = viewModel.subtitle
         footnoteLabel.text = viewModel.footnote
-        actionInfoLabel.attributedText = viewModel.actionInfoText
         switchButton.setTitle(viewModel.switchButtonText, for: .normal)
         continueButton.setTitle(viewModel.continueButtonText, for: .normal)
         footnoteLabel.isHidden = viewModel.footnoteIsHidden
         learnMoreButton.isHidden = viewModel.learnMoreButtonIsHidden
         continueButton.isHidden = viewModel.continueButtonIsHidden
         setupLearnMoreButtonTitle()
+        setupActionInfoButtonTitle()
     }
 
     private func setTitle() {
@@ -163,7 +163,7 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     private func setupColors() {
         view.backgroundColor = Colors.backgroundColor
         footnoteLabel.textColor = Colors.footnoteTextColor
-        actionInfoLabel.textColor = Colors.actionInfoTextColor
+        actionInfoButton.setTitleColor(Colors.actionInfoTextColor, for: .normal)
         learnMoreButton.tintColor = Colors.learnMoreButtonTextColor
         switchButton.backgroundColor = Colors.switchButtonBackgroundColor
         switchButton.tintColor = Colors.switchButtonTextColor
@@ -176,8 +176,6 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         subtitleLabel.adjustsFontForContentSizeCategory = true
         footnoteLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         footnoteLabel.adjustsFontForContentSizeCategory = true
-        actionInfoLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
-        actionInfoLabel.adjustsFontForContentSizeCategory = true
         learnMoreButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
         switchButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         continueButton.titleLabel?.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
@@ -227,6 +225,23 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         let learnMoreText = NSMutableAttributedString(string: "\(Strings.learnMoreButtonText) \u{FEFF}")
         learnMoreText.append(attachmentString)
         learnMoreButton.setAttributedTitle(learnMoreText, for: .normal)
+    }
+
+    private func setupActionInfoButtonTitle() {
+        actionInfoButton.setAttributedTitle(viewModel.actionInfoText, for: .normal)
+        actionInfoButton.isHidden = viewModel.actionInfoText == nil
+
+        if let actionInfoText = viewModel.actionInfoText,
+           !actionInfoText.string.isEmpty,
+           let titleLabel = actionInfoButton.titleLabel,
+           let stackView = actionInfoButton.superview as? UIStackView {
+            titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
+            titleLabel.adjustsFontForContentSizeCategory = true
+            titleLabel.textAlignment = .center
+            titleLabel.numberOfLines = 0
+            actionInfoButton.pinSubviewToAllEdges(titleLabel)
+            stackView.setCustomSpacing(Metrics.actionInfoButtonBottomSpacing, after: actionInfoButton)
+        }
     }
 
     // MARK: Actions
@@ -281,6 +296,7 @@ private extension JetpackFullscreenOverlayViewController {
         static let titleKern: CGFloat = 0.37
         static let buttonsNormalBottomSpacing: CGFloat = 30
         static let singleButtonBottomSpacing: CGFloat = 60
+        static let actionInfoButtonBottomSpacing: CGFloat = 24
     }
 
     enum Constants {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -98,17 +98,29 @@
                                         </view>
                                     </subviews>
                                 </stackView>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gHv-Wo-L7c" userLabel="Action Info Button">
+                                    <rect key="frame" x="29" y="418" width="317" height="30"/>
+                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                    <state key="normal">
+                                        <color key="titleColor" systemColor="secondaryLabelColor"/>
+                                    </state>
+                                </button>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstItem="TTg-Z6-h4X" firstAttribute="leading" secondItem="PbU-M0-J6O" secondAttribute="leading" constant="29" id="2d6-L5-bKl"/>
                                 <constraint firstItem="TTg-Z6-h4X" firstAttribute="top" relation="greaterThanOrEqual" secondItem="PbU-M0-J6O" secondAttribute="top" id="2nW-cN-NOi"/>
+                                <constraint firstItem="gHv-Wo-L7c" firstAttribute="leading" secondItem="TTg-Z6-h4X" secondAttribute="leading" id="9zz-z1-X7R"/>
                                 <constraint firstAttribute="trailing" secondItem="TTg-Z6-h4X" secondAttribute="trailing" constant="29" id="Q2G-S5-HVM"/>
-                                <constraint firstItem="TTg-Z6-h4X" firstAttribute="centerY" secondItem="PbU-M0-J6O" secondAttribute="centerY" id="WsY-Y2-V51"/>
+                                <constraint firstAttribute="bottom" secondItem="gHv-Wo-L7c" secondAttribute="bottom" constant="8" id="SJ0-jW-GXy"/>
+                                <constraint firstItem="gHv-Wo-L7c" firstAttribute="top" relation="greaterThanOrEqual" secondItem="TTg-Z6-h4X" secondAttribute="bottom" constant="20" id="xfD-Di-6UY"/>
+                                <constraint firstItem="gHv-Wo-L7c" firstAttribute="trailing" secondItem="TTg-Z6-h4X" secondAttribute="trailing" id="yKf-rX-Gsr"/>
                             </constraints>
                         </view>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="TTg-Z6-h4X" firstAttribute="centerY" secondItem="Qla-b8-9Ag" secondAttribute="centerY" priority="750" id="Bb8-jX-f5p"/>
                         <constraint firstItem="PbU-M0-J6O" firstAttribute="top" secondItem="Qla-b8-9Ag" secondAttribute="top" id="VPH-IZ-hYf"/>
                         <constraint firstAttribute="trailing" secondItem="PbU-M0-J6O" secondAttribute="trailing" id="VQr-HE-qvN"/>
                         <constraint firstAttribute="bottom" secondItem="PbU-M0-J6O" secondAttribute="bottom" id="ZRn-ZX-cw2"/>
@@ -120,15 +132,8 @@
                 <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="354" placeholderIntrinsicHeight="166" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vcE-wc-fHe">
                     <rect key="frame" x="10.5" y="471" width="354" height="166"/>
                     <subviews>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gHv-Wo-L7c" userLabel="Action Info Button">
-                            <rect key="frame" x="0.0" y="0.0" width="354" height="34"/>
-                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                            <state key="normal">
-                                <color key="titleColor" systemColor="secondaryLabelColor"/>
-                            </state>
-                        </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VGE-FS-gsd">
-                            <rect key="frame" x="0.0" y="42" width="354" height="50"/>
+                            <rect key="frame" x="0.0" y="0.0" width="354" height="50"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="354" id="93l-ng-h5B"/>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="DD0-7r-C5O">
@@ -142,7 +147,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hPW-8A-Di4">
-                            <rect key="frame" x="0.0" y="100" width="354" height="66"/>
+                            <rect key="frame" x="0.0" y="58" width="354" height="108"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="cH2-GJ-f7z">
                                     <variation key="heightClass=compact-widthClass=regular" constant="44"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -11,7 +11,7 @@
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="JetpackFullscreenOverlayViewController" customModule="WordPress" customModuleProvider="target">
             <connections>
-                <outlet property="actionInfoLabel" destination="aEp-ih-kuy" id="Cwy-BJ-fhk"/>
+                <outlet property="actionInfoButton" destination="gHv-Wo-L7c" id="cmp-X3-xhS"/>
                 <outlet property="animationView" destination="v3d-AD-Jsf" id="8wg-bB-WH5"/>
                 <outlet property="buttonsSuperViewBottomConstraint" destination="zhh-p2-mZx" id="4cZ-ra-9SF"/>
                 <outlet property="contentStackView" destination="TTg-Z6-h4X" id="rbe-WF-3kb"/>
@@ -98,23 +98,13 @@
                                         </view>
                                     </subviews>
                                 </stackView>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aEp-ih-kuy">
-                                    <rect key="frame" x="29" y="427.5" width="317" height="20.5"/>
-                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                    <nil key="textColor"/>
-                                    <nil key="highlightedColor"/>
-                                </label>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstItem="TTg-Z6-h4X" firstAttribute="leading" secondItem="PbU-M0-J6O" secondAttribute="leading" constant="29" id="2d6-L5-bKl"/>
                                 <constraint firstItem="TTg-Z6-h4X" firstAttribute="top" relation="greaterThanOrEqual" secondItem="PbU-M0-J6O" secondAttribute="top" id="2nW-cN-NOi"/>
-                                <constraint firstItem="aEp-ih-kuy" firstAttribute="trailing" secondItem="TTg-Z6-h4X" secondAttribute="trailing" id="OkA-Av-jes"/>
                                 <constraint firstAttribute="trailing" secondItem="TTg-Z6-h4X" secondAttribute="trailing" constant="29" id="Q2G-S5-HVM"/>
-                                <constraint firstAttribute="bottom" secondItem="aEp-ih-kuy" secondAttribute="bottom" constant="8" id="UMz-vz-s2I"/>
                                 <constraint firstItem="TTg-Z6-h4X" firstAttribute="centerY" secondItem="PbU-M0-J6O" secondAttribute="centerY" id="WsY-Y2-V51"/>
-                                <constraint firstItem="aEp-ih-kuy" firstAttribute="leading" secondItem="TTg-Z6-h4X" secondAttribute="leading" id="b5S-wL-EE8"/>
-                                <constraint firstItem="aEp-ih-kuy" firstAttribute="top" relation="greaterThanOrEqual" secondItem="TTg-Z6-h4X" secondAttribute="top" id="f30-as-UAp"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -130,8 +120,15 @@
                 <stackView opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="354" placeholderIntrinsicHeight="166" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="vcE-wc-fHe">
                     <rect key="frame" x="10.5" y="471" width="354" height="166"/>
                     <subviews>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gHv-Wo-L7c" userLabel="Action Info Button">
+                            <rect key="frame" x="0.0" y="0.0" width="354" height="34"/>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal">
+                                <color key="titleColor" systemColor="secondaryLabelColor"/>
+                            </state>
+                        </button>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VGE-FS-gsd">
-                            <rect key="frame" x="0.0" y="0.0" width="354" height="50"/>
+                            <rect key="frame" x="0.0" y="42" width="354" height="50"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="lessThanOrEqual" constant="354" id="93l-ng-h5B"/>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="DD0-7r-C5O">
@@ -145,7 +142,7 @@
                             </connections>
                         </button>
                         <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hPW-8A-Di4">
-                            <rect key="frame" x="0.0" y="58" width="354" height="108"/>
+                            <rect key="frame" x="0.0" y="100" width="354" height="66"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="50" id="cH2-GJ-f7z">
                                     <variation key="heightClass=compact-widthClass=regular" constant="44"/>
@@ -188,6 +185,9 @@
         </designable>
     </designables>
     <resources>
+        <systemColor name="secondaryLabelColor">
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -107,7 +107,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     }
 
     private static func actionInfoString() -> NSAttributedString {
-        let actionInfoBaseFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        let actionInfoBaseFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         let actionInfoBaseText = NSAttributedString(string: Strings.footnote, attributes: [.font: actionInfoBaseFont])
 
         let actionInfoTermsText = NSAttributedString(


### PR DESCRIPTION
Refs #20016

The T&C now lives inside the `UIStackView` on the bottom, which houses the "Switch" and "Continue" option. This is to fix the accessibility issue for large font sizes. Here's how it looks:

Before | After
--|--
<img src="https://user-images.githubusercontent.com/1299411/217323653-4a58dc9f-20cf-4308-a445-3ed99a2371b4.png"> | ![Fixed](https://user-images.githubusercontent.com/1299411/219770768-ff28674e-6ffd-4bcd-8885-1a957b6b4bf9.png)

Note that I've decided to implement the functionality, along with the review comments in #20132 through a separate PR.

## To test

Use this code in the `JetpackFeaturesRemovalCoordinator`:
```swift
    static func presentOverlayIfNeeded(in viewController: UIViewController,
                                       source: OverlaySource,
                                       forced: Bool = false,
                                       fullScreen: Bool = false,
                                       blog: Blog? = nil,
                                       onWillDismiss: JetpackOverlayDismissCallback? = nil,
                                       onDidDismiss: JetpackOverlayDismissCallback? = nil) {
//        let phase = generalPhase()
//        let frequencyConfig = phase.frequencyConfig
//        let frequencyTrackerPhaseString = source.frequencyTrackerPhaseString(phase: phase)
//
//        let coordinator = JetpackDefaultOverlayCoordinator()
//        let viewModel = JetpackFullscreenOverlayGeneralViewModel(phase: phase, source: source, blog: blog, coordinator: coordinator)
//        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
//        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
//        coordinator.navigationController = navigationViewController
//        coordinator.viewModel = viewModel
//        viewModel.onWillDismiss = onWillDismiss
//        viewModel.onDidDismiss = onDidDismiss
//        let frequencyTracker = JetpackOverlayFrequencyTracker(frequencyConfig: frequencyConfig,
//                                                              phaseString: frequencyTrackerPhaseString,
//                                                              source: source)
//        guard viewModel.shouldShowOverlay, frequencyTracker.shouldShow(forced: forced) else {
//            onWillDismiss?()
//            onDidDismiss?()
//            return
//        }
        let pluginVM = JetpackPluginOverlayViewModel(siteName: "site.blog", plugin: .multiple)
        let pluginVC = JetpackFullscreenOverlayViewController(with: pluginVM)
        let pluginCoordinator = JetpackPluginOverlayCoordinator(viewController: pluginVC)
        let navigationViewController = UINavigationController(rootViewController: pluginVC)
        pluginVM.coordinator = pluginCoordinator

        presentOverlay(navigationViewController: navigationViewController, in: viewController, fullScreen: fullScreen)
//        frequencyTracker.track()
```

This is a temporary test code that forces the overlay appear every time the app is minimized. Here are the testing notes:

- Enable the feature flag `jetpackInstallPluginSupport`.
- Open the Jetpack app, and observe that the plugin install overlay is called.
- Go to Xcode > Environment Overrides > Enable Dynamic Type. Set the size to AX1 / Accessibility 1.
- Verify that the Terms & Conditions text is now always visible above the button.

### Testing for cases without `actionInfo`

Return `nil` for `actionInfoText` in `JetpackPluginOverlayViewModel`, so we can test other cases that don't need `actionInfo`:

```swift
let actionInfoText: NSAttributedString? = nil // JetpackPluginOverlayViewModel.actionInfoString()
```

- Run the app again.
- Verify that the terms & conditions button is gone, and doesn't introduce any extra spaces to the existing one.

## Regression Notes
1. Potential unintended areas of impact
Potentially affecting the Features Removal overlay.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
