### PR TITLE
Fix: Do not bounce to Safari when both apps are installed

### DIFF
--- a/WordPress/Classes/Extensions/UIApplication+AppAvailability.swift
+++ b/WordPress/Classes/Extensions/UIApplication+AppAvailability.swift
@@ -3,6 +3,7 @@ import Foundation
 enum AppScheme: String {
     case wordpress = "wordpress://"
     case wordpressMigrationV1 = "wordpressmigration+v1://"
+    case jetpack = "jetpack://"
 }
 
 extension UIApplication {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -524,9 +524,12 @@ extension WordPressAppDelegate {
         //
         // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
         if MigrationAppDetection.isCounterpartAppInstalled {
-            // If possible, try to convert the URL to a WP Admin link and open it in Safari.
-            WPAdminConvertibleRouter.shared.handle(url: url)
-            return
+            // If we can handle the URL, then let the UniversalLinkRouter do it.
+            guard UniversalLinkRouter.shared.canHandle(url: url) else {
+                // Otherwise, try to convert the URL to a WP Admin link and open it in Safari.
+                WPAdminConvertibleRouter.shared.handle(url: url)
+                return
+            }
         }
 
         trackDeepLink(for: url) { url in

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -523,7 +523,9 @@ extension WordPressAppDelegate {
         // TODO: Remove this after the Universal Link routes for the WordPress app are removed.
         //
         // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
-        if MigrationAppDetection.isCounterpartAppInstalled && !UniversalLinkRouter.shared.canHandle(url: url) {
+        if MigrationAppDetection.isCounterpartAppInstalled {
+            // If possible, try to convert the URL to a WP Admin link and open it in Safari.
+            WPAdminConvertibleRouter.shared.handle(url: url)
             return
         }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -516,6 +516,17 @@ extension WordPressAppDelegate {
             return
         }
 
+        // When a counterpart WordPress/Jetpack app is detected, ensure that the router can handle the URL.
+        // Passing a URL that the router couldn't handle results in opening the URL in Safari, which will
+        // cause the other app to "catch" the intent — and leads to a navigation loop between the two apps.
+        //
+        // TODO: Remove this after the Universal Link routes for the WordPress app are removed.
+        //
+        // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
+        if MigrationAppDetection.isCounterpartAppInstalled && !UniversalLinkRouter.shared.canHandle(url: url) {
+            return
+        }
+
         trackDeepLink(for: url) { url in
             UniversalLinkRouter.shared.handle(url: url)
         }

--- a/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
@@ -1,0 +1,96 @@
+/// A router that handles routes that can be converted to /wp-admin links.
+///
+/// Note that this is a workaround for an infinite redirect issue between WordPress and Jetpack
+/// when both apps are installed.
+///
+/// This can be removed once we remove the Universal Link routes for the WordPress app.
+struct WPAdminConvertibleRouter: LinkRouter {
+    static let shared = WPAdminConvertibleRouter(routes: [
+        EditPostRoute()
+    ])
+
+    let routes: [Route]
+    let matcher: RouteMatcher
+
+    init(routes: [Route]) {
+        self.routes = routes
+        matcher = RouteMatcher(routes: routes)
+    }
+
+    func canHandle(url: URL) -> Bool {
+        return matcher.routesMatching(url).count > 0
+    }
+
+    func handle(url: URL, shouldTrack track: Bool = false, source: DeepLinkSource? = nil) {
+        matcher.routesMatching(url).forEach { route in
+            route.action.perform(route.values, source: nil, router: self)
+        }
+    }
+}
+
+// MARK: - Routes
+
+struct EditPostRoute: Route {
+    let path = "/post/:domain/:postID"
+    let section: DeepLinkSection? = nil
+    let action: NavigationAction = WPAdminConvertibleNavigationAction.editPost
+    let jetpackPowered: Bool = false
+}
+
+// MARK: - Navigation Action
+
+enum WPAdminConvertibleNavigationAction: NavigationAction {
+    case editPost
+
+    func perform(_ values: [String: String], source: UIViewController?, router: LinkRouter) {
+        let wpAdminURL: URL? = {
+            switch self {
+            case .editPost:
+                guard let url = blogURLString(from: values),
+                      let postID = postID(from: values) else {
+                    return nil
+                }
+
+                var components = URLComponents(string: "https://\(url)/wp-admin/post.php")
+                components?.queryItems = [
+                    .init(name: "post", value: postID),
+                    .init(name: "action", value: "edit"),
+                    .init(name: "calypsoify", value: "1")
+                ]
+                return components?.url
+            }
+        }()
+
+        guard let wpAdminURL else {
+            return
+        }
+
+        UIApplication.shared.open(wpAdminURL)
+    }
+}
+
+private extension WPAdminConvertibleNavigationAction {
+    func blogURLString(from values: [String: String]?) -> String? {
+        guard let domain = values?["domain"] else {
+            return nil
+        }
+
+        // First, check if the provided domain is a siteID.
+        // If it is, then try to look up existing blogs and return the URL instead.
+        if let siteID = Int(domain),
+           let blog = try? Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext),
+           let siteURL = blog.hostURL as? String {
+            return siteURL
+        }
+
+        if let _ = URL(string: domain) {
+            return domain
+        }
+
+        return nil
+    }
+
+    func postID(from values: [String: String]?) -> String? {
+        return values?["postID"]
+    }
+}

--- a/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
@@ -77,10 +77,9 @@ private extension WPAdminConvertibleNavigationAction {
 
         // First, check if the provided domain is a siteID.
         // If it is, then try to look up existing blogs and return the URL instead.
-        if let siteID = Int(domain),
-           let blog = try? Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext),
-           let siteURL = blog.hostURL as? String {
-            return siteURL
+        if let siteID = Int(domain) {
+            let blog = try? Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext)
+            return blog?.hostURL as? String
         }
 
         if let _ = URL(string: domain) {

--- a/WordPress/Classes/Utility/Universal Links/Route.swift
+++ b/WordPress/Classes/Utility/Universal Links/Route.swift
@@ -44,6 +44,14 @@ extension NavigationAction {
                 return false
         }
 
+        // TODO: This is a workaround. Remove after the Universal Link routes for the WordPress app are removed.
+        //
+        // Don't fallback to Safari if the counterpart WordPress/Jetpack app is installed.
+        // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
+        if MigrationAppDetection.isCounterpartAppInstalled {
+            return false
+        }
+
         let noOptions: [UIApplication.OpenExternalURLOptionsKey: Any] = [:]
         UIApplication.shared.open(url, options: noOptions, completionHandler: nil)
         return true

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -150,6 +150,14 @@ struct UniversalLinkRouter: LinkRouter {
         }
 
         if matches.isEmpty {
+            // TODO: This is a workaround. Remove after the Universal Link routes for the WordPress app are removed.
+            //
+            // Don't fallback to Safari if the counterpart WordPress/Jetpack app is installed.
+            // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
+            if MigrationAppDetection.isCounterpartAppInstalled {
+                return
+            }
+
             UIApplication.shared.open(url,
                                       options: [:],
                                       completionHandler: nil)

--- a/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
+++ b/WordPress/Jetpack/Classes/ViewRelated/WordPress-to-Jetpack Migration/Common/MigrationAppDetection.swift
@@ -23,4 +23,9 @@ struct MigrationAppDetection {
 
         return .wordPressNotInstalled
     }
+
+    static var isCounterpartAppInstalled: Bool {
+        let scheme: AppScheme = AppConfiguration.isJetpack ? .wordpress : .jetpack
+        return UIApplication.shared.canOpen(app: scheme)
+    }
 }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -5304,6 +5304,8 @@
 		FE23EB4C26E7C91F005A1698 /* richCommentStyle.css in Resources */ = {isa = PBXBuildFile; fileRef = FE23EB4826E7C91F005A1698 /* richCommentStyle.css */; };
 		FE25C235271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
 		FE25C236271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */; };
+		FE29EFCD29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */; };
+		FE29EFCE29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */; };
 		FE2E3729281C839C00A1E82A /* BloggingPromptsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */; };
 		FE320CC5294705990046899B /* ReaderPostBackupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE320CC4294705990046899B /* ReaderPostBackupTests.swift */; };
 		FE32E7F12844971000744D80 /* ReminderScheduleCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE32E7F02844971000744D80 /* ReminderScheduleCoordinatorTests.swift */; };
@@ -8987,6 +8989,7 @@
 		FE23EB4726E7C91F005A1698 /* richCommentTemplate.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = richCommentTemplate.html; path = Resources/HTML/richCommentTemplate.html; sourceTree = "<group>"; };
 		FE23EB4826E7C91F005A1698 /* richCommentStyle.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; name = richCommentStyle.css; path = Resources/HTML/richCommentStyle.css; sourceTree = "<group>"; };
 		FE25C234271F23000084E1DB /* ReaderCommentsNotificationSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderCommentsNotificationSheetViewController.swift; sourceTree = "<group>"; };
+		FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPAdminConvertibleRouter.swift; sourceTree = "<group>"; };
 		FE2E3728281C839C00A1E82A /* BloggingPromptsServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BloggingPromptsServiceTests.swift; sourceTree = "<group>"; };
 		FE320CC4294705990046899B /* ReaderPostBackupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderPostBackupTests.swift; sourceTree = "<group>"; };
 		FE32E7F02844971000744D80 /* ReminderScheduleCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderScheduleCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -17476,6 +17479,7 @@
 			children = (
 				FE4DC5A2293A75FC008F322F /* MigrationDeepLinkRouter.swift */,
 				FE4DC5A6293A79F1008F322F /* WordPressExportRoute.swift */,
+				FE29EFCC29A91160007CE034 /* WPAdminConvertibleRouter.swift */,
 			);
 			path = Migration;
 			sourceTree = "<group>";
@@ -20949,6 +20953,7 @@
 				F5D399302541F25B0058D0AB /* SheetActions.swift in Sources */,
 				93F7214F271831820021A09F /* SiteStatsPinnedItemStore.swift in Sources */,
 				9895401126C1F39300EDEB5A /* EditCommentTableViewController.swift in Sources */,
+				FE29EFCD29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */,
 				8B7F51C924EED804008CF5B5 /* ReaderTracker.swift in Sources */,
 				E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */,
 				931215E4267F5003008C3B69 /* ReferrerDetailsTableViewController.swift in Sources */,
@@ -22962,6 +22967,7 @@
 				FABB20CF2602FC2C00C8785C /* PageListViewController.swift in Sources */,
 				FABB20D02602FC2C00C8785C /* CoreDataHelper.swift in Sources */,
 				FABB20D12602FC2C00C8785C /* LocalCoreDataService.m in Sources */,
+				FE29EFCE29A91160007CE034 /* WPAdminConvertibleRouter.swift in Sources */,
 				FABB20D22602FC2C00C8785C /* AztecNavigationController.swift in Sources */,
 				FABB20D32602FC2C00C8785C /* Notification+Interface.swift in Sources */,
 				FABB20D42602FC2C00C8785C /* ReaderSaveForLater+Analytics.swift in Sources */,


### PR DESCRIPTION
Refs #19755, p4a5px-2Rv-p2

### Context

When handling Universal Links, the app bounces the URL to Safari if it couldn't handle the link due to various reasons (unhandled routes, insufficient permission, etc). When both WordPress and Jetpack apps are installed, the URLs bounced by one app will be caught by the other, and since it couldn't handle it too, the other app will bounce the URL back again—leading to an infinite loop.

In #19775, this was handled by removing the bounce code in the Reader route since we're already displaying an error message with an option to display the URL in an in-app browser. However, p4a5px-2Rv-p2 shows that there are routes other than the Reader that can cause the infinite redirect.

### The fix

This PR adds a workaround for this issue by:
- Disabling the bounce to Safari when both apps are installed.
- For certain routes (e.g. `wordpress.com/post/(:siteURL|:siteID)/:postID`), the link will be converted to a wp-admin link (`https://<site-url>/wp-admin/post.php?post=...`), and will be opened in Safari.

## To test

### Environment 1: Both apps are installed

- Have both WordPress and Jetpack apps installed on the device or simulator.
- As there are test cases involving private sites, to make things easier, log in to your WordPress.com account and ensure that you use an account that has access to a private site.
- Tap the links as described by the table below, and verify the expectation column is correct:

No. | Link | Expectation
-|-|-
1 | A valid "edit post" link with site URL (`/post/:siteURL/:postID`) | Opens wp-admin link in Safari
2 | A valid "edit post" link with site ID (`/post/:siteID/:postID`) | Opens wp-admin link in Safari
3 | An **invalid** "edit post" link, e.g. with a wrong site ID. | Does nothing
4 | Any `*.wordpress.com` link that leads to a private site with insufficient access (e.g. a P2 post that you're not a member of) | Does nothing
5 | Any valid deeplink route, for example `https://wordpress.com/me` | Deeplinks into the feature

### Environment 2: Only one app installed

- Have only one app installed (either WordPress or Jetpack).
- Log in to your WordPress.com account.
- Tap the links as described by the table below, and verify the expectation column is correct:

No. | Link | Expectation
-|-|-
1 | A valid "edit post" link with site URL (`/post/:siteURL/:postID`) | Opens the link in Safari
2 | A valid "edit post" link with site ID (`/post/:siteID/:postID`) | Opens the link in Safari
3 | An **invalid** "edit post" link, e.g. with a wrong site ID. | Opens the link in Safari
4 | Any `*.wordpress.com` link that leads to a private site with insufficient access (e.g. a P2 post that you're not a member of) | Does nothing
5 | Any valid deeplink route, for example `https://wordpress.com/me` | Deeplinks into the feature

- Repeat the steps above, but now testing with the other app.

## Regression Notes
1. Potential unintended areas of impact
Some deeplink scenarios could be impacted or not correctly processed.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.