### PR TITLE
[JP Plugin] Add overlay presentation logic for WordPress

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -1,9 +1,12 @@
+import Foundation
+
 @objc
 class JetpackInstallPluginHelper: NSObject {
 
     // MARK: Dependencies
 
     private let repository: UserPersistentRepository
+    private let currentDateProvider: CurrentDateProvider
     private let receipt: RecentJetpackInstallReceipt
     private let blog: Blog
     private let siteIDString: String
@@ -15,7 +18,12 @@ class JetpackInstallPluginHelper: NSObject {
 
     /// Determines whether the plugin install overlay should be shown for this `blog`.
     var shouldShowOverlay: Bool {
-        shouldPromptInstall && !isOverlayAlreadyShown
+        // For Jetpack, the overlay will be shown once per site.
+        if AppConfiguration.isJetpack {
+            return shouldPromptInstall && !isOverlayAlreadyShown
+        }
+
+        return shouldShowOverlayInWordPress
     }
 
     // MARK: Methods
@@ -25,7 +33,13 @@ class JetpackInstallPluginHelper: NSObject {
     /// - Parameter blog: The `Blog` to show the install cards for,
     /// - Returns: True if the install cards should be shown for this blog.
     @objc static func shouldShowCard(for blog: Blog?) -> Bool {
-        return JetpackInstallPluginHelper(blog)?.shouldShowCard ?? false
+        // cards are only shown in Jetpack.
+        guard AppConfiguration.isJetpack,
+              let helper = JetpackInstallPluginHelper(blog) else {
+            return false
+        }
+
+        return helper.shouldShowCard
     }
 
     /// Convenience entry point to show the Jetpack Install Plugin overlay when needed.
@@ -69,6 +83,7 @@ class JetpackInstallPluginHelper: NSObject {
 
     init?(_ blog: Blog?,
           repository: UserPersistentRepository = UserPersistentStoreFactory.instance(),
+          currentDateProvider: CurrentDateProvider = DefaultCurrentDateProvider(),
           receipt: RecentJetpackInstallReceipt = .shared) {
         guard let blog,
               let siteID = blog.dotComID?.stringValue,
@@ -80,6 +95,7 @@ class JetpackInstallPluginHelper: NSObject {
         self.blog = blog
         self.siteIDString = siteID
         self.repository = repository
+        self.currentDateProvider = currentDateProvider
         self.receipt = receipt
     }
 
@@ -91,6 +107,11 @@ class JetpackInstallPluginHelper: NSObject {
     }
 
     func markOverlayAsShown() {
+        guard AppConfiguration.isJetpack else {
+            markOverlayShownInWordPress()
+            return
+        }
+
         if isOverlayAlreadyShown {
             return
         }
@@ -102,6 +123,7 @@ class JetpackInstallPluginHelper: NSObject {
 
 private extension JetpackInstallPluginHelper {
 
+    /// Returns true if the card has been set to hidden for `blog`. For Jetpack only.
     var isCardHidden: Bool {
         cardHiddenSites.contains { $0 == siteIDString }
     }
@@ -115,6 +137,7 @@ private extension JetpackInstallPluginHelper {
         }
     }
 
+    /// Returns true if the overlay has been shown for `blog`. For Jetpack only.
     var isOverlayAlreadyShown: Bool {
         overlayShownSites.contains { $0 == siteIDString }
     }
@@ -132,9 +155,12 @@ private extension JetpackInstallPluginHelper {
         blog.jetpackIsConnectedWithoutFullPlugin && !receipt.installed(for: siteIDString)
     }
 
+    // MARK: Constants
+
     struct Constants {
         static let cardHiddenSitesKey = "jetpack-install-card-hidden-sites"
         static let overlayShownSitesKey = "jetpack-install-overlay-shown-sites"
+        static let maxOverlayShownPerSite = 3 // TODO: allow this value to be configurable via remote.
     }
 }
 
@@ -154,5 +180,108 @@ class RecentJetpackInstallReceipt {
 
     func store(_ siteID: String) {
         siteIDs.insert(siteID)
+    }
+}
+
+// MARK: - WordPress Helpers
+
+private extension JetpackInstallPluginHelper {
+
+    var shouldShowOverlayInWordPress: Bool {
+        let overlayInfo = WordPressOverlayInfo(siteID: siteIDString,
+                                               repository: repository,
+                                               currentDateProvider: currentDateProvider)
+
+        guard overlayInfo.amountShown < Constants.maxOverlayShownPerSite,
+              currentDateProvider.date() >= overlayInfo.nextOccurrence else {
+            return false
+        }
+
+        return shouldPromptInstall
+    }
+
+    func markOverlayShownInWordPress() {
+        let overlayInfo = WordPressOverlayInfo(siteID: siteIDString,
+                                               repository: repository,
+                                               currentDateProvider: currentDateProvider)
+
+        overlayInfo.updateNextOccurrence()
+    }
+}
+
+private class WordPressOverlayInfo {
+    private static let dateFormatter = ISO8601DateFormatter()
+    private let siteID: String
+    private let repository: UserPersistentRepository
+    private let currentDateProvider: CurrentDateProvider
+
+    /// Tracks the overlay occurrences for all sites in dictionary format.
+    ///
+    /// The occurrences are stored as an array of date strings, and the amount of strings tell how many times
+    /// the overlay has been shown for the site.
+    ///
+    /// For example, given `["2023-03-17 17:00", "2023-03-25 11:00"]`, this tells that:
+    ///     - The overlay has been shown 2 times, and
+    ///     - The third overlay may be shown after 2023-03-25 11:00.
+    ///
+    private var overlayOccurrenceSites: [String: [String]] {
+        get {
+            (repository.dictionary(forKey: Constants.overlayOccurrenceSitesKey) as? [String: [String]]) ?? .init()
+        }
+        set {
+            repository.set(newValue, forKey: Constants.overlayOccurrenceSitesKey)
+        }
+    }
+
+    /// How many times the overlay has been shown for the site.
+    var amountShown: Int {
+        overlayOccurrenceSites[siteID]?.count ?? 0
+    }
+
+    /// The minimum date before the overlay can be shown again for the site.
+    private(set) var nextOccurrence: Date {
+        get {
+            guard let dateString = overlayOccurrenceSites[siteID]?.last,
+                  let date = Self.dateFormatter.date(from: dateString) else {
+                return .distantPast
+            }
+            return date
+        }
+        set {
+            var mutableDictionary = overlayOccurrenceSites
+            var occurrencesForSite = mutableDictionary[siteID] ?? [String]()
+            occurrencesForSite.append(Self.dateFormatter.string(from: newValue))
+            mutableDictionary[siteID] = occurrencesForSite
+
+            overlayOccurrenceSites = mutableDictionary
+        }
+    }
+
+    init(siteID: String, repository: UserPersistentRepository, currentDateProvider: CurrentDateProvider) {
+        self.siteID = siteID
+        self.repository = repository
+        self.currentDateProvider = currentDateProvider
+    }
+
+    func updateNextOccurrence() {
+        nextOccurrence = currentDateProvider.date().addingTimeInterval(delay(after: amountShown + 1))
+    }
+
+    private func delay(after amountShown: Int) -> TimeInterval {
+        switch amountShown {
+        case 1:
+            return Constants.oneDayInterval
+        case 2:
+            return Constants.threeDaysInterval
+        default:
+            return Constants.oneWeekInterval
+        }
+    }
+
+    private struct Constants {
+        static let overlayOccurrenceSitesKey = "jetpack-install-overlay-occurrence-sites"
+        static let oneDayInterval: TimeInterval = 60 * 60 * 24
+        static let threeDaysInterval: TimeInterval = oneDayInterval * 3
+        static let oneWeekInterval: TimeInterval = oneDayInterval * 7
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 @objc
 class JetpackInstallPluginHelper: NSObject {
 
@@ -18,12 +16,12 @@ class JetpackInstallPluginHelper: NSObject {
 
     /// Determines whether the plugin install overlay should be shown for this `blog`.
     var shouldShowOverlay: Bool {
-        // For Jetpack, the overlay will be shown once per site.
-        if AppConfiguration.isJetpack {
-            return shouldPromptInstall && !isOverlayAlreadyShown
+        guard AppConfiguration.isJetpack else {
+            return shouldShowOverlayInWordPress
         }
 
-        return shouldShowOverlayInWordPress
+        // For Jetpack, the overlay will be shown once per site.
+        return shouldPromptInstall && !isOverlayAlreadyShown
     }
 
     // MARK: Methods


### PR DESCRIPTION
Refs #20377 

As titled, this adds the presentation logic for the WordPress app. Some notes:

- The overlay will be shown a maximum number of times. This number is currently hardcoded, but this will be updated separately to account for remote configurations.
- There's also a scaled delay between each overlay.
- The overlay information data is stored in User Defaults.
- Plugin install card is hidden in WordPress.

## To test

### WordPress app
- Prepare a self-hosted site with individual Jetpack plugins installed & connected to your WordPress.com account.
- Launch the WordPress app, and enable the "Jetpack Individual Plugin Support" feature flag.
- Relaunch the app.
- Switch to your self-hosted site.
- 🔎 Verify that the overlay should now be shown.
  - Note that this is still showing the overlay with contents intended for the Jetpack app.
- Dismiss the overlay.
- 🔎 Verify that the plugin install card is not shown.

> **Note**: 
> You can verify that the "next occurrence date" for the second overlay is scheduled properly by opening the `plist` file that stores the User Defaults. For convenience, I used [SimSim](https://github.com/dsmelov/simsim) to quickly access the Simulator's Library > Preferences folder.

### Jetpack app

🔎 Verify that this change does not affect the overlay presentation logic in the Jetpack app: overlay should only be shown once per site and the plugin install card is shown on the dashboard.

## Regression Notes
1. Potential unintended areas of impact
Should be none. The feature is not released.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manually tested the changes.

3. What automated tests I added (or what prevented me from doing so)
N/A, but will add tests later in a separate PR.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
