### PR TITLE
Add dynamic type support

### DIFF
--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
@@ -3,6 +3,7 @@ import WidgetKit
 
 @available(iOS 16.0, *)
 struct LockScreenSingleStatView: View {
+    @Environment(\.sizeCategory) var sizeCategory
     @Environment(\.widgetFamily) var family: WidgetFamily
     let viewModel: LockScreenSingleStatViewModel
 
@@ -13,18 +14,37 @@ struct LockScreenSingleStatView: View {
                 VStack(alignment: .leading) {
                     Text(viewModel.siteName)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.system(size: 11))
+                        .font(.caption2)
                         .minimumScaleFactor(0.8)
                         .lineLimit(1)
-                    Text(viewModel.value)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.system(size: 20, weight: .bold))
-                        .minimumScaleFactor(0.5)
-                        .foregroundColor(.white)
-                    Text("\(viewModel.title) \(viewModel.dateRange)")
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .font(.system(size: 11))
-                        .minimumScaleFactor(0.8)
+                    if sizeCategory <= ContentSizeCategory.large {
+                        VStack {
+                            Text(viewModel.value)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.title3)
+                                .minimumScaleFactor(0.5)
+                                .foregroundColor(.white)
+                            Text("\(viewModel.title) \(viewModel.dateRange)")
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .font(.caption2)
+                                .minimumScaleFactor(0.8)
+                        }
+                    } else {
+                        HStack {
+                            Text(viewModel.value)
+                                .font(.title3)
+                                .minimumScaleFactor(0.1)
+                                .foregroundColor(.white)
+                            VStack {
+                                Text(viewModel.title)
+                                    .font(.headline)
+                                    .minimumScaleFactor(0.5)
+                                Text(viewModel.dateRange)
+                                    .font(.headline)
+                                    .minimumScaleFactor(0.5)
+                            }
+                        }
+                    }
                 }
                 .padding(
                     EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8)
@@ -41,7 +61,7 @@ struct LockScreenSingleStatView_Previews: PreviewProvider {
     static let viewModel = LockScreenSingleStatViewModel(
         siteName: "My WordPress Site",
         title: "Views",
-        value: "649",
+        value: 649123.abbreviatedString(),
         dateRange: "Today",
         updatedTime: Date()
     )


### PR DESCRIPTION
This PR is for improving the comments for previous PR https://github.com/wordpress-mobile/WordPress-iOS/pull/20312
1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved) 
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (TBD) 👈 you're here!
- Add dynamic type support and change layout if needed
- Raise and track the discussion about localization concerns and dynamic-type support
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved)
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved)
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved)
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)

## Description
To add dynamic type support to the widget view, we need
- First, replace the fixed-size font with the dynamic font. I chose the font with the same size as the design based on the [typography document](https://developer.apple.com/design/human-interface-guidelines/foundations/typography#specifications).

- Second, add a horizontal layout for the size category larger than large, as we discussed in [PR #20312 ](https://github.com/wordpress-mobile/WordPress-iOS/pull/20312). The existing font already be the maximum font size, so I change the layout to get available spaces as the temporary solution, and I will compose a post to clarify with the design team in the meanwhile.
<img width="593" alt="image" src="https://user-images.githubusercontent.com/3096210/225609863-3a8af52d-06be-418c-a7fc-2e359ba19fa2.png">

## Testing instructions
Given added the widget to the lock screen, changed the size category in Settings > Display and Brightness > Text Size
The font size and layout should be changed based on the font size (the result could refer to the above preview screenshot)

## Regression Notes
1. Potential unintended areas of impact
The UI representation for today views the widget in the lock screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Check the design is still good (I will double confirm with the designer)

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
