### PR TITLE
Add another `performAndSave` overload

### DIFF
--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -25,7 +25,7 @@ let NotificationSyncMediatorDidUpdateNotifications = "NotificationSyncMediatorDi
 final class NotificationSyncMediator {
     /// Returns the Main Managed Context
     ///
-    fileprivate let contextManager: CoreDataStackSwift
+    private let contextManager: CoreDataStackSwift
 
     /// Sync Service Remote
     ///

--- a/WordPress/Classes/Utility/ContextManager.swift
+++ b/WordPress/Classes/Utility/ContextManager.swift
@@ -8,6 +8,18 @@ let ContextManagerModelNameCurrent = "$CURRENT"
 
 public protocol CoreDataStackSwift: CoreDataStack {
 
+    /// Execute the given block with a background context and save the changes.
+    ///
+    /// This function _does not block_ its running thread. The block is executed in background and its return value
+    /// is passed onto the `completion` block which is executed on the given `queue`.
+    ///
+    /// - Parameters:
+    ///   - block: A closure which uses the given `NSManagedObjectContext` to make Core Data model changes.
+    ///   - completion: A closure which is called with the return value of the `block`, after the changed made
+    ///         by the `block` is saved.
+    ///   - queue: A queue on which to execute the completion block.
+    func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) -> T, completion: ((T) -> Void)?, on queue: DispatchQueue)
+
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T, completion: ((Result<T, Error>) -> Void)?, on queue: DispatchQueue)
 
     func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async throws -> T
@@ -109,6 +121,17 @@ public class ContextManager: NSObject, CoreDataStack, CoreDataStackSwift {
                 done()
             }
         })
+    }
+
+    public func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) -> T, completion: ((T) -> Void)?, on queue: DispatchQueue) {
+        performAndSave(
+            block,
+            completion: { (result: Result<T, Error>) in
+                // It's safe to force-unwrap here, since the `block` does not throw an error.
+                completion?(try! result.get())
+            },
+            on: queue
+        )
     }
 
     public func performAndSave<T>(_ block: @escaping (NSManagedObjectContext) throws -> T) async throws -> T {


### PR DESCRIPTION
Add an variant of `performAndSave` which returns a value without ever throwing an error. I'm surprised that I never added this function before, which seems like a pretty common requirement.

The changes in `NotificationSyncMediator` show case how this function can be used, in a more readable way than the blocking `performAndSave(_:)` call.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
