### PR TITLE
Hide banners and badges for main Jetpack features (draft)

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -34,17 +34,4 @@ class JetpackBrandingCoordinator {
             return false
         }
     }
-
-    /// Determines if the Jetpack banner or badge should be shown for Stats, Reader, or Notifications.
-    ///
-    /// - Returns: true if we should show the banner or badge.
-    static func shouldShowBannerOrBadgeForMainFeatures() -> Bool {
-        let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
-        switch phase {
-        case .two, .three:
-            return true
-        default:
-            return false
-        }
-    }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackBrandingCoordinator.swift
@@ -34,4 +34,17 @@ class JetpackBrandingCoordinator {
             return false
         }
     }
+
+    /// Determines if the Jetpack banner or badge should be shown for Stats, Reader, or Notifications.
+    ///
+    /// - Returns: true if we should show the banner or badge.
+    static func shouldShowBannerOrBadgeForMainFeatures() -> Bool {
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase()
+        switch phase {
+        case .two, .three:
+            return true
+        default:
+            return false
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -509,7 +509,7 @@ private extension NotificationSettingsViewController {
         var showBadge: Bool {
             switch self {
             case .blog:
-                return JetpackBrandingVisibility.all.enabled && JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures()
+                return JetpackBrandingVisibility.all.enabled && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
             default:
                 return false
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -509,7 +509,7 @@ private extension NotificationSettingsViewController {
         var showBadge: Bool {
             switch self {
             case .blog:
-                return JetpackBrandingVisibility.all.enabled
+                return JetpackBrandingVisibility.all.enabled && JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures()
             default:
                 return false
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -632,7 +632,8 @@ extension NotificationsViewController {
     /// Called on view load to determine whether the Jetpack banner should be shown on the view
     /// Also called in the completion block of the JetpackLoginViewController to show the banner once the user connects to a .com account
     func configureJetpackBanner() {
-        guard JetpackBrandingVisibility.all.enabled else {
+        guard JetpackBrandingVisibility.all.enabled,
+              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
             return
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.notifications)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -633,7 +633,7 @@ extension NotificationsViewController {
     /// Also called in the completion block of the JetpackLoginViewController to show the banner once the user connects to a .com account
     func configureJetpackBanner() {
         guard JetpackBrandingVisibility.all.enabled,
-              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
+              JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
             return
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.notifications)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -116,7 +116,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         /// We used this method to show the Jetpack badge rather than setting `tableFooterView` because it scaled better with Dynamic type.
-        guard section == 0, JetpackBrandingVisibility.all.enabled else {
+        guard section == 0,
+              JetpackBrandingVisibility.all.enabled,
+              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
             return nil
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.readerDetail)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -118,7 +118,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         /// We used this method to show the Jetpack badge rather than setting `tableFooterView` because it scaled better with Dynamic type.
         guard section == 0,
               JetpackBrandingVisibility.all.enabled,
-              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
+              JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
             return nil
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBadgeScreen.readerDetail)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -532,7 +532,7 @@ import Combine
         }
 
         guard JetpackBrandingVisibility.all.enabled,
-              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
+              JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
             return
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.reader)

--- a/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderStreamViewController.swift
@@ -531,7 +531,8 @@ import Combine
             return
         }
 
-        guard JetpackBrandingVisibility.all.enabled else {
+        guard JetpackBrandingVisibility.all.enabled,
+              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
             return
         }
         let textProvider = JetpackBrandingTextProvider(screen: JetpackBannerScreen.reader)

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -114,7 +114,7 @@ class SiteStatsDashboardViewController: UIViewController {
 
     func configureJetpackBanner() {
         guard JetpackBrandingVisibility.all.enabled,
-              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
+              JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
             jetpackBannerView.removeFromSuperview()
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -113,7 +113,8 @@ class SiteStatsDashboardViewController: UIViewController {
     }
 
     func configureJetpackBanner() {
-        guard JetpackBrandingVisibility.all.enabled else {
+        guard JetpackBrandingVisibility.all.enabled,
+              JetpackBrandingCoordinator.shouldShowBannerOrBadgeForMainFeatures() else {
             jetpackBannerView.removeFromSuperview()
             return
         }


### PR DESCRIPTION
Depends on #20332

## Description

> **Note**:
> Depending on how the static screens will be shown, we might not need this PR and this can be discarded.

During the `static screens` phase, we'll display a static screen in Stats, Reader, and Notifications. However, in phase three we are still showing banners and badges within these features.

This PR prevents banners and badges from showing in Stats, Reader, and Notifications after phase three.

## To test

### Banners and badges in phase 3 should be visible

- Launch the WordPress app.
- Go to the Stats screen from the Site Menu.
- 🔎 Verify that the Jetpack banner is visible.
- Go to the Reader tab. 
- 🔎 Verify that the Jetpack banner is visible.
- Tap any Reader post, and scroll down to the comments section.
- 🔎 Verify that the Jetpack badge is visible.
- Go to the Notifications tab.
- 🔎 Verify that the Jetpack banner is visible.
- Go to Notification Settings.
- 🔎 Verify that the Jetpack badge is visible.

### Banners and badges should be hidden during static screens phase

- Go to debug settings, and enable the static screens feature flag.
- Close the app.
- 🔁  Go through the steps from the previous section, this time verifying that the banners & badges should NOT be visible.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
