### PR TITLE
Jetpack Focus: Add static poster for Stats

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -56,7 +56,7 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowStats() -> Bool {
-        return JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
     }
 
     /// Convenience method that returns the view controller for Stats based on the features removal state.

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -56,7 +56,21 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldShowStats() -> Bool {
-        return JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures()
+        return JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+    }
+
+    /// Convenience method that returns the view controller for Stats based on the features removal state.
+    ///
+    /// - Returns: Either the actual Stats view, or the static poster for Stats.
+    @objc func viewControllerForStats() -> UIViewController {
+        guard shouldShowStats() else {
+            return MovedToJetpackViewController(source: .stats)
+        }
+
+        let statsView = StatsViewController()
+        statsView.blog = blog
+        statsView.navigationItem.largeTitleDisplayMode = .never
+        return statsView
     }
 
     @objc func shouldAddJetpackSection() -> Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -464,7 +464,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
 {
     [super traitCollectionDidChange:previousTraitCollection];
-    
+
     // Required to add / remove "Home" section when switching between regular and compact width
     [self configureTableViewData];
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -1638,11 +1638,9 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/stats/";
 }
 
 - (void)showStatsFromSource:(BlogDetailsNavigationSource)source
-{    
+{
     [self trackEvent:WPAnalyticsStatStatsAccessed fromSource:source];
-    StatsViewController *statsView = [StatsViewController new];
-    statsView.blog = self.blog;
-    statsView.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
+    UIViewController *statsView = [self viewControllerForStats];
 
     // Calling `showDetailViewController:sender:` should do this automatically for us,
     // but when showing stats from our 3D Touch shortcut iOS sometimes incorrectly

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -93,4 +93,17 @@ extension WPTabBarController {
     @objc func setupColors() {
         tabBar.isTranslucent = false
     }
+
+    open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+        guard let selectedViewController else {
+            return super.supportedInterfaceOrientations
+        }
+
+        if let splitViewController = selectedViewController as? WPSplitViewController,
+           let topDetailViewController = splitViewController.topDetailViewController {
+            return topDetailViewController.supportedInterfaceOrientations
+        }
+
+        return selectedViewController.supportedInterfaceOrientations
+    }
 }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -554,14 +554,6 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     [super viewDidLayoutSubviews];
 }
 
-- (UIInterfaceOrientationMask)supportedInterfaceOrientations {
-    UIViewController *currentViewController = self.selectedViewController;
-    if (currentViewController != nil) {
-        return currentViewController.supportedInterfaceOrientations;
-    }
-    return super.supportedInterfaceOrientations;
-}
-
 #pragma mark - UIViewControllerTransitioningDelegate
 
 - (UIPresentationController *)presentationControllerForPresentedViewController:(UIViewController *)presented presentingViewController:(UIViewController *)presenting sourceViewController:(UIViewController *)source


### PR DESCRIPTION
Resolves #20323

## Description

This PR updates the navigation logic to show the static poster for Stats during `static screens` phase.

<img src="https://user-images.githubusercontent.com/1299411/225663715-bc312575-b7e4-4ad8-b434-91d5764a92ae.png" width=250 />

`shouldShowStats()` is updated to return true when the Jetpack features should be shown AND enabled. So, when the Jetpack features are disabled, the `viewControllerForStats` will correctly return the static poster instead.

⚠️ Please note that there's an issue with Notifications. Tapping on Stats notifications will still take you to the Stats view controller, skipping the Jetpack feature removal checks as it'll go through this `displayStatsWithSiteID` method:

https://github.com/wordpress-mobile/WordPress-iOS/blob/3dfbb57c56a07b1bd224656f7f36398e78b2316a/WordPress/Classes/Utility/ContentCoordinator.swift#L68-L70

Here's an example Stats notification:

<img src="https://user-images.githubusercontent.com/1299411/225672690-4b783f2b-60f6-4a30-a58e-a17706054826.png" width=250 />

I can look into fixing this through a separate PR. The idea is to go through the `MySitesCoordinator` route, or somehow get access to the `viewControllerForStats()` method.

## To test

### Phase 3

- Launch the WordPress app.
- Tap Stats from the Site Menu.
- 🔎 Verify that the Stats screen is shown.
- Tap a Stats deeplink, e.g. https://wordpress.com/stats.
  - If you're on simulator, copy this command into your terminal: `xcrun simctl openurl booted https://wordpress.com/stats`
- 🔎 Verify that the Stats screen is shown.
- From the home screen, Long-press (3D touch) on the WordPress app.
- 🔎 Verify that the Stats menu is listed.
- Add a Stats widget.
- 🔎 Verify that the Stats widget is displayed correctly.
- Launch the WordPress app on iPad.
- 🔎 Verify that Stats is selected by default.

### Phase Static Screens

- Go to App Settings > Debug and enable the Static Screens feature flag.
- Close and relaunch the WordPress app.
- Tap Stats from the Site Menu.
- 🔎 Verify that the static poster is shown.
- Tap a Stats deeplink, e.g. https://wordpress.com/stats.
  - If you're on simulator, copy this command into your terminal: `xcrun simctl openurl booted https://wordpress.com/stats`
- 🔎 Verify that the deeplink is not processed. 
- From the home screen, Long-press (3D touch) on the WordPress app.
- 🔎 Verify that the Stats menu is NOT listed.
- Add a Stats widget.
- 🔎 Verify that the Stats widget displays `Stats have moved to the Jetpack app. Switching is free and only takes a minute`.
- Launch the WordPress app on iPad.
- 🔎 Verify that Posts is selected by default.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
