### PR TITLE
Blaze: update child vc after fetching blaze status

### DIFF
--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -27,7 +27,7 @@ final class BlazeService {
     ///   - success: Closure to be called on success
     ///   - failure: Closure to be caleld on failure
     func updateStatus(for blog: Blog,
-                      success: ((Bool) -> Void)? = nil,
+                      success: (() -> Void)? = nil,
                       failure: ((Error) -> Void)? = nil) {
         guard let siteId = blog.dotComID?.intValue else {
             failure?(BlazeServiceError.invalidSiteId)
@@ -50,7 +50,7 @@ final class BlazeService {
                     DDLogInfo("Successfully updated isBlazeApproved value for blog: \(approved)")
 
                 }, completion: {
-                    success?(approved)
+                    success?()
                 }, on: .main)
 
             case .failure(let error):

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -958,6 +958,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         guard FeatureFlag.blaze.enabled,
               let blog = blog,
               let blazeService = BlazeService() else {
+            completion()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -126,9 +126,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 return
             }
 
-            updateBlazeStatus(for: newBlog)
+            updateBlazeStatus(for: newBlog) { [weak self] in
+                self?.showBlogDetails(for: newBlog)
+            }
             showSitePicker(for: newBlog)
-            showBlogDetails(for: newBlog)
             updateNavigationTitle(for: newBlog)
             updateSegmentedControl(for: newBlog, switchTabsIfNeeded: true)
             createFABIfNeeded()
@@ -426,9 +427,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             return
         }
 
-        updateBlazeStatus(for: mainBlog)
+        updateBlazeStatus(for: mainBlog) { [weak self] in
+            self?.showBlogDetails(for: mainBlog)
+        }
         showSitePicker(for: mainBlog)
-        showBlogDetails(for: mainBlog)
         updateNavigationTitle(for: mainBlog)
         updateSegmentedControl(for: mainBlog, switchTabsIfNeeded: true)
     }
@@ -818,10 +820,12 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self.switchTab(to: .siteMenu)
             }
 
-            self.updateBlazeStatus(for: blog)
+            self.updateBlazeStatus(for: blog) { 
+                self.updateChildViewController(for: blog)
+            }
+            
             self.updateNavigationTitle(for: blog)
             self.updateSegmentedControl(for: blog)
-            self.updateChildViewController(for: blog)
             self.createFABIfNeeded()
             self.fetchPrompt(for: blog)
 
@@ -950,14 +954,14 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Blaze
 
-    private func updateBlazeStatus(for blog: Blog?) {
+    private func updateBlazeStatus(for blog: Blog?, completion: @escaping () -> Void) {
         guard FeatureFlag.blaze.enabled,
               let blog = blog,
               let blazeService = BlazeService() else {
             return
         }
 
-        blazeService.updateStatus(for: blog)
+        blazeService.updateStatus(for: blog, success: completion)
     }
 
     // MARK: - Blogging Prompts

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -820,10 +820,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
                 self.switchTab(to: .siteMenu)
             }
 
-            self.updateBlazeStatus(for: blog) { 
+            self.updateBlazeStatus(for: blog) {
                 self.updateChildViewController(for: blog)
             }
-            
+
             self.updateNavigationTitle(for: blog)
             self.updateSegmentedControl(for: blog)
             self.createFABIfNeeded()


### PR DESCRIPTION
Part of #20091 
Part of #20092

- Fixes the logic for fetching / updating the blaze status

## How to test
0. Make sure that Blaze is enabled via the debug menu
1. Log into a site that has Blaze enabled (See peeHDf-zm-p2 for more info on Blaze requirements)
3. ✅ A Blaze dashboard card is displayed (The default tab for the My Site screen should be the dashboard i.e. "Home")
4. Switch to the "Menu" tab
5. ✅ A Blaze menu item is displayed
6. Switch to another site that has Blaze enabled
7. ✅ A Blaze menu item is displayed
8. Switch to the "Home" tab
9. ✅ A Blaze dashboard card is displayed
10. Switch to another site that doesn't have Blaze enabled
11. ✅ A Blaze dashboard card is NOT displayed
12. Switch to the "Menu" tab
13. ✅ A Blaze menu item is NOT displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
