### PR TITLE
Add API docs to various forms of `performAndSave` function

### DIFF
--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -10,7 +10,7 @@ public protocol CoreDataStackSwift: CoreDataStack {
 
     /// Execute the given block with a background context and save the changes _if the block does not throw an error_.
     ///
-    /// This function _does not block_ its running thread. The block is executed in background and the its return value
+    /// This function _does not block_ its running thread. The block is executed in background and the return value
     /// (or an error) is passed onto the `completion` block which is executed on the given `queue`.
     ///
     /// - Parameters:
@@ -24,7 +24,7 @@ public protocol CoreDataStackSwift: CoreDataStack {
     /// Execute the given block with a background context and save the changes _if the block does not throw an error_.
     ///
     /// - Parameter block: A closure that uses the given `NSManagedObjectContext` to make Core Data model changes.
-    /// The changes are only saved if the block does not throw an error.
+    ///     The changes are only saved if the block does not throw an error.
     /// - Returns: The value returned by the `block`
     /// - Throws: The error thrown by the `block`, in which case the Core Data changes made by the `block` is discarded.
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async throws -> T

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -8,8 +8,25 @@ let ContextManagerModelNameCurrent = "$CURRENT"
 
 public protocol CoreDataStackSwift: CoreDataStack {
 
+    /// Execute the given block with a background context and save the changes _if the block does not throw an error_.
+    ///
+    /// This function _does not block_ its running thread. The block is executed in background and the its return value
+    /// (or an error) is passed onto the `completion` block which is executed on the given `queue`.
+    ///
+    /// - Parameters:
+    ///   - block: A closure that uses the given `NSManagedObjectContext` to make Core Data model changes. The changes
+    ///         are only saved if the block does not throw an error.
+    ///   - completion: A closure which is called with the `block`'s execution result, which is either an error thrown
+    ///         by the `block` or the return value of the `block`.
+    ///   - queue: A queue on which to execute the completion block.
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T, completion: ((Result<T, Error>) -> Void)?, on queue: DispatchQueue)
 
+    /// Execute the given block with a background context and save the changes _if the block does not throw an error_.
+    ///
+    /// - Parameter block: A closure that uses the given `NSManagedObjectContext` to make Core Data model changes.
+    /// The changes are only saved if the block does not throw an error.
+    /// - Returns: The value returned by the `block`
+    /// - Throws: The error thrown by the `block`, in which case the Core Data changes made by the `block` is discarded.
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async throws -> T
 
 }

--- a/WordPress/Classes/Utility/CoreDataStack.h
+++ b/WordPress/Classes/Utility/CoreDataStack.h
@@ -9,8 +9,26 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context;
 - (void)saveContext:(NSManagedObjectContext *)context withCompletionBlock:(void (^ _Nullable)(void))completionBlock onQueue:(dispatch_queue_t)queue NS_SWIFT_NAME(save(_:completion:on:));
+
+/// Execute the given block with a background context and save the changes.
+///
+/// This function _blocks_ its running thread. The changed made by the `aBlock` argument are saved before this
+/// function returns.
+///
+/// - Parameter aBlock: A closure which uses the given `NSManagedObjectContext` to make Core Data model changes.
 - (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
+
+/// Execute the given block with a background context and save the changes _if the block does not throw an error_.
+///
+/// This function _does not block_ its running thread. The `aBlock` argument is executed in the background. The
+/// `completion` block is called after the Core Data model changes are saved.
+///
+/// - Parameters:
+///   - aBlock: A block which uses the given `NSManagedObjectContext` to make Core Data model changes.
+///   - completion: A closure which is called after the changes made by the `block` are saved.
+///   - queue: A queue on which to execute the `completion` block.
 - (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^ _Nullable)(void))completion onQueue:(dispatch_queue_t)queue;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Utility/CoreDataStack.h
+++ b/WordPress/Classes/Utility/CoreDataStack.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /// This function _blocks_ its running thread. The changed made by the `aBlock` argument are saved before this
 /// function returns.
 ///
-/// - Parameter aBlock: A closure which uses the given `NSManagedObjectContext` to make Core Data model changes.
+/// - Parameter aBlock: A block which uses the given `NSManagedObjectContext` to make Core Data model changes.
 - (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock;
 
 /// Execute the given block with a background context and save the changes _if the block does not throw an error_.
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///
 /// - Parameters:
 ///   - aBlock: A block which uses the given `NSManagedObjectContext` to make Core Data model changes.
-///   - completion: A closure which is called after the changes made by the `block` are saved.
+///   - completion: A block which is called after the changes made by the `block` are saved.
 ///   - queue: A queue on which to execute the `completion` block.
 - (void)performAndSaveUsingBlock:(void (^)(NSManagedObjectContext *context))aBlock completion:(void (^ _Nullable)(void))completion onQueue:(dispatch_queue_t)queue;
 


### PR DESCRIPTION
Better late than never—I probably should have documented these APIs earlier.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
