### PR TITLE
Fix failure block getting called twice in `PostCategoryService`

### DIFF
--- a/WordPress/WordPressTest/PostCategoryServiceTests.m
+++ b/WordPress/WordPressTest/PostCategoryServiceTests.m
@@ -126,4 +126,30 @@
                                  failure:^(NSError * _Nonnull error) {}];
 }
 
+- (void)testSyncSuccessShouldBeCalledOnce
+{
+    TaxonomyServiceRemoteREST *remote = self.service.remoteForStubbing;
+
+    XCTestExpectation *completion = [self expectationWithDescription:@"Only the success block is called"];
+    OCMStub([remote getCategoriesWithSuccess:[OCMArg invokeBlock]
+                                     failure:[OCMArg isNotNil]]);
+    [self.service syncCategoriesForBlog:self.blog
+                                success:^{ [completion fulfill]; }
+                                failure:^(NSError * _Nonnull error) {[completion fulfill]; }];
+    [self waitForExpectations:@[completion] timeout:1];
+}
+
+- (void)testSyncFailureShouldBeCalledOnce
+{
+    TaxonomyServiceRemoteREST *remote = self.service.remoteForStubbing;
+
+    XCTestExpectation *completion = [self expectationWithDescription:@"Only the failure block is called"];
+    OCMStub([remote getCategoriesWithSuccess:[OCMArg isNotNil]
+                                     failure:[OCMArg invokeBlock]]);
+    [self.service syncCategoriesForBlog:self.blog
+                                success:^{ [completion fulfill]; }
+                                failure:^(NSError * _Nonnull error) {[completion fulfill]; }];
+    [self waitForExpectations:@[completion] timeout:1];
+}
+
 @end


### PR DESCRIPTION
Fixes #20191 

**Note:** this is a cherry-pick from #20196. Here is a copy of the description from that PR:

> Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/20191, which was introduced by https://github.com/wordpress-mobile/WordPress-iOS/pull/19956.
> 
> We should not call the failure during execution of the Core Data block, which is the first argument of performAndSavingUsingBlock:completion, since the second argument completion block is always going to be called. When the Blog can't be found for some reason, both of the failure and success blocks are called, which causes the unbalanced dispatch_group_enter and dispatch_group_leave calls in https://github.com/wordpress-mobile/WordPress-iOS/issues/20191.

I also mentioned in https://github.com/wordpress-mobile/WordPress-iOS/pull/20196#pullrequestreview-1311080949 about how easy it is to lose context when matching these `dispatch_group` calls, especially when dealing with nested closures. In the future, I wonder if it's worth it to consider creating a thin wrapper for `dispatch_group` 🤔 .

## To test

Verify that the tests are passing.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
