### PR TITLE
Fix #20191: both the success and failure blocks may get called

### DIFF
--- a/WordPress/WordPressTest/PostCategoryServiceTests.m
+++ b/WordPress/WordPressTest/PostCategoryServiceTests.m
@@ -126,4 +126,30 @@
                                  failure:^(NSError * _Nonnull error) {}];
 }
 
+- (void)testSyncSuccessShouldBeCalledOnce
+{
+    TaxonomyServiceRemoteREST *remote = self.service.remoteForStubbing;
+
+    XCTestExpectation *completion = [self expectationWithDescription:@"Only the success block is called"];
+    OCMStub([remote getCategoriesWithSuccess:[OCMArg invokeBlock]
+                                     failure:[OCMArg isNotNil]]);
+    [self.service syncCategoriesForBlog:self.blog
+                                success:^{ [completion fulfill]; }
+                                failure:^(NSError * _Nonnull error) {[completion fulfill]; }];
+    [self waitForExpectations:@[completion] timeout:1];
+}
+
+- (void)testSyncFailureShouldBeCalledOnce
+{
+    TaxonomyServiceRemoteREST *remote = self.service.remoteForStubbing;
+
+    XCTestExpectation *completion = [self expectationWithDescription:@"Only the failure block is called"];
+    OCMStub([remote getCategoriesWithSuccess:[OCMArg isNotNil]
+                                     failure:[OCMArg invokeBlock]]);
+    [self.service syncCategoriesForBlog:self.blog
+                                success:^{ [completion fulfill]; }
+                                failure:^(NSError * _Nonnull error) {[completion fulfill]; }];
+    [self waitForExpectations:@[completion] timeout:1];
+}
+
 @end


### PR DESCRIPTION
Fix #20191, which was introduced by https://github.com/wordpress-mobile/WordPress-iOS/pull/19956.

We should not call the `failure` during execution of the Core Data block, which is the first argument of `performAndSavingUsingBlock:completion`, since the second argument `completion` block is always going to be called. When the `Blog` can't be found for some reason, both of the failure and success blocks are called, which causes the unbalanced `dispatch_group_enter` and `dispatch_group_leave` calls in #20191.

**Please note**: this PR targets the 21.8 release due to this is a crash fix. @mokagio please let me know if you think I should target the trunk branch instead.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
