### PR TITLE
Add localizable string for "Views Today" title

### DIFF
--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenSingleStatViewModel.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenSingleStatViewModel.swift
@@ -4,7 +4,5 @@ struct LockScreenSingleStatViewModel {
     let siteName: String
     let title: String
     let value: String
-    let dateRange: String
-    let footer: String
     let updatedTime: Date
 }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenSingleStatViewModel.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenSingleStatViewModel.swift
@@ -5,5 +5,6 @@ struct LockScreenSingleStatViewModel {
     let title: String
     let value: String
     let dateRange: String
+    let footer: String
     let updatedTime: Date
 }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
@@ -4,16 +4,12 @@ struct LockScreenWidgetViewModelMapper {
     let data: HomeWidgetData
 
     func getLockScreenSingleStatViewModel(
-        title: String,
-        dateRange: String,
-        footer: String
+        title: String
     ) -> LockScreenSingleStatViewModel {
         LockScreenSingleStatViewModel(
             siteName: getSiteName(),
             title: title,
             value: getViews(),
-            dateRange: dateRange,
-            footer: footer,
             updatedTime: data.date
         )
     }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
@@ -3,12 +3,17 @@ import Foundation
 struct LockScreenWidgetViewModelMapper {
     let data: HomeWidgetData
 
-    func getLockScreenSingleStatViewModel(title: String, dateRange: String) -> LockScreenSingleStatViewModel {
+    func getLockScreenSingleStatViewModel(
+        title: String,
+        dateRange: String,
+        footer: String
+    ) -> LockScreenSingleStatViewModel {
         LockScreenSingleStatViewModel(
             siteName: getSiteName(),
             title: title,
             value: getViews(),
             dateRange: dateRange,
+            footer: footer,
             updatedTime: data.date
         )
     }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
@@ -8,7 +8,8 @@ struct LockScreenSingleStatWidgetViewProvider: LockScreenStatsWidgetsViewProvide
         let mapper = LockScreenWidgetViewModelMapper(data: data)
         let viewModel = mapper.getLockScreenSingleStatViewModel(
             title: LocalizableStrings.viewsTitle,
-            dateRange: LocalizableStrings.todayWidgetTitle
+            dateRange: LocalizableStrings.todayWidgetTitle,
+            footer: LocalizableStrings.viewsInTodayTitle
         )
         return LockScreenSingleStatView(viewModel: viewModel)
     }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
@@ -7,9 +7,7 @@ struct LockScreenSingleStatWidgetViewProvider: LockScreenStatsWidgetsViewProvide
     func buildSiteSelectedView(_ data: HomeWidgetData) -> LockScreenSingleStatView {
         let mapper = LockScreenWidgetViewModelMapper(data: data)
         let viewModel = mapper.getLockScreenSingleStatViewModel(
-            title: LocalizableStrings.viewsTitle,
-            dateRange: LocalizableStrings.todayWidgetTitle,
-            footer: LocalizableStrings.viewsInTodayTitle
+            title: LocalizableStrings.viewsInTodayTitle
         )
         return LockScreenSingleStatView(viewModel: viewModel)
     }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
@@ -21,7 +21,7 @@ struct LockScreenSingleStatView: View {
                         .font(.system(size: 20, weight: .bold))
                         .minimumScaleFactor(0.5)
                         .foregroundColor(.white)
-                    Text("\(viewModel.title) \(viewModel.dateRange)")
+                    Text(viewModel.footer)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.system(size: 11))
                         .minimumScaleFactor(0.8)
@@ -43,6 +43,7 @@ struct LockScreenSingleStatView_Previews: PreviewProvider {
         title: "Views",
         value: "649",
         dateRange: "Today",
+        footer: "Views Today",
         updatedTime: Date()
     )
 

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenSingleStatView.swift
@@ -21,7 +21,7 @@ struct LockScreenSingleStatView: View {
                         .font(.system(size: 20, weight: .bold))
                         .minimumScaleFactor(0.5)
                         .foregroundColor(.white)
-                    Text(viewModel.footer)
+                    Text(viewModel.title)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .font(.system(size: 11))
                         .minimumScaleFactor(0.8)
@@ -40,10 +40,8 @@ struct LockScreenSingleStatView: View {
 struct LockScreenSingleStatView_Previews: PreviewProvider {
     static let viewModel = LockScreenSingleStatViewModel(
         siteName: "My WordPress Site",
-        title: "Views",
+        title: "Views Today",
         value: "649",
-        dateRange: "Today",
-        footer: "Views Today",
         updatedTime: Date()
     )
 

--- a/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
+++ b/WordPress/WordPressStatsWidgets/Views/Localization/LocalizableStrings.swift
@@ -16,6 +16,11 @@ enum LocalizableStrings {
                                                         value: "This Week",
                                                         comment: "Title of this week widget")
 
+    // Lock Screen Widgets content
+    static let viewsInTodayTitle = AppLocalizedString("widget.lockscreen.todayview.label",
+                                                   value: "Views Today",
+                                                   comment: "Title of the one-liner information consist of views field and today date range in lock screen today views widget")
+
     // Widgets content
     static let viewsTitle = AppLocalizedString("widget.today.views.label",
                                                value: "Views",

--- a/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
+++ b/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
@@ -5,24 +5,18 @@ final class WidgetsViewModelMapperTests: XCTestCase {
     func testSingleStatViewModel() {
         let views = 649875
         let date = Date()
-        let title = "Views"
-        let dateRange = "Today"
-        let footer = "Views Today"
+        let title = "Views Today"
         let todayStats = makeTodayWidgetStats(views: views)
         let data = makeTodayData(stats: todayStats, date: date)
 
         let sut = makeSUT(data)
         let viewModel = sut.getLockScreenSingleStatViewModel(
-            title: title,
-            dateRange: dateRange,
-            footer: footer
+            title: title
         )
 
         XCTAssertEqual(viewModel.siteName, data.siteName)
         XCTAssertEqual(viewModel.title, title)
         XCTAssertEqual(viewModel.value, views.abbreviatedString())
-        XCTAssertEqual(viewModel.dateRange, dateRange)
-        XCTAssertEqual(viewModel.footer, footer)
         XCTAssertEqual(viewModel.updatedTime, date)
     }
 

--- a/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
+++ b/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
@@ -7,19 +7,22 @@ final class WidgetsViewModelMapperTests: XCTestCase {
         let date = Date()
         let title = "Views"
         let dateRange = "Today"
+        let footer = "Views Today"
         let todayStats = makeTodayWidgetStats(views: views)
         let data = makeTodayData(stats: todayStats, date: date)
 
         let sut = makeSUT(data)
         let viewModel = sut.getLockScreenSingleStatViewModel(
             title: title,
-            dateRange: dateRange
+            dateRange: dateRange,
+            footer: footer
         )
 
         XCTAssertEqual(viewModel.siteName, data.siteName)
         XCTAssertEqual(viewModel.title, title)
         XCTAssertEqual(viewModel.value, views.abbreviatedString())
         XCTAssertEqual(viewModel.dateRange, dateRange)
+        XCTAssertEqual(viewModel.footer, footer)
         XCTAssertEqual(viewModel.updatedTime, date)
     }
 


### PR DESCRIPTION
This PR is for improving the comments for previous PR https://github.com/wordpress-mobile/WordPress-iOS/pull/20312
1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved) 
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (TBD) 
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved) 👈 you're here!
- Add localization key for "views today"
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved) 
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved)
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)

## Description
Add a new LocalizableStrings for "Views Today", because in some languages, we need better translation rather than simply concatenating two fields ("Views" + "Today").

Question: Based on the [document](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/docs/localization.md), we use [GlotPress](https://translate.wordpress.org/projects/apps/ios/) for translation, should I need to manually add the key to notify translation team? (I don't have permission to access that)

## Testing instructions
"Views Today" displayed on the bottom
<img width="150" alt="image" src="https://user-images.githubusercontent.com/3096210/225785814-8a639cc9-013e-4aa6-a78f-e403bcfd964b.png">

## Regression Notes
1. Potential unintended areas of impact
The UI representation for today views the widget in the lock screen

2. What I did to test those areas of impact (or what existing automated tests I relied on)
The widgets displayed as expected

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
