### PR TITLE
[Domain Purchasing Site Creation] Add Feature Flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -46,6 +46,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case wordPressSupportForum
     case jetpackIndividualPluginSupport
     case blaze
+    case siteCreationDomainPurchasing
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -145,6 +146,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .jetpackIndividualPluginSupport:
             return false
         case .blaze:
+            return false
+        case .siteCreationDomainPurchasing:
             return false
         }
     }
@@ -282,6 +285,8 @@ extension FeatureFlag {
             return "Jetpack Individual Plugin Support"
         case .blaze:
             return "Blaze"
+        case .siteCreationDomainPurchasing:
+            return "Site Creation Domain Purchasing"
         }
     }
 


### PR DESCRIPTION
Fixes #20073

To test:
1. Simply go to debug settings and check if the "Site Creation Domain Purchase" flag exists at the end of the list.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
