### PR TITLE
Remove an unused closure argument

### DIFF
--- a/WordPress/Classes/Services/PostService+Revisions.swift
+++ b/WordPress/Classes/Services/PostService+Revisions.swift
@@ -3,12 +3,7 @@ import Foundation
 
 extension PostService {
 
-    /// PostService API to get the revisions list
-    ///
-    /// - Parameters:
-    ///   - post: A valid abstract post
-    ///   - success: The success block accepts an optional list of Revisions
-    ///   - failure: The failure block accepts an optional error
+    /// PostService API to get the revisions list and store them into the Core Data data store.
     func getPostRevisions(for post: AbstractPost,
                           success: @escaping () -> Void,
                           failure: @escaping (Error?) -> Void) {

--- a/WordPress/Classes/Services/PostService+Revisions.swift
+++ b/WordPress/Classes/Services/PostService+Revisions.swift
@@ -10,7 +10,7 @@ extension PostService {
     ///   - success: The success block accepts an optional list of Revisions
     ///   - failure: The failure block accepts an optional error
     func getPostRevisions(for post: AbstractPost,
-                          success: @escaping ([Revision]?) -> Void,
+                          success: @escaping () -> Void,
                           failure: @escaping (Error?) -> Void) {
         guard let blogId = post.blog.dotComID,
             let postId = post.postID,
@@ -27,9 +27,7 @@ extension PostService {
                                         let revisions = self.syncPostRevisions(from: remoteRevisions ?? [],
                                                                                for: postId.intValue,
                                                                                with: blogId.intValue)
-                                        ContextManager.sharedInstance().save(self.managedObjectContext, completion: {
-                                            success(revisions)
-                                        }, on: .main)
+                                        ContextManager.sharedInstance().save(self.managedObjectContext, completion: success, on: .main)
                                     }
         }, failure: failure)
     }

--- a/WordPress/Classes/Services/PostService+Revisions.swift
+++ b/WordPress/Classes/Services/PostService+Revisions.swift
@@ -19,9 +19,11 @@ extension PostService {
                                 postId: postId.intValue,
                                 success: { (remoteRevisions) in
                                     self.managedObjectContext.perform {
-                                        let revisions = self.syncPostRevisions(from: remoteRevisions ?? [],
-                                                                               for: postId.intValue,
-                                                                               with: blogId.intValue)
+                                        let _ = self.syncPostRevisions(
+                                            from: remoteRevisions ?? [],
+                                            for: postId.intValue,
+                                            with: blogId.intValue
+                                        )
                                         ContextManager.sharedInstance().save(self.managedObjectContext, completion: success, on: .main)
                                     }
         }, failure: failure)

--- a/WordPress/Classes/ViewRelated/Post/Revisions/ShowRevisionsListManger.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/ShowRevisionsListManger.swift
@@ -29,7 +29,7 @@ final class ShowRevisionsListManger {
 
         isLoading = true
 
-        postService.getPostRevisions(for: post, success: { [weak self] _ in
+        postService.getPostRevisions(for: post, success: { [weak self] in
             DispatchQueue.main.async {
                 self?.isLoading = false
                 self?.revisionsView?.stopLoading(success: true, error: nil)


### PR DESCRIPTION
The post revisions objects passed to the closure is not used in the call site, this PR removes it to avoid potential issues (see [this PR comment below](https://github.com/wordpress-mobile/WordPress-iOS/pull/20267#discussion_r1127265870)).

I don't think this change has any impact on the app.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
I've verified the post revisions (viewed from the "History" of a posts) are displayed correctly.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
