### PR TITLE
[JP Plugin] Update the plugin for the Jetpack install cards when the blog is set

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -55,6 +55,7 @@ class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         self.blog = blog
         self.presenterViewController = viewController
+        cardView.updatePlugin(JetpackPlugin(from: blog.jetpackConnectionActivePlugins))
     }
 
     private func setupView() {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
@@ -5,7 +5,7 @@ class JetpackRemoteInstallCardView: UIView {
 
     // MARK: Properties
 
-    private let viewModel: JetpackRemoteInstallCardViewModel
+    private var viewModel: JetpackRemoteInstallCardViewModel
 
     private lazy var animation: Animation? = {
         effectiveUserInterfaceLayoutDirection == .leftToRight ?
@@ -94,6 +94,14 @@ class JetpackRemoteInstallCardView: UIView {
 
     // MARK: Functions
 
+    func updatePlugin(_ plugin: JetpackPlugin?) {
+        guard let plugin else {
+            return
+        }
+        viewModel.installedPlugin = plugin
+        noticeLabel.attributedText = viewModel.noticeLabel
+    }
+
     @objc func onLearnMoreTap() {
         viewModel.onLearnMoreTap()
     }
@@ -134,6 +142,8 @@ struct JetpackRemoteInstallCardViewModel {
 
     let onHideThisTap: UIActionHandler
     let onLearnMoreTap: () -> Void
+    var installedPlugin: JetpackPlugin
+
     var noticeLabel: NSAttributedString {
         switch installedPlugin {
         case .multiple:
@@ -148,8 +158,6 @@ struct JetpackRemoteInstallCardViewModel {
             return boldNoticeText
         }
     }
-
-    private let installedPlugin: JetpackPlugin
 
     init(onHideThisTap: @escaping UIActionHandler = { _ in },
          onLearnMoreTap: @escaping () -> Void = {},

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -54,6 +54,7 @@ class JetpackRemoteInstallTableViewCell: UITableViewCell {
     func configure(blog: Blog, viewController: BlogDetailsViewController?) {
         self.blog = blog
         self.presenterViewController = viewController
+        cardView.updatePlugin(JetpackPlugin(from: blog.jetpackConnectionActivePlugins))
     }
 
     private func setupView() {


### PR DESCRIPTION
> **Warning**
> Auto-merge is on

## Description

Update the Jetpack install cards to properly reflect the installed plugins for the selected blog instead of defaulting to `.multiple`.

<img width="358" src="https://user-images.githubusercontent.com/2454408/221948011-77edc5fd-e621-4e74-a2d9-d9096c4c022e.png">

## Testing

To test:

- Enable the feature flag `jetpackIndividualPluginSupport`
- Setup a self-hosted site with an individual Jetpack plugin and connected to your account
- Install Jetpack and login
- Navigate to the `Home` screen if necessary
- **Verify** the Jetpack install card text is correct for whatever plugin you selected
- Tap on `Menu`
- **Verify** the Jetpack install card text is correct for whatever plugin you selected

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
