### PR TITLE
Fix: Skip parsing blogging reminders schedule in background

### DIFF
--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -115,7 +115,7 @@ private extension BloggingRemindersScheduleFormatter {
     static func stringToAttributedString(_ string: String) -> NSAttributedString {
         // When the app is in a background state, return the non-emphasized plain String instead.
         // Parsing a HTML string in the background may lead to a crash.
-        // Refer to ReaderCommentsViewController.m:1088 for a similar scenario and explanation.
+        // Refer to https://github.com/wordpress-mobile/WordPress-iOS/pull/17678 for a similar scenario and explanation.
         if UIApplication.shared.applicationState == .background {
             return .init(string: string.removedHTMLEmphases())
         }

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduleFormatter.swift
@@ -113,6 +113,13 @@ private extension BloggingRemindersScheduleFormatter {
     }
 
     static func stringToAttributedString(_ string: String) -> NSAttributedString {
+        // When the app is in a background state, return the non-emphasized plain String instead.
+        // Parsing a HTML string in the background may lead to a crash.
+        // Refer to ReaderCommentsViewController.m:1088 for a similar scenario and explanation.
+        if UIApplication.shared.applicationState == .background {
+            return .init(string: string.removedHTMLEmphases())
+        }
+
         let htmlData = NSString(string: string).data(using: String.Encoding.unicode.rawValue) ?? Data()
         let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [.documentType: NSAttributedString.DocumentType.html]
 
@@ -174,5 +181,15 @@ private extension BloggingRemindersScheduleFormatter {
 
         static let everydayRemindersShortDescription = NSLocalizedString("Every day",
                                                                                  comment: "Short title telling the user they will receive a blogging reminder every day of the week.")
+    }
+}
+
+private extension String {
+    /// Convenient method to remove HTML emphasis tags from a given string.
+    func removedHTMLEmphases() -> String {
+        guard let expression = try? NSRegularExpression(pattern: "</?strong>", options: .caseInsensitive) else {
+            return self
+        }
+        return expression.stringByReplacingMatches(in: self, range: NSMakeRange(0, self.count), withTemplate: String())
     }
 }


### PR DESCRIPTION
Fixes #20188

Based on the [Sentry reports](https://a8c.sentry.io/issues/3947495027/?project=571677), the issue is occurring after the app enters a `background` state. Looking at the stack trace, this is very similar to #17678 where the app tries to convert an HTML string to an attributed string while in background mode due to snapshot generation.

This PR mitigates this issue by following a similar approach to #17678, where the attributed string process is skipped when the application is backgrounded. However, note that I wasn't able to reproduce this specific crash in Site Settings.

## To test

- Go to Site Settings.
- Scroll until the Blogging Reminders section is visible.
- Minimize the app, and open the app again.
- Make sure that the app doesn't crash.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
