### PR TITLE
Run Flux tests before Jetpack/WordPress unit tests

### DIFF
--- a/WordPress/WordPressTest/WordPressUnitTests.xctestplan
+++ b/WordPress/WordPressTest/WordPressUnitTests.xctestplan
@@ -31,16 +31,16 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:WordPress.xcodeproj",
-        "identifier" : "E16AB92914D978240047A2E5",
-        "name" : "WordPressTest"
+        "containerPath" : "container:..\/WordPressFlux",
+        "identifier" : "WordPressFluxTests",
+        "name" : "WordPressFluxTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:..\/WordPressFlux",
-        "identifier" : "WordPressFluxTests",
-        "name" : "WordPressFluxTests"
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "E16AB92914D978240047A2E5",
+        "name" : "WordPressTest"
       }
     }
   ],


### PR DESCRIPTION
When you run more than one test target via a test plan, the Xcode console will show the logs for only the last target to run.

By running the Flux tests first and the Jetpack/WordPress last, we keep what are most likely to be the logs we are interested into in the console at the end of each test run.

It's useful to keep an eye on what's printed in the console when the tests run because one can notice all sorts of runtime issues through them.

(_Noticed this while looking at the unit tests for https://github.com/wordpress-mobile/WordPress-iOS/pull/20201_)

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**