### PR TITLE
Stats: Fix a crash when a difference substring on Insights cell is at the end of the label

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -339,6 +339,7 @@ class StatsTotalInsightsCell: StatsBaseCell {
             return NSAttributedString(string: string, attributes: defaultAttributes)
         }
 
+        let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
         let nsRange = NSRange(range, in: string)
 
         let mutableString = NSMutableAttributedString(string: string, attributes: defaultAttributes)
@@ -354,7 +355,6 @@ class StatsTotalInsightsCell: StatsBaseCell {
             return nil
         }
 
-        let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
         let range: Range<String.Index> = firstIndex..<string.index(lastIndex, offsetBy: -1)
 
         return range

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -335,22 +335,29 @@ class StatsTotalInsightsCell: StatsBaseCell {
     private func attributedDifferenceString(_ string: String, highlightAttributes: [NSAttributedString.Key: Any]) -> NSAttributedString {
         let defaultAttributes = [NSAttributedString.Key.font: UIFont.preferredFont(forTextStyle: .subheadline), NSAttributedString.Key.foregroundColor: UIColor.textSubtle]
 
-        guard let firstIndex = string.firstIndex(of: TextContent.differenceDelimiter),
-              let lastIndex = string.lastIndex(of: TextContent.differenceDelimiter),
-              firstIndex != lastIndex else {
-                  return NSAttributedString(string: string, attributes: defaultAttributes)
-              }
+        guard let range = StatsTotalInsightsCell.rangeOfDifferenceSubstring(string) else {
+            return NSAttributedString(string: string, attributes: defaultAttributes)
+        }
 
-        let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
-
-        // Move the end of the range back by one as we've removed a character
-        let range: Range<String.Index> = firstIndex..<string.index(lastIndex, offsetBy: -1)
         let nsRange = NSRange(range, in: string)
 
         let mutableString = NSMutableAttributedString(string: string, attributes: defaultAttributes)
         mutableString.addAttributes(highlightAttributes, range: nsRange)
 
         return NSAttributedString(attributedString: mutableString)
+    }
+
+    static func rangeOfDifferenceSubstring(_ string: String) -> Range<String.Index>? {
+        guard let firstIndex = string.firstIndex(of: TextContent.differenceDelimiter),
+              let lastIndex = string.lastIndex(of: TextContent.differenceDelimiter),
+              firstIndex != lastIndex else {
+            return nil
+        }
+
+        let string = string.replacingOccurrences(of: String(TextContent.differenceDelimiter), with: "")
+        let range: Range<String.Index> = firstIndex..<string.index(lastIndex, offsetBy: -1)
+
+        return range
     }
 
     @objc private func guideTapped() {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		0147D651294B6EA600AA6410 /* StatsRevampStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0147D650294B6EA600AA6410 /* StatsRevampStoreTests.swift */; };
 		0148CC292859127F00CF5D96 /* StatsWidgetsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */; };
 		0148CC2B2859C87000CF5D96 /* BlogServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */; };
+		015BA4EB29A788A300920F4B /* StatsTotalInsightsCellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */; };
 		01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
 		01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
 		01CE500C290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
@@ -5613,6 +5614,7 @@
 		0147D650294B6EA600AA6410 /* StatsRevampStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsRevampStoreTests.swift; sourceTree = "<group>"; };
 		0148CC282859127F00CF5D96 /* StatsWidgetsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsWidgetsStoreTests.swift; sourceTree = "<group>"; };
 		0148CC2A2859C87000CF5D96 /* BlogServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogServiceMock.swift; sourceTree = "<group>"; };
+		015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTotalInsightsCellTests.swift; sourceTree = "<group>"; };
 		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsPeriodHelperTests.swift; sourceTree = "<group>"; };
@@ -11392,6 +11394,7 @@
 				400A2C942217B68D000A8A59 /* TopViewedVideoStatsRecordValueTests.swift */,
 				400A2C962217B883000A8A59 /* VisitsSummaryStatsRecordValueTests.swift */,
 				01E78D1C296EA54F00FB6863 /* StatsPeriodHelperTests.swift */,
+				015BA4EA29A788A300920F4B /* StatsTotalInsightsCellTests.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -22805,6 +22808,7 @@
 				C856749A243F4292001A995E /* TenorMockDataHelper.swift in Sources */,
 				01E78D1D296EA54F00FB6863 /* StatsPeriodHelperTests.swift in Sources */,
 				3FFE3C0828FE00D10021BB96 /* StatsSegmentedControlDataTests.swift in Sources */,
+				015BA4EB29A788A300920F4B /* StatsTotalInsightsCellTests.swift in Sources */,
 				D81C2F5820F86CEA002AE1F1 /* NetworkStatus.swift in Sources */,
 				E1C545801C6C79BB001CEB0E /* MediaSettingsTests.swift in Sources */,
 				C3439B5F27FE3A3C0058DA55 /* SiteCreationWizardLauncherTests.swift in Sources */,

--- a/WordPress/WordPressTest/StatsTotalInsightsCellTests.swift
+++ b/WordPress/WordPressTest/StatsTotalInsightsCellTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import WordPress
+
+final class StatsTotalInsightsCellTests: XCTestCase {
+
+    func testRangeOfDifferenceSubtringWhenDifferenceAtTheStart() {
+        let string = "*+1 (1%)* higher than the previous 7-days"
+        let range = StatsTotalInsightsCell.rangeOfDifferenceSubstring(string)
+
+        let startIndex = string.startIndex
+        let endIndex = string.index(startIndex, offsetBy: 7)
+        let expectedRange = startIndex..<endIndex
+
+        XCTAssertEqual(range, expectedRange)
+    }
+
+    func testRangeOfDifferenceSubtringWhenDifferenceAtTheEnd() {
+        let string = "Higher than the previous 7-days by *+1 (1%)*"
+        let range = StatsTotalInsightsCell.rangeOfDifferenceSubstring(string)
+
+        let startIndex = string.index(string.startIndex, offsetBy: 35)
+        let endIndex = string.index(startIndex, offsetBy: 7)
+        let expectedRange = startIndex..<endIndex
+
+        XCTAssertEqual(range, expectedRange)
+    }
+
+    func testRangeOfDifferenceSubtringWhenDifferenceAtTheMiddle() {
+        let string = "Higher by *+1 (1%)* compared to the previous 7-days"
+        let range = StatsTotalInsightsCell.rangeOfDifferenceSubstring(string)
+
+        let startIndex = string.index(string.startIndex, offsetBy: 10)
+        let endIndex = string.index(startIndex, offsetBy: 7)
+        let expectedRange = startIndex..<endIndex
+
+        XCTAssertEqual(range, expectedRange)
+    }
+}


### PR DESCRIPTION
Fixes #20199

Crashes are being reported on Sentry for `StatsInsightsTotalsCell` in `zh` locale. 

The crashes happen when calculating a `Range` when a difference substring is at the end of the comparison label. `zh` localization puts the difference substring at the end, that's why the crashes only happen in this locale.

### Example
**Would result in no crash**: +1 (1%) higher than the previous 7-days"
**Would result in a crash**:  Higher than the previous 7-days by +1 (1%)"

## Solution

1. Extract a range calculation into a separate method
2. Write successful and failing unit tests
3. Fix the issue by calculating range from the original string and not from the shorter updated string

## To test:

1. Set iPhone language as English
4. Open Jetpack
5. Open Stats
6. Add "Total Likes", "Total Comments", or "Views and Visitors" cards, make sure the have a difference label at the bottom (for example "+1 (1%) higher than the previous 7-days"
7. Change iPhone language to Chinese
8. Reopen Stats
6. The app should not be crashing anymore

## Regression Notes

1. Potential unintended areas of impact
Breaking the attributed string building functionality when fixing the issue

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I wrote test to ensure the range calculation continues to work the same as before just without the crash

4. What automated tests I added (or what prevented me from doing so)
Extracted range calculation into a separate method and added unit tests

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

<img width="372" alt="image" src="https://user-images.githubusercontent.com/4062343/220906125-81856527-e350-4cb7-a95c-22648ec2679d.png">
