### PR TITLE
Change a few `performAndSave` calls to the asynchronous version

### DIFF
--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -480,11 +480,9 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
         return obj.objectID;
     }];
     NSMutableDictionary *blogVisibility = [NSMutableDictionary dictionaryWithCapacity:blogIds.count];
-    AccountServiceRemoteREST * __block remote = nil;
 
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         WPAccount *defaultAccount = [WPAccount lookupDefaultWordPressComAccountInContext:context];
-        remote = [self remoteForAccount:defaultAccount];
 
         for (NSManagedObjectID *blogId in blogIds) {
             Blog *blog = [context existingObjectWithID:blogId error:nil];
@@ -497,11 +495,13 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
             }
             blog.visible = visible;
         }
-    }];
-
-    [remote updateBlogsVisibility:blogVisibility success:nil failure:^(NSError *error) {
-        DDLogError(@"Error setting blog visibility: %@", error);
-    }];
+    } completion:^{
+        WPAccount *defaultAccount = [WPAccount lookupDefaultWordPressComAccountInContext:self.coreDataStack.mainContext];
+        AccountServiceRemoteREST *remote = [self remoteForAccount:defaultAccount];
+        [remote updateBlogsVisibility:blogVisibility success:nil failure:^(NSError *error) {
+            DDLogError(@"Error setting blog visibility: %@", error);
+        }];
+    } onQueue:dispatch_get_main_queue()];
 }
 
 @end

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -212,8 +212,7 @@ NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
             [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
                 Blog *blogInContext = (Blog *)[context objectWithID:blogID];
                 [self updateSettings:blogInContext.settings withRemoteSettings:remoteSettings];
-
-            }];
+            } completion:nil onQueue:dispatch_get_main_queue()];
         };
         id<BlogServiceRemote> remote = [self remoteForBlog:blogInContext];
         if ([remote isKindOfClass:[BlogServiceRemoteXMLRPC class]]) {

--- a/WordPress/Classes/Services/PeopleService.swift
+++ b/WordPress/Classes/Services/PeopleService.swift
@@ -267,13 +267,13 @@ struct PeopleService {
     /// Nukes all users from Core Data.
     ///
     func removeManagedPeople() {
-        coreDataStack.performAndSave { context in
+        coreDataStack.performAndSave({ context in
             let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Person")
             request.predicate = NSPredicate(format: "siteID = %@", NSNumber(value: siteID))
             if let objects = (try? context.fetch(request)) as? [NSManagedObject] {
                 objects.forEach { context.delete($0) }
             }
-        }
+        }, completion: nil, on: .main)
     }
 
     /// Validates Invitation Recipients.


### PR DESCRIPTION
This PR changed a few call sites the synchronous (as in it waits for the saving to complete) version to the asynchronous one. See pbArwn-5Qy-p2#how-does-this-apply-to-the-wp-and-jp-ios-apps for detailed reasoning.

I've reviewed the changed call site and I believe they don't actually need to be performed synchronously, as they don't refer the updated result immediately after the saving completes.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.