### PR TITLE
Remove no-longer-required `brew update` from CI commands

### DIFF
--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Prototype Builds want the latest version of Sentry CLI
-brew update
+# Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,7 +1,6 @@
 #!/bin/bash -eu
 
-# FIXIT-13.1: Prototype Builds want the latest version of Sentry CLI
-brew update
+# Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/release-build-jetpack.sh
+++ b/.buildkite/commands/release-build-jetpack.sh
@@ -1,41 +1,8 @@
 #!/bin/bash -eu
 
-echo "--- :arrow_down: Installing Release Dependencies"
-# Disabled to hopefully work past the failure seen in
-# https://buildkite.com/automattic/wordpress-ios/builds/12513#01865ef3-8a38-4303-b028-bead44ee943d
-#
-# ==> Installing python@3.11
-# ==> Pouring python@3.11--3.11.2.monterey.bottle.1.tar.gz
-# Error: The `brew link` step did not complete successfully
-# The formula built, but is not symlinked into /usr/local
-# Could not symlink bin/2to3
-# Target /usr/local/bin/2to3
-# is a symlink belonging to python@3.10. You can unlink it:
-#   brew unlink python@3.10
-#
-# To force the link and overwrite all conflicting files:
-#   brew link --overwrite python@3.11
-#
-# To list all files that would be deleted:
-#   brew link --overwrite --dry-run python@3.11
-#
-# Possible conflicting files are:
-# /usr/local/bin/2to3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/2to3
-# /usr/local/bin/idle3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/idle3
-# /usr/local/bin/pydoc3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/pydoc3
-# /usr/local/bin/python3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3
-# /usr/local/bin/python3-config -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3-config
-# /usr/local/share/man/man1/python3.1 -> /usr/local/Cellar/python@3.10/3.10.9/share/man/man1/python3.1
-# /usr/local/lib/pkgconfig/python3-embed.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3-embed.pc
-# /usr/local/lib/pkgconfig/python3.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3.pc
-# /usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Headers
-# /usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Python
-# /usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Resources
-# /usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/Current
-#
-# brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick
 brew install ghostscript
+# Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/release-build-wordpress-internal.sh
+++ b/.buildkite/commands/release-build-wordpress-internal.sh
@@ -1,41 +1,9 @@
 #!/bin/bash -eu
 
 echo "--- :arrow_down: Installing Release Dependencies"
-# Disabled to hopefully work past the failure seen in
-# https://buildkite.com/automattic/wordpress-ios/builds/12513#01865ef3-8a38-4303-b028-bead44ee943d
-#
-# ==> Installing python@3.11
-# ==> Pouring python@3.11--3.11.2.monterey.bottle.1.tar.gz
-# Error: The `brew link` step did not complete successfully
-# The formula built, but is not symlinked into /usr/local
-# Could not symlink bin/2to3
-# Target /usr/local/bin/2to3
-# is a symlink belonging to python@3.10. You can unlink it:
-#   brew unlink python@3.10
-#
-# To force the link and overwrite all conflicting files:
-#   brew link --overwrite python@3.11
-#
-# To list all files that would be deleted:
-#   brew link --overwrite --dry-run python@3.11
-#
-# Possible conflicting files are:
-# /usr/local/bin/2to3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/2to3
-# /usr/local/bin/idle3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/idle3
-# /usr/local/bin/pydoc3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/pydoc3
-# /usr/local/bin/python3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3
-# /usr/local/bin/python3-config -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3-config
-# /usr/local/share/man/man1/python3.1 -> /usr/local/Cellar/python@3.10/3.10.9/share/man/man1/python3.1
-# /usr/local/lib/pkgconfig/python3-embed.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3-embed.pc
-# /usr/local/lib/pkgconfig/python3.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3.pc
-# /usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Headers
-# /usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Python
-# /usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Resources
-# /usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/Current
-#
-# brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick
 brew install ghostscript
+# Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 
 echo "--- :rubygems: Setting up Gems"

--- a/.buildkite/commands/release-build-wordpress.sh
+++ b/.buildkite/commands/release-build-wordpress.sh
@@ -1,41 +1,9 @@
 #!/bin/bash -eu
 
 echo "--- :arrow_down: Installing Release Dependencies"
-# Disabled to hopefully work past the failure seen in
-# https://buildkite.com/automattic/wordpress-ios/builds/12513#01865ef3-8a38-4303-b028-bead44ee943d
-#
-# ==> Installing python@3.11
-# ==> Pouring python@3.11--3.11.2.monterey.bottle.1.tar.gz
-# Error: The `brew link` step did not complete successfully
-# The formula built, but is not symlinked into /usr/local
-# Could not symlink bin/2to3
-# Target /usr/local/bin/2to3
-# is a symlink belonging to python@3.10. You can unlink it:
-#   brew unlink python@3.10
-#
-# To force the link and overwrite all conflicting files:
-#   brew link --overwrite python@3.11
-#
-# To list all files that would be deleted:
-#   brew link --overwrite --dry-run python@3.11
-#
-# Possible conflicting files are:
-# /usr/local/bin/2to3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/2to3
-# /usr/local/bin/idle3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/idle3
-# /usr/local/bin/pydoc3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/pydoc3
-# /usr/local/bin/python3 -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3
-# /usr/local/bin/python3-config -> /usr/local/Cellar/python@3.10/3.10.9/bin/python3-config
-# /usr/local/share/man/man1/python3.1 -> /usr/local/Cellar/python@3.10/3.10.9/share/man/man1/python3.1
-# /usr/local/lib/pkgconfig/python3-embed.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3-embed.pc
-# /usr/local/lib/pkgconfig/python3.pc -> /usr/local/Cellar/python@3.10/3.10.9/lib/pkgconfig/python3.pc
-# /usr/local/Frameworks/Python.framework/Headers -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Headers
-# /usr/local/Frameworks/Python.framework/Python -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Python
-# /usr/local/Frameworks/Python.framework/Resources -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Resources
-# /usr/local/Frameworks/Python.framework/Versions/Current -> /usr/local/Cellar/python@3.10/3.10.9/Frameworks/Python.framework/Versions/Current
-#
-# brew update # Update homebrew to temporarily fix a bintray issue
 brew install imagemagick
 brew install ghostscript
+# Sentry CLI needs to be up-to-date
 brew upgrade sentry-cli
 
 echo "--- :rubygems: Setting up Gems"


### PR DESCRIPTION
We added this back in the day to address a Bintray issue that prevented Homebrew from installing dependencies. See 3a1c00c7bd25483b0f0e6940bd449a01793ca441 and https://github.com/wordpress-mobile/WordPress-iOS/pull/16373

The fix hasn't been required for a long time but the operation never gave us any trouble until some weeks ago, see 78fcc6f3ce6c419de9c3a375c66a4ade96c8906f.

Now it's a good time to go back and cleanup.

## Testing

If CI is successful, in particular the installable builds, this change will be safe to merge.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**
