### PR TITLE
Use `CoreDataStack` in a few service types

### DIFF
--- a/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
+++ b/WordPress/Classes/Models/Notifications/Actions/NotificationAction.swift
@@ -19,7 +19,7 @@ class DefaultNotificationActionCommand: FormattableContentActionCommand {
     }()
 
     private(set) lazy var actionsService: NotificationActionsService? = {
-        return NotificationActionsService(managedObjectContext: mainContext!)
+        return NotificationActionsService(coreDataStack: ContextManager.shared)
     }()
 
     init(on: Bool) {

--- a/WordPress/Classes/Services/JetpackRestoreService.swift
+++ b/WordPress/Classes/Services/JetpackRestoreService.swift
@@ -1,16 +1,19 @@
 import Foundation
 
-@objc class JetpackRestoreService: LocalCoreDataService {
+@objc class JetpackRestoreService: CoreDataService {
 
     private lazy var serviceV1: ActivityServiceRemote_ApiVersion1_0 = {
-        let api = WordPressComRestApi.defaultApi(in: managedObjectContext)
+        let api = coreDataStack.performQuery {
+            WordPressComRestApi.defaultApi(in: $0)
+        }
 
         return ActivityServiceRemote_ApiVersion1_0(wordPressComRestApi: api)
     }()
 
     private lazy var service: ActivityServiceRemote = {
-        let api = WordPressComRestApi.defaultApi(in: managedObjectContext,
-                                                 localeKey: WordPressComRestApi.LocaleKeyV2)
+        let api = coreDataStack.performQuery {
+            WordPressComRestApi.defaultApi(in: $0, localeKey: WordPressComRestApi.LocaleKeyV2)
+        }
 
         return ActivityServiceRemote(wordPressComRestApi: api)
     }()

--- a/WordPress/Classes/Services/JetpackScanService.swift
+++ b/WordPress/Classes/Services/JetpackScanService.swift
@@ -1,9 +1,10 @@
 import Foundation
 
-@objc class JetpackScanService: LocalCoreDataService {
+@objc class JetpackScanService: CoreDataService {
     private lazy var service: JetpackScanServiceRemote = {
-        let api = WordPressComRestApi.defaultApi(in: managedObjectContext,
-                                                 localeKey: WordPressComRestApi.LocaleKeyV2)
+        let api = coreDataStack.performQuery {
+            WordPressComRestApi.defaultApi(in: $0, localeKey: WordPressComRestApi.LocaleKeyV2)
+        }
 
         return JetpackScanServiceRemote(wordPressComRestApi: api)
     }()

--- a/WordPress/Classes/Services/NotificationActionsService.swift
+++ b/WordPress/Classes/Services/NotificationActionsService.swift
@@ -3,7 +3,7 @@ import CocoaLumberjack
 
 /// This service encapsulates all of the Actions that can be performed with a NotificationBlock
 ///
-class NotificationActionsService: LocalCoreDataService {
+class NotificationActionsService: CoreDataService {
 
     /// Follows a Site referenced by a given NotificationBlock.
     ///
@@ -280,10 +280,10 @@ private extension NotificationActionsService {
 private extension NotificationActionsService {
 
     var commentService: CommentService {
-        return CommentService(coreDataStack: ContextManager.shared)
+        return CommentService(coreDataStack: coreDataStack)
     }
 
     var siteService: ReaderSiteService {
-        return ReaderSiteService(coreDataStack: ContextManager.shared)
+        return ReaderSiteService(coreDataStack: coreDataStack)
     }
 }

--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -4,18 +4,18 @@ import Foundation
 /// The purpose of this service is to encapsulate the Restful API that performs Mobile 2FA
 /// Code Verification.
 ///
-@objc open class PushAuthenticationService: LocalCoreDataService {
+class PushAuthenticationService {
 
-    @objc open var authenticationServiceRemote: PushAuthenticationServiceRemote?
+    var authenticationServiceRemote: PushAuthenticationServiceRemote?
 
     /// Designated Initializer
     ///
     /// - Parameter managedObjectContext: A Reference to the MOC that should be used to interact with
     ///                                   the Core Data Persistent Store.
     ///
-    public required override init(managedObjectContext: NSManagedObjectContext) {
-        super.init(managedObjectContext: managedObjectContext)
-        self.authenticationServiceRemote = PushAuthenticationServiceRemote(wordPressComRestApi: apiForRequest())
+    init(coreDataStack: CoreDataStack) {
+        let api = coreDataStack.performQuery(self.apiForRequest(in:))
+        self.authenticationServiceRemote = PushAuthenticationServiceRemote(wordPressComRestApi: api)
     }
 
     /// Authorizes a WordPress.com Login Attempt (2FA Protected Accounts)
@@ -24,7 +24,7 @@ import Foundation
     ///     - token: The Token sent over by the backend, via Push Notifications.
     ///     - completion: The completion block to be executed when the remote call finishes.
     ///
-    @objc open func authorizeLogin(_ token: String, completion: @escaping ((Bool) -> ())) {
+    func authorizeLogin(_ token: String, completion: @escaping ((Bool) -> ())) {
         if self.authenticationServiceRemote == nil {
             return
         }
@@ -43,11 +43,11 @@ import Foundation
     ///
     /// - Returns: WordPressComRestApi instance.  It can be an anonymous API instance if there are no credentials.
     ///
-    fileprivate func apiForRequest() -> WordPressComRestApi {
+    private func apiForRequest(in context: NSManagedObjectContext) -> WordPressComRestApi {
 
         var api: WordPressComRestApi? = nil
 
-        if let unwrappedRestApi = (try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext))?.wordPressComRestApi {
+        if let unwrappedRestApi = (try? WPAccount.lookupDefaultWordPressComAccount(in: context))?.wordPressComRestApi {
             if unwrappedRestApi.hasCredentials() {
                 api = unwrappedRestApi
             }

--- a/WordPress/Classes/Services/QRLoginService.swift
+++ b/WordPress/Classes/Services/QRLoginService.swift
@@ -1,12 +1,12 @@
 import Foundation
 import WordPressKit
 
-class QRLoginService: LocalCoreDataService {
+class QRLoginService {
     private let service: QRLoginServiceRemote
 
-    init(managedObjectContext: NSManagedObjectContext, remoteService: QRLoginServiceRemote? = nil) {
-        self.service = remoteService ?? QRLoginServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
-        super.init()
+    init(coreDataStack: CoreDataStack, remoteService: QRLoginServiceRemote? = nil) {
+        self.service = remoteService ??
+            coreDataStack.performQuery({ QRLoginServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: $0, localeKey: WordPressComRestApi.LocaleKeyV2)) })
     }
 
     func validate(token: QRLoginToken, success: @escaping(QRLoginValidationResponse) -> Void, failure: @escaping(Error?, QRLoginError?) -> Void) {

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -6,14 +6,18 @@ typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
 
 /// Allows searching for sites / feeds in the Reader.
 ///
-@objc class ReaderSiteSearchService: LocalCoreDataService {
+@objc class ReaderSiteSearchService: CoreDataService {
 
     // The size of a single page of results when performing a search.
     static let pageSize = 20
 
     private func apiRequest() -> WordPressComRestApi {
-        let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: managedObjectContext)
-        if let api = defaultAccount?.wordPressComRestApi, api.hasCredentials() {
+        let api = coreDataStack.performQuery {
+            let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: $0)
+            return defaultAccount?.wordPressComRestApi
+        }
+
+        if let api, api.hasCredentials() {
             return api
         }
 

--- a/WordPress/Classes/Utility/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/PushAuthenticationManager.swift
@@ -20,8 +20,7 @@ class PushAuthenticationManager {
 
 
     convenience init() {
-        let context = ContextManager.sharedInstance().mainContext
-        let service = PushAuthenticationService(managedObjectContext: context)
+        let service = PushAuthenticationService(coreDataStack: ContextManager.shared)
         self.init(pushAuthenticationService: service)
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackRestoreStatusCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Status/Coordinators/JetpackRestoreStatusCoordinator.swift
@@ -23,8 +23,8 @@ class JetpackRestoreStatusCoordinator {
     init(site: JetpackSiteRef,
          view: JetpackRestoreStatusView,
          service: JetpackRestoreService? = nil,
-         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
-        self.service = service ?? JetpackRestoreService(managedObjectContext: context)
+         coreDataStack: CoreDataStack = ContextManager.shared) {
+        self.service = service ?? JetpackRestoreService(coreDataStack: coreDataStack)
         self.site = site
         self.view = view
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/Coordinators/JetpackRestoreWarningCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Warning/Coordinators/JetpackRestoreWarningCoordinator.swift
@@ -24,8 +24,8 @@ class JetpackRestoreWarningCoordinator {
          rewindID: String?,
          view: JetpackRestoreWarningView,
          service: JetpackRestoreService? = nil,
-         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
-        self.service = service ?? JetpackRestoreService(managedObjectContext: context)
+         coreDataStack: CoreDataStack = ContextManager.shared) {
+        self.service = service ?? JetpackRestoreService(coreDataStack: coreDataStack)
         self.site = site
         self.rewindID = rewindID
         self.restoreTypes = restoreTypes

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -65,9 +65,9 @@ class JetpackScanCoordinator {
     init(blog: Blog,
          view: JetpackScanView,
          service: JetpackScanService? = nil,
-         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+         coreDataStack: CoreDataStack = ContextManager.shared) {
 
-        self.service = service ?? JetpackScanService(managedObjectContext: context)
+        self.service = service ?? JetpackScanService(coreDataStack: coreDataStack)
         self.blog = blog
         self.view = view
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanHistoryCoordinator.swift
@@ -35,9 +35,9 @@ class JetpackScanHistoryCoordinator {
     init(blog: Blog,
          view: JetpackScanHistoryView,
          service: JetpackScanService? = nil,
-         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+         coreDataStack: CoreDataStack = ContextManager.shared) {
 
-        self.service = service ?? JetpackScanService(managedObjectContext: context)
+        self.service = service ?? JetpackScanService(coreDataStack: coreDataStack)
         self.blog = blog
         self.view = view
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -1453,7 +1453,7 @@ private extension NotificationDetailsViewController {
     }
 
     var actionsService: NotificationActionsService {
-        return NotificationActionsService(managedObjectContext: mainContext)
+        return NotificationActionsService(coreDataStack: ContextManager.shared)
     }
 
     enum DisplayError: Error {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1859,7 +1859,7 @@ private extension NotificationsViewController {
     }
 
     var actionsService: NotificationActionsService {
-        return NotificationActionsService(managedObjectContext: mainContext)
+        return NotificationActionsService(coreDataStack: ContextManager.shared)
     }
 
     var userDefaults: UserPersistentRepository {

--- a/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginVerifyCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginVerifyCoordinator.swift
@@ -15,12 +15,12 @@ class QRLoginVerifyCoordinator {
          parentCoordinator: QRLoginParentCoordinator,
          connectionChecker: QRLoginConnectionChecker = QRLoginInternetConnectionChecker(),
          service: QRLoginService? = nil,
-         context: NSManagedObjectContext = ContextManager.sharedInstance().mainContext) {
+         coreDataStack: CoreDataStack = ContextManager.shared) {
         self.token = token
         self.view = view
         self.connectionChecker = connectionChecker
         self.parentCoordinator = parentCoordinator
-        self.service = service ?? QRLoginService(managedObjectContext: context)
+        self.service = service ?? QRLoginService(coreDataStack: coreDataStack)
     }
 
     enum ViewState {

--- a/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderSiteSearchViewController.swift
@@ -106,8 +106,7 @@ class ReaderSiteSearchViewController: UITableViewController, UIViewControllerRes
             showLoadingView()
         }
 
-        let context = ContextManager.sharedInstance().mainContext
-        let service = ReaderSiteSearchService(managedObjectContext: context)
+        let service = ReaderSiteSearchService(coreDataStack: ContextManager.shared)
         service.performSearch(with: query,
                               page: page,
                               success: { [weak self] (feeds, hasMore, totalFeeds) in

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -71,7 +71,7 @@ final class SiteCreationWizardLauncher {
     private func initStep(_ step: SiteCreationStep) -> WizardStep {
         switch step {
         case .address:
-            let addressService = DomainsServiceAdapter(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            let addressService = DomainsServiceAdapter(coreDataStack: ContextManager.shared)
             return WebAddressStep(creator: self.creator, service: addressService)
         case .design:
             // we call dropLast to remove .siteAssembly

--- a/WordPress/WordPressTest/ApproveCommentActionTests.swift
+++ b/WordPress/WordPressTest/ApproveCommentActionTests.swift
@@ -10,7 +10,7 @@ final class ApproveCommentActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }

--- a/WordPress/WordPressTest/EditCommentActionTests.swift
+++ b/WordPress/WordPressTest/EditCommentActionTests.swift
@@ -10,7 +10,7 @@ final class EditCommentActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }

--- a/WordPress/WordPressTest/LikeCommentActionTests.swift
+++ b/WordPress/WordPressTest/LikeCommentActionTests.swift
@@ -10,7 +10,7 @@ final class LikeCommentActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }

--- a/WordPress/WordPressTest/MarkAsSpamActionTests.swift
+++ b/WordPress/WordPressTest/MarkAsSpamActionTests.swift
@@ -10,7 +10,7 @@ final class MarkAsSpamActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }

--- a/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationManagerTests.swift
@@ -48,7 +48,7 @@ class PushAuthenticationManagerTests: CoreDataTestCase {
     override func setUp() {
         super.setUp()
 
-        mockPushAuthenticationService = MockPushAuthenticationService(managedObjectContext: contextManager.mainContext)
+        mockPushAuthenticationService = MockPushAuthenticationService(coreDataStack: contextManager)
 
         pushAuthenticationManager = PushAuthenticationManager(pushAuthenticationService: mockPushAuthenticationService)
         pushAuthenticationManager?.alertControllerProxy = mockAlertControllerProxy

--- a/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
+++ b/WordPress/WordPressTest/PushAuthenticationServiceTests.swift
@@ -26,7 +26,7 @@ class PushAuthenticationServiceTests: CoreDataTestCase {
         super.setUp()
         mockRemoteApi = MockWordPressComRestApi()
         mockPushAuthenticationServiceRemote = MockPushAuthenticationServiceRemote(wordPressComRestApi: mockRemoteApi)
-        pushAuthenticationService = PushAuthenticationService(managedObjectContext: mainContext)
+        pushAuthenticationService = PushAuthenticationService(coreDataStack: contextManager)
         pushAuthenticationService.authenticationServiceRemote = mockPushAuthenticationServiceRemote
     }
 

--- a/WordPress/WordPressTest/QRLogin/QRLoginVerifyCoordinatorTests.swift
+++ b/WordPress/WordPressTest/QRLogin/QRLoginVerifyCoordinatorTests.swift
@@ -8,7 +8,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testCoordinationStateIsSetOnInit() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -16,7 +16,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Verify the coordinator is in the right state
         XCTAssertEqual(coordinator.state, .verifyingCode)
@@ -25,7 +25,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testValidationRenderSuccess() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -33,7 +33,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         service.responseExpectation = .success
 
@@ -54,7 +54,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testValidationQRLoginError() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
 
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -62,7 +62,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         service.responseExpectation = .failure
         coordinator.start()
@@ -82,7 +82,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testValidationNoConnectionError() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: false)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -90,7 +90,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         service.responseExpectation = .failure
         coordinator.start()
@@ -113,7 +113,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testConfirmFromWaitingForUserVerificationAndSucceeds() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -121,7 +121,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Configure the mocks
         coordinator.state = .waitingForUserVerification
@@ -145,7 +145,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testConfirmFromWaitingForUserVerificationAndFails() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -153,7 +153,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Configure the mocks
         coordinator.state = .waitingForUserVerification
@@ -177,7 +177,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testConfirmFromWaitingForUserVerificationAndHasNoInternet() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: false)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -185,7 +185,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Configure the mocks
         coordinator.state = .waitingForUserVerification
@@ -210,7 +210,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testConfirmTappedFromErrorState() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -218,7 +218,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Configure the mocks
         coordinator.state = .error
@@ -237,7 +237,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testConfirmTappedFromDoneState() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -245,7 +245,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Configure the mocks
         coordinator.state = .done
@@ -265,7 +265,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
     func testCancelButtonTapped() {
         let view = QRLoginVerifyViewMock()
         let parentCoordinator = ParentCoorinatorMock()
-        let service = QRLoginServiceMock(managedObjectContext: mainContext)
+        let service = QRLoginServiceMock(coreDataStack: contextManager)
         let connectionChecker = QRConnectionCheckerMock(mockConnectionAvailable: true)
 
         let coordinator = QRLoginVerifyCoordinator(token: testToken,
@@ -273,7 +273,7 @@ class QRLoginVerifyCoordinatorTests: CoreDataTestCase {
                                                    parentCoordinator: parentCoordinator,
                                                    connectionChecker: connectionChecker,
                                                    service: service,
-                                                   context: mainContext)
+                                                   coreDataStack: contextManager)
 
         // Trigger the action
         coordinator.cancel()

--- a/WordPress/WordPressTest/ReplyToCommentActionTests.swift
+++ b/WordPress/WordPressTest/ReplyToCommentActionTests.swift
@@ -9,7 +9,7 @@ final class ReplyToCommentActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }

--- a/WordPress/WordPressTest/SiteAddressServiceTests.swift
+++ b/WordPress/WordPressTest/SiteAddressServiceTests.swift
@@ -10,7 +10,7 @@ class SiteAddressServiceTests: CoreDataTestCase {
 
     override func setUpWithError() throws {
         remoteApi = MockWordPressComRestApi()
-        service = DomainsServiceAdapter(managedObjectContext: mainContext, api: remoteApi)
+        service = DomainsServiceAdapter(coreDataStack: contextManager, api: remoteApi)
 
         let json = Bundle(for: SiteSegmentTests.self).url(forResource: "domain-suggestions", withExtension: "json")!
         let data = try Data(contentsOf: json)

--- a/WordPress/WordPressTest/TrashCommentActionTests.swift
+++ b/WordPress/WordPressTest/TrashCommentActionTests.swift
@@ -9,7 +9,7 @@ final class TrashCommentActionTests: CoreDataTestCase {
         }
 
         init(on: Bool, coreDataStack: CoreDataStack) {
-            service = MockNotificationActionsService(managedObjectContext: coreDataStack.mainContext)
+            service = MockNotificationActionsService(coreDataStack: coreDataStack)
             super.init(on: on)
         }
     }


### PR DESCRIPTION
I find there are a few types that doesn't actually use `NSManagedObjectContext` much, which makes replacing them with `CoreDataStack` fairly straight-forward. Instead of creating many small PRs, I created this medium-sized one to include all these very similar changes.

Again, it might be easier to review commit by commit.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
