### PR TITLE
When Start Over action is selected, open documentation for all the WordPress app users

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -956,7 +956,7 @@ static NSString *const EmptySiteSupportURL = @"https://en.support.wordpress.com/
     NSParameterAssert([blog supportsSiteManagementServices]);
 
     [WPAppAnalytics track:WPAnalyticsStatSiteSettingsStartOverAccessed withBlog:self.blog];
-    if (self.blog.hasPaidPlan) {
+    if ([SupportConfigurationObjC isStartOverSupportEnabled] && self.blog.hasPaidPlan) {
         StartOverViewController *viewController = [[StartOverViewController alloc] initWithBlog:blog];
         [self.navigationController pushViewController:viewController animated:YES];
     } else {

--- a/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportConfiguration.swift
@@ -33,3 +33,9 @@ enum SupportConfiguration {
         return isJetpack && migrationState == .completed
     }
 }
+
+@objc class SupportConfigurationObjC: NSObject {
+    @objc static var isStartOverSupportEnabled: Bool {
+        return SupportConfiguration.current() == .zendesk
+    }
+}


### PR DESCRIPTION
Fixes #20351

## Testing instructions

⚠️ Note: https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags?platform=ios&marketing_version=22.0 `wordpress_support_forum_remote_field` should be set to `true` before testing

### Case 1 WordPress app 22.0:
1. Open the WordPress app
2. Navigate to a WordPress.com paid site (Personal or Premium plan)
3. Click on Site Settings and under Advanced navigate to Start Over
4. Notice `https://en.support.wordpress.com/empty-site` opening

### Case 2 Jetpack app 22.0:
1. Open the WordPress app
2. Navigate to a WordPress.com paid site (Personal or Premium plan)
3. Click on Site Settings and under Advanced navigate to Start Over
4. Notice the paid option to contact support.

## Regression Notes

1. Potential unintended areas of impact

I'm following the logic of https://github.com/wordpress-mobile/WordPress-iOS/issues/20240 which removes WP Zendesk support for all WP app users only starting from 22.0, so I used the same flags here. It could be not what's intended.

2. What I did to test those areas of impact (or what existing automated tests I relied on)

3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Images & Videos

https://user-images.githubusercontent.com/4062343/225849554-3b9c50a0-7a2e-4f78-a747-b622159b1b57.mp4