### PR TITLE
Jetpack Focus: Replace Reader and Notification with static tabs

### DIFF
--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -65,7 +65,7 @@ class RootViewCoordinator {
 
     // MARK: JP Features State
 
-    /// Used to determine if the expected app UI type based on the removal phase.
+    /// Used to determine the expected app UI type based on the removal phase.
     private static func appUIType(featureFlagStore: RemoteFeatureFlagStore) -> AppUIType {
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {

--- a/WordPress/Classes/System/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/RootViewCoordinator.swift
@@ -11,6 +11,7 @@ class RootViewCoordinator {
     enum AppUIType {
         case normal
         case simplified
+        case staticScreens
     }
 
     // MARK: Static shared variables
@@ -48,14 +49,15 @@ class RootViewCoordinator {
          windowManager: WindowManager?) {
         self.featureFlagStore = featureFlagStore
         self.windowManager = windowManager
-        if Self.shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: featureFlagStore) {
-            self.currentAppUIType = .normal
-            self.rootViewPresenter = WPTabBarController()
-        }
-        else {
-            self.currentAppUIType = .simplified
+        self.currentAppUIType = Self.appUIType(featureFlagStore: featureFlagStore)
+        switch self.currentAppUIType {
+        case .normal:
+            self.rootViewPresenter = WPTabBarController(staticScreens: false)
+        case .simplified:
             let meScenePresenter = MeScenePresenter()
             self.rootViewPresenter = MySitesCoordinator(meScenePresenter: meScenePresenter, onBecomeActiveTab: {})
+        case .staticScreens:
+            self.rootViewPresenter = StaticScreensTabBarWrapper()
         }
         updateJetpackFeaturesRemovalCoordinatorState()
         updatePromptsIfNeeded()
@@ -63,14 +65,16 @@ class RootViewCoordinator {
 
     // MARK: JP Features State
 
-    /// Used to determine if the Jetpack features are to be displayed or not based on the removal phase.
-    private static func shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: RemoteFeatureFlagStore) -> Bool {
+    /// Used to determine if the expected app UI type based on the removal phase.
+    private static func appUIType(featureFlagStore: RemoteFeatureFlagStore) -> AppUIType {
         let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: featureFlagStore)
         switch phase {
         case .four, .newUsers, .selfHosted:
-            return false
+            return .simplified
+        case .staticScreens:
+            return .staticScreens
         default:
-            return true
+            return .normal
         }
     }
 
@@ -84,7 +88,7 @@ class RootViewCoordinator {
     /// - Returns: Boolean value describing whether the UI was reloaded or not.
     @discardableResult
     func reloadUIIfNeeded(blog: Blog?) -> Bool {
-        let newUIType: AppUIType = Self.shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: featureFlagStore) ? .normal : .simplified
+        let newUIType: AppUIType = Self.appUIType(featureFlagStore: featureFlagStore)
         let oldUIType = currentAppUIType
         guard newUIType != oldUIType, let windowManager else {
             return false
@@ -120,10 +124,12 @@ class RootViewCoordinator {
     private func reloadUI(using windowManager: WindowManager) {
         switch currentAppUIType {
         case .normal:
-            self.rootViewPresenter = WPTabBarController()
+            self.rootViewPresenter = WPTabBarController(staticScreens: false)
         case .simplified:
             let meScenePresenter = MeScenePresenter()
             self.rootViewPresenter = MySitesCoordinator(meScenePresenter: meScenePresenter, onBecomeActiveTab: {})
+        case .staticScreens:
+            self.rootViewPresenter = StaticScreensTabBarWrapper()
         }
         windowManager.showUI(animated: false)
     }

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -51,7 +51,7 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
     }
 
     func showReaderTab() {
-        tabBarController.showReaderTab()
+        // Do nothing
     }
 
     func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -1,5 +1,8 @@
 import Foundation
 
+/// `StaticScreensTabBarWrapper` is used as the root presenter when Jetpack features are disabled
+///  but not fully removed. The class wraps around `WPTabBarController`
+///  but disables all Reader and Notifications functionality
 class StaticScreensTabBarWrapper: RootViewPresenter {
 
     // MARK: Private Variables

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+class StaticScreensTabBarWrapper: RootViewPresenter {
+
+    // MARK: Private Variables
+
+    private let tabBarController = WPTabBarController(staticScreens: true)
+
+    // MARK: General
+
+    var rootViewController: UIViewController {
+        return tabBarController
+    }
+
+    var currentViewController: UIViewController? {
+        return tabBarController.currentViewController
+    }
+
+    func getMeScenePresenter() -> ScenePresenter {
+        tabBarController.getMeScenePresenter()
+    }
+
+    func currentlySelectedScreen() -> String {
+        tabBarController.currentlySelectedScreen()
+    }
+
+    func showBlogDetails(for blog: Blog) {
+        tabBarController.showBlogDetails(for: blog)
+    }
+
+    func currentlyVisibleBlog() -> Blog? {
+        tabBarController.currentlyVisibleBlog()
+    }
+
+    func willDisplayPostSignupFlow() {
+        tabBarController.willDisplayPostSignupFlow()
+    }
+
+    // MARK: Reader
+
+    var readerTabViewController: ReaderTabViewController? {
+        return nil
+    }
+
+    var readerCoordinator: ReaderCoordinator? {
+        return nil
+    }
+
+    var readerNavigationController: UINavigationController? {
+        return nil
+    }
+
+    func showReaderTab() {
+        tabBarController.showReaderTab()
+    }
+
+    func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {
+        // Do nothing
+    }
+
+    func switchToDiscover() {
+        // Do nothing
+    }
+
+    func switchToSavedPosts() {
+        // Do nothing
+    }
+
+    func resetReaderDiscoverNudgeFlow() {
+        // Do nothing
+    }
+
+    func resetReaderTab() {
+        // Do nothing
+    }
+
+    func navigateToReaderSearch() {
+        // Do nothing
+    }
+
+    func navigateToReaderSearch(withSearchText: String) {
+        // Do nothing
+    }
+
+    func switchToTopic(where predicate: (ReaderAbstractTopic) -> Bool) {
+        // Do nothing
+    }
+
+    func switchToMyLikes() {
+        // Do nothing
+    }
+
+    func switchToFollowedSites() {
+        // Do nothing
+    }
+
+    func navigateToReaderSite(_ topic: ReaderSiteTopic) {
+        // Do nothing
+    }
+
+    func navigateToReaderTag(_ topic: ReaderTagTopic) {
+        // Do nothing
+    }
+
+    func navigateToReader(_ pushControlller: UIViewController?) {
+        // Do nothing
+    }
+
+    // MARK: My Site
+
+    var mySitesCoordinator: MySitesCoordinator {
+        return tabBarController.mySitesCoordinator
+    }
+
+    func showMySitesTab() {
+        tabBarController.showMySitesTab()
+    }
+
+    func showPages(for blog: Blog) {
+        tabBarController.showPages(for: blog)
+    }
+
+    func showPosts(for blog: Blog) {
+        tabBarController.showPosts(for: blog)
+    }
+
+    func showMedia(for blog: Blog) {
+        tabBarController.showMedia(for: blog)
+    }
+
+    // MARK: Notifications
+
+    var notificationsViewController: NotificationsViewController? {
+        return nil
+    }
+
+    func showNotificationsTab() {
+        // Do nothing
+    }
+
+    func showNotificationsTabForNote(withID notificationID: String) {
+        // Do nothing
+    }
+
+    func switchNotificationsTabToNotificationSettings() {
+        // Do nothing
+    }
+
+    func popNotificationsTabToRoot() {
+        // Do nothing
+    }
+}

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -16,7 +16,6 @@ import Foundation
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let allowsDomainRegistration: Bool = false
-    @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showAddSelfHostedSiteButton: Bool = true
     @objc static let showsQuickActions: Bool = true

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -186,7 +186,7 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
         guard let currentAppUIType else {
             return shouldShowJetpackFeaturesBasedOnCurrentPhase(featureFlagStore: featureFlagStore)
         }
-        return currentAppUIType == .normal
+        return currentAppUIType != .simplified
     }
 
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -135,6 +135,11 @@ final class MovedToJetpackViewController: UIViewController {
         animationView.play()
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        animationView.currentProgress = 1.0
+    }
+
     // MARK: - Navigation overrides
 
     override public var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Get Jetpack App/MovedToJetpackViewController.swift
@@ -115,7 +115,7 @@ final class MovedToJetpackViewController: UIViewController {
 
     // MARK: - Initializers
 
-    init(source: MovedToJetpackSource) {
+    @objc init(source: MovedToJetpackSource) {
         self.source = source
         self.viewModel = MovedToJetpackViewModel(source: source)
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackViewController.swift
@@ -139,8 +139,12 @@ final class MovedToJetpackViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        animationView.currentProgress = 1.0
         tracker.trackScreenDisplayed()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        animationView.currentProgress = 1.0
     }
 
     // MARK: - Navigation overrides

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController.swift
@@ -1594,16 +1594,10 @@ private extension NotificationsViewController {
     }
 
     var noResultsMessageText: String? {
-        guard AppConfiguration.showsReader else {
-            return nil
-        }
         return filter.noResultsMessage
     }
 
     var noResultsButtonText: String? {
-        guard AppConfiguration.showsReader else {
-            return nil
-        }
         return filter.noResultsButtonTitle
     }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -30,6 +30,8 @@ extern NSNotificationName const WPTabBarHeightChangedNotification;
 @property (nonatomic, strong) id<ScenePresenter> meScenePresenter;
 @property (nonatomic, strong, readonly) ReaderTabViewModel *readerTabViewModel;
 
+- (instancetype)initWithStaticScreens:(BOOL)shouldUseStaticScreens;
+
 - (NSString *)currentlySelectedScreen;
 
 - (void)showMySitesTab;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -455,22 +455,23 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 {
     UITabBarItem *notificationsTabBarItem = self.notificationsNavigationController.tabBarItem;
     
-    if (!self.shouldUseStaticScreens) {
-        // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
-        NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
-        if (count > 0 || ![self welcomeNotificationSeen]) {
-            notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
-            notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
-        } else {
-            notificationsTabBarItem.image = self.notificationsTabBarImage;
-            notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
-        }
+    if (self.shouldUseStaticScreens) {
+        notificationsTabBarItem.image = self.notificationsTabBarImage;
+        notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
+        return;
+    }
 
-        if (UIApplication.sharedApplication.isCreatingScreenshots) {
-            notificationsTabBarItem.image = self.notificationsTabBarImage;
-            notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
-        }
+    // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
+    NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - [ZendeskUtils unreadNotificationsCount];
+    if (count > 0 || ![self welcomeNotificationSeen]) {
+        notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
+        notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");
     } else {
+        notificationsTabBarItem.image = self.notificationsTabBarImage;
+        notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
+    }
+
+    if (UIApplication.sharedApplication.isCreatingScreenshots) {
         notificationsTabBarItem.image = self.notificationsTabBarImage;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -553,6 +553,14 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [super viewDidLayoutSubviews];
 }
 
+- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
+    UIViewController *currentViewController = self.selectedViewController;
+    if (currentViewController != nil) {
+        return currentViewController.supportedInterfaceOrientations;
+    }
+    return UIInterfaceOrientationMaskAllButUpsideDown;
+}
+
 #pragma mark - UIViewControllerTransitioningDelegate
 
 - (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented presentingViewController:(UIViewController *)presenting sourceViewController:(UIViewController *)source

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -48,6 +48,8 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 @interface WPTabBarController () <UITabBarControllerDelegate, UIViewControllerRestoration>
 
+@property (nonatomic, assign) BOOL shouldUseStaticScreens;
+
 @property (nonatomic, strong) NotificationsViewController *notificationsViewController;
 
 @property (nonatomic, strong) UINavigationController *readerNavigationController;
@@ -79,10 +81,11 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 #pragma mark - Instance methods
 
-- (instancetype)init
+- (instancetype)initWithStaticScreens:(BOOL)shouldUseStaticScreens
 {
     self = [super init];
     if (self) {
+        _shouldUseStaticScreens = shouldUseStaticScreens;
         [self setDelegate:self];
         [self setRestorationIdentifier:WPTabBarRestorationID];
         [self setRestorationClass:[WPTabBarController class]];
@@ -128,6 +131,11 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
                          context:nil];
     }
     return self;
+}
+
+- (instancetype)init
+{
+    return [self initWithStaticScreens:NO];
 }
 
 - (void)dealloc

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -558,7 +558,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     if (currentViewController != nil) {
         return currentViewController.supportedInterfaceOrientations;
     }
-    return UIInterfaceOrientationMaskAllButUpsideDown;
+    return super.supportedInterfaceOrientations;
 }
 
 #pragma mark - UIViewControllerTransitioningDelegate

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -466,7 +466,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
             notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
         }
 
-        if( UIApplication.sharedApplication.isCreatingScreenshots ) {
+        if (UIApplication.sharedApplication.isCreatingScreenshots) {
             notificationsTabBarItem.image = self.notificationsTabBarImage;
             notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications", @"Notifications tab bar item accessibility label");
         }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -471,27 +471,11 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     
 }
 
-- (void) showReaderBadge:(NSNotification *)notification
-{
-    UIImage *readerTabBarImage = [[UIImage imageNamed:@"icon-tab-reader-unread"] imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
-    self.readerNavigationController.tabBarItem.image = readerTabBarImage;
-
-    if( UIApplication.sharedApplication.isCreatingScreenshots ) {
-        [self hideReaderBadge:nil];
-    }
-}
-
--(BOOL) welcomeNotificationSeen
+- (BOOL)welcomeNotificationSeen
 {
     NSUserDefaults *standardUserDefaults = [UserPersistentStoreFactory userDefaultsInstance];
     NSString *welcomeNotificationSeenKey = @"welcomeNotificationSeen";
     return [standardUserDefaults boolForKey: welcomeNotificationSeenKey];
-}
-
-- (void) hideReaderBadge:(NSNotification *)notification
-{
-    UIImage *readerTabBarImage = [UIImage imageNamed:@"icon-tab-reader"];
-    self.readerNavigationController.tabBarItem.image = readerTabBarImage;
 }
 
 #pragma mark - NSObject(NSKeyValueObserving) Helpers

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -287,16 +287,9 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 
 - (NSArray<UIViewController *> *)tabViewControllers
 {
-    if (AppConfiguration.showsReader) {
-        return @[
-            self.mySitesCoordinator.rootViewController,
-            self.readerNavigationController,
-            self.notificationsSplitViewController
-        ];
-    }
-    
     return @[
         self.mySitesCoordinator.rootViewController,
+        self.readerNavigationController,
         self.notificationsSplitViewController
     ];
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -164,7 +164,13 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
 - (UINavigationController *)readerNavigationController
 {
     if (!_readerNavigationController) {
-        _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:self.makeReaderTabViewController];
+        UIViewController *rootViewController;
+        if (self.shouldUseStaticScreens) {
+            rootViewController = [[MovedToJetpackViewController alloc] initWithSource:MovedToJetpackSourceReader];
+        } else {
+            rootViewController = self.makeReaderTabViewController;
+        }
+        _readerNavigationController = [[UINavigationController alloc] initWithRootViewController:rootViewController];
         _readerNavigationController.navigationBar.translucent = NO;
         _readerNavigationController.view.backgroundColor = [UIColor murielBasicBackground];
 

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -16,7 +16,6 @@ import Foundation
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let allowsDomainRegistration: Bool = true
-    @objc static let showsReader: Bool = true
     @objc static let showsCreateButton: Bool = true
     @objc static let showAddSelfHostedSiteButton: Bool = true
     @objc static let showsQuickActions: Bool = true

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1811,6 +1811,8 @@
 		8096218E28E55F8600940A5D /* JetpackDraftActionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 8096218528E55C9400940A5D /* JetpackDraftActionExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8096219328E5613700940A5D /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 433840C622C2BA5B00CB13F8 /* AppImages.xcassets */; };
 		8096219428E561A800940A5D /* AppImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = FABB286B2603086900C8785C /* AppImages.xcassets */; };
+		80A2153D29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A2153C29C35197002FE8EB /* StaticScreensTabBarWrapper.swift */; };
+		80A2153E29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80A2153C29C35197002FE8EB /* StaticScreensTabBarWrapper.swift */; };
 		80B016CF27FEBDC900D15566 /* DashboardCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */; };
 		80B016D12803AB9F00D15566 /* DashboardPostsListCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */; };
 		80B016D22803AB9F00D15566 /* DashboardPostsListCardCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */; };
@@ -7097,6 +7099,7 @@
 		8096218828E55D2400940A5D /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		8096218928E55D2400940A5D /* Info-Internal.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Internal.plist"; sourceTree = "<group>"; };
 		8096218A28E55D2400940A5D /* Info-Alpha.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-Alpha.plist"; sourceTree = "<group>"; };
+		80A2153C29C35197002FE8EB /* StaticScreensTabBarWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StaticScreensTabBarWrapper.swift; sourceTree = "<group>"; };
 		80B016CE27FEBDC900D15566 /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		80B016D02803AB9F00D15566 /* DashboardPostsListCardCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardPostsListCardCell.swift; sourceTree = "<group>"; };
 		80C523A329959DE000B1C14B /* BlazeWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeWebViewController.swift; sourceTree = "<group>"; };
@@ -12781,6 +12784,7 @@
 				803BB988295B80D300B3F6D6 /* RootViewPresenter+EditorNavigation.swift */,
 				803BB97F295957CF00B3F6D6 /* WPTabBarController+RootViewPresenter.swift */,
 				803BB982295957F600B3F6D6 /* MySitesCoordinator+RootViewPresenter.swift */,
+				80A2153C29C35197002FE8EB /* StaticScreensTabBarWrapper.swift */,
 			);
 			name = "Root View";
 			sourceTree = "<group>";
@@ -20915,6 +20919,7 @@
 				AE2F3128270B6DE200B2A9C2 /* NSMutableAttributedString+ApplyAttributesToQuotes.swift in Sources */,
 				B53AD9BC1BE95687009AB87E /* SettingsTextViewController.m in Sources */,
 				E1389ADB1C59F7C200FB2466 /* PlanListViewController.swift in Sources */,
+				80A2153D29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
 				1E485A90249B61440000A253 /* GutenbergRequestAuthenticator.swift in Sources */,
 				084FC3BC299155C900A17BCF /* JetpackOverlayCoordinator.swift in Sources */,
 				8370D10A11FA499A009D650F /* WPTableViewActivityCell.m in Sources */,
@@ -23529,6 +23534,7 @@
 				FABB22082602FC2C00C8785C /* PostSearchHeader.swift in Sources */,
 				FABB22092602FC2C00C8785C /* ReaderPostCardContentLabel.swift in Sources */,
 				FA90EFF0262E74210055AB22 /* JetpackWebViewControllerFactory.swift in Sources */,
+				80A2153E29C35197002FE8EB /* StaticScreensTabBarWrapper.swift in Sources */,
 				FABB220A2602FC2C00C8785C /* FilterChipButton.swift in Sources */,
 				FABB220B2602FC2C00C8785C /* StatsRecordValue+CoreDataClass.swift in Sources */,
 				FABB220C2602FC2C00C8785C /* Blog.m in Sources */,


### PR DESCRIPTION
Closes #20324
Closes #20325 

## Description
This PR replaces the reader and notifications tabs with static pages. This is done by utilizing a new `RootViewPresenter` that wraps around a modified version of `WPTabBarController` that displays static screens and disables all reader and notifications functionalities.

The PR also introduces these changes:
* Fixes a bug where navigating away from `MovedToJetpackViewController` too soon causes the animation to remain stuck: 51ef693
* Redefines `jetpackFeaturesEnabled` so that it only changes when the UI is reloaded: 07ae3f8b391e568d2e40972e8a0aeb79ad700cc2
* Forces portrait mode for the new static tabs: e0e8569e540968e214573e631cc122d49b72ffad

## Screenshots

|Reader|Notifications|
| - | - |
|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-16 at 17 41 32](https://user-images.githubusercontent.com/25306722/225671698-573a3660-f536-469d-8de8-b6bf64b0668d.png)|![Simulator Screen Shot - iPhone 14 Pro - 2023-03-16 at 17 41 34](https://user-images.githubusercontent.com/25306722/225671712-50b6b211-90ff-4178-ba6a-e08d340999a1.png)|


## Testing Instructions

1. Install the WordPress app
2. From the debug menu, **disable** the "Jetpack Features Removal Static Screens Phase" feature flag
3. Go back to My Site
4. Close and reopen the app if the dashboard is not showing
5. Navigate to Reader and Notifications and make sure they are functional
6. From the debug menu, **enable** the "Jetpack Features Removal Static Screens Phase" feature flag
7. Navigate back to My Site
8. Close and reopen the app
9. The UI should reload, and the dashboard should be gone
10. Navigate to the Reader tab
11. Make sure the static screen is displayed
12. Rotate the device to landscape and make sure the view doesn't rotate
13. Repeat the last three steps for the Notifications tab

## Regression Notes
1. Potential unintended areas of impact
Phase 4 of features removal where the tab bar is completely gone.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Tested manually.

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.