### PR TITLE
[UI Tests] Enable Retry on Failure for the JetpackUITests suite.

### DIFF
--- a/WordPress/WordPressUITests/JetpackUITests.xctestplan
+++ b/WordPress/WordPressUITests/JetpackUITests.xctestplan
@@ -15,7 +15,8 @@
       "containerPath" : "container:WordPress.xcodeproj",
       "identifier" : "FABB1F8F2602FC2C00C8785C",
       "name" : "Jetpack"
-    }
+    },
+    "testRepetitionMode" : "retryOnFailure"
   },
   "testTargets" : [
     {


### PR DESCRIPTION
The objective of this PR is to enable the Xcode's `Retry on Failure` feature just like we have on WordPressUITests.

**Context**
It was noticed that it was disabled while investigating a test failure in a couple of CI builds ([this](https://buildkite.com/automattic/wordpress-ios/builds/13259) and [this](https://buildkite.com/automattic/wordpress-ios/builds/13286)), where `testAddGalleryBlock()` would fail a single time and break CI step.

The test fails during the `SetUp` while checking if the Login Prologue screen is loaded, right after typing the password and tapping `Continue` button. 

<details>
  <summary>Login Prologue screen</summary>
  <img width="200" src="https://user-images.githubusercontent.com/42008628/227034116-2f1bf712-e8ac-4055-88cc-84d8509a0578.png">
</details>

From the Xcode results in CI, the last screenshot taken is from the `Log in` screen with a spinning wheel on top of the `Continue` button, suggesting that the log could be taking a little longer. 

<details>
  <summary>Last screenshot from CI run</summary>
  <img width="200" alt="image" src="https://user-images.githubusercontent.com/42008628/227035597-4455738d-91bd-4fed-afb6-a3ac552cf3aa.png">
</details>

One thing to notice is that `testAddGalleryBlock()` is always the first test to run, so we don't know if the other tests would also fail or even the same test on a retrial as the `Login` flow is common to most of the tests. Since I couldn't reproduce the issue locally and not all the CI runs are failing, I'm comfortable with enabling the automatic Retries, to deal with potential network/workers performance issues, as we've been doing with the WordPressUITests.
