### PR TITLE
Blaze: Fix overlay description string

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazeOverlayViewModel.swift
@@ -67,7 +67,7 @@ struct BlazeOverlayViewModel {
 
         static let description1 = NSLocalizedString("blaze.overlay.descriptionOne", value: "Promote any post or page in only a few minutes for just a few dollars a day.", comment: "Description for the Blaze overlay.")
         static let description2 = NSLocalizedString("blaze.overlay.descriptionTwo", value: "Your content will appear on millions of WordPress and Tumblr sites.", comment: "Description for the Blaze overlay.")
-        static let description3 = NSLocalizedString("blaze.overlay.descriptionThree", value: "Track your campaigns performance and cancel at anytime.", comment: "Description for the Blaze overlay.")
+        static let description3 = NSLocalizedString("blaze.overlay.descriptionThree", value: "Track your campaign's performance and cancel at anytime.", comment: "Description for the Blaze overlay.")
 
         static let blazeButtonTitle = NSLocalizedString("blaze.overlay.buttonTitle", value: "Blaze a post now", comment: "Button title for a Blaze overlay prompting users to select a post to blaze.")
         static let blazePostButtonTitle = NSLocalizedString("blaze.overlay.withPost.buttonTitle", value: "Blaze this post", comment: "Button title for the Blaze overlay prompting users to blaze the selected post.")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCardView.swift
@@ -12,6 +12,7 @@ final class BlazeCardView: UIView {
         let label = UILabel()
         label.font = Style.titleLabelFont
         label.text = Strings.title
+        label.textColor = .text
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false
@@ -22,6 +23,7 @@ final class BlazeCardView: UIView {
         let label = UILabel()
         label.font = Style.descriptionLabelFont
         label.text = Strings.description
+        label.textColor = .textSubtle
         label.numberOfLines = 0
         label.adjustsFontForContentSizeCategory = true
         label.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
Fixes #20354

## Description
- Adds missing apostrophe for description string
- Updates Blaze dashboard card description text color (p5T066-3Ue-p2#comment-14521)

## Notes
- I think there's something else we need to do to update existing strings. I've asked about in Slack (p1679066719910259-slack-CC7L49W13)

## How to test
0. Delete and reinstall the Jetpack app
1. Log in and switch to a Blaze enabled site
2. Switch to the dashboard tab if needed
3. ✅ The Blaze card description label uses the secondary text color
4. Tap on the card
5. ✅ The third bullet point in the Blaze overlay reads: "Track your campaign's performance and cancel at anytime."

## Regression Notes
1. Potential unintended areas of impact
n/a

2. What I did to test those areas of impact (or what existing automated tests I relied on)
n/a

6. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.