### PR TITLE
Hide My Site FAB behind a feature flag

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 22.0
 -----
 * [*] Remove large title in Reader and Notifications tabs. [#20271]
+* [*] Hide the FAB in My Site screen. [#20289]
 * [*] [internal] Refactored the Core Data operations (saving the site data) after a new site is created. [#20270]
 * [*] [internal] Refactored updating user role in the "People" screen on the "My Sites" tab. [#20244]
 * [*] [internal] Refactor managing social connections and social buttons in the "Sharing" screen. [#20265]

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -48,6 +48,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case blaze
     case siteCreationDomainPurchasing
     case readerUserBlocking
+    case showMySiteFAB
 
     /// Returns a boolean indicating if the feature is enabled
     var enabled: Bool {
@@ -152,6 +153,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .readerUserBlocking:
             return true
+        case .showMySiteFAB:
+            return false
         }
     }
 
@@ -180,8 +183,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
-            default:
-                return nil
+        default:
+            return nil
         }
     }
 }
@@ -292,6 +295,8 @@ extension FeatureFlag {
             return "Site Creation Domain Purchasing"
         case .readerUserBlocking:
             return "Reader User Blocking"
+        case .showMySiteFAB:
+            return "Show My Site FAB"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -27,6 +27,8 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
         }
     }
 
+    private let showsFAB: Bool
+
     private var isShowingDashboard: Bool {
         return segmentedControl.selectedSegmentIndex == Section.dashboard.rawValue
     }
@@ -98,11 +100,16 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Initializers
 
-    init(meScenePresenter: ScenePresenter, blogService: BlogService? = nil, mySiteSettings: MySiteSettings = MySiteSettings()) {
+    init(
+        meScenePresenter: ScenePresenter,
+        blogService: BlogService? = nil,
+        mySiteSettings: MySiteSettings = MySiteSettings(),
+        showsFAB: Bool = FeatureFlag.showMySiteFAB.enabled
+    ) {
         self.meScenePresenter = meScenePresenter
         self.blogService = blogService ?? BlogService(coreDataStack: ContextManager.shared)
         self.mySiteSettings = mySiteSettings
-
+        self.showsFAB = showsFAB
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -660,6 +667,9 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
     // MARK: - FAB
 
     private func createFABIfNeeded() {
+        guard showsFAB else {
+            return
+        }
         createButtonCoordinator?.removeCreateButton()
         createButtonCoordinator = makeCreateButtonCoordinator()
         createButtonCoordinator?.add(to: view,


### PR DESCRIPTION
## Requirement
> Remove the FAB from My Site tab as an AB test (duplication/redundancy) - @osullivanchris 

Source pbArwn-5Uc-p2#comment-7395

## Description

This PR hides the FAB in My Site behind a feature flag called `Show My Site FAB`. The feature flag is `false` by default.

| Before | After |
| ------- | ----- |
| ![](https://user-images.githubusercontent.com/9609223/224013562-a70d33b5-5010-4d4c-920b-76e5da8e71b3.png) | ![](https://user-images.githubusercontent.com/9609223/224012459-369c58f0-2cb2-4f87-803b-7c2ae2b94848.png) |

## Test Instructions

1. Install Jetpack and log into your account.
2. Head to **My Site** tab.
3. **Verify** the **FAB** that used to be in the bottom-right corner is no longer visible.

## Regression Notes
1. Potential unintended areas of impact
Double check the FAB is still visible in **My Site > Posts** and **My SIte > Pages** screens.

4. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual tests.

5. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.