### PR TITLE
Jetpack Focus: Introduce new Static Screens phase

### DIFF
--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -48,7 +48,7 @@ class RootViewCoordinator {
          windowManager: WindowManager?) {
         self.featureFlagStore = featureFlagStore
         self.windowManager = windowManager
-        if Self.shouldEnableJetpackFeatures(featureFlagStore: featureFlagStore) {
+        if Self.shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: featureFlagStore) {
             self.currentAppUIType = .normal
             self.rootViewPresenter = WPTabBarController()
         }
@@ -64,7 +64,7 @@ class RootViewCoordinator {
     // MARK: JP Features State
 
     /// Used to determine if the Jetpack features are enabled based on the removal phase.
-    private static func shouldEnableJetpackFeatures(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
+    private static func shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {
         case .four, .newUsers, .selfHosted:
@@ -84,7 +84,7 @@ class RootViewCoordinator {
     /// - Returns: Boolean value describing whether the UI was reloaded or not.
     @discardableResult
     func reloadUIIfNeeded(blog: Blog?) -> Bool {
-        let newUIType: AppUIType = Self.shouldEnableJetpackFeatures(featureFlagStore: featureFlagStore) ? .normal : .simplified
+        let newUIType: AppUIType = Self.shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: featureFlagStore) ? .normal : .simplified
         let oldUIType = currentAppUIType
         guard newUIType != oldUIType, let windowManager else {
             return false

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -63,7 +63,7 @@ class RootViewCoordinator {
 
     // MARK: JP Features State
 
-    /// Used to determine if the Jetpack features are enabled based on the removal phase.
+    /// Used to determine if the Jetpack features are to be displayed or not based on the removal phase.
     private static func shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -43,6 +43,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackFeaturesRemovalPhaseFour
     case jetpackFeaturesRemovalPhaseNewUsers
     case jetpackFeaturesRemovalPhaseSelfHosted
+    case jetpackFeaturesRemovalStaticPosters
     case wordPressSupportForum
     case jetpackIndividualPluginSupport
     case blaze
@@ -142,6 +143,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return false
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return false
+        case .jetpackFeaturesRemovalStaticPosters:
+            return false
         case .wordPressSupportForum:
             return true
         case .jetpackIndividualPluginSupport:
@@ -174,6 +177,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "jp_removal_new_users"
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return "jp_removal_self_hosted"
+        case .jetpackFeaturesRemovalStaticPosters:
+            return "jp_removal_static_posters"
         case .jetpackMigrationPreventDuplicateNotifications:
             return "prevent_duplicate_notifs_remote_field"
         case .wordPressSupportForum:
@@ -282,6 +287,8 @@ extension FeatureFlag {
             return "Jetpack Features Removal Phase For New Users"
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return "Jetpack Features Removal Phase For Self-Hosted Sites"
+        case .jetpackFeaturesRemovalStaticPosters:
+            return "Jetpack Features Removal Static Posters Phase"
         case .wordPressSupportForum:
             return "Provide support through a forum"
         case .jetpackIndividualPluginSupport:

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -288,7 +288,7 @@ extension FeatureFlag {
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return "Jetpack Features Removal Phase For Self-Hosted Sites"
         case .jetpackFeaturesRemovalStaticPosters:
-            return "Jetpack Features Removal Static Posters Phase"
+            return "Jetpack Features Removal Static Screens Phase"
         case .wordPressSupportForum:
             return "Provide support through a forum"
         case .jetpackIndividualPluginSupport:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -56,39 +56,39 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowStats() -> Bool {
-        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        return JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
     }
 
     @objc func shouldAddJetpackSection() -> Bool {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false
         }
         return blog.shouldShowJetpackSection
     }
 
     @objc func shouldAddGeneralSection() -> Bool {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false
         }
         return blog.shouldShowJetpackSection == false
     }
 
     @objc func shouldAddPersonalizeSection() -> Bool {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false
         }
         return blog.supports(.themeBrowsing) || blog.supports(.menus)
     }
 
     @objc func shouldAddSharingRow() -> Bool {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false
         }
         return blog.supports(.sharing)
     }
 
     @objc func shouldAddPeopleRow() -> Bool {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false
         }
         return blog.supports(.people)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -27,6 +27,8 @@ class JetpackBrandingCoordinator {
         case .two:
             fallthrough
         case .three:
+            fallthrough
+        case .staticScreens:
             return true
         default:
             return false

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -12,6 +12,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         case four
         case newUsers = "new_users"
         case selfHosted = "self_hosted"
+        case staticScreens = "static_screens"
 
         var frequencyConfig: OverlayFrequencyTracker.FrequencyConfig {
             switch self {
@@ -99,6 +100,9 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseFour) {
             return .four
         }
+        if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalStaticPosters) {
+            return .staticScreens
+        }
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseThree) {
             return .three
         }
@@ -118,7 +122,8 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         }
 
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseNewUsers)
-            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseFour) {
+            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseFour)
+            || featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalStaticPosters) {
             return .two
         }
         if featureFlagStore.value(for: FeatureFlag.jetpackFeaturesRemovalPhaseThree)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingVisibility.swift
@@ -16,7 +16,7 @@ enum JetpackBrandingVisibility {
             return AppConfiguration.isWordPress &&
             AccountHelper.isDotcomAvailable() &&
             FeatureFlag.jetpackPowered.enabled &&
-            JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+            JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
         case .wordPressApp:
             return AppConfiguration.isWordPress
         case .dotcomAccounts:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Menu Card/JetpackBrandingMenuCardPresenter.swift
@@ -62,7 +62,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(featureFlagStore: featureFlagStore)
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures(featureFlagStore: featureFlagStore)
         switch (phase, jetpackFeaturesEnabled) {
         case (.three, true):
             return true
@@ -77,7 +77,7 @@ class JetpackBrandingMenuCardPresenter {
         guard isCardEnabled() else {
             return false
         }
-        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled(featureFlagStore: featureFlagStore)
+        let jetpackFeaturesEnabled = JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures(featureFlagStore: featureFlagStore)
         switch (phase, jetpackFeaturesEnabled) {
         case (.four, false):
             fallthrough

--- a/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
+++ b/WordPress/WordPressTest/JetpackBrandingMenuCardPresenterTests.swift
@@ -232,6 +232,7 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
         remoteFeatureFlagsStore.removalPhaseFour = false
         remoteFeatureFlagsStore.removalPhaseNewUsers = false
         remoteFeatureFlagsStore.removalPhaseSelfHosted = false
+        remoteFeatureFlagsStore.removalPhaseStaticScreens = false
 
         // Set phase
         switch phase {
@@ -249,6 +250,8 @@ final class JetpackBrandingMenuCardPresenterTests: CoreDataTestCase {
             remoteFeatureFlagsStore.removalPhaseNewUsers = true
         case .selfHosted:
             remoteFeatureFlagsStore.removalPhaseSelfHosted = true
+        case .staticScreens:
+            remoteFeatureFlagsStore.removalPhaseStaticScreens = true
         }
     }
 }

--- a/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
+++ b/WordPress/WordPressTest/RemoteFeatureFlagStoreMock.swift
@@ -9,6 +9,7 @@ class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
     var removalPhaseFour = false
     var removalPhaseNewUsers = false
     var removalPhaseSelfHosted = false
+    var removalPhaseStaticScreens = false
 
     override func value(for flag: OverrideableFlag) -> Bool {
         guard let flag = flag as? WordPress.FeatureFlag else {
@@ -27,6 +28,8 @@ class RemoteFeatureFlagStoreMock: RemoteFeatureFlagStore {
             return removalPhaseNewUsers
         case .jetpackFeaturesRemovalPhaseSelfHosted:
             return removalPhaseSelfHosted
+        case .jetpackFeaturesRemovalStaticPosters:
+            return removalPhaseStaticScreens
         default:
             return super.value(for: flag)
         }


### PR DESCRIPTION
Closes #20329

## Description
This PR introduces a new "Static Screens" phase. Some aspects of the phase are implemented, but the main tasks of showing static screens in Stats, Reader, and Notifications are yet to come.


## Testing Instructions

1. Install the WordPress app
2. From the debug menu, enable the "Jetpack Features Removal Static Screens Phase" feature flag
3. Go back to My Site
4. Close and reopen the app
5. Make sure that the dashboard is not available
6. Make sure that the tab bar is available and Stats, Reader, and Notifications are accessible
7. Make sure that Sub-features like Activity Log are accessible
8. Make sure that no cards are added to the menu
9. Try creating a site, make sure that the flow is disabled and you're shown an overlay pointing to the Jetpack app
10. Add a Stats widget to your home screen
11. Tap the widget
12. Make sure the app opens, but an overlay is not displayed
13. Open the editor, and make sure that JP-powered blocks are not available (Check #19691 for a full list)

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.