### PR TITLE
[UI Tests] Make current WordPress UI Tests to run against Jetpack app locally

### DIFF
--- a/WordPress/JetpackUITests-Info.plist
+++ b/WordPress/JetpackUITests-Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -44,17 +44,17 @@ public class SupportScreen: ScreenObject {
         )
     }
 
-    public func contactSupport() throws -> ContactUsScreen {
+    public func contactSupport(userEmail: String) throws -> ContactUsScreen {
         app.cells["contact-support-button"].tap()
-        addContactInformationIfNeeded()
+        addContactInformationIfNeeded(userEmail)
         return try ContactUsScreen()
     }
 
-    private func addContactInformationIfNeeded() {
+    private func addContactInformationIfNeeded(_ email: String) {
         let emailTextField = app.textFields["Email"]
         if emailTextField.waitForExistence(timeout: 3) {
             emailTextField.tap()
-            emailTextField.typeText("user@test.zzz")
+            emailTextField.typeText(email)
             app.buttons["OK"].tap()
         }
     }

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -45,18 +45,14 @@ public class SupportScreen: ScreenObject {
     }
 
     public func contactSupport(userEmail: String) throws -> ContactUsScreen {
-        app.cells["contact-support-button"].tap()
-        addContactInformationIfNeeded(userEmail)
-        return try ContactUsScreen()
-    }
-
-    private func addContactInformationIfNeeded(_ email: String) {
         let emailTextField = app.textFields["Email"]
-        if emailTextField.waitForExistence(timeout: 3) {
-            emailTextField.tap()
-            emailTextField.typeText(email)
-            app.buttons["OK"].tap()
-        }
+
+        app.cells["contact-support-button"].tap()
+        emailTextField.tap()
+        emailTextField.typeText(userEmail)
+        app.buttons["OK"].tap()
+
+        return try ContactUsScreen()
     }
 
     public func assertVisitForumButtonEnabled() -> SupportScreen {

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -9,6 +9,14 @@ public class SupportScreen: ScreenObject {
         $0.buttons["close-button"]
     }
 
+    private let contactSupportButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.cells["contact-support-button"]
+    }
+
+    private let contactEmailFieldGetter: (XCUIApplication) -> XCUIElement = {
+        $0.textFields["Email"]
+    }
+
     private let visitForumsButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.cells["visit-wordpress-forums-button"]
     }
@@ -34,6 +42,21 @@ public class SupportScreen: ScreenObject {
             app: app,
             waitTimeout: 7
         )
+    }
+
+    public func contactSupport() throws -> ContactUsScreen {
+        app.cells["contact-support-button"].tap()
+        addContactInformationIfNeeded()
+        return try ContactUsScreen()
+    }
+
+    private func addContactInformationIfNeeded() {
+        let emailTextField = app.textFields["Email"]
+        if emailTextField.waitForExistence(timeout: 3) {
+            emailTextField.tap()
+            emailTextField.typeText("user@test.zzz")
+            app.buttons["OK"].tap()
+        }
     }
 
     public func assertVisitForumButtonEnabled() -> SupportScreen {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8586,6 +8586,7 @@
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
 		EA14534229AD874C001F3143 /* JetpackUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JetpackUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA14534329AD874E001F3143 /* JetpackUITests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "JetpackUITests-Info.plist"; path = "/Users/tiagomarques/repos/WordPress-iOS/WordPress/JetpackUITests-Info.plist"; sourceTree = "<absolute>"; };
+		EA14534629AEF479001F3143 /* JetpackUITests.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = JetpackUITests.xctestplan; sourceTree = "<group>"; };
 		EA78189327596B2F00554DFA /* ContactUsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
 		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EAD2BF4127594DAB00A847BB /* StatsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
@@ -10183,7 +10184,6 @@
 				FF37F90822385C9F00AFA3DB /* RELEASE-NOTES.txt */,
 				B565D41C3DB27630CD503F9A /* Pods */,
 				F5E156B425DDD53A00EEEDFB /* Recovered References */,
-				EA14534329AD874E001F3143 /* JetpackUITests-Info.plist */,
 			);
 			name = CustomTemplate;
 			sourceTree = "<group>";
@@ -17637,6 +17637,8 @@
 				CC8A5EAA22159FA6001B7874 /* WPUITestCredentials.swift */,
 				CCA44DF422C4C4D6006E294F /* README.md */,
 				CCCF53BD237B13EA0035E9CA /* WordPressUITests.xctestplan */,
+				EA14534629AEF479001F3143 /* JetpackUITests.xctestplan */,
+				EA14534329AD874E001F3143 /* JetpackUITests-Info.plist */,
 			);
 			path = WordPressUITests;
 			sourceTree = "<group>";

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3278,6 +3278,23 @@
 		E6F2788421BC1A4A008B4DB5 /* PlanFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */; };
 		E6FACB1E1EC675E300284AC7 /* GravatarProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */; };
 		E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B921F5DD9A1F257C792EC225 /* Pods_WordPressTest.framework */; };
+		EA14532929AD874C001F3143 /* MainNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA0B7D61CAC1F9F00533B9D /* MainNavigationTests.swift */; };
+		EA14532A29AD874C001F3143 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
+		EA14532B29AD874C001F3143 /* EditorAztecTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4D82F1FF11DEF00A11345 /* EditorAztecTests.swift */; };
+		EA14532C29AD874C001F3143 /* EditorGutenbergTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2BB0CF228ACF710034F9AB /* EditorGutenbergTests.swift */; };
+		EA14532D29AD874C001F3143 /* LoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716911CAAC87B0006E2D4 /* LoginTests.swift */; };
+		EA14532E29AD874C001F3143 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4E9E1FD664F5007AE3E4 /* BaseScreen.swift */; };
+		EA14532F29AD874C001F3143 /* SupportScreenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5BA46826A59D620043A6F2 /* SupportScreenTests.swift */; };
+		EA14533029AD874C001F3143 /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BF4127594DAB00A847BB /* StatsTests.swift */; };
+		EA14533129AD874C001F3143 /* WPUITestCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8A5EAA22159FA6001B7874 /* WPUITestCredentials.swift */; };
+		EA14533229AD874C001F3143 /* SignupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC7CB97222B1510900642EE9 /* SignupTests.swift */; };
+		EA14533329AD874C001F3143 /* EditorFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC52188B2278C622008998CE /* EditorFlow.swift */; };
+		EA14533429AD874C001F3143 /* UIApplication+mainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B3626F825A665E500D7CCE3 /* UIApplication+mainWindow.swift */; };
+		EA14533529AD874C001F3143 /* LoginFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = BED4D8321FF11E3800A11345 /* LoginFlow.swift */; };
+		EA14533629AD874C001F3143 /* XCTest+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2716A01CABC7D40006E2D4 /* XCTest+Extensions.swift */; };
+		EA14533829AD874C001F3143 /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FA640572670CCD40064401E /* UITestsFoundation.framework */; };
+		EA14533929AD874C001F3143 /* BuildkiteTestCollector in Frameworks */ = {isa = PBXBuildFile; productRef = EA14532529AD874C001F3143 /* BuildkiteTestCollector */; };
+		EA14533A29AD874C001F3143 /* Pods_WordPressUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8DCE7542239FBC709B90EA85 /* Pods_WordPressUITests.framework */; };
 		EA78189427596B2F00554DFA /* ContactUsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA78189327596B2F00554DFA /* ContactUsScreen.swift */; };
 		EAB10E4027487F5D000DA4C1 /* ReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */; };
 		EAD2BF4227594DAB00A847BB /* StatsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD2BF4127594DAB00A847BB /* StatsTests.swift */; };
@@ -5557,6 +5574,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1D6058900D05DD3D006BFB54;
 			remoteInfo = WordPress;
+		};
+		EA14534429AD877C001F3143 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 29B97313FDCFA39411CA2CEA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = FABB1F8F2602FC2C00C8785C;
+			remoteInfo = Jetpack;
 		};
 		F1F163D425658B4D003DC13B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -8560,6 +8584,8 @@
 		E6F2787E21BC1A49008B4DB5 /* PlanFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanFeature.swift; sourceTree = "<group>"; };
 		E6FACB1D1EC675E300284AC7 /* GravatarProfile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GravatarProfile.swift; sourceTree = "<group>"; };
 		E850CD4B77CF21E683104B5A /* Pods-WordPressStatsWidgets.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressStatsWidgets.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressStatsWidgets/Pods-WordPressStatsWidgets.debug.xcconfig"; sourceTree = "<group>"; };
+		EA14534229AD874C001F3143 /* JetpackUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JetpackUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA14534329AD874E001F3143 /* JetpackUITests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "JetpackUITests-Info.plist"; path = "/Users/tiagomarques/repos/WordPress-iOS/WordPress/JetpackUITests-Info.plist"; sourceTree = "<absolute>"; };
 		EA78189327596B2F00554DFA /* ContactUsScreen.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactUsScreen.swift; sourceTree = "<group>"; };
 		EAB10E3F27487F5D000DA4C1 /* ReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTests.swift; sourceTree = "<group>"; };
 		EAD2BF4127594DAB00A847BB /* StatsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatsTests.swift; sourceTree = "<group>"; };
@@ -8804,7 +8830,6 @@
 		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
 		F4E79300296EEE320025E8E0 /* MigrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationState.swift; sourceTree = "<group>"; };
 		F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostService.swift; sourceTree = "<group>"; };
-		F4EDAA4E29A65B4300622D3D /* WordPress 148.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 148.xcdatamodel"; sourceTree = "<group>"; };
 		F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconTests.swift; sourceTree = "<group>"; };
 		F4F09CCB2989BF5B00A5F420 /* ReaderSiteService_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ReaderSiteService_Internal.h; sourceTree = "<group>"; };
 		F4F9D5E92909622E00502576 /* MigrationWelcomeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationWelcomeViewController.swift; sourceTree = "<group>"; };
@@ -9314,6 +9339,16 @@
 				3F338B71289BD3040014ADC5 /* Nimble in Frameworks */,
 				3F3B23C22858A1B300CACE60 /* BuildkiteTestCollector in Frameworks */,
 				E8DEE110E4BC3FA1974AB1BB /* Pods_WordPressTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA14533729AD874C001F3143 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA14533829AD874C001F3143 /* UITestsFoundation.framework in Frameworks */,
+				EA14533929AD874C001F3143 /* BuildkiteTestCollector in Frameworks */,
+				EA14533A29AD874C001F3143 /* Pods_WordPressUITests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -10070,6 +10105,7 @@
 				80F6D05428EE866A00953C1A /* JetpackNotificationServiceExtension.appex */,
 				0107E0EA28F97D5000DE87DB /* JetpackStatsWidgets.appex */,
 				0107E15428FE9DB200DE87DB /* JetpackIntents.appex */,
+				EA14534229AD874C001F3143 /* JetpackUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -10147,6 +10183,7 @@
 				FF37F90822385C9F00AFA3DB /* RELEASE-NOTES.txt */,
 				B565D41C3DB27630CD503F9A /* Pods */,
 				F5E156B425DDD53A00EEEDFB /* Recovered References */,
+				EA14534329AD874E001F3143 /* JetpackUITests-Info.plist */,
 			);
 			name = CustomTemplate;
 			sourceTree = "<group>";
@@ -17968,6 +18005,29 @@
 			productReference = E16AB92A14D978240047A2E5 /* WordPressTest.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		EA14532229AD874C001F3143 /* JetpackUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = EA14533D29AD874C001F3143 /* Build configuration list for PBXNativeTarget "JetpackUITests" */;
+			buildPhases = (
+				EA14532729AD874C001F3143 /* [CP] Check Pods Manifest.lock */,
+				EA14532829AD874C001F3143 /* Sources */,
+				EA14533729AD874C001F3143 /* Frameworks */,
+				EA14533B29AD874C001F3143 /* Resources */,
+				EA14533C29AD874C001F3143 /* Set Up Simulator */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				EA14534529AD877C001F3143 /* PBXTargetDependency */,
+			);
+			name = JetpackUITests;
+			packageProductDependencies = (
+				EA14532529AD874C001F3143 /* BuildkiteTestCollector */,
+			);
+			productName = WordPressUITests;
+			productReference = EA14534229AD874C001F3143 /* JetpackUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		F1F163BD25658B4D003DC13B /* WordPressIntents */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = F1F163DC25658B4D003DC13B /* Build configuration list for PBXNativeTarget "WordPressIntents" */;
@@ -18173,6 +18233,9 @@
 						LastSwiftMigration = 1000;
 						TestTargetID = 1D6058900D05DD3D006BFB54;
 					};
+					EA14532229AD874C001F3143 = {
+						TestTargetID = FABB1F8F2602FC2C00C8785C;
+					};
 					F1F163BD25658B4D003DC13B = {
 						CreatedOnToolsVersion = 12.2;
 						ProvisioningStyle = Manual;
@@ -18267,6 +18330,7 @@
 				80F6D01F28EE866A00953C1A /* JetpackNotificationServiceExtension */,
 				0107E0B128F97D5000DE87DB /* JetpackStatsWidgets */,
 				0107E13828FE9DB200DE87DB /* JetpackIntents */,
+				EA14532229AD874C001F3143 /* JetpackUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -18811,6 +18875,13 @@
 				7E53AB0620FE6905005796FE /* activity-log-comment.json in Resources */,
 				93C882A41EEB18D700227A59 /* rsd.xml in Resources */,
 				F44FB6D12878A1020001E3CE /* user-suggestions.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		EA14533B29AD874C001F3143 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -19992,6 +20063,46 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "# Print commands before executing them (useful for troubleshooting)\nset -x\nDEST=$CONFIGURATION_BUILD_DIR/$UNLOCALIZED_RESOURCES_FOLDER_PATH\n\nif [[ \"$CONFIGURATION\" = *Debug* && ! \"$PLATFORM_NAME\" == *simulator ]]; then\nIP=$(ipconfig getifaddr en0)\nif [ -z \"$IP\" ]; then\nIP=$(ifconfig | grep 'inet ' | grep -v ' 127.' | cut -d\\   -f2  | awk 'NR==1{print $1}')\nfi\n\necho \"$IP\" > \"$DEST/ip.txt\"\nfi\n\nBUNDLE_FILE=\"$DEST/main.jsbundle\"\ncp ${PODS_ROOT}/Gutenberg/bundle/ios/App.js \"${BUNDLE_FILE}\"\n\nBUNDLE_ASSETS=\"$DEST/assets/\"\ncp -r ${PODS_ROOT}/Gutenberg/bundle/ios/assets/ \"${BUNDLE_ASSETS}\"\n";
+		};
+		EA14532729AD874C001F3143 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-WordPressUITests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		EA14533C29AD874C001F3143 /* Set Up Simulator */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Set Up Simulator";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Close all simulators so on next launch they use the settings below\nxcrun simctl shutdown all\n\n# Disable the hardware keyboard in the simulator\ndefaults write com.apple.iphonesimulator ConnectHardwareKeyboard -bool false\n";
 		};
 		F9C5CF0222CD5DB0007CEF56 /* Copy Alternate Internal Icons (if needed) */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -22987,6 +23098,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		EA14532829AD874C001F3143 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				EA14532929AD874C001F3143 /* MainNavigationTests.swift in Sources */,
+				EA14532A29AD874C001F3143 /* ReaderTests.swift in Sources */,
+				EA14532B29AD874C001F3143 /* EditorAztecTests.swift in Sources */,
+				EA14532C29AD874C001F3143 /* EditorGutenbergTests.swift in Sources */,
+				EA14532D29AD874C001F3143 /* LoginTests.swift in Sources */,
+				EA14532E29AD874C001F3143 /* BaseScreen.swift in Sources */,
+				EA14532F29AD874C001F3143 /* SupportScreenTests.swift in Sources */,
+				EA14533029AD874C001F3143 /* StatsTests.swift in Sources */,
+				EA14533129AD874C001F3143 /* WPUITestCredentials.swift in Sources */,
+				EA14533229AD874C001F3143 /* SignupTests.swift in Sources */,
+				EA14533329AD874C001F3143 /* EditorFlow.swift in Sources */,
+				EA14533429AD874C001F3143 /* UIApplication+mainWindow.swift in Sources */,
+				EA14533529AD874C001F3143 /* LoginFlow.swift in Sources */,
+				EA14533629AD874C001F3143 /* XCTest+Extensions.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F1F163BA25658B4D003DC13B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -24934,6 +25066,11 @@
 			isa = PBXTargetDependency;
 			target = 1D6058900D05DD3D006BFB54 /* WordPress */;
 			targetProxy = E16AB93E14D978520047A2E5 /* PBXContainerItemProxy */;
+		};
+		EA14534529AD877C001F3143 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = FABB1F8F2602FC2C00C8785C /* Jetpack */;
+			targetProxy = EA14534429AD877C001F3143 /* PBXContainerItemProxy */;
 		};
 		F1F163D525658B4D003DC13B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -28420,6 +28557,196 @@
 			};
 			name = Release;
 		};
+		EA14533E29AD874C001F3143 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 27AE66536E0C5378203F9312 /* Pods-WordPressUITests.debug.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "JetpackUITests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.jetpack.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = Debug;
+		};
+		EA14533F29AD874C001F3143 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = B787A850C6163034630E7AF2 /* Pods-WordPressUITests.release.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_STYLE = Manual;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = "";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "JetpackUITests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.jetpack.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = Release;
+		};
+		EA14534029AD874C001F3143 /* Release-Internal */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10BBFF34EBDA2F9B8CB48DF6 /* Pods-WordPressUITests.release-internal.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "JetpackUITests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.jetpack.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = "Release-Internal";
+		};
+		EA14534129AD874C001F3143 /* Release-Alpha */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1B77149F6C65D343E7E3AD09 /* Pods-WordPressUITests.release-alpha.xcconfig */;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				INFOPLIST_FILE = "JetpackUITests-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.jetpack.JetpackUITests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 5.0;
+				TEST_TARGET_NAME = Jetpack;
+			};
+			name = "Release-Alpha";
+		};
 		F1F163DD25658B4D003DC13B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D67306CD28F2440FF6B0065C /* Pods-WordPressIntents.debug.xcconfig */;
@@ -29500,6 +29827,17 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		EA14533D29AD874C001F3143 /* Build configuration list for PBXNativeTarget "JetpackUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				EA14533E29AD874C001F3143 /* Debug */,
+				EA14533F29AD874C001F3143 /* Release */,
+				EA14534029AD874C001F3143 /* Release-Internal */,
+				EA14534129AD874C001F3143 /* Release-Alpha */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		F1F163DC25658B4D003DC13B /* Build configuration list for PBXNativeTarget "WordPressIntents" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -29614,6 +29952,14 @@
 				minimumVersion = 0.2.2;
 			};
 		};
+		EA14532629AD874C001F3143 /* XCRemoteSwiftPackageReference "test-collector-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/buildkite/test-collector-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.3.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -29680,6 +30026,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 3FF1442E266F3C2400138163 /* XCRemoteSwiftPackageReference "ScreenObject" */;
 			productName = ScreenObject;
+		};
+		EA14532529AD874C001F3143 /* BuildkiteTestCollector */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = EA14532629AD874C001F3143 /* XCRemoteSwiftPackageReference "test-collector-swift" */;
+			productName = BuildkiteTestCollector;
 		};
 		FABB1FA62602FC2C00C8785C /* WordPressFlux */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
@@ -1,16 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1420"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "FABB1F8F2602FC2C00C8785C"
+               BuildableName = "Jetpack.app"
+               BlueprintName = "Jetpack"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:WordPressUITests/JetpackUITests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -55,6 +77,15 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "FABB1F8F2602FC2C00C8785C"
+            BuildableName = "Jetpack.app"
+            BlueprintName = "Jetpack"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/JetpackUITests.xcscheme
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EA14532229AD874C001F3143"
+               BuildableName = "JetpackUITests.xctest"
+               BlueprintName = "JetpackUITests"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "EditorAztecTests">
+               </Test>
+               <Test
+                  Identifier = "LoginTests/testEmailMagicLinkLogin()">
+               </Test>
+               <Test
+                  Identifier = "SignupTests">
+               </Test>
+               <Test
+                  Identifier = "SignupTests/testEmailSignup()">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/WordPress/WordPressUITests/JetpackUITests.xctestplan
+++ b/WordPress/WordPressUITests/JetpackUITests.xctestplan
@@ -23,7 +23,8 @@
         "EditorAztecTests",
         "LoginTests\/testEmailMagicLinkLogin()",
         "SignupTests",
-        "SignupTests\/testEmailSignup()"
+        "SignupTests\/testEmailSignup()",
+        "SupportScreenTests\/testSupportForumsCanBeLoadedDuringLogin()"
       ],
       "target" : {
         "containerPath" : "container:WordPress.xcodeproj",

--- a/WordPress/WordPressUITests/JetpackUITests.xctestplan
+++ b/WordPress/WordPressUITests/JetpackUITests.xctestplan
@@ -1,0 +1,36 @@
+{
+  "configurations" : [
+    {
+      "id" : "6250F91E-8E09-40AF-96F5-C7474EE19AB4",
+      "name" : "Foundation-EN-US",
+      "options" : {
+        "language" : "en",
+        "region" : "US"
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : false,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:WordPress.xcodeproj",
+      "identifier" : "FABB1F8F2602FC2C00C8785C",
+      "name" : "Jetpack"
+    }
+  },
+  "testTargets" : [
+    {
+      "skippedTests" : [
+        "EditorAztecTests",
+        "LoginTests\/testEmailMagicLinkLogin()",
+        "SignupTests",
+        "SignupTests\/testEmailSignup()"
+      ],
+      "target" : {
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "EA14532229AD874C001F3143",
+        "name" : "JetpackUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
+++ b/WordPress/WordPressUITests/Tests/MainNavigationTests.swift
@@ -10,6 +10,7 @@ class MainNavigationTests: XCTestCase {
         try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         mySiteScreen = try TabNavComponent()
             .goToMySiteScreen()
+            .goToMenu()
     }
 
     override func tearDownWithError() throws {
@@ -25,7 +26,6 @@ class MainNavigationTests: XCTestCase {
         XCTAssert(MySiteScreen.isLoaded(), "MySitesScreen screen isn't loaded.")
 
         try mySiteScreen
-            .goToMenu()
             .goToPeople()
 
         XCTAssertTrue(PeopleScreen.isLoaded(), "PeopleScreen screen isn't loaded.")

--- a/WordPress/WordPressUITests/Tests/StatsTests.swift
+++ b/WordPress/WordPressUITests/Tests/StatsTests.swift
@@ -8,6 +8,7 @@ class StatsTests: XCTestCase {
         setUpTestSuite()
         _ = try LoginFlow.login(siteUrl: WPUITestCredentials.testWPcomSiteAddress, email: WPUITestCredentials.testWPcomUserEmail, password: WPUITestCredentials.testWPcomPassword)
         statsScreen = try MySiteScreen()
+            .goToMenu()
             .goToStatsScreen()
             .switchTo(mode: .insights)
             .refreshStatsIfNeeded()
@@ -20,14 +21,12 @@ class StatsTests: XCTestCase {
     }
 
     let insightsStats: [String] = [
-        "Views",
-        "2,243",
-        "Posts",
-        "2",
-        "Visitors",
-        "1,201",
-        "Best views ever",
-        "48"
+        "Your views in the last 7-days are -9 (-82%) lower than the previous 7-days. ",
+        "Thursday",
+        "34% of views",
+        "Best Hour",
+        "4 AM",
+        "25% of views"
     ]
 
     let yearsStats: [String] = [

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -24,7 +24,7 @@ class SupportScreenTests: XCTestCase {
         try PrologueScreen()
             .selectContinue()
             .selectHelp()
-            .contactSupport()
+            .contactSupport(userEmail: WPUITestCredentials.contactSupportUserEmail)
             .assertCanNotSendEmptyMessage()
             .enterText("A")
             .assertCanSendMessage()

--- a/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
+++ b/WordPress/WordPressUITests/Tests/SupportScreenTests.swift
@@ -19,4 +19,14 @@ class SupportScreenTests: XCTestCase {
             .visitForums()
             .assertForumsLoaded()
     }
+
+    func testContactUsCanBeLoadedDuringLogin() throws {
+        try PrologueScreen()
+            .selectContinue()
+            .selectHelp()
+            .contactSupport()
+            .assertCanNotSendEmptyMessage()
+            .enterText("A")
+            .assertCanSendMessage()
+    }
 }

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -76,7 +76,7 @@ extension XCTestCase {
         static let tag = "tag \(Date().toString())"
     }
 
-    public func removeApp(_ appName: String = "WordPress", app: XCUIApplication = XCUIApplication()) {
+    public func removeApp(_ appName: String = XCUIApplication().label, app: XCUIApplication = XCUIApplication()) {
         app.terminate()
 
         let appToRemove = Constants.homeApp.icons[appName]

--- a/WordPress/WordPressUITests/WPUITestCredentials.swift
+++ b/WordPress/WordPressUITests/WPUITestCredentials.swift
@@ -14,4 +14,5 @@ struct WPUITestCredentials {
     static let signupUsername: String = "e2eflowsignuptestingmobile"
     static let signupDisplayName: String = "Eeflowsignuptestingmobile"
     static let signupPassword: String = "mocked_password"
+    static let contactSupportUserEmail: String = "user@test.zzz"
 }

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -31,6 +31,7 @@
         "MainNavigationTests",
         "SignupTests\/testEmailSignup()",
         "StatsTests",
+        "SupportScreenTests\/testContactUsCanBeLoadedDuringLogin()",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -29,6 +29,7 @@
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
         "SignupTests\/testEmailSignup()",
+        "StatsTests",
         "SupportScreenTests\/testSupportScreenLoads()"
       ],
       "target" : {

--- a/WordPress/WordPressUITests/WordPressUITests.xctestplan
+++ b/WordPress/WordPressUITests/WordPressUITests.xctestplan
@@ -28,6 +28,7 @@
         "LoginTests\/testSelfHostedUsernamePasswordLoginLogout()",
         "LoginTests\/testUnsuccessfulLogin()",
         "LoginTests\/testWpcomUsernamePasswordLogin()",
+        "MainNavigationTests",
         "SignupTests\/testEmailSignup()",
         "StatsTests",
         "SupportScreenTests\/testSupportScreenLoads()"


### PR DESCRIPTION
### What
The objective of this PR is to make the current Wordpress UI Tests to run against the Jetpack app locally. 

### How
A `JetpackUITests` test plan was created similar to the existing `WordPressUITests`, but targeting the Jetpack app (Kudos to @jostnes for further investigating it when I thought it was not possible to leverage the same files, even though it didn't make sense to me)

Some tests and a XCTest+Extensions needed adjustments to either be able to run for both apps or to run on JP only, since features are about to be removed from WP app.

[MainNavigationTests.swift]([WordPress/WordPressUITests/Tests/MainNavigationTests.swift](https://github.com/wordpress-mobile/WordPress-iOS/pull/20226/files?file-filters%5B%5D=.swift&file-filters%5B%5D=.xcscheme&file-filters%5B%5D=.xctestplan&show-viewed-files=true#diff-4bc751f92978a61af7d3d2a82da30de4fe53def339f8d97e0af0b98182ba3e03)) - Small change due to the fact that the JP opens in the `Home` tab by default while WP opens the `Menu`.

[StatsTests.swift](https://github.com/wordpress-mobile/WordPress-iOS/pull/20226/files?file-filters%5B%5D=.swift&file-filters%5B%5D=.xcscheme&file-filters%5B%5D=.xctestplan&show-viewed-files=true#diff-aa1f96f94d1ff8535f93494403c70d30aaa943211f79830c1a629949b1d864cc) - JP has a revamped Stats that didn't go to WP. With the revamp, the `Insights` tab changed and now displays different data, which was reflected in the test's expected data. Since `Stats` is being removed from WP next week, I thought it didn't worth the effort making the test run for both, so I just disabled `Stats` tests for WP.

[SupportScreenTests.swift](https://github.com/wordpress-mobile/WordPress-iOS/pull/20226/files?file-filters%5B%5D=.swift&file-filters%5B%5D=.xcscheme&file-filters%5B%5D=.xctestplan&show-viewed-files=true#diff-d55595f0cfac7390cdc253d501abb8ac5db09159775cdc9563b2f2cc7387002b) | [SupportScreen.swift](https://github.com/wordpress-mobile/WordPress-iOS/pull/20226/files?file-filters%5B%5D=.swift&file-filters%5B%5D=.xcscheme&file-filters%5B%5D=.xctestplan&show-viewed-files=true#diff-4e3360cb13875012daef30636d83aac2cb35e66b8dc469e46f7a9425e8c3ac5d) - While it looks like a new test being added, it's just bringing back a previously existing test.  `Contact Us` screen has recently moved from WP to JP and at that moment `testContactUsCanBeLoadedDuringLogin()` was converted into `testSupportForumsCanBeLoadedDuringLogin()`. Now `testContactUsCanBeLoadedDuringLogin()` is back for JP and disabled for WP, the same way as `testSupportForumsCanBeLoadedDuringLogin()` is enabled only for WP. 

[XCTest+Extensions.swift](https://github.com/wordpress-mobile/WordPress-iOS/pull/20226/files?file-filters%5B%5D=.swift&file-filters%5B%5D=.xcscheme&file-filters%5B%5D=.xctestplan&show-viewed-files=true#diff-0e744622889925d683626e21ce5271000e5853df2158900d5eae18df3e9fb15f) - Small change to make the `removeApp` work for both apps.

### Testing
* `WordPressUITests` must pass in CI.
* Run `JetpackUITests` test plan locally and all tests should pass. 
<img width="300" src="https://user-images.githubusercontent.com/42008628/222489284-fedfe809-92f0-4763-949b-43e2c5c021dc.png">
