### PR TITLE
Fix crash when Quick Start is removed from the WordPress app

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
+++ b/WordPress/Classes/ViewRelated/Blog/QuickStartTourGuide.swift
@@ -84,15 +84,7 @@ open class QuickStartTourGuide: NSObject {
     }
 
     @objc static func quickStartEnabled(for blog: Blog) -> Bool {
-        let enabled = QuickStartFactory.collections(for: blog).isEmpty == false
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
-            if enabled { // If quick start exists, remove it to clean up.
-                QuickStartTourGuide.shared.remove(from: blog)
-            }
-            return false
-        }
-
-        return enabled
+        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() && QuickStartFactory.collections(for: blog).isEmpty == false
     }
 
     /// Provides a tour to suggest to the user


### PR DESCRIPTION
This is a workaround to prevent the crash happening in #20245. The crash happens when the app attempts to clean up Quick Start tours. The clean up is done when the app determines that Jetpack features are no longer to be shown. However, the clean up produces a Core Data crash which I haven't understood properly yet. So a workaround is to simply not do the clean up and leave the Quick Start tours in Core Data. They won't be visible to the user.

Fixes #20245

To test:
1. Install the WP app
2. Create a new site
3. Say yes to Quick Start 
4. Enable the `jetpackFeaturesRemovalPhaseNewUsers` feature flag (it's best to do this in code and remove the `jp_removal_new_users` remote flag entirely to avoid the remote flag overriding and disabling this)
5. Open the app again

## Regression Notes
1. Potential unintended areas of impact

This could have effects on Quick Start or the main My Site tab.

6. What I did to test those areas of impact (or what existing automated tests I relied on)

Manual testing as described above.

7. What automated tests I added (or what prevented me from doing so)

This is a temporary workaround and quick fix so I think it's not worth adding automated testing now.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
