### PR TITLE
Include JPiOS in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,4 +7,4 @@
 ### Steps to reproduce the behavior
 
 
-##### Tested on [device], iOS [version], WPiOS [version]
+##### Tested on [device], iOS [version], JPiOS / WPiOS [version]

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,4 +7,4 @@
 ### Steps to reproduce the behavior
 
 
-##### Tested on [device], iOS [version], JPiOS / WPiOS [version]
+##### Tested on [device], iOS [version], Jetpack iOS / WordPress iOS [version]


### PR DESCRIPTION
Adds JPiOS to the version collected for the issue. I assume most of the time these versions will match, but it will also serve as a reminder to include both versions if they differ.