### PR TITLE
Use CrashLogging class to capture migration errors on Sentry 

### DIFF
--- a/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
+++ b/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
@@ -1,0 +1,13 @@
+import Foundation
+import AutomatticTracks
+
+extension CrashLogging {
+
+    static let main: CrashLogging = {
+        if let crashLogging = WordPressAppDelegate.crashLogging {
+            return crashLogging
+        }
+        let stack = WPLoggingStack()
+        return stack.crashLogging
+    }()
+}

--- a/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
+++ b/WordPress/Classes/Utility/Logging/CrashLogging+Singleton.swift
@@ -7,6 +7,8 @@ extension CrashLogging {
         if let crashLogging = WordPressAppDelegate.crashLogging {
             return crashLogging
         }
+        // `WordPressAppDelegate.crashLogging` is probably never going to be nil
+        // So the following code won't be executed at runtime.
         let stack = WPLoggingStack()
         return stack.crashLogging
     }()

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -1,3 +1,6 @@
+import Foundation
+import AutomatticTracks
+
 protocol ContentDataMigrating {
     /// Exports user content data to a shared location that's accessible by the Jetpack app.
     ///
@@ -13,7 +16,7 @@ protocol ContentDataMigrating {
     func deleteExportedData()
 }
 
-enum DataMigrationError: LocalizedError {
+enum DataMigrationError: LocalizedError, CustomNSError {
     case databaseCopyError
     case sharedUserDefaultsNil
     case dataNotReadyToImport
@@ -33,17 +36,20 @@ final class DataMigrator {
     private let keychainUtils: KeychainUtils
     private let localDefaults: UserPersistentRepository
     private let sharedDefaults: UserPersistentRepository?
+    private let crashLogger: CrashLogging
 
     init(coreDataStack: CoreDataStack = ContextManager.sharedInstance(),
          backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName)?.appendingPathComponent("WordPress.sqlite"),
          keychainUtils: KeychainUtils = KeychainUtils(),
          localDefaults: UserPersistentRepository = UserDefaults.standard,
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName)) {
+         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
+         crashLogger: CrashLogging = .main) {
         self.coreDataStack = coreDataStack
         self.backupLocation = backupLocation
         self.keychainUtils = keychainUtils
         self.localDefaults = localDefaults
         self.sharedDefaults = sharedDefaults
+        self.crashLogger = crashLogger
     }
 }
 
@@ -74,7 +80,9 @@ extension DataMigrator: ContentDataMigrating {
         }
 
         guard let backupLocation, restoreDatabase(from: backupLocation) else {
-            completion?(.failure(.databaseCopyError))
+            let error = DataMigrationError.databaseCopyError
+            self.crashLogger.logError(error)
+            completion?(.failure(error))
             return
         }
 
@@ -83,7 +91,9 @@ extension DataMigrator: ContentDataMigrating {
         isDataReadyToMigrate = false
 
         guard populateFromSharedDefaults() else {
-            completion?(.failure(.sharedUserDefaultsNil))
+            let error = DataMigrationError.sharedUserDefaultsNil
+            self.crashLogger.logError(error)
+            completion?(.failure(error))
             return
         }
 

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -25,7 +25,7 @@ enum DataMigrationError: LocalizedError, CustomNSError {
     var errorDescription: String? {
         switch self {
         case .databaseImportError: return "The database couldn't be copied from shared directory"
-        case.databaseExportError: return "The database couldn't be copied to shared directory"
+        case .databaseExportError: return "The database couldn't be copied to shared directory"
         case .sharedUserDefaultsNil: return "Shared user defaults not found"
         case .dataNotReadyToImport: return "The data wasn't ready to import"
         }

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -17,13 +17,15 @@ protocol ContentDataMigrating {
 }
 
 enum DataMigrationError: LocalizedError, CustomNSError {
-    case databaseCopyError
+    case databaseImportError
+    case databaseExportError
     case sharedUserDefaultsNil
     case dataNotReadyToImport
 
     var errorDescription: String? {
         switch self {
-        case .databaseCopyError: return "The database couldn't be copied to/from shared directory"
+        case .databaseImportError: return "The database couldn't be copied from shared directory"
+        case.databaseExportError: return "The database couldn't be copied to shared directory"
         case .sharedUserDefaultsNil: return "Shared user defaults not found"
         case .dataNotReadyToImport: return "The data wasn't ready to import"
         }
@@ -59,7 +61,7 @@ extension DataMigrator: ContentDataMigrating {
 
     func exportData(completion: ((Result<Void, DataMigrationError>) -> Void)? = nil) {
         guard let backupLocation, copyDatabase(to: backupLocation) else {
-            completion?(.failure(.databaseCopyError))
+            completion?(.failure(.databaseExportError))
             return
         }
         guard populateSharedDefaults() else {
@@ -80,7 +82,7 @@ extension DataMigrator: ContentDataMigrating {
         }
 
         guard let backupLocation, restoreDatabase(from: backupLocation) else {
-            let error = DataMigrationError.databaseCopyError
+            let error = DataMigrationError.databaseImportError
             self.crashLogger.logError(error)
             completion?(.failure(error))
             return

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -61,11 +61,15 @@ extension DataMigrator: ContentDataMigrating {
 
     func exportData(completion: ((Result<Void, DataMigrationError>) -> Void)? = nil) {
         guard let backupLocation, copyDatabase(to: backupLocation) else {
-            completion?(.failure(.databaseExportError))
+            let error = DataMigrationError.databaseExportError
+            self.crashLogger.logError(error)
+            completion?(.failure(error))
             return
         }
         guard populateSharedDefaults() else {
-            completion?(.failure(.sharedUserDefaultsNil))
+            let error = DataMigrationError.sharedUserDefaultsNil
+            self.crashLogger.logError(error)
+            completion?(.failure(error))
             return
         }
         BloggingRemindersScheduler.handleRemindersMigration()

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -30,6 +30,18 @@ enum DataMigrationError: LocalizedError, CustomNSError {
         case .dataNotReadyToImport: return "The data wasn't ready to import"
         }
     }
+
+    static var errorDomain: String {
+        return String(describing: DataMigrationError.self)
+    }
+
+    var errorUserInfo: [String: Any] {
+        var userInfo = [String: Any]()
+        if let errorDescription {
+            userInfo[NSDebugDescriptionErrorKey] = errorDescription
+        }
+        return userInfo
+    }
 }
 
 final class DataMigrator {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3565,6 +3565,8 @@
 		F4D9AF4F288AD2E300803D40 /* SuggestionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */; };
 		F4D9AF51288AE23500803D40 /* SuggestionTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */; };
 		F4D9AF53288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */; };
+		F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
+		F4DDE2C329C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */; };
 		F4E79301296EEE320025E8E0 /* MigrationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E79300296EEE320025E8E0 /* MigrationState.swift */; };
 		F4EDAA4C29A516EA00622D3D /* ReaderPostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */; };
 		F4EDAA4D29A516EA00622D3D /* ReaderPostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */; };
@@ -8858,6 +8860,7 @@
 		F4D9AF4E288AD2E300803D40 /* SuggestionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionViewModelTests.swift; sourceTree = "<group>"; };
 		F4D9AF50288AE23500803D40 /* SuggestionTableViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionTableViewTests.swift; sourceTree = "<group>"; };
 		F4D9AF52288AE2BA00803D40 /* SuggestionsTableViewDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestionsTableViewDelegateMock.swift; sourceTree = "<group>"; };
+		F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CrashLogging+Singleton.swift"; sourceTree = "<group>"; };
 		F4E79300296EEE320025E8E0 /* MigrationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationState.swift; sourceTree = "<group>"; };
 		F4EDAA4B29A516E900622D3D /* ReaderPostService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ReaderPostService.swift; sourceTree = "<group>"; };
 		F4EF4BAA291D3D4700147B61 /* SiteIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteIconTests.swift; sourceTree = "<group>"; };
@@ -11880,6 +11883,7 @@
 				986CC4D120E1B2F6004F300E /* CustomLogFormatter.swift */,
 				8B3DECAA2388506400A459C2 /* SentryStartupEvent.swift */,
 				3F39C93427A09927001EC300 /* WordPressLibraryLogger.swift */,
+				F4DDE2C129C92F0D00C02A76 /* CrashLogging+Singleton.swift */,
 			);
 			path = Logging;
 			sourceTree = "<group>";
@@ -20830,6 +20834,7 @@
 				987535632282682D001661B4 /* DetailDataCell.swift in Sources */,
 				E17E67031FA22C93009BDC9A /* PluginViewModel.swift in Sources */,
 				B5E167F419C08D18009535AA /* NSCalendar+Helpers.swift in Sources */,
+				F4DDE2C229C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				4629E4212440C5B20002E15C /* GutenbergCoverUploadProcessor.swift in Sources */,
 				FF00889F204E01AE007CCE66 /* MediaQuotaCell.swift in Sources */,
 				982DDF94263238A6002B3904 /* LikeUserPreferredBlog+CoreDataClass.swift in Sources */,
@@ -24087,6 +24092,7 @@
 				46F584832624DCC80010A723 /* BlockEditorSettingsService.swift in Sources */,
 				FABB233D2602FC2C00C8785C /* SiteStatsPeriodViewModel.swift in Sources */,
 				FABB233F2602FC2C00C8785C /* AnnouncementCell.swift in Sources */,
+				F4DDE2C329C92F0D00C02A76 /* CrashLogging+Singleton.swift in Sources */,
 				FABB23402602FC2C00C8785C /* ReaderStreamViewController.swift in Sources */,
 				98ED5964265EBD0000A0B33E /* ReaderDetailLikesListController.swift in Sources */,
 				FABB23412602FC2C00C8785C /* SeparatorsView.swift in Sources */,

--- a/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
+++ b/WordPress/WordPressTest/ContentMigrationCoordinatorTests.swift
@@ -70,7 +70,7 @@ final class ContentMigrationCoordinatorTests: CoreDataTestCase {
     }
 
     func test_startAndDo_givenExportError_shouldInvokeClosureWithError() {
-        mockDataMigrator.exportErrorToReturn = .databaseCopyError
+        mockDataMigrator.exportErrorToReturn = .databaseExportError
 
         let expect = expectation(description: "Content migration should fail")
         coordinator.startAndDo { result in


### PR DESCRIPTION
## Description 

This PR uses the `CrashLogging` class to capture Jetpack migration errors instead of handling them silently. **This PR doesn't change the migration logic.**

## Test Instructions

I don't know how to test these changes. We probably have to force an error and see if it will appear on Sentry, but Sentry is disabled in the development environment. 

I've seen custom errors captured on Sentry ( [this one, for example ](https://a8c.sentry.io/issues/3984975907/?project=5716771&query=is:unresolved+firstRelease:21.9.0.4+timesSeen:%3E5&statsPeriod=90d&stream_index=1)) before, so I think it's safe to assume that this PR will work as expected.

That being said, It would be great to smoke-test the WP-JP migration flow.

1. Clean install WordPress and Jetpack.
2. On WordPress, log into your account.
3. Find a Jetpack-powered feature and tap the badge.
4. Tap "Try the new Jetpack button."
5. **Expect** the migration flow to start on Jetpack.

## Regression Notes
1. Potential unintended areas of impact
Smoke the WP->JP migration flow.

6. What did I do to test those areas of impact (or what existing automated tests I relied on )
None.

7. What automated tests I added (or what prevented me from doing so)
None.

## PR submission checklist:
- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements to my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
