### PR TITLE
Improve Formatting and Text of In-App Feedback Survey

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,8 @@
 * [*] [internal] Refactored updating user role in the "People" screen on the "My Sites" tab. [#20244]
 * [*] [internal] Refactor managing social connections and social buttons in the "Sharing" screen. [#20265]
 * [*] [internal] Refactor uploading media assets. [#20294]
+* [*] Visual improvements were made to the in-app survey along with updated text to differentiate between the WordPress and Jetpack apps. [#20276]
+
 
 21.9
 -----

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -48,6 +48,10 @@ extension AppConstants {
         static let workWithUsURL = "https://make.wordpress.org/mobile/handbook"
     }
 
+    struct AppRatings {
+        static let prompt = NSLocalizedString("What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the app")
+    }
+
     struct PostSignUpInterstitial {
         static let welcomeTitleText = NSLocalizedString("Welcome to WordPress", comment: "Post Signup Interstitial Title Text for WordPress iOS")
     }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -49,7 +49,7 @@ extension AppConstants {
     }
 
     struct AppRatings {
-        static let prompt = NSLocalizedString("What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the app")
+        static let prompt = NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
     }
 
     struct PostSignUpInterstitial {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -8,9 +8,9 @@ extension NotificationsViewController {
     func setupAppRatings() {
         inlinePromptView.setupHeading(NSLocalizedString("What do you think about WordPress?",
                                                         comment: "This is the string we display when prompting the user to review the app"))
-        let yesTitle = NSLocalizedString("I Like It",
+        let yesTitle = NSLocalizedString("I like it",
                                          comment: "This is one of the buttons we display inside of the prompt to review the app")
-        let noTitle = NSLocalizedString("Could Be Better",
+        let noTitle = NSLocalizedString("Could improve",
                                         comment: "This is one of the buttons we display inside of the prompt to review the app")
 
         inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -53,9 +53,9 @@ extension NotificationsViewController {
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.inlinePromptView.setupHeading(NSLocalizedString("Could you tell us how we could improve?",
                                                                   comment: "This is the text we display to the user when we ask them for a review and they've indicated they don't like the app"))
-            let yesTitle = NSLocalizedString("Send Feedback",
+            let yesTitle = NSLocalizedString("Send feedback",
                                              comment: "This is one of the buttons we display when prompting the user for a review")
-            let noTitle = NSLocalizedString("No Thanks",
+            let noTitle = NSLocalizedString("No thanks",
                                             comment: "This is one of the buttons we display when prompting the user for a review")
             self?.inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
                 self?.gatherFeedback()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -6,8 +6,7 @@ extension NotificationsViewController {
     static let contactURL = "https://support.wordpress.com/contact/"
 
     func setupAppRatings() {
-        inlinePromptView.setupHeading(NSLocalizedString("What do you think about WordPress?",
-                                                        comment: "This is the string we display when prompting the user to review the app"))
+        inlinePromptView.setupHeading(AppConstants.AppRatings.prompt)
         let yesTitle = NSLocalizedString("I like it",
                                          comment: "This is one of the buttons we display inside of the prompt to review the app")
         let noTitle = NSLocalizedString("Could improve",

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -7,9 +7,9 @@ extension NotificationsViewController {
 
     func setupAppRatings() {
         inlinePromptView.setupHeading(AppConstants.AppRatings.prompt)
-        let yesTitle = NSLocalizedString("I like it",
+        let yesTitle = NSLocalizedString("notifications.appRatings.prompt.yes.buttonTitle", value: "I like it",
                                          comment: "This is one of the buttons we display inside of the prompt to review the app")
-        let noTitle = NSLocalizedString("Could improve",
+        let noTitle = NSLocalizedString("notifications.appRatings.prompt.no.buttonTitle", value: "Could improve",
                                         comment: "This is one of the buttons we display inside of the prompt to review the app")
 
         inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
@@ -53,9 +53,9 @@ extension NotificationsViewController {
         UIView.animate(withDuration: 0.3) { [weak self] in
             self?.inlinePromptView.setupHeading(NSLocalizedString("Could you tell us how we could improve?",
                                                                   comment: "This is the text we display to the user when we ask them for a review and they've indicated they don't like the app"))
-            let yesTitle = NSLocalizedString("Send feedback",
+            let yesTitle = NSLocalizedString("notifications.appRatings.sendFeedback.yes.buttonTitle", value: "Send feedback",
                                              comment: "This is one of the buttons we display when prompting the user for a review")
-            let noTitle = NSLocalizedString("No thanks",
+            let noTitle = NSLocalizedString("notifications.appRatings.sendFeedback.no.buttonTitle", value: "No thanks",
                                             comment: "This is one of the buttons we display when prompting the user for a review")
             self?.inlinePromptView.setupYesButton(title: yesTitle) { [weak self] button in
                 self?.gatherFeedback()

--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -53,6 +53,7 @@ class AppFeedbackPromptView: UIView {
         leftButton.setTitleColor(.white, for: .normal)
         leftButton.titleLabel?.font = textFont
         leftButton.accessibilityIdentifier = "yes-button"
+        leftButton.titleLabel?.adjustsFontSizeToFitWidth = true
         buttonStack.addArrangedSubview(leftButton)
 
         // Could improve Button
@@ -64,6 +65,7 @@ class AppFeedbackPromptView: UIView {
         rightButton.setTitleColor(.text, for: .normal)
         rightButton.titleLabel?.font = textFont
         rightButton.accessibilityIdentifier = "no-button"
+        rightButton.titleLabel?.adjustsFontSizeToFitWidth = true
         buttonStack.addArrangedSubview(rightButton)
 
         setupConstraints()

--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -55,7 +55,7 @@ class AppFeedbackPromptView: UIView {
         leftButton.accessibilityIdentifier = "yes-button"
         buttonStack.addArrangedSubview(leftButton)
 
-        // Could be Better Button
+        // Could improve Button
         rightButton.translatesAutoresizingMaskIntoConstraints = false
         rightButton.backgroundColor = .secondaryButtonBackground
         rightButton.borderWidth = 1.0

--- a/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
+++ b/WordPress/Classes/ViewRelated/Ratings/AppFeedbackPromptView.swift
@@ -44,6 +44,7 @@ class AppFeedbackPromptView: UIView {
         buttonStack.translatesAutoresizingMaskIntoConstraints = false
         buttonStack.axis = .horizontal
         buttonStack.spacing = LayoutConstants.buttonSpacing
+        buttonStack.isLayoutMarginsRelativeArrangement = true
         addSubview(buttonStack)
 
         // Yes Button
@@ -53,7 +54,6 @@ class AppFeedbackPromptView: UIView {
         leftButton.setTitleColor(.white, for: .normal)
         leftButton.titleLabel?.font = textFont
         leftButton.accessibilityIdentifier = "yes-button"
-        leftButton.titleLabel?.adjustsFontSizeToFitWidth = true
         buttonStack.addArrangedSubview(leftButton)
 
         // Could improve Button
@@ -65,7 +65,6 @@ class AppFeedbackPromptView: UIView {
         rightButton.setTitleColor(.text, for: .normal)
         rightButton.titleLabel?.font = textFont
         rightButton.accessibilityIdentifier = "no-button"
-        rightButton.titleLabel?.adjustsFontSizeToFitWidth = true
         buttonStack.addArrangedSubview(rightButton)
 
         setupConstraints()
@@ -79,20 +78,23 @@ class AppFeedbackPromptView: UIView {
         leftButton.removeTarget(nil, action: nil, for: .touchUpInside)
         leftButton.setTitle(title, for: .normal)
         leftButton.on(.touchUpInside, call: tapHandler)
+        evaluateStackAxisMode()
     }
 
     func setupNoButton(title: String, tapHandler: @escaping (UIControl) -> Void) {
         rightButton.removeTarget(nil, action: nil, for: .touchUpInside)
         rightButton.setTitle(title, for: .normal)
         rightButton.on(.touchUpInside, call: tapHandler)
+        evaluateStackAxisMode()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        evaluateStackAxisMode()
+    }
 
-        buttonStack.axis = .horizontal
-        buttonStack.isLayoutMarginsRelativeArrangement = true
-
+    /// Evaluate the width of the buttons to determine if the stack view should go into vertical mode.
+    private func evaluateStackAxisMode() {
         // measure the width of the view with the new font sizes to see if the buttons are too wide.
         leftButton.updateFontSizeToMatchSystem()
         rightButton.updateFontSizeToMatchSystem()

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -49,7 +49,7 @@ extension AppConstants {
     }
 
     struct AppRatings {
-        static let prompt = NSLocalizedString("What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the app")
+        static let prompt = NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
     }
 
     struct PostSignUpInterstitial {

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -48,6 +48,10 @@ extension AppConstants {
         static let workWithUsURL = "https://automattic.com/work-with-us"
     }
 
+    struct AppRatings {
+        static let prompt = NSLocalizedString("What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the app")
+    }
+
     struct PostSignUpInterstitial {
         static let welcomeTitleText = NSLocalizedString("Welcome to Jetpack", comment: "Post Signup Interstitial Title Text for Jetpack iOS")
     }


### PR DESCRIPTION
Fixes #20248

## Description

This PR aims to improve the formatting and text used in the in-app feedback survey on the Notifications screen. The following enhancements were applied:
- Sentence case is now used instead of title case for button text
- The prompt "What do you think about [app name]?" is now dynamic and should show "WordPress" or "Jetpack" depending on the app
- The button titled "Could be better" has been revised to "Could improve"
- The view should switch to a vertical layout rather than truncating button text in horizontal mode

|  | Before | After |
| - | - | - |
| Initial prompt | ![Simulator Screen Shot - iPad (10th generation) - 2023-03-07 at 15 40 46](https://user-images.githubusercontent.com/2092798/223551786-59692f00-013c-4667-862f-eb8535f1a1a1.png) | ![Simulator Screen Shot - iPad (10th generation) - 2023-03-07 at 15 44 08](https://user-images.githubusercontent.com/2092798/223552157-7cbe7ee6-5e9e-4dde-82b2-b54ed3f950fd.png) |
| Could improve | ![Simulator Screen Shot - iPad (10th generation) - 2023-03-07 at 15 42 27](https://user-images.githubusercontent.com/2092798/223551910-0a86b90a-5058-4b2b-b104-66cd16762493.png) | ![Simulator Screen Shot - iPad (10th generation) - 2023-03-07 at 15 44 13](https://user-images.githubusercontent.com/2092798/223551942-60669b42-0062-41b9-88df-605a6e1ae04a.png) |

## Testing

The survey is normally shown based on preset timings. For testing purposes we can force the survey to be shown by:

<details>
<summary>
Programmatically applying a patch and then building locally.
</summary>

1. Copy the diff below
2. Check out this branch and run `pbpaste | git apply` on macOS
3. Build the branch

**Note:** After the patch is applied, the survey should appear every time the Notifications view is shown. However, if "Send feedback" is chosen, the altered state will require the app to be reinstalled to test again.

```
diff --git a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
index ebff11f370..aa215186ff 100644
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -247,12 +247,14 @@ class NotificationsViewController: UIViewController, UIViewControllerRestoration
             return
         }
 
-        if shouldShowPrimeForPush {
-            setupNotificationPrompt()
-        } else if AppRatingUtility.shared.shouldPromptForAppReview(section: InlinePrompt.section) {
-            setupAppRatings()
-            self.showInlinePrompt()
-        }
+//        if shouldShowPrimeForPush {
+//            setupNotificationPrompt()
+//        } else if AppRatingUtility.shared.shouldPromptForAppReview(section: InlinePrompt.section) {
+//            setupAppRatings()
+//            self.showInlinePrompt()
+//        }
+        setupAppRatings()
+        self.showInlinePrompt()
 
         showNotificationPrimerAlertIfNeeded()
         showSecondNotificationsAlertIfNeeded()
@@ -1652,11 +1654,11 @@ extension NotificationsViewController: NoResultsViewControllerDelegate {
 //
 internal extension NotificationsViewController {
     func showInlinePrompt() {
-        guard inlinePromptView.alpha != WPAlphaFull,
-            userDefaults.notificationPrimerAlertWasDisplayed,
-            userDefaults.notificationsTabAccessCount >= Constants.inlineTabAccessCount else {
-            return
-        }
+//        guard inlinePromptView.alpha != WPAlphaFull,
+//            userDefaults.notificationPrimerAlertWasDisplayed,
+//            userDefaults.notificationsTabAccessCount >= Constants.inlineTabAccessCount else {
+//            return
+//        }
 
         UIView.animate(withDuration: WPAnimationDurationDefault, delay: 0, options: .curveEaseIn, animations: {
             self.inlinePromptView.isHidden = false
```
</details>

or

[Running a build from this temporary PR with the patch above applied.](https://github.com/wordpress-mobile/WordPress-iOS/pull/20277)

### Manual Tests

**Note:** The app may need to be reinstalled or restarted to reset the survey state for some tests.

- Test different orientations and device form factors (iPhone, iPad)
- Test a11y sizes (note: the highest a11y sizes may not be fully supported)
- Test light / dark mode

### Test 1: Initial prompt - WordPress app

1. Load the survey in the Notifications view

**Expectations:**
- Prompt text should read "What do you think about WordPress?" and no text should be truncated
- Buttons below should read "I like it" and "Could improve" and the "I like it" button should be blue

### Test 2: I like it pressed - WordPress app

1. Load the survey in the Notifications view
2. Tap "I like it"
3. Expect to see a prompt from the OS: "Enjoying WordPress?" where you can tap a star to rate it on the App Store.

**Note:** It may require a clean installation or a restart of the app to show the iOS prompt.

### Test 3: Could improve pressed - WordPress app

1. Load the survey in the Notifications view
2. Tap "Could improve"

**Expectations:**
- Buttons now read "Send feedback" and "No thanks"
- "Send feedback" button should be blue

3. Tap "Send feedback"
4. Expect a prompt for name and email (this is a Zendesk prompt)
5. Repeat this test and choose "No thanks" on step 3
6. Expect the survey to disappear

### Test 4: Initial prompt - Jetpack app

1. Load the survey in the Notifications view

**Expectations:**
- Prompt text should read "What do you think about Jetpack?" and no text should be truncated
- Buttons below should read "I like it" and "Could improve" and the "I like it" button should be green

### Test 5: I like it pressed - Jetpack app

1. Load the survey in the Notifications view
2. Tap "I like it"
3. Expect to see a prompt from the OS: "Enjoying Jetpack?" where you can tap a star to rate it on the App Store.

**Note:** It may require a clean installation or a restart of the app to show the iOS prompt.

### Test 6: Could improve pressed - Jetpack app

1. Load the survey in the Notifications view
2. Tap "Could improve"

**Expectations:**
- Buttons now read "Send feedback" and "No thanks"
- "Send feedback" button should be green

3. Tap "Send feedback"
4. Expect a prompt for name and email (this is a Zendesk prompt)
5. Repeat this test and choose "No thanks" on step 3
6. Expect the survey to disappear

## Regression Notes
1. Potential unintended areas of impact
- Only visual impacts - text could be truncated or too small

2. What I did to test those areas of impact (or what existing automated tests I relied on)
- Manual testing steps above

3. What automated tests I added (or what prevented me from doing so)
- None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
