### PR TITLE
[Jetpack Plugin]: Update overlay for WordPress configuration

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -53,13 +53,20 @@ class JetpackInstallPluginHelper: NSObject {
         // create the overlay stack.
         let viewModel = JetpackPluginOverlayViewModel(siteName: siteURLString, plugin: plugin)
         let overlayViewController = JetpackFullscreenOverlayViewController(with: viewModel)
-        let coordinator = JetpackPluginOverlayCoordinator(blog: blog,
-                                                          viewController: overlayViewController,
-                                                          installDelegate: delegate)
-        viewModel.coordinator = coordinator
+        var coordinator: JetpackOverlayCoordinator?
 
         // present the overlay.
         let navigationViewController = UINavigationController(rootViewController: overlayViewController)
+        if AppConfiguration.isWordPress {
+            let defaultCoordinator = JetpackDefaultOverlayCoordinator()
+            defaultCoordinator.navigationController = navigationViewController
+            coordinator = defaultCoordinator
+        } else {
+            coordinator = JetpackPluginOverlayCoordinator(blog: blog,
+                                                          viewController: overlayViewController,
+                                                          installDelegate: delegate)
+        }
+        viewModel.coordinator = coordinator
         let shouldUseFormSheet = WPDeviceIdentification.isiPad()
         navigationViewController.modalPresentationStyle = shouldUseFormSheet ? .formSheet : .fullScreen
         presentingViewController.present(navigationViewController, animated: true) {


### PR DESCRIPTION
See #20375

## Description

Adds new strings to the Jetpack plugin overlay to display in WordPress. Additionally, it uses the default overlay coordinator to start the process to switch to the Jetpack app. 

| WordPress | Jetpack |
|------------|---------|
| ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 19 58 44](https://user-images.githubusercontent.com/2454408/227064972-140856ff-68b1-4af2-ab32-75b363d5409e.png) | ![Simulator Screen Shot - iPhone 14 Pro - 2023-03-22 at 19 58 29](https://user-images.githubusercontent.com/2454408/227064990-7b20220f-0694-4601-85a9-78202041d9de.png) |

## Testing

To test:

**WordPress**
- Setup a self-hosted site with an individual plugin connected to your WordPress account
- Setup a self-hosted site with multiple individual plugins connected to your WordPress account
- Enable the feature flag `jetpackIndividualPluginSupport` through code or the debug menu
- Select the self-hosted site with a single plugin installed
- When switching/selecting the self-hosted site, the overlay should appear. If not, the JP plugin dashboard card should also appear and you can tap on 'Learn more' to view the overlay.
- **Verify:**
  - Animated logo matches what is shown in the Jetpack app for individual plugins overlay.
  - Title is: `Sorry, this site isn't supported by the WordPress app`
  - Singular plugin paragraph is: `{site_host} is using the {jetpack_plugin_name} plugin, which isn't supported by the WordPress app.`
  - `{site_host}` and `{jetpack_plugin_name` are bolded
  - Second paragraph is: `Please switch to the Jetpack app where we'll guide you through connecting the full Jetpack plugin so that you can use all the apps features for this site.`
  - Primary button text is: `Switch to the Jetpack app`
  - Secondary button text is: `Continue without Jetpack`
  - Tapping the primary button begins the Jetpack migration flow and attempts to open Jetpack
  - Tapping the secondary button dismisses the overlay
- Switch to the site with multiple plugins and repeat the steps to get the overlay to appear
- **Verify**: 
  - Multiple plugin paragraph is: `{site_host} is using individual Jetpack plugins, which isn't supported by the WordPress app.`
  - `{site_host}` is bolded

**Jetpack quick test**

- Launch Jetpack and login 
- Repeat the same steps from the WordPress instructions
- **Verify**:
  - Title and paragraphs remain unchanged and is the correct strings
  - Terms and conditions displays, is tappable, and opens the correct site
  - Primary and secondary button actions remain unchanged


## Regression Notes
1. Potential unintended areas of impact
Plugin overlay on Jetpack

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing and verifying it remains unchanged

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
