### PR TITLE
Reduce references to `managedObjectContext` in `ReaderPostService`

### DIFF
--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -138,7 +138,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             return;
         }
 
-        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil];
+        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:self.managedObjectContext];
 
         NSError *error;
         BOOL obtainedID = [self.managedObjectContext obtainPermanentIDsForObjects:@[post] error:&error];
@@ -167,7 +167,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             return;
         }
 
-        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil];
+        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:self.managedObjectContext];
 
         NSError *error;
         BOOL obtainedID = [self.managedObjectContext obtainPermanentIDsForObjects:@[post] error:&error];
@@ -727,7 +727,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             }
 
             // Create or update the synced posts.
-            NSMutableArray *newPosts = [self makeNewPostsFromRemotePosts:posts forTopic:readerTopic];
+            NSMutableArray *newPosts = [self makeNewPostsFromRemotePosts:posts forTopic:readerTopic inContext:self.managedObjectContext];
 
             // When refreshing, some content previously synced may have been deleted remotely.
             // Remove anything we've synced that is missing.
@@ -1102,11 +1102,11 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
  @param topic The `ReaderAbsractTopic` to assign to the created posts.
  @return An array of `ReaderPost` objects
  */
-- (NSMutableArray *)makeNewPostsFromRemotePosts:(NSArray *)posts forTopic:(ReaderAbstractTopic *)topic
+- (NSMutableArray *)makeNewPostsFromRemotePosts:(NSArray *)posts forTopic:(ReaderAbstractTopic *)topic inContext:(NSManagedObjectContext *)context
 {
     NSMutableArray *newPosts = [NSMutableArray array];
     for (RemoteReaderPost *post in posts) {
-        ReaderPost *newPost = [self createOrReplaceFromRemotePost:post forTopic:topic];
+        ReaderPost *newPost = [self createOrReplaceFromRemotePost:post forTopic:topic inContext:context];
         if (newPost != nil) {
             [newPosts addObject:newPost];
         } else {
@@ -1123,9 +1123,11 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
  @param topic The `ReaderAbstractTopic` to assign to the created post.
  @return A `ReaderPost` model object whose properties are populated with the values from the passed dictionary.
  */
-- (ReaderPost *)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic
+- (ReaderPost *)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic inContext:(NSManagedObjectContext *)context
 {
-    return [ReaderPost createOrReplaceFromRemotePost:remotePost forTopic:topic context:self.managedObjectContext];
+    NSParameterAssert(context != nil);
+    NSParameterAssert(topic == nil || topic.managedObjectContext == context);
+    return [ReaderPost createOrReplaceFromRemotePost:remotePost forTopic:topic context:context];
 }
 
 @end

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -46,7 +46,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 {
     NSNumber *rank = @([[NSDate date] timeIntervalSinceReferenceDate]);
     if (offset > 0) {
-        rank = [self rankForPostAtOffset:offset - 1 forTopic:topic];
+        rank = [self rankForPostAtOffset:offset - 1 forTopic:topic inContext:self.managedObjectContext];
     }
 
     if (offset >= ReaderPostServiceMaxSearchPosts && [topic isKindOfClass:[ReaderSearchTopic class]]) {
@@ -630,7 +630,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     return count;
 }
 
-- (NSNumber *)rankForPostAtOffset:(NSUInteger)offset forTopic:(ReaderAbstractTopic *)topic
+- (NSNumber *)rankForPostAtOffset:(NSUInteger)offset forTopic:(ReaderAbstractTopic *)topic inContext:(NSManagedObjectContext *)context
 {
     NSError *error;
     NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:@"ReaderPost"];
@@ -643,7 +643,7 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
     fetchRequest.fetchOffset = offset;
     fetchRequest.fetchLimit = 1;
 
-    ReaderPost *post = [[self.managedObjectContext executeFetchRequest:fetchRequest error:&error] firstObject];
+    ReaderPost *post = [[context executeFetchRequest:fetchRequest error:&error] firstObject];
     if (error || !post) {
         DDLogError(@"Error fetching post at a specific offset.", error);
         return nil;

--- a/WordPress/Classes/Services/ReaderPostService.m
+++ b/WordPress/Classes/Services/ReaderPostService.m
@@ -84,12 +84,13 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
 
 - (void)updateTopic:(NSManagedObjectID *)topicObjectID withAlgorithm:(NSString *)algorithm
 {
-    [self.managedObjectContext performBlock:^{
+    NSManagedObjectContext *context = self.managedObjectContext;
+    [context performBlock:^{
         NSError *error;
-        ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[self.managedObjectContext existingObjectWithID:topicObjectID error:&error];
+        ReaderAbstractTopic *topic = (ReaderAbstractTopic *)[context existingObjectWithID:topicObjectID error:&error];
         topic.algorithm = algorithm;
 
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        [[ContextManager sharedInstance] saveContext:context];
     }];
 }
 
@@ -138,15 +139,16 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             return;
         }
 
-        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:self.managedObjectContext];
+        NSManagedObjectContext *context = self.managedObjectContext;
+        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:context];
 
         NSError *error;
-        BOOL obtainedID = [self.managedObjectContext obtainPermanentIDsForObjects:@[post] error:&error];
+        BOOL obtainedID = [context obtainPermanentIDsForObjects:@[post] error:&error];
         if (!obtainedID) {
             DDLogError(@"Error obtaining a permanent ID for post. %@, %@", post, error);
         }
 
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        [[ContextManager sharedInstance] saveContext:context];
         success(post);
 
     } failure:^(NSError *error) {
@@ -167,15 +169,16 @@ static NSString * const ReaderPostGlobalIDKey = @"globalID";
             return;
         }
 
-        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:self.managedObjectContext];
+        NSManagedObjectContext *context = self.managedObjectContext;
+        ReaderPost *post = [self createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:context];
 
         NSError *error;
-        BOOL obtainedID = [self.managedObjectContext obtainPermanentIDsForObjects:@[post] error:&error];
+        BOOL obtainedID = [context obtainPermanentIDsForObjects:@[post] error:&error];
         if (!obtainedID) {
             DDLogError(@"Error obtaining a permanent ID for post. %@, %@", post, error);
         }
 
-        [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
+        [[ContextManager sharedInstance] saveContext:context];
         success(post);
 
     } failure:^(NSError *error) {

--- a/WordPress/WordPressTest/ReaderPostServiceTest.m
+++ b/WordPress/WordPressTest/ReaderPostServiceTest.m
@@ -11,7 +11,7 @@
 
 @interface ReaderPostService()
 
-- (ReaderPost *)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic;
+- (ReaderPost *)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic inContext:(NSManagedObjectContext *)context;
 
 @end
 
@@ -39,7 +39,7 @@
     ReaderPostService *service = [[ReaderPostService alloc] initWithManagedObjectContext:context];
 
     RemoteReaderPost *remotePost = [self remoteReaderPostForTests];
-    ReaderPost *post = [service createOrReplaceFromRemotePost:remotePost forTopic:nil];
+    ReaderPost *post = [service createOrReplaceFromRemotePost:remotePost forTopic:nil inContext:context];
     [coreDataStack saveContext:context];
 
     [service deletePostsWithNoTopic];


### PR DESCRIPTION
This PR is the first half of replacing `managedObjectContext` with `CoreDataStack` in `ReaderPostService`. All changes in this PR are internal changes to the `ReaderPostService`. They are mostly replacing `self.managedObjectContext` with a function argument, which is still the same object as `self.managedObjectContext`. So, no real app logic should be changed in this PR.

With this PR merged, I'll follow up with the real change—replacing `managedObjectContext` with `CoreDataStack`, which hopefully will have less and clearer diff.

Again, reviewing commit by commit with "Hide whitespace" option on should help code review.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
