### PR TITLE
Comments: Fix a crash when replying to a post

### DIFF
--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1048,6 +1048,7 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
     [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
         ReaderPost *post = [context existingObjectWithID:postObjectID error:nil];
         Comment *comment = [self createHierarchicalCommentWithContent:content withParent:parentID postID:post.postID siteID:siteID inContext:context];
+        objectID = comment.objectID;
         // This fixes an issue where the comment may not appear for some posts after a successful posting
         // More information: https://github.com/wordpress-mobile/WordPress-iOS/issues/13259
         comment.post = post;


### PR DESCRIPTION
Fixes #20306

## Description
Fixes a crash that happens when replying to a post from the reader.

## Note
⚠️ The PR temporarily targets `release/21.8.1`, but it should be updated to target `release/21.8.2` once it's available. And then, the "DO NOT MERGE" label can be removed.

## Testing Instructions

1. Cold start the Jetpack or WordPress app
2. Logged in to a WordPress.com account, go to Reader
3. Select a post where comments can be submitted ([example](https://twstokes.wordpress.com/2023/03/09/here-is-a-post/))
4. Submit a comment
5. Make sure the comment is successfully submitted and the app doesn't crash
6. Submit a hierarchical comment (reply to a comment)
7. Make sure the comment is successfully submitted, and the app doesn't crash

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.