### PR TITLE
Fix a typo in `RELEASE-NOTES.txt` (latter -> later)

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 
 21.9
 -----
-* [*] [internal] Refactored fetching posts in the Reader tab, including post related operations (i.e. like/unlike, save for latter, etc.) [#20197]
+* [*] [internal] Refactored fetching posts in the Reader tab, including post related operations (i.e. like/unlike, save for later, etc.) [#20197]
 * [**] Reader: Add a button in the post menu to block an author and stop seeing their posts. [#20193]
 * [**] [Jetpack-only] Jetpack individual plugin support: Warns user about sites with only individual plugins not supporting all features of the app yet and gives the ability to install the full Jetpack plugin. [#20223]
 * [**] [Jetpack-only] Help: Display the Jetpack app FAQ card on Help screen when switching from the WordPress app to the Jetpack app is complete. [#20232]


### PR DESCRIPTION
What is says on the title. Sorry for missing this when reviewing #20197 @crazytonyli 

I noticed this when pasting the raw release notes in ASC. I fixed it manually there, too. Triggering an update in the release branch seemed unnecessary given they'll soon be replaced by the editorialized version. `RELEASE-NOTES.txt`, however, is long lived, so it seemed worth opening this PR.

Nothing to test since this is a standalone text file change.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
