### PR TITLE
Prevent inconsistent state in UI tests

### DIFF
--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -9,7 +9,7 @@ class JetpackScreenshotGeneration: XCTestCase {
     override func setUpWithError() throws {
         super.setUp()
 
-        let app = XCUIApplication(bundleIdentifier: "com.automattic.jetpack")
+        let app = XCUIApplication.jetpack
 
         // This does the shared setup including injecting mocks and launching the app
         setUpTestSuite(for: app, removeBeforeLaunching: true)
@@ -30,7 +30,7 @@ class JetpackScreenshotGeneration: XCTestCase {
 
     override func tearDown() {
         super.tearDown()
-        removeApp(XCUIApplication(bundleIdentifier: "com.automattic.jetpack"))
+        removeApp(.jetpack)
     }
 
     func testGenerateScreenshots() throws {
@@ -95,4 +95,9 @@ extension ScreenObject {
 
         return self
     }
+}
+
+extension XCUIApplication {
+
+    static let jetpack = XCUIApplication(bundleIdentifier: "com.automattic.jetpack")
 }

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -9,13 +9,12 @@ class JetpackScreenshotGeneration: XCTestCase {
     override func setUpWithError() throws {
         super.setUp()
 
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        let app = XCUIApplication(bundleIdentifier: "com.automattic.jetpack")
 
         // This does the shared setup including injecting mocks and launching the app
-        setUpTestSuite(for: "Jetpack")
+        setUpTestSuite(for: app, removeBeforeLaunching: true)
 
         // The app is already launched so we can set it up for screenshots here
-        let app = XCUIApplication()
         setupSnapshot(app)
 
         if XCUIDevice.isPad {
@@ -30,9 +29,8 @@ class JetpackScreenshotGeneration: XCTestCase {
     }
 
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
-        removeApp("Jetpack")
+        removeApp(XCUIApplication(bundleIdentifier: "com.automattic.jetpack"))
     }
 
     func testGenerateScreenshots() throws {

--- a/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
+++ b/WordPress/JetpackScreenshotGeneration/JetpackScreenshotGeneration.swift
@@ -29,8 +29,8 @@ class JetpackScreenshotGeneration: XCTestCase {
     }
 
     override func tearDown() {
-        super.tearDown()
         removeApp(.jetpack)
+        super.tearDown()
     }
 
     func testGenerateScreenshots() throws {

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -106,4 +106,5 @@ extension ScreenObject {
 public enum Apps {
 
     public static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+    public static let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 }

--- a/WordPress/UITestsFoundation/Globals.swift
+++ b/WordPress/UITestsFoundation/Globals.swift
@@ -54,7 +54,7 @@ extension ScreenObject {
 
     public func openMagicLink() {
         XCTContext.runActivity(named: "Open magic link in Safari") { activity in
-            let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+            let safari = Apps.safari
             safari.launch()
 
             // Select the URL bar when Safari opens
@@ -76,7 +76,7 @@ extension ScreenObject {
     }
 
     public func findSafariAddressBar(hasBeenTapped: Bool) -> XCUIElement {
-        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        let safari = Apps.safari
 
         // when the device is iPad and addressBar has not been tapped the element is a button
         if UIDevice.current.userInterfaceIdiom == .pad && !hasBeenTapped {
@@ -101,4 +101,9 @@ extension ScreenObject {
 
         return self
     }
+}
+
+public enum Apps {
+
+    public static let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
 }

--- a/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
+++ b/WordPress/UITestsFoundation/Screens/Me/SupportScreen.swift
@@ -76,7 +76,7 @@ public class SupportScreen: ScreenObject {
     }
 
     public func assertForumsLoaded() {
-        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        let safari = Apps.safari
         guard safari.wait(for: .runningForeground, timeout: 4) else {
             XCTFail("Safari wait failed")
             return

--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -20,12 +20,15 @@ public extension XCTestCase {
         app.terminate()
 
         let appToRemove = Apps.springboard.icons[appName]
-        if appToRemove.exists {
-            appToRemove.firstMatch.press(forDuration: 1)
-            waitAndTap(Apps.springboard.buttons["Remove App"])
-            waitAndTap(Apps.springboard.alerts.buttons["Delete App"])
-            waitAndTap(Apps.springboard.alerts.buttons["Delete"])
+
+        guard appToRemove.exists else {
+            return
         }
+
+        appToRemove.firstMatch.press(forDuration: 1)
+        waitAndTap(Apps.springboard.buttons["Remove App"])
+        waitAndTap(Apps.springboard.alerts.buttons["Delete App"])
+        waitAndTap(Apps.springboard.alerts.buttons["Delete"])
     }
 
 }

--- a/WordPress/UITestsFoundation/XCTestCase+Utils.swift
+++ b/WordPress/UITestsFoundation/XCTestCase+Utils.swift
@@ -1,0 +1,31 @@
+import XCTest
+
+public extension XCTestCase {
+
+    func removeApp(_ app: XCUIApplication = XCUIApplication()) {
+        // We need to store the app name before calling `terminate()` if we want to delete it.
+        // Otherwise, we won't be able to access it to read its name as the test will fail with:
+        //
+        // > Failed to get matching snapshot: Application org.wordpress is not running
+        //
+        // Launch the app to access its name so we can deleted it from Springboard
+        switch app.state {
+        case .unknown, .notRunning:
+            app.launch()
+        case _:
+            break
+        }
+
+        let appName = app.label
+        app.terminate()
+
+        let appToRemove = Apps.springboard.icons[appName]
+        if appToRemove.exists {
+            appToRemove.firstMatch.press(forDuration: 1)
+            waitAndTap(Apps.springboard.buttons["Remove App"])
+            waitAndTap(Apps.springboard.alerts.buttons["Delete App"])
+            waitAndTap(Apps.springboard.alerts.buttons["Delete"])
+        }
+    }
+
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -632,6 +632,7 @@
 		3F09CCA82428FF3300D00A8C /* ReaderTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F09CCA72428FF3300D00A8C /* ReaderTabViewController.swift */; };
 		3F09CCAA2428FF8300D00A8C /* ReaderTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F09CCA92428FF8300D00A8C /* ReaderTabView.swift */; };
 		3F09CCAE24292EFD00D00A8C /* ReaderTabItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F09CCAD24292EFD00D00A8C /* ReaderTabItem.swift */; };
+		3F107B1929B6F7E0009B3658 /* XCTestCase+Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F107B1829B6F7E0009B3658 /* XCTestCase+Utils.swift */; };
 		3F170E242655917400F6F670 /* UIView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F170E232655917400F6F670 /* UIView+SwiftUI.swift */; };
 		3F170E252655917400F6F670 /* UIView+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F170E232655917400F6F670 /* UIView+SwiftUI.swift */; };
 		3F1AD48123FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1AD48023FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift */; };
@@ -6252,6 +6253,7 @@
 		3F09CCA72428FF3300D00A8C /* ReaderTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabViewController.swift; sourceTree = "<group>"; };
 		3F09CCA92428FF8300D00A8C /* ReaderTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabView.swift; sourceTree = "<group>"; };
 		3F09CCAD24292EFD00D00A8C /* ReaderTabItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderTabItem.swift; sourceTree = "<group>"; };
+		3F107B1829B6F7E0009B3658 /* XCTestCase+Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Utils.swift"; sourceTree = "<group>"; };
 		3F170E232655917400F6F670 /* UIView+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+SwiftUI.swift"; sourceTree = "<group>"; };
 		3F1AD48023FC87A400BB1375 /* BlogDetailsViewController+MeButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlogDetailsViewController+MeButtonTests.swift"; sourceTree = "<group>"; };
 		3F1B66A223A2F54B0075F09E /* ReaderReblogActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogActionTests.swift; sourceTree = "<group>"; };
@@ -11203,6 +11205,7 @@
 				3FE39A4326F8391D006E2B3A /* Screens */,
 				3FA640592670CCD40064401E /* UITestsFoundation.h */,
 				3F762E9426784B540088CD45 /* WireMock.swift */,
+				3F107B1829B6F7E0009B3658 /* XCTestCase+Utils.swift */,
 				3FB5C2B227059AC8007D0ECE /* XCUIElement+Scroll.swift */,
 				3F762E9A26784D2A0088CD45 /* XCUIElement+Utils.swift */,
 				3F762E9826784CC90088CD45 /* XCUIElementQuery+Utils.swift */,
@@ -22324,6 +22327,7 @@
 				3F2F855026FAF227000FCDA5 /* SignupEmailScreen.swift in Sources */,
 				3F2F855826FAF227000FCDA5 /* SignupEpilogueScreen.swift in Sources */,
 				3F2F855726FAF227000FCDA5 /* WelcomeScreenSignupComponent.swift in Sources */,
+				3F107B1929B6F7E0009B3658 /* XCTestCase+Utils.swift in Sources */,
 				3F2F855326FAF227000FCDA5 /* EditorPostSettings.swift in Sources */,
 				3F2F856026FAF235000FCDA5 /* NotificationsScreen.swift in Sources */,
 				3F2F854026FAE9DC000FCDA5 /* BlockEditorScreen.swift in Sources */,

--- a/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
+++ b/WordPress/WordPressScreenshotGeneration/WordPressScreenshotGeneration.swift
@@ -9,13 +9,12 @@ class WordPressScreenshotGeneration: XCTestCase {
     override func setUpWithError() throws {
         super.setUp()
 
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        let app = XCUIApplication(bundleIdentifier: "org.wordpress")
 
         // This does the shared setup including injecting mocks and launching the app
-        setUpTestSuite(for: "WordPress")
+        setUpTestSuite(for: app, removeBeforeLaunching: true)
 
         // The app is already launched so we can set it up for screenshots here
-        let app = XCUIApplication()
         setupSnapshot(app)
 
         if XCUIDevice.isPad {

--- a/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
+++ b/WordPress/WordPressUITests/Utils/XCTest+Extensions.swift
@@ -75,34 +75,4 @@ extension XCTestCase {
         static let category = "iOS Test"
         static let tag = "tag \(Date().toString())"
     }
-
-    public func removeApp(_ app: XCUIApplication = XCUIApplication()) {
-        // We need to store the app name before calling `terminate()` if we want to delete it.
-        // Otherwise, we won't be able to access it to read its name as the test will fail with:
-        //
-        // > Failed to get matching snapshot: Application org.wordpress is not running
-        //
-        // Launch the app to access its name so we can deleted it from Springboard
-        switch app.state {
-        case .unknown, .notRunning:
-            app.launch()
-        case _:
-            break
-        }
-
-        let appName = app.label
-        app.terminate()
-
-        let appToRemove = Constants.homeApp.icons[appName]
-        if appToRemove.exists {
-            appToRemove.firstMatch.press(forDuration: 1)
-            waitAndTap(Constants.homeApp.buttons["Remove App"])
-            waitAndTap(Constants.homeApp.alerts.buttons["Delete App"])
-            waitAndTap(Constants.homeApp.alerts.buttons["Delete"])
-        }
-    }
-
-    private enum Constants {
-        static let homeApp = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-    }
 }


### PR DESCRIPTION
While looking at #20226, I noticed the possibility for a inconsistent state. In the following methods, it's possible to pass the name of an app that is different from the `app` parameter:

https://github.com/wordpress-mobile/WordPress-iOS/blob/f5c8424947372018f487109666c9319bb8261cec/WordPress/WordPressUITests/Utils/XCTest%2BExtensions.swift#L6

https://github.com/wordpress-mobile/WordPress-iOS/blob/f5c8424947372018f487109666c9319bb8261cec/WordPress/WordPressUITests/Utils/XCTest%2BExtensions.swift#L79

Admittedly, the way the code was used made it unlikely it happened. But still, it's best if we can remove the chance of it happening in the first place.

Since the name of the app to terminate is its `label` property, this PR access that internally and only requires the one `app: XCUIApplication` parameter.

## Testing

I verified this works by running all four UI test targets locally and observing the app correctly starting and resetting. I have to say that I run into some test failures in all four targets, however I don't think they are related to these changes. We'll see what CI has to say about it...

While I was at it, I also moved the code from the `XCTest+Extensions.swift` file that is shared across targets (suboptimal) to a new `XCTestCase+Utils.swift` file that is part of the UITestsFoundation dependency.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
