### PR TITLE
Blaze: Track overlay events

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -443,8 +443,8 @@ import Foundation
     case jetpackInstallFullPluginCardDismissed
 
     // Blaze
-    case blazeFeatureDisplayed
-    case blazeFeatureTapped
+    case blazeEntryPointDisplayed
+    case blazeEntryPointTapped
     case blazeContextualMenuAccessed
     case blazeCardHidden
     case blazeFlowStarted
@@ -1219,14 +1219,14 @@ import Foundation
             return "jp_install_full_plugin_card_dismissed"
 
         // Blaze
-        case .blazeFeatureDisplayed:
-            return "blaze_feature_displayed"
-        case .blazeFeatureTapped:
-            return "blaze_feature_tapped"
+        case .blazeEntryPointDisplayed:
+            return "blaze_entry_point_displayed"
+        case .blazeEntryPointTapped:
+            return "blaze_entry_point_tapped"
         case .blazeContextualMenuAccessed:
-            return "blaze_feature_menu_accessed"
+            return "blaze_entry_point_menu_accessed"
         case .blazeCardHidden:
-            return "blaze_feature_hide_tapped"
+            return "blaze_entry_point_hide_tapped"
         case .blazeFlowStarted:
             return "blaze_flow_started"
         case .blazeFlowCanceled:

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -447,6 +447,9 @@ import Foundation
     case blazeEntryPointTapped
     case blazeContextualMenuAccessed
     case blazeCardHidden
+    case blazeOverlayDisplayed
+    case blazeOverlayButtonTapped
+    case blazeOverlayDismissed
     case blazeFlowStarted
     case blazeFlowCanceled
     case blazeFlowCompleted
@@ -1227,6 +1230,12 @@ import Foundation
             return "blaze_entry_point_menu_accessed"
         case .blazeCardHidden:
             return "blaze_entry_point_hide_tapped"
+        case .blazeOverlayDisplayed:
+            return "blaze_overlay_displayed"
+        case .blazeOverlayButtonTapped:
+            return "blaze_overlay_button_tapped"
+        case .blazeOverlayDismissed:
+            return "blaze_overlay_dismissed"
         case .blazeFlowStarted:
             return "blaze_flow_started"
         case .blazeFlowCanceled:

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -21,6 +21,18 @@ import Foundation
         WPAnalytics.track(.blazeCardHidden, properties: analyticsProperties(for: source))
     }
 
+    static func trackOverlayDisplayed(for source: BlazeSource) {
+        WPAnalytics.track(.blazeOverlayDisplayed, properties: analyticsProperties(for: source))
+    }
+
+    static func trackOverlayButtonTapped(for source: BlazeSource) {
+        WPAnalytics.track(.blazeOverlayButtonTapped, properties: analyticsProperties(for: source))
+    }
+
+    static func trackOverlayDismissed(for source: BlazeSource) {
+        WPAnalytics.track(.blazeOverlayDismissed, properties: analyticsProperties(for: source))
+    }
+
     static func trackBlazeFlowStarted(for source: BlazeSource) {
         WPAnalytics.track(.blazeFlowStarted, properties: analyticsProperties(for: source))
     }

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -5,12 +5,12 @@ import Foundation
     private static let currentStepPropertyKey = "current_step"
     private static let errorPropertyKey = "error"
 
-    static func trackBlazeFeatureDisplayed(for source: BlazeSource) {
-        WPAnalytics.track(.blazeFeatureDisplayed, properties: analyticsProperties(for: source))
+    static func trackEntryPointDisplayed(for source: BlazeSource) {
+        WPAnalytics.track(.blazeEntryPointDisplayed, properties: analyticsProperties(for: source))
     }
 
-    static func trackBlazeFeatureTapped(for source: BlazeSource) {
-        WPAnalytics.track(.blazeFeatureTapped, properties: analyticsProperties(for: source))
+    static func trackEntryPointTapped(for source: BlazeSource) {
+        WPAnalytics.track(.blazeEntryPointTapped, properties: analyticsProperties(for: source))
     }
 
     static func trackContextualMenuAccessed(for source: BlazeSource) {

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewController.swift
@@ -138,6 +138,11 @@ final class BlazeOverlayViewController: UIViewController {
         setupView()
     }
 
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        BlazeEventsTracker.trackOverlayDisplayed(for: source)
+    }
+
     // MARK: - Setup
 
     private func setupNavigationBar() {
@@ -170,10 +175,13 @@ final class BlazeOverlayViewController: UIViewController {
     // MARK: - Button Action
 
     @objc private func closeButtonTapped() {
+        BlazeEventsTracker.trackOverlayDismissed(for: source)
         dismiss(animated: true)
     }
 
     @objc private func blazeButtonTapped() {
+        BlazeEventsTracker.trackOverlayButtonTapped(for: source)
+
         guard let post else {
             BlazeWebViewCoordinator.presentBlazeFlow(in: self, source: source, blog: blog, delegate: self)
             return

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -14,7 +14,7 @@ class DashboardBlazeCardCell: DashboardCollectionViewCell {
                   let blog = self?.blog else {
                 return
             }
-            BlazeEventsTracker.trackBlazeFeatureTapped(for: .dashboardCard)
+            BlazeEventsTracker.trackEntryPointTapped(for: .dashboardCard)
             BlazeOverlayCoordinator.presentBlazeOverlay(in: presentingViewController, source: .dashboardCard, blog: blog)
         }
 
@@ -62,6 +62,6 @@ class DashboardBlazeCardCell: DashboardCollectionViewCell {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {
         self.blog = blog
         self.presentingViewController = viewController
-        BlazeEventsTracker.trackBlazeFeatureDisplayed(for: .dashboardCard)
+        BlazeEventsTracker.trackEntryPointDisplayed(for: .dashboardCard)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -446,7 +446,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     
     if ([self shouldShowBlaze]) {
-        [BlazeEventsTracker trackBlazeFeatureDisplayedFor:BlazeSourceMenuItem];
+        [BlazeEventsTracker trackEntryPointDisplayedFor:BlazeSourceMenuItem];
     }
 }
 
@@ -1668,7 +1668,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (void)showBlaze
 {
-    [BlazeEventsTracker trackBlazeFeatureTappedFor:BlazeSourceMenuItem];
+    [BlazeEventsTracker trackEntryPointTappedFor:BlazeSourceMenuItem];
     
     [BlazeOverlayCoordinator presentBlazeOverlayInViewController:self
                                                           source:BlazeSourceMenuItem

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -515,7 +515,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func blazePage(_ page: AbstractPost) {
-        BlazeEventsTracker.trackBlazeFeatureTapped(for: .pagesList)
+        BlazeEventsTracker.trackEntryPointTapped(for: .pagesList)
         BlazeOverlayCoordinator.presentBlazeOverlay(in: self, source: .pagesList, blog: blog, post: page)
     }
 
@@ -776,7 +776,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
             self?.blazePage(page)
         })
 
-        BlazeEventsTracker.trackBlazeFeatureDisplayed(for: .pagesList)
+        BlazeEventsTracker.trackEntryPointDisplayed(for: .pagesList)
     }
 
     private func addEditAction(to controller: UIAlertController, for page: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostActionSheet.swift
@@ -77,7 +77,7 @@ class PostActionSheet {
                         self?.interactivePostViewDelegate?.share(post, fromView: view)
                     }
                 case .blaze:
-                    BlazeEventsTracker.trackBlazeFeatureDisplayed(for: .postsList)
+                    BlazeEventsTracker.trackEntryPointDisplayed(for: .postsList)
                     actionSheetController.addDefaultActionWithTitle(Titles.blaze) { [weak self] _ in
                         self?.interactivePostViewDelegate?.blaze(post)
                     }

--- a/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListViewController.swift
@@ -784,7 +784,7 @@ class PostListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     func blaze(_ post: AbstractPost) {
-        BlazeEventsTracker.trackBlazeFeatureTapped(for: .postsList)
+        BlazeEventsTracker.trackEntryPointTapped(for: .postsList)
         BlazeOverlayCoordinator.presentBlazeOverlay(in: self, source: .postsList, blog: blog, post: post)
     }
 


### PR DESCRIPTION
Part of #20093
Part of #20094

## Description
- Renames entry point events (See: pe7hp4-b3-p2#comment-126)
- Adds tracking for blaze overlay events

## How to test

Make sure the following events are tracked with the correct source (dashboard_card, menu_item, posts_list, pages_list), and validate them on Tracks.

### Blaze entry points events

Event | Description
:--- | :---
blaze_entry_point_displayed | Called when a Blaze entry point is displayed.
blaze_entry_point_tapped | Called when a Blaze entry point is tapped.
blaze_entry_point_menu_accessed | Called when the menu is accessed from within a Blaze card entry point.
blaze_entry_point_hide_tapped | Called when the hide this menu option is tapped from within a Blaze card entry point.

### Blaze overlay events

Event | Description
:--- | :---
blaze_overlay_displayed | Called when the Blaze overlay is displayed.
blaze_overlay_button_tapped | Called when the “Blaze a post now” or the “Blaze this post” action button is tapped on the Blaze overlay.
blaze_overlay_dismissed | Called when the Blaze overlay is dismissed.

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.