### PR TITLE
Blaze: update blaze status on pull to refresh

### DIFF
--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -36,7 +36,7 @@ import WordPressKit
             completion?()
             return
         }
-        
+
         remote.getStatus(forSiteId: siteId) { result in
             switch result {
             case .success(let approved):

--- a/WordPress/Classes/Services/BlazeService.swift
+++ b/WordPress/Classes/Services/BlazeService.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressKit
 
-final class BlazeService {
+@objc final class BlazeService: NSObject {
 
     private let contextManager: CoreDataStack
     private let remote: BlazeServiceRemote
@@ -18,21 +18,25 @@ final class BlazeService {
         self.remote = remote ?? .init(wordPressComRestApi: account.wordPressComRestV2Api)
     }
 
+    @objc class func createService() -> BlazeService? {
+        self.init()
+    }
+
     // MARK: - Methods
 
-    /// Fetches and updates blaze status from the server.
+    /// Fetches a site's blaze status from the server, and updates the blog's isBlazeApproved property.
     ///
     /// - Parameters:
     ///   - blog: A blog
     ///   - completion: Closure to be called on success
-    func updateStatus(for blog: Blog,
-                      completion: (() -> Void)? = nil) {
+    @objc func getStatus(for blog: Blog,
+                         completion: (() -> Void)? = nil) {
         guard let siteId = blog.dotComID?.intValue else {
             DDLogError("Invalid site ID for Blaze")
             completion?()
             return
         }
-
+        
         remote.getStatus(forSiteId: siteId) { result in
             switch result {
             case .success(let approved):

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -185,6 +185,14 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         DDLogError(@"Failed to sync Editor settings");
         dispatch_group_leave(syncGroup);
     }];
+    
+    if ([BlazeHelper isBlazeFlagEnabled]) {
+        BlazeService *blazeService = [BlazeService createService];
+        dispatch_group_enter(syncGroup);
+        [blazeService getStatusFor:blog completion:^{
+            dispatch_group_leave(syncGroup);
+        }];
+    }
 
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -186,13 +186,11 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
     
-    if ([BlazeHelper isBlazeFlagEnabled]) {
-        BlazeService *blazeService = [BlazeService createService];
-        dispatch_group_enter(syncGroup);
-        [blazeService getStatusFor:blog completion:^{
-            dispatch_group_leave(syncGroup);
-        }];
-    }
+    BlazeService *blazeService = [BlazeService createService];
+    dispatch_group_enter(syncGroup);
+    [blazeService getStatusFor:blog completion:^{
+        dispatch_group_leave(syncGroup);
+    }];
 
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/pull/20273#issuecomment-1458990945

## Description
- Addresses a [bug](https://github.com/wordpress-mobile/WordPress-iOS/pull/20273#issuecomment-1458990945) where the dashboard wasn't being refreshed on pull-to-refresh

## Root cause
Calling `blogDashboardViewController?.update(blog: blog)` doesn't update the dashboard. The `update` method should be used when setting a new blog; it shouldn't be used to refresh the current blog.

https://github.com/wordpress-mobile/WordPress-iOS/blob/d8bd9e008dfc6cc70dcfc96b8e42522a9aa04e47/WordPress/Classes/ViewRelated/Blog/Blog%20Dashboard/BlogDashboardViewController.swift#L111-L121

## The fix
Calling `pulledToRefresh` after updating the blaze status, on both the dashboard and the site menu. The `pulledToRefresh` methods handle reloading the dashboard / site menu.

## How to test

1. On the Jetpack app, switch to a Blaze-eligible site
2. Navigate to the dashboard
3. On Calypso, make the site private
4. On the Jetpack app, pull down to refresh
5. ✅ The blaze dashboard card should not be displayed
6. On Calypso, make the site public
7. On the Jetpack app, pull down to refresh
8. ✅ The blaze dashboard card should be displayed



https://user-images.githubusercontent.com/6711616/224046711-3e443fc5-8d97-4907-b7d3-1c2a9a14e333.mov



## Regression Notes
1. Potential unintended areas of impact
WordPress app, pull-to-refresh on the My Site screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
