### PR TITLE
Jetpack Focus: Add new strings in banners and badges for the static screens phase

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -34,7 +34,7 @@ struct JetpackBrandingTextProvider {
         case .three:
             return phaseThreeText()
         case .staticScreens:
-            return phaseStaticScreensText()
+            return Strings.phaseStaticScreensText
         default:
             return Strings.defaultText
         }
@@ -61,15 +61,6 @@ struct JetpackBrandingTextProvider {
         }
 
         return String(format: movingInString, featureName, dateString)
-    }
-
-    private func phaseStaticScreensText() -> String {
-        guard let screen = screen, let featureName = screen.featureName else {
-            return Strings.defaultText // Screen not provided, or was opted out by defining a nil featureName
-        }
-
-        let stringFormat = isPlural ? Strings.phaseStaticScreensPluralTextFormat : Strings.phaseStaticScreensSingularTextFormat
-        return String(format: stringFormat, featureName)
     }
 
     private func dateString(now: Date, deadline: Date) -> String? {
@@ -119,21 +110,10 @@ private extension JetpackBrandingTextProvider {
         static let phaseThreeSingularMovingInText = NSLocalizedString("jetpack.branding.badge_banner.moving_in.singular",
                                                                       value: "%@ is moving in %@",
                                                                       comment: "Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks")
-        static let phaseStaticScreensPluralTextFormat = NSLocalizedString(
+        static let phaseStaticScreensText = NSLocalizedString(
             "jetpack.branding.badge_banner.moving_in_days.plural",
-            value: "%@ are moving in a few days",
-            comment: """
-            Title of a badge or banner indicating when a feature in plural form will be removed in a few days.
-            The '%@' part will be replaced with the feature name. Example: Menus are moving in a few days.
-            """
-        )
-        static let phaseStaticScreensSingularTextFormat = NSLocalizedString(
-            "jetpack.branding.badge_banner.moving_in_days.singular",
-            value: "%@ is moving in a few days",
-            comment: """
-            Title of a badge or banner indicating when a feature in singular form will be removed in a few days.
-            The '%@' part will be replaced with the feature name. Example: Activity is moving in a few days.
-            """
+            value: "Moving to the Jetpack app in a few days.",
+            comment: "Title of a badge or banner indicating that this feature will be moved in a few days."
         )
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -33,6 +33,8 @@ struct JetpackBrandingTextProvider {
             return Strings.phaseTwoText
         case .three:
             return phaseThreeText()
+        case .staticScreens:
+            return phaseStaticScreensText()
         default:
             return Strings.defaultText
         }
@@ -59,6 +61,15 @@ struct JetpackBrandingTextProvider {
         }
 
         return String(format: movingInString, featureName, dateString)
+    }
+
+    private func phaseStaticScreensText() -> String {
+        guard let screen = screen, let featureName = screen.featureName else {
+            return Strings.defaultText // Screen not provided, or was opted out by defining a nil featureName
+        }
+
+        let stringFormat = isPlural ? Strings.phaseStaticScreensPluralTextFormat : Strings.phaseStaticScreensSingularTextFormat
+        return String(format: stringFormat, featureName)
     }
 
     private func dateString(now: Date, deadline: Date) -> String? {
@@ -108,6 +119,22 @@ private extension JetpackBrandingTextProvider {
         static let phaseThreeSingularMovingInText = NSLocalizedString("jetpack.branding.badge_banner.moving_in.singular",
                                                                       value: "%@ is moving in %@",
                                                                       comment: "Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks")
+        static let phaseStaticScreensPluralTextFormat = NSLocalizedString(
+            "jetpack.branding.badge_banner.moving_in_days.plural",
+            value: "%@ are moving in a few days",
+            comment: """
+            Title of a badge or banner indicating when a feature in plural form will be removed in a few days.
+            The '%@' part will be replaced with the feature name. Example: Menus are moving in a few days.
+            """
+        )
+        static let phaseStaticScreensSingularTextFormat = NSLocalizedString(
+            "jetpack.branding.badge_banner.moving_in_days.singular",
+            value: "%@ is moving in a few days",
+            comment: """
+            Title of a badge or banner indicating when a feature in singular form will be removed in a few days.
+            The '%@' part will be replaced with the feature name. Example: Activity is moving in a few days.
+            """
+        )
     }
 
     private var isPlural: Bool {


### PR DESCRIPTION
Refs #20328
Depends on #20331

## Description

As titled, this adds a new string variation for both singular and plural variants to be displayed in the Jetpack banners and badges during the `static screens` phase.

## To test

- Launch the app, go to debug settings, and enable the static screens feature flag.
- Close the app and relaunch the app.
- Go to Activity Log from the Site menu.
- 🔎 Verify that the Jetpack banner is shown with the new string: `Moving to the Jetpack app in a few days.`

Since the change is centralized, verifying the change in one place should be enough. However, feel free to test other places too as you'd like 🙂 

## Regression Notes
1. Potential unintended areas of impact
Should be none. The new strings are only applied when the `staticScreens` phase is active.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
