### PR TITLE
Refactor `SharingService` to use `CoreDataStack`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 22.0
 -----
+* [*] [internal] Refactor managing social connections and social buttons in the "Sharing" screen. [#20265]
 
 
 21.9

--- a/WordPress/Classes/Models/PublicizeService+Lookup.swift
+++ b/WordPress/Classes/Models/PublicizeService+Lookup.swift
@@ -16,7 +16,6 @@ extension PublicizeService {
         try? lookupPublicizeServiceNamed(name, in: context)
     }
 
-
     /// Returns an array of all cached `PublicizeService` objects.
     ///
     /// - Returns: An array of `PublicizeService`.  The array is empty if no objects are cached.

--- a/WordPress/Classes/Models/PublicizeService+Lookup.swift
+++ b/WordPress/Classes/Models/PublicizeService+Lookup.swift
@@ -1,0 +1,31 @@
+extension PublicizeService {
+    /// Finds a cached `PublicizeService` matching the specified service name.
+    ///
+    /// - Parameter name: The name of the service. This is the `serviceID` attribute for a `PublicizeService` object.
+    ///
+    /// - Returns: The requested `PublicizeService` or nil.
+    ///
+    static func lookupPublicizeServiceNamed(_ name: String, in context: NSManagedObjectContext) throws -> PublicizeService? {
+        let request = NSFetchRequest<PublicizeService>(entityName: PublicizeService.classNameWithoutNamespaces())
+        request.predicate = NSPredicate(format: "serviceID = %@", name)
+        return try context.fetch(request).first
+    }
+
+    @objc(lookupPublicizeServiceNamed:inContext:)
+    static func objc_lookupPublicizeServiceNamed(_ name: String, in context: NSManagedObjectContext) -> PublicizeService? {
+        try? lookupPublicizeServiceNamed(name, in: context)
+    }
+
+
+    /// Returns an array of all cached `PublicizeService` objects.
+    ///
+    /// - Returns: An array of `PublicizeService`.  The array is empty if no objects are cached.
+    ///
+    @objc(allPublicizeServicesInContext:error:)
+    static func allPublicizeServices(in context: NSManagedObjectContext) throws -> [PublicizeService] {
+        let request = NSFetchRequest<PublicizeService>(entityName: PublicizeService.classNameWithoutNamespaces())
+        let sortDescriptor = NSSortDescriptor(key: "order", ascending: true)
+        request.sortDescriptors = [sortDescriptor]
+        return try context.fetch(request)
+    }
+}

--- a/WordPress/Classes/Models/SharingButton+Lookup.swift
+++ b/WordPress/Classes/Models/SharingButton+Lookup.swift
@@ -1,0 +1,32 @@
+extension SharingButton {
+
+    /// Returns an array of all cached `SharingButtons` objects.
+    ///
+    /// - Parameters
+    ///     - blog: A `Blog` object
+    ///
+    /// - Returns: An array of `SharingButton`s.  The array is empty if no objects are cached.
+    ///
+    @objc(allSharingButtonsForBlog:inContext:error:)
+    static func allSharingButtons(for blog: Blog, in context: NSManagedObjectContext) throws -> [SharingButton] {
+        let request = NSFetchRequest<SharingButton>(entityName: SharingButton.classNameWithoutNamespaces())
+        request.predicate = NSPredicate(format: "blog = %@", blog)
+        request.sortDescriptors = [NSSortDescriptor(key: "order", ascending: true)]
+        return try context.fetch(request)
+    }
+
+    /// Finds a cached `SharingButton` by its `buttonID` for the specified `Blog`
+    ///
+    /// - Parameters:
+    ///     - buttonID: The button ID of the `sharingButton`.
+    ///     - blog: The blog that owns the sharing button.
+    ///
+    /// - Returns: The requested `SharingButton` or nil.
+    ///
+    static func lookupSharingButton(byID buttonID: String, for blog: Blog, in context: NSManagedObjectContext) throws -> SharingButton? {
+        let request = NSFetchRequest<SharingButton>(entityName: SharingButton.classNameWithoutNamespaces())
+        request.predicate = NSPredicate(format: "buttonID = %@ AND blog = %@", buttonID, blog)
+        return try context.fetch(request).first
+    }
+
+}

--- a/WordPress/Classes/Models/SharingButton+Lookup.swift
+++ b/WordPress/Classes/Models/SharingButton+Lookup.swift
@@ -2,9 +2,6 @@ extension SharingButton {
 
     /// Returns an array of all cached `SharingButtons` objects.
     ///
-    /// - Parameters
-    ///     - blog: A `Blog` object
-    ///
     /// - Returns: An array of `SharingButton`s.  The array is empty if no objects are cached.
     ///
     @objc(allSharingButtonsForBlog:inContext:error:)
@@ -18,7 +15,7 @@ extension SharingButton {
     /// Finds a cached `SharingButton` by its `buttonID` for the specified `Blog`
     ///
     /// - Parameters:
-    ///     - buttonID: The button ID of the `sharingButton`.
+    ///     - buttonID: The button ID of the `SharingButton`.
     ///     - blog: The blog that owns the sharing button.
     ///
     /// - Returns: The requested `SharingButton` or nil.

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -304,7 +304,7 @@ import WordPressKit
     ///     - remoteServices: An array of `RemotePublicizeService` objects to merge.
     ///     - success: An optional callback block to be performed when core data has saved the changes.
     ///
-    fileprivate func mergePublicizeServices(_ remoteServices: [RemotePublicizeService], success: (() -> Void)? ) {
+    private func mergePublicizeServices(_ remoteServices: [RemotePublicizeService], success: (() -> Void)? ) {
         coreDataStack.performAndSave({ context in
             let currentPublicizeServices = (try? PublicizeService.allPublicizeServices(in: context)) ?? []
 
@@ -329,7 +329,7 @@ import WordPressKit
     ///
     /// - Returns: A `PublicizeService`.
     ///
-    fileprivate func createOrReplaceFromRemotePublicizeService(_ remoteService: RemotePublicizeService, in context: NSManagedObjectContext) -> PublicizeService {
+    private func createOrReplaceFromRemotePublicizeService(_ remoteService: RemotePublicizeService, in context: NSManagedObjectContext) -> PublicizeService {
         var pubService = try? PublicizeService.lookupPublicizeServiceNamed(remoteService.serviceID, in: context)
         if pubService == nil {
             pubService = NSEntityDescription.insertNewObject(forEntityName: PublicizeService.classNameWithoutNamespaces(),
@@ -361,7 +361,7 @@ import WordPressKit
     ///
     /// - Returns: A `PublicizeConnection`.
     ///
-    fileprivate func createOrReplacePublicizeConnectionForBlogWithObjectID(
+    private func createOrReplacePublicizeConnectionForBlogWithObjectID(
         _ blogObjectID: NSManagedObjectID,
         remoteConnection: RemotePublicizeConnection,
         in context: NSManagedObjectContext
@@ -428,7 +428,7 @@ import WordPressKit
     ///     - remoteSharingButtons: An array of `RemoteSharingButton` objects to merge.
     ///     - onComplete: An optional callback block to be performed when core data has saved the changes.
     ///
-    fileprivate func mergeSharingButtonsForBlog(_ blogObjectID: NSManagedObjectID, remoteSharingButtons: [RemoteSharingButton], onComplete: (() -> Void)?) {
+    private func mergeSharingButtonsForBlog(_ blogObjectID: NSManagedObjectID, remoteSharingButtons: [RemoteSharingButton], onComplete: (() -> Void)?) {
         coreDataStack.performAndSave({ context in
             let blog = try context.existingObject(with: blogObjectID) as! Blog
 
@@ -459,7 +459,7 @@ import WordPressKit
     ///
     /// - Returns: A `SharingButton`.
     ///
-    fileprivate func createOrReplaceFromRemoteSharingButton(_ remoteButton: RemoteSharingButton, blog: Blog, in context: NSManagedObjectContext) -> SharingButton {
+    private func createOrReplaceFromRemoteSharingButton(_ remoteButton: RemoteSharingButton, blog: Blog, in context: NSManagedObjectContext) -> SharingButton {
         var shareButton = try? SharingButton.lookupSharingButton(byID: remoteButton.buttonID, for: blog, in: context)
         if shareButton == nil {
             shareButton = NSEntityDescription.insertNewObject(forEntityName: SharingButton.classNameWithoutNamespaces(),
@@ -486,7 +486,7 @@ import WordPressKit
     ///
     /// - Returns: An array of `RemoteSharingButton` objects.
     ///
-    fileprivate func remoteShareButtonsFromShareButtons(_ shareButtons: [SharingButton]) -> [RemoteSharingButton] {
+    private func remoteShareButtonsFromShareButtons(_ shareButtons: [SharingButton]) -> [RemoteSharingButton] {
         return shareButtons.map { (shareButton) -> RemoteSharingButton in
             let btn = RemoteSharingButton()
             btn.buttonID = shareButton.buttonID
@@ -508,7 +508,7 @@ import WordPressKit
     ///
     /// - Parameter blog: The blog to use for the rest api.
     ///
-    fileprivate func remoteForBlog(_ blog: Blog) -> SharingServiceRemote? {
+    private func remoteForBlog(_ blog: Blog) -> SharingServiceRemote? {
         guard let api = blog.wordPressComRestApi() else {
             return nil
         }

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -172,7 +172,7 @@ import WordPressKit
                         WPAppAnalytics.track(.sharingPublicizeConnectionAvailableToAllChanged, withProperties: properties, withBlogID: value.siteID)
 
                         self.coreDataStack.performAndSave({ context in
-                            _ = try self.createOrReplacePublicizeConnectionForBlogWithObjectID(blogObjectID, remoteConnection: remoteConnection, in: context)
+                            try self.createOrReplacePublicizeConnectionForBlogWithObjectID(blogObjectID, remoteConnection: remoteConnection, in: context)
                         }, completion: { result in
                             switch result {
                             case .success:

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -6,8 +6,22 @@ import WordPressKit
 /// SharingService is responsible for wrangling publicize services, publicize
 /// connections, and keyring connections.
 ///
-open class SharingService: LocalCoreDataService {
-    @objc let SharingAPIErrorNotFound = "not_found"
+@objc class SharingService: NSObject {
+    let SharingAPIErrorNotFound = "not_found"
+
+    private let coreDataStack: CoreDataStackSwift
+
+    /// The initialiser for Objective-C code.
+    ///
+    /// Using `ContextManager` as the argument becuase `CoreDataStackSwift` is not accessible from Objective-C code.
+    @objc
+    init(contextManager: ContextManager) {
+        self.coreDataStack = contextManager
+    }
+
+    init(coreDataStack: CoreDataStackSwift) {
+        self.coreDataStack = coreDataStack
+    }
 
     // MARK: - Publicize Related Methods
 
@@ -19,7 +33,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters
     ///     - failure: An optional failure block accepting an `NSError` parameter
     ///
-    @objc open func syncPublicizeServicesForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc func syncPublicizeServicesForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         guard let remote = remoteForBlog(blog) else {
             return
         }
@@ -39,7 +53,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting an array of `KeyringConnection` objects
     ///     - failure: An optional failure block accepting an `NSError` parameter
     ///
-    @objc open func fetchKeyringConnectionsForBlog(_ blog: Blog, success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc func fetchKeyringConnectionsForBlog(_ blog: Blog, success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
         guard let remote = remoteForBlog(blog) else {
             return
         }
@@ -61,7 +75,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting a `PublicizeConnection` parameter.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc open func createPublicizeConnectionForBlog(_ blog: Blog,
+    @objc func createPublicizeConnectionForBlog(_ blog: Blog,
         keyring: KeyringConnection,
         externalUserID: String?,
         success: ((PublicizeConnection) -> Void)?,
@@ -116,7 +130,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc open func updateSharedForBlog(
+    @objc func updateSharedForBlog(
         _ blog: Blog,
         shared: Bool,
         forPublicizeConnection pubConn: PublicizeConnection,
@@ -194,7 +208,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc open func updateExternalID(_ externalID: String,
+    @objc func updateExternalID(_ externalID: String,
         forBlog blog: Blog,
         forPublicizeConnection pubConn: PublicizeConnection,
         success: (() -> Void)?,
@@ -238,7 +252,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc open func deletePublicizeConnectionForBlog(_ blog: Blog, pubConn: PublicizeConnection, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc func deletePublicizeConnectionForBlog(_ blog: Blog, pubConn: PublicizeConnection, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         // optimistically delete the connection locally.
         coreDataStack.performAndSave({ context in
             let blogInContext = try context.existingObject(with: blog.objectID) as! Blog
@@ -369,7 +383,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
-    @objc open func syncSharingButtonsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc func syncSharingButtonsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
             return
@@ -391,7 +405,7 @@ open class SharingService: LocalCoreDataService {
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
-    @objc open func updateSharingButtonsForBlog(_ blog: Blog, sharingButtons: [SharingButton], success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc func updateSharingButtonsForBlog(_ blog: Blog, sharingButtons: [SharingButton], success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
 
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {

--- a/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingAuthorizationHelper.m
@@ -175,7 +175,7 @@
         [self.delegate sharingAuthorizationHelper:self willFetchKeyringsForService:self.publicizeService];
     }
 
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self.blog managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     __weak __typeof__(self) weakSelf = self;
     [sharingService fetchKeyringConnectionsForBlog:self.blog success:^(NSArray *keyringConnections) {
         if ([weakSelf.delegate respondsToSelector:@selector(sharingAuthorizationHelper:didFetchKeyringsForService:)]) {
@@ -340,7 +340,7 @@
 
     [self dismissNavViewController];
 
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self.blog managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
 
     [sharingService updateExternalID:externalID forBlog:self.blog forPublicizeConnection:publicizeConnection success:^{
         if ([self.delegate respondsToSelector:@selector(sharingAuthorizationHelper:didConnectToService:withPublicizeConnection:)]) {
@@ -367,7 +367,7 @@
 
     [self dismissNavViewController];
 
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self.blog managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     [sharingService createPublicizeConnectionForBlog:self.blog
                                              keyring:keyConn
                                       externalUserID:externalUserID

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -78,8 +78,7 @@ import WordPressShared
                                                                 action: #selector(doneButtonTapped))
         }
 
-        let service = SharingService(managedObjectContext: viewContext)
-        buttons = service.allSharingButtonsForBlog(self.blog)
+        buttons = (try? SharingButton.allSharingButtons(for: blog, in: viewContext)) ?? []
         configureTableView()
         setupSections()
 
@@ -641,8 +640,7 @@ import WordPressShared
     /// `buttons` property and refreshes the button section and the more section.
     ///
     private func reloadButtons() {
-        let service = SharingService(managedObjectContext: viewContext)
-        buttons = service.allSharingButtonsForBlog(blog)
+        buttons = (try? SharingButton.allSharingButtons(for: blog, in: viewContext)) ?? []
 
         refreshButtonsSection()
         refreshMoreSection()

--- a/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/SharingButtonsViewController.swift
@@ -554,7 +554,7 @@ import WordPressShared
     /// when finished.  Fails silently if there is an error.
     ///
     private func syncSharingButtons() {
-        let service = SharingService(managedObjectContext: viewContext)
+        let service = SharingService(coreDataStack: ContextManager.shared)
         service.syncSharingButtonsForBlog(self.blog,
             success: { [weak self] in
                 self?.reloadButtons()
@@ -651,7 +651,7 @@ import WordPressShared
     /// - Parameter refresh: True if the tableview sections should be reloaded.
     ///
     private func syncButtonChangesToBlog(_ refresh: Bool) {
-        let service = SharingService(managedObjectContext: viewContext)
+        let service = SharingService(coreDataStack: ContextManager.shared)
         service.updateSharingButtonsForBlog(blog,
             sharingButtons: buttons,
             success: {[weak self] in

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -34,8 +34,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
     if (self) {
         _blog = blog;
         _publicizeConnection = connection;
-        SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-        PublicizeService *publicizeService = [sharingService findPublicizeServiceNamed:connection.service];
+        PublicizeService *publicizeService = [PublicizeService lookupPublicizeServiceNamed:connection.service inContext:[self managedObjectContext]];
         if (publicizeService) {
             self.helper = [[SharingAuthorizationHelper alloc] initWithViewController:self
                                                                                 blog:self.blog

--- a/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingDetailViewController.m
@@ -205,7 +205,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 - (void)updateSharedGlobally:(BOOL)shared
 {
     __weak __typeof(self) weakSelf = self;
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     [sharingService updateSharedForBlog:self.blog
                                  shared:shared
                  forPublicizeConnection:self.publicizeConnection
@@ -224,7 +224,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         return;
     }
 
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
 
     __weak __typeof(self) weakSelf = self;
     if (self.helper == nil) {
@@ -242,7 +242,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)disconnectPublicizeConnection
 {
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     [sharingService deletePublicizeConnectionForBlog:self.blog pubConn:self.publicizeConnection success:nil failure:^(NSError *error) {
         DDLogError([error description]);
         [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Disconnect failed", @"Message to show when Publicize disconnect failed")];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -90,8 +90,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)refreshPublicizers
 {
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    self.publicizeServices = [sharingService allPublicizeServices];
+    self.publicizeServices = [PublicizeService allPublicizeServicesInContext:[self managedObjectContext] error:nil];
 
     [self.tableView reloadData];
 }

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -357,11 +357,12 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 {
     // Sync sharing buttons if they have never been synced. Otherwise, the
     // management vc can worry about fetching the latest sharing buttons.
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    NSArray *buttons = [sharingService allSharingButtonsForBlog:self.blog];
+    NSArray *buttons = [SharingButton allSharingButtonsForBlog:self.blog inContext:[self managedObjectContext] error:nil];
     if ([buttons count] > 0) {
         return;
     }
+
+    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
     [sharingService syncSharingButtonsForBlog:self.blog success:nil failure:^(NSError *error) {
         DDLogError([error description]);
     }];

--- a/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/SharingViewController.m
@@ -323,7 +323,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)syncPublicizeServices
 {
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     __weak __typeof__(self) weakSelf = self;
     [sharingService syncPublicizeServicesForBlog:self.blog success:^{
         [weakSelf syncConnections];
@@ -362,7 +362,7 @@ static NSString *const CellIdentifier = @"CellIdentifier";
         return;
     }
 
-    SharingService *sharingService = [[SharingService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
     [sharingService syncSharingButtonsForBlog:self.blog success:nil failure:^(NSError *error) {
         DDLogError([error description]);
     }];

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1131,6 +1131,8 @@
 		4A2172FF28F688890006F4F1 /* Blog+Media.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2172FD28F688890006F4F1 /* Blog+Media.swift */; };
 		4A266B8F282B05210089CF3D /* JSONObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B8E282B05210089CF3D /* JSONObjectTests.swift */; };
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
+		4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
+		4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A526BDF296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A526BE0296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A82C43128D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
@@ -6619,6 +6621,7 @@
 		4A2172FD28F688890006F4F1 /* Blog+Media.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Blog+Media.swift"; sourceTree = "<group>"; };
 		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
+		4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeService+Lookup.swift"; sourceTree = "<group>"; };
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
 		4A526BDE296BE9A50007B5BA /* CoreDataService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreDataService.h; sourceTree = "<group>"; };
 		4A82C43028D321A300486CFF /* Blog+Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog+Post.swift"; sourceTree = "<group>"; };
@@ -10414,6 +10417,7 @@
 				E6374DBD1C444D8B00F24720 /* PublicizeConnection.swift */,
 				4A1E77C82988997C006281CC /* PublicizeConnection+Creation.swift */,
 				E6374DBE1C444D8B00F24720 /* PublicizeService.swift */,
+				4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */,
 				8BB185D424B66FE600A4CCE8 /* ReaderCard+CoreDataClass.swift */,
 				8BB185D324B66FE500A4CCE8 /* ReaderCard+CoreDataProperties.swift */,
 				5D42A3DC175E7452005CFF05 /* ReaderPost.h */,
@@ -20557,6 +20561,7 @@
 				F12FA5D92428FA8F0054DA21 /* AuthenticationService.swift in Sources */,
 				E16A76F11FC4758300A661E3 /* JetpackSiteRef.swift in Sources */,
 				B5B56D3219AFB68800B4E29B /* WPStyleGuide+Reply.swift in Sources */,
+				4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */,
 				C7234A422832C2BA0045C63F /* QRLoginScanningViewController.swift in Sources */,
 				801D94EF2919E7D70051993E /* JetpackFullscreenOverlayGeneralViewModel.swift in Sources */,
 				30EABE0918A5903400B73A9C /* WPBlogTableViewCell.m in Sources */,
@@ -23550,6 +23555,7 @@
 				FABB21C22602FC2C00C8785C /* JetpackRestoreFailedViewController.swift in Sources */,
 				8067340B27E3A50900ABC95E /* UIViewController+RemoveQuickStart.m in Sources */,
 				FABB21C32602FC2C00C8785C /* ActionSheetViewController.swift in Sources */,
+				4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */,
 				C737553F27C80DD500C6E9A1 /* String+CondenseWhitespace.swift in Sources */,
 				FABB21C42602FC2C00C8785C /* PostService+Revisions.swift in Sources */,
 				FABB21C52602FC2C00C8785C /* SourcePostAttribution.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1133,6 +1133,8 @@
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
 		4A358DE629B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
 		4A358DE729B5EB8D00BFCEBE /* PublicizeService+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */; };
+		4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */; };
+		4A358DEA29B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */; };
 		4A526BDF296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A526BE0296BE9A50007B5BA /* CoreDataService.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A526BDD296BE9A50007B5BA /* CoreDataService.m */; };
 		4A82C43128D321A300486CFF /* Blog+Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A82C43028D321A300486CFF /* Blog+Post.swift */; };
@@ -6622,6 +6624,7 @@
 		4A266B8E282B05210089CF3D /* JSONObjectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONObjectTests.swift; sourceTree = "<group>"; };
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
 		4A358DE529B5EB8D00BFCEBE /* PublicizeService+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PublicizeService+Lookup.swift"; sourceTree = "<group>"; };
+		4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SharingButton+Lookup.swift"; sourceTree = "<group>"; };
 		4A526BDD296BE9A50007B5BA /* CoreDataService.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CoreDataService.m; sourceTree = "<group>"; };
 		4A526BDE296BE9A50007B5BA /* CoreDataService.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CoreDataService.h; sourceTree = "<group>"; };
 		4A82C43028D321A300486CFF /* Blog+Post.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Blog+Post.swift"; sourceTree = "<group>"; };
@@ -10443,6 +10446,7 @@
 				E1DB326B1D9ACD4A00C8FEBC /* ReaderTeamTopic.swift */,
 				E10290731F30615A00DAC588 /* Role.swift */,
 				E6E27D611C6144DB0063F821 /* SharingButton.swift */,
+				4A358DE829B5F14C00BFCEBE /* SharingButton+Lookup.swift */,
 				E6D170361EF9D8D10046D433 /* SiteInfo.swift */,
 				B06378BE253F639D00FD45D2 /* SiteSuggestion+CoreDataClass.swift */,
 				B06378BF253F639D00FD45D2 /* SiteSuggestion+CoreDataProperties.swift */,
@@ -21418,6 +21422,7 @@
 				E14DFAFB1E07E7C400494688 /* Data.swift in Sources */,
 				E14B40FD1C58B806005046F6 /* AccountSettingsViewController.swift in Sources */,
 				98B11B892216535100B7F2D7 /* StatsChildRowsView.swift in Sources */,
+				4A358DE929B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */,
 				08CC677F1C49B65A00153AD7 /* Menu.m in Sources */,
 				BE13B3E71B2B58D800A4211D /* BlogListViewController.m in Sources */,
 				C768B5B425828A5D00556E75 /* JetpackScanStatusCell.swift in Sources */,
@@ -23668,6 +23673,7 @@
 				FABB22132602FC2C00C8785C /* BlogSiteVisibilityHelper.m in Sources */,
 				FABB22142602FC2C00C8785C /* TitleBadgeDisclosureCell.swift in Sources */,
 				FABB22152602FC2C00C8785C /* FormattableContent.swift in Sources */,
+				4A358DEA29B5F14C00BFCEBE /* SharingButton+Lookup.swift in Sources */,
 				FABB22162602FC2C00C8785C /* WebAddressWizardContent.swift in Sources */,
 				C7AFF87D283D5CF4000E01DF /* QRLoginVerifyCoordinator.swift in Sources */,
 				FABB22172602FC2C00C8785C /* VisitsSummaryStatsRecordValue+CoreDataProperties.swift in Sources */,


### PR DESCRIPTION
Use `CoreDataStack` instead of `NSManagedObjectContext` in `SharingService`. See the "Issue" and "Proposal" sections of https://github.com/wordpress-mobile/WordPress-iOS/pull/19893 for rationale behind this change.

Like other similar PRs, I recommend reviewing this one commit by commit too.

## Test Instructions

Only the "Sharing" screen (under the My Site tab) is affected by this change. Verifying the features in it still works should be enough, i.e. connect/disconnect to a SNS, show/hide sharing buttons.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What are describe in the "Test Instructions" section above.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
