### PR TITLE
Do not use `performAndSave` for query

### DIFF
--- a/WordPress/Classes/Services/JetpackCapabilitiesService.swift
+++ b/WordPress/Classes/Services/JetpackCapabilitiesService.swift
@@ -8,9 +8,8 @@ import WordPressKit
         if let capabilitiesServiceRemote {
             self.capabilitiesServiceRemote = capabilitiesServiceRemote
         } else {
-            var api: WordPressComRestApi!
-            coreDataStack.performAndSave {
-                api = WordPressComRestApi.defaultApi(in: $0, localeKey: WordPressComRestApi.LocaleKeyV2)
+            let api = coreDataStack.performQuery {
+                WordPressComRestApi.defaultApi(in: $0, localeKey: WordPressComRestApi.LocaleKeyV2)
             }
 
             self.capabilitiesServiceRemote = JetpackCapabilitiesServiceRemote(wordPressComRestApi: api)

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -412,8 +412,8 @@ static NSString * const ReaderTopicCurrentTopicPathKey = @"ReaderTopicCurrentTop
 
     // Find existing tag by slug
     NSManagedObjectID * __block existingTopic = nil;
-    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext * _Nonnull context) {
-        existingTopic = [[ReaderTagTopic lookupWithSlug:slug inContext:context] objectID];
+    [self.coreDataStack.mainContext performBlockAndWait:^{
+        existingTopic = [[ReaderTagTopic lookupWithSlug:slug inContext:self.coreDataStack.mainContext] objectID];
     }];
     if (existingTopic) {
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Selector/BlogSelectorViewController.m
@@ -237,12 +237,11 @@
 - (void)syncBlogs
 {
     id<CoreDataStack> coreDataStack = [ContextManager sharedInstance];
-    [coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-        WPAccount *account = [WPAccount lookupDefaultWordPressComAccountInContext:context];
+    [coreDataStack.mainContext performBlock:^{
+        WPAccount *account = [WPAccount lookupDefaultWordPressComAccountInContext:coreDataStack.mainContext];
         if (account == nil) {
             return;
         }
-
         BlogService *blogService = [[BlogService alloc] initWithCoreDataStack:coreDataStack];
         [blogService syncBlogsForAccount:account success:nil failure:nil];
     }];


### PR DESCRIPTION
As the function name `performAndSave` suggests, it should be used for saving rather than query.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
