### PR TITLE
[JP Plugin] Add remote feature flag and remote config

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -46,6 +46,7 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
     case jetpackFeaturesRemovalStaticPosters
     case wordPressSupportForum
     case jetpackIndividualPluginSupport
+    case wordPressIndividualPluginSupport
     case blaze
     case siteCreationDomainPurchasing
     case readerUserBlocking
@@ -149,6 +150,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return true
         case .jetpackIndividualPluginSupport:
             return AppConfiguration.isJetpack
+        case .wordPressIndividualPluginSupport:
+            return false
         case .blaze:
             return false
         case .siteCreationDomainPurchasing:
@@ -185,6 +188,8 @@ enum FeatureFlag: Int, CaseIterable, OverrideableFlag {
             return "wordpress_support_forum_remote_field"
         case .blaze:
             return "blaze"
+        case .wordPressIndividualPluginSupport:
+            return "wp_individual_plugin_overlay"
             default:
                 return nil
         }
@@ -293,6 +298,8 @@ extension FeatureFlag {
             return "Provide support through a forum"
         case .jetpackIndividualPluginSupport:
             return "Jetpack Individual Plugin Support"
+        case .wordPressIndividualPluginSupport:
+            return "Jetpack Individual Plugin Support for WordPress"
         case .blaze:
             return "Blaze"
         case .siteCreationDomainPurchasing:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -47,4 +47,8 @@ struct RemoteConfig {
     var blazeFlowCompletedStep: RemoteConfigParameter<String> {
         RemoteConfigParameter<String>(key: "blaze_completed_step_hash", defaultValue: "step-5", store: store)
     }
+
+    var wordPressPluginOverlayMaxShown: RemoteConfigParameter<String> {
+        RemoteConfigParameter<String>(key: "wp_plugin_overlay_max_shown", defaultValue: "3", store: store)
+    }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteConfig.swift
@@ -48,7 +48,7 @@ struct RemoteConfig {
         RemoteConfigParameter<String>(key: "blaze_completed_step_hash", defaultValue: "step-5", store: store)
     }
 
-    var wordPressPluginOverlayMaxShown: RemoteConfigParameter<String> {
-        RemoteConfigParameter<String>(key: "wp_plugin_overlay_max_shown", defaultValue: "3", store: store)
+    var wordPressPluginOverlayMaxShown: RemoteConfigParameter<Int> {
+        RemoteConfigParameter<Int>(key: "wp_plugin_overlay_max_shown", defaultValue: 3, store: store)
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -192,11 +192,7 @@ class RecentJetpackInstallReceipt {
 private extension JetpackInstallPluginHelper {
 
     var maxOverlayShownPerSite: Int {
-        guard let stringValue = remoteConfig.wordPressPluginOverlayMaxShown.value,
-              let intValue = Int(stringValue) else {
-            return 0
-        }
-        return intValue
+        remoteConfig.wordPressPluginOverlayMaxShown.value ?? 0
     }
 
     var shouldShowOverlayInWordPress: Bool {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift
@@ -17,12 +17,12 @@ class JetpackInstallPluginHelper: NSObject {
 
     /// Determines whether the plugin install overlay should be shown for this `blog`.
     var shouldShowOverlay: Bool {
-        guard AppConfiguration.isJetpack else {
-            return shouldShowOverlayInWordPress
+        if AppConfiguration.isJetpack {
+            // For Jetpack, the overlay will be shown once per site.
+            return shouldPromptInstall && !isOverlayAlreadyShown
         }
 
-        // For Jetpack, the overlay will be shown once per site.
-        return shouldPromptInstall && !isOverlayAlreadyShown
+        return shouldShowOverlayInWordPress
     }
 
     // MARK: Methods
@@ -125,7 +125,11 @@ class JetpackInstallPluginHelper: NSObject {
 private extension JetpackInstallPluginHelper {
 
     static var isFeatureEnabled: Bool {
-        FeatureFlag.jetpackIndividualPluginSupport.enabled || FeatureFlag.wordPressIndividualPluginSupport.enabled
+        if AppConfiguration.isJetpack {
+            return FeatureFlag.jetpackIndividualPluginSupport.enabled
+        }
+
+        return FeatureFlag.wordPressIndividualPluginSupport.enabled
     }
 
     /// Returns true if the card has been set to hidden for `blog`. For Jetpack only.


### PR DESCRIPTION
Resolves #20377 
Refs pctCYC-HX-p2#remote-configuration

This PR adds a separate feature flag, to be specifically used for WordPress. The reason is that this flag will be overridable from the remote (via the `wp_individual_plugin_overlay` remote key).

Additionally, I've also added a remote config (`wp_plugin_overlay_max_shown`) to determine the overlay display limit in WordPress. The config is not implemented yet, but it should fall back to the default value.

## To test

Same as the test steps from #20382, but now modifying a different feature flag:

### WordPress app
- Prepare a self-hosted site with individual Jetpack plugins installed & connected to your WordPress.com account.
- Launch the WordPress app, and enable the `WordPress Individual Plugin Support` feature flag.
- Relaunch the app.
- Switch to your self-hosted site.
- 🔎 Verify that the overlay should now be shown.
  - Note that this is still showing the overlay with contents intended for the Jetpack app.
- Dismiss the overlay.
- 🔎 Verify that the plugin install card is not shown.

### Jetpack app
🔎 Verify that this change does not affect the overlay presentation logic in the Jetpack app: overlay should only be shown once per site and the plugin install card is shown on the dashboard.

## Regression Notes
1. Potential unintended areas of impact
Should be none.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing.

3. What automated tests I added (or what prevented me from doing so)
N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.