### PR TITLE
Jetpack Focus: Wrap static screen in scrollview

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -27,7 +27,7 @@ final class MovedToJetpackViewController: UIViewController {
         NSLayoutConstraint.activate([
             stackView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: Metrics.stackViewMargin),
             stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Metrics.stackViewMargin),
+            stackView.leadingAnchor.constraint(equalTo: view.readableContentGuide.leadingAnchor, constant: Metrics.stackViewMargin),
             stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
 
@@ -248,7 +248,7 @@ extension MovedToJetpackViewController {
     }
 
     private enum Metrics {
-        static let stackViewMargin: CGFloat = 30
+        static let stackViewMargin: CGFloat = 20
         static let stackViewSpacing: CGFloat = 20
         static let hintToJetpackButtonSpacing: CGFloat = 40
         static let buttonHeight: CGFloat = 50

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -5,6 +5,35 @@ final class MovedToJetpackViewController: UIViewController {
 
     // MARK: - Subviews
 
+    private lazy var scrollView: UIScrollView = {
+        let scrollView = UIScrollView()
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.bounces = false
+
+        /// Configure constraints
+        scrollView.addSubview(containerView)
+        scrollView.pinSubviewToAllEdges(containerView)
+
+        return scrollView
+    }()
+
+    private lazy var containerView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        /// Configure constraints
+        view.addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(greaterThanOrEqualTo: view.topAnchor, constant: Metrics.stackViewMargin),
+            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: Metrics.stackViewMargin),
+            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+
+        return view
+    }()
+
     private lazy var stackView: UIStackView = {
         let subviews = [
             animationContainerView,
@@ -152,12 +181,12 @@ final class MovedToJetpackViewController: UIViewController {
 
     private func setupView() {
         view.backgroundColor = .basicBackground
-        view.addSubview(stackView)
+        view.addSubview(scrollView)
+        view.pinSubviewToAllEdges(scrollView)
 
         NSLayoutConstraint.activate([
-            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: Metrics.stackViewMargin),
-            stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            containerView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            containerView.heightAnchor.constraint(greaterThanOrEqualTo: view.heightAnchor, constant: 0),
             jetpackButton.heightAnchor.constraint(equalToConstant: Metrics.buttonHeight),
             jetpackButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
             jetpackButton.centerXAnchor.constraint(equalTo: stackView.centerXAnchor),


### PR DESCRIPTION
Part of #20330 

## Description
This PR wraps the content of the "Moved to Jetpack" static screen in a scrollview, to handle cases where the content height becomes taller than the screen height due to text size etc.

## How to test
1. In `MovedToJetpackViewController.swift`, expose the init method to Obj-C by annotating it with `@objc` (I intentionally didn't commit this change in order to avoid conficts w other PRs)
2. In `BlogDetailsViewController.m`, replace `L1671` with
```
    MovedToJetpackViewController *controller = [[MovedToJetpackViewController alloc] initWithSource:MovedToJetpackSourceReader];
```
3. Build and run the WordPress app
4. On the My Site screen, switch to the site menu tab if needed
5. Tap on "Activity Log"
6. ✅ The static screen matches the design
7. Rotate the device to landscape orientation
8. ✅ The static screen is scrollable


https://user-images.githubusercontent.com/6711616/225653082-13f566a7-fc95-4b6b-81b4-21b57906b0c6.mp4



## Regression Notes
1. Potential unintended areas of impact
Static screen design

9. What I did to test those areas of impact (or what existing automated tests I relied on)
Confirmed changes don't cause a regression for portrait orientation

10. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
