### PR TITLE
Blaze: Fix feature flag and fetching

### DIFF
--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -24,13 +24,12 @@ final class BlazeService {
     ///
     /// - Parameters:
     ///   - blog: A blog
-    ///   - success: Closure to be called on success
-    ///   - failure: Closure to be caleld on failure
+    ///   - completion: Closure to be called on success
     func updateStatus(for blog: Blog,
-                      success: (() -> Void)? = nil,
-                      failure: ((Error) -> Void)? = nil) {
+                      completion: (() -> Void)? = nil) {
         guard let siteId = blog.dotComID?.intValue else {
-            failure?(BlazeServiceError.invalidSiteId)
+            DDLogError("Invalid site ID for Blaze")
+            completion?()
             return
         }
 
@@ -42,7 +41,7 @@ final class BlazeService {
 
                     guard let blog = Blog.lookup(withObjectID: blog.objectID, in: context) else {
                         DDLogError("Unable to update isBlazeApproved value for blog")
-                        failure?(BlazeServiceError.blogNotFound)
+                        completion?()
                         return
                     }
 
@@ -50,21 +49,13 @@ final class BlazeService {
                     DDLogInfo("Successfully updated isBlazeApproved value for blog: \(approved)")
 
                 }, completion: {
-                    success?()
+                    completion?()
                 }, on: .main)
 
             case .failure(let error):
                 DDLogError("Unable to fetch isBlazeApproved value from remote: \(error.localizedDescription)")
-                failure?(error)
+                completion?()
             }
         }
-    }
-}
-
-extension BlazeService {
-
-    enum BlazeServiceError: Error {
-        case invalidSiteId
-        case blogNotFound
     }
 }

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -6,6 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 extern NSString *const WordPressMinimumVersion;
 extern NSString *const WPBlogUpdatedNotification;
+extern NSString *const WPBlogSettingsUpdatedNotification;
 
 @class WPAccount;
 @class SiteInfo;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -21,6 +21,7 @@ NSString *const VideopressEnabled = @"videopress_enabled";
 NSString *const WordPressMinimumVersion = @"4.0";
 NSString *const HttpsPrefix = @"https://";
 NSString *const WPBlogUpdatedNotification = @"WPBlogUpdatedNotification";
+NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotification";
 
 @implementation BlogService
 

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
@@ -1,8 +1,13 @@
 import Foundation
 
-final class BlazeHelper {
+@objcMembers final class BlazeHelper: NSObject {
 
-    static func isBlazeFlagEnabled(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> Bool {
+    /// Using two separate methods (rather than one method with a default argument) for Obj-C compatibility.
+    static func isBlazeFlagEnabled() -> Bool {
+        return isBlazeFlagEnabled(featureFlagStore: RemoteFeatureFlagStore())
+    }
+
+    static func isBlazeFlagEnabled(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
         guard AppConfiguration.isJetpack else {
             return false
         }

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
@@ -2,8 +2,15 @@ import Foundation
 
 final class BlazeHelper {
 
+    static func isBlazeFlagEnabled(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> Bool {
+        guard AppConfiguration.isJetpack else {
+            return false
+        }
+        return featureFlagStore.value(for: FeatureFlag.blaze)
+    }
+
     static func shouldShowCard(for blog: Blog) -> Bool {
-        guard FeatureFlag.blaze.enabled && blog.isBlazeApproved else {
+        guard isBlazeFlagEnabled() && blog.isBlazeApproved else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1777,7 +1777,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 
 - (BOOL)shouldShowBlaze
 {
-    return [Feature enabled:FeatureFlagBlaze] && [self.blog supports:BlogFeatureBlaze];
+    return [BlazeHelper isBlazeFlagEnabled] && [self.blog supports:BlogFeatureBlaze];
 }
 
 #pragma mark - Remove Site

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -960,7 +960,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - Blaze
 
     private func updateBlazeStatus(for blog: Blog?, completion: @escaping () -> Void) {
-        guard FeatureFlag.blaze.enabled,
+        guard BlazeHelper.isBlazeFlagEnabled(),
               let blog = blog,
               let blazeService = BlazeService() else {
             completion()

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -273,7 +273,7 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     }
 
     private func subscribeToSiteSettingsUpdated() {
-        NotificationCenter.default.addObserver(forName: NSNotification.Name.WPBlogUpdated, object: nil, queue: nil) { [weak self] _ in
+        NotificationCenter.default.addObserver(forName: NSNotification.Name.WPBlogSettingsUpdated, object: nil, queue: nil) { [weak self] _ in
             guard let blog = self?.blog else {
                 return
             }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -1138,7 +1138,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     
     BlogService *blogService = [[BlogService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     [blogService updateSettingsForBlog:self.blog success:^{
-        [NSNotificationCenter.defaultCenter postNotificationName:WPBlogUpdatedNotification object:nil];
+        [NSNotificationCenter.defaultCenter postNotificationName:WPBlogSettingsUpdatedNotification object:nil];
     } failure:^(NSError *error) {
         [SVProgressHUD showDismissibleErrorWithStatus:NSLocalizedString(@"Settings update failed", @"Message to show when setting save failed")];
         DDLogError(@"Error while trying to update BlogSettings: %@", error);

--- a/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageListViewController.swift
@@ -767,7 +767,7 @@ class PageListViewController: AbstractPostListViewController, UIViewControllerRe
     }
 
     private func addBlazeAction(to controller: UIAlertController, for page: AbstractPost) {
-        guard FeatureFlag.blaze.enabled && page.canBlaze else {
+        guard BlazeHelper.isBlazeFlagEnabled() && page.canBlaze else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -36,6 +36,8 @@ class PostCardStatusViewModel: NSObject {
 
     private let isInternetReachable: Bool
 
+    private let isBlazeFlagEnabled: Bool
+
     var progressBlock: ((Float) -> Void)? = nil {
         didSet {
             if let _ = oldValue, let uuid = progressObserverUUID {
@@ -52,9 +54,12 @@ class PostCardStatusViewModel: NSObject {
         }
     }
 
-    init(post: Post, isInternetReachable: Bool = ReachabilityUtils.isInternetReachable()) {
+    init(post: Post,
+         isInternetReachable: Bool = ReachabilityUtils.isInternetReachable(),
+         isBlazeFlagEnabled: Bool = BlazeHelper.isBlazeFlagEnabled()) {
         self.post = post
         self.isInternetReachable = isInternetReachable
+        self.isBlazeFlagEnabled = isBlazeFlagEnabled
         super.init()
     }
 
@@ -186,7 +191,7 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.share)
             }
 
-            if BlazeHelper.isBlazeFlagEnabled() && post.canBlaze {
+            if isBlazeFlagEnabled && post.canBlaze {
                 buttons.append(.blaze)
             }
 

--- a/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostCardStatusViewModel.swift
@@ -186,7 +186,7 @@ class PostCardStatusViewModel: NSObject {
                 buttons.append(.share)
             }
 
-            if FeatureFlag.blaze.enabled && post.canBlaze {
+            if BlazeHelper.isBlazeFlagEnabled() && post.canBlaze {
                 buttons.append(.blaze)
             }
 

--- a/WordPress/WordPressTest/PostActionSheetTests.swift
+++ b/WordPress/WordPressTest/PostActionSheetTests.swift
@@ -158,7 +158,7 @@ class PostActionSheetTests: CoreDataTestCase {
             .published()
             .build()
 
-        let viewModel = PostCardStatusViewModel(post: post)
+        let viewModel = PostCardStatusViewModel(post: post, isBlazeFlagEnabled: true)
 
         postActionSheet.show(for: viewModel, from: view)
         tap("Promote with Blaze", in: viewControllerMock.viewControllerPresented)


### PR DESCRIPTION
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/20091
Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/20092
https://github.com/wordpress-mobile/WordPress-iOS/pull/20219#issuecomment-1448621588

## Description
- Restricted Blaze to the Jetpack app
- Added calls to update the blaze status when:
    - Site settings are updated
    - Pull-to-refresh is triggered

## To test

### Restrict Blaze to Jetpack app
1. Build the Jetpack app
2. Enable Blaze via the debug menu
3. Switch to a Blaze eligible site - let's call this site A
4. ✅ The Blaze entry points are accessible (Dashboard card, menu item, posts list context menu, pages list context menu)
5. Build the WordPress app and log into the account you're logged into in the Jetpack app
6. Enable Blaze via the debug menu
7. Switch to site A
8. ✅ The Blaze entry points are NOT accessible (Dashboard card, menu item, posts list context menu, pages list context menu)

### Update Blaze status when site settings are updated
1. On the Jetpack app, switch to a Blaze eligible site
2. ✅ The Blaze entry points are accessible (Dashboard card, menu item, posts list context menu, pages list context menu)
3. Go to the Site Settings screen and make the site private
4. Go back to the My Site screen
5. ✅ The Blaze entry points are NOT accessible (Dashboard card, menu item, posts list context menu, pages list context menu)


### Update Blaze status on pull-to-refresh
1. On the Jetpack app, switch to a Blaze eligible site
2. ✅ The Blaze entry points are accessible (Dashboard card, menu item, posts list context menu, pages list context menu)
3. On Calypso, make the site private
4. On the Jetpack app, pull down to refresh
6. ✅ The Blaze entry points are NOT accessible (Dashboard card, menu item, posts list context menu, pages list context menu)


## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

3. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
