### PR TITLE
Add database upgrade and downgrade tests for the `importData` function

### DIFF
--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -13,7 +13,7 @@ class DataMigratorTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        context = try! createInMemoryContext()
+        context = try! createContext()
         coreDataStack = CoreDataStackMock(mainContext: context)
         keychainUtils = KeychainUtilsMock()
         sharedUserDefaults = InMemoryUserDefaults()
@@ -115,6 +115,98 @@ class DataMigratorTests: XCTestCase {
         // Then
         XCTAssertNil(sharedUserDefaults.object(forKey: Constants.defaultsWrapperKey))
     }
+
+    func test_importData_databaseUpgradeFromOlderModel_shouldSucceed() {
+        // Given
+        sharedUserDefaults.set(true, forKey: Constants.readyToMigrateKey)
+        sharedUserDefaults.set(["test": 1], forKey: Constants.defaultsWrapperKey)
+
+        let (currentModel, previousModel) = getRecentObjectModels()
+        guard let currentModel, let previousModel else {
+            XCTFail("Invalid core data models")
+            return
+        }
+
+        // Set the active database to the current database model
+        let currentDatabaseFile = temporaryDatabaseFileURL()
+        context = try! createFileContext(for: currentModel, at: currentDatabaseFile)
+        coreDataStack = CoreDataStackMock(mainContext: context)
+
+        // Create a previous database model at the backup location
+        let backupLocation = temporaryDatabaseFileURL()
+        _ = try! createFileContext(for: previousModel, at: backupLocation)
+
+        migrator = DataMigrator(coreDataStack: coreDataStack,
+                                backupLocation: backupLocation,
+                                keychainUtils: keychainUtils,
+                                localDefaults: localUserDefaults,
+                                sharedDefaults: sharedUserDefaults)
+
+        // When
+        let expect = expectation(description: "Import data should succeed")
+        migrator.importData { result in
+            // Then
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail("Import data failed: \(error)")
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1)
+
+        // Prevents a warning about deleting an open file descriptor
+        migrator = nil
+        coreDataStack = nil
+        context = nil
+    }
+
+    func test_importData_databaseDowngradeFromNewerModel_shouldSucceed() {
+        // Given
+        sharedUserDefaults.set(true, forKey: Constants.readyToMigrateKey)
+        sharedUserDefaults.set(["test": 1], forKey: Constants.defaultsWrapperKey)
+
+        let (currentModel, previousModel) = getRecentObjectModels()
+        guard let currentModel, let previousModel else {
+            XCTFail("Invalid core data models")
+            return
+        }
+
+        // Set the active database to the previous database model
+        let currentDatabaseFile = temporaryDatabaseFileURL()
+        context = try! createFileContext(for: previousModel, at: currentDatabaseFile)
+        coreDataStack = CoreDataStackMock(mainContext: context)
+
+        // Create the current database model at the backup location
+        let backupLocation = temporaryDatabaseFileURL()
+        _ = try! createFileContext(for: currentModel, at: backupLocation)
+
+        migrator = DataMigrator(coreDataStack: coreDataStack,
+                                backupLocation: backupLocation,
+                                keychainUtils: keychainUtils,
+                                localDefaults: localUserDefaults,
+                                sharedDefaults: sharedUserDefaults)
+
+        // When
+        let expect = expectation(description: "Import data should succeed")
+        migrator.importData { result in
+            // Then
+            switch result {
+            case .success:
+                break
+            case .failure(let error):
+                XCTFail("Import data failed: \(error)")
+            }
+            expect.fulfill()
+        }
+        wait(for: [expect], timeout: 1)
+
+        // Prevents a warning about deleting an open file descriptor
+        migrator = nil
+        coreDataStack = nil
+        context = nil
+    }
 }
 
 // MARK: - CoreDataStackMock
@@ -187,14 +279,19 @@ private extension DataMigratorTests {
         static let defaultsWrapperKey = "defaults_staging_dictionary"
     }
 
-    func createInMemoryContext() throws -> NSManagedObjectContext {
-        let managedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!
-        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: managedObjectModel)
-        try persistentStoreCoordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
+    func createContext(for model: NSManagedObjectModel = NSManagedObjectModel.mergedModel(from: [Bundle.main])!,
+                       type: String = NSInMemoryStoreType,
+                       at location: URL? = nil) throws -> NSManagedObjectContext {
+        let persistentStoreCoordinator = NSPersistentStoreCoordinator(managedObjectModel: model)
+        try persistentStoreCoordinator.addPersistentStore(ofType: type, configurationName: nil, at: location, options: nil)
         let managedObjectContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
         managedObjectContext.persistentStoreCoordinator = persistentStoreCoordinator
 
         return managedObjectContext
+    }
+
+    func createFileContext(for model: NSManagedObjectModel, at location: URL) throws -> NSManagedObjectContext {
+        return try createContext(for: model, type: NSSQLiteStoreType, at: location)
     }
 
     func getExportDataMigratorError(_ migrator: DataMigrator) -> DataMigrationError? {
@@ -208,5 +305,84 @@ private extension DataMigratorTests {
             }
         }
         return migratorError
+    }
+
+    func getModelNames() -> [String] {
+        guard let modelFileURL = Bundle.main.url(forResource: "WordPress", withExtension: "momd"),
+              let versionInfo = NSDictionary(contentsOf: modelFileURL.appendingPathComponent("VersionInfo.plist")),
+              let modelNames = (versionInfo["NSManagedObjectModel_VersionHashes"] as? [String: AnyObject])?.keys else {
+            return []
+        }
+        let sortedModelNames = modelNames.sorted { $0.compare($1, options: .numeric) == .orderedAscending }
+        return sortedModelNames
+    }
+
+    func getModelObject(for modelName: String) -> NSManagedObjectModel? {
+        guard let url = urlForModel(name: modelName) else {
+            return nil
+        }
+        return NSManagedObjectModel(contentsOf: url)
+    }
+
+    func urlForModel(name: String) -> URL? {
+        if let url = Bundle.main.url(forResource: name, withExtension: "mom") {
+            return url
+        }
+
+        let momdPaths = Bundle.main.paths(forResourcesOfType: "momd", inDirectory: nil)
+        for path in momdPaths {
+            if let url = Bundle.main.url(forResource: name, withExtension: "mom", subdirectory: URL(fileURLWithPath: path).lastPathComponent) {
+                return url
+            }
+        }
+
+        return nil
+    }
+
+    func getRecentObjectModels() -> (current: NSManagedObjectModel?, previous: NSManagedObjectModel?) {
+        let models = getModelNames()
+        guard models.count > 1,
+              let currentModel = getModelObject(for: models[models.count - 1]),
+              let previousModel = getModelObject(for: models[models.count - 2]) else {
+            return (current: nil, previous: nil)
+        }
+        return (current: currentModel, previous: previousModel)
+    }
+
+    // Slightly modified from: https://developer.apple.com/documentation/xctest/xctestcase/2887226-addteardownblock
+    func temporaryDatabaseFileURL() -> URL {
+        // Create a URL for an unique file in the system's temporary directory.
+        let directory = NSTemporaryDirectory()
+        let filename = "\(UUID().uuidString).sqlite"
+        let fileURL = URL(fileURLWithPath: directory).appendingPathComponent(filename)
+
+        // Add a teardown block to delete any file at `fileURL`.
+        addTeardownBlock {
+            do {
+                let fileManager = FileManager.default
+                let shmFileURL = URL(string: fileURL.absoluteString.appending("-shm"))
+                let walFileURL = URL(string: fileURL.absoluteString.appending("-wal"))
+                let files = [fileURL, shmFileURL, walFileURL]
+
+                try files.forEach { file in
+                    guard let file else {
+                        return
+                    }
+                    // Check that the file exists before trying to delete it.
+                    if fileManager.fileExistsAtURL(file) {
+                        // Perform the deletion.
+                        try fileManager.removeItem(at: file)
+                        // Verify that the file no longer exists after the deletion.
+                        XCTAssertFalse(fileManager.fileExistsAtURL(file))
+                    }
+                }
+            } catch {
+                // Treat any errors during file deletion as a test failure.
+                XCTFail("Error while deleting temporary file: \(error)")
+            }
+        }
+
+        // Return the temporary file URL for use in a test method.
+        return fileURL
     }
 }


### PR DESCRIPTION
## Description

The `21.7.2` hotfix was due to the `importData` function call failing after a model change to the database. This adds a couple tests that will check importing a model upgrade (older WordPress version → newer Jetpack version) and a model downgrade (newer WordPress version → older Jetpack version).

## Testing

To test:
- Modify this code: https://github.com/wordpress-mobile/WordPress-iOS/blob/1be5d8cf6be34a2245400a2164375d123fb161b6/WordPress/Classes/Utility/CoreDataHelper.swift#L253-L265

To:
```swift
//        try? migrateDatabaseIfNecessary(at: databaseLocation)

        mainContext.reset()
        try storeCoordinator.remove(store)
        let databaseReplaced = replaceDatabase(from: databaseLocation, to: currentDatabaseLocation)

        do {
//            let options = [NSMigratePersistentStoresAutomaticallyOption: true,
//                                 NSInferMappingModelAutomaticallyOption: true]
            try storeCoordinator.addPersistentStore(ofType: NSSQLiteStoreType,
                                                    configurationName: nil,
                                                    at: currentDatabaseLocation,
                                                    options: nil)
```

- Run the `DataMigratorTests` tests
- **Verify**:
  - ❌ `test_importData_databaseUpgradeFromOlderModel_shouldSucceed` fails
  - ❌ `test_importData_databaseDowngradeFromNewerModel_shouldSucceed` fails
- Uncomment out the line: https://github.com/wordpress-mobile/WordPress-iOS/blob/1be5d8cf6be34a2245400a2164375d123fb161b6/WordPress/Classes/Utility/CoreDataHelper.swift#L253 
- Run the `DataMigratorTests` tests
- **Verify**:
  - ✅ `test_importData_databaseUpgradeFromOlderModel_shouldSucceed` passes
  - ❌ `test_importData_databaseDowngradeFromNewerModel_shouldSucceed` fails
- Revert all changes to `CoreDataHelper`
- Run the `DataMigratorTests` tests
- **Verify**:
  - ✅ `test_importData_databaseUpgradeFromOlderModel_shouldSucceed` passes
  - ✅ `test_importData_databaseDowngradeFromNewerModel_shouldSucceed` passes

## Regression Notes
1. Potential unintended areas of impact
Potential side effects from creating a database file

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and cleanup teardown code

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
