### PR TITLE
Remove mobile forum from the release notes of release/21.8

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,6 @@
 21.8
 -----
 * [*] [WordPress-only] We have redesigned and simplified the landing screen. [#20061]
-* [**] [internal] New Forum Support Help Card Screen. [#19993]
 * [*] [internal] Refactored account related operations (i.e. log in and out of the app). [#19893]
 * [*] [internal] Refactored comment related operations (i.e. like a comment, reply to a post or comment).
 * [*] [internal] Refactored how reader topics are fetched from the database. [#20129]


### PR DESCRIPTION
The mobile forum feature did not make it into release/21.8 fully, removing the mention from the release notes
