### PR TITLE
[Domain Purchasing Site Creation] Update tracks

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -2,10 +2,24 @@ import Foundation
 
 extension WPAnalytics {
     static func domainsProperties(for blog: Blog) -> [AnyHashable: Any] {
-        domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan)
+        // For now we do not have the `siteCreation` route implemented so hardcoding `menu`
+        domainsProperties(usingCredit: blog.canRegisterDomainWithPaidPlan, origin: .menu)
     }
 
-    static func domainsProperties(usingCredit: Bool) -> [AnyHashable: Any] {
-        ["using_credit": usingCredit.stringLiteral]
+    static func domainsProperties(
+        usingCredit: Bool,
+        origin: DomainPurchaseWebViewViewOrigin?
+    ) -> [AnyHashable: Any] {
+        var dict: [AnyHashable: Any] = ["using_credit": usingCredit.stringLiteral]
+        if FeatureFlag.siteCreationDomainPurchasing.enabled,
+           let origin = origin {
+            dict["origin"] = origin.rawValue
+        }
+        return dict
     }
+}
+
+enum DomainPurchaseWebViewViewOrigin: String {
+    case siteCreation = "site_creation"
+    case menu
 }

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -54,7 +54,13 @@ class RegisterDomainDetailsViewController: UITableViewController {
         super.viewDidAppear(animated)
 
         // This form is only used to redeem an existing domain credit
-        WPAnalytics.track(.domainsRegistrationFormViewed, properties: WPAnalytics.domainsProperties(usingCredit: true))
+        WPAnalytics.track(
+            .domainsRegistrationFormViewed,
+            properties: WPAnalytics.domainsProperties(
+                usingCredit: true,
+                origin: .menu
+            )
+        )
     }
 
     private func configureView() {
@@ -187,7 +193,13 @@ class RegisterDomainDetailsViewController: UITableViewController {
 extension RegisterDomainDetailsViewController {
 
     @objc private func registerDomainButtonTapped(sender: UIButton) {
-        WPAnalytics.track(.domainsRegistrationFormSubmitted, properties: WPAnalytics.domainsProperties(usingCredit: true))
+        WPAnalytics.track(
+            .domainsRegistrationFormSubmitted,
+            properties: WPAnalytics.domainsProperties(
+                usingCredit: true,
+                origin: nil
+            )
+        )
 
         viewModel.register()
     }

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/WebAddressWizardContent.swift
@@ -365,10 +365,14 @@ final class WebAddressWizardContent: CollapsableHeaderViewController {
     }
 
     private func trackDomainsSelection(_ domainSuggestion: DomainSuggestion) {
-        let domainSuggestionProperties: [String: AnyObject] = [
+        var domainSuggestionProperties: [String: Any] = [
             "chosen_domain": domainSuggestion.domainName as AnyObject,
             "search_term": lastSearchQuery as AnyObject
         ]
+
+        if FeatureFlag.siteCreationDomainPurchasing.enabled {
+            domainSuggestionProperties["domain_cost"] = domainSuggestion.costString
+        }
 
         WPAnalytics.track(.enhancedSiteCreationDomainsSelected, withProperties: domainSuggestionProperties)
     }


### PR DESCRIPTION
Refs #20086

## Testing:

1. Launch & Login Jetpack
2. Enable `Site Creation Domain Purchasing` feature flag

### Domains Selected
3. Open "My Sites".
4. Tap ➕ icon to create a new site
5. Tap "Create Wordpress.com site"
6. Finish the flow and tap "Done".
7. Verify if the `enhanced_site_creation_domains_selected` event has been fired with the new `domain_cost` parameter.
8. Repeat the flow with Feature Flag disabled and verify new parameter is not in the event.

### Webview Viewed
3. Enable feature flag
4. Menu -> Domains -> "Search for a domain" -> Select one option and tap "Select domain"
5. Verify if the `domains_purchase_webview_viewed` event has been fired with the new `origin` parameter. The parameter must be "menu". The other option will be available after that screen is implemented.
6. Repeat the steps with the feature flag turned off and verify the `origin` parameter is not in the event.

I did not add the other 2 events mentioned in the issue as I am not sure how to test them also `domains_registration_form_submitted` seem to already exist in code. I think we need revisit them once the flow is in place.

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
