### PR TITLE
Blaze: Add entry point for page list

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze/BlazeWebViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/BlazeWebViewCoordinator.swift
@@ -5,6 +5,7 @@ import UIKit
     case dashboardCard
     case menuItem
     case postsList
+    case pagesList
 
     var description: String {
         switch self {
@@ -14,6 +15,8 @@ import UIKit
             return "menu_item"
         case .postsList:
             return "posts_list"
+        case .pagesList:
+            return "pages_list"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -515,7 +515,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func blazePage(_ page: Page) {
-        // TODO: track event
+        BlazeEventsTracker.trackBlazeFeatureTapped(for: .pagesList)
         BlazeWebViewCoordinator.presentBlazeFlow(in: self, source: .pagesList, blog: blog, postID: page.postID)
     }
 
@@ -778,7 +778,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             }
         })
 
-        // TODO: track event
+        BlazeEventsTracker.trackBlazeFeatureDisplayed(for: .pagesList)
     }
 
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -514,6 +514,11 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         QuickStartTourGuide.shared.visited(.newPage)
     }
 
+    private func blazePage(_ page: Page) {
+        // TODO: track event
+        BlazeWebViewCoordinator.presentBlazeFlow(in: self, source: .pagesList, blog: blog, postID: page.postID)
+    }
+
     fileprivate func editPage(_ page: Page) {
         guard !PostCoordinator.shared.isUploading(post: page) else {
             presentAlertForPageBeingUploaded()
@@ -668,6 +673,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
                     strongSelf.viewPost(page)
                 })
 
+                addBlazeAction(to: alertController, for: page)
                 addSetParentAction(to: alertController, for: page, at: indexPath)
                 addSetHomepageAction(to: alertController, for: page, at: indexPath)
                 addSetPostsPageAction(to: alertController, for: page, at: indexPath)
@@ -758,6 +764,21 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
     override func deletePost(_ apost: AbstractPost) {
         super.deletePost(apost)
+    }
+
+    private func addBlazeAction(to controller: UIAlertController, for page: AbstractPost) {
+        guard FeatureFlag.blaze.enabled && page.canBlaze else {
+            return
+        }
+
+        let buttonTitle = NSLocalizedString("pages.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the page with Blaze.")
+        controller.addActionWithTitle(buttonTitle, style: .default, handler: { [weak self] _ in
+            if let page = self?.pageForObjectID(page.objectID) {
+                self?.blazePage(page)
+            }
+        })
+
+        // TODO: track event
     }
 
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -514,7 +514,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
         QuickStartTourGuide.shared.visited(.newPage)
     }
 
-    private func blazePage(_ page: Page) {
+    private func blazePage(_ page: AbstractPost) {
         BlazeEventsTracker.trackBlazeFeatureTapped(for: .pagesList)
         BlazeWebViewCoordinator.presentBlazeFlow(in: self, source: .pagesList, blog: blog, postID: page.postID)
     }
@@ -773,9 +773,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
 
         let buttonTitle = NSLocalizedString("pages.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the page with Blaze.")
         controller.addActionWithTitle(buttonTitle, style: .default, handler: { [weak self] _ in
-            if let page = self?.pageForObjectID(page.objectID) {
-                self?.blazePage(page)
-            }
+            self?.blazePage(page)
         })
 
         BlazeEventsTracker.trackBlazeFeatureDisplayed(for: .pagesList)


### PR DESCRIPTION
Closes #20210 

## How to test

1. Switch to a site that's eligible for Blaze (See peeHDf-zm-p2 for more info on Blaze requirements)
2. Create three types of pages: public, private, and password protected
3. Go to the pages lists screen and select the published tab
4. On the public page, tap the ellipsis button
5. ✅ A "Promote with Blaze" alert action is displayed
6. ✅ `blaze_feature_displayed <source: posts_list>` is tracked
7. Tap on "Promote with Blaze"
8. ✅ A Blaze webview is presented with the page details filled out 
9. ✅ `blaze_feature_tapped <source: posts_list>` is tracked
10. On the private page, tap the ellipsis button
11. ✅ A "Promote with Blaze" alert action is NOT displayed
12. On the password protected page, tap the ellipsis button
13. ✅ A "Promote with Blaze" alert action is NOT displayed
14. On the pages list screen, switch to the drafts tab
15. On any page, tap the ellipsis button
16. ✅ A "Promote with Blaze" alert action is NOT displayed
17. Switch to a site that's not eligible for Blaze
18. On any page, tap the ellipsis button
19. ✅ A "Promote with Blaze" alert action is NOT displayed


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
