### PR TITLE
Fix inline notification prompt attempting to show when permission is already granted

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -22,6 +22,7 @@ extension NotificationsViewController {
         }
 
         AppRatingUtility.shared.userWasPromptedToReview()
+        WPAnalytics.track(.appReviewsSawPrompt)
     }
 
     private func likedApp() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+PushPrimer.swift
@@ -20,6 +20,8 @@ extension NotificationsViewController {
             case .denied:
                 self?.setupWinback()
             default:
+                // The user has already allowed notifications so we set the inline prompt to acknowledged so it isn't called anymore
+                UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
                 break
             }
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -2015,7 +2015,12 @@ extension NotificationsViewController: UIViewControllerTransitioningDelegate {
     }
 
     private func notificationAlertApproveAction(_ controller: FancyAlertViewController) {
-        InteractiveNotificationsManager.shared.requestAuthorization { _ in
+        InteractiveNotificationsManager.shared.requestAuthorization { allowed in
+            if allowed {
+                // User has allowed notifications so we don't need to show the inline prompt
+                UserPersistentStoreFactory.instance().notificationPrimerInlineWasAcknowledged = true
+            }
+
             DispatchQueue.main.async {
                 controller.dismiss(animated: true)
             }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1665,8 +1665,6 @@ internal extension NotificationsViewController {
         UIView.animate(withDuration: WPAnimationDurationDefault * 0.5, delay: WPAnimationDurationDefault * 0.75, options: .curveEaseIn, animations: {
             self.inlinePromptView.alpha = WPAlphaFull
         })
-
-        WPAnalytics.track(.appReviewsSawPrompt)
     }
 
     func hideInlinePrompt(delay: TimeInterval) {


### PR DESCRIPTION
Fixes #20337

## Description

- Fixes the notification inline prompt from always attempting to appear even when a user already granted notification permissions
- Moves the `appReviewsSawPrompt` analytic to the `setupAppRatings` function so it's more accurate. `showInlinePrompt` (where it was) is called with multiple different inline prompts (notification permission, winback notification permission, and reviews prompt)

## Testing

To test:

- Fresh install the app
- Login
- Select the `Notifications` tab
- When the notification dialog appears, hit `Allow`
- Set a breakpoint here: https://github.com/wordpress-mobile/WordPress-iOS/blob/3dfbb57c56a07b1bd224656f7f36398e78b2316a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift#L251
- Tap on another tab
- Switch back to `Notifications`
- **Verify** the breakpoint is not hit
- Move the breakpoint to the whole if condition
- Tap on another tab
- Switch back to `Notifications`
- **Verify** the app reviews condition is now being checked

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
