### PR TITLE
Hiding dashboard cards: generalize logic for storing preferences

### DIFF
--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -10,7 +10,7 @@ public class BloggingPromptSettings: NSManagedObject {
         self.reminderTime = remoteSettings.reminderTime
         self.promptRemindersEnabled = remoteSettings.promptRemindersEnabled
         self.isPotentialBloggingSite = remoteSettings.isPotentialBloggingSite
-        updatePromptSettingsIfNecessary(siteID: String(siteID), enabled: isPotentialBloggingSite)
+        updatePromptSettingsIfNecessary(siteID: Int(siteID), enabled: isPotentialBloggingSite)
         self.reminderDays = reminderDays ?? BloggingPromptSettingsReminderDays(context: context)
         reminderDays?.configure(with: remoteSettings.reminderDays)
     }
@@ -24,12 +24,10 @@ public class BloggingPromptSettings: NSManagedObject {
         return dateFormatter.date(from: reminderTime)
     }
 
-    private func updatePromptSettingsIfNecessary(siteID: String, enabled: Bool) {
-        let repository = UserPersistentStoreFactory.instance()
-        var promptsEnabledSettings = repository.promptsEnabledSettings
-        if promptsEnabledSettings[siteID] == nil {
-            promptsEnabledSettings[siteID] = enabled
-            repository.promptsEnabledSettings = promptsEnabledSettings
+    private func updatePromptSettingsIfNecessary(siteID: Int, enabled: Bool) {
+        let service = BlogDashboardPersonalizationService(siteID: siteID)
+        if !service.hasPreference(for: .prompts) {
+            service.setEnabled(enabled, for: .prompts)
         }
     }
 

--- a/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
+++ b/WordPress/Classes/Stores/UserPersistentRepositoryUtility.swift
@@ -17,8 +17,6 @@ private enum UPRUConstants {
     static let announcementsVersionDisplayedKey = "announcementsVersionDisplayed"
     static let isJPContentImportCompleteKey = "jetpackContentImportComplete"
     static let jetpackContentMigrationStateKey = "jetpackContentMigrationState"
-    static let promptsEnabledSettingsKey = "prompts-enabled-site-settings"
-    static let blazeCardEnabledSettingsKey = "blaze-card-enabled-site-settings"
 }
 
 protocol UserPersistentRepositoryUtility: AnyObject {
@@ -185,31 +183,6 @@ extension UserPersistentRepositoryUtility {
             }
         } set {
             UserPersistentStoreFactory.instance().set(newValue.rawValue, forKey: UPRUConstants.jetpackContentMigrationStateKey)
-        }
-    }
-
-    var promptsEnabledSettings: [String: Bool] {
-        get {
-            guard let sites = UserPersistentStoreFactory.instance().dictionary(forKey: UPRUConstants.promptsEnabledSettingsKey) as? [String: Bool] else {
-                return [String: Bool]()
-            }
-            return sites
-        }
-        set {
-            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.promptsEnabledSettingsKey)
-        }
-    }
-
-    var blazeCardEnabledSettings: [String: Bool] {
-        get {
-            guard let sites = UserPersistentStoreFactory.instance().dictionary(forKey: UPRUConstants.blazeCardEnabledSettingsKey) as? [String: Bool] else {
-                return [String: Bool]()
-            }
-            return sites
-        }
-        set {
-            UserPersistentStoreFactory.instance().set(newValue, forKey: UPRUConstants.blazeCardEnabledSettingsKey)
-
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeHelper.swift
@@ -18,34 +18,16 @@ import Foundation
         guard isBlazeFlagEnabled() && blog.isBlazeApproved else {
             return false
         }
-
-        guard let siteID = blog.dotComID?.stringValue else {
-            return false
-        }
-
-        initializeBlazeCardSettingsIfNecessary(siteID: siteID)
-
-        return UserPersistentStoreFactory.instance().blazeCardEnabledSettings[siteID] ?? false
+        return true
     }
 
     static func hideBlazeCard(for blog: Blog?) {
         guard let blog,
-              let siteID = blog.dotComID?.stringValue else {
+              let siteID = blog.dotComID?.intValue else {
             DDLogError("Blaze: error hiding blaze card.")
             return
         }
-        let repository = UserPersistentStoreFactory.instance()
-        var blazeCardEnabledSettings = repository.blazeCardEnabledSettings
-        blazeCardEnabledSettings[siteID] = false
-        repository.blazeCardEnabledSettings = blazeCardEnabledSettings
-    }
-
-    static func initializeBlazeCardSettingsIfNecessary(siteID: String) {
-        let repository = UserPersistentStoreFactory.instance()
-        var blazeCardEnabledSettings = repository.blazeCardEnabledSettings
-        if blazeCardEnabledSettings[siteID] == nil {
-            blazeCardEnabledSettings[siteID] = true
-            repository.blazeCardEnabledSettings = blazeCardEnabledSettings
-        }
+        BlogDashboardPersonalizationService(siteID: siteID)
+            .setEnabled(false, for: .blaze)
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -25,7 +25,6 @@ class DashboardBlazeCardCell: DashboardCollectionViewCell {
         let onHideThisTap: UIActionHandler = { [weak self] _ in
             BlazeEventsTracker.trackHideThisTapped(for: .dashboardCard)
             BlazeHelper.hideBlazeCard(for: self?.blog)
-            self?.presentingViewController?.reloadCardsLocally()
         }
 
         return BlazeCardViewModel(onViewTap: onViewTap,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -352,13 +352,13 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     static func shouldShowCard(for blog: Blog) -> Bool {
         guard FeatureFlag.bloggingPrompts.enabled,
               blog.isAccessibleThroughWPCom(),
-              let promptsService = BloggingPromptsService(blog: blog),
-              let siteID = blog.dotComID?.stringValue else {
+              let promptsService = BloggingPromptsService(blog: blog) else {
             return false
         }
 
         guard let todaysPrompt = promptsService.localTodaysPrompt else {
-            return false
+            // If there is no cached prompt, it can't have been skipped. So show the card.
+            return true
         }
 
         return !userSkippedPrompt(todaysPrompt, for: blog)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardPersonalizationService.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Manages dashboard settings such as card visibility.
+struct BlogDashboardPersonalizationService {
+    private let repository: UserPersistentRepository
+    private let siteID: String
+
+    init(repository: UserPersistentRepository = UserDefaults.standard,
+         siteID: Int) {
+        self.repository = repository
+        self.siteID = String(siteID)
+    }
+
+    func isEnabled(_ card: DashboardCard) -> Bool {
+        getSettings(for: card)[siteID] ?? true
+    }
+
+    func hasPreference(for card: DashboardCard) -> Bool {
+        getSettings(for: card)[siteID] != nil
+    }
+
+    func setEnabled(_ isEnabled: Bool, for card: DashboardCard) {
+        var settings = getSettings(for: card)
+        settings[siteID] = isEnabled
+        repository.set(settings, forKey: makeKey(for: card))
+
+        NotificationCenter.default.post(name: .blogDashboardPersonalizationSettingsChanged, object: self)
+    }
+
+    private func getSettings(for card: DashboardCard) -> [String: Bool] {
+        repository.dictionary(forKey: makeKey(for: card)) as? [String: Bool] ?? [:]
+    }
+}
+
+private func makeKey(for card: DashboardCard) -> String {
+    if card == .prompts {
+        // This key was defined statically in the previous versions, and the
+        // naming convention wasn't matching the other keys, so it had to be
+        // special-cased to avoid losing data.
+        return "prompts-enabled-site-settings"
+    }
+    return "\(card.rawValue)-card-enabled-site-settings"
+}
+
+extension NSNotification.Name {
+    /// Sent whenever any of the blog settings managed by ``BlogDashboardPersonalizationService``
+    /// are changed.
+    static let blogDashboardPersonalizationSettingsChanged = NSNotification.Name("BlogDashboardPersonalizationSettingsChanged")
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -1,15 +1,21 @@
 import Foundation
 import WordPressKit
 
-class BlogDashboardService {
+final class BlogDashboardService {
 
     private let remoteService: DashboardServiceRemote
     private let persistence: BlogDashboardPersistence
     private let postsParser: BlogDashboardPostsParser
+    private let repository: UserPersistentRepository
 
-    init(managedObjectContext: NSManagedObjectContext, remoteService: DashboardServiceRemote? = nil, persistence: BlogDashboardPersistence = BlogDashboardPersistence(), postsParser: BlogDashboardPostsParser? = nil) {
+    init(managedObjectContext: NSManagedObjectContext,
+         remoteService: DashboardServiceRemote? = nil,
+         persistence: BlogDashboardPersistence = BlogDashboardPersistence(),
+         repository: UserPersistentRepository = UserDefaults.standard,
+         postsParser: BlogDashboardPostsParser? = nil) {
         self.remoteService = remoteService ?? DashboardServiceRemote(wordPressComRestApi: WordPressComRestApi.defaultApi(in: managedObjectContext, localeKey: WordPressComRestApi.LocaleKeyV2))
         self.persistence = persistence
+        self.repository = repository
         self.postsParser = postsParser ?? BlogDashboardPostsParser(managedObjectContext: managedObjectContext)
     }
 
@@ -79,16 +85,14 @@ class BlogDashboardService {
 private extension BlogDashboardService {
 
     func parse(_ entity: BlogDashboardRemoteEntity?, blog: Blog, dotComID: Int) -> [DashboardCardModel] {
-        var items: [DashboardCardModel] = []
-        DashboardCard.allCases.forEach { card in
-            guard card.shouldShow(for: blog, apiResponse: entity) else {
-                return
+        let personalizationService = BlogDashboardPersonalizationService(repository: repository, siteID: dotComID)
+        return DashboardCard.allCases.compactMap { card in
+            guard personalizationService.isEnabled(card),
+                  card.shouldShow(for: blog, apiResponse: entity) else {
+                return nil
             }
-
-            let cardModel = DashboardCardModel(cardType: card, dotComID: dotComID, entity: entity)
-            items.append(cardModel)
+            return DashboardCardModel(cardType: card, dotComID: dotComID, entity: entity)
         }
-        return items
     }
 
     func decode(_ cardsDictionary: NSDictionary, blog: Blog) -> BlogDashboardRemoteEntity? {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -102,7 +102,7 @@ class BlogDashboardViewModel {
         })
     }
 
-    func loadCardsFromCache() {
+    @objc func loadCardsFromCache() {
         let cards = service.fetchLocal(blog: blog)
         updateCurrentCards(cards: cards)
     }
@@ -127,6 +127,7 @@ private extension BlogDashboardViewModel {
         NotificationCenter.default.addObserver(self, selector: #selector(showDraftsCardIfNeeded), name: .newPostCreated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showScheduledCardIfNeeded), name: .newPostScheduled, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(showNextPostCardIfNeeded), name: .newPostPublished, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(loadCardsFromCache), name: .blogDashboardPersonalizationSettingsChanged, object: nil)
     }
 
     func updateCurrentCards(cards: [DashboardCardModel]) {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Blogging.swift
@@ -92,23 +92,20 @@ private extension SiteSettingsViewController {
     }
 
     var isPromptsSwitchEnabled: Bool {
-        guard let siteID = blog.dotComID?.stringValue else {
+        guard let siteID = blog.dotComID else {
             return false
         }
-
-        return UserPersistentStoreFactory.instance().promptsEnabledSettings[siteID] ?? false
+        return BlogDashboardPersonalizationService(siteID: siteID.intValue).isEnabled(.prompts)
     }
 
     var promptsSwitchOnChange: (Bool) -> () {
         return { [weak self] isPromptsEnabled in
             WPAnalytics.track(.promptsSettingsShowPromptsTapped, properties: ["enabled": isPromptsEnabled])
-            guard let siteID = self?.blog.dotComID?.stringValue else {
+            guard let siteID = self?.blog.dotComID else {
                 return
             }
-            let repository = UserPersistentStoreFactory.instance()
-            var promptsEnabledSettings = repository.promptsEnabledSettings
-            promptsEnabledSettings[siteID] = isPromptsEnabled
-            repository.promptsEnabledSettings = promptsEnabledSettings
+            BlogDashboardPersonalizationService(siteID: siteID.intValue)
+                .setEnabled(isPromptsEnabled, for: .prompts)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -301,9 +301,8 @@ private extension CreateButtonCoordinator {
               let blog = blog,
               blog.isAccessibleThroughWPCom(),
               let prompt = prompt,
-              let siteID = blog.dotComID?.stringValue,
-              let isPromptsEnabled = UserPersistentStoreFactory.instance().promptsEnabledSettings[siteID],
-              isPromptsEnabled,
+              let siteID = blog.dotComID,
+              BlogDashboardPersonalizationService(siteID: siteID.intValue).isEnabled(.prompts),
               !userSkippedPrompt(prompt, for: blog) else {
             return nil
         }

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -292,6 +292,9 @@
 		0A9610F928B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
+		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
+		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
+		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
 		1702BBDC1CEDEA6B00766A33 /* BadgeLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDB1CEDEA6B00766A33 /* BadgeLabel.swift */; };
 		1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1702BBDF1CF3034E00766A33 /* DomainsService.swift */; };
 		17039225282E6D2800F602E9 /* ViewsVisitorsLineChartCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC772B0728201F5300664C02 /* ViewsVisitorsLineChartCell.swift */; };
@@ -5881,6 +5884,8 @@
 		0A69300A28B5AA5E00E98DE1 /* FullScreenCommentReplyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelTests.swift; sourceTree = "<group>"; };
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
+		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
+		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		131D0EE49695795ECEDAA446 /* Pods-WordPressTest.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressTest.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressTest/Pods-WordPressTest.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		150B6590614A28DF9AD25491 /* Pods-Apps-Jetpack.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		152F25D5C232985E30F56CAC /* Pods-Apps-Jetpack.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Apps-Jetpack.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Apps-Jetpack/Pods-Apps-Jetpack.debug.xcconfig"; sourceTree = "<group>"; };
@@ -13353,6 +13358,7 @@
 			children = (
 				8B6214E227B1B2F3001DF7B6 /* BlogDashboardService.swift */,
 				8BBC778A27B5531700DBA087 /* BlogDashboardPersistence.swift */,
+				0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */,
 				8BAC9D9D27BAB97E008EA44C /* BlogDashboardRemoteEntity.swift */,
 				8B15CDAA27EB89AC00A75749 /* BlogDashboardPostsParser.swift */,
 			);
@@ -13363,6 +13369,7 @@
 			isa = PBXGroup;
 			children = (
 				8B6214E527B1B446001DF7B6 /* BlogDashboardServiceTests.swift */,
+				0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */,
 				8BE9AB8727B6B5A300708E45 /* BlogDashboardPersistenceTests.swift */,
 				8B2D4F5427ECE376009B085C /* BlogDashboardPostsParserTests.swift */,
 				8BD34F0827D144FF005E931C /* BlogDashboardStateTests.swift */,
@@ -22113,6 +22120,7 @@
 				082AB9DD1C4F035E000CA523 /* PostTag.m in Sources */,
 				0107E16428FFED1800DE87DB /* WidgetConfiguration.swift in Sources */,
 				82FC612A1FA8B6F000A1757E /* ActivityListViewModel.swift in Sources */,
+				0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */,
 				F19153BD2549ED0800629EC4 /* UITextField+WorkaroundContinueIssue.swift in Sources */,
 				E17780801C97FA9500FA7E14 /* StoreKit+Debug.swift in Sources */,
 				E1ADE0EB20A9EF6200D6AADC /* PrivacySettingsViewController.swift in Sources */,
@@ -23086,6 +23094,7 @@
 				AB2211F425ED6E7A00BF72FC /* CommentServiceTests.swift in Sources */,
 				08E77F471EE9D72F006F9515 /* MediaThumbnailExporterTests.swift in Sources */,
 				59FBD5621B5684F300734466 /* ThemeServiceTests.m in Sources */,
+				0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */,
 				85F8E19D1B018698000859BB /* PushAuthenticationServiceTests.swift in Sources */,
 				931215E1267DE1C0008C3B69 /* StatsTotalRowDataTests.swift in Sources */,
 				F41E4E8C28F18B7B001880C6 /* AppIconListViewModelTests.swift in Sources */,
@@ -24830,6 +24839,7 @@
 				FABB257B2602FC2C00C8785C /* WPAccount.m in Sources */,
 				80C523A529959DE000B1C14B /* BlazeWebViewController.swift in Sources */,
 				FABB257C2602FC2C00C8785C /* CLPlacemark+Formatting.swift in Sources */,
+				0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */,
 				FABB257D2602FC2C00C8785C /* SiteStatsDetailTableViewController.swift in Sources */,
 				FABB257E2602FC2C00C8785C /* MessageAnimator.swift in Sources */,
 				C3AB4879292F114A001F7AF8 /* UIApplication+AppAvailability.swift in Sources */,

--- a/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
+++ b/WordPress/WordPressTest/Dashboard/BlogDashboardPersonalizationServiceTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import Nimble
+
+@testable import WordPress
+
+final class BlogDashboardPersonalizationServiceTests: XCTestCase {
+    private let repository = InMemoryUserDefaults()
+
+    func testThatSettingsAreSavedPersistently() {
+        // Given
+        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+            .setEnabled(false, for: .prompts)
+
+        // When new service is created
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+
+        // Then settings are retained
+        XCTAssertFalse(service.isEnabled(.prompts))
+    }
+
+    func testThatServiceNotifiesAboutChanges() {
+        // Given
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+        XCTAssertFalse(service.hasPreference(for: .prompts))
+
+        let expectation = self.expectation(forNotification: .blogDashboardPersonalizationSettingsChanged, object: nil)
+
+        // When
+        service.setEnabled(false, for: .prompts)
+
+        // Then notification is sent
+        wait(for: [expectation], timeout: 1)
+        XCTAssertTrue(service.hasPreference(for: .prompts))
+    }
+
+    func testThatSettingsAreSavedPerSite() {
+        // Given prompts disabled for site 1
+        BlogDashboardPersonalizationService(repository: repository, siteID: 1)
+            .setEnabled(false, for: .quickStart)
+
+        // When service is created for site 2
+        let service = BlogDashboardPersonalizationService(repository: repository, siteID: 2)
+
+        // Then settings for site 1 are ignored
+        XCTAssertTrue(service.isEnabled(.quickStart))
+    }
+}


### PR DESCRIPTION
Related issue: #20296

Hey 👋. I'm working on adding [an ability to hide](https://jetpackmobile.wordpress.com/2023/03/14/hiding-dashboard-cards-i2-ios/) any of the dashboard cards. It is the first PR in the series. 

The PR contains the necessary groundwork for allowing any dashboard cards to be hidden. It introduces a new `BlogDashboardPersonalizationService` type to manage these preferences. The keys for the cards are generated dynamically. The format of the keys and the data matches the format previously used for Prompts and Blaze cards, ensuring the existing data is migrated automatically. 

## Testing Instructions

There are no functional changes. I performed the following tests to verify there are no regressions:

**Test 1**

1. Open the Dashboard and hide the Prompts card by selecting "Turn off prompt" in the context menu (three dots)
2. Verify that the Prompts card and the Prompts header in the "Create New" menu are both hidden
3. Open Menu / Site Settings
4. Verify that the "Show Prompts" toggle is off
5. Turn the toggle on
6. Open Dashboard and verify that the Prompts card is now visible again

**Test 2**

1. Tap the context menu (three dots) on the Blaze card and select "Hide this"
2. Verify that the Blaze card is still hidden

**Test 3**

1. Install the previous version of the app (clean install)
2. Tap the context menu (three dots) on the Prompts card and select "Turn off prompts"
3. Update the app to the version from this PR
4. Verify that the Prompts card is still hidden

**Test 4**

1. Install the previous version of the app (clean install)
1. Tap the context menu (three dots) on the Blaze card and select "Hide this"
3. Update the app to the version from this PR
2. Verify that the Blaze card is still hidden

## Regression Notes

1. Potential unintended areas of impact: 
The existing feature for managing card visibility ("Turn off prompts", "Hide this" on the Blaze card)
3. What I did to test those areas of impact (or what existing automated tests I relied on):
I tested the scenarios from the "Testing Instructions" that included installing the previous version of the app and performing the migration.
4. What automated tests I added (or what prevented me from doing so)
I added full test coverage for the new service for managing preferences and also tested its integration with the service responsible for parsing the cards and deciding which ones to display

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
