### PR TITLE
Remove `MediaCoordinator`'s `Uploader` conformance

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -716,18 +716,6 @@ extension MediaCoordinator: MediaProgressCoordinatorDelegate {
     }
 }
 
-extension MediaCoordinator: Uploader {
-    func resume() {
-        coreDataStack.performAndSave { context in
-            Media
-                .failedMediaForUpload(automatedRetry: true, in: context)
-                .forEach() {
-                    self.retryMedia($0, automatedRetry: true)
-                }
-        }
-    }
-}
-
 extension MediaCoordinator {
     // Based on user logs we've collected for users, we've noticed the app sometimes
     // trying to upload a Media object and failing because the underlying file has disappeared from


### PR DESCRIPTION
The `MediaCoordinator`'s retry mechanism was removed about three and half years ago in https://github.com/wordpress-mobile/WordPress-iOS/pull/12416/commits/1c275523dfff838f4292b2ddfc8ae52e8e7c081b.

We may as well remove the problematic implementation, considering the automatic retry doesn't seem to come back.

The problematic part of the implementation is the `Media` objects are fetched from a temporary background context and then are passed to the retry function which may hold strong references to the `Media` objects even after the background context is released. The more correct way would be using `coreDataStack.performQuery` to fetch the `Media` objects from the main context.

## Regression Notes
1. Potential unintended areas of impact
None

2. What I did to test those areas of impact (or what existing automated tests I relied on)
None

3. What automated tests I added (or what prevented me from doing so)
None

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
