### PR TITLE
Use `CoreDataStack` in `ReaderSiteService`

### DIFF
--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -284,6 +284,6 @@ private extension NotificationActionsService {
     }
 
     var siteService: ReaderSiteService {
-        return ReaderSiteService(managedObjectContext: managedObjectContext)
+        return ReaderSiteService(coreDataStack: ContextManager.shared)
     }
 }

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -144,8 +144,6 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
  */
 - (void)clearInUseFlags;
 
-- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked inContext:(NSManagedObjectContext *)context;
-
 /**
  Updates in core data the following status of posts belonging to the specified site & url
 

--- a/WordPress/Classes/Services/ReaderPostService.h
+++ b/WordPress/Classes/Services/ReaderPostService.h
@@ -144,7 +144,7 @@ extern NSString * const ReaderPostServiceToggleSiteFollowingState;
  */
 - (void)clearInUseFlags;
 
-- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked;
+- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked inContext:(NSManagedObjectContext *)context;
 
 /**
  Updates in core data the following status of posts belonging to the specified site & url

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -571,12 +571,12 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     }];
 }
 
-- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked
+- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked inContext:(NSManagedObjectContext *)context
 {
     NSError *error;
     NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
     request.predicate = [NSPredicate predicateWithFormat:@"siteID = %@", siteID];
-    NSArray *results = [self.managedObjectContext executeFetchRequest:request error:&error];
+    NSArray *results = [context executeFetchRequest:request error:&error];
     if (error) {
         DDLogError(@"%@, error deleting posts belonging to siteID %@: %@", NSStringFromSelector(_cmd), siteID, error);
         return;
@@ -589,10 +589,6 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     for (ReaderPost *post in results) {
         post.isSiteBlocked = blocked;
     }
-
-    [self.managedObjectContext performBlockAndWait:^{
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
-    }];
 }
 
 

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -368,7 +368,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
         }
     };
 
-    ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithManagedObjectContext:self.managedObjectContext];
+    ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     if (!post.isExternal) {
         if (follow) {
             [siteService followSiteWithID:[post.siteID integerValue] success:successBlock failure:failureBlock];

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -571,26 +571,6 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     }];
 }
 
-- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked inContext:(NSManagedObjectContext *)context
-{
-    NSError *error;
-    NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
-    request.predicate = [NSPredicate predicateWithFormat:@"siteID = %@", siteID];
-    NSArray *results = [context executeFetchRequest:request error:&error];
-    if (error) {
-        DDLogError(@"%@, error deleting posts belonging to siteID %@: %@", NSStringFromSelector(_cmd), siteID, error);
-        return;
-    }
-
-    if ([results count] == 0) {
-        return;
-    }
-
-    for (ReaderPost *post in results) {
-        post.isSiteBlocked = blocked;
-    }
-}
-
 
 #pragma mark - Private Methods
 

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -1,5 +1,5 @@
 #import <Foundation/Foundation.h>
-#import "LocalCoreDataService.h"
+#import "CoreDataService.h"
 #import "ReaderTopicService.h"
 
 typedef NS_ENUM(NSUInteger, ReaderSiteServiceError) {
@@ -9,7 +9,7 @@ typedef NS_ENUM(NSUInteger, ReaderSiteServiceError) {
 
 extern NSString * const ReaderSiteServiceErrorDomain;
 
-@interface ReaderSiteService : LocalCoreDataService
+@interface ReaderSiteService : CoreDataService
 
 /**
  Follow a site by its URL.

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -260,23 +260,19 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 // Updates the site topic's following status in core data only.
 - (void)markUnfollowedSiteTopicWithFeedURL:(NSString *)feedURL
 {
-    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithFeedURL:feedURL inContext:self.managedObjectContext];
-    if (!topic) {
-        return;
-    }
-    topic.following = NO;
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithFeedURL:feedURL inContext:context];
+        topic.following = NO;
+    }];
 }
 
 // Updates the site topic's following status in core data only.
 - (void)markUnfollowedSiteTopicWithSiteID:(NSNumber *)siteID
 {
-    ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:self.managedObjectContext];
-    if (!topic) {
-        return;
-    }
-    topic.following = NO;
-    [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:siteID inContext:context];
+        topic.following = NO;
+    }];
 }
 
 #pragma mark - Error messages

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -149,12 +149,12 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
 - (void)syncPostsForFollowedSites
 {
-    ReaderAbstractTopic *followedSites = [ReaderAbstractTopic lookupFollowedSitesTopicInContext:self.managedObjectContext];
-    if (!followedSites) {
-        return;
-    }
-
     [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderAbstractTopic *followedSites = [ReaderAbstractTopic lookupFollowedSitesTopicInContext:context];
+        if (!followedSites) {
+            return;
+        }
+
         ReaderPostService *postService = [[ReaderPostService alloc] initWithManagedObjectContext:context];
         [postService fetchPostsForTopic:followedSites earlierThan:[NSDate date] success:nil failure:nil];
     }];

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -227,8 +227,10 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
 - (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked
 {
-    ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:self.managedObjectContext];
-    [service flagPostsFromSite:siteID asBlocked:blocked];
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+        ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
+        [service flagPostsFromSite:siteID asBlocked:blocked inContext:context];
+    }];
 }
 
 // Updates the site topic's following status in core data only.

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -228,9 +228,28 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 - (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked
 {
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-        ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
-        [service flagPostsFromSite:siteID asBlocked:blocked inContext:context];
+        [self flagPostsFromSite:siteID asBlocked:blocked inContext:context];
     }];
+}
+
+- (void)flagPostsFromSite:(NSNumber *)siteID asBlocked:(BOOL)blocked inContext:(NSManagedObjectContext *)context
+{
+    NSError *error;
+    NSFetchRequest *request = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
+    request.predicate = [NSPredicate predicateWithFormat:@"siteID = %@", siteID];
+    NSArray *results = [context executeFetchRequest:request error:&error];
+    if (error) {
+        DDLogError(@"%@, error deleting posts belonging to siteID %@: %@", NSStringFromSelector(_cmd), siteID, error);
+        return;
+    }
+
+    if ([results count] == 0) {
+        return;
+    }
+
+    for (ReaderPost *post in results) {
+        post.isSiteBlocked = blocked;
+    }
 }
 
 // Updates the site topic's following status in core data only.

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -198,11 +198,16 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
  */
 - (WordPressComRestApi *)apiForRequest
 {
-    WPAccount *defaultAccount = [WPAccount lookupDefaultWordPressComAccountInContext:self.managedObjectContext];
-    WordPressComRestApi *api = [defaultAccount wordPressComRestApi];
+    WordPressComRestApi * __block api = nil;
+    [self.coreDataStack.mainContext performBlockAndWait:^{
+        WPAccount *defaultAccount = [WPAccount lookupDefaultWordPressComAccountInContext:self.coreDataStack.mainContext];
+        api = [defaultAccount wordPressComRestApi];
+    }];
+
     if (![api hasCredentials]) {
         return nil;
     }
+
     return api;
 }
 

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -149,7 +149,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 
 - (void)syncPostsForFollowedSites
 {
-    [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         ReaderAbstractTopic *followedSites = [ReaderAbstractTopic lookupFollowedSitesTopicInContext:context];
         if (!followedSites) {
             return;
@@ -183,7 +183,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
 - (void)fetchTopicServiceWithID:(NSUInteger)siteID success:(void(^)(void))success failure:(void(^)(NSError *error))failure
 {
     DDLogInfo(@"Fetch and store followed topic");
-    ReaderTopicService *service  = [[ReaderTopicService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
+    ReaderTopicService *service  = [[ReaderTopicService alloc] initWithCoreDataStack:self.coreDataStack];
     [service siteTopicForSiteWithID:@(siteID)
                              isFeed:false
                             success:^(NSManagedObjectID *objectID, BOOL isFollowing) {

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -167,7 +167,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     
     [service findSiteIDForURL:siteURL success:^(NSUInteger siteID) {
         NSNumber *site = [NSNumber numberWithUnsignedLong:siteID];
-        ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:site inContext:self.managedObjectContext];
+        ReaderSiteTopic *topic = [ReaderSiteTopic lookupWithSiteID:site inContext:self.coreDataStack.mainContext];
         success(topic);
     } failure:^(NSError *error) {
         failure(error);

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -511,7 +511,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         } onQueue:dispatch_get_main_queue()];
     };
 
-    ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithManagedObjectContext:self.coreDataStack.mainContext];
+    ReaderSiteService *siteService = [[ReaderSiteService alloc] initWithCoreDataStack:self.coreDataStack];
     if (topic.isExternal) {
         if (newFollowValue) {
             [siteService followSiteAtURL:topic.feedURL success:successBlock failure:failureBlock];

--- a/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderBlockSiteAction.swift
@@ -7,7 +7,7 @@ final class ReaderBlockSiteAction {
     }
 
     func execute(with post: ReaderPost, context: NSManagedObjectContext, completion: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
-        let service = ReaderSiteService(managedObjectContext: context)
+        let service = ReaderSiteService(coreDataStack: ContextManager.shared)
         service.flagSite(withID: post.siteID,
                          asBlocked: asBlocked,
                          success: {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowedSitesViewController.swift
@@ -198,7 +198,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
 
 
     @objc func refreshFollowedPosts() {
-        let service = ReaderSiteService(managedObjectContext: managedObjectContext())
+        let service = ReaderSiteService(coreDataStack: ContextManager.shared)
         service.syncPostsForFollowedSites()
     }
 
@@ -240,7 +240,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
             return
         }
 
-        let service = ReaderSiteService(managedObjectContext: managedObjectContext())
+        let service = ReaderSiteService(coreDataStack: ContextManager.shared)
         service.followSite(by: url, success: { [weak self] in
             let notice = Notice(title: NSLocalizedString("Followed site", comment: "User followed a site."),
                                 message: url.host,
@@ -268,7 +268,7 @@ class ReaderFollowedSitesViewController: UIViewController, UIViewControllerResto
     }
 
     private func postFollowedNotification(siteUrl: URL) {
-        let service = ReaderSiteService(managedObjectContext: managedObjectContext())
+        let service = ReaderSiteService(coreDataStack: ContextManager.shared)
         service.topic(withSiteURL: siteUrl, success: { topic in
             if let topic = topic {
                 NotificationCenter.default.post(name: .ReaderSiteFollowed,


### PR DESCRIPTION
Changes in this PR are individually reviewable. I'd recommend reviewing commit by commit.

I discovered issue https://github.com/wordpress-mobile/WordPress-iOS/issues/20167 while testing changes in this PR. Even though following and unfollowing a site is an API of `ReaderSiteService`, but the issue isn't caused by `ReaderSiteService`, so I created [a dedicated PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20168) to fix it. Please note the issue is still reproducible in this branch and is safe to ignore it.

## Regression Notes
1. Potential unintended areas of impact
The Reader feature

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Follow, unfollow, block sites.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
