### PR TITLE
Fix incorrect Navigation Bar Appearance in Reader Detail screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -202,11 +202,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-
         ReaderTracker.shared.start(.readerPost)
-
-        // Reapply the appearance, this reset the navbar after presenting a view
-        featuredImage.applyTransparentNavigationBarAppearance(to: navigationController?.navigationBar)
     }
 
     override func viewDidDisappear(_ animated: Bool) {
@@ -558,10 +554,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func setupFeaturedImage() {
         configureFeaturedImage()
 
-        featuredImage.configure(scrollView: scrollView,
-                                navigationBar: navigationController?.navigationBar)
-
-        featuredImage.applyTransparentNavigationBarAppearance(to: navigationController?.navigationBar)
+        featuredImage.configure(
+            scrollView: scrollView,
+            navigationBar: navigationController?.navigationBar,
+            navigationItem: navigationItem
+        )
 
         guard !featuredImage.isLoaded else {
             return

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1049,11 +1049,7 @@ private extension ReaderDetailViewController {
 
     func barButtonItem(with image: UIImage, action: Selector) -> UIBarButtonItem {
         let image = image.withRenderingMode(.alwaysTemplate)
-        let button = UIButton(frame: CGRect(x: 0, y: 0, width: 44.0, height: image.size.height))
-        button.setImage(image, for: UIControl.State())
-        button.addTarget(self, action: action, for: .touchUpInside)
-
-        return UIBarButtonItem(customView: button)
+        return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
     }
 
     /// Checks if the view is visible in the viewport.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -79,29 +79,13 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     /// Listens for contentOffset changes to track when the user scrolls
     private var scrollViewObserver: NSKeyValueObservation?
 
-    /// Flag indicating whether the navigation bar appearance needs restoration when the view disappears. Default is `false`.
-    ///
-    /// Flag changes to `true` when this view changes the navigation bar tint color. In other words, when the `navBarTintColor` setter is called.
-    private var navigationBarAppearanceNeedsRestoration = false
-
-    /// The original navigation bar tint color.
-    ///
-    /// This property is used to restore the navigation bar tint color to its original value.
-    private var previousNavBarTintColor: UIColor?
-
     /// The navigation bar tint color changes depending on whether the featured image is visible or not.
     private var navBarTintColor: UIColor? {
         get {
             return navigationBar?.tintColor
         }
         set(newValue) {
-            // Ideally, we should be setting the navigationItem's tint color, but for some reason that didn't work.
-            // self.navigationItem?.setTintColor(.red)
-            if previousNavBarTintColor == nil {
-                self.previousNavBarTintColor = navigationBar?.tintColor
-            }
-            self.navigationBar?.tintColor = useCompatibilityMode ? .textInverted : newValue
-            self.navigationBarAppearanceNeedsRestoration = true
+            self.navigationItem?.setTintColor(useCompatibilityMode ? .textInverted : newValue)
         }
     }
 
@@ -126,7 +110,6 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     func viewWillDisappear() {
         scrollViewObserver?.invalidate()
         scrollViewObserver = nil
-        restoreNavigationBarAppearanceIfNeeded()
     }
 
     // MARK: - Public: Configuration
@@ -303,13 +286,6 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
         updateNavigationBar(with: offsetY)
     }
 
-    private func restoreNavigationBarAppearanceIfNeeded() {
-        guard navigationBarAppearanceNeedsRestoration else {
-            return
-        }
-        self.navigationBar?.tintColor = previousNavBarTintColor
-    }
-
     private func hideLoading() {
         UIView.animate(withDuration: 0.3, animations: {
             self.loadingView.alpha = 0.0
@@ -403,7 +379,7 @@ class ReaderDetailFeaturedImageView: UIView, NibLoadable {
     }
 
     private func reset() {
-        navigationBar?.tintColor = useCompatibilityMode ? .appBarTint : Styles.endTintColor
+        navigationItem?.setTintColor(useCompatibilityMode ? .appBarTint : Styles.endTintColor)
 
         resetStatusBarStyle()
         heightConstraint.constant = 0
@@ -460,5 +436,21 @@ extension ReaderDetailFeaturedImageView: UIGestureRecognizerDelegate {
 
         /// Do not accept the touch if outside the featured image view
         return isOutsideView == false
+    }
+}
+
+// MARK: - Private: Navigation Item Extension
+
+private extension UINavigationItem {
+
+    func setTintColor(_ color: UIColor?) {
+        self.leftBarButtonItem?.tintColor = color
+        self.rightBarButtonItem?.tintColor = color
+        self.leftBarButtonItems?.forEach {
+            $0.tintColor = color
+        }
+        self.rightBarButtonItems?.forEach {
+            $0.tintColor = color
+        }
     }
 }


### PR DESCRIPTION
Fixes #20362

## Description

This PR resolves a regression bug caused in this PR:
- https://github.com/wordpress-mobile/WordPress-iOS/pull/20278

The aforementioned PR changed the Reader's navigation bar appearance from transparent to opaque. The new navigation bar appearance is inherited by all view controllers that get pushed to the same navigation controller. But one view controller should keep the transparent navigation bar appearance. And that is the `ReaderDetailViewController`. 

This PR resolves that issue by refactoring the navigation bar appearance logic in `ReaderDetailViewController`. So instead of setting `navigationBar.standardAppearance`, I used `navigationItem.standardAppearance` instead.

##  Notes 

I recommend to review each commit individually and in this order:
1. [Resolve a regression bug that was causing the nav bar appearance to appear white in posts with featured image.](https://github.com/wordpress-mobile/WordPress-iOS/pull/20363/commits/c6ba7364c8e3c2f57f56a667bde1b45bc855b742) 
2. [Update the navigation bar tintColor using its navigation item](https://github.com/wordpress-mobile/WordPress-iOS/pull/20363/commits/83c68db1f4ee6c97fe051ad918d24fa8800c5751)
3. [Reorganize methods and properties](https://github.com/wordpress-mobile/WordPress-iOS/pull/20363/commits/fada9c4b8d5c558309f0e61977a8426f12294602)

## Screenshots

| Before | After |
| ------- | ----- |
| <img src="https://user-images.githubusercontent.com/9609223/226131530-19496f54-fec1-475a-b981-a5da475d35cc.png"/> | ![](https://user-images.githubusercontent.com/9609223/226132622-b6a5c608-596c-44e3-8c28-fd6b1357cc45.png) |

## Test Instructions
1. Install WordPress / Jetpack and login.
2. Enable Light Mode.
3. Head to a Post with a Featured Image:
    - Deep Link To: https://lostinamberland.wordpress.com/2023/03/18/way-too-far/
4. **Verify** the navigation bar appearance is transparent.

## Regression Notes
1. Potential unintended areas of impact
None.

6. What I did to test those areas of impact (or what existing automated tests I relied on)
None.

7. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
