### PR TITLE
Use `CoreDataStack` in `EnhancedSiteCreationService`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 22.0
 -----
-
+* [*] [internal] Refactored the Core Data operations (saving the site data) after a new site is created. [#20270]
 
 21.9
 -----

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/SiteCreationWizardLauncher.swift
@@ -85,7 +85,7 @@ final class SiteCreationWizardLauncher {
             let segmentsService = SiteCreationSegmentsService(coreDataStack: ContextManager.sharedInstance())
             return SiteSegmentsStep(creator: self.creator, service: segmentsService)
         case .siteAssembly:
-            let siteAssemblyService = EnhancedSiteCreationService(managedObjectContext: ContextManager.sharedInstance().mainContext)
+            let siteAssemblyService = EnhancedSiteCreationService(coreDataStack: ContextManager.sharedInstance())
             return SiteAssemblyStep(creator: self.creator, service: siteAssemblyService, onDismiss: onDismiss)
         }
     }


### PR DESCRIPTION
Use `CoreDataStack` instead of `NSManagedObjectContext` in `EnhancedSiteCreationService`. See the "Issue" and "Proposal" sections of https://github.com/wordpress-mobile/WordPress-iOS/pull/19893 for rationale behind this change.

I've also broken down the original `synchronize` function into two functions: one is creating a site in the database, and the other is syncing the newly created blog and current logged in account.

## Test instructions

Verify creating a new site still works.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What's described in the "Test instructions" section.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
