### PR TITLE
Fix #20298: query media observers safely

### DIFF
--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -557,8 +557,9 @@ class MediaCoordinator: NSObject {
         let onUpdate: ObserverBlock
     }
 
-    /// Utility method to return all observers for a specific media item,
-    /// including any 'wildcard' observers that are observing _all_ media items.
+    /// Utility method to return all observers for a `Media` item with the given `NSManagedObjectID`
+    /// and part of the posts with given `NSManagedObjectID`s, including any 'wildcard' observers
+    /// that are observing _all_ media items.
     ///
     private func observersForMedia(withObjectID mediaObjectID: NSManagedObjectID, originalPostIDs: [NSManagedObjectID]) -> [MediaObserver] {
         let mediaObservers = self.mediaObservers.values.filter({ $0.subject == .media(id: mediaObjectID) })


### PR DESCRIPTION
I believe the crash #20298 is related to accessing `media.posts` from an arbitrary queue rather than the context queue that the `media` instance is bound to.

## Test instructions

It's hard to verify the fix because the crash is not easy to verify. But it would be good verify the media uploading still works, i.e. from the "Media" screen, or a post editor.

## Regression Notes
1. Potential unintended areas of impact
None.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
What are described in the "Test instructions" section.

3. What automated tests I added (or what prevented me from doing so)
None.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
