### PR TITLE
Jetpack Focus: Add reusable static poster screen for removed features

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/UIColor+MurielColors.swift
@@ -79,6 +79,9 @@ extension UIColor {
     class func warning(_ shade: MurielColorShade) -> UIColor {
         return muriel(color: .warning, shade)
     }
+
+    /// Muriel jetpack green color
+    static var jetpackGreen = muriel(color: .jetpackGreen)
 }
 
 // MARK: - Grays

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -22,7 +22,6 @@ final class MovedToJetpackViewController: UIViewController {
         /// Configure spacing
         stackView.spacing = Metrics.stackViewSpacing
         stackView.setCustomSpacing(Metrics.hintToJetpackButtonSpacing, after: hintLabel)
-        stackView.setCustomSpacing(Metrics.buttonSpacing, after: jetpackButton)
 
         return stackView
     }()
@@ -194,7 +193,6 @@ extension MovedToJetpackViewController {
         static let stackViewMargin: CGFloat = 30
         static let stackViewSpacing: CGFloat = 20
         static let hintToJetpackButtonSpacing: CGFloat = 40
-        static let buttonSpacing: CGFloat = 10
         static let buttonHeight: CGFloat = 50
         static let externalIconSize = CGSize(width: 16, height: 16)
         static let externalIconBounds = CGRect(x: 0, y: -2, width: 16, height: 16)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -1,0 +1,188 @@
+import UIKit
+import Lottie
+
+final class MovedToJetpackViewController: UIViewController {
+
+    // MARK: - Subviews
+
+    private lazy var stackView: UIStackView = {
+        let subviews = [
+            animationContainerView,
+            titleLabel,
+            descriptionLabel,
+            hintLabel,
+            jetpackButton,
+            learnMoreButton
+        ]
+        let stackView = UIStackView(arrangedSubviews: subviews)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.alignment = .leading
+
+        /// Configure spacing
+        stackView.spacing = Metrics.stackViewSpacing
+        stackView.setCustomSpacing(Metrics.hintToJetpackButtonSpacing, after: hintLabel)
+        stackView.setCustomSpacing(Metrics.buttonSpacing, after: jetpackButton)
+
+        return stackView
+    }()
+
+    private lazy var animationContainerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        /// Configure constraints
+        view.addSubview(animationView)
+        view.pinSubviewToAllEdges(animationView)
+
+        return view
+    }()
+
+    private lazy var animationView: AnimationView = {
+        let animationView = AnimationView()
+        animationView.translatesAutoresizingMaskIntoConstraints = false
+        animationView.animation = animation
+        return animationView
+    }()
+
+    private lazy var titleLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = viewModel.title
+        label.font = WPStyleGuide.fontForTextStyle(.largeTitle, fontWeight: .bold)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 0
+        label.textColor = .text
+        return label
+    }()
+
+    private lazy var descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = viewModel.description
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 0
+        label.textColor = .text
+        return label
+    }()
+
+    private lazy var hintLabel: UILabel = {
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = viewModel.hint
+        label.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .regular)
+        label.adjustsFontForContentSizeCategory = true
+        label.adjustsFontSizeToFitWidth = true
+        label.numberOfLines = 0
+        label.textColor = .textSubtle
+        return label
+    }()
+
+    private lazy var jetpackButton: UIButton = {
+        let button = FancyButton()
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setTitle(viewModel.jetpackButtonTitle, for: .normal)
+        button.isPrimary = true
+        button.primaryNormalBackgroundColor = .jetpackGreen
+        button.primaryHighlightBackgroundColor = .muriel(color: .jetpackGreen, .shade80)
+        button.addTarget(self, action: #selector(jetpackButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    private lazy var learnMoreButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setAttributedTitle(learnMoreAttributedString(), for: .normal)
+        button.tintColor = .jetpackGreen
+        button.titleLabel?.font = WPStyleGuide.fontForTextStyle(.headline, fontWeight: .regular)
+        button.addTarget(self, action: #selector(learnMoreButtonTapped), for: .touchUpInside)
+        return button
+    }()
+
+    // MARK: - Properties
+
+    private let source: MovedToJetpackSource
+    private let viewModel: MovedToJetpackViewModel
+
+    /// Sets the animation based on the language orientation
+    private var animation: Animation? {
+        traitCollection.layoutDirection == .leftToRight ?
+        Animation.named(viewModel.animationLtr) :
+        Animation.named(viewModel.animationRtl)
+    }
+
+    // MARK: - Initializers
+
+    init(source: MovedToJetpackSource) {
+        self.source = source
+        self.viewModel = MovedToJetpackViewModel(source: source)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        // This VC is designed to be initialized programmatically.
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Lifecycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupView()
+        animationView.play()
+    }
+
+    // MARK: - Setup
+
+    private func setupView() {
+        view.backgroundColor = .basicBackground
+        view.addSubview(stackView)
+
+        NSLayoutConstraint.activate([
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.stackViewMargin),
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            jetpackButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
+            jetpackButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            jetpackButton.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),
+            learnMoreButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            learnMoreButton.centerXAnchor.constraint(equalTo: stackView.centerXAnchor)
+        ])
+    }
+
+    private func learnMoreAttributedString() -> NSAttributedString {
+        let externalAttachment = NSTextAttachment(image: UIImage.gridicon(.external, size: Metrics.externalIconSize).withTintColor(.jetpackGreen))
+        externalAttachment.bounds = Metrics.externalIconBounds
+        let attachmentString = NSAttributedString(attachment: externalAttachment)
+        let learnMoreText = NSMutableAttributedString(string: "\(viewModel.learnMoreButtonTitle) \u{FEFF}")
+        learnMoreText.append(attachmentString)
+        return NSAttributedString(attributedString: learnMoreText)
+    }
+
+    // MARK: - Button action
+
+    @objc private func jetpackButtonTapped() {
+        // TODO: Show Jetpack app
+    }
+
+    @objc private func learnMoreButtonTapped() {
+        // TODO: Show Jetpack support article
+    }
+
+}
+
+extension MovedToJetpackViewController {
+
+    private enum Metrics {
+        static let stackViewMargin: CGFloat = 30
+        static let stackViewSpacing: CGFloat = 20
+        static let hintToJetpackButtonSpacing: CGFloat = 40
+        static let buttonSpacing: CGFloat = 10
+        static let buttonHeight: CGFloat = 50
+        static let externalIconSize = CGSize(width: 16, height: 16)
+        static let externalIconBounds = CGRect(x: 0, y: -2, width: 16, height: 16)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -130,11 +130,18 @@ final class MovedToJetpackViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        navigationController?.delegate = self
         setupView()
         animationView.play()
     }
 
-    // MARK: - Setup
+    // MARK: - Navigation overrides
+
+    override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        return .portrait
+    }
+
+    // MARK: - View setup
 
     private func setupView() {
         view.backgroundColor = .basicBackground
@@ -179,7 +186,19 @@ final class MovedToJetpackViewController: UIViewController {
         let navigationController = UINavigationController(rootViewController: webViewController)
         self.present(navigationController, animated: true)
     }
+}
 
+// MARK: - UINavigationControllerDelegate
+
+extension MovedToJetpackViewController: UINavigationControllerDelegate {
+
+    func navigationControllerSupportedInterfaceOrientations(_ navigationController: UINavigationController) -> UIInterfaceOrientationMask {
+        return supportedInterfaceOrientations
+    }
+
+    func navigationControllerPreferredInterfaceOrientationForPresentation(_ navigationController: UINavigationController) -> UIInterfaceOrientation {
+        return .portrait
+    }
 }
 
 extension MovedToJetpackViewController {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -165,16 +165,30 @@ final class MovedToJetpackViewController: UIViewController {
     // MARK: - Button action
 
     @objc private func jetpackButtonTapped() {
-        // TODO: Show Jetpack app
+        // Try to export WordPress data to a shared location before redirecting the user.
+        ContentMigrationCoordinator.shared.startAndDo { _ in
+            JetpackRedirector.redirectToJetpack()
+        }
     }
 
     @objc private func learnMoreButtonTapped() {
-        // TODO: Show Jetpack support article
+        guard let url = URL(string: Constants.learnMoreButtonURL) else {
+            return
+        }
+
+        let webViewController = WebViewControllerFactory.controller(url: url, source: Constants.learnMoreWebViewSource)
+        let navigationController = UINavigationController(rootViewController: webViewController)
+        self.present(navigationController, animated: true)
     }
 
 }
 
 extension MovedToJetpackViewController {
+
+    private enum Constants {
+        static let learnMoreButtonURL = "https://jetpack.com/support/switch-to-the-jetpack-app/"
+        static let learnMoreWebViewSource = "jp_removal_static_poster"
+    }
 
     private enum Metrics {
         static let stackViewMargin: CGFloat = 30

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewModel.swift
@@ -75,43 +75,43 @@ extension MovedToJetpackViewModel {
     private enum Strings {
 
         static let statsTitle = NSLocalizedString(
-            "getJetpackApp.stats.title",
+            "movedToJetpack.stats.title",
             value: "Stats have moved to the Jetpack app.",
             comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
         )
 
         static let readerTitle = NSLocalizedString(
-            "getJetpackApp.reader.title",
+            "movedToJetpack.reader.title",
             value: "Reader has moved to the Jetpack app.",
             comment: "Title for the static screen displayed in the Reader screen prompting users to switch to the Jetpack app."
         )
 
         static let notificationsTitle = NSLocalizedString(
-            "getJetpackApp.notifications.title",
+            "movedToJetpack.notifications.title",
             value: "Notifications have moved to the Jetpack app.",
             comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
         )
 
         static let description = NSLocalizedString(
-            "getJetpackApp.description",
+            "movedToJetpack.description",
             value: "Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app, and can now only be found in the Jetpack app.",
             comment: "Description for the static screen displayed prompting users to switch the Jetpack app."
         )
 
         static let hint = NSLocalizedString(
-            "getJetpackApp.hint",
+            "movedToJetpack.hint",
             value: "Switching is free and only takes a minute.",
             comment: "Hint for the static screen displayed prompting users to switch the Jetpack app."
         )
 
         static let jetpackButtonTitle = NSLocalizedString(
-            "getJetpackApp.jetpackButtonTitle",
+            "movedToJetpack.jetpackButtonTitle",
             value: "Switch to the Jetpack app",
             comment: "Title for a button that prompts users to switch to the Jetpack app."
         )
 
         static let learnMoreButtonTitle = NSLocalizedString(
-            "getJetpackApp.learnMoreButtonTitle",
+            "movedToJetpack.learnMoreButtonTitle",
             value: "Learn more at jetpack.com",
             comment: "Title for a button that displays a blog post in a web view."
         )

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewModel.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+@objc enum MovedToJetpackSource: Int {
+    case stats
+    case reader
+    case notifications
+}
+
+struct MovedToJetpackViewModel {
+
+    let source: MovedToJetpackSource
+
+    var animationLtr: String {
+        switch source {
+        case .stats:
+            return Constants.statsLogoAnimationLtr
+        case .reader:
+            return Constants.readerLogoAnimationLtr
+        case .notifications:
+            return Constants.notificationsLogoAnimationLtr
+        }
+    }
+
+    var animationRtl: String {
+        switch source {
+        case .stats:
+            return Constants.statsLogoAnimationRtl
+        case .reader:
+            return Constants.readerLogoAnimationRtl
+        case .notifications:
+            return Constants.notificationsLogoAnimationRtl
+        }
+    }
+
+    var title: String {
+        switch source {
+        case .stats:
+            return Strings.statsTitle
+        case .reader:
+            return Strings.readerTitle
+        case .notifications:
+            return Strings.notificationsTitle
+        }
+    }
+
+    var description: String {
+        return Strings.description
+    }
+
+    var hint: String {
+        return Strings.hint
+    }
+
+    var jetpackButtonTitle: String {
+        return Strings.jetpackButtonTitle
+    }
+
+    var learnMoreButtonTitle: String {
+        return Strings.learnMoreButtonTitle
+    }
+
+}
+
+extension MovedToJetpackViewModel {
+
+    private enum Constants {
+        static let statsLogoAnimationLtr = "JetpackStatsLogoAnimation_ltr"
+        static let statsLogoAnimationRtl = "JetpackStatsLogoAnimation_rtl"
+        static let readerLogoAnimationLtr = "JetpackReaderLogoAnimation_ltr"
+        static let readerLogoAnimationRtl = "JetpackReaderLogoAnimation_rtl"
+        static let notificationsLogoAnimationLtr = "JetpackNotificationsLogoAnimation_ltr"
+        static let notificationsLogoAnimationRtl = "JetpackNotificationsLogoAnimation_rtl"
+    }
+
+    private enum Strings {
+
+        static let statsTitle = NSLocalizedString(
+            "getJetpackApp.stats.title",
+            value: "Stats have moved to the Jetpack app.",
+            comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
+        )
+
+        static let readerTitle = NSLocalizedString(
+            "getJetpackApp.reader.title",
+            value: "Reader has moved to the Jetpack app.",
+            comment: "Title for the static screen displayed in the Reader screen prompting users to switch to the Jetpack app."
+        )
+
+        static let notificationsTitle = NSLocalizedString(
+            "getJetpackApp.notifications.title",
+            value: "Notifications have moved to the Jetpack app.",
+            comment: "Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app."
+        )
+
+        static let description = NSLocalizedString(
+            "getJetpackApp.description",
+            value: "Stats, Reader, Notifications and other Jetpack powered features have been removed from the WordPress app, and can now only be found in the Jetpack app.",
+            comment: "Description for the static screen displayed prompting users to switch the Jetpack app."
+        )
+
+        static let hint = NSLocalizedString(
+            "getJetpackApp.hint",
+            value: "Switching is free and only takes a minute.",
+            comment: "Hint for the static screen displayed prompting users to switch the Jetpack app."
+        )
+
+        static let jetpackButtonTitle = NSLocalizedString(
+            "getJetpackApp.jetpackButtonTitle",
+            value: "Switch to the Jetpack app",
+            comment: "Title for a button that prompts users to switch to the Jetpack app."
+        )
+
+        static let learnMoreButtonTitle = NSLocalizedString(
+            "getJetpackApp.learnMoreButtonTitle",
+            value: "Learn more at jetpack.com",
+            comment: "Title for a button that displays a blog post in a web view."
+        )
+
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3646,6 +3646,10 @@
 		FA20751527A86B73001A644D /* UIScrollView+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA20751327A86B73001A644D /* UIScrollView+Helpers.swift */; };
 		FA25FA212609AA9C0005E08F /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25F9FD2609AA830005E08F /* AppConfiguration.swift */; };
 		FA25FA342609AAAA0005E08F /* AppConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA25FA332609AAAA0005E08F /* AppConfiguration.swift */; };
+		FA332AD029C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA332ACF29C1F97A00182FBB /* MovedToJetpackViewController.swift */; };
+		FA332AD129C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA332ACF29C1F97A00182FBB /* MovedToJetpackViewController.swift */; };
+		FA332AD429C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA332AD329C1FC7A00182FBB /* MovedToJetpackViewModel.swift */; };
+		FA332AD529C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA332AD329C1FC7A00182FBB /* MovedToJetpackViewModel.swift */; };
 		FA347AED26EB6E300096604B /* GrowAudienceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA347AEB26EB6E300096604B /* GrowAudienceCell.swift */; };
 		FA347AEE26EB6E300096604B /* GrowAudienceCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA347AEB26EB6E300096604B /* GrowAudienceCell.swift */; };
 		FA347AEF26EB6E300096604B /* GrowAudienceCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = FA347AEC26EB6E300096604B /* GrowAudienceCell.xib */; };
@@ -8912,6 +8916,8 @@
 		FA25F9FD2609AA830005E08F /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		FA25FA332609AAAA0005E08F /* AppConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConfiguration.swift; sourceTree = "<group>"; };
 		FA2D12891BCED0AD006F2A15 /* WordPress 40.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 40.xcdatamodel"; sourceTree = "<group>"; };
+		FA332ACF29C1F97A00182FBB /* MovedToJetpackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovedToJetpackViewController.swift; sourceTree = "<group>"; };
+		FA332AD329C1FC7A00182FBB /* MovedToJetpackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovedToJetpackViewModel.swift; sourceTree = "<group>"; };
 		FA347AEB26EB6E300096604B /* GrowAudienceCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GrowAudienceCell.swift; sourceTree = "<group>"; };
 		FA347AEC26EB6E300096604B /* GrowAudienceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = GrowAudienceCell.xib; sourceTree = "<group>"; };
 		FA347AF126EB7A420096604B /* StatsGhostGrowAudienceCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = StatsGhostGrowAudienceCell.xib; sourceTree = "<group>"; };
@@ -11267,6 +11273,7 @@
 				3FFA5ED32876216700830E28 /* Button */,
 				3F43704228932EE900475B6E /* Coordinator */,
 				80535DB62946C74B00873161 /* Menu Card */,
+				FA332AD229C1F98000182FBB /* Get Jetpack App */,
 			);
 			path = Branding;
 			sourceTree = "<group>";
@@ -17278,6 +17285,15 @@
 			name = "App Configuration";
 			sourceTree = "<group>";
 		};
+		FA332AD229C1F98000182FBB /* Get Jetpack App */ = {
+			isa = PBXGroup;
+			children = (
+				FA332ACF29C1F97A00182FBB /* MovedToJetpackViewController.swift */,
+				FA332AD329C1FC7A00182FBB /* MovedToJetpackViewModel.swift */,
+			);
+			path = "Get Jetpack App";
+			sourceTree = "<group>";
+		};
 		FA4F65B52594589C00EAA9F5 /* Jetpack Restore */ = {
 			isa = PBXGroup;
 			children = (
@@ -20446,6 +20462,7 @@
 				175CC17C2723103000622FB4 /* WPAnalytics+Domains.swift in Sources */,
 				400A2C842217A985000A8A59 /* TopViewedVideoStatsRecordValue+CoreDataProperties.swift in Sources */,
 				7E4123BE20F4097B00DF8486 /* NotificationContentRangeFactory.swift in Sources */,
+				FA332AD429C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */,
 				E6D170371EF9D8D10046D433 /* SiteInfo.swift in Sources */,
 				E16A76F31FC4766900A661E3 /* CredentialsService.swift in Sources */,
 				F9B862C92478170A008B093C /* EncryptedLogTableViewController.swift in Sources */,
@@ -21885,6 +21902,7 @@
 				7E3E7A5B20E44D950075D159 /* RichTextContentStyles.swift in Sources */,
 				40A71C66220E1952002E3D25 /* StatsRecord+CoreDataProperties.swift in Sources */,
 				7E846FF120FD0A0500881F5A /* ContentCoordinator.swift in Sources */,
+				FA332AD029C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */,
 				E690F6F025E05D180015A777 /* InviteLinks+CoreDataProperties.swift in Sources */,
 				B54E1DF41A0A7BBF00807537 /* NotificationMediaDownloader.swift in Sources */,
 				D86572172186C3600023A99C /* WizardDelegate.swift in Sources */,
@@ -23125,6 +23143,7 @@
 				FABB20EF2602FC2C00C8785C /* QuickStartTourGuide.swift in Sources */,
 				FABB20F02602FC2C00C8785C /* ReaderDetailToolbar.swift in Sources */,
 				FABB20F12602FC2C00C8785C /* RecentSitesService.swift in Sources */,
+				FA332AD129C1F97A00182FBB /* MovedToJetpackViewController.swift in Sources */,
 				8BD66ED52787530C00CCD95A /* PostsCardViewModel.swift in Sources */,
 				FABB20F22602FC2C00C8785C /* PlanService.swift in Sources */,
 				FABB20F32602FC2C00C8785C /* Routes+Mbar.swift in Sources */,
@@ -23652,6 +23671,7 @@
 				FABB22772602FC2C00C8785C /* InlineEditableNameValueCell.swift in Sources */,
 				FABB22782602FC2C00C8785C /* TodayStatsRecordValue+CoreDataProperties.swift in Sources */,
 				FABB22792602FC2C00C8785C /* WPCrashLoggingProvider.swift in Sources */,
+				FA332AD529C1FC7A00182FBB /* MovedToJetpackViewModel.swift in Sources */,
 				FABB227A2602FC2C00C8785C /* StockPhotosMedia.swift in Sources */,
 				FABB227B2602FC2C00C8785C /* FancyAlertViewController+SavedPosts.swift in Sources */,
 				FABB227C2602FC2C00C8785C /* WPRichTextMediaAttachment.swift in Sources */,


### PR DESCRIPTION
Fixes #20330

## Description
This PR adds a reusable static poster screen for Stats, Reader, and Notification. 

## How to test

1. In `DashboardQuickActionsCardCell.swift`, replace `L72` with
```
            let movedToJetpackViewController = MovedToJetpackViewController(source: .stats)
            sourceController.navigationController?.pushViewController(movedToJetpackViewController, animated: true)
```
2. Build and run the WordPress app
3. On the My Site screen, switch to the dashboard tab
4. Tap on the Stats quick action cell (The small text cell at the top)
5. ✅ The static poster screen matches the designs (ref: qk5s4q4mZsXknwhMWo2vIY-fi-439%3A5242)
6. Repeat the above steps for the `.reader` and `.notifications` sources

Stats | Reader | Notifications
-- | -- | --
<img src="https://user-images.githubusercontent.com/6711616/225423708-44f29878-b907-4fba-a610-af1130b4dd79.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/225423775-3cf55377-cc2e-48df-a73a-1d2a470434c2.png" width=200> | <img src="https://user-images.githubusercontent.com/6711616/225423826-ecc6c0c2-cd36-4cfd-aa97-00584cf6bd9e.png" width=200>




## Regression Notes
1. Potential unintended areas of impact
n/a

7. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

8. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.