### PR TITLE
Blaze: Show Blaze in general section

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -873,6 +873,21 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
                                                          [weakSelf showActivity];
                                                      }]];
     }
+    
+    if ([self shouldShowBlaze]) {
+        CGSize iconSize = CGSizeMake(BlogDetailGridiconSize, BlogDetailGridiconSize);
+        UIImage *blazeIcon = [[UIImage imageNamed:@"icon-blaze"] resizedImage:iconSize interpolationQuality:kCGInterpolationHigh];
+        BlogDetailsRow *blazeRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blaze", @"Noun. Links to a blog's Blaze screen.")
+                                                 accessibilityIdentifier:@"Blaze Row"
+                                                                   image:[blazeIcon imageFlippedForRightToLeftLayoutDirection]
+                                                              imageColor:nil
+                                                           renderingMode:UIImageRenderingModeAlwaysOriginal
+                                                                callback:^{
+                                                                    [weakSelf showBlaze];
+                                                                }];
+        blazeRow.showsSelectionState = NO;
+        [rows addObject:blazeRow];
+    }
 
 // Temporarily disabled
 //    if ([self.blog supports:BlogFeaturePlans] && ![self.blog isWPForTeams]) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -875,18 +875,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     
     if ([self shouldShowBlaze]) {
-        CGSize iconSize = CGSizeMake(BlogDetailGridiconSize, BlogDetailGridiconSize);
-        UIImage *blazeIcon = [[UIImage imageNamed:@"icon-blaze"] resizedImage:iconSize interpolationQuality:kCGInterpolationHigh];
-        BlogDetailsRow *blazeRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blaze", @"Noun. Links to a blog's Blaze screen.")
-                                                 accessibilityIdentifier:@"Blaze Row"
-                                                                   image:[blazeIcon imageFlippedForRightToLeftLayoutDirection]
-                                                              imageColor:nil
-                                                           renderingMode:UIImageRenderingModeAlwaysOriginal
-                                                                callback:^{
-                                                                    [weakSelf showBlaze];
-                                                                }];
-        blazeRow.showsSelectionState = NO;
-        [rows addObject:blazeRow];
+        [rows addObject:[self blazeRow]];
     }
 
 // Temporarily disabled
@@ -961,18 +950,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     }
     
     if ([self shouldShowBlaze]) {
-        CGSize iconSize = CGSizeMake(BlogDetailGridiconSize, BlogDetailGridiconSize);
-        UIImage *blazeIcon = [[UIImage imageNamed:@"icon-blaze"] resizedImage:iconSize interpolationQuality:kCGInterpolationHigh];
-        BlogDetailsRow *blazeRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blaze", @"Noun. Links to a blog's Blaze screen.")
-                                                 accessibilityIdentifier:@"Blaze Row"
-                                                                   image:[blazeIcon imageFlippedForRightToLeftLayoutDirection]
-                                                              imageColor:nil
-                                                           renderingMode:UIImageRenderingModeAlwaysOriginal
-                                                                callback:^{
-                                                                    [weakSelf showBlaze];
-                                                                }];
-        blazeRow.showsSelectionState = NO;
-        [rows addObject:blazeRow];
+        [rows addObject:[self blazeRow]];
     }
     NSString *title = @"";
 
@@ -983,6 +961,22 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows category:BlogDetailsSectionCategoryJetpack];
 }
 
+- (BlogDetailsRow *)blazeRow
+{
+    __weak __typeof(self) weakSelf = self;
+    CGSize iconSize = CGSizeMake(BlogDetailGridiconSize, BlogDetailGridiconSize);
+    UIImage *blazeIcon = [[UIImage imageNamed:@"icon-blaze"] resizedImage:iconSize interpolationQuality:kCGInterpolationHigh];
+    BlogDetailsRow *blazeRow = [[BlogDetailsRow alloc] initWithTitle:NSLocalizedString(@"Blaze", @"Noun. Links to a blog's Blaze screen.")
+                                             accessibilityIdentifier:@"Blaze Row"
+                                                               image:[blazeIcon imageFlippedForRightToLeftLayoutDirection]
+                                                          imageColor:nil
+                                                       renderingMode:UIImageRenderingModeAlwaysOriginal
+                                                            callback:^{
+                                                                [weakSelf showBlaze];
+                                                            }];
+    blazeRow.showsSelectionState = NO;
+    return blazeRow;
+}
 
 - (BlogDetailsSection *)publishTypeSectionViewModel
 {


### PR DESCRIPTION
## Description
Shows the Blaze menu item in the general section. The general section is shown if the jetpack section isn't shown.

## Note
The base branch for this PR will automatically update to `release/21.9` once #20290 gets merged into `release/21.9`

## How to test
1. Create a test p2 site
2. Change the site to be public
3. On the app, go to the site menu tab in the My Site screen
4. ✅ The Blaze menu item is displayed

## Regression Notes
1. Potential unintended areas of impact
n/a

6. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

7. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
