### PR TITLE
Fix: Hide Pages menu for users with insufficient roles

### DIFF
--- a/WordPress/Classes/Models/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog+Capabilities.swift
@@ -61,6 +61,12 @@ extension Blog {
         return !hasBusinessPlan && isUserCapableOf("scan")
     }
 
+    /// Returns true if the current user is allowed to list and edit the blog's Pages
+    ///
+    @objc public func isListingPagesAllowed() -> Bool {
+        return isAdmin || isUserCapableOf(.EditPages)
+    }
+
     private func isUserCapableOf(_ capability: String) -> Bool {
         return capabilities?[capability] as? Bool ?? false
     }

--- a/WordPress/Classes/Models/Blog.h
+++ b/WordPress/Classes/Models/Blog.h
@@ -104,7 +104,9 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureFileDownloadsStats,
     /// Does the blog support Blaze?
     BlogFeatureBlaze,
-    
+    /// Does the blog support listing and editing Pages?
+    BlogFeaturePages,
+
 };
 
 typedef NS_ENUM(NSInteger, SiteVisibility) {

--- a/WordPress/Classes/Models/Blog.m
+++ b/WordPress/Classes/Models/Blog.m
@@ -612,6 +612,8 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             return [self isHostedAtWPcom];
         case BlogFeatureBlaze:
             return [self isBlazeApproved];
+        case BlogFeaturePages:
+            return [self isListingPagesAllowed];
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -991,14 +991,16 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     mediaRow.quickStartIdentifier = QuickStartTourElementMediaScreen;
     [rows addObject:mediaRow];
 
-    BlogDetailsRow *pagesRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
-                                             accessibilityIdentifier:@"Site Pages Row"
-                                                    image:[UIImage gridiconOfType:GridiconTypePages]
-                                                 callback:^{
-        [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
-                                                 }];
-    pagesRow.quickStartIdentifier = QuickStartTourElementPages;
-    [rows addObject:pagesRow];
+    if ([self.blog supports:BlogFeaturePages]) {
+        BlogDetailsRow *pagesRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Pages", @"Noun. Title. Links to the blog's Pages screen.")
+                                                 accessibilityIdentifier:@"Site Pages Row"
+                                                        image:[UIImage gridiconOfType:GridiconTypePages]
+                                                     callback:^{
+            [weakSelf showPageListFromSource:BlogDetailsNavigationSourceRow];
+                                                     }];
+        pagesRow.quickStartIdentifier = QuickStartTourElementPages;
+        [rows addObject:pagesRow];
+    }
 
     BlogDetailsRow *commentsRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Comments", @"Noun. Title. Links to the blog's Comments screen.")
                                                           image:[[UIImage gridiconOfType:GridiconTypeComment] imageFlippedForRightToLeftLayoutDirection]


### PR DESCRIPTION
Fixes #19885

This PR hides the Pages menu item from the Site Menu when the user has no `edit_pages` capability. As for XML-RPC access, we only check whether the user is an admin of the site (marked by the `isAdmin` boolean field). This matches how it's currently implemented in Android:

https://github.com/wordpress-mobile/WordPress-Android/blob/1dd182a56f1df4ba168c6750db866484370bf14c/WordPress/src/main/java/org/wordpress/android/ui/mysite/items/listitem/SiteListItemBuilder.kt#L119

Caveat: Editor accounts via XML-RPC will lose access to the Pages menu because 1.) editors aren't admins, and 2.) we currently do not pull any role information from the XML-RPC sync processes. Perhaps this is something to explore in the future.

## To test

Follow the setup below, and verify the Pages menu visibility in My Sites > Menu.

Account type | Role | Pages menu
-|-|-
WordPress.com | Admin | 👁️ Visible
WordPress.com | Editor | 👁️ Visible
WordPress.com | Author | 🚫 Hidden
XML-RPC | Admin | 👁️ Visible
XML-RPC | Editor | 🚫 Hidden[^1]
XML-RPC | Author | 🚫 Hidden


## Regression Notes
1. Potential unintended areas of impact
See the caveat above about XML-RPC Editor roles.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: Note that this is a known issue. The current XML-RPC implementation only allows us to see if the user is an admin, but there's no information about the current user.