### PR TITLE
Fix database migration issue with different database models

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -243,7 +243,7 @@ private extension ContextManager {
         }
 
         guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType, at: storeURL),
-            objectModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata)
+            !objectModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata)
         else {
             return
         }

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -135,6 +135,41 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
             save(context, .asynchronously)
         }
     }
+
+    static func migrateDataModelsIfNecessary(storeURL: URL, objectModel: NSManagedObjectModel) throws {
+        guard FileManager.default.fileExists(atPath: storeURL.path) else {
+            DDLogInfo("No store exists at \(storeURL).  Skipping migration.")
+            return
+        }
+
+        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType, at: storeURL),
+            !objectModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata)
+        else {
+            return
+        }
+
+        DDLogWarn("Migration required for persistent store.")
+
+        guard let modelFileURL = Bundle.main.url(forResource: "WordPress", withExtension: "momd") else {
+            fatalError("Can't find WordPress.momd")
+        }
+
+        guard let versionInfo = NSDictionary(contentsOf: modelFileURL.appendingPathComponent("VersionInfo.plist")) else {
+            fatalError("Can't get the object model's version info")
+        }
+
+        guard let modelNames = (versionInfo["NSManagedObjectModel_VersionHashes"] as? [String: AnyObject])?.keys else {
+            fatalError("Can't parse the model versions")
+        }
+
+        let sortedModelNames = modelNames.sorted { $0.compare($1, options: .numeric) == .orderedAscending }
+        try CoreDataIterativeMigrator.iterativeMigrate(
+            sourceStore: storeURL,
+            storeType: NSSQLiteStoreType,
+            to: objectModel,
+            using: sortedModelNames
+        )
+    }
 }
 
 // MARK: - Private methods
@@ -236,40 +271,6 @@ private extension ContextManager {
         return persistentContainer
     }
 
-    static func migrateDataModelsIfNecessary(storeURL: URL, objectModel: NSManagedObjectModel) throws {
-        guard FileManager.default.fileExists(atPath: storeURL.path) else {
-            DDLogInfo("No store exists at \(storeURL).  Skipping migration.")
-            return
-        }
-
-        guard let metadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(ofType: NSSQLiteStoreType, at: storeURL),
-            !objectModel.isConfiguration(withName: nil, compatibleWithStoreMetadata: metadata)
-        else {
-            return
-        }
-
-        DDLogWarn("Migration required for persistent store.")
-
-        guard let modelFileURL = Bundle.main.url(forResource: "WordPress", withExtension: "momd") else {
-            fatalError("Can't find WordPress.momd")
-        }
-
-        guard let versionInfo = NSDictionary(contentsOf: modelFileURL.appendingPathComponent("VersionInfo.plist")) else {
-            fatalError("Can't get the object model's version info")
-        }
-
-        guard let modelNames = (versionInfo["NSManagedObjectModel_VersionHashes"] as? [String: AnyObject])?.keys else {
-            fatalError("Can't parse the model versions")
-        }
-
-        let sortedModelNames = modelNames.sorted { $0.compare($1, options: .numeric) == .orderedAscending }
-        try CoreDataIterativeMigrator.iterativeMigrate(
-            sourceStore: storeURL,
-            storeType: NSSQLiteStoreType,
-            to: objectModel,
-            using: sortedModelNames
-        )
-    }
 }
 
 extension ContextManager {

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -255,9 +255,12 @@ extension CoreDataStack {
         let databaseReplaced = replaceDatabase(from: databaseLocation, to: currentDatabaseLocation)
 
         do {
+            let options = [NSMigratePersistentStoresAutomaticallyOption: true,
+                                 NSInferMappingModelAutomaticallyOption: true]
             try storeCoordinator.addPersistentStore(ofType: NSSQLiteStoreType,
                                                     configurationName: nil,
-                                                    at: currentDatabaseLocation)
+                                                    at: currentDatabaseLocation,
+                                                    options: options)
 
             if databaseReplaced {
                 // The database was replaced successfully and the store added with no errors so we

--- a/WordPress/Classes/Utility/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreDataHelper.swift
@@ -250,6 +250,8 @@ extension CoreDataStack {
             throw ContextManager.ContextManagerError.missingDatabase
         }
 
+        try? migrateDatabaseIfNecessary(at: databaseLocation)
+
         mainContext.reset()
         try storeCoordinator.remove(store)
         let databaseReplaced = replaceDatabase(from: databaseLocation, to: currentDatabaseLocation)
@@ -329,5 +331,13 @@ extension CoreDataStack {
         _ = try? FileManager.default.replaceItemAt(location, withItemAt: databaseBackup)
         _ = try? FileManager.default.replaceItemAt(locationShm, withItemAt: shmBackup)
         _ = try? FileManager.default.replaceItemAt(locationWal, withItemAt: walBackup)
+    }
+
+    private func migrateDatabaseIfNecessary(at databaseLocation: URL) throws {
+        guard let modelFileURL = Bundle.main.url(forResource: "WordPress", withExtension: "momd"),
+              let objectModel = NSManagedObjectModel(contentsOf: modelFileURL) else {
+            return
+        }
+        try ContextManager.migrateDataModelsIfNecessary(storeURL: databaseLocation, objectModel: objectModel)
     }
 }


### PR DESCRIPTION
Partially fixes #20207

## Description

- Fixes a logic issue with the existing migrate model functions. Refer to the old Obj-C function here: https://github.com/wordpress-mobile/WordPress-iOS/blob/24db036f22c493ef847c9e6f4fc14d9f9fbd1144/WordPress/Classes/Utility/ContextManager.m#L219
- First attempts to manually migrate the database with existing functions
- If the manual migration fails, fall back to an automatic migration: https://developer.apple.com/documentation/coredata/using_lightweight_migration#2903991

> **Note**
> This does **not** fix the migration issue with `21.8` WordPress -> `21.7` Jetpack. It only fixes `21.7` WordPress -> `21.8` Jetpack. To fix both scenarios, these changes would need to be applied to the `21.7` branch.

## Testing

To test:

### WP -> JP Migration fix

- Checkout the `release/21.7.1` branch
- Install WordPress and login
- Begin the migration with any of the Jetpack powered banner entry points
- Checkout this branch `issue/20207-fix-model-jp-migration`
- Install Jetpack and launch
- Verify your data was migrated successfully

### App upgrade

- Checkout the `release/21.7.1` branch
- Install WordPress and login
- Install Jetpack and login
- Checkout this branch `issue/20207-fix-model-jp-migration`
- Install WordPress and launch
- Verify you are still logged in with your data
- Install Jetpack and launch
- Verify you are still logged in with your data

## Regression Notes
1. Potential unintended areas of impact
Potentially with the existing manual model migration functions


2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually testing the app upgrade scenario and comparing code to older working code


3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
