### PR TITLE
Weekly Updates: Fix crash caused by modifying the UI from a background thread

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,10 @@
 * [**] [Jetpack-only] Jetpack individual plugin support: Warns user about sites with only individual plugins not supporting all features of the app yet and gives the ability to install the full Jetpack plugin. [#20223]
 * [**] [Jetpack-only] Help: Display the Jetpack app FAQ card on Help screen when switching from the WordPress app to the Jetpack app is complete. [#20232]
 * [***] [Jetpack-only] Blaze: We added support for Blaze in the app. The user can now promote a post or page from the app to reach new audiences. [#20253]
+
+21.8.1
+-----
+
 * [**] [internal] Fixes a crash that happens in the background when the weekly roundup notification is being processed. [#20275]
 
 21.8

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,12 @@
 21.9
 -----
 
+* [*] [internal] Refactored fetching posts in the Reader tab, including post related operations (i.e. like/unlike, save for latter, etc.) [#20197]
+* [**] Reader: Add a button in the post menu to block an author and stop seeing their posts. [#20193]
+* [**] [Jetpack-only] Jetpack individual plugin support: Warns user about sites with only individual plugins not supporting all features of the app yet and gives the ability to install the full Jetpack plugin. [#20223]
+* [**] [Jetpack-only] Help: Display the Jetpack app FAQ card on Help screen when switching from the WordPress app to the Jetpack app is complete. [#20232]
+* [***] [Jetpack-only] Blaze: We added support for Blaze in the app. The user can now promote a post or page from the app to reach new audiences. [#20253]
+* [**] [internal] Fixes a crash that happens in the background when the weekly roundup notification is being processed. [#20275]
 
 21.8
 -----

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -115,18 +115,41 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
     }
 
     /// Used to determine if the Jetpack features are enabled based on the current app UI type.
+    /// This way we ensure features are not removed before reloading the UI.
+    /// But if this function is called from a background thread, we determine if the Jetpack Features
+    /// are enabled based on the removal phase regardless of the app UI state.
     /// Default root view coordinator is used.
     @objc
     static func jetpackFeaturesEnabled() -> Bool {
+        guard Thread.isMainThread else {
+            return shouldEnableJetpackFeatures()
+        }
         return jetpackFeaturesEnabled(rootViewCoordinator: .shared)
     }
 
     /// Used to determine if the Jetpack features are enabled based on the current app UI type.
     /// This way we ensure features are not removed before reloading the UI.
+    /// But if this function is called from a background thread, we determine if the Jetpack Features
+    /// are enabled based on the removal phase regardless of the app UI state.
     /// Using two separate methods (rather than one method with a default argument) because Obj-C.
     /// - Returns: `true` if UI type is normal, and `false` if UI type is simplified.
     static func jetpackFeaturesEnabled(rootViewCoordinator: RootViewCoordinator) -> Bool {
+        guard Thread.isMainThread else {
+            return shouldEnableJetpackFeatures()
+        }
         return rootViewCoordinator.currentAppUIType == .normal
+    }
+
+
+    /// Used to determine if the Jetpack features are enabled based on the removal phase regardless of the app UI state.
+    private static func shouldEnableJetpackFeatures(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> Bool {
+        let phase = generalPhase()
+        switch phase {
+        case .four, .newUsers, .selfHosted:
+            return false
+        default:
+            return true
+        }
     }
 
     /// Used to display feature-specific or feature-collection overlays.


### PR DESCRIPTION
Fixes #20266

## Description
The crash is caused by calling `JetpackNotificationMigrationService.shared.shouldPresentNotifications()` from a background thread. This gets triggered by the weekly roundup Background Processing task. This PR fixes this crash by avoiding the call to `RootViewCoordinator.shared` when assessing if JP features are enabled or not from a background thread.

## Testing Instructions

1. Checkout `trunk`
2. Perform the reproduction steps described in https://github.com/wordpress-mobile/WordPress-iOS/issues/20266#issuecomment-1458394093
3. Observe that the app crashes with the same stack trace as the original crash
4. Checkout this branch
5. Perform the same steps again
6. Observe that the app doesn't crash

P.S: If the app is left running, it might crash due to the workaround done to reproduce the crash. The workaround results in us repeatedly initializing `RootViewCoordinator`, which can eventually lead to a different crash.

## Regression Notes
1. Potential unintended areas of impact
Jetpack features removal

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested going back and forth from the normal phase,  phase 4, and new users phase. 

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.