### PR TITLE
[BugFix] Fix widget of home screen for WordPress disappeared

### DIFF
--- a/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
+++ b/WordPress/WordPressStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
@@ -31,6 +31,17 @@ struct LockScreenStatsWidget: Widget {
         }
         .configurationDisplayName(LocalizableStrings.todayWidgetTitle)
         .description(LocalizableStrings.todayPreviewDescription)
-        .supportedFamilies(FeatureFlag.lockScreenWidget.enabled ? [.accessoryRectangular] : [])
+        .supportedFamilies(supportedFamilies())
+    }
+}
+
+@available(iOS 16.0, *)
+extension LockScreenStatsWidget {
+    // TODO: Move to widget config after PR #20317 merged
+    func supportedFamilies() -> [WidgetFamily] {
+        guard AppConfiguration.isJetpack, FeatureFlag.lockScreenWidget.enabled else {
+            return []
+        }
+        return [.accessoryRectangular]
     }
 }

--- a/WordPress/WordPressStatsWidgets/StatsWidgets.swift
+++ b/WordPress/WordPressStatsWidgets/StatsWidgets.swift
@@ -7,7 +7,7 @@ struct WordPressStatsWidgets: WidgetBundle {
         WordPressHomeWidgetToday()
         WordPressHomeWidgetThisWeek()
         WordPressHomeWidgetAllTime()
-        if AppConfiguration.isJetpack, #available(iOS 16.0, *) {
+        if #available(iOS 16.0, *) {
             LockScreenStatsWidget()
         }
     }


### PR DESCRIPTION
Fixes: The home screen widget under the WordPress target disappeared as a side effect of PR #20309 

This is the first PR for fixing the side effect of PR #20309 
1.  https://github.com/wordpress-mobile/WordPress-iOS/pull/20309 (✅ Approved)
- Update compilation flag to `AppConfiguration.isJetpack`
2. https://github.com/wordpress-mobile/WordPress-iOS/pull/20312 (✅ Approved)
3. https://github.com/wordpress-mobile/WordPress-iOS/pull/20342 (TBD)
4. https://github.com/wordpress-mobile/WordPress-iOS/pull/20353 (✅ Approved)
5. https://github.com/wordpress-mobile/WordPress-iOS/pull/20371 (✅ Approved)  👈 you're here!
6. https://github.com/wordpress-mobile/WordPress-iOS/pull/20317 (✅ Approved)
7. https://github.com/wordpress-mobile/WordPress-iOS/pull/20368 (✅ Approved)
8. https://github.com/wordpress-mobile/WordPress-iOS/pull/20399 (✅ Approved)
9. https://github.com/wordpress-mobile/WordPress-iOS/pull/20405 (✅ Approved)
(Confirm the data display on UI correctly in this phase)
10. https://github.com/wordpress-mobile/WordPress-iOS/pull/20422 (✅ Approved)
11. https://github.com/wordpress-mobile/WordPress-iOS/pull/20427 (In Reviewing)

## Description
In the final [commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/20309/commits/1629d3b0253c9fc4723e848585bd65f17c3ff67c) of PR #20309, `JETPACK_STATS_WIDGETS` compilation flag was replaced with `AppConfiguration.isJetpack`.

However, the `WidgetBundleBuilder` body does not allow control flow statements. It works for the success block under Jetpack target, but when the condition fails under WordPress, it breaks the whole widget bundle body, causing WordPress home screen widgets not to be registered.

Solution:
To resolve this issue, I have to remove the control flow from the widget bundle by moving the app configuration checking to `supportedFamilies` of `LockScreenStatsWidget`, as same as the feature flag check for keeping the control logic in the same place.

Note: This `supportedFamilies` logic will move to `LockScreenTodayViewsStatWidgetConfig` once the PR #20317 is merged.

## Testing Instruction
### In WordPress target
- Should be able to add today, all time, and this week widgets to the home screen
### In Jetpack target
- Should be able to add today, all time, and this week widgets to the home screen
#### When the `FeatureFlag.lockScreenWidget` enabled
- Should be able to add today views widget to the lock screen
#### When the `FeatureFlag.lockScreenWidget` disabled
- Shouldn't see the Jetpack in the widget selection on the lock screen widget editor page

## Regression Notes
1. Potential unintended areas of impact
Home screen widget and lock screen widget

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Refer to **testing Instruction**

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
