### PR TITLE
Fix deadlock that can occur when initializing `RootViewCoordinator` 

### DIFF
--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -36,7 +36,7 @@ class RootViewCoordinator {
     private(set) var rootViewPresenter: RootViewPresenter
     private var currentAppUIType: AppUIType {
         didSet {
-            JetpackFeaturesRemovalCoordinator.currentAppUIType = currentAppUIType
+            updateJetpackFeaturesRemovalCoordinatorState()
         }
     }
     private var featureFlagStore: RemoteFeatureFlagStore
@@ -57,6 +57,7 @@ class RootViewCoordinator {
             let meScenePresenter = MeScenePresenter()
             self.rootViewPresenter = MySitesCoordinator(meScenePresenter: meScenePresenter, onBecomeActiveTab: {})
         }
+        updateJetpackFeaturesRemovalCoordinatorState()
         updatePromptsIfNeeded()
     }
 
@@ -71,6 +72,10 @@ class RootViewCoordinator {
         default:
             return true
         }
+    }
+
+    private func updateJetpackFeaturesRemovalCoordinatorState() {
+        JetpackFeaturesRemovalCoordinator.currentAppUIType = currentAppUIType
     }
 
     // MARK: UI Reload

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -34,7 +34,11 @@ class RootViewCoordinator {
     // MARK: Private instance variables
 
     private(set) var rootViewPresenter: RootViewPresenter
-    private(set) var currentAppUIType: AppUIType
+    private var currentAppUIType: AppUIType {
+        didSet {
+            JetpackFeaturesRemovalCoordinator.currentAppUIType = currentAppUIType
+        }
+    }
     private var featureFlagStore: RemoteFeatureFlagStore
     private var windowManager: WindowManager?
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -19,7 +19,6 @@ class JetpackBrandingMenuCardPresenter {
     private let persistenceStore: UserPersistentRepository
     private let currentDateProvider: CurrentDateProvider
     private let featureFlagStore: RemoteFeatureFlagStore
-    private let rootViewCoordinator: RootViewCoordinator
     private var phase: JetpackFeaturesRemovalCoordinator.GeneralPhase {
         return JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
     }
@@ -30,14 +29,12 @@ class JetpackBrandingMenuCardPresenter {
          remoteConfigStore: RemoteConfigStore = RemoteConfigStore(),
          featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
          persistenceStore: UserPersistentRepository = UserDefaults.standard,
-         currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider(),
-         rootViewCoordinator: RootViewCoordinator = .shared) {
+         currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider()) {
         self.blog = blog
         self.remoteConfigStore = remoteConfigStore
         self.persistenceStore = persistenceStore
         self.currentDateProvider = currentDateProvider
         self.featureFlagStore = featureFlagStore
-        self.rootViewCoordinator = rootViewCoordinator
     }
 
     // MARK: Public Functions
@@ -65,7 +62,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(rootViewCoordinator: rootViewCoordinator)
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(featureFlagStore: featureFlagStore)
         switch (phase, jetpackFeaturesEnabled) {
         case (.three, true):
             return true
@@ -80,7 +77,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(rootViewCoordinator: rootViewCoordinator)
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(featureFlagStore: featureFlagStore)
         switch (phase, jetpackFeaturesEnabled) {
         case (.four, false):
             fallthrough

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -7,14 +7,11 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
     private var remoteFeatureFlagsStore = RemoteFeatureFlagStoreMock()
     private var remoteConfigStore = RemoteConfigStoreMock()
     private var currentDateProvider: MockCurrentDateProvider!
-    private var rootViewCoordinator: RootViewCoordinator!
 
     override func setUp() {
         contextManager.useAsSharedInstance(untilTestFinished: self)
         mockUserDefaults = InMemoryUserDefaults()
         currentDateProvider = MockCurrentDateProvider()
-        rootViewCoordinator = RootViewCoordinator(featureFlagStore: remoteFeatureFlagsStore,
-                                                  windowManager: WindowManager(window: UIWindow()))
         let account = AccountBuilder(contextManager).build()
         UserSettings.defaultDotComUUID = account.uuid
     }
@@ -29,8 +26,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: blog,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
 
         // Normal phase
         setPhase(phase: .normal)
@@ -68,8 +64,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: blog,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
 
         // Normal phase
         setPhase(phase: .normal)
@@ -107,8 +102,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
         setPhase(phase: .three)
         remoteConfigStore.phaseThreeBlogPostUrl = "example.com"
 
@@ -126,8 +120,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
         setPhase(phase: .four)
 
         // When
@@ -144,8 +137,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: nil,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
         setPhase(phase: .newUsers)
         remoteConfigStore.phaseNewUsersBlogPostUrl = "example.com"
 
@@ -165,8 +157,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             blog: blog,
             remoteConfigStore: remoteConfigStore,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
         setPhase(phase: .selfHosted)
         remoteConfigStore.phaseSelfHostedBlogPostUrl = "example.com"
 
@@ -183,8 +174,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         let presenter = JetpackBrandingMenuCardPresenter(
             blog: nil,
             featureFlagStore: remoteFeatureFlagsStore,
-            persistenceStore: mockUserDefaults,
-            rootViewCoordinator: rootViewCoordinator)
+            persistenceStore: mockUserDefaults)
         setPhase(phase: .three)
 
         // When
@@ -260,8 +250,5 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         case .selfHosted:
             remoteFeatureFlagsStore.removalPhaseSelfHosted = true
         }
-
-        // Reload UI
-        rootViewCoordinator.reloadUIIfNeeded(blog: nil)
     }
 }


### PR DESCRIPTION
Fixes #20297

## Description
I was unable to reproduce the crash, but from the stack trace, it's obvious that it's a deadlock. The deadlock is triggered by initializing the shared instance of `RootViewCoordinator`. Apparently, in some cases, the code path of initializing `RootViewCoordinator` ends up in `NotificationsViewController.configureJetpackBanner`, which calls `RootViewCoordinator.shared` to decide if JP features are enabled or not. To fix this deadlock, I've removed the dependency of `JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled` on `RootViewCoordinator`.

## Testing Instructions

I wasn't able to reproduce the crash, so there are no specific testing instructions. Please review the code carefully. And retest #20275's testing instructions because the fix in this PR overrides the changes made in #20275.

## Regression Notes
1. Potential unintended areas of impact
Jetpack features removal

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested going back and forth from the normal phase,  phase 4, and new users phase. 
I also retested #19954's testing instructions.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.