### PR TITLE
[JP Plugin]: Add tracks for the plugin overlay in WordPress

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -427,9 +427,14 @@ import Foundation
     case jetpackBrandingMenuCardRemindLater
     case jetpackBrandingMenuCardContextualMenuAccessed
     case jetpackFeatureIncorrectlyAccessed
+
+    // Jetpack plugin overlay modal
     case jetpackInstallPluginModalViewed
     case jetpackInstallPluginModalDismissed
     case jetpackInstallPluginModalInstallTapped
+    case wordPressInstallPluginModalViewed
+    case wordPressInstallPluginModalDismissed
+    case wordPressInstallPluginModalSwitchTapped
 
     // Jetpack full plugin installation for individual sites
     case jetpackInstallFullPluginViewed
@@ -1204,12 +1209,20 @@ import Foundation
             return "remove_feature_card_menu_accessed"
         case .jetpackFeatureIncorrectlyAccessed:
             return "jetpack_feature_incorrectly_accessed"
+
+        // Jetpack plugin overlay modal
         case .jetpackInstallPluginModalViewed:
             return "jp_install_full_plugin_onboarding_modal_viewed"
         case .jetpackInstallPluginModalDismissed:
             return "jp_install_full_plugin_onboarding_modal_dismissed"
         case .jetpackInstallPluginModalInstallTapped:
             return "jp_install_full_plugin_onboarding_modal_install_tapped"
+        case .wordPressInstallPluginModalViewed:
+            return "wp_individual_site_overlay_viewed"
+        case .wordPressInstallPluginModalDismissed:
+            return "wp_individual_site_overlay_dismissed"
+        case .wordPressInstallPluginModalSwitchTapped:
+            return "wp_individual_site_overlay_primary_tapped"
 
         // Jetpack full plugin installation for individual sites
         case .jetpackInstallFullPluginViewed:

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -46,7 +46,7 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     }
 
     func didDisplayOverlay() {
-        WPAnalytics.track(.jetpackInstallPluginModalViewed)
+        track(.viewed)
     }
 
     func didTapLink() {
@@ -55,16 +55,19 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
 
     func didTapPrimary() {
         coordinator?.navigateToPrimaryRoute()
-        WPAnalytics.track(.jetpackInstallPluginModalInstallTapped)
+        track(.primaryButtonTapped)
     }
 
     func didTapClose() {
-        // TODO: Dismiss the overlay.
-        WPAnalytics.track(.jetpackInstallPluginModalDismissed)
+        track(.dismissed)
     }
 
     func didTapSecondary() {
         coordinator?.navigateToSecondaryRoute()
+
+        if AppConfiguration.isWordPress {
+            track(.dismissed)
+        }
     }
 
     func didTapActionInfo() {
@@ -79,6 +82,42 @@ class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
 // MARK: - Private Helpers
 
 private extension JetpackPluginOverlayViewModel {
+
+    enum JetpackPluginOverlayAnalytics {
+        case viewed
+        case dismissed
+        case primaryButtonTapped
+
+        var key: WPAnalyticsEvent {
+            AppConfiguration.isWordPress ? wordPressKey : jetpackKey
+        }
+
+        private var wordPressKey: WPAnalyticsEvent {
+            switch self {
+            case .viewed:
+                return .wordPressInstallPluginModalViewed
+            case .dismissed:
+                return .wordPressInstallPluginModalDismissed
+            case .primaryButtonTapped:
+                return .wordPressInstallPluginModalSwitchTapped
+            }
+        }
+
+        private var jetpackKey: WPAnalyticsEvent {
+            switch self {
+            case .viewed:
+                return .jetpackInstallPluginModalViewed
+            case .dismissed:
+                return .jetpackInstallPluginModalDismissed
+            case .primaryButtonTapped:
+                return .jetpackInstallPluginModalInstallTapped
+            }
+        }
+    }
+
+    func track(_ event: JetpackPluginOverlayAnalytics) {
+        WPAnalytics.track(event.key)
+    }
 
     func subtitle(withSiteName siteName: String, plugin: JetpackPlugin) -> NSAttributedString {
         switch plugin {


### PR DESCRIPTION
Closes #20375

## Description

Adds tracks for the plugin overlay in WordPress.

## Testing

**WordPress**

<details><summary>Test code</summary>

Replace https://github.com/wordpress-mobile/WordPress-iOS/blob/730128aed42301d82a22578fef5cc87c6a8087d9/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackInstallPluginHelper.swift#L195-L206

With:
```swift
    var shouldShowOverlayInWordPress: Bool {
        return true
//        let overlayInfo = WordPressOverlayInfo(siteID: siteIDString,
//                                               repository: repository,
//                                               currentDateProvider: currentDateProvider)
//
//        guard overlayInfo.amountShown < Constants.maxOverlayShownPerSite,
//              currentDateProvider.date() >= overlayInfo.nextOccurrence else {
//            return false
//        }
//
//        return shouldPromptInstall
    }
```
</details>

- Use the test code from above (Note: it will cause the overlay to keep appearing)
- Setup a self-hosted site with an individual plugin connected to your WP account
- Enable the feature flag `jetpackIndividualPluginSupport`
- Install WordPress and login
- Select the self-hosted site
- Run through the following actions and **verify** each event is sent:

| Action | Event |
|-------|-------|
| Overlay is displayed | `🔵 Tracked: wp_individual_site_overlay_viewed <>` |
| Tap on the dismiss in the top right (`X`) | `🔵 Tracked: wp_individual_site_overlay_dismissed <>` |
| Tap on `Continue without Jetpack` | `🔵 Tracked: wp_individual_site_overlay_dismissed <>` |
| Tap on `Switch to the Jetpack app` | `🔵 Tracked: wp_individual_site_overlay_primary_tapped <>` |

**Jetpack**

- Use the same site from above or setup a self-hosted site with an individual plugin connected to your WP account
- Install Jetpack and login
- Select the self-hosted site
- Use the Jetpack plugin install dashboard card 'Learn more' to make the overlay appear multiple times
- Run through the following actions and **verify** each event is sent:

| Action | Event |
|-------|-------|
| Overlay is displayed | `🔵 Tracked: jp_install_full_plugin_onboarding_modal_viewed <>` |
| Tap on the dismiss in the top right (`X`) | `🔵 Tracked: jp_install_full_plugin_onboarding_modal_dismissed <>` |
| Tap on `Install the full plugin` | `🔵 Tracked: jp_install_full_plugin_onboarding_modal_install_tapped <>` |

## Regression Notes
1. Potential unintended areas of impact
Jetpack plugin overlay analytics in the Jetpack app

2. What I did to test those areas of impact (or what existing automated tests I relied on)
Manual testing + test instructions in the PR

3. What automated tests I added (or what prevented me from doing so)
N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
