### PR TITLE
[Gutenberg] Allow audio upload to premium users after Jetpack features removal

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1200,7 +1200,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
                 .videoPressBlock: false,
                 .unsupportedBlockEditor: false,
                 .canEnableUnsupportedBlockEditor: false,
-                .isAudioBlockMediaUploadEnabled: false,
+                .isAudioBlockMediaUploadEnabled: !isFreeWPCom,
                 .mediaFilesCollectionBlock: false,
                 .reusableBlock: false,
                 .shouldUseFastImage: !post.blog.isPrivate(),


### PR DESCRIPTION
This PR fixes a bug where premium users can't upload Audio files after the Jetpack features are removed. The issue was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/19691.

**NOTE:** The issue addressed in this PR is only affecting the WordPress app as the removal of Jetpack features is only applied in that app.

## To test
**Preparation:**
1. Open the WordPress app.
2. Go to "Debug" screen via "Me -> App Settings" screen.
3. Enable "Jetpack Features Removal Phase Four" (when Jetpack features are removed)

### Simple site - **Paid plan**
1. Go to a Simple site with a paid plan.
2. Open/create a post.
4. Add an Audio block.
5. In the "Choose audio" picker, observe that it displays the following options:
  - WordPress Media Library
  - Insert from URL
  - Other Apps

### Simple site - **Free site**
1. Go to a Simple site with the free plan.
2. Open/create a post.
3. Add an Audio block.
4. In the "Choose audio" picker, observe that it only displays the option "Insert from URL".

## Regression Notes
1. Potential unintended areas of impact
N/A

8. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

9. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
