### PR TITLE
Replace some `ContextManager.shared` calls with `coreDataStack` instance variable

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -42,7 +42,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
 
     NSManagedObjectID *accountID = account.objectID;
     void (^notifyAccountChange)(void) = ^{
-        NSManagedObjectContext *mainContext = [[ContextManager sharedInstance] mainContext];
+        NSManagedObjectContext *mainContext = self.coreDataStack.mainContext;
         NSManagedObject *accountInContext = [mainContext existingObjectWithID:accountID error:nil];
         [[NSNotificationCenter defaultCenter] postNotificationName:WPAccountDefaultWordPressComAccountChangedNotification object:accountInContext];
 

--- a/WordPress/Classes/Services/BlogService+Domains.swift
+++ b/WordPress/Classes/Services/BlogService+Domains.swift
@@ -22,7 +22,7 @@ extension BlogService {
             return
         }
 
-        let service = DomainsService(coreDataStack: ContextManager.shared, account: account)
+        let service = DomainsService(coreDataStack: coreDataStack, account: account)
 
         service.refreshDomains(siteID: siteID) { result in
             switch result {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -127,7 +127,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
                                    dispatch_group_leave(syncGroup);
                                }];
 
-    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
+    PostCategoryService *categoryService = [[PostCategoryService alloc] initWithCoreDataStack:self.coreDataStack];
     dispatch_group_enter(syncGroup);
     [categoryService syncCategoriesForBlog:blog
                                    success:^{

--- a/WordPress/Classes/Services/CommentService+Likes.swift
+++ b/WordPress/Classes/Services/CommentService+Likes.swift
@@ -98,7 +98,7 @@ private extension CommentService {
             return
         }
 
-        ContextManager.shared.performAndSave({ derivedContext in
+        coreDataStack.performAndSave({ derivedContext in
             let likers = remoteLikeUsers.map { remoteUser in
                 LikeUserHelper.createOrUpdateFrom(remoteUser: remoteUser, context: derivedContext)
             }

--- a/WordPress/Classes/Services/CommentService+Replies.swift
+++ b/WordPress/Classes/Services/CommentService+Replies.swift
@@ -71,7 +71,7 @@ extension CommentService {
                 childComment.visibleOnReader = isVisible
             }
 
-            ContextManager.shared.save(context)
+            self.coreDataStack.save(context)
             DispatchQueue.main.async {
                 completion?()
             }

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -223,7 +223,7 @@ extension PlanService {
                         success()
                         return
                 }
-                ContextManager.shared.performAndSave({ context in
+                self.coreDataStack.performAndSave({ context in
                     PlanStorage.updateHasDomainCredit(
                         planIdInt,
                         forSite: siteID,

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
     id<TaxonomyServiceRemote> remote = [self remoteForBlog:blog];
     NSManagedObjectID *blogID = blog.objectID;
     [remote getCategoriesWithSuccess:^(NSArray *categories) {
-                               [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+                               [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
                                    Blog *blog = (Blog *)[context existingObjectWithID:blogID error:nil];
                                    if (!blog) {
                                        if (failure) {
@@ -61,7 +61,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSManagedObjectID *blogID = blog.objectID;
     [remote getCategoriesWithPaging:paging
                             success:^(NSArray<RemotePostCategory *> *categories) {
-                                [[ContextManager sharedInstance] performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+                                [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
                                     Blog *blog = (Blog *)[context existingObjectWithID:blogID error:nil];
                                     if (!blog) {
                                         if (failure) {
@@ -72,7 +72,7 @@ NS_ASSUME_NONNULL_BEGIN
                                     [self mergeCategories:categories forBlog:blog inContext:context];
                                 } completion: ^{
                                     if (success) {
-                                        NSManagedObjectContext *context = [[ContextManager sharedInstance] mainContext];
+                                        NSManagedObjectContext *context = [self.coreDataStack mainContext];
                                         NSArray *postCategories = [categories wp_map:^id(RemotePostCategory *obj) {
                                             return [PostCategory lookupWithBlogObjectID:blogID categoryID:obj.categoryID inContext:context];
                                         }];
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
                            if (success) {
                                PostCategory *newCategory = [PostCategory lookupWithBlogObjectID:blogObjectID
                                                                            categoryID:receivedCategory.categoryID
-                                                                            inContext:[[ContextManager sharedInstance] mainContext]];
+                                                                            inContext:[self.coreDataStack mainContext]];
                                success(newCategory);
                            }
                            if ([remote isKindOfClass:[TaxonomyServiceRemoteXMLRPC class]]) {

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -250,7 +250,7 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
         topicObjectID = topic.objectID;
     } completion:^{
         // Save / update the search phrase to use it as a suggestion later.
-        ReaderSearchSuggestionService *suggestionService = [[ReaderSearchSuggestionService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
+        ReaderSearchSuggestionService *suggestionService = [[ReaderSearchSuggestionService alloc] initWithCoreDataStack:self.coreDataStack];
         [suggestionService createOrUpdateSuggestionForPhrase:phrase];
 
         if (completion) {


### PR DESCRIPTION
What says in the title. The app shouldn't be impacted since `ContextManager.shared` and the `coreDataStack` variables refer to the same singleton.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
