### PR TITLE
Update and document parameter for build-for-testing script

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,4 +1,11 @@
 #!/bin/bash -eu
+APP=${1:-}
+
+# Run this at the start to fail early if value not available
+if [[ "$APP" != "wordpress" && "$APP" != "jetpack" ]]; then
+  echo "Error: Please provide either 'wordpress' or 'jetpack' as first parameter to this script
+  exit 1
+fi
 
 echo "--- :rubygems: Setting up Gems"
 install_gems
@@ -14,8 +21,8 @@ echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane "build_$1_for_testing"
+bundle exec fastlane "build_$APP_for_testing"
 
 echo "--- :arrow_up: Upload Build Products"
-tar -cf build-products-$1.tar DerivedData/Build/Products/
-upload_artifact build-products-$1.tar
+tar -cf build-products-$APP.tar DerivedData/Build/Products/
+upload_artifact build-products-$APP.tar

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -21,8 +21,8 @@ echo "--- Installing Secrets"
 bundle exec fastlane run configure_apply
 
 echo "--- :hammer_and_wrench: Building"
-bundle exec fastlane "build_$APP_for_testing"
+bundle exec fastlane build_${APP}_for_testing
 
 echo "--- :arrow_up: Upload Build Products"
-tar -cf build-products-$APP.tar DerivedData/Build/Products/
-upload_artifact build-products-$APP.tar
+tar -cf build-products-${APP}.tar DerivedData/Build/Products/
+upload_artifact build-products-${APP}.tar

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -3,7 +3,7 @@ APP=${1:-}
 
 # Run this at the start to fail early if value not available
 if [[ "$APP" != "wordpress" && "$APP" != "jetpack" ]]; then
-  echo "Error: Please provide either 'wordpress' or 'jetpack' as first parameter to this script
+  echo "Error: Please provide either 'wordpress' or 'jetpack' as first parameter to this script"
   exit 1
 fi
 


### PR DESCRIPTION
### What does this do
The follow-up to [a comment in PR](https://github.com/wordpress-mobile/WordPress-iOS/pull/20301#discussion_r1141953363) https://github.com/wordpress-mobile/WordPress-iOS/pull/20301. Instead of using `$1` as a parameter on `.buildkite/commands/build-for-testing.sh` file, this updates it to use a more descriptive name `$APP`, and also adds a condition on top of the file to make it fail earlier if the expected value is not provided.