### PR TITLE
Jetpack Focus: Add deep link handling during Static Screens phase

### DIFF
--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -54,7 +54,7 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
     }
 
     func showReaderTab() {
-        // Do nothing
+        tabBarController.showReaderTab()
     }
 
     func showReaderTab(forPost: NSNumber, onBlog: NSNumber) {

--- a/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
+++ b/WordPress/Classes/System/StaticScreensTabBarWrapper.swift
@@ -138,18 +138,18 @@ class StaticScreensTabBarWrapper: RootViewPresenter {
     }
 
     func showNotificationsTab() {
-        // Do nothing
+        tabBarController.showNotificationsTab()
     }
 
     func showNotificationsTabForNote(withID notificationID: String) {
-        // Do nothing
+        tabBarController.showNotificationsTab()
     }
 
     func switchNotificationsTabToNotificationSettings() {
-        // Do nothing
+        tabBarController.showNotificationsTab()
     }
 
     func popNotificationsTabToRoot() {
-        // Do nothing
+        // Do nothing since static notification tab will never have a stack
     }
 }

--- a/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
+++ b/WordPress/Classes/Utility/Universal Links/Routes+Reader.swift
@@ -66,6 +66,10 @@ extension ReaderRoute: Route {
 
 extension ReaderRoute: NavigationAction {
     func perform(_ values: [String: String], source: UIViewController? = nil, router: LinkRouter) {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            RootViewCoordinator.sharedPresenter.showReaderTab() // Show static reader tab
+            return
+        }
         guard let coordinator = RootViewCoordinator.sharedPresenter.readerCoordinator else {
             return
         }

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -170,7 +170,7 @@ struct UniversalLinkRouter: LinkRouter {
         }
 
         for matchedRoute in matches {
-            if matchedRoute.jetpackPowered && !JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
+            if matchedRoute.jetpackPowered && !JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() {
                 // Display overlay
                 RootViewCoordinator.sharedPresenter.mySitesCoordinator.displayJetpackOverlayForDisabledEntryPoint()
 

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -127,7 +127,7 @@ class MySitesCoordinator: NSObject {
     // MARK: - Stats
 
     func showStats(for blog: Blog) {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             unsupportedFeatureFallback()
             return
         }
@@ -136,7 +136,7 @@ class MySitesCoordinator: NSObject {
     }
 
     func showStats(for blog: Blog, timePeriod: StatsPeriodType, date: Date? = nil) {
-        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+        guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             unsupportedFeatureFallback()
             return
         }


### PR DESCRIPTION
Closes #20347

## Description
This PR enables capturing deep links during the static screens phase. In that phase, deep links will direct the user to the corresponding static screen. The PR handles widgets taps as well.

## Testing Instructions

### Phase 3

1. Make sure the Jetpack app is not installed on your testing device
2. Run the WordPress app
3. Open the debug menu and disable all "Jetpack Features Removal" flags
4. Close and reopen the app to trigger a UI reload if needed
5. Add a Stats widget
6. Tap on the widget
7. Make sure the app is opened and the stats screen is displayed
8. Copy the following links to a note on your device:
    * [wordpress.com/me/notifications](http://wordpress.com/me/notifications)
    * [wordpress.com/read](http://wordpress.com/read)
    * [wordpress.com/discover](http://wordpress.com/discover)
    * [wordpress.com/read/search](http://wordpress.com/read/search)
    * [wordpress.com/activities/likes](http://wordpress.com/activities/likes)
    * [wordpress.com/tag/food](http://wordpress.com/tag/food)
    * [wordpress.com/stats](http://wordpress.com/stats)
    * [wordpress.com/notifications](http://wordpress.com/notifications)
9. For each link:
    1. Tap on the link
    2. The app is opened
    3. Make sure the corresponding feature is displayed

### Static Screens Phase 

1. Make sure the Jetpack app is not installed on your testing device
2. Run the WordPress app
3. Open the debug menu and enable "Jetpack Features Removal Static Screens Phase” 
4. Close and reopen the app to trigger a UI reload if needed
5. Add a Stats widget
6. Tap on the widget
7. Make sure the app is opened and the stats static screen is displayed
8. Copy the following links to a note on your device:
    * [wordpress.com/me/notifications](http://wordpress.com/me/notifications)
    * [wordpress.com/read](http://wordpress.com/read)
    * [wordpress.com/discover](http://wordpress.com/discover)
    * [wordpress.com/read/search](http://wordpress.com/read/search)
    * [wordpress.com/activities/likes](http://wordpress.com/activities/likes)
    * [wordpress.com/tag/food](http://wordpress.com/tag/food)
    * [wordpress.com/stats](http://wordpress.com/stats)
    * [wordpress.com/notifications](http://wordpress.com/notifications)
9. For each link:
    1. Tap on the link
    2. The app is opened
    3. Make sure the corresponding static screen is displayed

### Phase 4 

1. Make sure the Jetpack app is not installed on your testing device
2. Run the WordPress app
3. Open the debug menu and enable "Jetpack Features Removal Phase Four” 
4. Close and reopen the app to trigger a UI reload if needed
5. Add a Stats widget
6. Tap on the widget
7. Make sure the app is opened, and an overlay is displayed
8. Dismiss the overlay
9. Make sure the stats screen is not displayed
10. Copy the following links to a note on your device:
    * [wordpress.com/me/notifications](http://wordpress.com/me/notifications)
    * [wordpress.com/read](http://wordpress.com/read)
    * [wordpress.com/discover](http://wordpress.com/discover)
    * [wordpress.com/read/search](http://wordpress.com/read/search)
    * [wordpress.com/activities/likes](http://wordpress.com/activities/likes)
    * [wordpress.com/tag/food](http://wordpress.com/tag/food)
    * [wordpress.com/stats](http://wordpress.com/stats)
    * [wordpress.com/notifications](http://wordpress.com/notifications)
11. For each link:
    1. Tap on the link
    2. The app is opened
    3. Make sure an overlay is displayed
    4. Dismiss the overlay
    5. Make sure the corresponding feature is not displayed

## Regression Notes
1. Potential unintended areas of impact
N/A

5. What I did to test those areas of impact (or what existing automated tests I relied on)
N/A

6. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.