### PR TITLE
Hiding dashboard cards: add context menus

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,9 @@
 -----
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
-* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
 * [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]
+* [**] Add context menus to "Drafts", "Scheduled Posts", and "Today's Stats" cards with an option to hide these cards. [#20384]
+* [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
 
 22.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,6 @@
 -----
 * [**] [internal] Refactor updating account related Core Data operations, which ususally happens during log in and out of the app. [#20394]
 * [***] [internal] Refactor uploading photos (from the device photo, the Free Photo library, and other sources) to the WordPress Media Library. Affected areas are where you can choose a photo and upload, including the "Media" screen, adding images to a post, updating site icon, etc. [#20322]
-* [**] Add a "Personalize Home Tab" button to the bottom of the Home tab that allows changing cards visibility. [#20369]
-* [**] Add context menus to "Drafts", "Scheduled Posts", and "Today's Stats" cards with an option to hide these cards. [#20384]
 * [**] [WordPress-only] Warns user about sites with only individual plugins not supporting core app features and offers the option to switch to the Jetpack app. [#20408]
 
 22.0

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -329,6 +329,8 @@ import Foundation
     // My Site Dashboard
     case dashboardCardShown
     case dashboardCardItemTapped
+    case dashboardCardContextualMenuAccessed
+    case dashboardCardHideTapped
     case mySiteTabTapped
     case mySiteSiteMenuShown
     case mySiteDashboardShown
@@ -1033,6 +1035,10 @@ import Foundation
             return "my_site_dashboard_card_shown"
         case .dashboardCardItemTapped:
             return "my_site_dashboard_card_item_tapped"
+        case .dashboardCardContextualMenuAccessed:
+            return "my_site_dashboard_contextual_menu_accessed"
+        case .dashboardCardHideTapped:
+            return "my_site_dashboard_card_hide_tapped"
         case .mySiteTabTapped:
             return "my_site_tab_tapped"
         case .mySiteSiteMenuShown:

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/BlazeCardView.swift
@@ -126,7 +126,7 @@ extension BlazeCardView {
                                                    comment: "Description for the Blaze dashboard card.")
         static let hideThis = NSLocalizedString("blaze.dashboard.card.menu.hide",
                                                  value: "Hide this",
-                                                 comment: "Title for a menu action in the context menu on the Jetpack install card.")
+                                                 comment: "Title for a menu action in the context menu on the Blaze card.")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCardCell.swift
@@ -19,10 +19,12 @@ class DashboardBlazeCardCell: DashboardCollectionViewCell {
         }
 
         let onEllipsisTap: () -> Void = { [weak self] in
+            BlogDashboardAnalytics.trackContextualMenuAccessed(for: .blaze)
             BlazeEventsTracker.trackContextualMenuAccessed(for: .dashboardCard)
         }
 
         let onHideThisTap: UIActionHandler = { [weak self] _ in
+            BlogDashboardAnalytics.trackHideTapped(for: .blaze)
             BlazeEventsTracker.trackHideThisTapped(for: .dashboardCard)
             BlazeHelper.hideBlazeCard(for: self?.blog)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -177,7 +177,7 @@ class BlogDashboardCardFrameView: UIView {
         addSubview(buttonContainerStackView)
 
         NSLayoutConstraint.activate([
-            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor),
+            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.buttonContainerStackViewPadding),
             buttonContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.buttonContainerStackViewPadding)
         ])
 
@@ -251,11 +251,11 @@ class BlogDashboardCardFrameView: UIView {
     private enum Constants {
         static let bottomPadding: CGFloat = 8
         static let headerPaddingWithEllipsisButtonHidden = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
-        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 4, left: 16, bottom: 0, right: 8)
+        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
         static let headerHorizontalSpacing: CGFloat = 5
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
-        static let ellipsisButtonPadding = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
+        static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -40,7 +40,8 @@ class BlogDashboardCardFrameView: UIView {
     /// Displayed only when an associated action is set
     private(set) lazy var ellipsisButton: UIButton = {
         let button = UIButton(type: .custom)
-        button.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
+        button.setImage(UIImage(named: "more-horizontal-mobile"), for: .normal)
+        button.tintColor = UIColor.listIcon
         button.contentEdgeInsets = Constants.ellipsisButtonPadding
         button.isAccessibilityElement = true
         button.accessibilityLabel = Strings.ellipsisButtonAccessibilityLabel
@@ -129,11 +130,6 @@ class BlogDashboardCardFrameView: UIView {
         }
     }
 
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        updateColors()
-    }
-
     /// Add a subview inside the card frame
     func add(subview: UIView) {
         mainStackView.addArrangedSubview(subview)
@@ -192,10 +188,6 @@ class BlogDashboardCardFrameView: UIView {
 
     func removeButtonContainerStackView() {
         buttonContainerStackView.removeFromSuperview()
-    }
-
-    private func updateColors() {
-        ellipsisButton.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
     }
 
     private func updateEllipsisButtonState() {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -177,7 +177,7 @@ class BlogDashboardCardFrameView: UIView {
         addSubview(buttonContainerStackView)
 
         NSLayoutConstraint.activate([
-            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor, constant: Constants.buttonContainerStackViewPadding),
+            buttonContainerStackView.topAnchor.constraint(equalTo: topAnchor),
             buttonContainerStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Constants.buttonContainerStackViewPadding)
         ])
 
@@ -251,11 +251,11 @@ class BlogDashboardCardFrameView: UIView {
     private enum Constants {
         static let bottomPadding: CGFloat = 8
         static let headerPaddingWithEllipsisButtonHidden = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
-        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
+        static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 4, left: 16, bottom: 0, right: 8)
         static let headerHorizontalSpacing: CGFloat = 5
         static let iconSize = CGSize(width: 18, height: 18)
         static let cornerRadius: CGFloat = 10
-        static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+        static let ellipsisButtonPadding = UIEdgeInsets(top: 8, left: 8, bottom: 8, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -25,16 +25,6 @@ class BlogDashboardCardFrameView: UIView {
         return topStackView
     }()
 
-    /// Card's icon image view
-    private lazy var iconImageView: UIImageView = {
-        let iconImageView = UIImageView(image: UIImage.gridicon(.posts, size: Constants.iconSize).withRenderingMode(.alwaysTemplate))
-        iconImageView.tintColor = .label
-        iconImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
-        iconImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        iconImageView.isAccessibilityElement = false
-        return iconImageView
-    }()
-
     /// Card's title
     private lazy var titleLabel: UILabel = {
         let titleLabel = UILabel()
@@ -43,19 +33,6 @@ class BlogDashboardCardFrameView: UIView {
         titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
         titleLabel.accessibilityTraits = .button
         return titleLabel
-    }()
-
-    /// Chevron displayed in case there's any action associated
-    private lazy var chevronImageView: UIImageView = {
-        let chevronImage = UIImage.gridicon(.chevronRight, size: Constants.iconSize).withRenderingMode(.alwaysTemplate)
-        let chevronImageView = UIImageView(image: chevronImage.imageFlippedForRightToLeftLayoutDirection())
-        chevronImageView.frame = CGRect(x: 0, y: 0, width: Constants.iconSize.width, height: Constants.iconSize.height)
-        chevronImageView.tintColor = .listIcon
-        chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        chevronImageView.isAccessibilityElement = false
-        chevronImageView.isHidden = true
-        chevronImageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
-        return chevronImageView
     }()
 
     /// Ellipsis Button displayed on the top right corner of the view.
@@ -102,19 +79,10 @@ class BlogDashboardCardFrameView: UIView {
         }
     }
 
-    /// The icon to be displayed at the header
-    var icon: UIImage? {
-        didSet {
-            iconImageView.image = icon?.withRenderingMode(.alwaysTemplate)
-            iconImageView.isHidden = icon == nil
-        }
-    }
-
     /// Closure to be called when anywhere in the view is tapped.
     /// If set, the chevron image is displayed.
     var onViewTap: (() -> Void)? {
         didSet {
-            updateChevronImageState()
             addViewTapGestureIfNeeded()
         }
     }
@@ -124,10 +92,8 @@ class BlogDashboardCardFrameView: UIView {
     /// If set, the chevron image is displayed.
     var onHeaderTap: (() -> Void)? {
         didSet {
-            updateChevronImageState()
             addHeaderTapGestureIfNeeded()
         }
-
     }
 
     /// Closure to be called when the ellipsis button is tapped..
@@ -177,7 +143,7 @@ class BlogDashboardCardFrameView: UIView {
         headerStackView.isHidden = true
         buttonContainerStackView.isHidden = false
 
-        if !ellipsisButton.isHidden || !chevronImageView.isHidden {
+        if !ellipsisButton.isHidden {
             mainStackViewTrailingConstraint?.constant = -Constants.mainStackViewTrailingPadding
         }
     }
@@ -228,30 +194,17 @@ class BlogDashboardCardFrameView: UIView {
         ellipsisButton.setImage(UIImage.gridicon(.ellipsis).imageWithTintColor(.listIcon), for: .normal)
     }
 
-    private func updateChevronImageState() {
-        chevronImageView.isHidden = onViewTap == nil && onHeaderTap == nil
-        assertOnTapRecognitionCorrectUsage()
-    }
-
     private func updateEllipsisButtonState() {
         ellipsisButton.isHidden = onEllipsisButtonTap == nil
         let headerPadding = ellipsisButton.isHidden ?
             Constants.headerPaddingWithEllipsisButtonHidden :
             Constants.headerPaddingWithEllipsisButtonShown
         headerStackView.layoutMargins = headerPadding
-        assertOnTapRecognitionCorrectUsage()
-    }
-
-    /// Only one of two types of action should be associated with the card.
-    /// Either ellipsis button tap, or view/header tap
-    private func assertOnTapRecognitionCorrectUsage() {
-        let bothTypesUsed = (onViewTap != nil || onHeaderTap != nil) && onEllipsisButtonTap != nil
-        assert(!bothTypesUsed, "Using onViewTap or onHeaderTap alongside onEllipsisButtonTap is not supported and will result in unexpected behavior.")
     }
 
     private func addHeaderTapGestureIfNeeded() {
         // Reset any previously added gesture recognizers
-        headerStackView.gestureRecognizers?.forEach {headerStackView.removeGestureRecognizer($0)}
+        headerStackView.gestureRecognizers?.forEach { headerStackView.removeGestureRecognizer($0) }
 
         // Add gesture recognizer if needed
         if onHeaderTap != nil {
@@ -262,7 +215,7 @@ class BlogDashboardCardFrameView: UIView {
 
     private func addViewTapGestureIfNeeded() {
         // Reset any previously added gesture recognizers
-        self.gestureRecognizers?.forEach {self.removeGestureRecognizer($0)}
+        self.gestureRecognizers?.forEach { self.removeGestureRecognizer($0) }
 
         // Add gesture recognizer if needed
         if onViewTap != nil {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -69,7 +69,6 @@ class DashboardPostsListCardCell: UICollectionViewCell, Reusable {
 
     private func addSubviews() {
         let frameView = BlogDashboardCardFrameView()
-        frameView.icon = UIImage.gridicon(.posts, size: Constants.iconSize)
         frameView.translatesAutoresizingMaskIntoConstraints = false
 
         frameView.add(subview: tableView)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -108,6 +108,8 @@ extension DashboardPostsListCardCell {
     }
 
     private func addContextMenu(card: DashboardCard, blog: Blog) {
+        guard FeatureFlag.personalizeHomeTab.enabled else { return }
+
         frameView.onEllipsisButtonTap = {
             BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -16,7 +16,7 @@ class DashboardPostsListCardCell: UICollectionViewCell, Reusable {
 
     // MARK: Views
 
-    private var frameView: BlogDashboardCardFrameView?
+    private let frameView = BlogDashboardCardFrameView()
 
     lazy var tableView: UITableView = {
         let tableView = PostCardTableView()
@@ -68,12 +68,8 @@ class DashboardPostsListCardCell: UICollectionViewCell, Reusable {
     }
 
     private func addSubviews() {
-        let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-
         frameView.add(subview: tableView)
-
-        self.frameView = frameView
 
         contentView.addSubview(frameView)
         contentView.pinSubviewToAllEdges(frameView, priority: Constants.constraintPriority)
@@ -103,23 +99,35 @@ extension DashboardPostsListCardCell {
             assertionFailure("Cell used with wrong card type")
             return
         }
+        addContextMenu(card: cardType, blog: blog)
+
         viewModel = PostsCardViewModel(blog: blog, status: status, view: self)
         viewModel?.viewDidLoad()
         tableView.dataSource = viewModel?.diffableDataSource
         viewModel?.refresh()
     }
 
+    private func addContextMenu(card: DashboardCard, blog: Blog) {
+        frameView.onEllipsisButtonTap = {
+            BlogDashboardAnalytics.trackContextualMenuAccessed(for: card)
+        }
+        frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+        frameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
+            BlogDashboardHelpers.makeHideCardAction(for: card, siteID: blog.dotComID?.intValue ?? 0)
+        ])
+    }
+
     private func configureDraftsList(blog: Blog) {
-        frameView?.title = Strings.draftsTitle
-        frameView?.titleHint = Strings.draftsTitleHint
-        frameView?.onHeaderTap = { [weak self] in
+        frameView.title = Strings.draftsTitle
+        frameView.titleHint = Strings.draftsTitleHint
+        frameView.onHeaderTap = { [weak self] in
             self?.presentPostList(with: .draft)
         }
     }
 
     private func configureScheduledList(blog: Blog) {
-        frameView?.title = Strings.scheduledTitle
-        frameView?.onHeaderTap = { [weak self] in
+        frameView.title = Strings.scheduledTitle
+        frameView.onHeaderTap = { [weak self] in
             self?.presentPostList(with: .scheduled)
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -15,7 +15,9 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         // NOTE: Remove the logic when support for iOS 14 is dropped
         if #available (iOS 15.0, *) {
             // assign an empty closure so the button appears.
-            frameView.onEllipsisButtonTap = {}
+            frameView.onEllipsisButtonTap = {
+                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .prompts)
+            }
             frameView.ellipsisButton.showsMenuAsPrimaryAction = true
             frameView.ellipsisButton.menu = contextMenu
         } else {
@@ -23,6 +25,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
             // iOS 13 doesn't support showing UIMenu programmatically.
             // iOS 14 doesn't support `UIDeferredMenuElement.uncached`.
             frameView.onEllipsisButtonTap = { [weak self] in
+                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .prompts)
                 self?.showMenuSheet()
             }
         }
@@ -500,6 +503,7 @@ private extension DashboardPromptsCardCell {
             return
         }
         WPAnalytics.track(.promptsDashboardCardMenuRemove)
+        BlogDashboardAnalytics.trackHideTapped(for: .prompts)
         let service = BlogDashboardPersonalizationService(siteID: siteID)
         service.setEnabled(false, for: .prompts)
         let notice = Notice(title: Strings.promptRemovedTitle, message: Strings.promptRemovedSubtitle, feedbackType: .success, actionTitle: Strings.undoSkipTitle) { _ in

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -11,7 +11,6 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
         frameView.title = Strings.cardFrameTitle
-        frameView.icon = Style.frameIconImage
 
         // NOTE: Remove the logic when support for iOS 14 is dropped
         if #available (iOS 15.0, *) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Start/DashboardQuickStartCardCell.swift
@@ -51,7 +51,6 @@ final class DashboardQuickStartCardCell: UICollectionViewCell, Reusable, BlogDas
             fallthrough
 
         case .newSite:
-            cardFrameView.icon = UIImage.gridicon(.listOrdered, size: Metrics.iconSize)
             configureOnEllipsisButtonTap(sourceRect: cardFrameView.ellipsisButton.frame)
             cardFrameView.showHeader()
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -42,7 +42,6 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
         let frameView = BlogDashboardCardFrameView()
         frameView.title = Strings.statsTitle
         frameView.titleHint = Strings.statsTitleHint
-        frameView.icon = UIImage.gridicon(.statsAlt, size: Constants.iconSize)
         self.frameView = frameView
 
         let statsStackview = DashboardStatsStackView()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardStatsCardCell.swift
@@ -6,7 +6,7 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
     // MARK: Private Variables
 
     private var viewModel: DashboardStatsViewModel?
-    private var frameView: BlogDashboardCardFrameView?
+    private let frameView = BlogDashboardCardFrameView()
     private var nudgeView: DashboardStatsNudgeView?
     private var statsStackView: DashboardStatsStackView?
 
@@ -39,10 +39,8 @@ class DashboardStatsCardCell: UICollectionViewCell, Reusable {
     }
 
     private func addSubviews() {
-        let frameView = BlogDashboardCardFrameView()
         frameView.title = Strings.statsTitle
         frameView.titleHint = Strings.statsTitleHint
-        self.frameView = frameView
 
         let statsStackview = DashboardStatsStackView()
         frameView.add(subview: statsStackview)
@@ -73,9 +71,18 @@ extension DashboardStatsCardCell: BlogDashboardCardConfigurable {
     }
 
     private func configureCard(for blog: Blog, in viewController: UIViewController) {
-
-        frameView?.onViewTap = { [weak self] in
+        frameView.onViewTap = { [weak self] in
             self?.showStats(for: blog, from: viewController)
+        }
+
+        if FeatureFlag.personalizeHomeTab.enabled {
+            frameView.onEllipsisButtonTap = {
+                BlogDashboardAnalytics.trackContextualMenuAccessed(for: .todaysStats)
+            }
+            frameView.ellipsisButton.showsMenuAsPrimaryAction = true
+            frameView.ellipsisButton.menu = UIMenu(title: "", options: .displayInline, children: [
+                BlogDashboardHelpers.makeHideCardAction(for: .todaysStats, siteID: blog.dotComID?.intValue ?? 0)
+            ])
         }
 
         statsStackView?.views = viewModel?.todaysViews

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
@@ -30,4 +30,12 @@ class BlogDashboardAnalytics {
             }
         }
     }
+
+    static func trackContextualMenuAccessed(for card: DashboardCard) {
+        WPAnalytics.track(.dashboardCardContextualMenuAccessed, properties: ["card": card.rawValue])
+    }
+
+    static func trackHideTapped(for card: DashboardCard) {
+        WPAnalytics.track(.dashboardCardHideTapped, properties: ["card": card.rawValue])
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardHelpers.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct BlogDashboardHelpers {
+    static func makeHideCardAction(for card: DashboardCard, siteID: Int) -> UIAction {
+        UIAction(
+            title: Strings.hideThis,
+            image: UIImage(systemName: "minus.circle"),
+            attributes: [.destructive],
+            handler: { _ in
+                BlogDashboardAnalytics.trackHideTapped(for: card)
+                BlogDashboardPersonalizationService(siteID: siteID)
+                    .setEnabled(false, for: card)
+            })
+    }
+
+    private enum Strings {
+        static let hideThis = NSLocalizedString("blogDashboard.contextMenu.hideThis", value: "Hide this", comment: "Title for the context menu action that hides the dashboard card.")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallCardView.swift
@@ -72,7 +72,6 @@ class JetpackRemoteInstallCardView: UIView {
     private lazy var cardFrameView: BlogDashboardCardFrameView = {
         let frameView = BlogDashboardCardFrameView()
         frameView.translatesAutoresizingMaskIntoConstraints = false
-        frameView.icon = .none
         frameView.onEllipsisButtonTap = {}
         frameView.ellipsisButton.showsMenuAsPrimaryAction = true
         frameView.ellipsisButton.menu = contextMenu

--- a/WordPress/Resources/AppImages.xcassets/more-horizontal-mobile.imageset/Contents.json
+++ b/WordPress/Resources/AppImages.xcassets/more-horizontal-mobile.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "more-horizontal-mobile.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "template-rendering-intent" : "template"
+  }
+}

--- a/WordPress/Resources/AppImages.xcassets/more-horizontal-mobile.imageset/more-horizontal-mobile.svg
+++ b/WordPress/Resources/AppImages.xcassets/more-horizontal-mobile.imageset/more-horizontal-mobile.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 13H13V11H11V13ZM5 13H7V11H5V13ZM17 11V13H19V11H17Z" fill="#3C3C43"/>
+</svg>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -304,6 +304,8 @@
 		0A9610FA28B2E56300076EBA /* UserSuggestion+Comparable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */; };
 		0A9687BC28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */; };
 		0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */; };
+		0C35FFF129CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
+		0C35FFF229CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */; };
 		0CB4056B29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056C29C78F06008EED0A /* BlogDashboardPersonalizationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */; };
 		0CB4056E29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */; };
@@ -5919,6 +5921,7 @@
 		0A9610F828B2E56300076EBA /* UserSuggestion+Comparable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserSuggestion+Comparable.swift"; sourceTree = "<group>"; };
 		0A9687BB28B40771009DCD2F /* FullScreenCommentReplyViewModelMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenCommentReplyViewModelMock.swift; sourceTree = "<group>"; };
 		0C35FFF329CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModelTests.swift; sourceTree = "<group>"; };
+		0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardHelpers.swift; sourceTree = "<group>"; };
 		0CB4056A29C78F06008EED0A /* BlogDashboardPersonalizationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationService.swift; sourceTree = "<group>"; };
 		0CB4056D29C7BA63008EED0A /* BlogDashboardPersonalizationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationServiceTests.swift; sourceTree = "<group>"; };
 		0CB4057029C8DCF4008EED0A /* BlogDashboardPersonalizationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlogDashboardPersonalizationViewModel.swift; sourceTree = "<group>"; };
@@ -13539,6 +13542,7 @@
 			isa = PBXGroup;
 			children = (
 				8B15D27328009EBF0076628A /* BlogDashboardAnalytics.swift */,
+				0C35FFF029CB81F700D224EB /* BlogDashboardHelpers.swift */,
 				8BC81D6427CFC0DA0057F790 /* BlogDashboardState.swift */,
 				80EF9285280D272E0064A971 /* DashboardPostsSyncManager.swift */,
 			);
@@ -21306,6 +21310,7 @@
 				B538F3891EF46EC8001003D5 /* UnknownEditorViewController.swift in Sources */,
 				937D9A1119F838C2007B9D5F /* AccountToAccount22to23.swift in Sources */,
 				400A2C772217A8A0000A8A59 /* VisitsSummaryStatsRecordValue+CoreDataClass.swift in Sources */,
+				0C35FFF129CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */,
 				D8212CB320AA6861008E8AE8 /* ReaderFollowAction.swift in Sources */,
 				F5D399302541F25B0058D0AB /* SheetActions.swift in Sources */,
 				93F7214F271831820021A09F /* SiteStatsPinnedItemStore.swift in Sources */,
@@ -24935,6 +24940,7 @@
 				FABB256B2602FC2C00C8785C /* InteractivePostView.swift in Sources */,
 				FABB256C2602FC2C00C8785C /* LinearGradientView.swift in Sources */,
 				FABB256D2602FC2C00C8785C /* WizardStep.swift in Sources */,
+				0C35FFF229CB81F700D224EB /* BlogDashboardHelpers.swift in Sources */,
 				C395FB242821FE4B00AE7C11 /* SiteDesignSection.swift in Sources */,
 				837B49D8283C2AE80061A657 /* BloggingPromptSettings+CoreDataClass.swift in Sources */,
 				FABB256E2602FC2C00C8785C /* PostPostViewController.swift in Sources */,


### PR DESCRIPTION
Related issue: #20296

Previous PRs (dependencies):

1. #20365
2. #20369

## Changes

- Add context menus with the "Hide this" button to "Drafts", "Scheduled Posts", and "Today's Stats" cards. Now every card from the new "Personalize Home Tab" screen has a "Hide this" button in the context menu. A couple more cards require special attention and will be made "personalizable" later.
- Remove unused code left after the recent dashboard cards [redesign](https://github.com/wordpress-mobile/WordPress-iOS/pull/20303) (already confirmed that these can be removed)
- Add generalized tracking for context menus and "Hide this" actions for cards (see `BlogDashboardAnalytics`)

## Screenshots

<img width="437" alt="Screenshot 2023-03-22 at 5 55 26 PM" src="https://user-images.githubusercontent.com/1567433/227047527-23be9179-14c1-4972-aeee-e86b0a923b93.png">

## Testing

*Prerequisites*
- "Personalize Home Tab" feature flag is enabled

**Test Case 1 (Draft Post)**

- Create a draft post and open dashboard
- Verify that the "Drafts" card now has a context menu
- Tap the context menu and select "Hide this"
- Verify that the card is hidden

**Test Case 2 (Schedule Post)**

- Create a scheduled post and open dashboard
- Verify that the "Schedules Posts" card now has a context menu
- Tap the context menu and select "Hide this"
- Verify that the card is hidden

**Test Case 3 (Both)**

- Create both a draft and a scheduled post
- Hide drafts
- Verify that schedules posts are still visible

**Test Case 4 (Stats)**

- Verify that the "Today's Stats" card has a context menu with the "Hide This" button
- Tap the button and verify that the card got hidden

**Test Case 5 (Stored Per-Site)**

- Create a draft for site A and hide the "Drafts" card 
- Switch to site B and create a draft 
- Verify that the "Drafts" cards is visible on Dashboard

**Test Case 6 (Regression)**

- Create a draft post
- Verify that the header and the individual posts are still tappable separately
- Verify that the context menu button is easy to tap with a finder (should preferably be testesd on the physical device)

*Other Testing Notes*:

- Test on iOS 14 to make sure context menus are displayed correctly
- Test with large dynamic type to make sure card titles don't overlap with the context menus
- An easy way to test all cards layout is by removing filter in `BlogDashboardService.parse`

## Regression Notes
1. Potential unintended areas of impact
This change affects primarily "Drafts," "Schedules Posts", and "Today's Stats" cards, but other dashboard cards were also affected. It must be verified that the context menu layout wasn't broken for other cards, such as Blaze.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing

4. What automated tests I added (or what prevented me from doing so)
n/a

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
