### PR TITLE
Enable forum support for all on WordPress

### DIFF
--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -4,22 +4,15 @@ enum SupportConfiguration {
     case zendesk
     case forum
 
-    private static func hasSiteWithPaidPlan() -> Bool {
-        let allBlogs = (try? BlogQuery().blogs(in: ContextManager.sharedInstance().mainContext)) ?? []
-        return allBlogs.contains { $0.hasPaidPlan }
-    }
-
     static func current(
         featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
         isWordPress: Bool = AppConfiguration.isWordPress,
-        zendeskEnabled: Bool = ZendeskUtils.zendeskEnabled,
-        hasPaidPlan: Bool = hasSiteWithPaidPlan()
-    ) -> SupportConfiguration {
+        zendeskEnabled: Bool = ZendeskUtils.zendeskEnabled) -> SupportConfiguration {
         guard zendeskEnabled else {
             return .forum
         }
 
-        if isWordPress && !hasPaidPlan && featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) {
+        if isWordPress && featureFlagStore.value(for: FeatureFlag.wordPressSupportForum) {
             return .forum
         } else {
             return .zendesk

--- a/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
+++ b/WordPress/WordPressTest/Support/SupportConfigurationTests.swift
@@ -8,56 +8,41 @@ final class SupportConfigurationTests: XCTestCase {
         XCTAssertEqual(configuration, .forum)
     }
 
-    func testSupportConfigurationWhenWordPressWithFreePlanAndFeatureFlagEnabled() {
+    func testSupportConfigurationWhenWordPressWithFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: true,
-            zendeskEnabled: true,
-            hasPaidPlan: false
+            zendeskEnabled: true
         )
 
         XCTAssertTrue(configuration == .forum)
     }
 
-    func testSupportConfigurationWhenWordPressWithFreePlanAndFeatureFlagDisabled() {
+    func testSupportConfigurationWhenWordPressWithFeatureFlagDisabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
             isWordPress: true,
-            zendeskEnabled: true,
-            hasPaidPlan: false
+            zendeskEnabled: true
         )
 
         XCTAssertTrue(configuration == .zendesk)
     }
 
-    func testSupportConfigurationWhenWordPressWithPaidPlanAndFeatureFlagEnabled() {
-        let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
-            isWordPress: true,
-            zendeskEnabled: true,
-            hasPaidPlan: true
-        )
-
-        XCTAssertTrue(configuration == .zendesk)
-    }
-
-    func testSupportConfigurationWhenJetpackWithFreePlanAndFeatureFlagEnabled() {
+    func testSupportConfigurationWhenJetpackWithFeatureFlagEnabled() {
         let configuration = SupportConfiguration.current(
             featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
             isWordPress: false,
-            zendeskEnabled: true,
-            hasPaidPlan: false
+            zendeskEnabled: true
         )
 
         XCTAssertTrue(configuration == .zendesk)
     }
 
-    func testSupportConfigurationWhenJetpackWithPaidPlanAndFeatureFlagEnabled() {
+    func testSupportConfigurationWhenJetpackWithFeatureFlagDisabled() {
         let configuration = SupportConfiguration.current(
-            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: true),
+            featureFlagStore: RemoteFeatureFlagStoreMock(isSupportForumEnabled: false),
             isWordPress: false,
-            zendeskEnabled: true,
-            hasPaidPlan: true
+            zendeskEnabled: true
         )
 
         XCTAssertTrue(configuration == .zendesk)


### PR DESCRIPTION
Enable showing forum for all

Fixes: #20240

|Before |After|
|-|-|
|<img width="400" alt="image" src="https://user-images.githubusercontent.com/4062343/225298157-7783b9cc-2e11-47b8-bb5c-fc81ff6a78b8.png">|<img width="400" alt="image" src="https://user-images.githubusercontent.com/4062343/225298364-04c70a1e-3866-48d2-9f3b-ae3f6a3316ea.png"> |

## To test

D104827-code

Note: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags?platform=ios&marketing_version=21.9 `wordpress_support_forum_remote_field` value should be `true` 

**WordPress**
1. Launch the WP app and log in.
2. Ensure you have selected a site with a paid plan.
3. Navigate to "Me → Help & Support".
4. Verify that  only Community forums is shown.
5. Tap the various options and ensure they're all working

**Jetpack** 
Repeat the tests above on Jetpack app. You should see only "Contact Support" for both cases.

## Regression Notes
1. Potential unintended areas of impact
check with both free and paid plans

2. What I did to test those areas of impact (or what existing automated tests I relied on)
manual testing

3. What automated tests I added (or what prevented me from doing so)
none

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.