### PR TITLE
Update account settings asynchronously

### DIFF
--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -74,7 +74,7 @@ class AccountSettingsService {
     }
 
     func getSettingsAttempt(count: Int = 0, completion: ((Result<AccountSettings, Error>) -> Void)? = nil) {
-        self.remote.getSettings(
+        remote.getSettings(
             success: { settings in
                 self.coreDataStack.performAndSave({ context in
                     if let managedSettings = self.managedAccountSettingsWithID(self.userID, in: context) {


### PR DESCRIPTION
This PR changes an synchronous `performAndSave` call to an asynchronous call, which should make this part more correct, since the updated settings may appear in the main context in the next run loop (see pbArwn-5Qy-p2#how-does-this-apply-to-the-wp-and-jp-ios-apps for detail).

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
