### PR TITLE
Only attempt to display overlay after blog list is dismissed

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -825,8 +825,10 @@ class MySiteViewController: UIViewController, NoResultsViewHost {
             self.updateChildViewController(for: blog)
             self.createFABIfNeeded()
             self.fetchPrompt(for: blog)
+        }
 
-            self.displayJetpackInstallOverlayIfNeeded()
+        sitePickerViewController.onBlogListDismiss = { [weak self] in
+            self?.displayJetpackInstallOverlayIfNeeded()
         }
 
         return sitePickerViewController

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SitePickerViewController.swift
@@ -15,6 +15,7 @@ final class SitePickerViewController: UIViewController {
     var siteIconPresenter: SiteIconPickerPresenter?
     var siteIconPickerPresenter: SiteIconPickerPresenter?
     var onBlogSwitched: ((Blog) -> Void)?
+    var onBlogListDismiss: (() -> Void)?
 
     let meScenePresenter: ScenePresenter
     let blogService: BlogService
@@ -125,7 +126,9 @@ extension SitePickerViewController: BlogDetailHeaderViewDelegate {
                 return
             }
             self?.switchToBlog(blog)
-            controller?.dismiss(animated: true)
+            controller?.dismiss(animated: true) {
+                self?.onBlogListDismiss?()
+            }
         }
 
         let navigationController = UINavigationController(rootViewController: blogListController)


### PR DESCRIPTION
Fixes: #20319

## Description

The overlay tries to present itself before the blog list view controller is dismissed causing it to not show. This changes the behavior to wait until the blog list is dismissed and then present the overlay.

## Testing

To test:

- Setup a self-hosted site with just a single Jetpack plugin and it connected to your WordPress account
- Launch the app and login
- Select a site other than the self-hosted site (If the overlay is displayed once, it doesn't appear again)
- Open the site picker
- Switch to the self-hosted site you just created
- **Verify** the overlay displays properly

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
