### PR TITLE
Jetpack app FAQ card on the Jetpack app support view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 -----
 * [*] [internal] Refactored fetching posts in the Reader tab, including post related operations (i.e. like/unlike, save for latter, etc.) [#20197]
 * [**] Reader: Add a button in the post menu to block an author and stop seeing their posts. [#20193]
-* [**] [Jetpack-only] Help: Display Migration FAQ card on Help screen when WP to JP migration is complete. [#20232]
+* [**] [Jetpack-only] Help: Display the Jetpack app FAQ card on Help screen when switching from the WordPress app to the Jetpack app is complete. [#20232]
 
 21.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] [internal] Refactored fetching posts in the Reader tab, including post related operations (i.e. like/unlike, save for latter, etc.) [#20197]
 * [**] Reader: Add a button in the post menu to block an author and stop seeing their posts. [#20193]
+* [**] [Jetpack-only] Help: Display Migration FAQ card on Help screen when WP to JP migration is complete. [#20232]
 
 21.8
 -----

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -450,8 +450,8 @@ import Foundation
 
     // Help & Support
     case supportOpenMobileForumTapped
-    case supportMigrationFAQTapped
-    case supportMigrationFAQViewed
+    case supportMigrationFAQButtonTapped
+    case supportMigrationFAQCardViewed
 
     /// A String that represents the event
     var value: String {
@@ -1227,9 +1227,9 @@ import Foundation
         // Help & Support
         case .supportOpenMobileForumTapped:
             return "support_open_mobile_forum_tapped"
-        case .supportMigrationFAQTapped:
+        case .supportMigrationFAQButtonTapped:
             return "support_migration_faq_tapped"
-        case .supportMigrationFAQViewed:
+        case .supportMigrationFAQCardViewed:
             return "support_migration_faq_viewed"
         } // END OF SWITCH
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -450,6 +450,7 @@ import Foundation
 
     // Help & Support
     case supportOpenMobileForumTapped
+    case supportOpenJetpackMigrationFAQ
 
     /// A String that represents the event
     var value: String {
@@ -1225,6 +1226,8 @@ import Foundation
         // Help & Support
         case .supportOpenMobileForumTapped:
             return "support_open_mobile_forum_tapped"
+        case .supportOpenJetpackMigrationFAQ:
+            return "support_open_jetpack_migration_faq_tapped"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -450,7 +450,8 @@ import Foundation
 
     // Help & Support
     case supportOpenMobileForumTapped
-    case supportOpenJetpackMigrationFAQ
+    case supportMigrationFAQTapped
+    case supportMigrationFAQViewed
 
     /// A String that represents the event
     var value: String {
@@ -1226,8 +1227,10 @@ import Foundation
         // Help & Support
         case .supportOpenMobileForumTapped:
             return "support_open_mobile_forum_tapped"
-        case .supportOpenJetpackMigrationFAQ:
-            return "support_open_jetpack_migration_faq_tapped"
+        case .supportMigrationFAQTapped:
+            return "support_migration_faq_tapped"
+        case .supportMigrationFAQViewed:
+            return "support_migration_faq_viewed"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -48,7 +48,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case blaze
     case siteCreationDomainPurchasing
     case readerUserBlocking
-    case jetpackMigrationSupportCard
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -153,8 +152,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .readerUserBlocking:
             return true
-        case .jetpackMigrationSupportCard:
-            return false
         }
     }
 
@@ -183,8 +180,6 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
-        case .jetpackMigrationSupportCard:
-            return "jetpack_migration_faq_card_remote_field"
             default:
                 return nil
         }
@@ -297,8 +292,6 @@ extension FeatureFlag {
             return "Site Creation Domain Purchasing"
         case .readerUserBlocking:
             return "Reader User Blocking"
-        case .jetpackMigrationSupportCard:
-            return "Jetpack Migration FAQ card in Help & Support"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -184,7 +184,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
         case .blaze:
             return "blaze"
         case .jetpackMigrationSupportCard:
-            return "support_open_jetpack_migration_faq_tapped"
+            return "jetpack_migration_faq_card_remote_field"
             default:
                 return nil
         }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -48,6 +48,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case blaze
     case siteCreationDomainPurchasing
     case readerUserBlocking
+    case jetpackMigrationSupportCard
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -152,6 +153,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .readerUserBlocking:
             return true
+        case .jetpackMigrationSupportCard:
+            return false
         }
     }
 
@@ -180,6 +183,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
+        case .jetpackMigrationSupportCard:
+            return "support_open_jetpack_migration_faq_tapped"
             default:
                 return nil
         }
@@ -292,6 +297,8 @@ extension FeatureFlag {
             return "Site Creation Domain Purchasing"
         case .readerUserBlocking:
             return "Reader User Blocking"
+        case .jetpackMigrationSupportCard:
+            return "Jetpack Migration FAQ card in Help & Support"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -27,12 +27,9 @@ enum SupportConfiguration {
     }
 
     static func isMigrationCardEnabled(
-        featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
         isJetpack: Bool = AppConfiguration.isJetpack,
         migrationState: MigrationState = UserPersistentStoreFactory.instance().jetpackContentMigrationState
     ) -> Bool {
-        return isJetpack
-            && featureFlagStore.value(for: FeatureFlag.jetpackMigrationSupportCard)
-            && migrationState == .completed
+        return isJetpack && migrationState == .completed
     }
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -25,4 +25,14 @@ enum SupportConfiguration {
             return .zendesk
         }
     }
+
+    static func isMigrationCardEnabled(
+        featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
+        isJetpack: Bool = AppConfiguration.isJetpack,
+        migrationState: MigrationState = UserPersistentStoreFactory.instance().jetpackContentMigrationState
+    ) -> Bool {
+        return isJetpack
+            && featureFlagStore.value(for: FeatureFlag.jetpackMigrationSupportCard)
+            && migrationState == .completed
+    }
 }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -50,6 +50,10 @@ class SupportTableViewController: UITableViewController {
         }
         ZendeskUtils.sharedInstance.cacheUnlocalizedSitePlans()
         ZendeskUtils.fetchUserInformation()
+
+        if SupportConfiguration.isMigrationCardEnabled() {
+            WPAnalytics.track(.supportMigrationFAQViewed)
+        }
     }
 
     override func viewDidLayoutSubviews() {
@@ -344,11 +348,11 @@ private extension SupportTableViewController {
         rows.append(ButtonRow(title: LocalizedText.jetpackMigrationButton,
                               accessibilityHint: LocalizedText.jetpackMigrationButtonAccessibilityHint,
                               action: { _ in
-            guard let url = Constants.jetpackMigrationFAQsURL else {
+            guard let url = Constants.jetpackMigrationFAQURL else {
                 return
             }
 
-            WPAnalytics.track(.supportOpenJetpackMigrationFAQ)
+            WPAnalytics.track(.supportMigrationFAQTapped)
             UIApplication.shared.open(url)
         },
                                           accessibilityIdentifier: nil))
@@ -496,9 +500,9 @@ private extension SupportTableViewController {
         static let contactEmail = NSLocalizedString("support.row.contactEmail.title", value: "Email", comment: "Support email label.")
 
         static let jetpackMigrationTitle = NSLocalizedString("support.row.jetpackMigration.title", value: "Thank you for switching to the Jetpack app!", comment: "An informational card title in Support view")
-        static let jetpackMigrationDescription = NSLocalizedString("support.row.jetpackMigration.description", value: "Our FAQs provide answers to common questions you may have.", comment: "An informational card description in Support view explaining what tapping the link on card does")
-        static let jetpackMigrationButton = NSLocalizedString("support.button.jetpackMigration.title", value: "Visit our FAQs", comment: "Option in Support view to visit the Jetpack migration FAQs website.")
-        static let jetpackMigrationButtonAccessibilityHint = NSLocalizedString("support.button.jetpackMigation.accessibilityHint", value: "Tap to visit the Jetpack migration FAQs in an external browser", comment: "Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQs website.")
+        static let jetpackMigrationDescription = NSLocalizedString("support.row.jetpackMigration.description", value: "Our FAQ provide answers to common questions you may have.", comment: "An informational card description in Support view explaining what tapping the link on card does")
+        static let jetpackMigrationButton = NSLocalizedString("support.button.jetpackMigration.title", value: "Visit our FAQ", comment: "Option in Support view to visit the Jetpack migration FAQ website.")
+        static let jetpackMigrationButtonAccessibilityHint = NSLocalizedString("support.button.jetpackMigation.accessibilityHint", value: "Tap to visit the Jetpack migration FAQ in an external browser", comment: "Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQ website.")
     }
 
     // MARK: - User Defaults Keys
@@ -511,7 +515,7 @@ private extension SupportTableViewController {
 
     struct Constants {
         static let appSupportURL = URL(string: "https://apps.wordpress.com/mobile-app-support/")
-        static let jetpackMigrationFAQsURL = URL(string: "https://jetpack.com/support/switch-to-the-jetpack-app/")
+        static let jetpackMigrationFAQURL = URL(string: "https://jetpack.com/support/switch-to-the-jetpack-app/")
 
         static let forumsURL = URL(string: "https://wordpress.org/support/forum/mobile/")
         static let automatticEmails = ["@automattic.com", "@a8c.com"]

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -579,22 +579,6 @@ private class ButtonCell: WPTableViewCellDefault {
 }
 
 private class MigrationCell: WPTableViewCell {
-    private let stackView: UIStackView = {
-        let stackView = UIStackView()
-        stackView.alignment = .leading
-        stackView.axis = .vertical
-        stackView.distribution = .equalSpacing
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        stackView.spacing = 10
-        return stackView
-    }()
-
-    let logoImageView: UIImageView = {
-        let imageView = UIImageView(image: .init(named: "wp-migration-welcome"))
-        imageView.contentMode = .scaleAspectFit
-        return imageView
-    }()
-
     let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
@@ -607,6 +591,22 @@ private class MigrationCell: WPTableViewCell {
         label.numberOfLines = 0
         label.font = WPStyleGuide.fontForTextStyle(.body)
         return label
+    }()
+
+    private let stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.alignment = .leading
+        stackView.axis = .vertical
+        stackView.distribution = .equalSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.spacing = 10
+        return stackView
+    }()
+
+    private let logoImageView: UIImageView = {
+        let imageView = UIImageView(image: .init(named: "wp-migration-welcome"))
+        imageView.contentMode = .scaleAspectFit
+        return imageView
     }()
 
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -500,7 +500,7 @@ private extension SupportTableViewController {
         static let contactEmail = NSLocalizedString("support.row.contactEmail.title", value: "Email", comment: "Support email label.")
 
         static let jetpackMigrationTitle = NSLocalizedString("support.row.jetpackMigration.title", value: "Thank you for switching to the Jetpack app!", comment: "An informational card title in Support view")
-        static let jetpackMigrationDescription = NSLocalizedString("support.row.jetpackMigration.description", value: "Our FAQ provide answers to common questions you may have.", comment: "An informational card description in Support view explaining what tapping the link on card does")
+        static let jetpackMigrationDescription = NSLocalizedString("support.row.jetpackMigration.description", value: "Our FAQ provides answers to common questions you may have.", comment: "An informational card description in Support view explaining what tapping the link on card does")
         static let jetpackMigrationButton = NSLocalizedString("support.button.jetpackMigration.title", value: "Visit our FAQ", comment: "Option in Support view to visit the Jetpack migration FAQ website.")
         static let jetpackMigrationButtonAccessibilityHint = NSLocalizedString("support.button.jetpackMigation.accessibilityHint", value: "Tap to visit the Jetpack migration FAQ in an external browser", comment: "Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQ website.")
     }

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -598,13 +598,14 @@ private class MigrationCell: WPTableViewCell {
     let titleLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
-        label.font = .systemFont(ofSize: label.font.pointSize, weight: .semibold)
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         return label
     }()
 
     let descriptionLabel: UILabel = {
         let label = UILabel()
         label.numberOfLines = 0
+        label.font = WPStyleGuide.fontForTextStyle(.body)
         return label
     }()
 

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -52,7 +52,7 @@ class SupportTableViewController: UITableViewController {
         ZendeskUtils.fetchUserInformation()
 
         if SupportConfiguration.isMigrationCardEnabled() {
-            WPAnalytics.track(.supportMigrationFAQViewed)
+            WPAnalytics.track(.supportMigrationFAQCardViewed)
         }
     }
 
@@ -352,7 +352,7 @@ private extension SupportTableViewController {
                 return
             }
 
-            WPAnalytics.track(.supportMigrationFAQTapped)
+            WPAnalytics.track(.supportMigrationFAQButtonTapped)
             UIApplication.shared.open(url)
         },
                                           accessibilityIdentifier: nil))
@@ -502,7 +502,7 @@ private extension SupportTableViewController {
         static let jetpackMigrationTitle = NSLocalizedString("support.row.jetpackMigration.title", value: "Thank you for switching to the Jetpack app!", comment: "An informational card title in Support view")
         static let jetpackMigrationDescription = NSLocalizedString("support.row.jetpackMigration.description", value: "Our FAQ provides answers to common questions you may have.", comment: "An informational card description in Support view explaining what tapping the link on card does")
         static let jetpackMigrationButton = NSLocalizedString("support.button.jetpackMigration.title", value: "Visit our FAQ", comment: "Option in Support view to visit the Jetpack migration FAQ website.")
-        static let jetpackMigrationButtonAccessibilityHint = NSLocalizedString("support.button.jetpackMigation.accessibilityHint", value: "Tap to visit the Jetpack migration FAQ in an external browser", comment: "Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQ website.")
+        static let jetpackMigrationButtonAccessibilityHint = NSLocalizedString("support.button.jetpackMigation.accessibilityHint", value: "Tap to visit the Jetpack app FAQ in an external browser", comment: "Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQ website.")
     }
 
     // MARK: - User Defaults Keys

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -333,6 +333,10 @@ private extension SupportTableViewController {
     // MARK: - Jetpack migration section
 
     private func createJetpackMigrationSection() -> ImmuTableSection? {
+        guard SupportConfiguration.isMigrationCardEnabled() else {
+            return nil
+        }
+
         var rows = [ImmuTableRow]()
         rows.append(MigrationRow(title: LocalizedText.jetpackMigrationTitle,
                                  description: LocalizedText.jetpackMigrationDescription,

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -347,6 +347,8 @@ private extension SupportTableViewController {
             guard let url = Constants.jetpackMigrationFAQsURL else {
                 return
             }
+
+            WPAnalytics.track(.supportOpenJetpackMigrationFAQ)
             UIApplication.shared.open(url)
         },
                                           accessibilityIdentifier: nil))


### PR DESCRIPTION
Fixes #20229

## Description

Create a Jetpack migration FAQ card on top of Support view. More details on the issue #20229

## Testing instructions

### Case 1 Happy Path:
1. Install WordPress
3. Install Jetpack
4. Perform migration
5. Open Me -> Help & Support
6. Confirm that the migration card appears on top
7. In console, "support_migration_faq_viewed" tracking should be visible
8. Click the "View our FAQs"
9. Jetpack.com explaining the migration should open
10. In console, "support_migration_faq_tapped" tracking should be visible

### Case 2 No card on WordPress app:
1. Install WordPress
3. Open Me -> Help & Support
4. No migration card should be visible

### Case 3 No card on Jetpack app without migration:
1. Install Jetpack
3. Open Me -> Help & Support
4. No migration card should be visible

## Regression Notes

1. Potential unintended areas of impact

Support View breaking

2. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

| Dark | Light |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/4062343/222378130-e03acfa9-3ce9-4b08-b16e-654b6dd63414.png)| ![image](https://user-images.githubusercontent.com/4062343/222378096-87929a6c-cfd3-4ab7-a5ad-4cc82eddee50.png)|
