### PR TITLE
Change the following button icon in Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,9 +1,11 @@
 22.0
 -----
 * [*] Remove large title in Reader and Notifications tabs. [#20271]
+* [*] Reader: Change the following button cog icon. [#20274]
+* [*] [Jetpack-only] Change the dark background color of toolbars and top tabs across the whole app. [#20278]
+* [*] Change the Reader's navigation bar background color to match other screens. [#20278]
 * [*] [internal] Refactored the Core Data operations (saving the site data) after a new site is created. [#20270]
 * [*] [internal] Refactored updating user role in the "People" screen on the "My Sites" tab. [#20244]
-* [*] Reader: Change the following button cog icon. [#20274]
 * [*] [internal] Refactor managing social connections and social buttons in the "Sharing" screen. [#20265]
 
 21.9

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Remove large title in Reader and Notifications tabs. [#20271]
 * [*] [internal] Refactored the Core Data operations (saving the site data) after a new site is created. [#20270]
 * [*] [internal] Refactored updating user role in the "People" screen on the "My Sites" tab. [#20244]
+* [*] Reader: Change the following button cog icon. [#20274]
 * [*] [internal] Refactor managing social connections and social buttons in the "Sharing" screen. [#20265]
 
 21.9

--- a/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Tab Navigation/ReaderTabViewController.swift
@@ -92,7 +92,8 @@ class ReaderTabViewController: UIViewController {
 
         // Settings Button
         settingsButton.spotlightOffset = ReaderTabConstants.spotlightOffset
-        settingsButton.setImage(.gridicon(.cog), for: .normal)
+        settingsButton.contentEdgeInsets = ReaderTabConstants.settingsButtonContentEdgeInsets
+        settingsButton.setImage(.gridicon(.readerFollowing), for: .normal)
         settingsButton.addTarget(self, action: #selector(didTapSettingsButton), for: .touchUpInside)
         settingsButton.accessibilityIdentifier = ReaderTabConstants.settingsButtonIdentifier
         let settingsButton = UIBarButtonItem(customView: settingsButton)
@@ -196,6 +197,7 @@ extension ReaderTabViewController {
         static let encodedIndexKey = "WPReaderTabControllerIndexRestorationKey"
         static let discoverIndex = 1
         static let spotlightOffset = UIOffset(horizontal: 20, vertical: -10)
+        static let settingsButtonContentEdgeInsets = UIEdgeInsets(top: 2, left: 0, bottom: 0, right: 0)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -160,11 +160,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
         _readerNavigationController.navigationBar.translucent = NO;
         _readerNavigationController.view.backgroundColor = [UIColor murielBasicBackground];
 
-        // Set a clear scroll edge background to allow for featured images that extend behind the navigation area.
-        UINavigationBarAppearance *appearance =_readerNavigationController.navigationBar.scrollEdgeAppearance;
-        appearance.backgroundColor = [UIColor clearColor];
-        _readerNavigationController.navigationBar.scrollEdgeAppearance = appearance;
-
         UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
         _readerNavigationController.tabBarItem.image = readerTabBarImage;
         _readerNavigationController.tabBarItem.selectedImage = readerTabBarImage;

--- a/WordPress/Jetpack/UIColor+JetpackColors.swift
+++ b/WordPress/Jetpack/UIColor+JetpackColors.swift
@@ -21,7 +21,7 @@ extension UIColor {
     }
 
     static var filterBarBackground: UIColor {
-        return UIColor(light: .white, dark: .gray(.shade100))
+        return .secondarySystemGroupedBackground
     }
 
     static var filterBarSelected: UIColor {


### PR DESCRIPTION
## Requirement

> Change icon in Reader for ‘followed topics/sites’ to the following icon - @osullivanchris 

Source pbArwn-5Uc-p2#comment-739 

## Related PR
This PR depends on:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20272

## Description

This PR changes the cog icon of the following button in Reader.

| Before | After |
| ------ | ----- |
| ![](https://user-images.githubusercontent.com/9609223/223447956-86135e9f-993d-4242-9977-ea12b91fcde5.png) | ![](https://user-images.githubusercontent.com/9609223/223445510-83302773-a10a-4765-80e7-ef313a5e786d.png) |

## Test Instructions

1. Install Jetpack app and log into your account.
2. Head to **Reader** screen.
3. **Verify** the following button next to 🔍 button has changed. It should look like the one in the screenshot.

## Regression Notes
1. Potential unintended areas of impact
None.

3. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

4. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.