### PR TITLE
[JP Plugin] Implement overlay logic

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -1,3 +1,5 @@
+import WordPressAuthenticator
+
 final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     private unowned let viewController: UIViewController
 
@@ -14,12 +16,27 @@ final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     }
 
     func navigateToSecondaryRoute() {
-        // TODO: Contact support with support origin.
+        guard let navigationController = viewController.navigationController else {
+            return
+        }
+
+        let supportViewController = SupportTableViewController()
+        supportViewController.sourceTag = Constants.supportSourceTag
+        navigationController.pushViewController(supportViewController, animated: true)
     }
 
     func navigateToLinkRoute(url: URL, source: String) {
         let webViewController = WebViewControllerFactory.controller(url: url, source: source)
         let navigationController = UINavigationController(rootViewController: webViewController)
         presentingViewController.present(navigationController, animated: true)
+    }
+}
+
+private extension JetpackPluginOverlayCoordinator {
+    enum Constants {
+        static let supportSourceTag = WordPressSupportSourceTag(
+            name: "jetpackInstallFullPluginOverlay",
+            origin: "origin:jp-install-full-plugin-overlay"
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -1,6 +1,10 @@
 final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     private unowned let viewController: UIViewController
 
+    private var presentingViewController: UIViewController {
+        return viewController.navigationController ?? viewController
+    }
+
     init(viewController: UIViewController) {
         self.viewController = viewController
     }
@@ -14,6 +18,8 @@ final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     }
 
     func navigateToLinkRoute(url: URL, source: String) {
-        // TODO: Open wordpress.com/tos via in-app browser.
+        let webViewController = WebViewControllerFactory.controller(url: url, source: source)
+        let navigationController = UINavigationController(rootViewController: webViewController)
+        presentingViewController.present(navigationController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -298,6 +298,10 @@ final class JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayVi
     var isCompact: Bool {
         return phase == .newUsers
     }
+
+    func didTapActionInfo() {
+        // No op.
+    }
 }
 
 // MARK: Helpers

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -274,6 +274,10 @@ final class JetpackFullscreenOverlayGeneralViewModel: JetpackFullscreenOverlayVi
         }
     }
 
+    var shouldDismissOnSecondaryButtonTap: Bool {
+        return true
+    }
+
     var analyticsSource: String {
         return source.rawValue
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -96,6 +96,10 @@ final class JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOver
     var isCompact: Bool {
         return false
     }
+
+    func didTapActionInfo() {
+        // No op
+    }
 }
 
 private extension JetpackFullscreenOverlaySiteCreationViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel.swift
@@ -77,6 +77,10 @@ final class JetpackFullscreenOverlaySiteCreationViewModel: JetpackFullscreenOver
         return true
     }
 
+    var shouldDismissOnSecondaryButtonTap: Bool {
+        return true
+    }
+
     var analyticsSource: String {
         return Constants.analyticsSource
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -272,6 +272,10 @@ class JetpackFullscreenOverlayViewController: UIViewController {
     @IBAction func learnMoreButtonPressed(_ sender: Any) {
         viewModel.didTapLink()
     }
+
+    @IBAction func actionInfoButtonTapped(_ sender: Any) {
+        viewModel.didTapActionInfo()
+    }
 }
 
 // MARK: Constants

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.swift
@@ -242,14 +242,18 @@ class JetpackFullscreenOverlayViewController: UIViewController {
         }
     }
 
-    // MARK: Actions
-
-    @objc private func closeButtonPressed(sender: UIButton) {
-        viewModel.didTapClose()
+    private func dismissOverlay() {
         viewModel.onWillDismiss?()
         dismiss(animated: true) { [weak self] in
             self?.viewModel.onDidDismiss?()
         }
+    }
+
+    // MARK: Actions
+
+    @objc private func closeButtonPressed(sender: UIButton) {
+        viewModel.didTapClose()
+        dismissOverlay()
     }
 
 
@@ -259,9 +263,9 @@ class JetpackFullscreenOverlayViewController: UIViewController {
 
     @IBAction func continueButtonPressed(_ sender: Any) {
         viewModel.didTapSecondary()
-        viewModel.onWillDismiss?()
-        dismiss(animated: true) { [weak self] in
-            self?.viewModel.onDidDismiss?()
+
+        if viewModel.shouldDismissOnSecondaryButtonTap {
+            dismissOverlay()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewController.xib
@@ -105,6 +105,9 @@
                                     <state key="normal">
                                         <color key="titleColor" systemColor="secondaryLabelColor"/>
                                     </state>
+                                    <connections>
+                                        <action selector="actionInfoButtonTapped:" destination="-1" eventType="touchUpInside" id="ceP-s4-257"/>
+                                    </connections>
                                 </button>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -32,6 +32,7 @@ protocol JetpackFullscreenOverlayViewModel: AnyObject {
     func didTapPrimary()
     func didTapClose()
     func didTapSecondary()
+    func didTapActionInfo()
 }
 
 extension JetpackFullscreenOverlayViewModel {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayViewModel.swift
@@ -13,6 +13,7 @@ protocol JetpackFullscreenOverlayViewModel: AnyObject {
     var switchButtonText: String { get }
     var continueButtonText: String? { get }
     var shouldShowCloseButton: Bool { get }
+    var shouldDismissOnSecondaryButtonTap: Bool { get }
     var analyticsSource: String { get }
     var actionInfoText: NSAttributedString? { get }
     var onWillDismiss: JetpackOverlayDismissCallback? { get }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -4,6 +4,8 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     private enum Constants {
         static let lottieLTRFileName = "JetpackInstallPluginLogoAnimation_ltr"
         static let lottieRTLFileName = "JetpackInstallPluginLogoAnimation_rtl"
+        static let termsURL = URL(string: "https://wordpress.com/tos")
+        static let webViewSource = "jetpack_plugin_install_overlay"
     }
 
     enum Plugin {
@@ -59,8 +61,14 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     }
 
     func didTapSecondary() {
-        // TODO: Make the auto-dismiss logic optional in the view controller's `continueButtonPressed`.
         coordinator?.navigateToSecondaryRoute()
+    }
+
+    func didTapActionInfo() {
+        guard let termsURL = Constants.termsURL else {
+            return
+        }
+        coordinator?.navigateToLinkRoute(url: termsURL, source: Constants.webViewSource)
     }
 
     private static func subtitle(withSiteName siteName: String, plugin: Plugin) -> NSAttributedString {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -23,6 +23,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     let switchButtonText = Strings.primaryButtonTitle
     let continueButtonText: String? = Strings.secondaryButtonTitle
     let shouldShowCloseButton = true
+    let shouldDismissOnSecondaryButtonTap = false
     let analyticsSource: String = ""
     var onWillDismiss: JetpackOverlayDismissCallback?
     var onDidDismiss: JetpackOverlayDismissCallback?

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -8,11 +8,6 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         static let webViewSource = "jetpack_plugin_install_overlay"
     }
 
-    enum Plugin {
-        case single(name: String)
-        case multiple
-    }
-
     // MARK: View Model Properties
 
     let title: String = Strings.title
@@ -38,7 +33,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
 
     // MARK: Methods
 
-    init(siteName: String, plugin: Plugin) {
+    init(siteName: String, plugin: JetpackPlugin) {
         self.subtitle = Self.subtitle(withSiteName: siteName, plugin: plugin)
     }
 
@@ -71,17 +66,22 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         coordinator?.navigateToLinkRoute(url: termsURL, source: Constants.webViewSource)
     }
 
-    private static func subtitle(withSiteName siteName: String, plugin: Plugin) -> NSAttributedString {
-        switch plugin {
-        case .single(let name):
-            return subtitleSinglePlugin(withSiteName: siteName, pluginName: name)
-        case .multiple:
-            return subtitlePluralPlugins(withSiteName: siteName)
-        }
+}
 
+// MARK: - Private Helpers
+
+private extension JetpackPluginOverlayViewModel {
+
+    static func subtitle(withSiteName siteName: String, plugin: JetpackPlugin) -> NSAttributedString {
+        switch plugin {
+        case .multiple:
+            return subtitleForPluralPlugins(withSiteName: siteName)
+        default:
+            return subtitleForSinglePlugin(withSiteName: siteName, pluginName: plugin.displayName)
+        }
     }
 
-    private static func subtitlePluralPlugins(withSiteName siteName: String) -> NSAttributedString {
+    static func subtitleForPluralPlugins(withSiteName siteName: String) -> NSAttributedString {
         let siteNameAttributedText = attributedSubtitle(
             with: siteName,
             fontWeight: .bold
@@ -97,7 +97,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         )
     }
 
-    private static func subtitleSinglePlugin(withSiteName siteName: String, pluginName: String) -> NSAttributedString {
+    static func subtitleForSinglePlugin(withSiteName siteName: String, pluginName: String) -> NSAttributedString {
         let siteNameAttributedText = attributedSubtitle(with: siteName, fontWeight: .bold)
         let jetpackBackupAttributedText = attributedSubtitle(with: pluginName,
             fontWeight: .bold
@@ -115,7 +115,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         )
     }
 
-    private static func actionInfoString() -> NSAttributedString {
+    static func actionInfoString() -> NSAttributedString {
         let actionInfoBaseFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
         let actionInfoBaseText = NSAttributedString(string: Strings.footnote, attributes: [.font: actionInfoBaseFont])
 
@@ -133,26 +133,13 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
         )
     }
 
-    private static func attributedSubtitle(with string: String, fontWeight: UIFont.Weight) -> NSAttributedString {
+    static func attributedSubtitle(with string: String, fontWeight: UIFont.Weight) -> NSAttributedString {
         let font = WPStyleGuide.fontForTextStyle(.body, fontWeight: fontWeight)
         return NSAttributedString(string: string, attributes: [.font: font])
     }
-}
 
-private extension NSAttributedString {
-    convenience init(format: NSAttributedString, args: (String, NSAttributedString)...) {
-        let mutableNSAttributedString = NSMutableAttributedString(attributedString: format)
+    // MARK: Strings
 
-        args.forEach { (key, attributedString) in
-            let range = NSString(string: mutableNSAttributedString.string).range(of: key)
-            mutableNSAttributedString.replaceCharacters(in: range, with: attributedString)
-        }
-        self.init(attributedString: mutableNSAttributedString)
-    }
-}
-
-// MARK: - Strings
-private extension JetpackPluginOverlayViewModel {
     enum Strings {
         static let title = NSLocalizedString(
             "jetpack.plugin.modal.title",
@@ -216,5 +203,17 @@ private extension JetpackPluginOverlayViewModel {
             value: "Contact Support",
             comment: "Jetpack Plugin Modal secondary button title"
         )
+    }
+}
+
+private extension NSAttributedString {
+    convenience init(format: NSAttributedString, args: (String, NSAttributedString)...) {
+        let mutableNSAttributedString = NSMutableAttributedString(attributedString: format)
+
+        args.forEach { (key, attributedString) in
+            let range = NSString(string: mutableNSAttributedString.string).range(of: key)
+            mutableNSAttributedString.replaceCharacters(in: range, with: attributedString)
+        }
+        self.init(attributedString: mutableNSAttributedString)
     }
 }


### PR DESCRIPTION
Closes #20016

This implements several logic on the Jetpack install overlay:

- Terms and conditions page now opens the web view when tapped.
- Tapping the secondary button no longer dismisses the overlay. In the case of plugin install, it now shows the support screen.
- Remove the `Plugin` enum and use `JetpackPlugin` instead to display the text body.

Note that tapping the primary button still does nothing. It requires the `Blog` object, which will be implemented in the wiring task here: #20153.

## To test

### Prerequisites

In `JetpackFeaturesRemovalCoordinator`, replace the `presentOverlayIfNeeded` method body with this:

```swift
    static func presentOverlayIfNeeded(in viewController: UIViewController,
                                       source: OverlaySource,
                                       forced: Bool = false,
                                       fullScreen: Bool = false,
                                       blog: Blog? = nil,
                                       onWillDismiss: JetpackOverlayDismissCallback? = nil,
                                       onDidDismiss: JetpackOverlayDismissCallback? = nil) {
        let pluginVM = JetpackPluginOverlayViewModel(siteName: "site.blog", plugin: .backup)
        let pluginVC = JetpackFullscreenOverlayViewController(with: pluginVM)
        let pluginCoordinator = JetpackPluginOverlayCoordinator(viewController: pluginVC)
        let navigationViewController = UINavigationController(rootViewController: pluginVC)
        pluginVM.coordinator = pluginCoordinator

        presentOverlay(navigationViewController: navigationViewController, in: viewController, fullScreen: fullScreen)
    }
```

Now that the overlay will always show, let's move on to the testing steps.

### Testing steps 

- Run the Jetpack app, and log into your WordPress.com account.
- Select any site, and the overlay should appear.
- 🔎 Verify that the body text shows `"... is using the Jetpack VaultPress Backup plugin, which doesn't ..."`
- Tap the terms & conditions text.
- 🔎 Verify that the terms web view is shown in a modal. 
- Tap the 'Contact Support' button.
- 🔎  Verify that the support screen is shown.
- Tap 'Tickets' (and enter any details here if prompted).
- Verify that the event `🔵 Tracked: support_ticket_list_viewed <source: origin:jp-install-full-plugin-overlay>` appears in the console.
- In the `presentOverlayIfNeeded` method, edit the `plugin` parameter value from `.backup` to `.multiple`.
- Run the Jetpack app again.
- 🔎 Verify that the body text shows `"... is using individual Jetpack plugins, which don't ..."`

## Regression Notes
1. Potential unintended areas of impact
Minor changes to the secondary button tap behavior of the `JetpackFullscreenOverlayViewController`.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
