### PR TITLE
[Gutenberg] Add VideoPress upload processor

### DIFF
--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -374,6 +374,11 @@ class PostCoordinator: NSObject {
             let gutenbergMediaFilesUploadProcessor = GutenbergMediaFilesUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             gutenbergProcessors.append(gutenbergMediaFilesUploadProcessor)
 
+            if let videoPressGUID = media.videopressGUID {
+                let gutenbergVideoPressUploadProcessor = GutenbergVideoPressUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, videoPressGUID: videoPressGUID)
+                gutenbergProcessors.append(gutenbergVideoPressUploadProcessor)
+            }
+
         } else if media.mediaType == .audio {
             let gutenbergAudioProcessor = GutenbergAudioUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, remoteURLString: remoteURLStr)
             gutenbergProcessors.append(gutenbergAudioProcessor)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -66,7 +66,7 @@ class GutenbergVideoPressUploadProcessor: Processor {
         guard let mediaID = videoPressBlock.attributes[VideoPressBlockKeys.id.rawValue] as? Int, mediaID == self.mediaUploadID else {
             return nil
         }
-        var block = "<!-- \(VideoPressBlockKeys.name) "
+        var block = "<!-- \(VideoPressBlockKeys.name.rawValue) "
         var attributes = videoPressBlock.attributes
         attributes[VideoPressBlockKeys.id.rawValue] = self.serverMediaID
         attributes[VideoPressBlockKeys.guid.rawValue] = self.videoPressGUID
@@ -79,7 +79,7 @@ class GutenbergVideoPressUploadProcessor: Processor {
         self.videoPressURL = VideoPressURL(attributes: attributes, guid: self.videoPressGUID)
         block += self.videoPressHtmlProcessor.process(videoPressBlock.content)
 
-        block += "<!-- /\(VideoPressBlockKeys.name) -->"
+        block += "<!-- /\(VideoPressBlockKeys.name.rawValue) -->"
         return block
     })
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -8,40 +8,40 @@ class GutenbergVideoPressUploadProcessor: Processor {
     let videoPressGUID: String
     var videoPressURL: String = ""
 
-    private struct VideoPressBlockKeys {
-        static var name = "wp:videopress/video"
-        static var id = "id"
-        static var guid = "guid"
-        static var resizeToParent = "resizeToParent"
-        static var cover = "cover"
-        static var autoplay = "autoplay"
-        static var controls = "controls"
-        static var loop = "loop"
-        static var muted = "muted"
-        static var playsinline = "playsinline"
-        static var poster = "poster"
-        static var preload = "preload"
-        static var seekbarColor = "seekbarColor"
-        static var seekbarPlayedColor = "seekbarPlayedColor"
-        static var seekbarLoadingColor = "seekbarLoadingColor"
-        static var useAverageColor = "useAverageColor"
+    private enum VideoPressBlockKeys: String {
+        case name = "wp:videopress/video"
+        case id
+        case guid
+        case resizeToParent
+        case cover
+        case autoplay
+        case controls
+        case loop
+        case muted
+        case playsinline
+        case poster
+        case preload
+        case seekbarColor
+        case seekbarPlayedColor
+        case seekbarLoadingColor
+        case useAverageColor
     }
 
-    private struct VideoPressURLQueryParams {
-        static var resizeToParent = "resizeToParent"
-        static var cover = "cover"
-        static var autoPlay = "autoPlay"
-        static var controls = "controls"
-        static var loop = "loop"
-        static var muted = "muted"
-        static var persistVolume = "persistVolume"
-        static var playsinline = "playsinline"
-        static var posterUrl = "posterUrl"
-        static var preloadContent = "preloadContent"
-        static var sbc = "sbc"
-        static var sbpc = "sbpc"
-        static var sblc = "sblc"
-        static var useAverageColor = "useAverageColor"
+    private enum VideoPressURLQueryParams: String {
+        case resizeToParent
+        case cover
+        case autoPlay
+        case controls
+        case loop
+        case muted
+        case persistVolume
+        case playsinline
+        case posterUrl
+        case preloadContent
+        case sbc
+        case sbpc
+        case sblc
+        case useAverageColor
     }
 
     init(mediaUploadID: Int32, serverMediaID: Int, videoPressGUID: String) {
@@ -61,14 +61,14 @@ class GutenbergVideoPressUploadProcessor: Processor {
         return html
     })
 
-    lazy var videoPressBlockProcessor = GutenbergBlockProcessor(for: VideoPressBlockKeys.name, replacer: { videoPressBlock in
-        guard let mediaID = videoPressBlock.attributes[VideoPressBlockKeys.id] as? Int, mediaID == self.mediaUploadID else {
+    lazy var videoPressBlockProcessor = GutenbergBlockProcessor(for: VideoPressBlockKeys.name.rawValue, replacer: { videoPressBlock in
+        guard let mediaID = videoPressBlock.attributes[VideoPressBlockKeys.id.rawValue] as? Int, mediaID == self.mediaUploadID else {
             return nil
         }
         var block = "<!-- \(VideoPressBlockKeys.name) "
         var attributes = videoPressBlock.attributes
-        attributes[VideoPressBlockKeys.id] = self.serverMediaID
-        attributes[VideoPressBlockKeys.guid] = self.videoPressGUID
+        attributes[VideoPressBlockKeys.id.rawValue] = self.serverMediaID
+        attributes[VideoPressBlockKeys.guid.rawValue] = self.videoPressGUID
         if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
             let jsonString = String(data: jsonData, encoding: .utf8) {
             block += jsonString
@@ -100,52 +100,52 @@ class GutenbergVideoPressUploadProcessor: Processor {
     func getVideoPressURL(_ attributes: [String: Any]) -> String {
         // Setting default values
         var options: [URLQueryItem] = [
-            URLQueryItem(name: VideoPressURLQueryParams.resizeToParent, value: true.stringLiteral),
-            URLQueryItem(name: VideoPressURLQueryParams.cover, value: true.stringLiteral),
+            URLQueryItem(name: VideoPressURLQueryParams.resizeToParent.rawValue, value: true.stringLiteral),
+            URLQueryItem(name: VideoPressURLQueryParams.cover.rawValue, value: true.stringLiteral),
         ]
 
-        if let autoplay = attributes[VideoPressBlockKeys.autoplay] as? Bool, autoplay == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay, value: autoplay.stringLiteral))
+        if let autoplay = attributes[VideoPressBlockKeys.autoplay.rawValue] as? Bool, autoplay == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay.rawValue, value: autoplay.stringLiteral))
         }
-        if let controls = attributes[VideoPressBlockKeys.controls] as? Bool, controls == false {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.controls, value: controls.stringLiteral))
+        if let controls = attributes[VideoPressBlockKeys.controls.rawValue] as? Bool, controls == false {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.controls.rawValue, value: controls.stringLiteral))
         }
-        if let loop = attributes[VideoPressBlockKeys.loop] as? Bool, loop == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.loop, value: loop.stringLiteral))
+        if let loop = attributes[VideoPressBlockKeys.loop.rawValue] as? Bool, loop == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.loop.rawValue, value: loop.stringLiteral))
         }
-        if let muted = attributes[VideoPressBlockKeys.muted] as? Bool, muted == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.muted, value: muted.stringLiteral))
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume, value: false.stringLiteral))
+        if let muted = attributes[VideoPressBlockKeys.muted.rawValue] as? Bool, muted == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.muted.rawValue, value: muted.stringLiteral))
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume.rawValue, value: false.stringLiteral))
         }
-        if let playinline = attributes[VideoPressBlockKeys.playsinline] as? Bool, playinline == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline, value: playinline.stringLiteral))
+        if let playinline = attributes[VideoPressBlockKeys.playsinline.rawValue] as? Bool, playinline == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline.rawValue, value: playinline.stringLiteral))
         }
-        if let poster = attributes[VideoPressBlockKeys.poster] as? String, !poster.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl, value: poster))
+        if let poster = attributes[VideoPressBlockKeys.poster.rawValue] as? String, !poster.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl.rawValue, value: poster))
         }
-        if let preload = attributes[VideoPressBlockKeys.preload] as? String, !preload.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent, value: preload))
+        if let preload = attributes[VideoPressBlockKeys.preload.rawValue] as? String, !preload.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: preload))
         }
         else {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent, value: "metadata"))
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: "metadata"))
         }
-        if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor] as? String, !seekbarColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc, value: seekbarColor))
+        if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor.rawValue] as? String, !seekbarColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc.rawValue, value: seekbarColor))
         }
-        if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor] as? String, !seekbarPlayedColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc, value: seekbarPlayedColor))
+        if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor.rawValue] as? String, !seekbarPlayedColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc.rawValue, value: seekbarPlayedColor))
         }
-        if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor] as? String, !seekbarLoadingColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc, value: seekbarLoadingColor))
+        if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor.rawValue] as? String, !seekbarLoadingColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc.rawValue, value: seekbarLoadingColor))
         }
-        if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor] as? Bool {
+        if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor.rawValue] as? Bool {
             if useAverageColor == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor, value: useAverageColor.stringLiteral))
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: useAverageColor.stringLiteral))
             }
         }
         // Adding `useAverageColor` param as its default value is true
         else {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor, value: true.stringLiteral))
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: true.stringLiteral))
         }
 
         guard let url = URL(string: "https://videopress.com/v/\(self.videoPressGUID)"), var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -6,7 +6,7 @@ class GutenbergVideoPressUploadProcessor: Processor {
     let mediaUploadID: Int32
     let serverMediaID: Int
     let videoPressGUID: String
-    var videoPressURL: String = ""
+    private var videoPressURL: VideoPressURL?
 
     private enum VideoPressBlockKeys: String {
         case name = "wp:videopress/video"
@@ -51,12 +51,13 @@ class GutenbergVideoPressUploadProcessor: Processor {
     }
 
     lazy var videoPressHtmlProcessor = HTMLProcessor(for: "figure", replacer: { (figure) in
+        let url = self.videoPressURL?.getURLString() ?? ""
         var attributes = figure.attributes
         var html = "<figure "
         let attributeSerializer = ShortcodeAttributeSerializer()
         html += attributeSerializer.serialize(figure.attributes)
         html += "><div class=\"jetpack-videopress-player__wrapper\">"
-        html += "\n\(self.videoPressURL.escapeHtmlNamedEntities())\n"
+        html += "\n\(url.escapeHtmlNamedEntities())\n"
         html += "</div></figure>"
         return html
     })
@@ -75,7 +76,7 @@ class GutenbergVideoPressUploadProcessor: Processor {
         }
         block += " -->"
 
-        self.videoPressURL = self.getVideoPressURL(attributes)
+        self.videoPressURL = VideoPressURL(attributes: attributes, guid: self.videoPressGUID)
         block += self.videoPressHtmlProcessor.process(videoPressBlock.content)
 
         block += "<!-- /\(VideoPressBlockKeys.name) -->"
@@ -84,88 +85,156 @@ class GutenbergVideoPressUploadProcessor: Processor {
 
     /// The VideoPress URL is built using the same logic we have in Jetpack:
     /// https://github.com/Automattic/jetpack/blob/b1b826ab38690c5fad18789301ac81297a458878/projects/packages/videopress/src/client/lib/url/index.ts#L19-L67
-    ///
-    /// In order to have a cleaner URL, we only set the options differing from the default VideoPress player settings:
-    /// - Autoplay: Turned OFF by default.
-    /// - Controls: Turned ON by default.
-    /// - Loop: Turned OFF by default.
-    /// - Muted: Turned OFF by default.
-    /// - Plays Inline: Turned OFF by default.
-    /// - Poster: No image by default.
-    /// - Preload: Metadata by default.
-    /// - SeekbarColor: No color by default.
-    /// - SeekbarPlayerColor: No color by default.
-    /// - SeekbarLoadingColor: No color by default.
-    /// - UseAverageColor: Turned ON by default.
-    func getVideoPressURL(_ attributes: [String: Any]) -> String {
-        // Setting default values
-        var options: [URLQueryItem] = [
-            URLQueryItem(name: VideoPressURLQueryParams.resizeToParent.rawValue, value: true.stringLiteral),
-            URLQueryItem(name: VideoPressURLQueryParams.cover.rawValue, value: true.stringLiteral),
-        ]
+    private struct VideoPressURL {
+        let attributes: [String: Any]
+        let guid: String
+        private var options: [URLQueryItem]
 
-        if let autoplay = attributes[VideoPressBlockKeys.autoplay.rawValue] as? Bool, autoplay == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay.rawValue, value: autoplay.stringLiteral))
+        init(attributes: [String: Any], guid: String) {
+            self.attributes = attributes
+            self.guid = guid
+            self.options = [URLQueryItem]()
+
+            // Populate options
+            addDefaultOptions()
+            addAutoPlayOption()
+            addControlsOption()
+            addLoopOption()
+            addVolumeOptions()
+            addPlaysInlineOption()
+            addPosterOption()
+            addPreloadOption()
+            addSeekbarOptions()
+            addUseAverageColorOption()
         }
-        if let controls = attributes[VideoPressBlockKeys.controls.rawValue] as? Bool, controls == false {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.controls.rawValue, value: controls.stringLiteral))
+
+        /// Returns the string of the VideoPress URL.
+        func getURLString() -> String {
+            guard let url = URL(string: "https://videopress.com/v/\(guid)"), var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+                return ""
+            }
+            urlComponents.queryItems = options
+            guard
+                let query = urlComponents.query,
+                /// In web, the query parameters are encoded using `encodeURIComponent` that percent encodes reserved characters (like `/` and `:`) that are not strictly necessary to be encoded based on RFC 3986.
+                /// In the spirit of generating an URL with the same encoding, we encode using `urlHostAllowed` which percent encodes all reserved characters.
+                ///
+                /// References:
+                /// - https://en.wikipedia.org/wiki/URL_encoding#Reserved_characters
+                /// - https://www.ietf.org/rfc/rfc3986.txt
+                /// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+                /// - https://github.com/WordPress/gutenberg/blob/1dfec0ab5f0977dcce2722bdfbe823926903e2a6/packages/url/src/build-query-string.js#L53
+                let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
+                return url.absoluteString
+            }
+            return "\(url.absoluteString)?\(encodedQuery)"
         }
-        if let loop = attributes[VideoPressBlockKeys.loop.rawValue] as? Bool, loop == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.loop.rawValue, value: loop.stringLiteral))
+
+        /// Adds default options.
+        private mutating func addDefaultOptions() {
+            options += [
+                URLQueryItem(name: VideoPressURLQueryParams.resizeToParent.rawValue, value: true.stringLiteral),
+                URLQueryItem(name: VideoPressURLQueryParams.cover.rawValue, value: true.stringLiteral),
+            ]
         }
-        if let muted = attributes[VideoPressBlockKeys.muted.rawValue] as? Bool, muted == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.muted.rawValue, value: muted.stringLiteral))
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume.rawValue, value: false.stringLiteral))
-        }
-        if let playinline = attributes[VideoPressBlockKeys.playsinline.rawValue] as? Bool, playinline == true {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline.rawValue, value: playinline.stringLiteral))
-        }
-        if let poster = attributes[VideoPressBlockKeys.poster.rawValue] as? String, !poster.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl.rawValue, value: poster))
-        }
-        if let preload = attributes[VideoPressBlockKeys.preload.rawValue] as? String, !preload.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: preload))
-        }
-        else {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: "metadata"))
-        }
-        if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor.rawValue] as? String, !seekbarColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc.rawValue, value: seekbarColor))
-        }
-        if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor.rawValue] as? String, !seekbarPlayedColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc.rawValue, value: seekbarPlayedColor))
-        }
-        if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor.rawValue] as? String, !seekbarLoadingColor.isEmpty {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc.rawValue, value: seekbarLoadingColor))
-        }
-        if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor.rawValue] as? Bool {
-            if useAverageColor == true {
-                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: useAverageColor.stringLiteral))
+
+        /// Adds AutoPlay option.
+        ///
+        /// Turned OFF by default.
+        private mutating func addAutoPlayOption() {
+            if let autoplay = attributes[VideoPressBlockKeys.autoplay.rawValue] as? Bool, autoplay == true {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay.rawValue, value: autoplay.stringLiteral))
             }
         }
-        // Adding `useAverageColor` param as its default value is true
-        else {
-            options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: true.stringLiteral))
+
+        /// Adds Controls option.
+        ///
+        /// Turned ON by default.
+        private mutating func addControlsOption() {
+            if let controls = attributes[VideoPressBlockKeys.controls.rawValue] as? Bool, controls == false {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.controls.rawValue, value: controls.stringLiteral))
+            }
         }
 
-        guard let url = URL(string: "https://videopress.com/v/\(self.videoPressGUID)"), var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
-            return ""
+        /// Adds Loop option.
+        ///
+        /// Turned OFF by default.
+        private mutating func addLoopOption() {
+            if let loop = attributes[VideoPressBlockKeys.loop.rawValue] as? Bool, loop == true {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.loop.rawValue, value: loop.stringLiteral))
+            }
         }
-        urlComponents.queryItems = options
-        guard
-            let query = urlComponents.query,
-            /// In web, the query parameters are encoded using `encodeURIComponent` that percent encodes reserved characters (like `/` and `:`) that are not strictly necessary to be encoded based on RFC 3986.
-            /// In the spirit of generating an URL with the same encoding, we encode using `urlHostAllowed` which percent encodes all reserved characters.
-            ///
-            /// References:
-            /// - https://en.wikipedia.org/wiki/URL_encoding#Reserved_characters
-            /// - https://www.ietf.org/rfc/rfc3986.txt
-            /// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
-            /// - https://github.com/WordPress/gutenberg/blob/1dfec0ab5f0977dcce2722bdfbe823926903e2a6/packages/url/src/build-query-string.js#L53
-            let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
-            return url.absoluteString
+
+        /// Adds Volume-related options.
+        ///
+        /// - Muted: Turned OFF by default.
+        private mutating func addVolumeOptions() {
+            if let muted = attributes[VideoPressBlockKeys.muted.rawValue] as? Bool, muted == true {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.muted.rawValue, value: muted.stringLiteral))
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume.rawValue, value: false.stringLiteral))
+            }
         }
-        return "\(url.absoluteString)?\(encodedQuery)"
+
+        /// Adds PlaysInline option.
+        ///
+        /// Turned OFF by default.
+        private mutating func addPlaysInlineOption() {
+            if let playinline = attributes[VideoPressBlockKeys.playsinline.rawValue] as? Bool, playinline == true {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline.rawValue, value: playinline.stringLiteral))
+            }
+        }
+
+        /// Adds Poster option.
+        ///
+        /// No image by default.
+        private mutating func addPosterOption() {
+            if let poster = attributes[VideoPressBlockKeys.poster.rawValue] as? String, !poster.isEmpty {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl.rawValue, value: poster))
+            }
+        }
+
+        /// Adds Preload option.
+        ///
+        /// Metadata by default.
+        private mutating func addPreloadOption() {
+            if let preload = attributes[VideoPressBlockKeys.preload.rawValue] as? String, !preload.isEmpty {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: preload))
+            }
+            else {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent.rawValue, value: "metadata"))
+            }
+        }
+
+        /// Adds Seekbar options.
+        ///
+        /// - SeekbarColor: No color by default.
+        /// - SeekbarPlayerColor: No color by default.
+        /// - SeekbarLoadingColor: No color by default.
+        private mutating func addSeekbarOptions() {
+            if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor.rawValue] as? String, !seekbarColor.isEmpty {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc.rawValue, value: seekbarColor))
+            }
+            if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor.rawValue] as? String, !seekbarPlayedColor.isEmpty {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc.rawValue, value: seekbarPlayedColor))
+            }
+            if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor.rawValue] as? String, !seekbarLoadingColor.isEmpty {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc.rawValue, value: seekbarLoadingColor))
+            }
+        }
+
+        /// Adds UseAverageColor option.
+        ///
+        /// Turned ON by default.
+        private mutating func addUseAverageColorOption() {
+            if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor.rawValue] as? Bool {
+                if useAverageColor == true {
+                    options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: useAverageColor.stringLiteral))
+                }
+            }
+            else {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor.rawValue, value: true.stringLiteral))
+            }
+        }
     }
 
     func process(_ text: String) -> String {

--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergVideoPressUploadProcessor.swift
@@ -1,0 +1,174 @@
+import Foundation
+import Aztec
+
+class GutenbergVideoPressUploadProcessor: Processor {
+
+    let mediaUploadID: Int32
+    let serverMediaID: Int
+    let videoPressGUID: String
+    var videoPressURL: String = ""
+
+    private struct VideoPressBlockKeys {
+        static var name = "wp:videopress/video"
+        static var id = "id"
+        static var guid = "guid"
+        static var resizeToParent = "resizeToParent"
+        static var cover = "cover"
+        static var autoplay = "autoplay"
+        static var controls = "controls"
+        static var loop = "loop"
+        static var muted = "muted"
+        static var playsinline = "playsinline"
+        static var poster = "poster"
+        static var preload = "preload"
+        static var seekbarColor = "seekbarColor"
+        static var seekbarPlayedColor = "seekbarPlayedColor"
+        static var seekbarLoadingColor = "seekbarLoadingColor"
+        static var useAverageColor = "useAverageColor"
+    }
+
+    private struct VideoPressURLQueryParams {
+        static var resizeToParent = "resizeToParent"
+        static var cover = "cover"
+        static var autoPlay = "autoPlay"
+        static var controls = "controls"
+        static var loop = "loop"
+        static var muted = "muted"
+        static var persistVolume = "persistVolume"
+        static var playsinline = "playsinline"
+        static var posterUrl = "posterUrl"
+        static var preloadContent = "preloadContent"
+        static var sbc = "sbc"
+        static var sbpc = "sbpc"
+        static var sblc = "sblc"
+        static var useAverageColor = "useAverageColor"
+    }
+
+    init(mediaUploadID: Int32, serverMediaID: Int, videoPressGUID: String) {
+        self.mediaUploadID = mediaUploadID
+        self.serverMediaID = serverMediaID
+        self.videoPressGUID = videoPressGUID
+    }
+
+    lazy var videoPressHtmlProcessor = HTMLProcessor(for: "figure", replacer: { (figure) in
+        var attributes = figure.attributes
+        var html = "<figure "
+        let attributeSerializer = ShortcodeAttributeSerializer()
+        html += attributeSerializer.serialize(figure.attributes)
+        html += "><div class=\"jetpack-videopress-player__wrapper\">"
+        html += "\n\(self.videoPressURL.escapeHtmlNamedEntities())\n"
+        html += "</div></figure>"
+        return html
+    })
+
+    lazy var videoPressBlockProcessor = GutenbergBlockProcessor(for: VideoPressBlockKeys.name, replacer: { videoPressBlock in
+        guard let mediaID = videoPressBlock.attributes[VideoPressBlockKeys.id] as? Int, mediaID == self.mediaUploadID else {
+            return nil
+        }
+        var block = "<!-- \(VideoPressBlockKeys.name) "
+        var attributes = videoPressBlock.attributes
+        attributes[VideoPressBlockKeys.id] = self.serverMediaID
+        attributes[VideoPressBlockKeys.guid] = self.videoPressGUID
+        if let jsonData = try? JSONSerialization.data(withJSONObject: attributes, options: .sortedKeys),
+            let jsonString = String(data: jsonData, encoding: .utf8) {
+            block += jsonString
+        }
+        block += " -->"
+
+        self.videoPressURL = self.getVideoPressURL(attributes)
+        block += self.videoPressHtmlProcessor.process(videoPressBlock.content)
+
+        block += "<!-- /\(VideoPressBlockKeys.name) -->"
+        return block
+    })
+
+    /// The VideoPress URL is built using the same logic we have in Jetpack:
+    /// https://github.com/Automattic/jetpack/blob/b1b826ab38690c5fad18789301ac81297a458878/projects/packages/videopress/src/client/lib/url/index.ts#L19-L67
+    ///
+    /// In order to have a cleaner URL, we only set the options differing from the default VideoPress player settings:
+    /// - Autoplay: Turned OFF by default.
+    /// - Controls: Turned ON by default.
+    /// - Loop: Turned OFF by default.
+    /// - Muted: Turned OFF by default.
+    /// - Plays Inline: Turned OFF by default.
+    /// - Poster: No image by default.
+    /// - Preload: Metadata by default.
+    /// - SeekbarColor: No color by default.
+    /// - SeekbarPlayerColor: No color by default.
+    /// - SeekbarLoadingColor: No color by default.
+    /// - UseAverageColor: Turned ON by default.
+    func getVideoPressURL(_ attributes: [String: Any]) -> String {
+        // Setting default values
+        var options: [URLQueryItem] = [
+            URLQueryItem(name: VideoPressURLQueryParams.resizeToParent, value: true.stringLiteral),
+            URLQueryItem(name: VideoPressURLQueryParams.cover, value: true.stringLiteral),
+        ]
+
+        if let autoplay = attributes[VideoPressBlockKeys.autoplay] as? Bool, autoplay == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.autoPlay, value: autoplay.stringLiteral))
+        }
+        if let controls = attributes[VideoPressBlockKeys.controls] as? Bool, controls == false {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.controls, value: controls.stringLiteral))
+        }
+        if let loop = attributes[VideoPressBlockKeys.loop] as? Bool, loop == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.loop, value: loop.stringLiteral))
+        }
+        if let muted = attributes[VideoPressBlockKeys.muted] as? Bool, muted == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.muted, value: muted.stringLiteral))
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.persistVolume, value: false.stringLiteral))
+        }
+        if let playinline = attributes[VideoPressBlockKeys.playsinline] as? Bool, playinline == true {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.playsinline, value: playinline.stringLiteral))
+        }
+        if let poster = attributes[VideoPressBlockKeys.poster] as? String, !poster.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.posterUrl, value: poster))
+        }
+        if let preload = attributes[VideoPressBlockKeys.preload] as? String, !preload.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent, value: preload))
+        }
+        else {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.preloadContent, value: "metadata"))
+        }
+        if let seekbarColor = attributes[VideoPressBlockKeys.seekbarColor] as? String, !seekbarColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbc, value: seekbarColor))
+        }
+        if let seekbarPlayedColor = attributes[VideoPressBlockKeys.seekbarPlayedColor] as? String, !seekbarPlayedColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sbpc, value: seekbarPlayedColor))
+        }
+        if let seekbarLoadingColor = attributes[VideoPressBlockKeys.seekbarLoadingColor] as? String, !seekbarLoadingColor.isEmpty {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.sblc, value: seekbarLoadingColor))
+        }
+        if let useAverageColor = attributes[VideoPressBlockKeys.useAverageColor] as? Bool {
+            if useAverageColor == true {
+                options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor, value: useAverageColor.stringLiteral))
+            }
+        }
+        // Adding `useAverageColor` param as its default value is true
+        else {
+            options.append(URLQueryItem(name: VideoPressURLQueryParams.useAverageColor, value: true.stringLiteral))
+        }
+
+        guard let url = URL(string: "https://videopress.com/v/\(self.videoPressGUID)"), var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return ""
+        }
+        urlComponents.queryItems = options
+        guard
+            let query = urlComponents.query,
+            /// In web, the query parameters are encoded using `encodeURIComponent` that percent encodes reserved characters (like `/` and `:`) that are not strictly necessary to be encoded based on RFC 3986.
+            /// In the spirit of generating an URL with the same encoding, we encode using `urlHostAllowed` which percent encodes all reserved characters.
+            ///
+            /// References:
+            /// - https://en.wikipedia.org/wiki/URL_encoding#Reserved_characters
+            /// - https://www.ietf.org/rfc/rfc3986.txt
+            /// - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+            /// - https://github.com/WordPress/gutenberg/blob/1dfec0ab5f0977dcce2722bdfbe823926903e2a6/packages/url/src/build-query-string.js#L53
+            let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
+            return url.absoluteString
+        }
+        return "\(url.absoluteString)?\(encodedQuery)"
+    }
+
+    func process(_ text: String) -> String {
+        return videoPressBlockProcessor.process(text)
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -532,6 +532,8 @@
 		17FCA6811FD84B4600DBA9C8 /* NoticeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCA6801FD84B4600DBA9C8 /* NoticeStore.swift */; };
 		1A433B1D2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */; };
 		1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */; };
+		1D19C56329C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
+		1D19C56429C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1E0462162566938300EB98EF /* GutenbergFileUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */; };
 		1E0FF01E242BC572008DA898 /* GutenbergWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */; };
@@ -6091,6 +6093,7 @@
 		1A433B1C2254CBEE00AE7910 /* WordPressComRestApi+Defaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressComRestApi+Defaults.swift"; sourceTree = "<group>"; };
 		1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressUIBundleTests.swift; sourceTree = "<group>"; };
 		1BC96E982E9B1A6DD86AF491 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
+		1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergVideoPressUploadProcessor.swift; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFileUploadProcessor.swift; sourceTree = "<group>"; };
@@ -17750,6 +17753,7 @@
 				91138454228373EB00FB02B7 /* GutenbergVideoUploadProcessor.swift */,
 				4629E4202440C5B20002E15C /* GutenbergCoverUploadProcessor.swift */,
 				F5E1577E25DE04E200EEEDFB /* GutenbergMediaFilesUploadProcessor.swift */,
+				1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */,
 				46638DF5244904A3006E8439 /* GutenbergBlockProcessor.swift */,
 			);
 			path = Processors;
@@ -21124,6 +21128,7 @@
 				40EE947F2213213F00CD264F /* PublicizeConnectionStatsRecordValue+CoreDataClass.swift in Sources */,
 				1702BBE01CF3034E00766A33 /* DomainsService.swift in Sources */,
 				8B1CF00F2433902700578582 /* PasswordAlertController.swift in Sources */,
+				1D19C56329C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */,
 				1770BD0D267A368100D5F8C0 /* BloggingRemindersPushPromptViewController.swift in Sources */,
 				FA7F92B825E61C7E00502D2A /* ReaderTagsFooter.swift in Sources */,
 				80535DB82946C79700873161 /* JetpackBrandingMenuCardCell.swift in Sources */,
@@ -24740,6 +24745,7 @@
 				FABB25352602FC2C00C8785C /* ReaderListTopic.swift in Sources */,
 				FABB25362602FC2C00C8785C /* PublicizeService.swift in Sources */,
 				FABB25372602FC2C00C8785C /* ActivityContentFactory.swift in Sources */,
+				1D19C56429C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */,
 				FABB25382602FC2C00C8785C /* TenorDataLoader.swift in Sources */,
 				FABB25392602FC2C00C8785C /* OverviewCell.swift in Sources */,
 				F4D829662931046F00038726 /* UIButton+Dismiss.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -534,6 +534,7 @@
 		1ABA150822AE5F870039311A /* WordPressUIBundleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */; };
 		1D19C56329C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
 		1D19C56429C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */; };
+		1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D19C56529C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift */; };
 		1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1D30AB110D05D00D00671497 /* Foundation.framework */; };
 		1E0462162566938300EB98EF /* GutenbergFileUploadProcessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */; };
 		1E0FF01E242BC572008DA898 /* GutenbergWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E0FF01D242BC572008DA898 /* GutenbergWebViewController.swift */; };
@@ -6094,6 +6095,7 @@
 		1ABA150722AE5F870039311A /* WordPressUIBundleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressUIBundleTests.swift; sourceTree = "<group>"; };
 		1BC96E982E9B1A6DD86AF491 /* Pods-WordPressShareExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WordPressShareExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-WordPressShareExtension/Pods-WordPressShareExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		1D19C56229C9D9A700FB0087 /* GutenbergVideoPressUploadProcessor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergVideoPressUploadProcessor.swift; sourceTree = "<group>"; };
+		1D19C56529C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GutenbergVideoPressUploadProcessorTests.swift; sourceTree = "<group>"; };
 		1D30AB110D05D00D00671497 /* Foundation.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		1D6058910D05DD3D006BFB54 /* WordPress.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = WordPress.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E0462152566938300EB98EF /* GutenbergFileUploadProcessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GutenbergFileUploadProcessor.swift; sourceTree = "<group>"; };
@@ -17795,6 +17797,7 @@
 				FF2EC3C12209AC19006176E1 /* GutenbergImgUploadProcessorTests.swift */,
 				FF1B11E6238FE27A0038B93E /* GutenbergGalleryUploadProcessorTests.swift */,
 				9123471A221449E200BD9F97 /* GutenbergInformativeDialogTests.swift */,
+				1D19C56529C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift */,
 				FF0B2566237A023C004E255F /* GutenbergVideoUploadProcessorTests.swift */,
 				4629E4222440C8160002E15C /* GutenbergCoverUploadProcessorTests.swift */,
 				AEE082892681C23C00DCF54B /* GutenbergRefactoredGalleryUploadProcessorTests.swift */,
@@ -23148,6 +23151,7 @@
 				0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */,
 				400199AB222590E100EB0906 /* AllTimeStatsRecordValueTests.swift in Sources */,
 				C8567498243F41CA001A995E /* MockTenorService.swift in Sources */,
+				1D19C56629C9DB0A00FB0087 /* GutenbergVideoPressUploadProcessorTests.swift in Sources */,
 				4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */,
 				4054F4642214F94D00D261AB /* StreakStatsRecordValueTests.swift in Sources */,
 				85B125411B028E34008A3D95 /* PushAuthenticationManagerTests.swift in Sources */,

--- a/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
+++ b/WordPress/WordPressTest/GutenbergVideoPressUploadProcessorTests.swift
@@ -1,0 +1,56 @@
+import Foundation
+import XCTest
+@testable import WordPress
+
+class GutenbergVideoPressUploadProcessorTests: XCTestCase {
+
+    let blockWithDefaultAttrsContent = """
+    <!-- wp:videopress/video {"id":-181231834} -->
+    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
+    <!-- /wp:videopress/video -->
+    """
+
+    let blockWithDefaultAttrsResultContent = """
+    <!-- wp:videopress/video {"guid":"AbCdE","id":100} -->
+    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
+    https://videopress.com/v/AbCdE?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true
+    </div></figure>
+    <!-- /wp:videopress/video -->
+    """
+
+    func testVideoPressBlockWithDefaultAttrsProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let videoPressGUID = "AbCdE"
+
+        let gutenbergVideoPressUploadProcessor = GutenbergVideoPressUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, videoPressGUID: videoPressGUID)
+        let resultContent = gutenbergVideoPressUploadProcessor.process(blockWithDefaultAttrsContent)
+
+        XCTAssertEqual(resultContent, blockWithDefaultAttrsResultContent, "Post content should be updated correctly")
+    }
+
+    let blockWithAttrsContent = """
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","id":-181231834,"loop":true,"muted":true,"playsinline":true,"poster":"https://test.files.wordpress.com/2022/02/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} -->
+    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"></figure>
+    <!-- /wp:videopress/video -->
+    """
+
+    let blockWithAttrsResultContent = """
+    <!-- wp:videopress/video {"autoplay":true,"controls":false,"description":"","guid":"AbCdE","id":100,"loop":true,"muted":true,"playsinline":true,"poster":"https:\\/\\/test.files.wordpress.com\\/2022\\/02\\/265-5000x5000-1.jpeg","preload":"none","seekbarColor":"#abb8c3","seekbarLoadingColor":"#cf2e2e","seekbarPlayedColor":"#9b51e0","title":"Demo title","useAverageColor":false} -->
+    <figure class="wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player"><div class="jetpack-videopress-player__wrapper">
+    https://videopress.com/v/AbCdE?resizeToParent=true&amp;cover=true&amp;autoPlay=true&amp;controls=false&amp;loop=true&amp;muted=true&amp;persistVolume=false&amp;playsinline=true&amp;posterUrl=https%3A%2F%2Ftest.files.wordpress.com%2F2022%2F02%2F265-5000x5000-1.jpeg&amp;preloadContent=none&amp;sbc=%23abb8c3&amp;sbpc=%239b51e0&amp;sblc=%23cf2e2e
+    </div></figure>
+    <!-- /wp:videopress/video -->
+    """
+
+    func testVideoPressBlockWithAttrsProcessor() {
+        let gutenbergMediaUploadID = Int32(-181231834)
+        let mediaID = 100
+        let videoPressGUID = "AbCdE"
+
+        let gutenbergVideoPressUploadProcessor = GutenbergVideoPressUploadProcessor(mediaUploadID: gutenbergMediaUploadID, serverMediaID: mediaID, videoPressGUID: videoPressGUID)
+        let resultContent = gutenbergVideoPressUploadProcessor.process(blockWithAttrsContent)
+
+        XCTAssertEqual(resultContent, blockWithAttrsResultContent, "Post content should be updated correctly")
+    }
+}


### PR DESCRIPTION
Related PRs:
- https://github.com/Automattic/jetpack/pull/29620

Fixes https://github.com/wordpress-mobile/gutenberg-mobile/issues/5570.

## To test

### Potential regressions
This change shouldn't impact the rest of the upload processors, however, it would be great to double-check it.

1. Create/open a post.
2. Add a Video block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Verify that the Video block shows the video.
9. Preview the post and observe that the video can be played.

### VideoPress block
**NOTE:** Use the changes from this PR to test this section.

1. Create/open a post.
2. Add a VideoPress block.
3. Select the "Choose from device" option.
4. Select a video.
5. While there’s an ongoing upload, close the post with publishing changes.
6. Verify that you see the upload progress in the post summary.
7. Re-open the post.
8. Preview the post and observe that the video can be played.

## Regression Notes
1. Potential unintended areas of impact
This change might impact other video upload processors.

11. What I did to test those areas of impact (or what existing automated tests I relied on)
I tested manually that upload processors work as expected.

12. What automated tests I added (or what prevented me from doing so)
Yes, I added automated tests for the new VideoPress upload processor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
