### PR TITLE
[Domain Purchasing] Fetch free and paid domains during site creation

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -661,6 +661,7 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
+    - WordPressKit
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -661,7 +661,6 @@ SPEC REPOS:
     - UIDeviceIdentifier
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
-    - WordPressKit
     - WordPressUI
     - WPMediaPicker
     - wpxmlrpc

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -51,6 +51,8 @@ final class DomainsServiceAdapter: SiteAddressService {
 
     // MARK: Properties
 
+    private let domainPurchasingEnabled = FeatureFlag.siteCreationDomainPurchasing.enabled
+
     /**
      Corresponds to:
 
@@ -112,11 +114,21 @@ final class DomainsServiceAdapter: SiteAddressService {
     }
 
     func addresses(for query: String, completion: @escaping SiteAddressServiceCompletion) {
+        let domainSuggestionType: DomainsServiceRemote.DomainSuggestionType = domainPurchasingEnabled
+        ? .freeAndPaid
+        : .wordPressDotComAndDotBlogSubdomains
         domainsService.getDomainSuggestions(query: query,
                                             quantity: domainRequestQuantity,
-                                            domainSuggestionType: .freeAndPaid,
+                                            domainSuggestionType: domainSuggestionType,
                                             success: { domainSuggestions in
-            completion(Result.success(self.sortSuggestions(for: query, suggestions: domainSuggestions)))
+            if self.domainPurchasingEnabled {
+                let hasExactMatch = domainSuggestions.contains { domain -> Bool in
+                    return domain.domainNameStrippingSubdomain.caseInsensitiveCompare(query) == .orderedSame
+                }
+                completion(Result.success(.init(hasExactMatch: hasExactMatch, domainSuggestions: domainSuggestions)))
+            } else {
+                completion(Result.success(self.sortSuggestions(for: query, suggestions: domainSuggestions)))
+            }
         },
                                             failure: { error in
             if (error as NSError).code == DomainsServiceAdapter.emptyResultsErrorCode {

--- a/WordPress/Classes/Services/SiteAddressService.swift
+++ b/WordPress/Classes/Services/SiteAddressService.swift
@@ -114,7 +114,7 @@ final class DomainsServiceAdapter: SiteAddressService {
     func addresses(for query: String, completion: @escaping SiteAddressServiceCompletion) {
         domainsService.getDomainSuggestions(query: query,
                                             quantity: domainRequestQuantity,
-                                            domainSuggestionType: .wordPressDotComAndDotBlogSubdomains,
+                                            domainSuggestionType: .freeAndPaid,
                                             success: { domainSuggestions in
             completion(Result.success(self.sortSuggestions(for: query, suggestions: domainSuggestions)))
         },

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressCell.swift
@@ -16,7 +16,7 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
 
     var model: DomainSuggestion? {
         didSet {
-            title.attributedText = AddressCell.processName(model?.domainName)
+            title.attributedText = AddressCell.processName(model)
         }
     }
 
@@ -72,6 +72,16 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
         }
     }
 
+    public static func processName(_ suggestion: DomainSuggestion?) -> NSAttributedString? {
+        guard let cost = suggestion?.costString,
+              let attributedString = AddressCell.processName(suggestion?.domainName) else {
+            return nil
+        }
+        let mutable = NSMutableAttributedString(attributedString: attributedString)
+        mutable.append(.init(string: " (\(cost))", attributes: TextStyleAttributes.defaults))
+        return mutable
+    }
+
     public static func processName(_ domainName: String?) -> NSAttributedString? {
         guard let name = domainName,
               let customName = name.components(separatedBy: ".").first else {
@@ -95,6 +105,6 @@ extension AddressCell {
     }
 
     func preferredContentSizeDidChange() {
-        title.attributedText = AddressCell.processName(model?.domainName)
+        title.attributedText = AddressCell.processName(model)
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Web Address/AddressCell.swift
@@ -77,6 +77,9 @@ final class AddressCell: UITableViewCell, ModelSettableCell {
               let attributedString = AddressCell.processName(suggestion?.domainName) else {
             return nil
         }
+        guard FeatureFlag.siteCreationDomainPurchasing.enabled else {
+            return attributedString
+        }
         let mutable = NSMutableAttributedString(attributedString: attributedString)
         mutable.append(.init(string: " (\(cost))", attributes: TextStyleAttributes.defaults))
         return mutable


### PR DESCRIPTION
Part of #20077

## Related PR
The following PR from WordPressKit repo should be reviewed as well:
- https://github.com/wordpress-mobile/WordPressKit-iOS/pull/585

## Description

This PR includes paid domains to `Site Creation` > `Domain Suggestions` screen. It also updates the UI of the domain suggestion table view cells, to indicate whether the domain is free or paid. Though the UI update is just for testing purposes.

**Note: The feature is still work in progress and the feature flag should never be enabled while the feature is still in this state.**

## Screenshots

| Before | After |
| ------ | ------ |
| ![](https://user-images.githubusercontent.com/9609223/225592734-e1ada41c-b022-407b-80ce-ab9020fa7fc2.png) | ![](https://user-images.githubusercontent.com/9609223/225592389-7ac1a4ad-78b4-498d-98b3-983c6d7abf17.png) |

## Test Instructions

#### Prerequisites:

<details><summary>Toggle the Site Creation Domain Purchasing feature (<code>Site Creation Domain Purchasing</code>)</summary>

1. Go to `Me` → `App Settings` → `Debug settings`
2. Scroll down until you find `Site Creation Domain Purchasing` flag.
4. Tap the switch on or off to toggle the `Site Creation Domain Purchasing` flag.
---
</details>

### Case 1: Feature Flag Disabled

1. Install the Jetpack app and login
2. Toggle the `Site Creation Domain Purchasing` feature flag `OFF`
3. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`
4. Continue the flow till `Choose a domain` screen
5. **Verify** free subdomains are suggested same as on trunk/beta/prod app

### Case 2: Feature Flag Enabled

1. Toggle the `Site Creation Domain Purchasing` feature flag `ON`
2. Start the Site Creation flow: `Open Site Picker` → `➕` → `Create WordPress.com site`
3. Continue the flow till `Choose a domain` screen
4. **Verify** free and paid domains are suggested

## Regression Notes
1. Potential unintended areas of impact
Domain suggestions screen with the domain purchasing feature flag disabled should be tested.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Existing unit tests should pass and manual testing.

3. What automated tests I added (or what prevented me from doing so)
None.

## Submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
