### PR TITLE
Blaze: Web view analytics

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -447,6 +447,10 @@ import Foundation
     case blazeFeatureTapped
     case blazeContextualMenuAccessed
     case blazeCardHidden
+    case blazeFlowStarted
+    case blazeFlowCanceled
+    case blazeFlowCompleted
+    case blazeFlowError
 
     // Help & Support
     case supportOpenMobileForumTapped
@@ -1221,6 +1225,15 @@ import Foundation
             return "blaze_feature_menu_accessed"
         case .blazeCardHidden:
             return "blaze_feature_hide_tapped"
+        case .blazeFlowStarted:
+            return "blaze_flow_started"
+        case .blazeFlowCanceled:
+            return "blaze_flow_canceled"
+        case .blazeFlowCompleted:
+            return "blaze_flow_completed"
+        case .blazeFlowError:
+            return "blaze_flow_error"
+
 
         // Help & Support
         case .supportOpenMobileForumTapped:

--- a/WordPress/Classes/ViewRelated/Blaze/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/BlazeEventsTracker.swift
@@ -24,7 +24,7 @@ import Foundation
         WPAnalytics.track(.blazeFlowStarted, properties: analyticsProperties(for: source))
     }
 
-    static func trackBlazeFLowCompleted(for source: BlazeSource, currentStep: String) {
+    static func trackBlazeFlowCompleted(for source: BlazeSource, currentStep: String) {
         WPAnalytics.track(.blazeFlowCompleted, properties: analyticsProperties(for: source, currentStep: currentStep))
     }
 

--- a/WordPress/Classes/ViewRelated/Blaze/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/BlazeEventsTracker.swift
@@ -2,6 +2,8 @@ import Foundation
 
 @objcMembers class BlazeEventsTracker: NSObject {
 
+    private static let currentStepPropertyKey = "current_step"
+
     static func trackBlazeFeatureDisplayed(for source: BlazeSource) {
         WPAnalytics.track(.blazeFeatureDisplayed, properties: analyticsProperties(for: source))
     }
@@ -18,7 +20,29 @@ import Foundation
         WPAnalytics.track(.blazeCardHidden, properties: analyticsProperties(for: source))
     }
 
+    static func trackBlazeFlowStarted(for source: BlazeSource) {
+        WPAnalytics.track(.blazeFlowStarted, properties: analyticsProperties(for: source))
+    }
+
+    static func trackBlazeFLowCompleted(for source: BlazeSource, currentStep: String) {
+        WPAnalytics.track(.blazeFlowCompleted, properties: analyticsProperties(for: source, currentStep: currentStep))
+    }
+
+    static func trackBlazeFlowCanceled(for source: BlazeSource, currentStep: String) {
+        WPAnalytics.track(.blazeFlowCanceled, properties: analyticsProperties(for: source, currentStep: currentStep))
+    }
+
+    static func trackBlazeFlowError(for source: BlazeSource, currentStep: String) {
+        WPAnalytics.track(.blazeFlowError, properties: analyticsProperties(for: source, currentStep: currentStep))
+    }
+
     private static func analyticsProperties(for source: BlazeSource) -> [String: String] {
         return [WPAppAnalyticsKeySource: source.description]
+    }
+
+    private static func analyticsProperties(for source: BlazeSource, currentStep: String) -> [String: String] {
+        return [
+            WPAppAnalyticsKeySource: source.description,
+            Self.currentStepPropertyKey: currentStep]
     }
 }

--- a/WordPress/Classes/ViewRelated/Blaze/BlazeWebViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/BlazeWebViewModel.swift
@@ -63,19 +63,26 @@ class BlazeWebViewModel {
 
     func startBlazeFlow() {
         guard let initialURL else {
-            // TODO: Track error
+            BlazeEventsTracker.trackBlazeFlowError(for: source, currentStep: currentStep)
             view.dismissView()
             return
         }
-        // TODO: Track flow started
         authenticatedRequest(for: initialURL, with: view.cookieJar) { [weak self] (request) in
-            self?.view.load(request: request)
+            guard let weakSelf = self else {
+                return
+            }
+            weakSelf.view.load(request: request)
+            BlazeEventsTracker.trackBlazeFlowStarted(for: weakSelf.source)
         }
     }
 
     func dismissTapped() {
-        // TODO: Track event
         view.dismissView()
+        if isFlowCompleted {
+            BlazeEventsTracker.trackBlazeFlowCompleted(for: source, currentStep: currentStep)
+        } else {
+            BlazeEventsTracker.trackBlazeFlowCanceled(for: source, currentStep: currentStep)
+        }
     }
 
     func shouldNavigate(request: URLRequest) -> WebNavigationPolicy {


### PR DESCRIPTION
Part of #20095
Part of #20096
Ref: pe7hp4-b3-p2

## Description
This PR adds analytics events for blaze web view events.

## Notes
There is one known issue where the current step is not accurate. This happens when we use an entry point that is not post-specific (Dashboard card or menu item). Then choose a post to promote. The current step at that moment stays `posts-list` instead of `step-1`. Ref: p1677558200851969-slack-C04LJFS1G5P

## Testing Instructions

### Flow Started

1. Open the app
2. Navigate to the Menu
3. Tap on "Blaze"
4. The blaze site web flow is presented in a modal
5. Verify that `blaze_flow_started <source: menu_item>` is tracked
6. Repeat the above steps for different entry points and make sure the source property is always correct

### Flow Canceled

1. Open the app
2. Navigate to the Menu
3. Tap on the Posts menu item
4. On a Blaze-enabled post, tap on the ellipsis button
5. Tap on "Promote with Blaze"
6. The blaze post web flow is presented in a modal
7. Tap "Cancel"
8. Verify that `blaze_flow_canceled <current_step: step-1, source: posts_list>` is tracked
9. Repeat the above steps by tapping the cancel button at different stages of the flow, and make sure the current_step property gets correctly updated

### Flow Completed

1. Open the app
2. Navigate to the Menu
3. Tap on the Posts menu item
4. On a Blaze-enabled post, tap on the ellipsis button
5. Tap on "Promote with Blaze"
6. The blaze post web flow is presented in a modal
7. Go through the whole flow
8. After the Ad is created, the nav bar button should read "Done"
9. Tap "Done"
10. Verify that `blaze_flow_completed <current_step: step-5, source: posts_list>` is tracked

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.