### PR TITLE
Fix WP.com post deeplink not opening in app

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -516,20 +516,19 @@ extension WordPressAppDelegate {
             return
         }
 
-        // When a counterpart WordPress/Jetpack app is detected, ensure that the router can handle the URL.
-        // Passing a URL that the router couldn't handle results in opening the URL in Safari, which will
-        // cause the other app to "catch" the intent — and leads to a navigation loop between the two apps.
-        //
-        // TODO: Remove this after the Universal Link routes for the WordPress app are removed.
-        //
-        // Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
-        if MigrationAppDetection.isCounterpartAppInstalled {
-            // If we can handle the URL, then let the UniversalLinkRouter do it.
-            guard UniversalLinkRouter.shared.canHandle(url: url) else {
-                // Otherwise, try to convert the URL to a WP Admin link and open it in Safari.
-                WPAdminConvertibleRouter.shared.handle(url: url)
-                return
-            }
+        /// If the counterpart WordPress/Jetpack app is installed, and the URL has a wp-admin link equivalent,
+        /// bounce the wp-admin link to Safari instead.
+        ///
+        /// Passing a URL that the router couldn't handle results in opening the URL in Safari, which will
+        /// cause the other app to "catch" the intent — and leads to a navigation loop between the two apps.
+        ///
+        /// TODO: Remove this after the Universal Link routes for the WordPress app are removed.
+        ///
+        /// Read more: https://github.com/wordpress-mobile/WordPress-iOS/issues/19755
+        if MigrationAppDetection.isCounterpartAppInstalled,
+           WPAdminConvertibleRouter.shared.canHandle(url: url) {
+            WPAdminConvertibleRouter.shared.handle(url: url)
+            return
         }
 
         trackDeepLink(for: url) { url in


### PR DESCRIPTION
Fixes #20293
Refs #20213, p1678384048655429-slack-C011BKNU1V5, p1678278001563359-slack-C0180B5PRJ4

> **Warning**:
> The PR temporarily targets `release/21.8.1`, but it should be updated to target `release/21.8.2` once it's available.

This fixes an issue where post links with subdomain hosts (i.e., `*.wordpress.com`) no longer open in the app after #20213 is merged. This is due to the `canHandle` method in `UniversalLinkRouter` checking if the host is exactly `wordpress.com` or `jetpack.com`:

https://github.com/wordpress-mobile/WordPress-iOS/blob/28ebe98a054d2bf20ddd77dc70bf6390250c94c7/WordPress/Classes/Utility/Universal%20Links/UniversalLinkRouter.swift#L132-L135

To prevent further side effects, the issue is fixed by avoiding the usage of `canHandle`, thus bringing the logic closer to before #20213 is merged while still solving the original issue.

## To Test

This will be using a similar test scenario from #20213, but with an added test case for better coverage. 

Note that the recommended way is to compile the app under test to your device, and have the counterpart app installed from TestFlight or AppStore. If you wish to fully test from the simulator, I'd recommend temporarily modifying these values in `UIApplication+AppAvailability`:

- `wordpress://` -> `wpdebug://`
- `jetpack://` -> `jpdebug://`

https://github.com/wordpress-mobile/WordPress-iOS/blob/28ebe98a054d2bf20ddd77dc70bf6390250c94c7/WordPress/Classes/Extensions/UIApplication%2BAppAvailability.swift#L3-L7

And don't forget to also compile both apps to the Simulator when testing for **Environment 1** below.

### Environment 1: Both apps are installed

- Have both WordPress and Jetpack apps installed on the device or simulator.
- As there are test cases involving private sites, to make things easier, log in to your WordPress.com account and ensure that you use an account that has access to a private site.
- Tap the links as described by the table below, and verify the expectation column is correct:

No. | Link | Expectation
-|-|-
1 | A valid "edit post" link with site URL (`wordpress.com/post/:siteURL/:postID`) | Opens wp-admin link in Safari
2 | A valid "edit post" link with site ID (`wordpress.com/post/:siteID/:postID`) | Opens wp-admin link in Safari
3 | An **invalid** "edit post" link, e.g. with a wrong site ID. | Does nothing
4 | Any `*.wordpress.com` link that leads to a private site with insufficient access, e.g. https://dvcyp2general.wordpress.com/2023/03/10/looking-back-at-wordpress/ | Shows "Error Loading Post"
5 | Any `*.wordpress.com` link that you have read access to, e.g. https://dvdchrtest.wordpress.com/2023/03/10/hello-wordpress/ | Opens the post in the app
6 | Any valid `wordpress.com` deeplink route, e.g.: https://wordpress.com/me | Deeplinks into the feature
7 | Invalid `wordpress.com` deeplink route, e.g.: https://wordpress.com/read/feeds/000000 | Does nothing, or shows some kind of error state[^1]

### Environment 2: Only one app installed

- Have only one app installed (either WordPress or Jetpack).
- Log in to your WordPress.com account.
- Tap the links as described by the table below, and verify the expectation column is correct:

No. | Link | Expectation
-|-|-
1 | A valid "edit post" link with site URL (`/post/:siteURL/:postID`) | Opens the link in Safari
2 | A valid "edit post" link with site ID (`/post/:siteID/:postID`) | Opens the link in Safari
3 | An **invalid** "edit post" link, e.g. with a wrong site ID. | Opens the link in Safari
4 | Any `*.wordpress.com` link that leads to a private site with insufficient access, e.g. https://dvcyp2general.wordpress.com/2023/03/10/looking-back-at-wordpress/ | Shows "Error Loading Post"
5 | Any `*.wordpress.com` link that you have read access to, e.g. https://dvdchrtest.wordpress.com/2023/03/10/hello-wordpress/ | Opens the post in the app
6 | Any valid `wordpress.com` deeplink route, for example: https://wordpress.com/me | Deeplinks into the feature
7 | Invalid `wordpress.com` deeplink route, e.g.: https://wordpress.com/read/feeds/000000 | Does nothing, or shows some kind of error state[^1]

- Repeat the steps above, but now testing with the other app.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The implementation is now closer to before #20213 is implemented.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested various deeplink scenarios.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

[^1]: This depends on how the error is handled on the specific route. But the key point here is that the infinite redirect between WP and JP should no longer be happening.