### PR TITLE
[JP Plugin] Wire up components and presentation logic

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -143,7 +143,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .wordPressSupportForum:
             return false
         case .jetpackIndividualPluginSupport:
-            return false
+            return true
         case .blaze:
             return false
         }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -143,7 +143,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .wordPressSupportForum:
             return false
         case .jetpackIndividualPluginSupport:
-            return true
+            return false
         case .blaze:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -347,3 +347,23 @@ private extension Collection where Element == DashboardCardModel {
         contains(where: { $0.cardType == .prompts })
     }
 }
+
+// MARK: - Jetpack Remote Install Delegate
+
+extension BlogDashboardViewController: JetpackRemoteInstallDelegate {
+    func jetpackRemoteInstallCompleted() {
+        dismiss(animated: true) {
+            self.pulledToRefresh()
+        }
+    }
+
+    func jetpackRemoteInstallCanceled() {
+        dismiss(animated: true) {
+            self.pulledToRefresh()
+        }
+    }
+
+    func jetpackRemoteInstallWebviewFallback() {
+        // No op
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -9,9 +9,13 @@ class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
 
     private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
         let onHideThisTap: UIActionHandler = { [weak self] _ in
+            guard let self,
+                  let helper = JetpackInstallPluginHelper(self.blog) else {
+                return
+            }
             WPAnalytics.track(.jetpackInstallFullPluginCardDismissed, properties: [WPAppAnalyticsKeyTabSource: "dashboard"])
-            JetpackInstallPluginHelper.hideCard(for: self?.blog)
-            self?.presenterViewController?.reloadCardsLocally()
+            helper.hideCard()
+            self.presenterViewController?.reloadCardsLocally()
         }
 
         let onLearnMoreTap: () -> Void = {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -19,7 +19,15 @@ class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
         }
 
         let onLearnMoreTap: () -> Void = {
+            guard let presenterViewController = self.presenterViewController else {
+                return
+            }
             WPAnalytics.track(.jetpackInstallFullPluginCardTapped, properties: [WPAppAnalyticsKeyTabSource: "dashboard"])
+            JetpackInstallPluginHelper.presentOverlayIfNeeded(in: presenterViewController,
+                                                              blog: self.blog,
+                                                              delegate: presenterViewController,
+                                                              force: true)
+
         }
         return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap,
                                                  onLearnMoreTap: onLearnMoreTap)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -417,7 +417,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     tourGuide.currentEntryPoint = QuickStartTourEntryPointBlogDetails;
     [WPAnalytics trackEvent: WPAnalyticsEventMySiteSiteMenuShown];
 
-    if ([self shouldShowJetpackInstall]) {
+    if ([self shouldShowJetpackInstallCard]) {
         [WPAnalytics trackEvent:WPAnalyticsEventJetpackInstallFullPluginCardViewed
                      properties:@{WPAppAnalyticsKeyTabSource: @"site_menu"}];
     }
@@ -750,7 +750,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
         [marr addObject:[self migrationSuccessSectionViewModel]];
     }
 
-    if ([self shouldShowJetpackInstall]) {
+    if ([self shouldShowJetpackInstallCard]) {
         [marr addObject:[self jetpackInstallSectionViewModel]];
     }
 
@@ -1707,7 +1707,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     [[QuickStartTourGuide shared] visited:QuickStartTourElementBlogDetailNavigation];
 }
 
-- (BOOL)shouldShowJetpackInstall
+- (BOOL)shouldShowJetpackInstallCard
 {
     return ![WPDeviceIdentification isiPad] && [JetpackInstallPluginHelper shouldShowCardFor:self.blog];
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -1056,10 +1056,30 @@ private extension MySiteViewController {
     }
 }
 
-// MARK: Jetpack Install Plugin
+// MARK: Jetpack Install Plugin Overlay
 
 private extension MySiteViewController {
     func displayJetpackInstallOverlayIfNeeded() {
-        JetpackPluginOverlayCoordinator.presentOverlayIfNeeded(for: self.blog, in: self)
+        JetpackInstallPluginHelper.presentOverlayIfNeeded(in: self, blog: blog, delegate: self)
+    }
+
+    func dismissOverlayAndRefresh() {
+        dismiss(animated: true) {
+            self.pulledToRefresh()
+        }
+    }
+}
+
+extension MySiteViewController: JetpackRemoteInstallDelegate {
+    func jetpackRemoteInstallCompleted() {
+        dismissOverlayAndRefresh()
+    }
+
+    func jetpackRemoteInstallCanceled() {
+        dismissOverlayAndRefresh()
+    }
+
+    func jetpackRemoteInstallWebviewFallback() {
+        // no op
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -188,6 +188,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
 
+        displayJetpackInstallOverlayIfNeeded()
+
         displayOverlayIfNeeded()
 
         workaroundLargeTitleCollapseBug()
@@ -819,6 +821,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             self.updateChildViewController(for: blog)
             self.createFABIfNeeded()
             self.fetchPrompt(for: blog)
+
+            self.displayJetpackInstallOverlayIfNeeded()
         }
 
         return sitePickerViewController
@@ -1049,5 +1053,13 @@ private extension MySiteViewController {
                 JetpackFeaturesRemovalCoordinator.presentOverlayIfNeeded(in: self, source: .appOpen, blog: self.blog)
             }
         }
+    }
+}
+
+// MARK: Jetpack Install Plugin
+
+private extension MySiteViewController {
+    func displayJetpackInstallOverlayIfNeeded() {
+        JetpackPluginOverlayCoordinator.presentOverlayIfNeeded(for: self.blog, in: self)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -5,49 +5,24 @@ final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     // MARK: Dependencies
 
     private unowned let viewController: UIViewController
+    private weak var installDelegate: JetpackRemoteInstallDelegate?
+    private let blog: Blog
 
     // MARK: Methods
 
-    /// Convenience entry point to show the Jetpack Install Plugin overlay when needed.
-    /// The overlay will only be shown when:
-    ///     1. User accesses this `Blog` via their WordPress.com account,
-    ///     2. The `Blog` has individual Jetpack plugin(s) installed, without the full Jetpack plugin,
-    ///     3. The overlay has never been shown for this site before (overrideable by setting `force` to `true`).
-    ///
-    /// - Parameters:
-    ///   - blog: The Blog that might need the full Jetpack plgin.
-    ///   - presentingViewController: The view controller that will be presenting the overlay.
-    ///   - force: Whether the overlay should be shown regardless if the overlay has been shown previously.
-    static func presentOverlayIfNeeded(for blog: Blog?,
-                                       in presentingViewController: UIViewController,
-                                       force: Bool = false) {
-        guard let blog,
-              let siteURLString = blog.displayURL as? String, // just the host URL without the scheme.
-              let plugin = JetpackPlugin(from: blog.jetpackConnectionActivePlugins),
-              let helper = JetpackInstallPluginHelper(blog),
-              helper.shouldShowOverlay || force else {
-            return
-        }
-
-        let viewModel = JetpackPluginOverlayViewModel(siteName: siteURLString, plugin: plugin)
-        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
-        let coordinator = JetpackPluginOverlayCoordinator(viewController: overlayViewController)
-        viewModel.coordinator = coordinator
-
-        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
-        let shouldUseFormSheet = WPDeviceIdentification.isiPad()
-        navigationViewController.modalPresentationStyle = shouldUseFormSheet ? .formSheet : .fullScreen
-        presentingViewController.present(navigationViewController, animated: true) {
-            helper.markOverlayAsShown()
-        }
-    }
-
-    init(viewController: UIViewController) {
+    init(blog: Blog, viewController: UIViewController, installDelegate: JetpackRemoteInstallDelegate? = nil) {
+        self.blog = blog
         self.viewController = viewController
+        self.installDelegate = installDelegate
     }
 
     func navigateToPrimaryRoute() {
-        // TODO: Navigate to the installation flow.
+        let viewModel = WPComJetpackRemoteInstallViewModel()
+        let installViewController = JetpackRemoteInstallViewController(blog: blog,
+                                                                       delegate: installDelegate,
+                                                                       viewModel: viewModel)
+
+        viewController.navigationController?.pushViewController(installViewController, animated: true)
     }
 
     func navigateToSecondaryRoute() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackPluginOverlayCoordinator.swift
@@ -1,10 +1,45 @@
 import WordPressAuthenticator
 
 final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
+
+    // MARK: Dependencies
+
     private unowned let viewController: UIViewController
 
-    private var presentingViewController: UIViewController {
-        return viewController.navigationController ?? viewController
+    // MARK: Methods
+
+    /// Convenience entry point to show the Jetpack Install Plugin overlay when needed.
+    /// The overlay will only be shown when:
+    ///     1. User accesses this `Blog` via their WordPress.com account,
+    ///     2. The `Blog` has individual Jetpack plugin(s) installed, without the full Jetpack plugin,
+    ///     3. The overlay has never been shown for this site before (overrideable by setting `force` to `true`).
+    ///
+    /// - Parameters:
+    ///   - blog: The Blog that might need the full Jetpack plgin.
+    ///   - presentingViewController: The view controller that will be presenting the overlay.
+    ///   - force: Whether the overlay should be shown regardless if the overlay has been shown previously.
+    static func presentOverlayIfNeeded(for blog: Blog?,
+                                       in presentingViewController: UIViewController,
+                                       force: Bool = false) {
+        guard let blog,
+              let siteURLString = blog.displayURL as? String, // just the host URL without the scheme.
+              let plugin = JetpackPlugin(from: blog.jetpackConnectionActivePlugins),
+              let helper = JetpackInstallPluginHelper(blog),
+              helper.shouldShowOverlay || force else {
+            return
+        }
+
+        let viewModel = JetpackPluginOverlayViewModel(siteName: siteURLString, plugin: plugin)
+        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
+        let coordinator = JetpackPluginOverlayCoordinator(viewController: overlayViewController)
+        viewModel.coordinator = coordinator
+
+        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        let shouldUseFormSheet = WPDeviceIdentification.isiPad()
+        navigationViewController.modalPresentationStyle = shouldUseFormSheet ? .formSheet : .fullScreen
+        presentingViewController.present(navigationViewController, animated: true) {
+            helper.markOverlayAsShown()
+        }
     }
 
     init(viewController: UIViewController) {
@@ -28,6 +63,7 @@ final class JetpackPluginOverlayCoordinator: JetpackOverlayCoordinator {
     func navigateToLinkRoute(url: URL, source: String) {
         let webViewController = WebViewControllerFactory.controller(url: url, source: source)
         let navigationController = UINavigationController(rootViewController: webViewController)
+        let presentingViewController = viewController.navigationController ?? viewController
         presentingViewController.present(navigationController, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -7,24 +7,24 @@ class JetpackInstallPluginHelper: NSObject {
     private let blog: Blog
     private let siteIDString: String
 
+    /// Determines whether the install cards should be shown for this `blog` in the My Site screen.
     var shouldShowCard: Bool {
         shouldPromptInstall && !isCardHidden
     }
 
+    /// Determines whether the plugin install overlay should be shown for this `blog`.
     var shouldShowOverlay: Bool {
         shouldPromptInstall && !isOverlayAlreadyShown
     }
 
     // MARK: Methods
 
-    @objc
-    static func shouldShowCard(for blog: Blog?) -> Bool {
+    /// Convenient static method that determines whether we should show the install cards for the given `blog`.
+    ///
+    /// - Parameter blog: The `Blog` to show the install cards for,
+    /// - Returns: True if the install cards should be shown for this blog.
+    @objc static func shouldShowCard(for blog: Blog?) -> Bool {
         return JetpackInstallPluginHelper(blog)?.shouldShowCard ?? false
-    }
-
-    @objc
-    static func shouldShowOverlay(for blog: Blog?) -> Bool {
-        return JetpackInstallPluginHelper(blog)?.shouldPromptInstall ?? false
     }
 
     init?(_ blog: Blog?, repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -27,6 +27,45 @@ class JetpackInstallPluginHelper: NSObject {
         return JetpackInstallPluginHelper(blog)?.shouldShowCard ?? false
     }
 
+    /// Convenience entry point to show the Jetpack Install Plugin overlay when needed.
+    /// The overlay will only be shown when:
+    ///     1. User accesses this `Blog` via their WordPress.com account,
+    ///     2. The `Blog` has individual Jetpack plugin(s) installed, without the full Jetpack plugin,
+    ///     3. The overlay has never been shown for this site before (overrideable by setting `force` to `true`).
+    ///
+    /// - Parameters:
+    ///   - blog: The Blog that might need the full Jetpack plgin.
+    ///   - presentingViewController: The view controller that will be presenting the overlay.
+    ///   - force: Whether the overlay should be shown regardless if the overlay has been shown previously.
+    static func presentOverlayIfNeeded(in presentingViewController: UIViewController,
+                                       blog: Blog?,
+                                       delegate: JetpackRemoteInstallDelegate?,
+                                       force: Bool = false) {
+        guard let blog,
+              let siteURLString = blog.displayURL as? String, // just the host URL without the scheme.
+              let plugin = JetpackPlugin(from: blog.jetpackConnectionActivePlugins),
+              let helper = JetpackInstallPluginHelper(blog),
+              helper.shouldShowOverlay || force else {
+            return
+        }
+
+        // create the overlay stack.
+        let viewModel = JetpackPluginOverlayViewModel(siteName: siteURLString, plugin: plugin)
+        let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
+        let coordinator = JetpackPluginOverlayCoordinator(blog: blog,
+                                                          viewController: overlayViewController,
+                                                          installDelegate: delegate)
+        viewModel.coordinator = coordinator
+
+        // present the overlay.
+        let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        let shouldUseFormSheet = WPDeviceIdentification.isiPad()
+        navigationViewController.modalPresentationStyle = shouldUseFormSheet ? .formSheet : .fullScreen
+        presentingViewController.present(navigationViewController, animated: true) {
+            helper.markOverlayAsShown()
+        }
+    }
+
     init?(_ blog: Blog?, repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
         guard let blog,
               let siteID = blog.dotComID?.stringValue,

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -1,46 +1,98 @@
-@objcMembers
+@objc
 class JetpackInstallPluginHelper: NSObject {
 
-    private static var cardHiddenSites: [String] {
-        get {
-            guard let sites = UserPersistentStoreFactory.instance().array(forKey: Constants.cardHiddenSitesKey) as? [String] else {
-                return [String]()
-            }
-            return sites
-        }
-        set {
-            UserPersistentStoreFactory.instance().set(newValue, forKey: Constants.cardHiddenSitesKey)
-        }
+    // MARK: Dependencies
+
+    private let repository: UserPersistentRepository
+    private let blog: Blog
+    private let siteIDString: String
+
+    var shouldShowCard: Bool {
+        shouldPromptInstall && !isCardHidden
     }
 
-    static func shouldShow(for blog: Blog?) -> Bool {
-        guard let blog, blog.account != nil else {
-            return false
-        }
-        let isFeatureEnabled = FeatureFlag.jetpackIndividualPluginSupport.enabled
-        return isFeatureEnabled && blog.jetpackIsConnectedWithoutFullPlugin
+    var shouldShowOverlay: Bool {
+        shouldPromptInstall && !isOverlayAlreadyShown
     }
 
+    // MARK: Methods
+
+    @objc
     static func shouldShowCard(for blog: Blog?) -> Bool {
-        guard let siteID = blog?.dotComID?.stringValue else {
-            return false
-        }
-        let isCardHidden = cardHiddenSites.contains { $0 == siteID }
-        return shouldShow(for: blog) && !isCardHidden
+        return JetpackInstallPluginHelper(blog)?.shouldShowCard ?? false
     }
 
-    static func hideCard(for blog: Blog?) {
-        guard let blog, let siteID = blog.dotComID?.stringValue else {
+    @objc
+    static func shouldShowOverlay(for blog: Blog?) -> Bool {
+        return JetpackInstallPluginHelper(blog)?.shouldPromptInstall ?? false
+    }
+
+    init?(_ blog: Blog?, repository: UserPersistentRepository = UserPersistentStoreFactory.instance()) {
+        guard let blog,
+              let siteID = blog.dotComID?.stringValue,
+              blog.account != nil,
+              FeatureFlag.jetpackIndividualPluginSupport.enabled else {
+            return nil
+        }
+
+        self.blog = blog
+        self.siteIDString = siteID
+        self.repository = repository
+    }
+
+    func hideCard() {
+        if isCardHidden {
             return
         }
-
-        var sites = cardHiddenSites
-        sites.append(siteID)
-        cardHiddenSites = sites
+        cardHiddenSites += [siteIDString]
     }
 
-    private struct Constants {
-        static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
+    func markOverlayAsShown() {
+        if isOverlayAlreadyShown {
+            return
+        }
+        overlayShownSites += [siteIDString]
+    }
+}
+
+// MARK: - Private Helpers
+
+private extension JetpackInstallPluginHelper {
+
+    var isCardHidden: Bool {
+        cardHiddenSites.contains { $0 == siteIDString }
     }
 
+    var cardHiddenSites: [String] {
+        get {
+            (repository.array(forKey: .cardHiddenSitesKey) as? [String]) ?? [String]()
+        }
+        set {
+            repository.set(newValue, forKey: .cardHiddenSitesKey)
+        }
+    }
+
+    var isOverlayAlreadyShown: Bool {
+        overlayShownSites.contains { $0 == siteIDString }
+    }
+
+    var overlayShownSites: [String] {
+        get {
+            (repository.array(forKey: .overlayShownSitesKey) as? [String]) ?? [String]()
+        }
+        set {
+            repository.set(newValue, forKey: .overlayShownSitesKey)
+        }
+    }
+
+    var shouldPromptInstall: Bool {
+        blog.jetpackIsConnectedWithoutFullPlugin
+    }
+}
+
+// MARK: - String Constants
+
+private extension String {
+    static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
+    static let overlayShownSitesKey = "jetpack-install-overlay-shown-sites"
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -104,10 +104,10 @@ private extension JetpackInstallPluginHelper {
 
     var cardHiddenSites: [String] {
         get {
-            (repository.array(forKey: .cardHiddenSitesKey) as? [String]) ?? [String]()
+            (repository.array(forKey: Constants.cardHiddenSitesKey) as? [String]) ?? [String]()
         }
         set {
-            repository.set(newValue, forKey: .cardHiddenSitesKey)
+            repository.set(newValue, forKey: Constants.cardHiddenSitesKey)
         }
     }
 
@@ -117,21 +117,19 @@ private extension JetpackInstallPluginHelper {
 
     var overlayShownSites: [String] {
         get {
-            (repository.array(forKey: .overlayShownSitesKey) as? [String]) ?? [String]()
+            (repository.array(forKey: Constants.overlayShownSitesKey) as? [String]) ?? [String]()
         }
         set {
-            repository.set(newValue, forKey: .overlayShownSitesKey)
+            repository.set(newValue, forKey: Constants.overlayShownSitesKey)
         }
     }
 
     var shouldPromptInstall: Bool {
         blog.jetpackIsConnectedWithoutFullPlugin
     }
-}
 
-// MARK: - String Constants
-
-private extension String {
-    static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
-    static let overlayShownSitesKey = "jetpack-install-overlay-shown-sites"
+    struct Constants {
+        static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
+        static let overlayShownSitesKey = "jetpack-install-overlay-shown-sites"
+    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackPlugin.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackPlugin.swift
@@ -7,6 +7,21 @@ enum JetpackPlugin: String {
     case boost      = "jetpack-boost"
     case multiple
 
+    init?(from rawValues: [String]?) {
+        guard let rawValues,
+              !rawValues.isEmpty else {
+            return nil
+        }
+
+        guard rawValues.count == 1,
+              let rawValue = rawValues.first else {
+            self = .multiple
+            return
+        }
+
+        self.init(rawValue: rawValue)
+    }
+
     var displayName: String {
         switch self {
         case .search:

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -118,6 +118,9 @@ private extension JetpackRemoteInstallViewController {
 
     /// Completes the Jetpack installation flow.
     func complete() {
+        if let siteID = blog.dotComID?.stringValue {
+            RecentJetpackInstallReceipt.shared.store(siteID)
+        }
         delegate?.jetpackRemoteInstallCompleted()
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -78,17 +78,11 @@ extension BlogDetailsViewController: JetpackRemoteInstallDelegate {
     }
 
     func jetpackRemoteInstallCompleted() {
-        dismiss(animated: true) {
-            self.configureTableViewData()
-            self.reloadTableViewPreservingSelection()
-        }
+        dismiss(animated: true)
     }
 
     func jetpackRemoteInstallCanceled() {
-        dismiss(animated: true) {
-            self.configureTableViewData()
-            self.reloadTableViewPreservingSelection()
-        }
+        dismiss(animated: true)
     }
 
     func jetpackRemoteInstallWebviewFallback() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -19,7 +19,14 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
             self.presenterViewController?.reloadTableView()
         }
         let onLearnMoreTap: () -> Void = {
+            guard let presenterViewController = self.presenterViewController else {
+                return
+            }
             WPAnalytics.track(.jetpackInstallFullPluginCardTapped, properties: [WPAppAnalyticsKeyTabSource: "site_menu"])
+            JetpackInstallPluginHelper.presentOverlayIfNeeded(in: presenterViewController,
+                                                              blog: self.blog,
+                                                              delegate: presenterViewController,
+                                                              force: true)
         }
         return JetpackRemoteInstallCardViewModel(onHideThisTap: onHideThisTap,
                                                  onLearnMoreTap: onLearnMoreTap)
@@ -58,7 +65,7 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
 
 // MARK: - BlogDetailsViewController view model
 
-extension BlogDetailsViewController {
+extension BlogDetailsViewController: JetpackRemoteInstallDelegate {
 
     @objc func jetpackInstallSectionViewModel() -> BlogDetailsSection {
         let row = BlogDetailsRow()
@@ -68,6 +75,24 @@ extension BlogDetailsViewController {
                                          footerTitle: nil,
                                          category: .jetpackInstallCard)
         return section
+    }
+
+    func jetpackRemoteInstallCompleted() {
+        dismiss(animated: true) {
+            self.configureTableViewData()
+            self.reloadTableViewPreservingSelection()
+        }
+    }
+
+    func jetpackRemoteInstallCanceled() {
+        dismiss(animated: true) {
+            self.configureTableViewData()
+            self.reloadTableViewPreservingSelection()
+        }
+    }
+
+    func jetpackRemoteInstallWebviewFallback() {
+        // No op
     }
 
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -10,9 +10,13 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
 
     private lazy var cardViewModel: JetpackRemoteInstallCardViewModel = {
         let onHideThisTap: UIActionHandler = { [weak self] _ in
+            guard let self,
+                  let helper = JetpackInstallPluginHelper(self.blog) else {
+                return
+            }
             WPAnalytics.track(.jetpackInstallFullPluginCardDismissed, properties: [WPAppAnalyticsKeyTabSource: "site_menu"])
-            JetpackInstallPluginHelper.hideCard(for: self?.blog)
-            self?.presenterViewController?.reloadTableView()
+            helper.hideCard()
+            self.presenterViewController?.reloadTableView()
         }
         let onLearnMoreTap: () -> Void = {
             WPAnalytics.track(.jetpackInstallFullPluginCardTapped, properties: [WPAppAnalyticsKeyTabSource: "site_menu"])


### PR DESCRIPTION
Refs #20153 

This PR implements the wiring logic between the overlay, dashboard cards, and the Remote Install flow. Some notes:

- I've made a slight refactor to `JetpackInstallPluginHelper` to be more instance-based with a failable initializer. It will fail when there are invalid conditions (blog without accounts, disabled feature flags, etc.)
- Added `JetpackRemoteInstallDelegate` conformance to `MySiteViewController`, `BlogDetailsViewController`, and `BlogDetailsViewController`, as these will be responsible for dismissing the entire flow after the user taps 'Done' or the Close button during the Remote Install flow. 
  - Plus, we'll have to refresh the data after the Remote Install flow completes. So this means triggering the `pulledToRefresh` or similar method.
  - Note: I'm thinking if it's possible to pass in `MySiteViewController` instead so the added code can be reduced 🤔 .
- Added the presentation logic for the overlay. The overlay will only be shown once per site and will use a similar `UserDefaults` approach to store the state.
  - Note that for the 'Learn more' interaction from the dashboard cards, we can ignore the overlay shown state by passing `true` for the `force` parameter.

## To test

We'll need to test three install paths as there are three different handlers.

### Prerequisites

- Make sure the `jetpackIndividualPluginSupport` flag is enabled. 
- Prepare a self-hosted site with individual Jetpack plugin(s) installed, and 
- Have the site connected to your WordPress.com account.

If you plan to reuse the same site for these scenarios, here are some steps to reset the Jetpack installation:
- Go to the Installed Plugins page (at `/wp-admin/plugins.php`).
- Deactivate and Delete the Jetpack plugin.
- Reconnect the site to your WordPress.com account by tapping on the Jetpack menu just below the Dashboard menu. 

### 1. Installing from the overlay

- Open the Jetpack app, and log in to your WordPress.com account.
- Select the self-hosted site that's already prepped.
- 🔎  Verify that the install overlay screen appears.
- Tap "Install the full plugin", and go through the installation process.
- At the completion screen, tap "Done". 
- 🔎 Verify that the installation modal is dismissed.
- 🔎 Verify that the install cards are not shown in the dashboard.
- 🔎 In the WP Admin, verify that the Jetpack plugin is installed and activated for the site.

### 2. Installing from the Home Dashboard

- Reset your site's Jetpack installation state if needed.
- Open the Jetpack app, and log in to your WordPress.com account.
- Select the self-hosted site that's already prepped.
- Ignore/close the overlay if it appears.
- 🔎 Verify that the install card should be visible on the dashboard.
- Tap "Learn more" on the install card.
- 🔎  Verify that the install overlay screen appears.
- Tap "Install the full plugin", and go through the installation process.
- At the completion screen, tap "Done". 
- 🔎 Verify that the installation modal is dismissed.
- 🔎 Verify that the install cards are not shown in the dashboard.
- 🔎 In the WP Admin, verify that the Jetpack plugin is installed and activated for the site.

### 3. Installing from the Site Menu

- Reset your site's Jetpack installation state if needed.
- Open the Jetpack app, and log in to your WordPress.com account.
- Select the self-hosted site that's already prepped.
- Ignore/close the overlay if it appears.
- Go to the Site Menu by tapping on the "Menu" item on the segmented control.
- 🔎 Verify that the install card should be visible.
- Tap "Learn more" on the install card.
- 🔎  Verify that the install overlay screen appears.
- Tap "Install the full plugin", and go through the installation process.
- At the completion screen, tap "Done". 
- 🔎 Verify that the installation modal is dismissed.
- 🔎 Verify that the install cards are not shown in the dashboard.
- 🔎 In the WP Admin, verify that the Jetpack plugin is installed and activated for the site.

## Regression Notes
1. Potential unintended areas of impact
Should be none, feature is unreleased.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
