### PR TITLE
[UI Tests] - Run UI Tests on Jetpack instead of WordPress app

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -17,5 +17,5 @@ echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane "build_$1_for_testing"
 
 echo "--- :arrow_up: Upload Build Products"
-tar -cf build-products.tar DerivedData/Build/Products/$1
-upload_artifact build-products.tar
+tar -cf build-products-$1.tar DerivedData/Build/Products/
+upload_artifact build-products-$1.tar

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -13,7 +13,7 @@ cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/projec
 echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
-echo "--- :hammer_and_wrench: :wordpress: Building"
+echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane "build_$1_for_testing"
 
 echo "--- :arrow_up: Upload Build Products"

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -14,7 +14,7 @@ echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_for_testing
+bundle exec fastlane build_jetpack_for_testing
 
 echo "--- :arrow_up: Upload Build Products"
 tar -cf build-products.tar DerivedData/Build/Products/

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -13,8 +13,8 @@ cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/projec
 echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
-echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane build_jetpack_for_testing
+echo "--- :hammer_and_wrench: :wordpress: Building"
+bundle exec fastlane "build_$1_for_testing"
 
 echo "--- :arrow_up: Upload Build Products"
 tar -cf build-products.tar DerivedData/Build/Products/

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -17,5 +17,5 @@ echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane "build_$1_for_testing"
 
 echo "--- :arrow_up: Upload Build Products"
-tar -cf build-products.tar DerivedData/Build/Products/
+tar -cf build-products.tar DerivedData/Build/Products/$1
 upload_artifact build-products.tar

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -eu
 
-DEVICE=$1
+APP=$1
+DEVICE=$2
 
 echo "Running UI tests on $DEVICE. The iOS version will be the latest available in the CI host."
 
@@ -13,8 +14,8 @@ else
 fi
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-jetpack.tar
-tar -xf build-products.tar
+download_artifact build-products-$APP.tar
+tar -xf build-products-$APP.tar
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -24,7 +24,6 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- 🔬 Testing"
-ls -la DerivedData/Build/Products/
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -26,7 +26,7 @@ echo "--- 🔬 Testing"
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e
-bundle exec fastlane test_without_building name:WordPressUITests device:"$DEVICE"
+bundle exec fastlane test_without_building name:Jetpack device:"$DEVICE"
 TESTS_EXIT_STATUS=$?
 set -e
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -13,7 +13,7 @@ else
 fi
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products.tar
+download_artifact build-products-jetpack.tar
 tar -xf build-products.tar
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -23,6 +23,7 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- 🔬 Testing"
+ls -la DerivedData/Build/Products/
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -37,7 +37,7 @@ if [[ "$TESTS_EXIT_STATUS" -ne 0 ]]; then
 fi
 
 echo "--- 📦 Zipping test results"
-cd build/results/ && zip -rq WordPress.xcresult.zip WordPress.xcresult && cd -
+cd build/results/ && zip -rq JetpackUITests.xcresult.zip JetpackUITests.xcresult && cd -
 
 echo "--- 🚦 Report Tests Status"
 if [[ $TESTS_EXIT_STATUS -eq 0 ]]; then

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
 
-APP=$1
-DEVICE=$2
+DEVICE=$1
 
 echo "Running UI tests on $DEVICE. The iOS version will be the latest available in the CI host."
 
@@ -14,8 +13,8 @@ else
 fi
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-$APP.tar
-tar -xf build-products-$APP.tar
+download_artifact build-products-jetpack.tar
+tar -xf build-products-jetpack.tar
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -23,7 +23,6 @@ echo "--- :cocoapods: Setting up Pods"
 install_cocoapods
 
 echo "--- 🔬 Testing"
-ls -la DerivedData/Build/Products/
 xcrun simctl list >> /dev/null
 rake mocks &
 set +e

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -12,6 +12,7 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- 🔬 Testing"
+ls -la DerivedData/Build/Products/
 set +e
 bundle exec fastlane test_without_building name:WordPressUnitTests
 TESTS_EXIT_STATUS=$?

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -14,7 +14,6 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- 🔬 Testing"
-ls -la DerivedData/Build/Products/
 set +e
 bundle exec fastlane test_without_building name:WordPressUnitTests
 TESTS_EXIT_STATUS=$?

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,12 +1,14 @@
 #!/bin/bash -eu
 
+APP=$1
+
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'
 export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-wordpress.tar
-tar -xf build-products.tar
+download_artifact build-products-$APP.tar
+tar -xf build-products-$APP.tar
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -12,7 +12,6 @@ echo "--- :rubygems: Setting up Gems"
 install_gems
 
 echo "--- 🔬 Testing"
-ls -la DerivedData/Build/Products/
 set +e
 bundle exec fastlane test_without_building name:WordPressUnitTests
 TESTS_EXIT_STATUS=$?

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -5,7 +5,7 @@ echo '--- :test-analytics: Configuring Test Analytics'
 export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products.tar
+download_artifact build-products-wordpress.tar
 tar -xf build-products.tar
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,14 +1,12 @@
 #!/bin/bash -eu
 
-APP=$1
-
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'
 export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-$APP.tar
-tar -xf build-products-$APP.tar
+download_artifact build-products-wordpress.tar
+tar -xf build-products-wordpress.tar
 
 echo "--- :rubygems: Setting up Gems"
 install_gems

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
   # Run Unit Tests
   #################
   - label: "🔬 :wordpress: Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh wordpress"
+    command: ".buildkite/commands/run-unit-tests.sh"
     depends_on: "build_wordpress"
     env: *common_env
     plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -87,20 +87,20 @@ steps:
                 - "#mobile-apps-tests-notif"
             if: build.state == "failed" && build.branch == "trunk"
 
-      # - label: "🔬 UI Tests (iPad)"
-      #   command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
-      #   depends_on: "build"
-      #   env: *common_env
-      #   plugins: *common_plugins
-      #   artifact_paths:
-      #     - "build/results/*"
-      #   notify:
-      #     - github_commit_status:
-      #         context: "UI Tests (iPad)"
-      #     - slack:
-      #         channels:
-      #           - "#mobile-apps-tests-notif"
-      #       if: build.state == "failed" && build.branch == "trunk"
+      - label: "🔬 UI Tests (iPad)"
+        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
+        depends_on: "build"
+        env: *common_env
+        plugins: *common_plugins
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "UI Tests (iPad)"
+          - slack:
+              channels:
+                - "#mobile-apps-tests-notif"
+            if: build.state == "failed" && build.branch == "trunk"
 
   # #################
   # # Linters

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -64,7 +64,7 @@ steps:
   # Run Unit Tests
   #################
   - label: "🔬 :wordpress: Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
+    command: ".buildkite/commands/run-unit-tests.sh wordpress"
     depends_on: "build_wordpress"
     env: *common_env
     plugins: *common_plugins
@@ -84,7 +84,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 :jetpack: UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh 'iPhone SE (3rd generation)'
+        command: .buildkite/commands/run-ui-tests.sh jetpack 'iPhone SE (3rd generation)'
         depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins
@@ -99,7 +99,7 @@ steps:
             if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 :jetpack: UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
+        command: .buildkite/commands/run-ui-tests.sh jetpack 'iPad Air (5th generation)'
         depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,28 +14,28 @@ common_params:
 # This is the default pipeline – it will build and test the app
 steps:
 
-  # #################
-  # # Create Prototype Builds for WP and JP
-  # #################
-  # - group: "🛠 Prototype Builds"
-  #   steps:
-  #     - label: "🛠 WordPress Prototype Build"
-  #       command: ".buildkite/commands/prototype-build-wordpress.sh"
-  #       env: *common_env
-  #       plugins: *common_plugins
-  #       if: "build.pull_request.id != null || build.pull_request.draft"
-  #       notify:
-  #         - github_commit_status:
-  #             context: "WordPress Prototype Build"
+  #################
+  # Create Prototype Builds for WP and JP
+  #################
+  - group: "🛠 Prototype Builds"
+    steps:
+      - label: "🛠 WordPress Prototype Build"
+        command: ".buildkite/commands/prototype-build-wordpress.sh"
+        env: *common_env
+        plugins: *common_plugins
+        if: "build.pull_request.id != null || build.pull_request.draft"
+        notify:
+          - github_commit_status:
+              context: "WordPress Prototype Build"
 
-  #     - label: "🛠 Jetpack Prototype Build"
-  #       command: ".buildkite/commands/prototype-build-jetpack.sh"
-  #       env: *common_env
-  #       plugins: *common_plugins
-  #       if: "build.pull_request.id != null || build.pull_request.draft"
-  #       notify:
-  #         - github_commit_status:
-  #             context: "Jetpack Prototype Build"
+      - label: "🛠 Jetpack Prototype Build"
+        command: ".buildkite/commands/prototype-build-jetpack.sh"
+        env: *common_env
+        plugins: *common_plugins
+        if: "build.pull_request.id != null || build.pull_request.draft"
+        notify:
+          - github_commit_status:
+              context: "Jetpack Prototype Build"
 
   #################
   # Build the app
@@ -49,23 +49,23 @@ steps:
       - github_commit_status:
           context: "Build for Testing"
 
-  # #################
-  # # Run Unit Tests
-  # #################
-  # - label: "🔬 Unit Tests"
-  #   command: ".buildkite/commands/run-unit-tests.sh"
-  #   depends_on: "build"
-  #   env: *common_env
-  #   plugins: *common_plugins
-  #   artifact_paths:
-  #     - "build/results/*"
-  #   notify:
-  #     - github_commit_status:
-  #         context: "Unit Tests"
-  #     - slack:
-  #         channels:
-  #           - "#mobile-apps-tests-notif"
-  #       if: build.state == "failed" && build.branch == "trunk"
+  #################
+  # Run Unit Tests
+  #################
+  - label: "🔬 Unit Tests"
+    command: ".buildkite/commands/run-unit-tests.sh"
+    depends_on: "build"
+    env: *common_env
+    plugins: *common_plugins
+    artifact_paths:
+      - "build/results/*"
+    notify:
+      - github_commit_status:
+          context: "Unit Tests"
+      - slack:
+          channels:
+            - "#mobile-apps-tests-notif"
+        if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # UI Tests
@@ -102,29 +102,29 @@ steps:
                 - "#mobile-apps-tests-notif"
             if: build.state == "failed" && build.branch == "trunk"
 
-  # #################
-  # # Linters
-  # #################
-  # - group: "Linters"
-  #   steps:
-  #     - label: "🧹 Lint Translations"
-  #       command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-  #       plugins:
-  #         - docker#v3.8.0:
-  #             image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-  #       agents:
-  #         queue: "default"
-  #       notify:
-  #         - github_commit_status:
-  #             context: "Lint Translations"
-  #     # This step uses Danger to run RuboCop, but it's "agnostic" about it.
-  #     # That is, it outwardly only mentions RuboCop, not Danger
-  #     - label: ":rubocop: Lint Ruby Tooling"
-  #       command: .buildkite/commands/rubocop-via-danger.sh
-  #       plugins: *common_plugins
-  #       agents:
-  #         queue: "android"
-  #     - label: ":sleuth_or_spy: Lint Localized Strings Format"
-  #       command: .buildkite/commands/lint-localized-strings-format.sh
-  #       plugins: *common_plugins
-  #       env: *common_env
+  #################
+  # Linters
+  #################
+  - group: "Linters"
+    steps:
+      - label: "🧹 Lint Translations"
+        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
+        plugins:
+          - docker#v3.8.0:
+              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+        agents:
+          queue: "default"
+        notify:
+          - github_commit_status:
+              context: "Lint Translations"
+      # This step uses Danger to run RuboCop, but it's "agnostic" about it.
+      # That is, it outwardly only mentions RuboCop, not Danger
+      - label: ":rubocop: Lint Ruby Tooling"
+        command: .buildkite/commands/rubocop-via-danger.sh
+        plugins: *common_plugins
+        agents:
+          queue: "android"
+      - label: ":sleuth_or_spy: Lint Localized Strings Format"
+        command: .buildkite/commands/lint-localized-strings-format.sh
+        plugins: *common_plugins
+        env: *common_env

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -14,28 +14,28 @@ common_params:
 # This is the default pipeline – it will build and test the app
 steps:
 
-  #################
-  # Create Prototype Builds for WP and JP
-  #################
-  - group: "🛠 Prototype Builds"
-    steps:
-      - label: "🛠 WordPress Prototype Build"
-        command: ".buildkite/commands/prototype-build-wordpress.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "WordPress Prototype Build"
+  # #################
+  # # Create Prototype Builds for WP and JP
+  # #################
+  # - group: "🛠 Prototype Builds"
+  #   steps:
+  #     - label: "🛠 WordPress Prototype Build"
+  #       command: ".buildkite/commands/prototype-build-wordpress.sh"
+  #       env: *common_env
+  #       plugins: *common_plugins
+  #       if: "build.pull_request.id != null || build.pull_request.draft"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "WordPress Prototype Build"
 
-      - label: "🛠 Jetpack Prototype Build"
-        command: ".buildkite/commands/prototype-build-jetpack.sh"
-        env: *common_env
-        plugins: *common_plugins
-        if: "build.pull_request.id != null || build.pull_request.draft"
-        notify:
-          - github_commit_status:
-              context: "Jetpack Prototype Build"
+  #     - label: "🛠 Jetpack Prototype Build"
+  #       command: ".buildkite/commands/prototype-build-jetpack.sh"
+  #       env: *common_env
+  #       plugins: *common_plugins
+  #       if: "build.pull_request.id != null || build.pull_request.draft"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "Jetpack Prototype Build"
 
   #################
   # Build the app
@@ -49,23 +49,23 @@ steps:
       - github_commit_status:
           context: "Build for Testing"
 
-  #################
-  # Run Unit Tests
-  #################
-  - label: "🔬 Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "Unit Tests"
-      - slack:
-          channels:
-            - "#mobile-apps-tests-notif"
-        if: build.state == "failed" && build.branch == "trunk"
+  # #################
+  # # Run Unit Tests
+  # #################
+  # - label: "🔬 Unit Tests"
+  #   command: ".buildkite/commands/run-unit-tests.sh"
+  #   depends_on: "build"
+  #   env: *common_env
+  #   plugins: *common_plugins
+  #   artifact_paths:
+  #     - "build/results/*"
+  #   notify:
+  #     - github_commit_status:
+  #         context: "Unit Tests"
+  #     - slack:
+  #         channels:
+  #           - "#mobile-apps-tests-notif"
+  #       if: build.state == "failed" && build.branch == "trunk"
 
   #################
   # UI Tests
@@ -87,44 +87,44 @@ steps:
                 - "#mobile-apps-tests-notif"
             if: build.state == "failed" && build.branch == "trunk"
 
-      - label: "🔬 UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
-        depends_on: "build"
-        env: *common_env
-        plugins: *common_plugins
-        artifact_paths:
-          - "build/results/*"
-        notify:
-          - github_commit_status:
-              context: "UI Tests (iPad)"
-          - slack:
-              channels:
-                - "#mobile-apps-tests-notif"
-            if: build.state == "failed" && build.branch == "trunk"
+      # - label: "🔬 UI Tests (iPad)"
+      #   command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
+      #   depends_on: "build"
+      #   env: *common_env
+      #   plugins: *common_plugins
+      #   artifact_paths:
+      #     - "build/results/*"
+      #   notify:
+      #     - github_commit_status:
+      #         context: "UI Tests (iPad)"
+      #     - slack:
+      #         channels:
+      #           - "#mobile-apps-tests-notif"
+      #       if: build.state == "failed" && build.branch == "trunk"
 
-  #################
-  # Linters
-  #################
-  - group: "Linters"
-    steps:
-      - label: "🧹 Lint Translations"
-        command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
-        plugins:
-          - docker#v3.8.0:
-              image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
-        agents:
-          queue: "default"
-        notify:
-          - github_commit_status:
-              context: "Lint Translations"
-      # This step uses Danger to run RuboCop, but it's "agnostic" about it.
-      # That is, it outwardly only mentions RuboCop, not Danger
-      - label: ":rubocop: Lint Ruby Tooling"
-        command: .buildkite/commands/rubocop-via-danger.sh
-        plugins: *common_plugins
-        agents:
-          queue: "android"
-      - label: ":sleuth_or_spy: Lint Localized Strings Format"
-        command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: *common_plugins
-        env: *common_env
+  # #################
+  # # Linters
+  # #################
+  # - group: "Linters"
+  #   steps:
+  #     - label: "🧹 Lint Translations"
+  #       command: "gplint /workdir/WordPress/Resources/AppStoreStrings.po"
+  #       plugins:
+  #         - docker#v3.8.0:
+  #             image: "public.ecr.aws/automattic/glotpress-validator:1.0.0"
+  #       agents:
+  #         queue: "default"
+  #       notify:
+  #         - github_commit_status:
+  #             context: "Lint Translations"
+  #     # This step uses Danger to run RuboCop, but it's "agnostic" about it.
+  #     # That is, it outwardly only mentions RuboCop, not Danger
+  #     - label: ":rubocop: Lint Ruby Tooling"
+  #       command: .buildkite/commands/rubocop-via-danger.sh
+  #       plugins: *common_plugins
+  #       agents:
+  #         queue: "android"
+  #     - label: ":sleuth_or_spy: Lint Localized Strings Format"
+  #       command: .buildkite/commands/lint-localized-strings-format.sh
+  #       plugins: *common_plugins
+  #       env: *common_env

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -38,23 +38,34 @@ steps:
               context: "Jetpack Prototype Build"
 
   #################
-  # Build the app
+  # Create Builds for Testing
   #################
-  - label: "🛠 Build for Testing"
-    key: "build"
-    command: ".buildkite/commands/build-for-testing.sh"
-    env: *common_env
-    plugins: *common_plugins
-    notify:
-      - github_commit_status:
-          context: "Build for Testing"
+  - group: "🛠 Builds for Testing"
+    steps:
+      - label: "🛠 :wordpress: Build for Testing"
+        key: "build_wordpress"
+        command: ".buildkite/commands/build-for-testing.sh wordpress"
+        env: *common_env
+        plugins: *common_plugins
+        notify:
+          - github_commit_status:
+              context: "WordPress Build for Testing"
+
+      - label: "🛠 :jetpack: Build for Testing"
+        key: "build_jetpack"
+        command: ".buildkite/commands/build-for-testing.sh jetpack"
+        env: *common_env
+        plugins: *common_plugins
+        notify:
+          - github_commit_status:
+              context: "Jetpack Build for Testing"
 
   #################
   # Run Unit Tests
   #################
-  - label: "🔬 Unit Tests"
+  - label: "🔬 :wordpress: Unit Tests"
     command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build"
+    depends_on: "build_wordpress"
     env: *common_env
     plugins: *common_plugins
     artifact_paths:
@@ -72,9 +83,9 @@ steps:
   #################
   - group: "🔬 UI Tests"
     steps:
-      - label: "🔬 UI Tests (iPhone)"
+      - label: "🔬 :jetpack: UI Tests (iPhone)"
         command: .buildkite/commands/run-ui-tests.sh 'iPhone SE (3rd generation)'
-        depends_on: "build"
+        depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins
         artifact_paths:
@@ -87,9 +98,9 @@ steps:
                 - "#mobile-apps-tests-notif"
             if: build.state == "failed" && build.branch == "trunk"
 
-      - label: "🔬 UI Tests (iPad)"
+      - label: "🔬 :jetpack: UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh "iPad Air (5th generation)"
-        depends_on: "build"
+        depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins
         artifact_paths:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -84,7 +84,7 @@ steps:
   - group: "🔬 UI Tests"
     steps:
       - label: "🔬 :jetpack: UI Tests (iPhone)"
-        command: .buildkite/commands/run-ui-tests.sh jetpack 'iPhone SE (3rd generation)'
+        command: .buildkite/commands/run-ui-tests.sh 'iPhone SE (3rd generation)'
         depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins
@@ -99,7 +99,7 @@ steps:
             if: build.state == "failed" && build.branch == "trunk"
 
       - label: "🔬 :jetpack: UI Tests (iPad)"
-        command: .buildkite/commands/run-ui-tests.sh jetpack 'iPad Air (5th generation)'
+        command: .buildkite/commands/run-ui-tests.sh 'iPad Air (5th generation)'
         depends_on: "build_jetpack"
         env: *common_env
         plugins: *common_plugins

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1400"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,12 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:WordPressUITests/JetpackUITests.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -28,6 +28,27 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "EA14532229AD874C001F3143"
+               BuildableName = "JetpackUITests.xctest"
+               BlueprintName = "JetpackUITests"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "LoginTests/testEmailMagicLinkLogin()">
+               </Test>
+               <Test
+                  Identifier = "SignupTests/testEmailSignup()">
+               </Test>
+               <Test
+                  Identifier = "SupportScreenTests/testSupportForumsCanBeLoadedDuringLogin()">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
       </Testables>
    </TestAction>
    <LaunchAction

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -79,7 +79,7 @@ platform :ios do
   desc 'Run tests without building'
   lane :test_without_building do |options|
     # Find the referenced .xctestrun file based on its name
-    build_products_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products', options[:name])
+    build_products_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products')
 
     xctestrun_path = Dir.glob(File.join(build_products_path, '*.xctestrun')).select do |path|
       path.include?(options[:name])

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -88,7 +88,7 @@ platform :ios do
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
-    scheme_name = (not options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress')
+    scheme_name = (!options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress')
 
     run_tests(
       workspace: WORKSPACE_PATH,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -89,13 +89,16 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}. xctestrun path is #{xctestrun_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
-    if options[:name] != "jetpack"
+    if options[:name] != 'Jetpack'
       inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+      scheme_name = 'WordPress'
+    elsif options[:name] == 'Jetpack'
+      scheme_name = 'JetpackUITests'
     end
 
     run_tests(
       workspace: WORKSPACE_PATH,
-      scheme: 'JetpackUITests',
+      scheme: scheme_name,
       device: options[:device],
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -36,7 +36,7 @@ platform :ios do
   # @called_by CI
   #
   desc 'Build WordPress for Testing'
-  lane :build_for_testing do |options|
+  lane :build_wordpress_for_testing do |options|
     run_tests(
       workspace: WORKSPACE_PATH,
       scheme: 'WordPress',

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -87,9 +87,9 @@ platform :ios do
 
     puts "build_products_path is #{build_products_path} and xctestrun_path is #{xctestrun_path}"
 
-    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}. xctestrun path is #{xctestrun_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
+    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
-    # Temporary skip Buildkite Analytics for Jetpack (not setup)
+    # Temporary skip Buildkite Analytics for tests running on Jetpack builds as it's not setup yet
     if options[:name] != 'Jetpack' && buildkite_ci?
       inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path)
       scheme_name = 'WordPress'

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -88,7 +88,7 @@ platform :ios do
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
-    scheme_name = (options[:name] != 'Jetpack' ? 'WordPress' : 'JetpackUITests')
+    scheme_name = (not options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress')
 
     run_tests(
       workspace: WORKSPACE_PATH,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -88,6 +88,7 @@ platform :ios do
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     # Temporary skip Buildkite Analytics for tests running on Jetpack builds as it's not setup yet
+    # To be added in: https://github.com/wordpress-mobile/WordPress-iOS/issues/20336
     if options[:name] != 'Jetpack' && buildkite_ci?
       inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path)
       scheme_name = 'WordPress'

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -87,14 +87,8 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
-    # Temporary skip Buildkite Analytics for tests running on Jetpack builds as it's not setup yet
-    # To be added in: https://github.com/wordpress-mobile/WordPress-iOS/issues/20336
-    if options[:name] != 'Jetpack' && buildkite_ci?
-      inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path)
-      scheme_name = 'WordPress'
-    elsif options[:name] == 'Jetpack'
-      scheme_name = 'JetpackUITests'
-    end
+    inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+    scheme_name = (options[:name] != 'Jetpack' ? 'WordPress' : 'JetpackUITests')
 
     run_tests(
       workspace: WORKSPACE_PATH,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -96,7 +96,7 @@ platform :ios do
     # - (WordPress, WordPressUnitTests)
     #
     # Because we only support those two modes, we can infer the scheme name from the xctestrun name
-    scheme = options[:name].include? 'Jetpack' ? 'JetpackUITests' : 'WordPress'
+    scheme = options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress'
 
     run_tests(
       workspace: WORKSPACE_PATH,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -89,8 +89,9 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}. xctestrun path is #{xctestrun_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
-    if options[:name] != 'Jetpack'
-      inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+    # Temporary skip Buildkite Analytics for Jetpack (not setup)
+    if options[:name] != 'Jetpack' && buildkite_ci?
+      inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path)
       scheme_name = 'WordPress'
     elsif options[:name] == 'Jetpack'
       scheme_name = 'JetpackUITests'

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -79,7 +79,7 @@ platform :ios do
   desc 'Run tests without building'
   lane :test_without_building do |options|
     # Find the referenced .xctestrun file based on its name
-    build_products_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products')
+    build_products_path = File.join(DERIVED_DATA_PATH, 'Build', 'Products', options[:name])
 
     xctestrun_path = Dir.glob(File.join(build_products_path, '*.xctestrun')).select do |path|
       path.include?(options[:name])

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -88,11 +88,19 @@ platform :ios do
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
-    scheme_name = (!options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress')
+    # Our current configuration allows for either running the Jetpack UI tests or the WordPress unit tests.
+    #
+    # Their scheme and xctestrun name pairing are:
+    #
+    # - (JetpackUITests, JetpackUITests)
+    # - (WordPress, WordPressUnitTests)
+    #
+    # Because we only support those two modes, we can infer the scheme name from the xctestrun name
+    scheme = options[:name].include? 'Jetpack' ? 'JetpackUITests' : 'WordPress'
 
     run_tests(
       workspace: WORKSPACE_PATH,
-      scheme: scheme_name,
+      scheme: scheme,
       device: options[:device],
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -96,7 +96,7 @@ platform :ios do
     # - (WordPress, WordPressUnitTests)
     #
     # Because we only support those two modes, we can infer the scheme name from the xctestrun name
-    scheme = options[:name] == 'Jetpack' ? 'JetpackUITests' : 'WordPress'
+    scheme = options[:name].include?('Jetpack') ? 'JetpackUITests' : 'WordPress'
 
     run_tests(
       workspace: WORKSPACE_PATH,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -85,8 +85,6 @@ platform :ios do
       path.include?(options[:name])
     end.first
 
-    puts "build_products_path is #{build_products_path} and xctestrun_path is #{xctestrun_path}"
-
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
 
     # Temporary skip Buildkite Analytics for tests running on Jetpack builds as it's not setup yet

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -85,13 +85,17 @@ platform :ios do
       path.include?(options[:name])
     end.first
 
-    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
+    puts "build_products_path is #{build_products_path} and xctestrun_path is #{xctestrun_path}"
 
-    inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+    UI.user_error!("Unable to find .xctestrun file at #{build_products_path}. xctestrun path is #{xctestrun_path}") if xctestrun_path.nil? || !File.exist?((xctestrun_path))
+
+    if options[:name] != "jetpack"
+      inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
+    end
 
     run_tests(
       workspace: WORKSPACE_PATH,
-      scheme: 'WordPress',
+      scheme: 'JetpackUITests',
       device: options[:device],
       deployment_target_version: options[:ios_version],
       ensure_devices_found: true,


### PR DESCRIPTION
### What does this do:
This main goal of this PR is to run the UI tests on Jetpack instead of WordPress, no changes are made to the unit test run. 

The changes that are done for this work:
1. Updated `Build the app` step into a `Create Builds for Testing` group to build WordPress and Jetpack apps. The reason is that the tests depend on a build to run the test on. For unit tests, it's WordPress. For UI tests, it's Jetpack. I would like to keep the unit test unchanged as part of this PR, so as discussed with @tiagomar the solution we came up with is to build both apps. Open to other alternatives if there are other ideas! 
2. Updated `build-products` folder name to `build-products-wordpress` and `build-products-jetpack` (app specific names) because, with only one folder, the content is overwritten by the content of the last app that completes building
3. Added the `JetpackUITests.xctestplan` into `Jetpack.xcscheme` (currently, there's no unit test .xctestplan for Jetpack in the project)
4. Skipped Buildkite Analytics for the Jetpack UI tests run. The test analytics for Jetpack hasn't been set up yet, so it is temporarily skipped until it's set up (created https://github.com/wordpress-mobile/WordPress-iOS/issues/20336 for tracking)

### To test:
- Test that Unit tests still run on the WordPress build and UI tests (iPhone and iPad) are running on Jetpack build in CI. Also, ensure that reports are created as artifacts for all test runs.
- Tests should work as expected locally (no changes to local tests)

Note:
Once the new step is approved and this lands in trunk, I'll update the branch protection rule to require `Jetpack Build for Testing` and `WordPress Build for Testing` steps and remove the `Build for Testing` step.