### PR TITLE
Create a standalone TimeLineProvider and TimelineEntry for the lock screen 

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2866,6 +2866,8 @@
 		C9B4778A29C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
 		C9B4778E29C85BC5008CBF49 /* LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */; };
 		C9B4779F29C88323008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
+		C9B477A829CC13C6008CBF49 /* LockScreenSiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */; };
+		C9B477A929CC13CB008CBF49 /* LockScreenSiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */; };
 		C9C21D7729BECFC1009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7B29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */; };
@@ -8123,6 +8125,7 @@
 		C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetData.swift; sourceTree = "<group>"; };
 		C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetEntry.swift; sourceTree = "<group>"; };
 		C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HomeWidgetData+LockScreenStatsWidgetData.swift"; sourceTree = "<group>"; };
+		C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenSiteListProvider.swift; sourceTree = "<group>"; };
 		C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidget.swift; sourceTree = "<group>"; };
 		C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetsView.swift; sourceTree = "<group>"; };
 		C9D7DDBF2613B84500104E95 /* WordPress 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 119.xcdatamodel"; sourceTree = "<group>"; };
@@ -15679,6 +15682,7 @@
 			isa = PBXGroup;
 			children = (
 				C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */,
+				C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */,
 				C9FE383B29C2A3A300D39841 /* Configs */,
 				C9FE382929C204D700D39841 /* Models */,
 				C9C21D8829BF4998009F68E5 /* Views */,
@@ -20519,6 +20523,7 @@
 				0107E0C028F97D5000DE87DB /* WordPressHomeWidgetToday.swift in Sources */,
 				0107E0C128F97D5000DE87DB /* FlexibleCard.swift in Sources */,
 				0107E0C228F97D5000DE87DB /* VerticalCard.swift in Sources */,
+				C9B477A929CC13CB008CBF49 /* LockScreenSiteListProvider.swift in Sources */,
 				0107E0C328F97D5000DE87DB /* ThisWeekWidgetStats.swift in Sources */,
 				0107E0C428F97D5000DE87DB /* HomeWidgetAllTimeData.swift in Sources */,
 				C9B4778529C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,
@@ -22391,6 +22396,7 @@
 				3F568A2F254216550048A9E4 /* FlexibleCard.swift in Sources */,
 				3F568A1F254213B60048A9E4 /* VerticalCard.swift in Sources */,
 				3F8B306825D1D4B8005A2903 /* ThisWeekWidgetStats.swift in Sources */,
+				C9B477A829CC13C6008CBF49 /* LockScreenSiteListProvider.swift in Sources */,
 				3F5C861A25C9EA2500BABE64 /* HomeWidgetAllTimeData.swift in Sources */,
 				3FE20C1525CF165700A15525 /* GroupedViewData.swift in Sources */,
 				C9B4778429C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2868,6 +2868,8 @@
 		C9B4779F29C88323008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
 		C9B477A829CC13C6008CBF49 /* LockScreenSiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */; };
 		C9B477A929CC13CB008CBF49 /* LockScreenSiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */; };
+		C9B477AC29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */; };
+		C9B477AD29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */; };
 		C9C21D7729BECFC1009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7B29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */; };
@@ -8126,6 +8128,7 @@
 		C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetEntry.swift; sourceTree = "<group>"; };
 		C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HomeWidgetData+LockScreenStatsWidgetData.swift"; sourceTree = "<group>"; };
 		C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenSiteListProvider.swift; sourceTree = "<group>"; };
+		C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetDataReader.swift; sourceTree = "<group>"; };
 		C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidget.swift; sourceTree = "<group>"; };
 		C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetsView.swift; sourceTree = "<group>"; };
 		C9D7DDBF2613B84500104E95 /* WordPress 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 119.xcdatamodel"; sourceTree = "<group>"; };
@@ -11076,6 +11079,7 @@
 				3F8EEC6F25B4849A00EC9DAE /* SiteListProvider.swift */,
 				C9C21D7529BECFAE009F68E5 /* LockScreenWidgets */,
 				C9FE382029C203EE00D39841 /* Extensions */,
+				C9B477AA29CC15C2008CBF49 /* Helpers */,
 				3FFDDCB925B8A65F008D5BDD /* Widgets */,
 				3FB34ABB25672A59001A74A6 /* Model */,
 				3FFDDC0325B89F0C008D5BDD /* Cache */,
@@ -15676,6 +15680,14 @@
 				C81CCD71243BF7A500A83E27 /* TenorStrings.swift */,
 			);
 			path = Tenor;
+			sourceTree = "<group>";
+		};
+		C9B477AA29CC15C2008CBF49 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */,
+			);
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		C9C21D7529BECFAE009F68E5 /* LockScreenWidgets */ = {
@@ -20512,6 +20524,7 @@
 				0107E0B828F97D5000DE87DB /* KeychainUtils.swift in Sources */,
 				0107E0B928F97D5000DE87DB /* BuildConfiguration.swift in Sources */,
 				0107E0BA28F97D5000DE87DB /* TodayWidgetStats.swift in Sources */,
+				C9B477AD29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */,
 				C9FE384129C2A3D200D39841 /* LockScreenTodayViewsStatWidgetConfig.swift in Sources */,
 				0107E16128FFE99300DE87DB /* WidgetConfiguration.swift in Sources */,
 				0107E0BB28F97D5000DE87DB /* StatsWidgetsService.swift in Sources */,
@@ -22385,6 +22398,7 @@
 				83A1B19A28AFE47C00E737AC /* KeychainUtils.swift in Sources */,
 				3F6BC06D25B24787007369D3 /* BuildConfiguration.swift in Sources */,
 				3F1FD2502548AD8B0060C53A /* TodayWidgetStats.swift in Sources */,
+				C9B477AC29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */,
 				C9FE384029C2A3D200D39841 /* LockScreenTodayViewsStatWidgetConfig.swift in Sources */,
 				0107E16A28FFED1800DE87DB /* WidgetConfiguration.swift in Sources */,
 				3F2F0C16256C6B2C003351C7 /* StatsWidgetsService.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2870,6 +2870,11 @@
 		C9B477A929CC13CB008CBF49 /* LockScreenSiteListProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */; };
 		C9B477AC29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */; };
 		C9B477AD29CC15D9008CBF49 /* WidgetDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */; };
+		C9B477AE29CC35A0008CBF49 /* WidgetDataReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */; };
+		C9B477B029CC35C5008CBF49 /* WidgetDataReaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477AF29CC35C5008CBF49 /* WidgetDataReaderTests.swift */; };
+		C9B477B229CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477B129CC4949008CBF49 /* HomeWidgetDataFileReader.swift */; };
+		C9B477B329CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477B129CC4949008CBF49 /* HomeWidgetDataFileReader.swift */; };
+		C9B477B429CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B477B129CC4949008CBF49 /* HomeWidgetDataFileReader.swift */; };
 		C9C21D7729BECFC1009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7B29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */; };
@@ -8129,6 +8134,8 @@
 		C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HomeWidgetData+LockScreenStatsWidgetData.swift"; sourceTree = "<group>"; };
 		C9B477A729CC13C6008CBF49 /* LockScreenSiteListProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenSiteListProvider.swift; sourceTree = "<group>"; };
 		C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WidgetDataReader.swift; sourceTree = "<group>"; };
+		C9B477AF29CC35C5008CBF49 /* WidgetDataReaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDataReaderTests.swift; sourceTree = "<group>"; };
+		C9B477B129CC4949008CBF49 /* HomeWidgetDataFileReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeWidgetDataFileReader.swift; sourceTree = "<group>"; };
 		C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidget.swift; sourceTree = "<group>"; };
 		C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetsView.swift; sourceTree = "<group>"; };
 		C9D7DDBF2613B84500104E95 /* WordPress 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 119.xcdatamodel"; sourceTree = "<group>"; };
@@ -15686,6 +15693,7 @@
 			isa = PBXGroup;
 			children = (
 				C9B477AB29CC15D9008CBF49 /* WidgetDataReader.swift */,
+				C9B477B129CC4949008CBF49 /* HomeWidgetDataFileReader.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -15744,6 +15752,7 @@
 			isa = PBXGroup;
 			children = (
 				C9FE383629C2067E00D39841 /* WidgetsViewModelMapperTests.swift */,
+				C9B477AF29CC35C5008CBF49 /* WidgetDataReaderTests.swift */,
 			);
 			path = Widgets;
 			sourceTree = "<group>";
@@ -20547,6 +20556,7 @@
 				0107E18F29000EA200DE87DB /* UIColor+MurielColors.swift in Sources */,
 				0107E0C828F97D5000DE87DB /* StatsValueView.swift in Sources */,
 				0107E0C928F97D5000DE87DB /* SiteListProvider.swift in Sources */,
+				C9B477B429CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */,
 				0107E0CA28F97D5000DE87DB /* HomeWidgetThisWeekData.swift in Sources */,
 				0107E0CB28F97D5000DE87DB /* WordPressHomeWidgetAllTime.swift in Sources */,
 				0107E0CC28F97D5000DE87DB /* KeyValueDatabase.swift in Sources */,
@@ -20974,6 +20984,7 @@
 				98AA9F2127EA890800B3A98C /* FeatureIntroductionViewController.swift in Sources */,
 				BE1071FC1BC75E7400906AFF /* WPStyleGuide+Blog.swift in Sources */,
 				B56695B01D411EEB007E342F /* KeyboardDismissHelper.swift in Sources */,
+				C9B477B229CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */,
 				F5B9D7F0245BA938002BB2C7 /* FancyAlertViewController+CreateButtonAnnouncement.swift in Sources */,
 				FF54D4641D6F3FA900A0DC4D /* GutenbergSettings.swift in Sources */,
 				3FAF9CC526D03C7400268EA2 /* DomainSuggestionViewControllerWrapper.swift in Sources */,
@@ -21246,6 +21257,7 @@
 				FAC1B81E29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
 				C9B4778E29C85BC5008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,
 				C81CCD84243BF7A600A83E27 /* NoResultsTenorConfiguration.swift in Sources */,
+				C9B477AE29CC35A0008CBF49 /* WidgetDataReader.swift in Sources */,
 				9A8ECE0F2254A3260043C8DA /* JetpackRemoteInstallViewController.swift in Sources */,
 				1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */,
 				9A2CD5372146B8C700AE5055 /* Array+Page.swift in Sources */,
@@ -22421,6 +22433,7 @@
 				0107E18E29000EA100DE87DB /* UIColor+MurielColors.swift in Sources */,
 				3F8EEC7025B4849A00EC9DAE /* SiteListProvider.swift in Sources */,
 				3F8B136D25D08F34004FAC0A /* HomeWidgetThisWeekData.swift in Sources */,
+				C9B477B329CC4949008CBF49 /* HomeWidgetDataFileReader.swift in Sources */,
 				3F5C86C025CA197500BABE64 /* WordPressHomeWidgetAllTime.swift in Sources */,
 				3F6BC07E25B247A4007369D3 /* KeyValueDatabase.swift in Sources */,
 				3F1FD27B2548AE900060C53A /* CocoaLumberjack.swift in Sources */,
@@ -23112,6 +23125,7 @@
 				D848CC1920FF3A2400A9038F /* FormattableNotIconTests.swift in Sources */,
 				32110547250BFC3E0048446F /* ImageDimensionParserTests.swift in Sources */,
 				E1AB5A3A1E0C464700574B4E /* DelayTests.swift in Sources */,
+				C9B477B029CC35C5008CBF49 /* WidgetDataReaderTests.swift in Sources */,
 				8B7F51CB24EED8A8008CF5B5 /* ReaderTrackerTests.swift in Sources */,
 				D848CC0320FF04FA00A9038F /* FormattableUserContentTests.swift in Sources */,
 				5948AD111AB73D19006E8882 /* WPAppAnalyticsTests.m in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2858,6 +2858,14 @@
 		C957C20626DCC1770037628F /* LandInTheEditorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957C20526DCC1770037628F /* LandInTheEditorHelper.swift */; };
 		C957C20726DCC1770037628F /* LandInTheEditorHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = C957C20526DCC1770037628F /* LandInTheEditorHelper.swift */; };
 		C99B08FC26081AD600CA71EB /* TemplatePreviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C99B08FB26081AD600CA71EB /* TemplatePreviewViewController.swift */; };
+		C9B4778429C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */; };
+		C9B4778529C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */; };
+		C9B4778629C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */; };
+		C9B4778729C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */; };
+		C9B4778929C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
+		C9B4778A29C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
+		C9B4778E29C85BC5008CBF49 /* LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */; };
+		C9B4779F29C88323008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */; };
 		C9C21D7729BECFC1009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */; };
 		C9C21D7B29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */; };
@@ -8112,6 +8120,9 @@
 		C957C20526DCC1770037628F /* LandInTheEditorHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LandInTheEditorHelper.swift; sourceTree = "<group>"; };
 		C99B039B2602F3CB00CA71EB /* WordPress 117.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 117.xcdatamodel"; sourceTree = "<group>"; };
 		C99B08FB26081AD600CA71EB /* TemplatePreviewViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatePreviewViewController.swift; sourceTree = "<group>"; };
+		C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetData.swift; sourceTree = "<group>"; };
+		C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetEntry.swift; sourceTree = "<group>"; };
+		C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "HomeWidgetData+LockScreenStatsWidgetData.swift"; sourceTree = "<group>"; };
 		C9C21D7629BECFC1009F68E5 /* LockScreenStatsWidget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidget.swift; sourceTree = "<group>"; };
 		C9C21D7A29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenStatsWidgetsView.swift; sourceTree = "<group>"; };
 		C9D7DDBF2613B84500104E95 /* WordPress 119.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "WordPress 119.xcdatamodel"; sourceTree = "<group>"; };
@@ -15689,6 +15700,7 @@
 			isa = PBXGroup;
 			children = (
 				C9FE382129C2040600D39841 /* HomeWidgetData+StatsURL.swift */,
+				C9B4778829C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -15704,6 +15716,8 @@
 		C9FE382929C204D700D39841 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				C9B4778229C85948008CBF49 /* LockScreenStatsWidgetData.swift */,
+				C9B4778329C85949008CBF49 /* LockScreenStatsWidgetEntry.swift */,
 				C9FE382B29C204E700D39841 /* LockScreenSingleStatViewModel.swift */,
 				C9FE382A29C204E700D39841 /* LockScreenWidgetViewModelMapper.swift */,
 			);
@@ -20482,6 +20496,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9B4778729C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */,
 				0107E0B428F97D5000DE87DB /* Constants.m in Sources */,
 				01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				C9C21D7C29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */,
@@ -20506,6 +20521,7 @@
 				0107E0C228F97D5000DE87DB /* VerticalCard.swift in Sources */,
 				0107E0C328F97D5000DE87DB /* ThisWeekWidgetStats.swift in Sources */,
 				0107E0C428F97D5000DE87DB /* HomeWidgetAllTimeData.swift in Sources */,
+				C9B4778529C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,
 				0107E0C528F97D5000DE87DB /* GroupedViewData.swift in Sources */,
 				C9C21D7829BECFC7009F68E5 /* LockScreenStatsWidget.swift in Sources */,
 				0107E0C628F97D5000DE87DB /* FeatureFlag.swift in Sources */,
@@ -20529,6 +20545,7 @@
 				0107E0D328F97D5000DE87DB /* Tracks+StatsWidgets.swift in Sources */,
 				0107E0D428F97D5000DE87DB /* HomeWidgetData.swift in Sources */,
 				0107E0D528F97D5000DE87DB /* HomeWidgetTodayData.swift in Sources */,
+				C9B4778A29C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */,
 				0107E0D628F97D5000DE87DB /* AllTimeWidgetStats.swift in Sources */,
 				0107E0D728F97D5000DE87DB /* Sites.intentdefinition in Sources */,
 				0107E0D828F97D5000DE87DB /* LocalizableStrings.swift in Sources */,
@@ -21209,6 +21226,7 @@
 				B59D994F1C0790CC0003D795 /* SettingsListEditorViewController.swift in Sources */,
 				9A4E215C21F75BBE00EFF212 /* QuickStartChecklistManager.swift in Sources */,
 				FAC1B81E29B0C2AC00E0C542 /* BlazeOverlayViewModel.swift in Sources */,
+				C9B4778E29C85BC5008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,
 				C81CCD84243BF7A600A83E27 /* NoResultsTenorConfiguration.swift in Sources */,
 				9A8ECE0F2254A3260043C8DA /* JetpackRemoteInstallViewController.swift in Sources */,
 				1724DDC81C60F1200099D273 /* PlanDetailViewController.swift in Sources */,
@@ -22267,6 +22285,7 @@
 				C39ABBAE294BE84000F6F278 /* BackupListViewController+JetpackBannerViewController.swift in Sources */,
 				1714F8D020E6DA8900226DCB /* RouteMatcher.swift in Sources */,
 				591A428F1A6DC6F2003807A6 /* WPGUIConstants.m in Sources */,
+				C9B4779F29C88323008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */,
 				3FD272E024CF8F270021F0C8 /* UIColor+Notice.swift in Sources */,
 				98830A922747043B0061A87C /* BorderedButtonTableViewCell.swift in Sources */,
 				FAD9457E25B5647B00F011B5 /* JetpackBackupOptionsCoordinator.swift in Sources */,
@@ -22349,6 +22368,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9B4778629C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */,
 				3F1FD30D2548B0A80060C53A /* Constants.m in Sources */,
 				01CE500C290A88BF00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				C9C21D7B29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */,
@@ -22373,6 +22393,7 @@
 				3F8B306825D1D4B8005A2903 /* ThisWeekWidgetStats.swift in Sources */,
 				3F5C861A25C9EA2500BABE64 /* HomeWidgetAllTimeData.swift in Sources */,
 				3FE20C1525CF165700A15525 /* GroupedViewData.swift in Sources */,
+				C9B4778429C85949008CBF49 /* LockScreenStatsWidgetData.swift in Sources */,
 				3F6BC04B25B2474C007369D3 /* FeatureFlag.swift in Sources */,
 				C9C21D7729BECFC1009F68E5 /* LockScreenStatsWidget.swift in Sources */,
 				3F8EEC4E25B4817000EC9DAE /* StatsWidgets.swift in Sources */,
@@ -22396,6 +22417,7 @@
 				98390AC3254C984700868F0A /* Tracks+StatsWidgets.swift in Sources */,
 				3FA53ED62565860900F4D9A2 /* HomeWidgetData.swift in Sources */,
 				3FB34ACB25672A90001A74A6 /* HomeWidgetTodayData.swift in Sources */,
+				C9B4778929C85956008CBF49 /* HomeWidgetData+LockScreenStatsWidgetData.swift in Sources */,
 				3F5C863B25C9EA8200BABE64 /* AllTimeWidgetStats.swift in Sources */,
 				3FD675D925C87A15009AB3C1 /* Sites.intentdefinition in Sources */,
 				3FE77C8325B0CA89007DE9E5 /* LocalizableStrings.swift in Sources */,

--- a/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+LockScreenStatsWidgetData.swift
+++ b/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+LockScreenStatsWidgetData.swift
@@ -6,13 +6,11 @@ extension HomeWidgetTodayData: LockScreenStatsWidgetData {
     }
 }
 
-
 extension HomeWidgetAllTimeData: LockScreenStatsWidgetData {
     var views: Int? {
         stats.views
     }
 }
-
 
 extension HomeWidgetThisWeekData: LockScreenStatsWidgetData {
     var views: Int? {

--- a/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+LockScreenStatsWidgetData.swift
+++ b/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+LockScreenStatsWidgetData.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+extension HomeWidgetTodayData: LockScreenStatsWidgetData {
+    var views: Int? {
+        stats.views
+    }
+}
+
+
+extension HomeWidgetAllTimeData: LockScreenStatsWidgetData {
+    var views: Int? {
+        stats.views
+    }
+}
+
+
+extension HomeWidgetThisWeekData: LockScreenStatsWidgetData {
+    var views: Int? {
+        nil
+    }
+}

--- a/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+StatsURL.swift
+++ b/WordPress/WordPressStatsWidgets/Extensions/HomeWidgetData+StatsURL.swift
@@ -8,7 +8,6 @@ extension HomeWidgetTodayData {
     }
 }
 
-
 extension HomeWidgetAllTimeData {
     static let statsUrl = "https://wordpress.com/stats/insights/"
 
@@ -16,7 +15,6 @@ extension HomeWidgetAllTimeData {
         URL(string: Self.statsUrl + "\(siteID)?source=widget")
     }
 }
-
 
 extension HomeWidgetThisWeekData {
     static let statsUrl = "https://wordpress.com/stats/week/"

--- a/WordPress/WordPressStatsWidgets/Helpers/HomeWidgetDataFileReader.swift
+++ b/WordPress/WordPressStatsWidgets/Helpers/HomeWidgetDataFileReader.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+final class HomeWidgetDataFileReader: WidgetDataCacheReader {
+    func widgetData<T: HomeWidgetData>(for siteID: String) -> T? {
+        /// - TODO: we should not really be needing to do this conversion.  Maybe we can evaluate a better mechanism for site identification.
+        guard let siteID = Int(siteID) else {
+            return nil
+        }
+
+        return T.read()?[siteID]
+    }
+}

--- a/WordPress/WordPressStatsWidgets/Helpers/WidgetDataReader.swift
+++ b/WordPress/WordPressStatsWidgets/Helpers/WidgetDataReader.swift
@@ -12,11 +12,16 @@ final class WidgetDataReader<T: HomeWidgetData> {
     func widgetData(for configuration: SelectSiteIntent, defaultSiteID: Int?) -> T? {
 
         /// If configuration.site.identifier has value but there's no widgetData, it means that this identifier comes from previously logged in account
-        return widgetData(for: configuration.site?.identifier ?? String(defaultSiteID))
-        ?? widgetData(for: String(defaultSiteID))
+        if let selectedSite = configuration.site?.identifier, let widgetData = widgetData(for: selectedSite) {
+            return widgetData
+        } else if let defaultSiteID = defaultSiteID {
+            return widgetData(for: String(defaultSiteID))
+        } else {
+            return nil
+        }
     }
 
-    func widgetData(for siteID: String) -> T? {
+    private func widgetData(for siteID: String) -> T? {
         /// - TODO: we should not really be needing to do this conversion.  Maybe we can evaluate a better mechanism for site identification.
         guard let siteID = Int(siteID) else {
             return nil

--- a/WordPress/WordPressStatsWidgets/Helpers/WidgetDataReader.swift
+++ b/WordPress/WordPressStatsWidgets/Helpers/WidgetDataReader.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+final class WidgetDataReader<T: HomeWidgetData> {
+    /// Returns cached widget data based on the selected site when editing widget and the default site.
+    /// Configuration.site is nil until IntentHandler is initialized.
+    /// Configuration.site can have old value after logging in with a different account. No way to reset configuration when the user logs out.
+    /// Using defaultSiteID if both of these cases.
+    /// - Parameters:
+    ///   - configuration: Configuration of the Widget Site Selection Intent
+    ///   - defaultSiteID: ID of the default site in the account
+    /// - Returns: Widget data
+    func widgetData(for configuration: SelectSiteIntent, defaultSiteID: Int?) -> T? {
+
+        /// If configuration.site.identifier has value but there's no widgetData, it means that this identifier comes from previously logged in account
+        return widgetData(for: configuration.site?.identifier ?? String(defaultSiteID))
+        ?? widgetData(for: String(defaultSiteID))
+    }
+
+    func widgetData(for siteID: String) -> T? {
+        /// - TODO: we should not really be needing to do this conversion.  Maybe we can evaluate a better mechanism for site identification.
+        guard let siteID = Int(siteID) else {
+            return nil
+        }
+
+        return T.read()?[siteID]
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenStatsWidgetConfig.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Configs/LockScreenStatsWidgetConfig.swift
@@ -1,7 +1,7 @@
 import WidgetKit
 
 protocol LockScreenStatsWidgetConfig {
-    associatedtype WidgetData: HomeWidgetData
+    associatedtype WidgetData: HomeWidgetData & LockScreenStatsWidgetData
     associatedtype ViewProvider: LockScreenStatsWidgetsViewProvider
 
     var supportFamilies: [WidgetFamily] { get }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
@@ -29,6 +29,7 @@ struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>
         widgetDataLoader.widgetData(
             for: configuration,
             defaultSiteID: defaultSiteID,
+            isJetpack: AppConfiguration.isJetpack,
             onNoData: {
                 completion(Timeline(entries: [.noData], policy: .never))
             }, onNoSite: {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
@@ -2,7 +2,6 @@ import WidgetKit
 import SwiftUI
 
 struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>: IntentTimelineProvider {
-
     let service: StatsWidgetsService
     let placeholderContent: T
 
@@ -12,7 +11,6 @@ struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>
     let minElapsedTimeToRefresh = 1
 
     private var defaultSiteID: Int? {
-
         UserDefaults(suiteName: WPAppGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
     }
 
@@ -23,60 +21,45 @@ struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>
     }
 
     func getSnapshot(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (LockScreenStatsWidgetEntry) -> Void) {
-
         let content = widgetDataLoader.widgetData(for: configuration, defaultSiteID: defaultSiteID) ?? placeholderContent
         completion(.siteSelected(content, context))
     }
 
     func getTimeline(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (Timeline<LockScreenStatsWidgetEntry>) -> Void) {
-        guard let defaults = UserDefaults(suiteName: WPAppGroupName) else {
-            completion(Timeline(entries: [.noData], policy: .never))
-            return
-        }
-        guard let defaultSiteID = defaultSiteID else {
-            let loggedIn = defaults.bool(forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
-
-            if loggedIn {
+        widgetDataLoader.widgetData(
+            for: configuration,
+            defaultSiteID: defaultSiteID,
+            onNoData: {
+                completion(Timeline(entries: [.noData], policy: .never))
+            }, onNoSite: {
                 completion(Timeline(entries: [.noSite], policy: .never))
-            } else {
+            }, onLoggedOut: {
                 completion(Timeline(entries: [.loggedOut], policy: .never))
+            }, onSiteSelected: { widgetData in
+                let date = Date()
+                let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: refreshInterval, to: date) ?? date
+                let elapsedTime = abs(Calendar.current.dateComponents([.minute], from: widgetData.date, to: date).minute ?? 0)
+
+                let privateCompletion = { (timelineEntry: LockScreenStatsWidgetEntry) in
+                    let timeline = Timeline(entries: [timelineEntry], policy: .after(nextRefreshDate))
+                    completion(timeline)
+                }
+                // if cached data are "too old", refresh them from the backend, otherwise keep them
+                guard elapsedTime > minElapsedTimeToRefresh else {
+                    privateCompletion(.siteSelected(widgetData, context))
+                    return
+                }
+
+                service.fetchStats(for: widgetData) { result in
+                    switch result {
+                    case .failure(let error):
+                        DDLogError("StatsWidgets: failed to fetch remote stats. Returned error: \(error.localizedDescription)")
+                        privateCompletion(.siteSelected(widgetData, context))
+                    case .success(let newWidgetData):
+                        privateCompletion(.siteSelected(newWidgetData, context))
+                    }
+                }
             }
-            return
-        }
-
-        guard let widgetData = widgetDataLoader.widgetData(for: configuration, defaultSiteID: defaultSiteID) else {
-            completion(Timeline(entries: [.noData], policy: .never))
-            return
-        }
-
-        let date = Date()
-        let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: refreshInterval, to: date) ?? date
-        let elapsedTime = abs(Calendar.current.dateComponents([.minute], from: widgetData.date, to: date).minute ?? 0)
-
-        let privateCompletion = { (timelineEntry: LockScreenStatsWidgetEntry) in
-            let timeline = Timeline(entries: [timelineEntry], policy: .after(nextRefreshDate))
-            completion(timeline)
-        }
-
-        // if cached data are "too old", refresh them from the backend, otherwise keep them
-        guard elapsedTime > minElapsedTimeToRefresh else {
-
-            privateCompletion(.siteSelected(widgetData, context))
-            return
-        }
-
-        service.fetchStats(for: widgetData) { result in
-
-            switch result {
-            case .failure(let error):
-                DDLogError("StatsWidgets: failed to fetch remote stats. Returned error: \(error.localizedDescription)")
-
-                privateCompletion(.siteSelected(widgetData, context))
-
-            case .success(let newWidgetData):
-
-                privateCompletion(.siteSelected(newWidgetData, context))
-            }
-        }
+        )
     }
 }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
@@ -24,19 +24,8 @@ struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>
 
     func getSnapshot(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (LockScreenStatsWidgetEntry) -> Void) {
 
-        guard let site = configuration.site,
-              let siteIdentifier = site.identifier,
-              let widgetData = widgetDataLoader.widgetData(for: siteIdentifier) else {
-
-            if let siteID = defaultSiteID, let content = T.read()?[siteID] {
-                completion(.siteSelected(content, context))
-            } else {
-                completion(.siteSelected(placeholderContent, context))
-            }
-            return
-        }
-
-        completion(.siteSelected(widgetData, context))
+        let content = widgetDataLoader.widgetData(for: configuration, defaultSiteID: defaultSiteID) ?? placeholderContent
+        completion(.siteSelected(content, context))
     }
 
     func getTimeline(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (Timeline<LockScreenStatsWidgetEntry>) -> Void) {

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
@@ -1,0 +1,120 @@
+import WidgetKit
+import SwiftUI
+
+struct LockScreenSiteListProvider<T: HomeWidgetData & LockScreenStatsWidgetData>: IntentTimelineProvider {
+
+    let service: StatsWidgetsService
+    let placeholderContent: T
+
+    // refresh interval of the widget, in minutes
+    let refreshInterval = 30
+    // minimum elapsed time, in minutes, before new data are fetched from the backend.
+    let minElapsedTimeToRefresh = 1
+
+    private var defaultSiteID: Int? {
+
+        UserDefaults(suiteName: WPAppGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
+    }
+
+    func placeholder(in context: Context) -> LockScreenStatsWidgetEntry {
+        LockScreenStatsWidgetEntry.siteSelected(placeholderContent, context)
+    }
+
+    func getSnapshot(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (LockScreenStatsWidgetEntry) -> Void) {
+
+        guard let site = configuration.site,
+              let siteIdentifier = site.identifier,
+              let widgetData = widgetData(for: siteIdentifier) else {
+
+            if let siteID = defaultSiteID, let content = T.read()?[siteID] {
+                completion(.siteSelected(content, context))
+            } else {
+                completion(.siteSelected(placeholderContent, context))
+            }
+            return
+        }
+
+        completion(.siteSelected(widgetData, context))
+    }
+
+    func getTimeline(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (Timeline<LockScreenStatsWidgetEntry>) -> Void) {
+        guard let defaults = UserDefaults(suiteName: WPAppGroupName) else {
+            completion(Timeline(entries: [.noData], policy: .never))
+            return
+        }
+        guard let defaultSiteID = defaultSiteID else {
+            let loggedIn = defaults.bool(forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
+
+            if loggedIn {
+                completion(Timeline(entries: [.noSite], policy: .never))
+            } else {
+                completion(Timeline(entries: [.loggedOut], policy: .never))
+            }
+            return
+        }
+
+        guard let widgetData = widgetData(for: configuration, defaultSiteID: defaultSiteID) else {
+            completion(Timeline(entries: [.noData], policy: .never))
+            return
+        }
+
+        let date = Date()
+        let nextRefreshDate = Calendar.current.date(byAdding: .minute, value: refreshInterval, to: date) ?? date
+        let elapsedTime = abs(Calendar.current.dateComponents([.minute], from: widgetData.date, to: date).minute ?? 0)
+
+        let privateCompletion = { (timelineEntry: LockScreenStatsWidgetEntry) in
+            let timeline = Timeline(entries: [timelineEntry], policy: .after(nextRefreshDate))
+            completion(timeline)
+        }
+
+        // if cached data are "too old", refresh them from the backend, otherwise keep them
+        guard elapsedTime > minElapsedTimeToRefresh else {
+
+            privateCompletion(.siteSelected(widgetData, context))
+            return
+        }
+
+        service.fetchStats(for: widgetData) { result in
+
+            switch result {
+            case .failure(let error):
+                DDLogError("StatsWidgets: failed to fetch remote stats. Returned error: \(error.localizedDescription)")
+
+                privateCompletion(.siteSelected(widgetData, context))
+
+            case .success(let newWidgetData):
+
+                privateCompletion(.siteSelected(newWidgetData, context))
+            }
+        }
+    }
+}
+
+
+// MARK: - Widget Data
+
+private extension LockScreenSiteListProvider {
+    /// Returns cached widget data based on the selected site when editing widget and the default site.
+    /// Configuration.site is nil until IntentHandler is initialized.
+    /// Configuration.site can have old value after logging in with a different account. No way to reset configuration when the user logs out.
+    /// Using defaultSiteID if both of these cases.
+    /// - Parameters:
+    ///   - configuration: Configuration of the Widget Site Selection Intent
+    ///   - defaultSiteID: ID of the default site in the account
+    /// - Returns: Widget data
+    func widgetData(for configuration: SelectSiteIntent, defaultSiteID: Int) -> T? {
+
+        /// If configuration.site.identifier has value but there's no widgetData, it means that this identifier comes from previously logged in account
+        return widgetData(for: configuration.site?.identifier ?? String(defaultSiteID))
+        ?? widgetData(for: String(defaultSiteID))
+    }
+
+    func widgetData(for siteID: String) -> T? {
+        /// - TODO: we should not really be needing to do this conversion.  Maybe we can evaluate a better mechanism for site identification.
+        guard let siteID = Int(siteID) else {
+            return nil
+        }
+
+        return T.read()?[siteID]
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
@@ -18,13 +18,11 @@ struct LockScreenStatsWidget<T: LockScreenStatsWidgetConfig>: Widget {
         IntentConfiguration(
             kind: config.kind,
             intent: SelectSiteIntent.self,
-            provider: SiteListProvider<T.WidgetData>(
+            provider: LockScreenSiteListProvider<T.WidgetData>(
                 service: StatsWidgetsService(),
-                placeholderContent: config.placeholderContent,
-                // TODO: remove widgetKind in creating lock screen widget provider and entry PR
-                widgetKind: .today
+                placeholderContent: config.placeholderContent
             )
-        ) { (entry: StatsWidgetEntry) -> LockScreenStatsWidgetsView in
+        ) { (entry: LockScreenStatsWidgetEntry) -> LockScreenStatsWidgetsView in
             return LockScreenStatsWidgetsView(
                 timelineEntry: entry,
                 viewProvider: config.viewProvider

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenStatsWidgetData.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenStatsWidgetData.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+protocol LockScreenStatsWidgetData {
+    var siteName: String { get }
+    var statsURL: URL? { get }
+    var views: Int? { get }
+    var date: Date { get }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenStatsWidgetEntry.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenStatsWidgetEntry.swift
@@ -1,0 +1,17 @@
+import WidgetKit
+
+enum LockScreenStatsWidgetEntry: TimelineEntry {
+    case siteSelected(LockScreenStatsWidgetData, TimelineProviderContext)
+    case loggedOut
+    case noSite
+    case noData
+
+    var date: Date {
+        switch self {
+        case .siteSelected(let widgetData, _):
+            return widgetData.date
+        case .loggedOut, .noSite, .noData:
+            return Date()
+        }
+    }
+}

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Models/LockScreenWidgetViewModelMapper.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct LockScreenWidgetViewModelMapper {
-    let data: HomeWidgetData
+    let data: LockScreenStatsWidgetData
 
     func getLockScreenSingleStatViewModel(
         title: String
@@ -14,33 +14,11 @@ struct LockScreenWidgetViewModelMapper {
         )
     }
 
-    // TODO: Add `LockScreenStatsWidgetData` in creating lock screen widget provider and entry PR
-    // define statsURL, views, date, siteName
-    // HomeWidgetTodayData, HomeWidgetAllTimeData, HomeWidgetThisWeekData conform to it
-    // to reduce the type converting
-    func getStatsURL() -> URL? {
-        if let todayData = data as? HomeWidgetTodayData {
-            return todayData.statsURL
-        } else if let allTimeData = data as? HomeWidgetAllTimeData {
-            return allTimeData.statsURL
-        } else if let thisWeekData = data as? HomeWidgetThisWeekData {
-            return thisWeekData.statsURL
-        } else {
-            return nil
-        }
-    }
-
     func getSiteName() -> String {
         data.siteName
     }
 
     func getViews() -> String {
-        if let todayData = data as? HomeWidgetTodayData {
-            return todayData.stats.views.abbreviatedString()
-        } else if let allTimeData = data as? HomeWidgetAllTimeData {
-            return allTimeData.stats.views.abbreviatedString()
-        } else {
-            return ""
-        }
+        data.views?.abbreviatedString() ?? ""
     }
 }

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/ViewProvider/LockScreenSingleStatWidgetViewProvider.swift
@@ -9,17 +9,12 @@ struct LockScreenSingleStatWidgetViewProvider: LockScreenStatsWidgetsViewProvide
 
     let title: String
 
-    func buildSiteSelectedView(_ data: HomeWidgetData) -> LockScreenSingleStatView {
+    func buildSiteSelectedView(_ data: LockScreenStatsWidgetData) -> LockScreenSingleStatView {
         let mapper = LockScreenWidgetViewModelMapper(data: data)
         let viewModel = mapper.getLockScreenSingleStatViewModel(
             title: title
         )
         return LockScreenSingleStatView(viewModel: viewModel)
-    }
-
-    func statsURL(_ data: HomeWidgetData) -> URL? {
-        let mapper = LockScreenWidgetViewModelMapper(data: data)
-        return mapper.getStatsURL()
     }
 
     // TODO: Build view for loggedOut status

--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenStatsWidgetsView.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/Views/LockScreenStatsWidgetsView.swift
@@ -8,7 +8,7 @@ protocol LockScreenStatsWidgetsViewProvider {
     associatedtype NoDataView: View
 
     @ViewBuilder
-    func buildSiteSelectedView(_ data: HomeWidgetData) -> SiteSelectedView
+    func buildSiteSelectedView(_ data: LockScreenStatsWidgetData) -> SiteSelectedView
 
     @ViewBuilder
     func buildLoggedOutView() -> LoggedOutView
@@ -18,12 +18,10 @@ protocol LockScreenStatsWidgetsViewProvider {
 
     @ViewBuilder
     func buildNoDataView() -> NoDataView
-
-    func statsURL(_ data: HomeWidgetData) -> URL?
 }
 
 struct LockScreenStatsWidgetsView<T: LockScreenStatsWidgetsViewProvider>: View {
-    let timelineEntry: StatsWidgetEntry
+    let timelineEntry: LockScreenStatsWidgetEntry
     let viewProvider: T
 
     @ViewBuilder
@@ -32,7 +30,7 @@ struct LockScreenStatsWidgetsView<T: LockScreenStatsWidgetsViewProvider>: View {
         case let .siteSelected(data, _):
             viewProvider
                 .buildSiteSelectedView(data)
-                .widgetURL(viewProvider.statsURL(data))
+                .widgetURL(data.statsURL)
         case .loggedOut:
             viewProvider
                 .buildLoggedOutView()
@@ -45,10 +43,6 @@ struct LockScreenStatsWidgetsView<T: LockScreenStatsWidgetsViewProvider>: View {
             viewProvider
                 .buildNoDataView()
                 .widgetURL(nil)
-        case .disabled:
-            // TODO: Remove disabled case when adding lock screen TimeLineProvider and Entry
-            // Lock Screen widget should not have disable status
-            EmptyView()
         }
     }
 }

--- a/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/WordPressStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -2,6 +2,7 @@ import WordPressKit
 
 /// Type that wraps the backend request for new stats
 class StatsWidgetsService {
+    typealias ResultType = HomeWidgetData & LockScreenStatsWidgetData
 
     private enum State {
         case loading
@@ -22,7 +23,7 @@ class StatsWidgetsService {
 
 
     func fetchStats(for widgetData: HomeWidgetData,
-                    completion: @escaping (Result<HomeWidgetData, Error>) -> Void) {
+                    completion: @escaping (Result<ResultType, Error>) -> Void) {
 
         guard !state.isLoading else {
             return
@@ -53,7 +54,7 @@ class StatsWidgetsService {
 
     private func fetchTodayStats(service: StatsServiceRemoteV2,
                                  widgetData: HomeWidgetTodayData,
-                                 completion: @escaping (Result<HomeWidgetData, Error>) -> Void) {
+                                 completion: @escaping (Result<ResultType, Error>) -> Void) {
 
         service.getInsight { [weak self] (insight: StatsTodayInsight?, error) in
             guard let self = self else {
@@ -92,7 +93,7 @@ class StatsWidgetsService {
 
     private func fetchAllTimeStats(service: StatsServiceRemoteV2,
                                    widgetData: HomeWidgetAllTimeData,
-                                   completion: @escaping (Result<HomeWidgetData, Error>) -> Void) {
+                                   completion: @escaping (Result<ResultType, Error>) -> Void) {
 
         service.getInsight { [weak self] (insight: StatsAllTimesInsight?, error) in
 
@@ -127,7 +128,7 @@ class StatsWidgetsService {
 
     private func fetchThisWeekStats(service: StatsServiceRemoteV2,
                                     widgetData: HomeWidgetThisWeekData,
-                                    completion: @escaping (Result<HomeWidgetData, Error>) -> Void) {
+                                    completion: @escaping (Result<ResultType, Error>) -> Void) {
 
         // Get the current date in the site's time zone.
         let siteTimeZone = widgetData.timeZone

--- a/WordPress/WordPressStatsWidgets/SiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/SiteListProvider.swift
@@ -25,19 +25,8 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
 
     func getSnapshot(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (StatsWidgetEntry) -> Void) {
 
-        guard let site = configuration.site,
-              let siteIdentifier = site.identifier,
-              let widgetData = widgetDataLoader.widgetData(for: siteIdentifier) else {
-
-            if let siteID = defaultSiteID, let content = T.read()?[siteID] {
-                completion(.siteSelected(content, context))
-            } else {
-                completion(.siteSelected(placeholderContent, context))
-            }
-            return
-        }
-
-        completion(.siteSelected(widgetData, context))
+        let content = widgetDataLoader.widgetData(for: configuration, defaultSiteID: defaultSiteID) ?? placeholderContent
+        completion(.siteSelected(content, context))
     }
 
     func getTimeline(for configuration: SelectSiteIntent, in context: Context, completion: @escaping (Timeline<StatsWidgetEntry>) -> Void) {

--- a/WordPress/WordPressStatsWidgets/SiteListProvider.swift
+++ b/WordPress/WordPressStatsWidgets/SiteListProvider.swift
@@ -33,6 +33,7 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
         widgetDataLoader.widgetData(
             for: configuration,
             defaultSiteID: defaultSiteID,
+            isJetpack: AppConfiguration.isJetpack,
             onDisabled: {
                 completion(Timeline(entries: [.disabled(widgetKind)], policy: .never))
             }, onNoData: {

--- a/WordPress/WordPressTest/Widgets/WidgetDataReaderTests.swift
+++ b/WordPress/WordPressTest/Widgets/WidgetDataReaderTests.swift
@@ -1,0 +1,176 @@
+import XCTest
+@testable import WordPress
+
+final class WidgetDataReaderTests: XCTestCase {
+    func testDisabled() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: nil, display: "")
+        let sut = makeSUT(
+            makeUserDefaults(suiteName: #function),
+            makeCacheReader(isCacheExisted: true),
+            isLoggedIn: true,
+            isJetpackDisabled: true
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: nil, isJetpack: false, expectDisabled: true)
+    }
+
+    func testNoSite() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: nil, display: "")
+        let sut = makeSUT(
+            makeUserDefaults(suiteName: #function),
+            makeCacheReader(isCacheExisted: true),
+            isLoggedIn: true,
+            isJetpackDisabled: false
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: nil, isJetpack: true, expectNoSite: true)
+    }
+
+    func testLoggedOut() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: nil, display: "")
+        let sut = makeSUT(
+            makeUserDefaults(suiteName: #function),
+            makeCacheReader(isCacheExisted: true),
+            isLoggedIn: false,
+            isJetpackDisabled: false
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: nil, isJetpack: true, expectLoggedOut: true)
+    }
+
+    func testNoDataWhenNoUserDefaults() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: nil, display: "")
+        let sut = makeSUT(
+            nil,
+            makeCacheReader(isCacheExisted: true),
+            isLoggedIn: false,
+            isJetpackDisabled: false
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: 123, isJetpack: true, expectNoData: true)
+    }
+
+    func testNoDataWhenWidgetDataNotFound() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: "test", display: "")
+        let sut = makeSUT(
+            makeUserDefaults(suiteName: #function),
+            makeCacheReader(isCacheExisted: false),
+            isLoggedIn: true,
+            isJetpackDisabled: false
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: 123, isJetpack: true, expectNoData: true)
+    }
+
+    func testSiteSelected() {
+        let intent = SelectSiteIntent()
+        intent.site = Site(identifier: "test", display: "")
+        let sut = makeSUT(
+            makeUserDefaults(suiteName: #function),
+            makeCacheReader(isCacheExisted: true),
+            isLoggedIn: true,
+            isJetpackDisabled: false
+        )
+
+        verifyWidgetStatus(sut, configuration: intent, defaultSiteID: 123, isJetpack: true, expectSiteSelected: true)
+    }
+}
+
+extension WidgetDataReaderTests {
+    func makeSUT(
+        _ userDefaults: UserDefaults?,
+        _ cacheReader: WidgetDataCacheReader,
+        isLoggedIn: Bool,
+        isJetpackDisabled: Bool
+    ) -> WidgetDataReader<HomeWidgetTodayData> {
+        userDefaults?.set(isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
+        userDefaults?.set(isJetpackDisabled, forKey: AppConfiguration.Widget.Stats.userDefaultsJetpackFeaturesDisabledKey)
+        return WidgetDataReader<HomeWidgetTodayData>(userDefaults, cacheReader)
+    }
+
+    func makeUserDefaults(suiteName: String) -> UserDefaults? {
+        let userDefaults = UserDefaults(suiteName: suiteName)
+        userDefaults?.removePersistentDomain(forName: suiteName)
+        return userDefaults
+    }
+
+    func makeCacheReader(isCacheExisted: Bool) -> MockHomeWidgetDataFileReader {
+        MockHomeWidgetDataFileReader(isMockDataReturned: isCacheExisted)
+    }
+
+    func verifyWidgetStatus(
+        _ sut: WidgetDataReader<HomeWidgetTodayData>,
+        configuration: SelectSiteIntent,
+        defaultSiteID: Int?,
+        isJetpack: Bool,
+        expectDisabled: Bool = false,
+        expectNoData: Bool = false,
+        expectNoSite: Bool = false,
+        expectLoggedOut: Bool = false,
+        expectSiteSelected: Bool = false
+    ) {
+        let disabledExpectation = XCTestExpectation(description: "Disabled Expectation")
+        disabledExpectation.isInverted = !expectDisabled
+        let noDataExpectation = XCTestExpectation(description: "NoData Expectation")
+        noDataExpectation.isInverted = !expectNoData
+        let noSiteExpectation = XCTestExpectation(description: "NoSite Expectation")
+        noSiteExpectation.isInverted = !expectNoSite
+        let loggedOutExpectation = XCTestExpectation(description: "LoggedOut Expectation")
+        loggedOutExpectation.isInverted = !expectLoggedOut
+        let siteSelectedExpectation = XCTestExpectation(description: "NoSiteSelected Expectation")
+        siteSelectedExpectation.isInverted = !expectSiteSelected
+
+        sut.widgetData(
+            for: configuration,
+            defaultSiteID: defaultSiteID,
+            isJetpack: isJetpack,
+            onDisabled: {
+                disabledExpectation.fulfill()
+            }, onNoData: {
+                noDataExpectation.fulfill()
+            }, onNoSite: {
+                noSiteExpectation.fulfill()
+            }, onLoggedOut: {
+                loggedOutExpectation.fulfill()
+            }, onSiteSelected: { _ in
+                siteSelectedExpectation.fulfill()
+            }
+        )
+
+        wait(for: [
+            disabledExpectation,
+            noDataExpectation,
+            noSiteExpectation,
+            loggedOutExpectation,
+            siteSelectedExpectation
+        ], timeout: 0.1)
+    }
+}
+
+struct MockHomeWidgetDataFileReader: WidgetDataCacheReader {
+    let mockData = HomeWidgetTodayData(siteID: 0,
+                                       siteName: "My WordPress Site",
+                                       url: "",
+                                       timeZone: TimeZone.current,
+                                       date: Date(),
+                                       stats: TodayWidgetStats(
+                                        views: 649,
+                                        visitors: 572,
+                                        likes: 16,
+                                        comments: 8
+                                       ))
+    let isMockDataReturned: Bool
+
+    func widgetData<T: HomeWidgetData>(for siteID: String) -> T? {
+        if isMockDataReturned {
+            return mockData as? T
+        } else {
+            return nil
+        }
+    }
+}

--- a/WordPress/WordPressTest/Widgets/WidgetDataReaderTests.swift
+++ b/WordPress/WordPressTest/Widgets/WidgetDataReaderTests.swift
@@ -125,23 +125,25 @@ extension WidgetDataReaderTests {
         let siteSelectedExpectation = XCTestExpectation(description: "NoSiteSelected Expectation")
         siteSelectedExpectation.isInverted = !expectSiteSelected
 
-        sut.widgetData(
+        switch sut.widgetData(
             for: configuration,
             defaultSiteID: defaultSiteID,
-            isJetpack: isJetpack,
-            onDisabled: {
-                disabledExpectation.fulfill()
-            }, onNoData: {
+            isJetpack: isJetpack
+        ) {
+        case .success:
+            siteSelectedExpectation.fulfill()
+        case .failure(let error):
+            switch error {
+            case .noData:
                 noDataExpectation.fulfill()
-            }, onNoSite: {
+            case .noSite:
                 noSiteExpectation.fulfill()
-            }, onLoggedOut: {
+            case .loggedOut:
                 loggedOutExpectation.fulfill()
-            }, onSiteSelected: { _ in
-                siteSelectedExpectation.fulfill()
+            case .jetpackFeatureDisabled:
+                disabledExpectation.fulfill()
             }
-        )
-
+        }
         wait(for: [
             disabledExpectation,
             noDataExpectation,

--- a/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
+++ b/WordPress/WordPressTest/Widgets/WidgetsViewModelMapperTests.swift
@@ -25,18 +25,18 @@ final class WidgetsViewModelMapperTests: XCTestCase {
         let data = makeTodayData(stats: todayStats, date: Date())
 
         let sut = makeSUT(data)
-        let statsURL = sut.getStatsURL()
+        let statsURL = data.statsURL
 
         XCTAssertEqual(statsURL?.absoluteString, "https://wordpress.com/stats/day/0?source=widget")
     }
 }
 
 extension WidgetsViewModelMapperTests {
-    func makeSUT(_ data: HomeWidgetData) -> LockScreenWidgetViewModelMapper {
+    func makeSUT(_ data: LockScreenStatsWidgetData) -> LockScreenWidgetViewModelMapper {
         LockScreenWidgetViewModelMapper(data: data)
     }
 
-    func makeTodayData(stats: TodayWidgetStats, date: Date) -> HomeWidgetTodayData {
+    func makeTodayData(stats: TodayWidgetStats, date: Date) -> LockScreenStatsWidgetData {
         HomeWidgetTodayData(siteID: 0,
                             siteName: "My WordPress Site",
                             url: "",


### PR DESCRIPTION
This is the PR for the refactoring of the timeline provider for lock screen widgets.

1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved) 
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (TBD) 
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved)
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved)
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved) 👈 you're here!
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)

## Description
While it is working to reuse the home screen timeline provider and entry for the lock screen, there are some differences in logic. For instance, the disable check and status are redundant for the lock screen widget.

Creating a timeline provider and entry specific to the lock screen to separate the concerns, which should be helpful for improving understandability and maintainability. Here are the steps I took to achieve this:

1. Add `LockScreenStatsWidgetData` to define the properties the lock screen widgets need.
2. Add `LockScreenSiteListProvider` to handle the `LockScreenStatsWidgetEntry` timeline.
3. Extract the widget load to `WidgetDataReader` for reusability and testability.
4. Expand the result type in `StatsWidgetsService` for sharing the fetchStats with two providers.
5. Update the view provider and view to be based on the lock screen widget, removing unnecessary type handling.

## Testing Instructions
This refractor did not introduce any new features. The following tests are for regression testing purposes.
### In WordPress target
#### Won't impact existing widgets
1. Added today, all-time, and this-week home screen widgets
2. Upgrade the app
3. Existing widgets still work well
#### New widget can be added
1. Upgrade the app
2. WordPress in the widget selection page in the home screen editor
3. Able to add today, all-time, and this-week widgets and display the correct stats data
#### Status switching
- Display disable message when fwf off
- Display no-site message when login with a new account without setup websites
- Display logged out message when logout the account

### In Jetpack target
#### Won't impact home screen widgets 
- As same as WordPress testing instructions
#### Won't impact lock screen widgets (refresh mechanism not implemented yet)
- Existing lock screen widgets work well after upgrading the app
- Able to add today views widget to the lock screen and display the correct stats data
#### Status switching
- Jetpack others status not implemented yet, status switching testing would in next PR

## Regression Notes
1. Potential unintended areas of impact
Home screen widgets

5. What I did to test those areas of impact (or what existing automated tests I relied on)
Refer to the above testing Instructions

6. What automated tests I added (or what prevented me from doing so)
`WidgetDataReaderTests` for testing status check

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
