### PR TITLE
Jetpack Focus: Change settings badge text in static screens phase

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingTextProvider.swift
@@ -34,7 +34,7 @@ struct JetpackBrandingTextProvider {
         case .three:
             return phaseThreeText()
         case .staticScreens:
-            return Strings.phaseStaticScreensText
+            return staticScreensPhaseText()
         default:
             return Strings.defaultText
         }
@@ -61,6 +61,14 @@ struct JetpackBrandingTextProvider {
         }
 
         return String(format: movingInString, featureName, dateString)
+    }
+
+    private func staticScreensPhaseText() -> String {
+        guard let screen = screen, let featureName = screen.featureName else {
+            return Strings.defaultText // Screen not provided, or was opted out by defining a nil featureName
+        }
+
+        return Strings.phaseStaticScreensText
     }
 
     private func dateString(now: Date, deadline: Date) -> String? {


### PR DESCRIPTION
## Description
This PR changes the settings badge text to "Jetpack powered" instead of "Moving to the Jetpack app in a few days" because, technically, settings won't be moving. 

## Testing Instructions

1. Install the WordPress app
2. From the debug menu, **enable** the "Jetpack Features Removal Static Screens Phase" feature flag
3. Navigate back to My Site
4. Close and reopen the app
5. Navigate to Settings
6. Make sure the badge reads "Jetpack Powered"
7. Navigate to Activity Logs
8. Make sure the badge reads "Moving to the Jetpack app in a few days"

## Regression Notes
1. Potential unintended areas of impact
N/A

2. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.